### PR TITLE
Stop speakers from reappearing while their provider is shutting down

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1405,7 +1405,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
     async def register(self, player: Player) -> None:
         """Register a player on the Player Controller."""
-        if self.mass.closing:
+        if self._teardown_in_progress(player):
             return
 
         # Use lock to prevent race conditions during concurrent player registrations
@@ -1440,6 +1440,12 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                 )
                 if cached_value is not None:
                     player.extra_data[ATTR_FAKE_POWER] = cached_value
+
+            # _registration_aborted below only works once the player is in the registry;
+            # until then the unregister pass of a provider unload cannot see it, so re-check
+            # the guard from the top of this method, which the awaits above may have staled
+            if self._teardown_in_progress(player):
+                return
 
             # finally actually register it
 
@@ -1499,7 +1505,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
     async def register_or_update(self, player: Player) -> None:
         """Register a new player on the controller or update existing one."""
-        if self.mass.closing:
+        if self._teardown_in_progress(player):
             return
 
         # the register lock ensures a replacement is never swapped in while register()
@@ -2268,6 +2274,14 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                     self.mass.config.set(f"{conf_base}/{CONF_REPORTED_MAC}", None)
                 else:
                     player.extra_data["reported_mac"] = cached_reported_mac
+
+    def _teardown_in_progress(self, player: Player) -> bool:
+        """
+        Return True if the server or this player's provider is shutting down.
+
+        :param player: The player that is in the process of being registered.
+        """
+        return self.mass.closing or player.provider.unloading
 
     def _registration_aborted(self, player: Player) -> bool:
         """

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -1018,6 +1018,10 @@ class MusicAssistant:
         # down state the sync may still be using, such as the mount of a network share
         await self.music.unschedule_provider_sync(instance_id, clear_persisted_state=is_removed)
         if provider := self._providers.get(instance_id):
+            # mark the provider as on its way out before anything is torn down: the steps
+            # below have await points, so without this a callback that is still in flight
+            # could register a player back onto a provider that is already gone
+            provider.unloading = True
             if isinstance(provider, PlayerProvider):
                 await self.players.on_provider_unload(provider)
             if isinstance(provider, MusicProvider):

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -57,6 +57,10 @@ class Provider:
         self._set_log_level_from_config(config)
         self.cache = mass.cache
         self.available = False
+        # set by the controller once teardown of this provider starts, so work that is
+        # already in flight (e.g. a discovery running in a worker thread) can tell a
+        # provider on its way out apart from one that is not loaded yet
+        self.unloading = False
         self.initialized = asyncio.Event()
 
     @property

--- a/tests/common.py
+++ b/tests/common.py
@@ -234,6 +234,7 @@ class MockProvider:
         self.mass = mass or MagicMock()
         self.dashboards = MagicMock()
         self.logger = logging.getLogger(f"test.{domain}")
+        self.unloading = False
 
 
 class MockPlayer(Player):

--- a/tests/core/test_provider_unload.py
+++ b/tests/core/test_provider_unload.py
@@ -367,3 +367,110 @@ async def test_failing_unregister_still_deregisters_the_provider(
 
     assert provider.instance_id not in mass_minimal._providers
     assert EventType.PROVIDERS_UPDATED in signalled
+
+
+async def _setup_bare_player_provider(
+    mass: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> PlayerProvider:
+    """Put a bare player provider on a minimal mass instance, ready to be unloaded."""
+    mass.players = PlayerController(mass)
+    mass.music = MagicMock(unschedule_provider_sync=AsyncMock())
+    # no queues exist in these tests, so get() must report a miss rather than a mock
+    mass.player_queues = MagicMock(on_player_register=AsyncMock(), get=MagicMock(return_value=None))
+    # discovery is not set up on the minimal instance and plays no part in these tests
+    monkeypatch.setattr(mass.discovery, "on_provider_unload", MagicMock())
+    # a registration reads the player's cached power state, so the cache has to work here
+    # for it to run all the way to the point where the player enters the registry
+    await mass.cache.setup(await mass.config.get_core_config("cache"))
+
+    provider_config = ProviderConfig(
+        values={},
+        type=ProviderType.PLAYER,
+        domain="test_player_provider",
+        instance_id="test_player_provider--instance",
+        name="Test player provider",
+    )
+    monkeypatch.setattr(provider_config, "get_value", lambda *_args, **_kwargs: "GLOBAL")
+    provider = PlayerProvider(
+        mass,
+        manifest=ProviderManifest(
+            type=ProviderType.PLAYER,
+            domain="test_player_provider",
+            name="Test player provider",
+            description="Test player provider",
+            codeowners=["@music-assistant"],
+        ),
+        config=provider_config,
+    )
+    provider.available = True
+    mass._providers[provider.instance_id] = provider
+    return provider
+
+
+async def test_unload_provider_rejects_late_player_registration(
+    mass_minimal: MusicAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A player provider on its way out can no longer register players."""
+    provider = await _setup_bare_player_provider(mass_minimal, monkeypatch)
+    monkeypatch.setattr(
+        "music_assistant.controllers.players.controller.enrich_device_mac_address",
+        AsyncMock(),
+    )
+
+    late_player = Player(provider, "late_player")
+
+    class LateRegisteringPlayer(Player):
+        """Player whose unload lets a discovery callback register another player."""
+
+        async def on_unload(self) -> None:
+            """Handle unload of the player."""
+            await super().on_unload()
+            # stands in for a discovery that was already running when the unload started
+            # and only reaches the controller once the players have been unregistered
+            await self.mass.players.register_or_update(late_player)
+
+    player = LateRegisteringPlayer(provider, "existing_player")
+    player.set_initialized()
+    mass_minimal.players._players[player.player_id] = player
+
+    await mass_minimal.unload_provider(provider.instance_id)
+
+    # without the guard the late player survives the unload with no provider behind it,
+    # so it is never unregistered and its on_unload never runs
+    assert mass_minimal.players._players == {}
+
+
+async def test_unload_provider_rejects_in_flight_player_registration(
+    mass_minimal: MusicAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registration that is already running when the unload starts is dropped as well."""
+    provider = await _setup_bare_player_provider(mass_minimal, monkeypatch)
+
+    registration_started = asyncio.Event()
+    resume_registration = asyncio.Event()
+
+    async def _blocked_enrich(*_args: object, **_kwargs: object) -> None:
+        """Park the registration in one of its awaits until the test releases it."""
+        registration_started.set()
+        await resume_registration.wait()
+
+    monkeypatch.setattr(
+        "music_assistant.controllers.players.controller.enrich_device_mac_address",
+        _blocked_enrich,
+    )
+
+    register = asyncio.create_task(mass_minimal.players.register(Player(provider, "in_flight")))
+    await asyncio.wait_for(registration_started.wait(), timeout=5)
+
+    # start the unload with the registration parked, and release it once the provider is
+    # flagged: the player is not in the registry yet, so the unregister pass cannot see it
+    unload = asyncio.create_task(mass_minimal.unload_provider(provider.instance_id))
+    async with asyncio.timeout(5):
+        while not provider.unloading:
+            await asyncio.sleep(0)
+    resume_registration.set()
+    await asyncio.gather(register, unload)
+
+    assert mass_minimal.players._players == {}


### PR DESCRIPTION
# What does this implement/fix?

When a player provider is reloaded, disabled or removed, Music Assistant unregisters all of its speakers first and shuts the provider down afterwards. That first step is not instant, so a speaker discovery that was already running could add a speaker back in the meantime. That speaker then belonged to a provider that no longer existed: it stayed in the list, was never cleaned up, and only went away after a server restart. Sonos (S1) is the clearest case, since its discovery runs in the background and re-adds speakers one at a time, so saving a setting during a scan could leave one behind.

- A provider is now marked as shutting down before any of its speakers are removed.
- The player controller refuses speakers from a provider that is shutting down, so this is handled once for every player provider instead of per provider.
- It checks again just before a speaker is actually added, since a speaker that was already halfway through being added is not yet visible to the cleanup.
- Added regression tests for both cases.

Complements #5492, which covers the other half: a speaker that is removed *after* it was added. That check reports any not-yet-added speaker as gone, so it cannot guard this window.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
