### PR TITLE
Ignore incoming media update events while starting HEOS playback

### DIFF
--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -62,6 +62,7 @@ class HeosPlayer(Player):
 
         self._device: PyHeosPlayer = device
         self._ma_controls_playback = False
+        self._ma_playback_starting = False
         self._queue_cleanup_lock = asyncio.Lock()
         self._queue_cleanup_pending = False
 
@@ -220,6 +221,14 @@ class HeosPlayer(Player):
             )
             return
 
+        if self._ma_playback_starting:
+            self.logger.debug(
+                "[%s] Ignoring now playing change while MA playback starts: %s",
+                self._device.name,
+                now_playing,
+            )
+            return
+
         # Only update if we're not playing from our queue
         # HEOS does not make a distinction on source ID when playing from a DLNA server, USB stick,
         # generic URL (like MA), or other local source.
@@ -334,10 +343,12 @@ class HeosPlayer(Player):
         )
 
         url = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
+        self._ma_playback_starting = True
         self._ma_controls_playback = True
         try:
             await self._device.play_url(url)
         except HeosError as err:
+            self._ma_playback_starting = False
             self._ma_controls_playback = False
             self._queue_cleanup_pending = False
             raise PlayerCommandFailed("Failed to start playback.") from err
@@ -346,7 +357,17 @@ class HeosPlayer(Player):
         self._attr_active_source = self.player_id
         self._queue_cleanup_pending = True
 
+        self.mass.call_later(
+            5,
+            self._finish_ma_playback_transition,
+            task_id=f"heos_playback_transition_{self.player_id}",
+        )
+
         self.update_state()
+
+    def _finish_ma_playback_transition(self) -> None:
+        """Stop suppressing delayed events from the source replaced by MA playback."""
+        self._ma_playback_starting = False
 
     def _schedule_queue_cleanup(self) -> None:
         """Debounce queue cleanup so rapid queue changes only trigger one follow-up."""

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -63,6 +63,7 @@ class HeosPlayer(Player):
         self._device: PyHeosPlayer = device
         self._ma_controls_playback = False
         self._ma_playback_starting = False
+        self._ma_playback_transition_timer_id = f"heos_playback_transition_{self.player_id}"
         self._queue_cleanup_lock = asyncio.Lock()
         self._queue_cleanup_pending = False
 
@@ -343,12 +344,13 @@ class HeosPlayer(Player):
         )
 
         url = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
+        self._cancel_ma_playback_transition()
         self._ma_playback_starting = True
         self._ma_controls_playback = True
         try:
             await self._device.play_url(url)
         except HeosError as err:
-            self._ma_playback_starting = False
+            self._cancel_ma_playback_transition()
             self._ma_controls_playback = False
             self._queue_cleanup_pending = False
             raise PlayerCommandFailed("Failed to start playback.") from err
@@ -360,14 +362,10 @@ class HeosPlayer(Player):
         self.mass.call_later(
             5,
             self._finish_ma_playback_transition,
-            task_id=f"heos_playback_transition_{self.player_id}",
+            task_id=self._ma_playback_transition_timer_id,
         )
 
         self.update_state()
-
-    def _finish_ma_playback_transition(self) -> None:
-        """Stop suppressing delayed events from the source replaced by MA playback."""
-        self._ma_playback_starting = False
 
     def _schedule_queue_cleanup(self) -> None:
         """Debounce queue cleanup so rapid queue changes only trigger one follow-up."""
@@ -477,6 +475,18 @@ class HeosPlayer(Player):
     async def select_source(self, source: str) -> None:
         """Handle SELECT SOURCE command on the player."""
         self.logger.debug("[%s] Selecting source %s", self._device.name, source)
+        self._cancel_ma_playback_transition()
         self._ma_controls_playback = False
         self._queue_cleanup_pending = False
         await self._device.play_input_source(source)
+
+    def _cancel_ma_playback_transition(self) -> None:
+        """Cancel the transition to MA-controlled playback."""
+        self.mass.cancel_timer(self._ma_playback_transition_timer_id)
+        self._ma_playback_starting = False
+
+    def _finish_ma_playback_transition(self) -> None:
+        """Apply the latest HEOS state after MA playback starts."""
+        self._ma_playback_starting = False
+        self._update_player_current_media()
+        self.update_state()

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -64,6 +64,7 @@ class HeosPlayer(Player):
         self._ma_controls_playback = False
         self._ma_playback_starting = False
         self._ma_playback_transition_timer_id = f"heos_playback_transition_{self.player_id}"
+        self._on_unload_callbacks.append(self._cancel_ma_playback_transition)
         self._queue_cleanup_lock = asyncio.Lock()
         self._queue_cleanup_pending = False
 

--- a/tests/providers/heos/test_player.py
+++ b/tests/providers/heos/test_player.py
@@ -178,6 +178,18 @@ async def test_select_source_ends_ma_playback_transition() -> None:
     mass.cancel_timer.assert_called_once_with(f"heos_playback_transition_{player.player_id}")
 
 
