### PR TITLE
Discard placeholder album art reported by LinkPlay/WiiM devices

### DIFF
--- a/music_assistant/helpers/upnp.py
+++ b/music_assistant/helpers/upnp.py
@@ -27,7 +27,12 @@ def parse_media_image_url(image_url: str | None) -> str | None:
     """
     if not image_url:
         return None
-    parsed = URL(image_url)
+    try:
+        parsed = URL(image_url)
+    except ValueError:
+        # a device can report a URL yarl refuses (bad port, unterminated IPv6),
+        # which is not fetchable either
+        return None
     if parsed.scheme not in ("http", "https"):
         return None
     if parsed.name.casefold() in PLACEHOLDER_IMAGE_NAMES:

--- a/music_assistant/helpers/upnp.py
+++ b/music_assistant/helpers/upnp.py
@@ -6,12 +6,33 @@ from typing import TYPE_CHECKING
 from xml.sax.saxutils import escape as xmlescape
 
 from music_assistant_models.enums import MediaType
+from yarl import URL
 
 from music_assistant.constants import MASS_LOGO_ONLINE
 from music_assistant.helpers.audio import get_mime_type
 
 if TYPE_CHECKING:
     from music_assistant.models.player import PlayerMedia
+
+# LinkPlay/WiiM firmware writes this token into any DIDL field it has no value for.
+# A device base URL is then prepended to it, which yields a URL that serves nothing.
+PLACEHOLDER_IMAGE_NAMES = frozenset({"un_known", "unknown"})
+
+
+def parse_media_image_url(image_url: str | None) -> str | None:
+    """
+    Return the media image URL reported by a device, or None if it points at no artwork.
+
+    :param image_url: Media image URL as reported by the device.
+    """
+    if not image_url:
+        return None
+    parsed = URL(image_url)
+    if parsed.scheme not in ("http", "https"):
+        return None
+    if parsed.name.casefold() in PLACEHOLDER_IMAGE_NAMES:
+        return None
+    return image_url
 
 
 # XML

--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -16,7 +16,7 @@ from music_assistant_models.enums import IdentifierType, PlaybackState, PlayerFe
 from music_assistant_models.errors import PlayerUnavailableError
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
-from music_assistant.helpers.upnp import create_didl_metadata
+from music_assistant.helpers.upnp import create_didl_metadata, parse_media_image_url
 from music_assistant.models.player import DeviceInfo, Player
 
 from .constants import PLAYER_CONFIG_ENTRIES
@@ -162,7 +162,7 @@ class DLNAPlayer(Player):
             media_title = self.device.media_title
             media_artist = self.device.media_artist
             media_album = self.device.media_album_name
-            media_image_url = self.device.media_image_url
+            media_image_url = parse_media_image_url(self.device.media_image_url)
             media_duration = self.device.media_duration
         except ParseError as err:
             # some devices (e.g. Bose SoundTouch) return malformed DIDL-Lite

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -13,7 +13,7 @@ from wiim.exceptions import WiimDeviceException, WiimRequestException
 from wiim.models import WiimGroupRole
 
 from music_assistant.constants import create_sample_rates_config_entry
-from music_assistant.helpers.upnp import create_didl_metadata
+from music_assistant.helpers.upnp import create_didl_metadata, parse_media_image_url
 from music_assistant.models.player import Player, PlayerMedia
 
 from .constants import (
@@ -427,7 +427,7 @@ class WiimPlayer(Player):
                 title=(media.title if media else None) or source_display_name,
                 artist=media.artist if media else None,
                 album=media.album if media else None,
-                image_url=media.image_url if media else None,
+                image_url=parse_media_image_url(media.image_url) if media else None,
                 duration=media.duration if media else None,
                 source_id=self._attr_active_source,
             )

--- a/tests/providers/dlna/test_device_state.py
+++ b/tests/providers/dlna/test_device_state.py
@@ -231,6 +231,23 @@ async def test_placeholder_album_art_is_discarded(reported: str) -> None:
     assert player.current_media.image_url is None
 
 
+@pytest.mark.parametrize(
+    "reported",
+    [
+        "http://[::1/cover.jpg",
+        "http://192.168.1.139:99999999/cover.jpg",
+        "http://192.168.1.139:port/cover.jpg",
+    ],
+)
+async def test_unparsable_album_art_does_not_break_the_update(reported: str) -> None:
+    """A device reporting an unparsable album art URL must not kill the player update."""
+    player = await _updated_player(media_image_url=reported)
+
+    assert player.current_media is not None
+    assert player.current_media.image_url is None
+    assert player.elapsed_time == 42.0
+
+
 @pytest.mark.parametrize(("reported", "expected"), [(0.5, 50), (0.0, 0), (1.0, 100)])
 async def test_volume_level_is_scaled_to_percent(reported: float, expected: int) -> None:
     """The device reports volume as a 0..1 fraction, the player as a percentage."""

--- a/tests/providers/dlna/test_device_state.py
+++ b/tests/providers/dlna/test_device_state.py
@@ -204,6 +204,33 @@ async def test_transport_state_event_polls_before_reading_the_position() -> None
     assert player.elapsed_time_last_updated >= started_at
 
 
+async def test_reported_album_art_is_applied() -> None:
+    """An album art URL reported by the device is adopted as-is."""
+    player = await _updated_player(media_image_url="http://192.168.1.10/cover.jpg")
+
+    assert player.current_media is not None
+    assert player.current_media.image_url == "http://192.168.1.10/cover.jpg"
+
+
+@pytest.mark.parametrize(
+    "reported",
+    [
+        # LinkPlay/WiiM firmware sends the literal 'un_known' as albumArtURI, which
+        # async_upnp_client resolves against the device base URL
+        "http://192.168.1.139:49152/un_known",
+        "http://192.168.1.139:49152/UN_KNOWN",
+        "http://192.168.1.139:49152/unknown",
+        "un_known",
+    ],
+)
+async def test_placeholder_album_art_is_discarded(reported: str) -> None:
+    """A device reporting a placeholder instead of album art must not leave an image URL."""
+    player = await _updated_player(media_image_url=reported)
+
+    assert player.current_media is not None
+    assert player.current_media.image_url is None
+
+
 @pytest.mark.parametrize(("reported", "expected"), [(0.5, 50), (0.0, 0), (1.0, 100)])
 async def test_volume_level_is_scaled_to_percent(reported: float, expected: int) -> None:
     """The device reports volume as a 0..1 fraction, the player as a percentage."""

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -171,6 +171,7 @@ class TestFalsePlayingFilter:
         """A PLAYING report with media loaded is a real start and passes through."""
         media = MagicMock()
         media.uri = "http://192.168.1.80:8097/single/abc/queue/item/uuid:test.flac"
+        media.image_url = None
         mock_wiim_device.play_mode = SOURCE_NETWORK
         mock_wiim_device.current_media = media
         mock_wiim_device.playing_status = PlayingStatus.PLAYING
@@ -340,3 +341,49 @@ class TestErrorHandling:
         await player.pause()
         assert player._attr_available is True
         player.update_state.assert_called()
+
+
+class TestPlaceholderAlbumArt:
+    """LinkPlay firmware reports a placeholder token instead of an album art URL."""
+
+    def _updated_player(
+        self, provider: MagicMock, device: MagicMock, image_url: str | None
+    ) -> WiimPlayer:
+        media = MagicMock()
+        media.uri = "http://192.168.1.80:8097/single/abc/queue/item/uuid:test.flac"
+        media.title = "Starry Night"
+        media.image_url = image_url
+        device.play_mode = SOURCE_NETWORK
+        device.current_media = media
+        device.playing_status = PlayingStatus.PLAYING
+        player = WiimPlayer(provider=provider, player_id="uuid:test", device=device)
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+        player._update_ma_state_from_sdk_cache()
+        return player
+
+    def test_reported_album_art_is_applied(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """An album art URL reported by the device is adopted as-is."""
+        player = self._updated_player(
+            mock_provider, mock_wiim_device, "https://192.168.1.243/data/AirplayArtWorkData.jpeg"
+        )
+
+        assert player._attr_current_media is not None
+        assert (
+            player._attr_current_media.image_url
+            == "https://192.168.1.243/data/AirplayArtWorkData.jpeg"
+        )
+
+    @pytest.mark.parametrize(
+        "reported",
+        ["http://192.168.1.139:49152/un_known", "http://192.168.1.139:49152/UN_KNOWN", "un_known"],
+    )
+    def test_placeholder_album_art_is_discarded(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock, reported: str
+    ) -> None:
+        """A device reporting a placeholder instead of album art must not leave an image URL."""
+        player = self._updated_player(mock_provider, mock_wiim_device, reported)
+
+        assert player._attr_current_media is not None
+        assert player._attr_current_media.image_url is None


### PR DESCRIPTION
# What does this implement/fix?

LinkPlay/WiiM firmware writes the literal token `un_known` into any DIDL field it has no value for. When a device mirrors a source Music Assistant did not start — a multiroom follower, AirPlay, line-in — that token ends up in `upnp:albumArtURI`.

Both resolvers join it against the device base URL:

- `async_upnp_client` in `DmrDevice.media_image_url` (DLNA provider)
- `WiimDevice.make_absolute_url` in the `wiim` SDK (WiiM provider)

The player then holds `http://<device-ip>:49152/un_known`. Palette extraction fetches it, gets a 404, and logs a warning plus a traceback, while the player keeps a dead artwork URL that never resolves.

Confirmed against a live device: `GetPositionInfo` on a WiiM acting as a multiroom follower returns `<TrackURI>MULTIROOM-SLAVE</TrackURI>` with `un_known` sitting in `song:description`. Music Assistant itself can never send this — `create_didl_metadata` always writes `media.image_url or MASS_LOGO_ONLINE`.

**Changes:**

- Add `parse_media_image_url` to `helpers/upnp.py`, rejecting placeholder tokens and values that are not an http(s) URL
- Apply it in the DLNA player before `set_current_media`
- Apply it in the WiiM player before building `PlayerMedia`
- Add regression tests for both providers

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
