### PR TITLE
Fix file shares importing nothing and hiding playlists (#6019)

### DIFF
--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -330,8 +330,9 @@ _LEGACY_ICON_MAP: dict[str, str] = {
 # "hue_username", the scrobblers under "_username", Open Subsonic its url under "baseURL").
 # Notes on the non-obvious entries:
 # - the filesystem providers' "content_type" is also surfaced by get_config_entries, but
-#   only as a read-only LABEL mirror (UI_ONLY, never persisted back to values), so moving
-#   it to setup_data is safe and required (it is read via get_provider_setup_value).
+#   only as a read-only mirror that carries the setup value as its default (so it is never
+#   persisted back to values), so moving it to setup_data is safe and required (it is read
+#   via get_provider_setup_value).
 # - hass "url"/"token"/"verify_ssl": on a Home Assistant add-on these come from fixed
 #   (hidden) config entries whose values equal what a stored copy would hold, so moving a
 #   stored copy is a harmless no-op there while restoring normal installs.

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -7,7 +7,7 @@ import builtins
 import logging
 from typing import TYPE_CHECKING, Any, TypeVar, final, overload
 
-from music_assistant_models.config_entries import ConfigValueType
+from music_assistant_models.config_entries import UI_ONLY, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType, EventType
 from music_assistant_models.errors import ActionUnavailable, UnsupportedFeaturedException
 
@@ -311,6 +311,10 @@ class Provider:
         """
         if (entry := self.config.values.get(key)) is None:
             return self.config.get_value(key, default)
+        if entry.type in UI_ONLY:
+            # a display-only entry holds label text rather than a value, so reading
+            # through it would shadow the caller's default
+            return default
         value = self.mass.config.get_raw_provider_config_value(self.instance_id, key)
         if value is None:
             return self.config.get_value(key, default)

--- a/music_assistant/providers/filesystem_cloud/base.py
+++ b/music_assistant/providers/filesystem_cloud/base.py
@@ -168,7 +168,9 @@ class CloudFileSystemProvider(LocalFileSystemProvider):
         # the content type is collected by the setup flow (setup_data); the parent reads it
         # from the legacy config values, so re-resolve it setup-data-aware (read-through keeps
         # pre-flow installs working)
-        self.media_content_type = cast("str", self.get_setup_value(CONF_CONTENT_TYPE))
+        self.media_content_type = cast(
+            "str", self.get_setup_value(CONF_CONTENT_TYPE, CONF_ENTRY_CONTENT_TYPE.default_value)
+        )
         self.root_folder_id = root_folder_id
         self._unregister_stream_route: Callable[[], None] | None = None
         # per-folder listing cache: folder path -> {child name -> (cloud id, item)};

--- a/music_assistant/providers/filesystem_google_drive/provider.py
+++ b/music_assistant/providers/filesystem_google_drive/provider.py
@@ -14,8 +14,6 @@ from typing import TYPE_CHECKING, Any, cast
 from aiohttp import ClientError
 from google_drive_api.api import GoogleDriveApi
 from google_drive_api.exceptions import AuthException, GoogleDriveApiError
-from music_assistant_models.config_entries import ConfigEntry
-from music_assistant_models.enums import ConfigEntryType
 from music_assistant_models.errors import (
     LoginFailed,
     ProviderUnavailableError,
@@ -32,6 +30,7 @@ from music_assistant.providers.filesystem_cloud.base import (
 )
 from music_assistant.providers.filesystem_local.constants import (
     CONF_CONTENT_TYPE,
+    CONF_ENTRY_CONTENT_TYPE,
     CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
     CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
     CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS,
@@ -39,6 +38,7 @@ from music_assistant.providers.filesystem_local.constants import (
     CONF_ENTRY_LIBRARY_SYNC_TRACKS,
     CONF_ENTRY_MISSING_ALBUM_ARTIST,
     CONF_ENTRY_PROPAGATE_GENRES,
+    content_type_config_entry,
 )
 
 from .auth import MAGoogleDriveAuth
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from aiohttp import ClientResponse
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -94,9 +94,11 @@ class GoogleDriveFileSystemProvider(CloudFileSystemProvider):
         """
         # the content type is set by the setup flow; surface it read-only so the sync
         # options' depends_on chains still resolve
-        content_type = getattr(self, "media_content_type", "music")
+        content_type = str(
+            self.get_setup_value(CONF_CONTENT_TYPE, CONF_ENTRY_CONTENT_TYPE.default_value)
+        )
         return (
-            ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
+            content_type_config_entry(content_type),
             CONF_ENTRY_MISSING_ALBUM_ARTIST,
             CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
             CONF_ENTRY_LIBRARY_SYNC_TRACKS,

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -19,9 +19,7 @@ import aiofiles
 import shortuuid
 import xmltodict
 from aiofiles.os import wrap
-from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import (
-    ConfigEntryType,
     ContentType,
     EventType,
     ExternalID,
@@ -116,6 +114,7 @@ from .constants import (
     SUPPORTED_EXTENSIONS,
     TRACK_EXTENSIONS,
     IsChapterFile,
+    content_type_config_entry,
 )
 from .cue import (
     CueSheetHandler,
@@ -137,7 +136,7 @@ from .helpers import (
 from .parsers import parse_album_nfo
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -204,9 +203,11 @@ class LocalFileSystemProvider(MusicProvider):
         """Return Config entries to configure this provider."""
         # content type and path are collected by the setup flow; surface the (immutable)
         # content type read-only so the sync options' depends_on chains still resolve
-        content_type = str(self.get_setup_value(CONF_CONTENT_TYPE, "music"))
+        content_type = str(
+            self.get_setup_value(CONF_CONTENT_TYPE, CONF_ENTRY_CONTENT_TYPE.default_value)
+        )
         return (
-            ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
+            content_type_config_entry(content_type),
             CONF_ENTRY_MISSING_ALBUM_ARTIST,
             CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
             CONF_ENTRY_LIBRARY_SYNC_TRACKS,

--- a/music_assistant/providers/filesystem_local/constants.py
+++ b/music_assistant/providers/filesystem_local/constants.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Final
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
@@ -44,9 +45,18 @@ CONF_ENTRY_CONTENT_TYPE = ConfigEntry(
         ConfigValueOption("sound_effects"),
     ],
 )
-CONF_ENTRY_CONTENT_TYPE_READ_ONLY = ConfigEntry.from_dict(
-    {**CONF_ENTRY_CONTENT_TYPE.to_dict(), "read_only": True}
-)
+
+
+def content_type_config_entry(content_type: str) -> ConfigEntry:
+    """
+    Return the read-only mirror of the (setup flow owned) content type for the options page.
+
+    :param content_type: The content type resolved from the provider's setup data.
+    """
+    # mirrored as the entry default so the other entries resolve their depends_on chain
+    # against it without it ever being persisted back into the stored values
+    return replace(CONF_ENTRY_CONTENT_TYPE, read_only=True, default_value=content_type)
+
 
 CONF_ENTRY_LIBRARY_SYNC_TRACKS = ConfigEntry(
     key="library_sync_tracks",

--- a/music_assistant/providers/filesystem_nfs/provider.py
+++ b/music_assistant/providers/filesystem_nfs/provider.py
@@ -8,8 +8,6 @@ from contextlib import suppress
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
-from music_assistant_models.config_entries import ConfigEntry
-from music_assistant_models.enums import ConfigEntryType
 from music_assistant_models.errors import SetupFailedError, UnsupportedSystemError
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
@@ -26,6 +24,7 @@ from music_assistant.providers.filesystem_local import (
 )
 from music_assistant.providers.filesystem_local.constants import (
     CONF_CONTENT_TYPE,
+    CONF_ENTRY_CONTENT_TYPE,
     CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
     CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
     CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS,
@@ -33,12 +32,13 @@ from music_assistant.providers.filesystem_local.constants import (
     CONF_ENTRY_LIBRARY_SYNC_TRACKS,
     CONF_ENTRY_MISSING_ALBUM_ARTIST,
     CONF_ENTRY_PROPAGATE_GENRES,
+    content_type_config_entry,
 )
 
 from .constants import CONF_EXPORT_PATH, CONF_HOST, CONF_NFS_VERSION, CONF_SUBFOLDER
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -87,9 +87,11 @@ class NFSFileSystemProvider(LocalFileSystemProvider):
         """Return Config entries to setup this provider."""
         # connection details and content type are collected by the setup flow; surface the
         # (immutable) content type read-only so the sync options' depends_on chains resolve
-        content_type = str(self.get_setup_value(CONF_CONTENT_TYPE, "music"))
+        content_type = str(
+            self.get_setup_value(CONF_CONTENT_TYPE, CONF_ENTRY_CONTENT_TYPE.default_value)
+        )
         return (
-            ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
+            content_type_config_entry(content_type),
             CONF_ENTRY_MISSING_ALBUM_ARTIST,
             CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
             CONF_ENTRY_LIBRARY_SYNC_TRACKS,

--- a/music_assistant/providers/filesystem_onedrive/provider.py
+++ b/music_assistant/providers/filesystem_onedrive/provider.py
@@ -17,8 +17,6 @@ from typing import TYPE_CHECKING, cast
 from urllib.parse import quote
 
 from aiohttp import ClientError
-from music_assistant_models.config_entries import ConfigEntry
-from music_assistant_models.enums import ConfigEntryType
 from music_assistant_models.errors import (
     LoginFailed,
     ProviderUnavailableError,
@@ -38,6 +36,7 @@ from music_assistant.providers.filesystem_cloud.base import (
 )
 from music_assistant.providers.filesystem_local.constants import (
     CONF_CONTENT_TYPE,
+    CONF_ENTRY_CONTENT_TYPE,
     CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
     CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
     CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS,
@@ -45,6 +44,7 @@ from music_assistant.providers.filesystem_local.constants import (
     CONF_ENTRY_LIBRARY_SYNC_TRACKS,
     CONF_ENTRY_MISSING_ALBUM_ARTIST,
     CONF_ENTRY_PROPAGATE_GENRES,
+    content_type_config_entry,
 )
 
 from .auth import MAOneDriveAuth
@@ -52,7 +52,7 @@ from .constants import GRAPH_BASE_URL
 
 if TYPE_CHECKING:
     from aiohttp import ClientResponse
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -98,9 +98,11 @@ class OneDriveFileSystemProvider(CloudFileSystemProvider):
         """
         # the content type is set by the setup flow; surface it read-only so the sync
         # options' depends_on chains still resolve
-        content_type = getattr(self, "media_content_type", "music")
+        content_type = str(
+            self.get_setup_value(CONF_CONTENT_TYPE, CONF_ENTRY_CONTENT_TYPE.default_value)
+        )
         return (
-            ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
+            content_type_config_entry(content_type),
             CONF_ENTRY_MISSING_ALBUM_ARTIST,
             CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
             CONF_ENTRY_LIBRARY_SYNC_TRACKS,

--- a/music_assistant/providers/filesystem_smb/__init__.py
+++ b/music_assistant/providers/filesystem_smb/__init__.py
@@ -23,6 +23,7 @@ from music_assistant.providers.filesystem_local import (
 )
 from music_assistant.providers.filesystem_local.constants import (
     CONF_CONTENT_TYPE,
+    CONF_ENTRY_CONTENT_TYPE,
     CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
     CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
     CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS,
@@ -30,6 +31,7 @@ from music_assistant.providers.filesystem_local.constants import (
     CONF_ENTRY_LIBRARY_SYNC_TRACKS,
     CONF_ENTRY_MISSING_ALBUM_ARTIST,
     CONF_ENTRY_PROPAGATE_GENRES,
+    content_type_config_entry,
 )
 
 if TYPE_CHECKING:
@@ -93,9 +95,11 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
         """Return Config entries to configure this provider."""
         # connection details and content type are collected by the setup flow; surface the
         # (immutable) content type read-only so the sync options' depends_on chains resolve
-        content_type = str(self.get_setup_value(CONF_CONTENT_TYPE, "music"))
+        content_type = str(
+            self.get_setup_value(CONF_CONTENT_TYPE, CONF_ENTRY_CONTENT_TYPE.default_value)
+        )
         return (
-            ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
+            content_type_config_entry(content_type),
             ConfigEntry(
                 key=CONF_CACHE_MODE,
                 type=ConfigEntryType.STRING,

--- a/music_assistant/providers/webdav/provider.py
+++ b/music_assistant/providers/webdav/provider.py
@@ -8,8 +8,6 @@ from typing import TYPE_CHECKING, cast
 from urllib.parse import quote, unquote, urlparse, urlunparse
 
 import aiohttp
-from music_assistant_models.config_entries import ConfigEntry
-from music_assistant_models.enums import ConfigEntryType
 from music_assistant_models.errors import (
     LoginFailed,
     MediaNotFoundError,
@@ -22,6 +20,7 @@ from music_assistant.controllers.tasks.context import update_current_task_progre
 from music_assistant.helpers.tags import get_embedded_image
 from music_assistant.providers.filesystem_local import LocalFileSystemProvider
 from music_assistant.providers.filesystem_local.constants import (
+    CONF_ENTRY_CONTENT_TYPE,
     CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
     CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
     CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS,
@@ -30,6 +29,7 @@ from music_assistant.providers.filesystem_local.constants import (
     CONF_ENTRY_MISSING_ALBUM_ARTIST,
     CONF_ENTRY_PROPAGATE_GENRES,
     SUPPORTED_EXTENSIONS,
+    content_type_config_entry,
 )
 from music_assistant.providers.filesystem_local.helpers import FileSystemItem, ScanErrors
 
@@ -37,7 +37,7 @@ from .constants import CONF_CONTENT_TYPE, CONF_URL, CONF_VERIFY_SSL
 from .helpers import WebDAVItem, build_webdav_url, webdav_propfind, webdav_test_connection
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -64,15 +64,19 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
         self.username = cast("str | None", self.get_setup_value(CONF_USERNAME))
         self.password = cast("str | None", self.get_setup_value(CONF_PASSWORD))
         self.verify_ssl = cast("bool", self.get_setup_value(CONF_VERIFY_SSL))
-        self.media_content_type = cast("str", self.get_setup_value(CONF_CONTENT_TYPE))
+        self.media_content_type = cast(
+            "str", self.get_setup_value(CONF_CONTENT_TYPE, CONF_ENTRY_CONTENT_TYPE.default_value)
+        )
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
         # connection details and content type are collected by the setup flow; surface the
         # (immutable) content type read-only so the sync options' depends_on chains resolve
-        content_type = str(self.get_setup_value(CONF_CONTENT_TYPE, "music"))
+        content_type = str(
+            self.get_setup_value(CONF_CONTENT_TYPE, CONF_ENTRY_CONTENT_TYPE.default_value)
+        )
         return (
-            ConfigEntry(key=CONF_CONTENT_TYPE, type=ConfigEntryType.LABEL, value=content_type),
+            content_type_config_entry(content_type),
             CONF_ENTRY_MISSING_ALBUM_ARTIST,
             CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
             CONF_ENTRY_LIBRARY_SYNC_TRACKS,

--- a/tests/providers/filesystem/test_content_type_resolution.py
+++ b/tests/providers/filesystem/test_content_type_resolution.py
@@ -1,0 +1,131 @@
+"""
+Regression tests for the content type as resolved through the real config machinery (#6019).
+
+Mirroring the setup-flow owned content type as a LABEL lost it for every share left on the
+default: "music" is not in stored values either, since a value equal to its default is never
+persisted. It resolved to None, which disabled the sync and hid playlists from the browser.
+
+test_content_type_default.py covers the constructor read against a mocked config; these
+drive the load path the server uses, which is what the options page resolves against.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
+from music_assistant_models.enums import ConfigEntryType, ProviderType
+from music_assistant_models.provider import ProviderManifest
+
+from music_assistant.constants import CONF_PATH, CONF_PROVIDERS
+from music_assistant.controllers.config.providers import DEFAULT_PROVIDER_CONFIG_ENTRIES
+from music_assistant.providers.filesystem_local import LocalFileSystemProvider
+from music_assistant.providers.filesystem_local.constants import (
+    CONF_CONTENT_TYPE,
+    CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS,
+    CONF_ENTRY_LIBRARY_SYNC_PODCASTS,
+)
+
+if TYPE_CHECKING:
+    from music_assistant.mass import MusicAssistant
+
+INSTANCE_ID = "filesystem_local--test"
+
+MANIFEST = ProviderManifest(
+    type=ProviderType.MUSIC,
+    domain="filesystem_local",
+    name="Local files",
+    description="",
+    codeowners=[],
+)
+
+
+async def _load_provider(
+    mass: MusicAssistant,
+    setup_data: dict[str, str],
+    values: dict[str, str] | None = None,
+) -> LocalFileSystemProvider:
+    """
+    Load a filesystem provider the way the server does, and return the instance.
+
+    :param mass: The MusicAssistant instance to load into.
+    :param setup_data: The provider's stored setup_data.
+    :param values: The provider's stored (raw) config values.
+    """
+    # the load-time ordering matters here: the config carries the server defaults only
+    # until rehydrate_provider_config re-parses it against the provider's own entries
+    raw = {
+        "type": ProviderType.MUSIC.value,
+        "domain": "filesystem_local",
+        "instance_id": INSTANCE_ID,
+        "default_name": "Local files",
+        "enabled": True,
+        "values": values or {},
+        "setup_data": {CONF_PATH: "/media", **setup_data},
+    }
+    mass.config.set(f"{CONF_PROVIDERS}/{INSTANCE_ID}", raw)
+    config = cast("ProviderConfig", ProviderConfig.parse(DEFAULT_PROVIDER_CONFIG_ENTRIES, raw))
+    mass.config.seed_stored_config_values(config)
+    provider = LocalFileSystemProvider(mass, MANIFEST, config)
+    await mass.config.rehydrate_provider_config(provider)
+    return provider
+
+
+async def test_music_share_without_a_stored_content_type(mass_minimal: MusicAssistant) -> None:
+    """An install that never changed the content type reads back as music, not None."""
+    # what an install upgraded from before the setup flows has on disk: "music" equals
+    # the entry default, so it was never persisted and there is nothing to migrate
+    provider = await _load_provider(mass_minimal, setup_data={})
+
+    assert provider.media_content_type == "music"
+    assert provider.config.get_value(CONF_CONTENT_TYPE) == "music"
+
+
+async def test_setup_data_content_type_wins(mass_minimal: MusicAssistant) -> None:
+    """A content type collected by the setup flow is used instead of the default."""
+    provider = await _load_provider(mass_minimal, setup_data={CONF_CONTENT_TYPE: "podcasts"})
+
+    assert provider.media_content_type == "podcasts"
+    assert provider.config.get_value(CONF_CONTENT_TYPE) == "podcasts"
+
+
+async def test_legacy_stored_content_type_is_read_through(mass_minimal: MusicAssistant) -> None:
+    """A non-default content type still in `values` survives until it is migrated."""
+    provider = await _load_provider(
+        mass_minimal, setup_data={}, values={CONF_CONTENT_TYPE: "audiobooks"}
+    )
+
+    assert provider.media_content_type == "audiobooks"
+
+
+async def test_sync_options_resolve_their_dependency(mass_minimal: MusicAssistant) -> None:
+    """The sync options gate on the mirrored content type, so it must hold a real value."""
+    provider = await _load_provider(mass_minimal, setup_data={})
+    entries = list(provider.config.values.values())
+
+    playlists = provider.config.values[CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS.key]
+    podcasts = provider.config.values[CONF_ENTRY_LIBRARY_SYNC_PODCASTS.key]
+    assert playlists.dependency_met(entries) is True
+    assert podcasts.dependency_met(entries) is False
+    # the toggles keep their own (default) value, which drives sync_library
+    assert provider.config.get_value(CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS.key) is True
+
+
+async def test_content_type_mirror_is_never_persisted(mass_minimal: MusicAssistant) -> None:
+    """The options-page mirror is display state and must not leak into stored values."""
+    provider = await _load_provider(mass_minimal, setup_data={CONF_CONTENT_TYPE: "podcasts"})
+
+    assert CONF_CONTENT_TYPE not in provider.config.to_raw()["values"]
+
+
+async def test_display_only_entry_does_not_shadow_the_default(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A UI-only entry holds no value, so reading its key must fall back to the default."""
+    provider = await _load_provider(mass_minimal, setup_data={})
+    provider.config.values["banner"] = ConfigEntry(
+        key="banner", type=ConfigEntryType.LABEL, value="music"
+    )
+
+    assert provider.get_config_value("banner", "fallback") == "fallback"
+    assert provider.get_setup_value("banner", "fallback") == "fallback"

--- a/tests/providers/filesystem/test_content_type_resolution.py
+++ b/tests/providers/filesystem/test_content_type_resolution.py
@@ -12,13 +12,17 @@ drive the load path the server uses, which is what the options page resolves aga
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, patch
 
 from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
 from music_assistant_models.enums import ConfigEntryType, ProviderType
 from music_assistant_models.provider import ProviderManifest
 
-from music_assistant.constants import CONF_PATH, CONF_PROVIDERS
-from music_assistant.controllers.config.providers import DEFAULT_PROVIDER_CONFIG_ENTRIES
+from music_assistant.constants import (
+    CONF_PATH,
+    CONF_PROVIDERS,
+    DEFAULT_PROVIDER_CONFIG_ENTRIES,
+)
 from music_assistant.providers.filesystem_local import LocalFileSystemProvider
 from music_assistant.providers.filesystem_local.constants import (
     CONF_CONTENT_TYPE,
@@ -90,7 +94,12 @@ async def test_setup_data_content_type_wins(mass_minimal: MusicAssistant) -> Non
 
 
 async def test_legacy_stored_content_type_is_read_through(mass_minimal: MusicAssistant) -> None:
-    """A non-default content type still in `values` survives until it is migrated."""
+    """
+    A non-default content type still in `values` is read through instead of lost.
+
+    `migrate_provider_setup_data` moves such a value into `setup_data` at startup, before any
+    provider loads; the read path stays correct without depending on that having run.
+    """
     provider = await _load_provider(
         mass_minimal, setup_data={}, values={CONF_CONTENT_TYPE: "audiobooks"}
     )
@@ -116,6 +125,31 @@ async def test_content_type_mirror_is_never_persisted(mass_minimal: MusicAssista
     provider = await _load_provider(mass_minimal, setup_data={CONF_CONTENT_TYPE: "podcasts"})
 
     assert CONF_CONTENT_TYPE not in provider.config.to_raw()["values"]
+
+
+async def test_content_type_survives_saving_the_options_page(mass_minimal: MusicAssistant) -> None:
+    """Saving the options page keeps the content type where the setup flow put it."""
+    provider = await _load_provider(mass_minimal, setup_data={CONF_CONTENT_TYPE: "audiobooks"})
+    # the options page posts back every entry it was handed, the read-only mirror included
+    posted = {entry.key: entry.value for entry in provider.config.values.values()}
+
+    with (
+        patch.object(
+            mass_minimal.config, "get_provider_config", AsyncMock(return_value=provider.config)
+        ),
+        patch.object(mass_minimal, "load_provider_config", AsyncMock()),
+    ):
+        await mass_minimal.config._update_provider_config(INSTANCE_ID, posted)
+    stored = mass_minimal.config.get(f"{CONF_PROVIDERS}/{INSTANCE_ID}")
+
+    # the save rebuilds `values` from the declared entries and only preserves stored keys
+    # that have no entry, so a mirror written there would be dropped by the next save
+    assert CONF_CONTENT_TYPE not in stored["values"]
+    assert stored["setup_data"][CONF_CONTENT_TYPE] == "audiobooks"
+    reloaded = await _load_provider(
+        mass_minimal, setup_data=stored["setup_data"], values=stored["values"]
+    )
+    assert reloaded.media_content_type == "audiobooks"
 
 
 async def test_display_only_entry_does_not_shadow_the_default(

--- a/tests/providers/yandex_station/test_provider_cascade.py
+++ b/tests/providers/yandex_station/test_provider_cascade.py
@@ -17,6 +17,7 @@ from typing import Any, cast
 from unittest import mock
 
 import pytest
+from music_assistant_models.enums import ConfigEntryType
 from music_assistant_models.errors import LoginFailed, ResourceTemporarilyUnavailable
 from ya_passport_auth import SecretStr
 
@@ -36,6 +37,9 @@ _MOD = "music_assistant.providers.yandex_station.provider"
 
 class _StubConfigValue:
     """Minimal stand-in for a ``ConfigValue`` so ``.value = ...`` works."""
+
+    # get_config_value checks the entry type before reading it, so the stub carries one
+    type = ConfigEntryType.STRING
 
     def __init__(self, value: Any) -> None:
         self.value = value


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Unfortunately the setup flow change in beta 10 dropped the `content_type` config entry and used a LABEL in its place, which has resulted in the loss of the default value for the filesystem provider content type. [#5506](https://github.com/music-assistant/server/issues/5506) restored the fallback for the local provider's own read, but the mirror on the options page still holds no value, so the sync options don't resolve their depends_on against it, and WebDAV/OneDrive/Google Drive read the content type through their own paths which were left without a fallback. This PR restores the read-only entry, so on next restart the default value of "music" will be used again and affected shares recover on their own. Shares explicitly set to audiobooks/podcasts were never affected.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6019

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
