### PR TITLE
Fix broken playlists page after upgrading from stable to beta

### DIFF
--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -9,7 +9,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 
-DB_SCHEMA_VERSION: Final[int] = 56
+DB_SCHEMA_VERSION: Final[int] = 57
 
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -978,9 +978,9 @@ async def migrate_database(  # noqa: PLR0915
 
     if prev_version <= 56:
         # the stable branch numbers its schema versions independently of this one, so a
-        # stable database can report a version that leapfrogs steps it never ran: stable's
-        # v43 skips the columns added below at <= 41 and <= 42. Re-add them for every
-        # pre-57 database; the ALTERs are no-ops where the column already exists.
+        # stable database can report a version that leapfrogs steps it never ran: stable
+        # 41-43 never got the columns this branch adds at <= 41 and <= 42. Re-add them for
+        # every pre-57 database; the ALTERs are no-ops where the column already exists.
         for table, column in (
             (DB_TABLE_PLAYLISTS, "[translation_key] TEXT"),
             (DB_TABLE_PLAYLISTS, "[translation_params] json"),

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -976,6 +976,22 @@ async def migrate_database(  # noqa: PLR0915
             " AND supported_mediatypes LIKE '%sound_effect%'"
         )
 
+    if prev_version <= 56:
+        # the stable branch numbers its schema versions independently of this one, so a
+        # stable database can report a version that leapfrogs steps it never ran: stable's
+        # v43 skips the columns added below at <= 41 and <= 42. Re-add them for every
+        # pre-57 database; the ALTERs are no-ops where the column already exists.
+        for table, column in (
+            (DB_TABLE_PLAYLISTS, "[translation_key] TEXT"),
+            (DB_TABLE_PLAYLISTS, "[translation_params] json"),
+            (DB_TABLE_PLAYLOG, "[playback_speed] REAL NOT NULL DEFAULT 1.0"),
+        ):
+            try:
+                await database.execute(f"ALTER TABLE {table} ADD COLUMN {column}")
+            except Exception as err:
+                if "duplicate column" not in str(err):
+                    raise
+
     # NOTE: this genre restore runs after the <= 50 step on purpose: it inserts genres
     # with the current code/schema, so the external_ids column must be gone first.
     if prev_version <= 47:

--- a/tests/controllers/music/test_music_migrations.py
+++ b/tests/controllers/music/test_music_migrations.py
@@ -289,13 +289,7 @@ async def test_migrate_database_backfills_external_id_lookup(
     # the external_ids columns (and their unusable indexes) are dropped;
     # the lookup table is now the single source of truth
     for table in MEDIA_TABLES:
-        columns = {
-            column["name"]
-            for column in await music.database.get_rows_from_query(
-                f"PRAGMA table_info({table})", limit=0
-            )
-        }
-        assert "external_ids" not in columns
+        assert "external_ids" not in await _table_columns(music.database, table)
     old_indexes = await music.database.get_rows_from_query(
         "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE '%_external_ids_idx'"
     )

--- a/tests/controllers/music/test_music_migrations.py
+++ b/tests/controllers/music/test_music_migrations.py
@@ -63,6 +63,12 @@ async def database(tmp_path: Path) -> AsyncGenerator[DatabaseConnection]:
         "[external_id_type] TEXT NOT NULL, [external_id] TEXT NOT NULL, "
         "[item_id] INTEGER NOT NULL)"
     )
+    # tests that exercise a specific playlog layout replace this stand-in
+    await db.execute(
+        f"CREATE TABLE {DB_TABLE_PLAYLOG}([id] INTEGER PRIMARY KEY, [userid] TEXT NOT NULL, "
+        "[playback_speed] REAL NOT NULL DEFAULT 1.0, "
+        "UNIQUE(userid))"
+    )
     await db.commit()
     yield db
     await db.close()
@@ -100,6 +106,7 @@ def _playlog_entry(userid: str, timestamp: int = 100) -> dict[str, object]:
 
 async def _create_legacy_playlog_table(database: DatabaseConnection) -> None:
     """Create the playlog table as it exists on pre-userid installs."""
+    await database.execute(f"DROP TABLE {DB_TABLE_PLAYLOG}")
     # original table layout (schema version <= 22) with the 3-column UNIQUE constraint
     await database.execute(
         f"""CREATE TABLE {DB_TABLE_PLAYLOG}(
@@ -129,6 +136,14 @@ async def _create_legacy_playlog_table(database: DatabaseConnection) -> None:
         f"ON {DB_TABLE_PLAYLOG}(item_id,provider,media_type,userid)"
     )
     await database.commit()
+
+
+async def _table_columns(database: DatabaseConnection, table: str) -> set[str]:
+    """Return the column names of the given table."""
+    return {
+        column["name"]
+        for column in await database.get_rows_from_query(f"PRAGMA table_info({table})", limit=0)
+    }
 
 
 async def test_migration_rebuilds_playlog_with_stale_unique_constraint(
@@ -171,6 +186,7 @@ async def test_migration_leaves_correct_playlog_untouched(
     database: DatabaseConnection,
 ) -> None:
     """A playlog table that already has the 4-column constraint is not rebuilt."""
+    await database.execute(f"DROP TABLE {DB_TABLE_PLAYLOG}")
     await database.execute(
         f"""CREATE TABLE {DB_TABLE_PLAYLOG}(
             [id] INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -475,3 +491,43 @@ async def test_migration_strips_sound_effect_from_playlists(
     assert rows[2]["supported_mediatypes"] == "corrupt value naming sound_effect"
     # a playlist left with nothing yields an empty list, not NULL (the column is NOT NULL)
     assert json.loads(rows[3]["supported_mediatypes"]) == []
+
+
+async def test_migration_adds_columns_leapfrogged_by_the_stable_schema_version(
+    database: DatabaseConnection,
+) -> None:
+    """A stable database gets the columns its own schema version made it skip."""
+    # the stable branch numbers its schema versions independently: its v43 already has the
+    # 4-column playlog constraint, but never got playback_speed or the playlist translation
+    # columns, which this branch gates behind steps a v43 database no longer runs
+    await database.execute(f"DROP TABLE {DB_TABLE_PLAYLOG}")
+    await database.execute(
+        f"""CREATE TABLE {DB_TABLE_PLAYLOG}(
+            [id] INTEGER PRIMARY KEY AUTOINCREMENT,
+            [item_id] TEXT NOT NULL,
+            [provider] TEXT NOT NULL,
+            [media_type] TEXT NOT NULL,
+            [name] TEXT NOT NULL,
+            [image] json,
+            [timestamp] INTEGER DEFAULT 0,
+            [fully_played] BOOLEAN,
+            [seconds_played] INTEGER,
+            [userid] TEXT NOT NULL,
+            [queue_id] TEXT,
+            [user_initiated] BOOLEAN NOT NULL DEFAULT 1,
+            UNIQUE(item_id, provider, media_type, userid));"""
+    )
+    await database.commit()
+
+    mass = MagicMock()
+    mass.cache.clear = AsyncMock()
+    await migrate_database(
+        mass,
+        database,
+        MagicMock(),
+        prev_version=43,
+        create_tables=AsyncMock(),
+    )
+
+    assert {"translation_key", "translation_params"} <= await _table_columns(database, "playlists")
+    assert "playback_speed" in await _table_columns(database, DB_TABLE_PLAYLOG)


### PR DESCRIPTION
# What does this implement/fix?

Switching a stable install over to the beta image left the library database missing a few
columns, so the Playlists page failed with `no such column: playlists.translation_key`, and
resuming an audiobook/podcast hit the same on `playlog.playback_speed`.

Cause: stable numbers its database schema versions independently from beta. Stable's current
version (43) is a *higher* number than the beta steps that add these columns (41 and 42), so
those steps were skipped on upgrade even though a stable database never ran them.

- Add a migration step that re-adds `playlists.translation_key`, `playlists.translation_params`
  and `playlog.playback_speed` to every existing database (no-op where they already exist)
- Bump the library schema version so the step also repairs installs that already upgraded to
  the beta and are now broken

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
