### PR TITLE
Tidy up the Sonos S1 error handling helper

### DIFF
--- a/music_assistant/providers/sonos_s1/helpers.py
+++ b/music_assistant/providers/sonos_s1/helpers.py
@@ -101,7 +101,7 @@ def sync_get_visible_zones(soco: SoCo) -> set[SoCo]:
 
 
 def _handle_soco_error(
-    instance: Any,
+    instance: SonosPlayer,
     err: Exception,
     function: str,
     errorcodes: list[str] | None,
@@ -112,17 +112,8 @@ def _handle_soco_error(
         _LOGGER.debug("Error code %s ignored in call to %s", error_code, function)
         return
 
-    if (target := _find_target_identifier(instance)) is None:
-        msg = "Unexpected use of soco_error"
-        raise RuntimeError(msg) from err
-
+    soco = instance.soco
+    # Only use attributes with no I/O
+    target = soco._player_name or soco.ip_address
     message = f"Error calling {function} on {target}: {err}"
     raise SonosUpdateError(message) from err
-
-
-def _find_target_identifier(instance: Any) -> str | None:
-    """Return the name or IP address of the speaker, or None if the instance holds no SoCo."""
-    if soco := getattr(instance, "soco", None):
-        # Only use attributes with no I/O
-        return str(soco._player_name or soco.ip_address)
-    return None


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5445, which removed two unreachable branches from the Sonos S1 error helper but left the scaffolding around them in place.

The helper still took an untyped `instance` and guarded against it not holding a speaker connection. That guard can never run: the decorator only accepts methods on a Sonos player, and mypy already rejects anything else where the decorator is applied. With the guard gone, the small lookup it protected has a single caller and reads better inline.

- Type the helper against `SonosPlayer` instead of `Any`
- Drop the unreachable "unexpected use" guard
- Fold the single-caller speaker-name lookup into its only caller

No behaviour change.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
