### PR TITLE
Fix local code checks failing on some numba versions

### DIFF
--- a/tests/test_numba_cache_isolation.py
+++ b/tests/test_numba_cache_isolation.py
@@ -18,4 +18,5 @@ def test_numba_kernel_cache_is_process_private(pytestconfig: pytest.Config) -> N
     # a TemporaryDirectory of this session's own, so no other process can be writing there
     assert os.environ["NUMBA_CACHE_DIR"] == pytestconfig.stash[NUMBA_CACHE_DIR].name
     # numba snapshots the variable as it is imported, so a mismatch means it got in first
-    assert os.environ["NUMBA_CACHE_DIR"] == numba_config.CACHE_DIR  # type: ignore[attr-defined]
+    # (numba ships type info only on newer versions, where CACHE_DIR is set at runtime)
+    assert os.environ["NUMBA_CACHE_DIR"] == numba_config.CACHE_DIR  # type: ignore[attr-defined, unused-ignore]


### PR DESCRIPTION
# What does this implement/fix?

The test that guards numba's compile cache reads `CACHE_DIR` from numba's config. numba comes in as
an unpinned indirect dependency, and only its newer releases ship type information. Where the type
checker can read numba it sees that `CACHE_DIR` is set at runtime and rejects the lookup; on older
releases it never looks at all. So the exemption that the first case needs was reported as
unnecessary in the second, and the check failed on every local commit while CI stayed green.

The exemption now covers both cases, the same way the rest of the codebase already handles this.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
