### PR TITLE
Fix Apple TV now-playing screen losing progress and artwork

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -210,6 +210,12 @@ AIRPLAY_REJOIN_ATTEMPT_DELAYS: Final[tuple[int, ...]] = (5,)
 # does not fetch URLs). 512px keeps the SET_PARAMETER payload small while still
 # looking sharp on speaker apps and the Apple TV now-playing screen.
 AIRPLAY_ARTWORK_SIZE: Final[int] = 512
+# How long a track-change metadata push waits for that render, so the artwork
+# can ride the SENDMETA bundle and the receiver rewrites its now-playing state
+# once instead of twice (bare replace, then artwork). A render that misses the
+# budget is not abandoned: it keeps running and is delivered with the
+# stand-alone ARTWORK command once it completes.
+AIRPLAY_ARTWORK_RENDER_TIMEOUT: Final[float] = 1.5
 EXTERNAL_ARTWORK_PATH_PREFIX: Final[str] = "external_artwork"
 
 # Per-protocol credential storage keys

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -119,10 +119,13 @@ class AirPlayStream:
         self._stopping = False
         self._cleanup_complete = False
         self._stop_lock = asyncio.Lock()
-        # Set the moment stop() begins, so a track-change metadata push waiting
-        # out its artwork render budget inside the metadata lock yields to the
-        # teardown right away instead of stalling it for the full budget.
-        self._teardown_started = asyncio.Event()
+        # Both wake a track-change metadata push waiting out its artwork render
+        # budget inside the metadata lock: the first is set permanently the
+        # moment stop() begins, the second while start() is waiting on the lock
+        # (a pending START is time-critical — the anchor lead is a few hundred
+        # ms). Either makes the bounded wait yield so the teardown or START
+        # proceeds and the artwork follows asynchronously.
+        self._teardown_started, self._start_waiting = asyncio.Event(), asyncio.Event()
         self._connected = asyncio.Event()
         # Set when the stderr reader ends, i.e. the binary is gone. A connect
         # wait watches it so a process that died (for example on a rejected
@@ -513,7 +516,12 @@ class AirPlayStream:
         start_cmd = f"START_UNIX_MS={start_unix_ms}\nACTION=START"
         if join:
             start_cmd = f"START_UNIX_MS={start_unix_ms}\nSTART_JOIN=1\nACTION=START"
-        async with self._metadata_lock:
+        self._start_waiting.set()
+        try:
+            await self._metadata_lock.acquire()
+        finally:
+            self._start_waiting.clear()
+        try:
             if not await self._write_cli_command(start_cmd):
                 # Surfacing the dropped delivery lets the session fall back to a
                 # cold restart instead of waiting on an anchor that never happens.
@@ -532,6 +540,8 @@ class AirPlayStream:
             # from the post-anchor media-updated nudge (+1s) does the job with
             # one refresh instead of two.
             self._metadata_generation += 1
