### PR TITLE
Auto-merge dependency bumps without manual conflict resolution

### DIFF
--- a/.github/workflows/auto-merge-dependency-updates.yml
+++ b/.github/workflows/auto-merge-dependency-updates.yml
@@ -8,11 +8,19 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - dev
+  push:
+    branches:
+      - dev
+    paths:
+      - pyproject.toml
+      - requirements_all.txt
 
 env:
   EXPECTED_APP_BOT_LOGIN: musicassistant-bot[bot]
   EXPECTED_APP_BOT_LOGIN_ENCODED: musicassistant-bot%5Bbot%5D
   EXPECTED_APP_BOT_ID: "304008617"
+  EXPECTED_APP_SLUG: musicassistant-bot
+  EXPECTED_APP_INSTALLATION_ID: "146062122"
 
 # CRITICAL SECURITY: This workflow uses pull_request_target which runs in the context
 # of the base repository and has access to secrets. Multiple security checks ensure
@@ -24,8 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     # Only run if branch name matches the expected pattern
     if: |
-      startsWith(github.event.pull_request.head.ref, 'auto-update-frontend-') ||
-      startsWith(github.event.pull_request.head.ref, 'auto-update-models-')
+      github.event_name == 'pull_request_target' && (
+        startsWith(github.event.pull_request.head.ref, 'auto-update-frontend-') ||
+        startsWith(github.event.pull_request.head.ref, 'auto-update-models-')
+      )
 
     permissions:
       contents: write
@@ -281,3 +291,191 @@ jobs:
           gh pr comment "${{ steps.pr.outputs.number }}" -R "${{ github.repository }}" --body "🤖 This PR has been automatically approved and will be merged once all checks pass."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Re-cutting raises a synchronize event, which puts the PR back through the job above.
+  discover-stale:
+    name: Find stale dependency PRs
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      prs: ${{ steps.find.outputs.prs }}
+      any: ${{ steps.find.outputs.any }}
+    steps:
+      - name: List open bump PRs that are behind dev
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # a fork PR with a matching branch name has no such ref here and would 404 the compare
+          CANDIDATES=$(gh pr list -R "$REPO" --base dev --state open --limit 50 \
+            --json number,headRefName,author,isCrossRepository \
+            | jq -c --arg bot "$EXPECTED_APP_BOT_LOGIN" --arg slug "$EXPECTED_APP_SLUG" '[.[]
+              | select(.isCrossRepository | not)
+              # gh renders the App as app/<slug>, the REST API as <slug>[bot]; accept either
+              | select(.author.login == $bot or .author.login == "app/\($slug)")
+              | select(.headRefName | test("^auto-update-(models|frontend)-[0-9][0-9a-zA-Z.]*$"))
+              | .number]')
+
+          SELECTED='[]'
+          for NUMBER in $(echo "$CANDIDATES" | jq -r '.[]'); do
+            BRANCH=$(gh pr view "$NUMBER" -R "$REPO" --json headRefName --jq '.headRefName')
+
+            # the branch can vanish when its PR merges, and a 404 body lands on stdout not stderr
+            BEHIND=$(gh api "/repos/$REPO/compare/dev...$BRANCH" --jq '.behind_by' 2>/dev/null || true)
+            if ! [[ "$BEHIND" =~ ^[0-9]+$ ]] || [ "$BEHIND" -eq 0 ]; then
+              echo "PR #$NUMBER is gone or up to date with dev, skipping"
+              continue
+            fi
+
+            # Re-cutting discards the branch, so leave any PR that carries more than a pin alone.
+            EXTRA=$(gh pr diff "$NUMBER" -R "$REPO" \
+              | grep -E '^[+-]' \
+              | grep -vE '^(\+\+\+|---)' \
+              | grep -vE '^[+-][[:space:]]*"?music-assistant-(frontend|models)==[0-9][0-9a-zA-Z.]*"?,?[[:space:]]*$' \
+              || true)
+            if [ -n "$EXTRA" ]; then
+              echo "PR #$NUMBER carries non-pin changes, skipping:"
+              echo "$EXTRA"
+              continue
+            fi
+
+            echo "PR #$NUMBER ($BRANCH) is $BEHIND commit(s) behind dev, queueing refresh"
+            SELECTED=$(echo "$SELECTED" | jq -c --argjson n "$NUMBER" '. + [$n]')
+          done
+
+          echo "prs=$SELECTED" >> "$GITHUB_OUTPUT"
+          if [ "$(echo "$SELECTED" | jq 'length')" -gt 0 ]; then
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  refresh-stale:
+    name: Re-cut PR #${{ matrix.pr }}
+    needs: discover-stale
+    if: needs.discover-stale.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    concurrency:
+      # Serialise per branch so two dev pushes in quick succession cannot race on the same ref.
+      group: refresh-stale-${{ matrix.pr }}
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        pr: ${{ fromJSON(needs.discover-stale.outputs.prs) }}
+    steps:
+      - name: Read PR metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ matrix.pr }}
+        run: |
+          gh pr view "$NUMBER" -R "$REPO" --json headRefName,title,body > /tmp/pr.json
+          BRANCH=$(jq -r '.headRefName' /tmp/pr.json)
+          TITLE=$(jq -r '.title' /tmp/pr.json)
+          # via a file: release notes carry backticks and newlines the shell would re-interpret
+          jq -r '.body' /tmp/pr.json > /tmp/body
+
+          if [[ "$BRANCH" == auto-update-models-* ]]; then
+            PACKAGE="music-assistant-models"
+            VERSION="${BRANCH#auto-update-models-}"
+          else
+            PACKAGE="music-assistant-frontend"
+            VERSION="${BRANCH#auto-update-frontend-}"
+          fi
+
+          # the version reaches a sed program below, so it must carry no metacharacters
+          if ! [[ "$VERSION" =~ ^[0-9][0-9a-zA-Z.]*$ ]]; then
+            echo "Refusing to act on malformed version '$VERSION' from branch '$BRANCH'"
+            exit 1
+          fi
+
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "package=$PACKAGE" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+
+      - name: Check out dev
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: dev
+          persist-credentials: false
+
+      - name: Apply the version pin
+        id: pin
+        env:
+          PACKAGE: ${{ steps.pr.outputs.package }}
+          VERSION: ${{ steps.pr.outputs.version }}
+        run: |
+          # in-place edit keeps requirements_all.txt in the order gen_requirements_all produces
+          sed -i.bak "s/$PACKAGE==.*/$PACKAGE==$VERSION\",/" pyproject.toml
+          sed -i.bak "s/$PACKAGE==.*/$PACKAGE==$VERSION/" requirements_all.txt
+          rm -f pyproject.toml.bak requirements_all.txt.bak
+
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "dev already pins $PACKAGE==$VERSION, nothing to re-cut"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+          # Defense in depth against a sed that matched more than intended.
+          UNEXPECTED=$(git diff -U0 \
+            | grep -E '^[+-]' \
+            | grep -vE '^(\+\+\+|---)' \
+            | grep -vE '^[+-][[:space:]]*"?music-assistant-(frontend|models)==[0-9][0-9a-zA-Z.]*"?,?[[:space:]]*$' \
+            || true)
+          if [ -n "$UNEXPECTED" ]; then
+            echo "Refusing to push, the pin edit touched more than a version:"
+            echo "$UNEXPECTED"
+            exit 1
+          fi
+          git diff --stat
+
+      - name: Create branch token
+        if: steps.pin.outputs.changed == 'true'
+        id: push_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Verify GitHub App identity
+        if: steps.pin.outputs.changed == 'true'
+        env:
+          APP_SLUG: ${{ steps.push_token.outputs.app-slug }}
+          INSTALLATION_ID: ${{ steps.push_token.outputs.installation-id }}
+        run: |
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ] || \
+             [ "$INSTALLATION_ID" != "$EXPECTED_APP_INSTALLATION_ID" ]; then
+            echo "Unexpected GitHub App installation: $APP_SLUG/$INSTALLATION_ID" >&2
+            exit 1
+          fi
+
+      - name: Re-cut the branch on top of dev
+        if: steps.pin.outputs.changed == 'true'
+        # commits through the API, so the author is the App bot and the gate above still passes
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.push_token.outputs.token }}
+          commit-message: ${{ steps.pr.outputs.title }}
+          branch: ${{ steps.pr.outputs.branch }}
+          base: dev
+          delete-branch: true
+          sign-commits: true
+          title: ${{ steps.pr.outputs.title }}
+          body-path: /tmp/body
+          labels: |
+            dependencies


