### PR TITLE
Skip the provider search for an empty search query

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -325,6 +325,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             (by instance id or domain), where the special value "library" selects
             the library. Omit to search the library and all available providers.
         """
+        if not search_query.strip():
+            # several providers reject an empty query with a hard error
+            return SearchResults()
         if not media_types:
             media_types = MediaType.ALL
         if library_only and providers is None:

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -246,6 +246,20 @@ async def test_search_provider_cache_hit_avoids_provider_call() -> None:
     prov.search.assert_not_awaited()
 
 
+async def test_empty_search_query_skips_all_providers() -> None:
+    """An empty or whitespace-only query returns empty results without querying providers."""
+    prov = _make_search_provider("prov_a")
+    controller = _make_controller([prov])
+
+    for search_query in ("", "   ", "\n\t"):
+        result = await controller.search(search_query, media_types=[MediaType.TRACK], limit=5)
+
+        assert result == SearchResults()
+        prov.search.assert_not_awaited()
+        cast("AsyncMock", controller.search_library).assert_not_awaited()
+        cast("AsyncMock", controller.mass.cache.get).assert_not_awaited()
+
+
 async def test_search_provider_cache_expiration_by_provider_type() -> None:
     """Streaming provider results are cached longer than local provider results."""
     prov_stream = _make_search_provider("prov_stream")


### PR DESCRIPTION
# What does this implement/fix?

An empty or whitespace-only search term was dispatched to every music provider. Providers that reject an empty query (Apple Music, YouTube Music) return HTTP 400, so a single empty search logged an ERROR with a full traceback for each provider:

```
ERROR [music_assistant.music] Search on provider Apple Music failed: 400, message='Bad Request', url='https://api.music.apple.com/v1/catalog/nl/search?term=&types=artists,albums,songs,playlists&limit=8'
ERROR [music_assistant.music] Search on provider YouTube Music failed: Server returned HTTP 400: Bad Request. Request contains an invalid argument.
```

`MusicController.search` now short-circuits an empty query and returns an empty result set. Since `@api_command("music/search")` decorates that same method, this covers the websocket API, the MCP server tools, the MSX bridge and all internal callers in one place instead of per provider.

- Return empty `SearchResults` for an empty or whitespace-only search query, before the cache lookup, the library query and the provider fan-out.
- Add a regression test asserting no provider, library or cache call is made for an empty query.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
