### PR TITLE
Stop AirPlay from re-sending unchanged artwork on every seek

### DIFF
--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -16,6 +16,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Final, cast
+from urllib.parse import urlsplit
 from uuid import uuid4
 
 from music_assistant_models.enums import PlaybackState
@@ -629,8 +630,12 @@ class AirPlayStream:
             # full metadata each time — which makes an Apple TV re-render its
             # Now Playing popup.
             text_checksum = f"{item_id}|{title}|{artist}|{album}"
-            artwork_checksum = metadata.image_url or ""
-            metadata_checksum = f"{text_checksum}|{metadata.image_url}"
+            # the artwork identity must survive URL-form changes: the session
+            # media and the player state carry the same image behind different
+            # base URLs, and re-sending on such a flip would re-render and
+            # re-push identical artwork on every seek and media update
+            artwork_checksum = _artwork_identity(metadata.image_url) if metadata.image_url else ""
+            metadata_checksum = f"{text_checksum}|{artwork_checksum}"
 
         artwork_url: str | None = None
         artwork_render: asyncio.Task[str | None] | None = None
@@ -828,7 +833,7 @@ class AirPlayStream:
                 and metadata_generation == self._metadata_generation
                 and await self.send_cli_command(f"ARTWORK={artwork}")
             ):
-                self._metadata_artwork_checksum = artwork_url
+                self._metadata_artwork_checksum = _artwork_identity(artwork_url)
 
     async def _build_cli_args(  # noqa: PLR0915
         self,
@@ -1861,6 +1866,22 @@ class AirPlayStream:
             self.player.display_name,
             margin_ms,
         )
+
+
+def _artwork_identity(image_url: str) -> str:
+    """
+    Return a URL-form independent identity for a cover-art URL.
+
+    :param image_url: The cover-art URL as carried on the player media.
+    """
+    # An imageproxy URL embeds a server base URL (webserver or stream server,
+    # depending on who built the PlayerMedia) plus size/format parameters, but
+    # the opaque image id in its path alone identifies the underlying image.
+    # Any other URL is its own identity.
+    _, sep, image_id = urlsplit(image_url).path.partition("/imageproxy/")
+    if sep and image_id:
+        return image_id
+    return image_url
 
 
 def _status_int(fields: Mapping[str, str], key: str) -> int:

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -16,14 +16,13 @@ from contextlib import suppress
 from dataclasses import dataclass
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Final, cast
-from urllib.parse import urlsplit
 from uuid import uuid4
 
 from music_assistant_models.enums import PlaybackState
 from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