### PR DESCRIPTION
# What does this implement/fix?

The `music-assistant-models` and `music-assistant-frontend` pins sit on adjacent lines in `pyproject.toml`, and because `requirements_all.txt` is sorted they are alphabetical neighbours there too. Each bump branch is cut from `dev` when its own package releases. When both PRs are open, the one that merges second lands inside the other's diff context and conflicts.

A conflicting PR cannot auto-merge, so somebody resolves it by hand. That breaks the flow twice over:

- The merge commit is authored by a human, and the `Verify commit authors` gate requires every commit to be the App bot. Auto-merge then fails permanently on that PR.
- Resolving in the GitHub web editor bypasses pre-commit, so `requirements_all.txt` keeps the hand-merged order and the `gen_requirements_all` hook fails lint.

Five of the last thirteen models bumps hit this (#5495, #5419, #5388, #5117, #5095) and each one was merged by hand.

This makes the recovery automatic instead of manual, so the process stays hands off. It does not relax the author gate. With the refresh in place no human touches these branches, so every commit stays bot-authored.

## Changes

- Add a `push` trigger on `dev`, filtered to `pyproject.toml` and `requirements_all.txt`, which is exactly the condition that can strand a bump PR.
- Add `discover-stale`: lists open `auto-update-(models|frontend)-*` PRs, skips those still on top of `dev`, and skips any whose diff contains anything other than a version pin, so a PR carrying real work is never rebuilt.
- Add `refresh-stale`: checks out `dev` (never the PR head), re-applies the pin with the same `sed` the release workflows use, re-validates the diff, then re-cuts the branch through `peter-evans/create-pull-request` with the App token. The commit is authored by the bot.
- Gate the existing `auto-merge` job on `github.event_name == 'pull_request_target'` so it is unaffected by the new trigger.

The force-push raises a `synchronize` event, which re-runs the existing `auto-merge` job against a clean branch. That merge pushes `dev`, which re-cuts the next stale PR. The cycle drains and terminates because each pass merges one PR.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

## Verification notes

Checked locally, since a workflow cannot be exercised before it is on `dev`:

- The `discover-stale` shell was dry-run against the live repo and selects correctly.
- Replayed the #5495 failure at the moment it broke (branch `84f103b9` against `dev` `106e6f74`): `behind_by: 1`, diff is pin-only, so it would have been selected and rebuilt.
- The `sed` applied to `dev` produces output byte-identical to a correct bump, `requirements_all.txt` ordering included.

Two things only a live run can confirm: that `MUSIC_ASSISTANT_BOT_CLIENT_ID` / `MUSIC_ASSISTANT_BOT_PRIVATE_KEY` are present on this repo (inferred from `dependabot-sync-manifests.yml` using them), and that installation `146062122` has `contents: write` on a branch with an open PR.

