### PR TITLE
Report a clear error when AI Radio TTS generation fails

### DIFF
--- a/music_assistant/providers/ai_radio/constants.py
+++ b/music_assistant/providers/ai_radio/constants.py
@@ -45,6 +45,9 @@ SHOW_START_TIMEOUT_SECONDS = 300
 AI_QUERY_TIMEOUT_SECONDS = 180
 TTS_QUERY_TIMEOUT_SECONDS = 180
 
+# ffprobe reports no status code, so its message is all we have to spot a failed render
+TTS_SERVER_ERROR_MARKERS = ("Server returned 5XX", "HTTP error 5")
+
 SUPPORTED_FEATURES: set[Any] = set()
 EMPTY_SECTION_ID = "EMPTY_SECTION"
 VALID_WEB_SEARCH_MODES = {"disabled", "allow", "force"}

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -29,6 +29,7 @@ from .constants import (
     CLIP_STREAMDETAILS_EXPIRATION,
     DEFERRED_PLACEHOLDERS,
     TTS_QUERY_TIMEOUT_SECONDS,
+    TTS_SERVER_ERROR_MARKERS,
 )
 from .helpers import soft_limit_text
 
@@ -74,9 +75,10 @@ class AIRadioRenderMixin:
                 queue_item.extra_attributes[ATTR_RENDERED_TEXT] = text
                 # the signal is what marks the items cache dirty and schedules the persist
                 self.mass.player_queues.signal_update(queue_item.queue_id, items_changed=True)
-            path, stream_type, audio_format = await self._mint_clip_media(queue_item, text, item_id)
+            path, stream_type, audio_format, duration = await self._mint_clip_media(
+                queue_item, text, item_id
+            )
 
-        duration = await self._probe_duration(path)
         return StreamDetails(
             provider=self.instance_id,
             item_id=item_id,
@@ -174,10 +176,13 @@ class AIRadioRenderMixin:
 
     async def _mint_clip_media(
         self, queue_item: QueueItem, text: str, clip_id: str
-    ) -> tuple[str, StreamType, AudioFormat]:
+    ) -> tuple[str, StreamType, AudioFormat, int | None]:
         """Convert the script to playable audio via the configured TTS engine."""
         try:
-            return await self._render_tts_media(text)
+            path, stream_type, audio_format = await self._render_tts_media(text)
+            # the probe is the first fetch, so a failed render surfaces here and not in playback
+            duration = await self._probe_duration(path)
+            return path, stream_type, audio_format, duration
         except Exception as err:
             self.logger.warning("AI Radio clip %s failed TTS: %s", clip_id, err)
             self._record_skip(queue_item, f"TTS failed: {err}")
@@ -217,6 +222,11 @@ class AIRadioRenderMixin:
         try:
             tags = await async_parse_tags(path, require_duration=True)
         except (InvalidDataError, OSError) as err:
+            if any(marker in str(err) for marker in TTS_SERVER_ERROR_MARKERS):
+                raise MusicAssistantError(
+                    "Error during TTS generation. Does your TTS provider have enough credit? "
+                    "Check the logs of your TTS provider for the reason."
+                ) from err
             self.logger.warning("Could not determine AI Radio clip duration: %s", err)
             return None
         return int(tags.duration) if tags.duration else None

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -19,6 +19,7 @@ from music_assistant_models.errors import (
 from music_assistant_models.media_items import AudioFormat, ProviderMapping, SoundEffect
 from music_assistant_models.queue_item import QueueItem
 
+from music_assistant.helpers.tags import AudioTags
 from music_assistant.models.plugin import PluginProvider, TTSEngine
 from music_assistant.providers.ai_radio.constants import (
     ATTR_MAX_CHARS,
@@ -308,6 +309,57 @@ async def test_probe_failure_is_not_fatal() -> None:
     streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
 
     assert streamdetails.duration is None
+
+
+class RealProbeRenderer(DummyRenderer):
+    """Harness that exercises the mixin's real duration probe instead of the stub."""
+
+    _probe_duration = AIRadioRenderMixin._probe_duration
+
+
+def _failing_probe(message: str, monkeypatch: pytest.MonkeyPatch) -> RealProbeRenderer:
+    """Build a renderer whose duration probe fails with the given ffprobe message."""
+
+    async def _raise(*_args: Any, **_kwargs: Any) -> AudioTags:
+        raise InvalidDataError(message)
+
+    monkeypatch.setattr("music_assistant.providers.ai_radio.rendering.async_parse_tags", _raise)
+    renderer = RealProbeRenderer()
+    renderer._sessions = {"sess": SessionState(session_id="sess", station_id="st")}
+    _attach_queue(renderer, [_clip_item("sess_001")])
+    return renderer
+
+
+async def test_tts_server_error_fails_the_clip_with_an_actionable_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An engine that hands out a URL it cannot render fails the clip, not the playback."""
+    renderer = _failing_probe(
+        "Unable to retrieve info for http://ha.invalid/api/tts_proxy/1.mp3 "
+        "(Server returned 5XX Server Error reply)",
+        monkeypatch,
+    )
+
+    with pytest.raises(MediaNotFoundError):
+        await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    session = renderer._sessions["sess"]
+    assert session.skipped_sections == 1
+    assert "enough credit" in session.last_render_error
+
+
+async def test_unmeasurable_clip_still_plays(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A probe that only fails to measure the audio leaves the clip playable."""
+    renderer = _failing_probe(
+        "Unable to retrieve info for http://ha.invalid/api/tts_proxy/1.mp3 "
+        "(Invalid or unsupported media file)",
+        monkeypatch,
+    )
+
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert streamdetails.duration is None
+    assert renderer._sessions["sess"].skipped_sections == 0
 
 
 async def test_render_tts_media_streams_a_url_over_http() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Home Assistant hands out a TTS proxy URL before it renders the audio, so `tts_get_url` always succeeds. When the render then fails (for example a Gemini TTS quota of `429 RESOURCE_EXHAUSTED`), HA logs the reason itself and answers the fetch with a bare 500 and an empty body.

AI Radio treated that as "duration unknown", played the dead URL anyway, and left the user with a warning per clip plus an ffmpeg `HTTP error 500`. Nothing pointed at the real cause.

The duration probe is the first fetch of the audio, so it is also where a failed render shows up. It now tells a server error apart from a clip it simply cannot measure, and fails the clip with a message the user can act on.

- Move the duration probe into `_mint_clip_media`, so a failed render runs through the path that already logs the clip and records the error on the session.
- Fail the clip on a server error with: `Error during TTS generation. Does your TTS provider have enough credit? Check the logs of your TTS provider for the reason.`
- Keep every other probe failure best-effort. A clip that cannot be measured still plays without a duration.

The message is a hint, not the cause, because HA sends no body. A follow-up in HA core could put the error in the 500 body and make this exact.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