+async def test_player_unload_cancels_playback_transition() -> None:
+    """Cancel the playback transition when the player unloads."""
+    player = _make_player(_url_stream_now_playing())
+    mass = cast("MagicMock", player.mass)
+    player._ma_playback_starting = True
+
+    await player.on_unload()
+
+    mass.cancel_timer.assert_any_call(f"heos_playback_transition_{player.player_id}")
+    assert player._ma_playback_starting is False
+
+
 def test_media_position_and_duration_reported_in_seconds() -> None:
     """HEOS reports milliseconds; the media must carry seconds."""
     player = _make_player(_external_now_playing(113000))

--- a/tests/providers/heos/test_player.py
+++ b/tests/providers/heos/test_player.py
@@ -105,6 +105,29 @@ def test_external_source_now_playing_still_updates_media() -> None:
     assert player._attr_current_media.title == "External Track"
 
 
+def test_external_source_is_ignored_during_ma_playback_transition() -> None:
+    """Suppress external-source media updates while MA playback is starting."""
+    player = _make_player(_external_now_playing(None))
+    player._ma_playback_starting = True
+    player._ma_controls_playback = True
+    current_media = PlayerMedia(
+        uri="http://ma/stream/foo", media_type=MediaType.TRACK, title="MA Track"
+    )
+    player._attr_current_media = current_media
+
+    player._update_player_current_media()
+
+    assert player._ma_playback_starting is True
+    assert player._ma_controls_playback is True
+    assert player._attr_current_media.title == "MA Track"
+
+    player._finish_ma_playback_transition()
+    player._update_player_current_media()
+
+    assert player._attr_current_media.title == "External Track"
+    assert player._ma_controls_playback is False
+
+
 def test_media_position_and_duration_reported_in_seconds() -> None:
     """HEOS reports milliseconds; the media must carry seconds."""
     player = _make_player(_external_now_playing(113000))

--- a/tests/providers/heos/test_player.py
+++ b/tests/providers/heos/test_player.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
 
 from music_assistant_models.enums import MediaType
 from pyheos import PlayState as HeosPlayState
@@ -122,10 +123,59 @@ def test_external_source_is_ignored_during_ma_playback_transition() -> None:
     assert player._attr_current_media.title == "MA Track"
 
     player._finish_ma_playback_transition()
-    player._update_player_current_media()
 
     assert player._attr_current_media.title == "External Track"
     assert player._ma_controls_playback is False
+
+
+async def test_new_ma_playback_cancels_previous_transition() -> None:
+    """Keep a new MA playback transition protected from the previous timer."""
+    player = _make_player(_url_stream_now_playing())
+    mass = cast("MagicMock", player.mass)
+    device = cast("MagicMock", player._device)
+    transition_pending = True
+
+    def cancel_timer(task_id: str) -> None:
+        nonlocal transition_pending
+        assert task_id == f"heos_playback_transition_{player.player_id}"
+        transition_pending = False
+
+    async def play_url(_: str) -> None:
+        if transition_pending:
+            player._finish_ma_playback_transition()
+
+    mass.cancel_timer.side_effect = cancel_timer
+    mass.streams.resolve_stream_url = AsyncMock(return_value="http://ma/stream/new")
+    device.play_url = AsyncMock(side_effect=play_url)
+    player._ma_playback_starting = True
+
+    await player.play_media(
+        PlayerMedia(
+            uri="library://track/2",
+            media_type=MediaType.TRACK,
+            title="New MA Track",
+        )
+    )
+
+    assert player._ma_playback_starting is True
+    mass.cancel_timer.assert_called_once_with(f"heos_playback_transition_{player.player_id}")
+
+
+async def test_select_source_ends_ma_playback_transition() -> None:
+    """Allow an explicit source change to update HEOS media immediately."""
+    player = _make_player(_url_stream_now_playing())
+    mass = cast("MagicMock", player.mass)
+    device = cast("MagicMock", player._device)
+    player._ma_playback_starting = True
+
+    async def play_input_source(_: str) -> None:
+        assert player._ma_playback_starting is False
+
+    device.play_input_source = AsyncMock(side_effect=play_input_source)
+
+    await player.select_source("aux_in_1")
+
+    mass.cancel_timer.assert_called_once_with(f"heos_playback_transition_{player.player_id}")
 
 
 def test_media_position_and_duration_reported_in_seconds() -> None:


### PR DESCRIPTION
# What does this implement/fix?

We tried different fixes based on available data to check whether we want to update the metadata on a playing HEOS device. The problem is that HEOS can send media update events out of order and potentially a little bit delayed, causing the metadata inside MA to get overriden. This mostly happens when HEOS is playing from an external source before starting playback from MA.

Because the combination with out of order events, and HEOS not providing us with any data from the media update (besides 'URL Stream') is not reliable to check whether we should accept the update, this fix adds a transition period during which those updates are ignored. The transition period is currently set to 5 seconds, in my testing my devices always seem to report back the correct state after +-1.5 seconds, but environments with all wireless devices might have slower responses.
In my opinion, 5 seconds is fine, this just means users cannot start playback from another source on the HEOS device. Well, they can but MA will just ignore those updates until a new update comes in after the 5 second period.

<!-- Quick description and explanation of changes. -->

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5614

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