+        finally:
+            self._metadata_lock.release()
         self.mass.create_task(
             self._send_current_metadata_without_progress,
             task_id=f"airplay_metadata_after_start_{self._stream_id}",
@@ -748,7 +758,8 @@ class AirPlayStream:
 
         Called with the metadata lock held. A render that misses the budget is
         never cancelled: the returned task keeps running so the caller can hand
-        it to :meth:`_render_and_send_artwork` for the ARTWORK delivery.
+        it to :meth:`_render_and_send_artwork` for the ARTWORK delivery. The
+        wait also yields early to a teardown or a pending START.
 
         :param artwork_url: The cover-art URL to render.
         :param metadata_generation: Generation the render belongs to.
@@ -758,11 +769,14 @@ class AirPlayStream:
         artwork_render = asyncio.create_task(
             self._prepare_artwork(artwork_url, metadata_generation)
         )
-        # A teardown must not sit out the render budget behind the metadata
-        # lock, so it releases this wait early; the caller's doomed bundle
-        # write is then dropped by send_cli_command.
+        # Neither a teardown nor a time-critical START must sit out the render
+        # budget behind the metadata lock, so both release this wait early: a
+        # teardown's doomed bundle write is then dropped by send_cli_command,
+        # and a START's bundle goes out without artwork (the render delivers
+        # through the ARTWORK command once it completes).
         teardown = asyncio.ensure_future(self._teardown_started.wait())
-        waiters: set[asyncio.Future[Any]] = {artwork_render, teardown}
+        start_waiting = asyncio.ensure_future(self._start_waiting.wait())
+        waiters: set[asyncio.Future[Any]] = {artwork_render, teardown, start_waiting}
         try:
             await asyncio.wait(
                 waiters,
@@ -775,6 +789,7 @@ class AirPlayStream:
             raise
         finally:
             teardown.cancel()
+            start_waiting.cancel()
         artwork_file = artwork_render.result() if artwork_render.done() else None
         return artwork_file, artwork_render
 
@@ -811,8 +826,6 @@ class AirPlayStream:
                 and not self._stopped
                 and not self._stopping
                 and metadata_generation == self._metadata_generation
-                # the SENDMETA bundle may have delivered this artwork already
-                and self._metadata_artwork_checksum != artwork_url
                 and await self.send_cli_command(f"ARTWORK={artwork}")
             ):
                 self._metadata_artwork_checksum = artwork_url

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -15,7 +15,7 @@ import time
 from contextlib import suppress
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Final, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 from uuid import uuid4
 
 from music_assistant_models.enums import PlaybackState
@@ -26,6 +26,7 @@ from music_assistant.helpers.images import get_image_thumb_path
 from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter
 from music_assistant.helpers.process import AsyncProcess
 from music_assistant.providers.airplay.constants import (
+    AIRPLAY_ARTWORK_RENDER_TIMEOUT,
     AIRPLAY_ARTWORK_SIZE,
     AIRPLAY_CONTENT_CUT_TOLERANCE_MS,
     AIRPLAY_JOIN_START_ACK_TIMEOUT_MS,
@@ -118,6 +119,10 @@ class AirPlayStream:
         self._stopping = False
         self._cleanup_complete = False
         self._stop_lock = asyncio.Lock()
+        # Set the moment stop() begins, so a track-change metadata push waiting
+        # out its artwork render budget inside the metadata lock yields to the
+        # teardown right away instead of stalling it for the full budget.
+        self._teardown_started = asyncio.Event()
         self._connected = asyncio.Event()
         # Set when the stderr reader ends, i.e. the binary is gone. A connect
         # wait watches it so a process that died (for example on a rejected
@@ -324,6 +329,7 @@ class AirPlayStream:
             if self._cleanup_complete:
                 return
             self._stopping = True
+            self._teardown_started.set()
             async with self._metadata_lock:
                 self._metadata_generation += 1
                 try:
@@ -581,7 +587,7 @@ class AirPlayStream:
         """Clear the accumulated re-anchor shift."""
         self.cumulative_shift_seconds = 0.0
 
-    async def send_metadata(
+    async def send_metadata(  # noqa: PLR0915
         self,
         progress: int | None,
         metadata: PlayerMedia | None,
@@ -617,6 +623,7 @@ class AirPlayStream:
             metadata_checksum = f"{text_checksum}|{metadata.image_url}"
 
         artwork_url: str | None = None
+        artwork_render: asyncio.Task[str | None] | None = None
         metadata_generation = 0
         async with self._metadata_lock:
             if self._stopped or self._stopping:
@@ -634,19 +641,55 @@ class AirPlayStream:
                 and (needs_artwork or text_checksum != self._metadata_text_checksum)
             ):
                 if text_checksum != self._metadata_text_checksum:
+                    artwork_file: str | None = None
+                    if (
+                        send_artwork
+                        and metadata.image_url
+                        and needs_artwork
+                        and metadata_generation not in self._artwork_render_generations
+                    ):
+                        # Budgeted pre-render so metadata and artwork ride ONE
+                        # SENDMETA push: back-to-back now-playing rewrites (a
+                        # bare replace followed by the artwork) intermittently
+                        # wedge the Apple TV now-playing screen. A render that
+                        # misses the budget keeps running and delivers through
+                        # the ARTWORK command instead.
+                        self._artwork_render_generations.add(metadata_generation)
+                        artwork_url = metadata.image_url
+                        artwork_file, artwork_render = await self._render_artwork_bounded(
+                            artwork_url, metadata_generation
+                        )
                     # ITEMID gives the binary a stable per-track identity, so
                     # a later tag refinement for the same queue item (library
                     # enrichment can settle after playback starts) updates the
                     # receiver's now-playing item in place instead of
                     # presenting as a new track.
                     cmd = f"TITLE={title}\nARTIST={artist}\nALBUM={album}\n"
-                    cmd += f"DURATION={duration}\nITEMID={item_id}\nACTION=SENDMETA\n"
+                    cmd += f"DURATION={duration}\nITEMID={item_id}\n"
+                    if artwork_file:
+                        cmd += f"ARTWORKFILE={artwork_file}\n"
+                    cmd += "ACTION=SENDMETA\n"
                     if not await self.send_cli_command(cmd):
+                        if artwork_render is not None:
+                            # the identity push never went out, so drop the
+                            # render and let the next update retry from scratch
+                            artwork_render.cancel()
+                            self._artwork_render_generations.discard(metadata_generation)
                         return
                     self._metadata_text_checksum = text_checksum
-                    # the metadata push carried the previous position; always
-                    # follow with a fresh progress correction
-                    self._last_progress_sent = None
+                    # the push resets a changed track to position zero (a
+                    # same-item refinement carries the current position), so
+                    # the correction below only follows when playback is
+                    # actually elsewhere (mid-track start, tag refinement)
+                    self._last_progress_sent = 0
+                    if artwork_file:
+                        # the bundle delivered the artwork: settle it and stand
+                        # down the ARTWORK follow-up
+                        self._metadata_artwork_checksum = artwork_checksum
+                        self._artwork_render_generations.discard(metadata_generation)
+                        needs_artwork = False
+                        artwork_url = None
+                        artwork_render = None
                 if metadata_generation != self._metadata_generation:
                     return
                 if (
@@ -669,7 +712,7 @@ class AirPlayStream:
                     self._last_progress_sent = progress
 
         if artwork_url is not None:
-            await self._render_and_send_artwork(artwork_url, metadata_generation)
+            await self._render_and_send_artwork(artwork_url, metadata_generation, artwork_render)
 
     def _full_media_duration(self, metadata: PlayerMedia) -> int:
         """
@@ -697,17 +740,67 @@ class AirPlayStream:
                     return min(int(full_duration), 3600)
         return min(metadata.duration or 0, 3600)
 
-    async def _render_and_send_artwork(self, artwork_url: str, metadata_generation: int) -> None:
+    async def _render_artwork_bounded(
+        self, artwork_url: str, metadata_generation: int
+    ) -> tuple[str | None, asyncio.Task[str | None]]:
+        """
+        Start the artwork render and wait for it within the bundling budget.
+
+        Called with the metadata lock held. A render that misses the budget is
+        never cancelled: the returned task keeps running so the caller can hand
+        it to :meth:`_render_and_send_artwork` for the ARTWORK delivery.
+
+        :param artwork_url: The cover-art URL to render.
+        :param metadata_generation: Generation the render belongs to.
+        :return: The rendered artwork path (None when the budget was missed or
+            the render failed) and the render task itself.
+        """
+        artwork_render = asyncio.create_task(
+            self._prepare_artwork(artwork_url, metadata_generation)
+        )
+        # A teardown must not sit out the render budget behind the metadata
+        # lock, so it releases this wait early; the caller's doomed bundle
+        # write is then dropped by send_cli_command.
+        teardown = asyncio.ensure_future(self._teardown_started.wait())
+        waiters: set[asyncio.Future[Any]] = {artwork_render, teardown}
+        try:
+            await asyncio.wait(
+                waiters,
+                timeout=AIRPLAY_ARTWORK_RENDER_TIMEOUT,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        except asyncio.CancelledError:
+            artwork_render.cancel()
+            self._artwork_render_generations.discard(metadata_generation)
+            raise
+        finally:
+            teardown.cancel()
+        artwork_file = artwork_render.result() if artwork_render.done() else None
+        return artwork_file, artwork_render
+
+    async def _render_and_send_artwork(
+        self,
+        artwork_url: str,
+        metadata_generation: int,
+        render: asyncio.Task[str | None] | None = None,
+    ) -> None:
         """
         Render and apply artwork for the current metadata generation.
 
         :param artwork_url: Source URL for the artwork; settles as the
             delivered artwork identity once the binary accepts the command.
         :param metadata_generation: Generation that must still be current before apply.
+        :param render: Render already under way for this generation to deliver,
+            instead of starting a new one.
         """
         try:
-            artwork = await self._prepare_artwork(artwork_url, metadata_generation)
+            if render is not None:
+                artwork = await render
+            else:
+                artwork = await self._prepare_artwork(artwork_url, metadata_generation)
         except asyncio.CancelledError:
+            if render is not None:
+                render.cancel()
             async with self._metadata_lock:
                 self._artwork_render_generations.discard(metadata_generation)
             raise
@@ -718,6 +811,8 @@ class AirPlayStream:
                 and not self._stopped
                 and not self._stopping
                 and metadata_generation == self._metadata_generation
+                # the SENDMETA bundle may have delivered this artwork already
+                and self._metadata_artwork_checksum != artwork_url
                 and await self.send_cli_command(f"ARTWORK={artwork}")
             ):
                 self._metadata_artwork_checksum = artwork_url

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2574,8 +2574,58 @@ async def test_track_change_artwork_missing_the_budget_follows_as_artwork_comman
     commands = [args.args[0].decode() for args in write_command.await_args_list]
     assert "ARTWORKFILE" not in commands[0]
     assert commands[0].endswith("ACTION=SENDMETA\n")
-    assert commands[-1] == "ARTWORK=/cache/late.jpg\n"
+    assert [command for command in commands if command.startswith("ARTWORK=")] == [
+        "ARTWORK=/cache/late.jpg\n"
+    ]
     assert stream._metadata_artwork_checksum == "image"
+
+
+@pytest.mark.asyncio
+async def test_pending_start_interrupts_the_artwork_wait() -> None:
+    """A pending START releases the bounded artwork wait instead of queueing behind it."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream._cli_proc = MagicMock(closed=False)
+    stream._connected.set()
+    metadata = MagicMock(
+        queue_item_id="item-1",
+        duration=180,
+        title="Track",
+        artist="Artist",
+        album="Album",
+        image_url="image",
+    )
+    release_render = asyncio.Event()
+    render_started = asyncio.Event()
+
+    async def _prepare_artwork(_image_url: str, _generation: int) -> str:
+        render_started.set()
+        await release_render.wait()
+        return "/cache/late.jpg"
+
+    with (
+        patch.object(
+            stream,
+            "_write_cli_command",
+            new_callable=AsyncMock,
+            side_effect=_acking_write_cli_command(stream),
+        ) as write_command,
+        patch.object(
+            stream, "_prepare_artwork", new_callable=AsyncMock, side_effect=_prepare_artwork
+        ),
+    ):
+        push = asyncio.create_task(stream.send_metadata(0, metadata))
+        await render_started.wait()
+        # the metadata push sits in its render budget holding the lock; the
+        # START must release that wait instead of losing its anchor lead to it
+        assert await stream.start(START_UNIX_MS, 0) == START_UNIX_MS
+        release_render.set()
+        await push
+
+    commands = [args.args[0] for args in write_command.await_args_list]
+    assert commands[0].endswith("ACTION=SENDMETA\n")
+    assert "ARTWORKFILE" not in commands[0]
+    assert commands[1].startswith(f"START_UNIX_MS={START_UNIX_MS}")
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -1340,6 +1340,7 @@ async def test_start_transition_artwork_settled_or_retried(complete_before_start
             new_callable=AsyncMock,
             side_effect=prepare_artwork,
         ),
+        patch("music_assistant.providers.airplay.stream.AIRPLAY_ARTWORK_RENDER_TIMEOUT", 0.05),
     ):
         pretransition_task = asyncio.create_task(stream.send_metadata(None, metadata))
         await render_started.wait()
@@ -1353,10 +1354,12 @@ async def test_start_transition_artwork_settled_or_retried(complete_before_start
     commands = [args.args[0] for args in write_command.await_args_list]
     start_command = f"START_UNIX_MS={START_UNIX_MS}\nACTION=START"
     if complete_before_start:
-        # artwork delivered before the anchor stays settled; re-pushing it
-        # around the START would make an Apple TV re-render its screen
+        # artwork delivered inside the transition bundle stays settled;
+        # re-pushing it around the START would make an Apple TV re-render
+        # its screen
         assert commands[-1] == start_command
-        assert "ARTWORK=/cache/pretransition.jpg" in commands
+        assert any("ARTWORKFILE=/cache/pretransition.jpg" in command for command in commands)
+        assert not any(command.startswith("ARTWORK=") for command in commands)
     else:
         # the anchor superseded the in-flight render; the post-anchor push
         # renders again and delivers the artwork once
@@ -1874,11 +1877,11 @@ async def test_initial_metadata_skips_artwork() -> None:
     ):
         await stream.send_metadata(0, metadata, send_artwork=False)
 
-    assert send_command.await_count == 2
-    commands = [args.args[0] for args in send_command.await_args_list]
-    assert "TITLE=Track" in commands[0]
-    # the progress correction rides along right after the metadata push
-    assert commands[1].endswith("PROGRESS=0")
+    # the metadata push resets the device position to zero, so a push at the
+    # start of a track needs no separate progress correction
+    assert send_command.await_count == 1
+    assert "TITLE=Track" in send_command.await_args_list[0].args[0]
+    assert stream._last_progress_sent == 0
     send_artwork.assert_not_awaited()
 
 
@@ -2322,19 +2325,23 @@ async def test_concurrent_metadata_updates_only_send_latest_artwork() -> None:
             new_callable=AsyncMock,
             side_effect=_prepare_artwork,
         ),
+        patch("music_assistant.providers.airplay.stream.AIRPLAY_ARTWORK_RENDER_TIMEOUT", 0.05),
     ):
         old_task = asyncio.create_task(stream.send_metadata(0, old_metadata))
         await first_render_started.wait()
         new_task = asyncio.create_task(stream.send_metadata(0, new_metadata))
-        await asyncio.sleep(0)
+        # the new update supersedes the old render once the old push's render
+        # budget lapses and the metadata lock is released
+        await new_task
         assert stream._metadata_generation == 2
         release_first_render.set()
-        await asyncio.gather(old_task, new_task)
+        await old_task
 
     commands = [call.args[0].decode() for call in write_command.await_args_list]
     assert any("TITLE=New track" in command for command in commands)
     assert not any("ARTWORK=old.jpg" in command for command in commands)
-    assert commands[-1] == "ARTWORK=new.jpg\n"
+    assert "ARTWORKFILE=new.jpg\n" in commands[-1]
+    assert commands[-1].endswith("ACTION=SENDMETA\n")
 
 
 @pytest.mark.asyncio
@@ -2451,6 +2458,7 @@ async def test_repeated_metadata_retries_superseded_artwork() -> None:
             new_callable=AsyncMock,
             side_effect=_prepare_artwork,
         ) as prepare_artwork,