-from music_assistant.helpers.images import get_image_thumb_path
+from music_assistant.helpers.images import _extract_imageproxy_id, get_image_thumb_path
 from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter
 from music_assistant.helpers.process import AsyncProcess
 from music_assistant.providers.airplay.constants import (
@@ -1878,10 +1877,7 @@ def _artwork_identity(image_url: str) -> str:
     # depending on who built the PlayerMedia) plus size/format parameters, but
     # the opaque image id in its path alone identifies the underlying image.
     # Any other URL is its own identity.
-    _, sep, image_id = urlsplit(image_url).path.partition("/imageproxy/")
-    if sep and image_id:
-        return image_id
-    return image_url
+    return _extract_imageproxy_id(image_url) or image_url
 
 
 def _status_int(fields: Mapping[str, str], key: str) -> int:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2364,9 +2364,15 @@ async def test_artwork_url_form_change_does_not_resend_artwork() -> None:
 
     # the queue session builds the image URL on the stream server base, the
     # player state on the webserver base - same image id behind both forms
-    session_media = make_metadata("http://192.168.1.5:8097/imageproxy/abc123?size=512&fmt=jpeg")
-    state_media = make_metadata("http://192.168.1.5:8095/imageproxy/abc123?size=512&fmt=png")
-    other_image_media = make_metadata("http://192.168.1.5:8095/imageproxy/def456?size=512&fmt=png")
+    image_id = "ab" * 32
+    other_image_id = "cd" * 32
+    session_media = make_metadata(
+        f"http://192.168.1.5:8097/imageproxy/{image_id}?size=512&fmt=jpeg"
+    )
+    state_media = make_metadata(f"http://192.168.1.5:8095/imageproxy/{image_id}?size=512&fmt=png")
+    other_image_media = make_metadata(
+        f"http://192.168.1.5:8095/imageproxy/{other_image_id}?size=512&fmt=png"
+    )
 
     with (
         patch.object(stream.commands_pipe, "write", new_callable=AsyncMock) as write_command,
@@ -2392,7 +2398,7 @@ async def test_artwork_url_form_change_does_not_resend_artwork() -> None:
     assert len(bundled) == 1
     assert resends == ["ARTWORK=/cache/thumb.jpg\n"]
     assert prepare_artwork.await_count == 2
-    assert stream._metadata_artwork_checksum == "def456"
+    assert stream._metadata_artwork_checksum == other_image_id
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2345,6 +2345,57 @@ async def test_concurrent_metadata_updates_only_send_latest_artwork() -> None:
 
 
 @pytest.mark.asyncio
+async def test_artwork_url_form_change_does_not_resend_artwork() -> None:
+    """Alternating URL forms of the same imageproxy image send artwork only once."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream._cli_proc = MagicMock(closed=False)
+
+    def make_metadata(image_url: str) -> MagicMock:
+        return MagicMock(
+            corrected_elapsed_time=0,
+            queue_item_id="item-1",
+            title="Track",
+            artist="Artist",
+            album="Album",
+            duration=180,
+            image_url=image_url,
+        )
+
+    # the queue session builds the image URL on the stream server base, the
+    # player state on the webserver base - same image id behind both forms
+    session_media = make_metadata("http://192.168.1.5:8097/imageproxy/abc123?size=512&fmt=jpeg")
+    state_media = make_metadata("http://192.168.1.5:8095/imageproxy/abc123?size=512&fmt=png")
+    other_image_media = make_metadata("http://192.168.1.5:8095/imageproxy/def456?size=512&fmt=png")
+
+    with (
+        patch.object(stream.commands_pipe, "write", new_callable=AsyncMock) as write_command,
+        patch.object(
+            stream,
+            "_prepare_artwork",
+            new_callable=AsyncMock,
+            return_value="/cache/thumb.jpg",
+        ) as prepare_artwork,
+    ):
+        await stream.send_metadata(None, session_media)
+        generation_after_first_send = stream._metadata_generation
+        # the post-START push (session media) and the media-updated push
+        # (player state) alternate on every seek
+        await stream.send_metadata(None, state_media)
+        await stream.send_metadata(None, session_media)
+        assert stream._metadata_generation == generation_after_first_send
+        await stream.send_metadata(None, other_image_media)
+
+    commands = [call.args[0].decode() for call in write_command.await_args_list]
+    bundled = [command for command in commands if "ARTWORKFILE=" in command]
+    resends = [command for command in commands if command.startswith("ARTWORK=")]
+    assert len(bundled) == 1
+    assert resends == ["ARTWORK=/cache/thumb.jpg\n"]
+    assert prepare_artwork.await_count == 2
+    assert stream._metadata_artwork_checksum == "def456"
+
+
+@pytest.mark.asyncio
 async def test_metadata_revert_resends_text_after_superseded_artwork() -> None:
     """Reverting while artwork renders restores the previously displayed track text."""
     player = _make_player()


### PR DESCRIPTION
# What does this implement/fix?

During playback on an AirPlay player, every seek (and every track start) re-rendered and re-sent the exact same cover art to the player twice, even though nothing changed. The player-side binary detected the identical bytes and dropped them, but the server kept doing the useless work and flooding the traffic log.

Cause: the same cover art image is referenced through two different URL forms (one built on the stream server address, one on the webserver address). The artwork dedupe compared the full URL, so the two forms kept flipping the "artwork changed" check back and forth.

- Dedupe artwork on the imageproxy image id instead of the full URL, so different URL forms of the same image no longer trigger a re-send
- Added a test that repeated media updates with the same image send the artwork only once

**Related issue (if applicable):**

- related issue N/A (found in traffic log analysis)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
