### PR TITLE
Stop a player registration that was cancelled halfway

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1420,56 +1420,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             if not player.state.enabled:
                 return
 
-            conf_base = f"{CONF_PLAYERS}/{player_id}/values"
             if player.type not in (PlayerType.GROUP, PlayerType.STEREO_PAIR):
-                # Save the original MAC reported by the provider (before ARP enrichment)
-                reported_mac = player.device_info.identifiers.get(IdentifierType.MAC_ADDRESS)
-
-                # Try to use cached ARP MAC from config for fast matching on restart.
-                # This allows protocol linking to work immediately even if ARP is slow/fails.
-                cached_arp_mac: str | None = self.mass.config.get(
-                    f"{conf_base}/{CONF_CACHED_ARP_MAC}", None
-                )
-                if cached_arp_mac and is_valid_mac_address(cached_arp_mac):
-                    player.device_info.add_identifier(IdentifierType.MAC_ADDRESS, cached_arp_mac)
-
-                # Enrich device MAC address via ARP if needed
-                # (handles invalid MACs, locally-administered MACs, and missing MACs)
-                await enrich_device_mac_address(player.device_info, self.logger)
-
-                # Cache the resolved MAC for fast matching on subsequent restarts
-                current_mac = player.device_info.identifiers.get(IdentifierType.MAC_ADDRESS)
-                if (
-                    current_mac
-                    and is_valid_mac_address(current_mac)
-                    and current_mac != cached_arp_mac
-                ):
-                    self.mass.config.set(f"{conf_base}/{CONF_CACHED_ARP_MAC}", current_mac)
-
-                # Store original reported MAC if it differs from the resolved MAC.
-                # This enables multi-MAC matching for devices with multiple interfaces
-                # (e.g., WiFi + Ethernet) where ARP resolves one interface but the
-                # protocol reports the other.
-                if reported_mac and is_valid_mac_address(reported_mac) and current_mac:
-                    if reported_mac.upper() != current_mac.upper():
-                        player.extra_data["reported_mac"] = reported_mac
-                        self.mass.config.set(f"{conf_base}/{CONF_REPORTED_MAC}", reported_mac)
-                    else:
-                        # Provider's reported MAC matches the resolved MAC; clear any stale
-                        # stored reported MAC to avoid false-positive multi-MAC matches.
-                        self.mass.config.set(f"{conf_base}/{CONF_REPORTED_MAC}", None)
-                elif not reported_mac or not is_valid_mac_address(reported_mac):
-                    # Restore reported MAC from config on restart only when the provider
-                    # did not supply a usable MAC address.
-                    cached_reported_mac: str | None = self.mass.config.get(
-                        f"{conf_base}/{CONF_REPORTED_MAC}", None
-                    )
-                    if cached_reported_mac and is_valid_mac_address(cached_reported_mac):
-                        if current_mac and cached_reported_mac.upper() == current_mac.upper():
-                            # Cached value matches the resolved MAC; clear stale entry.
-                            self.mass.config.set(f"{conf_base}/{CONF_REPORTED_MAC}", None)
-                        else:
-                            player.extra_data["reported_mac"] = cached_reported_mac
+                await self._resolve_mac_addresses(player)
 
             # restore 'fake' power state from cache if available.
             # Group players intentionally do NOT restore their fake-power
@@ -1506,12 +1458,16 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             player.update_state(signal_event=False)
             # ensure we fetch and set the latest/full config for the player
             player_config = await self.mass.config.get_player_config(player_id)
+            if self._registration_aborted(player):
+                return
             player.set_config(player_config)
             # update state again now that config is loaded
             player.update_state(signal_event=False)
             self._save_underlying_player_id(player)
             # call hook after the player is registered and config is set
             await player.on_config_updated()
+            if self._registration_aborted(player):
+                return
 
             # Handle protocol linking
             self._evaluate_protocol_links(player)
@@ -1532,6 +1488,10 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             # register playerqueue for this player (if not a protocol player)
             if player.state.type != PlayerType.PROTOCOL:
                 await self.mass.player_queues.on_player_register(player)