+        patch("music_assistant.providers.airplay.stream.AIRPLAY_ARTWORK_RENDER_TIMEOUT", 0.05),
     ):
         first_b_task = asyncio.create_task(stream.send_metadata(0, metadata_b))
         await first_artwork_started.wait()
@@ -2467,13 +2475,15 @@ async def test_repeated_metadata_retries_superseded_artwork() -> None:
     assert rendered_images == ["b-image", "c-image", "b-image"]
     assert "ARTWORK=b-stale.jpg\n" not in commands
     assert "ARTWORK=c.jpg\n" not in commands
-    assert commands[-1] == "ARTWORK=b-final.jpg\n"
+    # the final B render completed within the budget, so it rides the bundle
+    assert "ARTWORKFILE=b-final.jpg\n" in commands[-1]
+    assert commands[-1].endswith("ACTION=SENDMETA\n")
     assert stream._metadata_artwork_checksum == "b-image"
 
 
 @pytest.mark.asyncio
 async def test_send_metadata_passes_cached_artwork_path_to_binary() -> None:
-    """The ARTWORK command passes the absolute cache path returned by preparation."""
+    """The staged artwork carries the absolute cache path returned by preparation."""
     player = _make_player()
     stream = AirPlayStream(player)
     metadata = MagicMock(
@@ -2492,7 +2502,109 @@ async def test_send_metadata_passes_cached_artwork_path_to_binary() -> None:
     ):
         await stream.send_metadata(None, metadata)
 
