### PR TITLE
Fix dependency auto-merge workflow env contract test

### DIFF
--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -498,6 +498,8 @@ def test_dependency_auto_merge_enforces_app_bot_identity_contract() -> None:
         "EXPECTED_APP_BOT_LOGIN": "musicassistant-bot[bot]",
         "EXPECTED_APP_BOT_LOGIN_ENCODED": "musicassistant-bot%5Bbot%5D",
         "EXPECTED_APP_BOT_ID": "304008617",
+        "EXPECTED_APP_SLUG": "musicassistant-bot",
+        "EXPECTED_APP_INSTALLATION_ID": "146062122",
     }
 
     job = workflow["jobs"]["auto-merge"]
@@ -549,6 +551,11 @@ def test_dependency_auto_merge_enforces_app_bot_identity_contract() -> None:
     assert "python3 -m pip download --no-deps" in availability_check
     assert "--approve" in steps["Auto-approve PR"]["run"]
     assert "--auto --squash" in steps["Enable auto-merge"]["run"]
+
+    refresh_steps = {step["name"]: step for step in workflow["jobs"]["refresh-stale"]["steps"]}
+    identity_check = refresh_steps["Verify GitHub App identity"]["run"]
+    assert '[ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ] ||' in identity_check
+    assert '[ "$INSTALLATION_ID" != "$EXPECTED_APP_INSTALLATION_ID" ]; then' in identity_check
 
 
 def test_release_workflow_uses_minimum_preflight_permissions_and_expected_app() -> None:


### PR DESCRIPTION
# What does this implement/fix?

#5499 added a `refresh-stale` job that mints a GitHub App token, so
`auto-merge-dependency-updates.yml` gained `EXPECTED_APP_SLUG` and
`EXPECTED_APP_INSTALLATION_ID` in its top-level `env`.
`test_dependency_auto_merge_enforces_app_bot_identity_contract` asserts that
`env` mapping exactly and still listed only the three bot-login constants, so
`dev` is red.

That assert is the first one in the test, so every later assertion in the
function was skipped in CI as well.

## Changes

- Add both constants to the expected `env` mapping.
- Assert that the `Verify GitHub App identity` step of `refresh-stale` compares
  against both, so the new constants stay covered instead of only declared.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