+                if self._registration_aborted(player):
+                    # the queue restore outlived the unregister that already cleaned it up,
+                    # so drop the queue we just recreated for a player that is gone
+                    self.mass.player_queues.on_player_remove(player_id, permanent=False)
 
         # Schedule debounced update of all players since can_group_with values may change
         # when a new player is added (provider IDs expand to include the new player)
@@ -1542,15 +1502,26 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         if self.mass.closing:
             return
 
-        if player.player_id in self._players:
-            self._players[player.player_id] = player
-            player.update_state()
-            # the derived-transport edge may have been set/revoked after the
-            # initial registration (e.g. via a bridge claim)
-            self._save_underlying_player_id(player)
-            # Also schedule update when replacing existing player
-            self._schedule_update_all_players()
-            return
+        # the register lock ensures a replacement is never swapped in while register()
+        # is still setting the player up
+        async with self._register_lock:
+            if (existing := self._players.get(player.player_id)) is not None:
+                self._players[player.player_id] = player
+                if existing is not player:
+                    # a fresh instance starts out with a base config only, so it needs
+                    # the config the registration resolved before it can be used
+                    player.set_config(existing.config)
+                    await player.on_config_updated()
+                # the replacement takes over the identity of an already registered
+                # player, so it must be marked initialized as well
+                player.set_initialized()
+                player.update_state()
+                # the derived-transport edge may have been set/revoked after the
+                # initial registration (e.g. via a bridge claim)
+                self._save_underlying_player_id(player)
+                # Also schedule update when replacing existing player
+                self._schedule_update_all_players()
+                return
 
         await self.register(player)
 
@@ -2243,6 +2214,75 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
     def __iter__(self) -> Iterator[Player]:
         """Iterate over all players."""
         return iter(self._players.values())
+
+    async def _resolve_mac_addresses(self, player: Player) -> None:
+        """
+        Resolve and persist the MAC addresses used to match the player against protocols.
+
+        :param player: The player to resolve the MAC address(es) for.
+        """
+        conf_base = f"{CONF_PLAYERS}/{player.player_id}/values"
+        # Save the original MAC reported by the provider (before ARP enrichment)
+        reported_mac = player.device_info.identifiers.get(IdentifierType.MAC_ADDRESS)
+
+        # Try to use cached ARP MAC from config for fast matching on restart.
+        # This allows protocol linking to work immediately even if ARP is slow/fails.
+        cached_arp_mac: str | None = self.mass.config.get(
+            f"{conf_base}/{CONF_CACHED_ARP_MAC}", None
+        )
+        if cached_arp_mac and is_valid_mac_address(cached_arp_mac):
+            player.device_info.add_identifier(IdentifierType.MAC_ADDRESS, cached_arp_mac)
+
+        # Enrich device MAC address via ARP if needed
+        # (handles invalid MACs, locally-administered MACs, and missing MACs)
+        await enrich_device_mac_address(player.device_info, self.logger)
+
+        # Cache the resolved MAC for fast matching on subsequent restarts
+        current_mac = player.device_info.identifiers.get(IdentifierType.MAC_ADDRESS)
+        if current_mac and is_valid_mac_address(current_mac) and current_mac != cached_arp_mac:
+            self.mass.config.set(f"{conf_base}/{CONF_CACHED_ARP_MAC}", current_mac)
+
+        # Store original reported MAC if it differs from the resolved MAC.
+        # This enables multi-MAC matching for devices with multiple interfaces
+        # (e.g., WiFi + Ethernet) where ARP resolves one interface but the
+        # protocol reports the other.
+        if reported_mac and is_valid_mac_address(reported_mac) and current_mac:
+            if reported_mac.upper() != current_mac.upper():
+                player.extra_data["reported_mac"] = reported_mac
+                self.mass.config.set(f"{conf_base}/{CONF_REPORTED_MAC}", reported_mac)
+            else:
+                # Provider's reported MAC matches the resolved MAC; clear any stale
+                # stored reported MAC to avoid false-positive multi-MAC matches.
+                self.mass.config.set(f"{conf_base}/{CONF_REPORTED_MAC}", None)
+        elif not reported_mac or not is_valid_mac_address(reported_mac):
+            # Restore reported MAC from config on restart only when the provider
+            # did not supply a usable MAC address.
+            cached_reported_mac: str | None = self.mass.config.get(
+                f"{conf_base}/{CONF_REPORTED_MAC}", None
+            )
+            if cached_reported_mac and is_valid_mac_address(cached_reported_mac):
+                if current_mac and cached_reported_mac.upper() == current_mac.upper():
+                    # Cached value matches the resolved MAC; clear stale entry.
+                    self.mass.config.set(f"{conf_base}/{CONF_REPORTED_MAC}", None)
+                else:
+                    player.extra_data["reported_mac"] = cached_reported_mac
+
+    def _registration_aborted(self, player: Player) -> bool:
+        """
+        Return True if the given player is no longer the registered player for its ID.
+
+        :param player: The player that is in the process of being registered.
+        """
+        # registration awaits provider I/O while the player is already in the registry,
+        # so an unregister (e.g. a provider unload or a device disconnect) can drop or
+        # replace it in the meantime, after which registration must stop
+        if self._players.get(player.player_id) is player:
+            return False
+        self.logger.debug(
+            "Registration of player %s aborted: it was unregistered while setting up",
+            player.player_id,
+        )
+        return True
 
     async def _release_player_for_play_media(self, player: Player) -> None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1512,6 +1512,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                     # the config the registration resolved before it can be used
                     player.set_config(existing.config)
                     await player.on_config_updated()