-    assert send_command.await_args_list[-1] == call(f"ARTWORK={cached_path}")
+    assert f"ARTWORKFILE={cached_path}\n" in send_command.await_args_list[-1].args[0]
+
+
+@pytest.mark.asyncio
+async def test_track_change_bundles_ready_artwork_into_a_single_push() -> None:
+    """A track change whose artwork renders within budget lands as ONE bundled write."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    metadata = MagicMock(
+        queue_item_id="item-1",
+        duration=180,
+        title="Track",
+        artist="Artist",
+        album="Album",
+        image_url="image",
+    )
+
+    with (
+        patch.object(stream.commands_pipe, "write", new_callable=AsyncMock) as write_command,
+        patch.object(stream, "_prepare_artwork", new=AsyncMock(return_value="/cache/art.jpg")),
+    ):
+        await stream.send_metadata(0, metadata)
+
+    assert write_command.await_count == 1
+    lines = write_command.await_args_list[0].args[0].decode().splitlines()
+    assert "TITLE=Track" in lines
+    assert "ITEMID=item-1" in lines
+    # the artwork is staged before the SENDMETA applies the whole bundle
+    assert lines[-2:] == ["ARTWORKFILE=/cache/art.jpg", "ACTION=SENDMETA"]
+    # the push resets the device position to zero: no PROGRESS correction
+    assert stream._last_progress_sent == 0
+    assert stream._metadata_artwork_checksum == "image"
+
+
+@pytest.mark.asyncio
+async def test_track_change_artwork_missing_the_budget_follows_as_artwork_command() -> None:
+    """A render missing the bundling budget still delivers via ARTWORK once it completes."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    metadata = MagicMock(
+        queue_item_id="item-1",
+        duration=180,
+        title="Track",
+        artist="Artist",
+        album="Album",
+        image_url="image",
+    )
+    release_render = asyncio.Event()
+
+    async def _prepare_artwork(_image_url: str, _generation: int) -> str:
+        await release_render.wait()
+        return "/cache/late.jpg"
+
+    with (
+        patch.object(stream.commands_pipe, "write", new_callable=AsyncMock) as write_command,
+        patch.object(
+            stream, "_prepare_artwork", new_callable=AsyncMock, side_effect=_prepare_artwork
+        ),
+        patch("music_assistant.providers.airplay.stream.AIRPLAY_ARTWORK_RENDER_TIMEOUT", 0.01),
+    ):
+        push = asyncio.create_task(stream.send_metadata(0, metadata))
+        async with asyncio.timeout(2):
+            while write_command.await_count == 0:
+                await asyncio.sleep(0)
+        # the identity bundle went out without artwork once the budget lapsed
+        assert stream._metadata_artwork_checksum == ""
+        release_render.set()
+        await push
+
+    commands = [args.args[0].decode() for args in write_command.await_args_list]
+    assert "ARTWORKFILE" not in commands[0]
+    assert commands[0].endswith("ACTION=SENDMETA\n")
+    assert commands[-1] == "ARTWORK=/cache/late.jpg\n"
+    assert stream._metadata_artwork_checksum == "image"
+
+
+@pytest.mark.asyncio
+async def test_track_change_starting_mid_track_sends_a_progress_correction() -> None:
+    """A track change landing mid-position corrects the timeline after the bundle."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = MagicMock(closed=False)
+    metadata = MagicMock(
+        queue_item_id="item-1",
+        duration=180,
+        title="Track",
+        artist="Artist",
+        album="Album",
+        image_url="image",
+    )
+
+    with (
+        patch.object(stream.commands_pipe, "write", new_callable=AsyncMock) as write_command,
+        patch.object(stream, "_prepare_artwork", new=AsyncMock(return_value="/cache/art.jpg")),
+    ):
+        await stream.send_metadata(120, metadata)
+
+    commands = [args.args[0].decode() for args in write_command.await_args_list]
+    assert len(commands) == 2
+    assert commands[0].endswith("ACTION=SENDMETA\n")
+    # the push reset the device position to zero, so the mid-track start is
+    # corrected right after
+    assert commands[1].endswith("PROGRESS=120\n")
+    assert stream._last_progress_sent == 120
 
 
 @pytest.mark.asyncio
@@ -2508,13 +2620,21 @@ async def test_failed_artwork_delivery_is_retried() -> None:
         image_url="image",
     )
     artwork_path = "/cache/thumbnails/artwork.jpg"
+    release_render = asyncio.Event()
+
+    async def _prepare_artwork(_image_url: str, _generation: int) -> str:
+        # the first render misses the bundling budget, so the artwork goes
+        # out through the stand-alone ARTWORK command
+        if not release_render.is_set():
+            await release_render.wait()
+        return artwork_path
 
     with (
         patch.object(
             stream,
             "_prepare_artwork",
             new_callable=AsyncMock,
-            return_value=artwork_path,
+            side_effect=_prepare_artwork,
         ) as prepare_artwork,
         patch.object(
             stream,
@@ -2522,8 +2642,14 @@ async def test_failed_artwork_delivery_is_retried() -> None:
             new_callable=AsyncMock,
             side_effect=[True, False, True],
         ) as send_command,
+        patch("music_assistant.providers.airplay.stream.AIRPLAY_ARTWORK_RENDER_TIMEOUT", 0.01),
     ):
-        await stream.send_metadata(None, metadata)
+        first_push = asyncio.create_task(stream.send_metadata(None, metadata))
+        async with asyncio.timeout(2):
+            while send_command.await_count == 0:
+                await asyncio.sleep(0)
+        release_render.set()
+        await first_push
         assert stream._metadata_artwork_checksum == ""
         await stream.send_metadata(None, metadata)
 
@@ -2577,7 +2703,8 @@ async def test_text_refinement_keeps_delivered_artwork_settled() -> None:
 
     prepare_artwork.assert_awaited_once()
     commands = [args.args[0] for args in send_command.await_args_list]
-    assert commands.count(f"ARTWORK={artwork_path}") == 1
+    assert sum(f"ARTWORKFILE={artwork_path}\n" in command for command in commands) == 1
+    assert "ARTWORKFILE" not in commands[-1]
     assert "TITLE=Track (Remastered)" in commands[-1]
 
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes the remaining Apple TV now-playing issues after the AirPlay rewrite: the progress bar showed 0:00 while paused, and skipping tracks could make the progress bar or the cover art disappear from the now-playing screen until the Music app was reopened.

The cause (confirmed on real hardware with wire logs): pausing only sent a playback-state change without the frozen position, and every track change rewrote the Apple TV's now-playing state three times in quick succession — which intermittently wedged its screen.

- At a track change the artwork render now gets a short budget (1.5s) so metadata and artwork ride ONE bundled push to the device; slower renders still follow via the existing artwork command
- No more redundant position correction right after a track change (the push itself starts the new track at zero)
- Companion binary changes in music-assistant/airplay-cli#58: pause/resume now push the frozen/resumed position, and the artwork identity is kept stable across track changes so the cover no longer flickers or vanishes
- Requires the binary release carrying airplay-cli#58: its auto-release opens a separate `CLIAIRPLAY_VERSION` bump PR on this repo, which merges before this one

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5279

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