+                    if self._registration_aborted(player):
+                        return
                 # the replacement takes over the identity of an already registered
                 # player, so it must be marked initialized as well
                 player.set_initialized()

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -54,7 +54,7 @@ from music_assistant.constants import (
 from music_assistant.controllers.players import PlayerController
 from music_assistant.controllers.webserver.helpers.auth_middleware import current_user
 from music_assistant.models.player_provider import PlayerProvider
-from tests.common import MockPlayer, MockProvider
+from tests.common import MockPlayer, MockProvider, create_mock_config
 
 
 def _player_config_stub(
@@ -756,6 +756,227 @@ class TestUnregisterCleanup:
         asyncio.run(controller.unregister("nonexistent"))
 
         assert "set_members_other" in controller._player_command_locks
+
+
+class TestRegisterUnregisterRace:
+    """Test registration that is interrupted by an unregister of the same player."""
+
+    @staticmethod
+    def _stub_register_calls(mock_mass: MagicMock) -> None:
+        """Stub the awaited mass calls made during register/unregister."""
+        # the player config store is read as a mapping during protocol link evaluation
+        mock_mass.config.get = MagicMock(return_value={})
+        mock_mass.cache.get = AsyncMock(return_value=None)
+        mock_mass.config.get_player_config = AsyncMock(return_value=create_mock_config("Player 1"))
+        mock_mass.player_queues.on_player_register = AsyncMock()
+        mock_mass.player_queues.on_player_remove = MagicMock()
+
+    @staticmethod
+    def _player_added_signalled(mock_mass: MagicMock) -> bool:
+        """Return True if a PLAYER_ADDED event was signalled."""
+        return any(
+            call_args.args and call_args.args[0] == EventType.PLAYER_ADDED
+            for call_args in mock_mass.signal_event.call_args_list
+        )
+
+    async def test_register_aborts_when_unregistered_during_config_load(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player unregistered while its config loads is not announced as added."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+
+        async def _unregister_midway(player_id: str) -> MagicMock:
+            # stands in for a provider unload or device disconnect landing
+            # while register awaits the player config
+            await controller.unregister(player_id)
+            return create_mock_config("Player 1")
+
+        mock_mass.config.get_player_config = AsyncMock(side_effect=_unregister_midway)
+        config_hook = AsyncMock()
+
+        with (
+            patch(
+                "music_assistant.controllers.players.controller.enrich_device_mac_address",
+                AsyncMock(),
+            ),
+            patch.object(player, "on_config_updated", config_hook),
+        ):
+            await controller.register(player)
+
+        assert "player_1" not in controller._players
+        assert not player.initialized.is_set()
+        # setup stops right away: the provider hook must not run on a player
+        # whose on_unload already ran
+        config_hook.assert_not_called()
+        mock_mass.player_queues.on_player_register.assert_not_called()
+        assert not self._player_added_signalled(mock_mass)
+
+    async def test_register_aborts_when_unregistered_during_config_hook(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player unregistered while its on_config_updated hook runs is not announced."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+
+        async def _unregister_midway() -> None:
+            await controller.unregister("player_1")
+
+        with (
+            patch(
+                "music_assistant.controllers.players.controller.enrich_device_mac_address",
+                AsyncMock(),
+            ),
+            patch.object(player, "on_config_updated", AsyncMock(side_effect=_unregister_midway)),
+        ):
+            await controller.register(player)
+
+        assert "player_1" not in controller._players
+        assert not player.initialized.is_set()
+        mock_mass.player_queues.on_player_register.assert_not_called()
+        assert not self._player_added_signalled(mock_mass)
+
+    async def test_register_drops_queue_recreated_after_unregister(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A queue restored after the unregister already removed it is dropped again."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+
+        events: list[str] = []
+
+        async def _unregister_midway(registering_player: MockPlayer) -> None:
+            # on_player_register restores the queue from cache before storing it, so an
+            # unregister can land in between and have its cleanup undone
+            await controller.unregister(registering_player.player_id)
+            events.append("queue_created")
+
+        def _track_removal(*_args: object, **_kwargs: object) -> None:
+            events.append("queue_removed")
+
+        mock_mass.player_queues.on_player_remove = MagicMock(side_effect=_track_removal)
+        mock_mass.player_queues.on_player_register = AsyncMock(side_effect=_unregister_midway)
+
+        with patch(
+            "music_assistant.controllers.players.controller.enrich_device_mac_address",
+            AsyncMock(),
+        ):
+            await controller.register(player)
+
+        assert "player_1" not in controller._players
+        # the queue recreated for the removed player must be cleaned up again
+        assert events == ["queue_removed", "queue_created", "queue_removed"]
+
+    async def test_register_or_update_marks_replacement_initialized(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Replacing a registered player carries the initialized state to the new object."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        existing = MockPlayer(provider, "player_1", "Player 1")
+        existing.set_initialized()
+        controller._players = {"player_1": existing}
+        replacement = MockPlayer(provider, "player_1", "Player 1")
+
+        await controller.register_or_update(replacement)
+
+        assert controller._players["player_1"] is replacement
+        assert replacement.initialized.is_set()
+
+    async def test_register_or_update_hands_config_to_replacement(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A replacement instance inherits the config of the player it takes over."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        existing = MockPlayer(provider, "player_1", "Player 1")
+        resolved_config = create_mock_config("Player 1")
+        existing.set_config(resolved_config)
+        existing.set_initialized()
+        controller._players = {"player_1": existing}
+        replacement = MockPlayer(provider, "player_1", "Player 1")
+        config_hook = AsyncMock()
+
+        with patch.object(replacement, "on_config_updated", config_hook):
+            await controller.register_or_update(replacement)
+
+        # without the resolved config the replacement would read defaults for every
+        # config backed setting (group members, flow mode, visibility, ...)
+        assert replacement.config is resolved_config
+        config_hook.assert_awaited_once()
+
+    async def test_register_or_update_leaves_same_instance_untouched(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Re-announcing the same instance does not re-run its config hook."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        player.set_initialized()
+        controller._players = {"player_1": player}
+        config_hook = AsyncMock()
+
+        with patch.object(player, "on_config_updated", config_hook):
+            await controller.register_or_update(player)
+
+        assert controller._players["player_1"] is player
+        config_hook.assert_not_called()
+
+    async def test_register_or_update_waits_for_inflight_register(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player is never swapped out while register() is still setting it up."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        replacement = MockPlayer(provider, "player_1", "Player 1")
+        release = asyncio.Event()
+        registering = asyncio.Event()
+
+        async def _blocked_config(*_args: object) -> MagicMock:
+            registering.set()
+            await release.wait()
+            return create_mock_config("Player 1")
+
+        mock_mass.config.get_player_config = AsyncMock(side_effect=_blocked_config)
+
+        with patch(
+            "music_assistant.controllers.players.controller.enrich_device_mac_address",
+            AsyncMock(),
+        ):
+            register_task = asyncio.create_task(controller.register(player))
+            # only proceed once register() is provably inside its critical section
+            await registering.wait()
+            update_task = asyncio.create_task(controller.register_or_update(replacement))
+            await _yield_to_loop()
+
+            # register() is still in flight, so the replacement must not be swapped in yet
+            assert controller._players["player_1"] is player
+            assert not update_task.done()
+
+            release.set()
+            await register_task
+            await update_task
+
+        assert controller._players["player_1"] is replacement
+        assert player.initialized.is_set()
+        assert replacement.initialized.is_set()
+
+
+async def _yield_to_loop() -> None:
+    """Give other pending tasks a chance to run up to their next suspension point."""
+    for _ in range(5):
+        await asyncio.sleep(0)
 
 
 def _set_play_media_override(mock_mass: MagicMock, value: bool) -> None:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -764,8 +764,9 @@ class TestRegisterUnregisterRace:
     @staticmethod
     def _stub_register_calls(mock_mass: MagicMock) -> None:
         """Stub the awaited mass calls made during register/unregister."""
-        # the player config store is read as a mapping during protocol link evaluation
-        mock_mass.config.get = MagicMock(return_value={})
+        # registration reads config keys with differently typed defaults (mapping for the
+        # player config store, str | None for the cached MAC addresses)
+        mock_mass.config.get = MagicMock(side_effect=lambda _key, default=None: default)
         mock_mass.cache.get = AsyncMock(return_value=None)
         mock_mass.config.get_player_config = AsyncMock(return_value=create_mock_config("Player 1"))
         mock_mass.player_queues.on_player_register = AsyncMock()
@@ -912,6 +913,30 @@ class TestRegisterUnregisterRace:
         # config backed setting (group members, flow mode, visibility, ...)
         assert replacement.config is resolved_config
         config_hook.assert_awaited_once()
+
+    async def test_register_or_update_aborts_when_replacement_is_unregistered(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A replacement unregistered while its config hook runs is not marked ready."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        existing = MockPlayer(provider, "player_1", "Player 1")
+        existing.set_config(create_mock_config("Player 1"))
+        existing.set_initialized()
+        controller._players = {"player_1": existing}
+        replacement = MockPlayer(provider, "player_1", "Player 1")
+
+        async def _unregister_midway() -> None:
+            await controller.unregister("player_1")
+
+        with patch.object(
+            replacement, "on_config_updated", AsyncMock(side_effect=_unregister_midway)
+        ):
+            await controller.register_or_update(replacement)
+
+        assert "player_1" not in controller._players
+        assert not replacement.initialized.is_set()
 
     async def test_register_or_update_leaves_same_instance_untouched(
         self, mock_mass: MagicMock


### PR DESCRIPTION
# What does this implement/fix?

A player is added to the player registry *before* its configuration is loaded, so anything that unregisters it in the meantime — a provider reload, or a speaker dropping off the network mid-setup — could interleave with its own setup. When that happened the setup carried on regardless: it announced a player that had already been removed and left a queue behind for it that nothing would ever clean up.

Related to the review of #5483, which surfaced this.

- Registration now stops as soon as its player is dropped or replaced.
- A queue restored after the player was already removed is cleaned up again.
- A player is never swapped out while its setup is still running.
- When a player is replaced by a fresh instance, it now hands over its configuration and is marked as ready. Previously the replacement was left with empty settings and disappeared from the interface entirely — a sync group would come back without its members, for example.
- Moved the MAC address lookup into its own helper to keep the registration routine readable.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
