### PR TITLE
Name the right speaker when Sonos S1 grouping fails

### DIFF
--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -283,7 +283,6 @@ class SonosPlayer(Player):
         else:
             await self.stop()
 
-    @soco_error()
     async def set_members(
         self,
         player_ids_to_add: list[str] | None = None,
@@ -301,14 +300,12 @@ class SonosPlayer(Player):
         if player_ids_to_remove:
             for player_id in player_ids_to_remove:
                 if player_to_remove := cast("SonosPlayer", self.mass.players.get_player(player_id)):
-                    await asyncio.to_thread(player_to_remove.soco.unjoin)
-                    player_to_remove.schedule_poll()
+                    await player_to_remove._unjoin()
 
         if player_ids_to_add:
             for player_id in player_ids_to_add:
                 if player_to_add := cast("SonosPlayer", self.mass.players.get_player(player_id)):
-                    await asyncio.to_thread(player_to_add.soco.join, self.soco)
-                    player_to_add.schedule_poll()
+                    await player_to_add._join(self.soco)
 
     def schedule_poll(self) -> None:
         """Read the speaker state back shortly after a command was sent to it."""
@@ -561,6 +558,22 @@ class SonosPlayer(Player):
         if players := self.mass.players.all_players(provider_filter=_provider.instance_id):
             any_speaker = cast("SonosPlayer", players[0])
             any_speaker.soco.zone_group_state.clear_cache()
+
+    @soco_error()
+    async def _join(self, coordinator: SoCo) -> None:
+        """
+        Join this speaker to the group of the given coordinator.
+
+        :param coordinator: The SoCo instance of the speaker leading the group.
+        """
+        await asyncio.to_thread(self.soco.join, coordinator)
+        self.schedule_poll()
+
+    @soco_error()
+    async def _unjoin(self) -> None:
+        """Remove this speaker from the group it is currently in."""
+        await asyncio.to_thread(self.soco.unjoin)
+        self.schedule_poll()
 
     def _extract_mac_from_player_id(self) -> str | None:
         """

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -247,17 +247,58 @@ async def test_set_members_polls_the_speakers_it_regrouped(timer_mass: MusicAssi
     assert _pending_polls(timer_mass) == sorted([_poll_id(study), _poll_id(hallway)])
 
 
-async def test_grouping_failure_is_reported_as_a_player_command_failure(
+async def test_join_failure_names_the_speaker_that_refused(
     timer_mass: MusicAssistant,
 ) -> None:
-    """A speaker that refuses to join surfaces as a typed player command failure."""
+    """A speaker that refuses to join is named in the failure, not the group leader."""
     kitchen = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
     study = _make_player(timer_mass, "RINCON_000E58BBBBBB01400", "Study")
     cast("MagicMock", timer_mass.players).get_player.side_effect = {study.player_id: study}.get
     study.soco.join.side_effect = SoCoException("the speaker refused to join")
 
-    with pytest.raises(PlayerCommandFailed, match="Kitchen"):
+    with pytest.raises(PlayerCommandFailed, match="Study") as exc_info:
         await kitchen.set_members(player_ids_to_add=[study.player_id])
+
+    assert "Kitchen" not in str(exc_info.value)
+
+
+async def test_grouping_leaves_the_speakers_after_a_failure_untouched(
+    timer_mass: MusicAssistant,
+) -> None:
+    """Speakers joined before a failure keep their poll, the ones after it are never reached."""
+    kitchen = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    study = _make_player(timer_mass, "RINCON_000E58BBBBBB01400", "Study")
+    hallway = _make_player(timer_mass, "RINCON_000E58CCCCCC01400", "Hallway")
+    attic = _make_player(timer_mass, "RINCON_000E58DDDDDD01400", "Attic")
+    cast("MagicMock", timer_mass.players).get_player.side_effect = {
+        study.player_id: study,
+        hallway.player_id: hallway,
+        attic.player_id: attic,
+    }.get
+    hallway.soco.join.side_effect = SoCoException("the speaker refused to join")
+
+    with pytest.raises(PlayerCommandFailed, match="Hallway"):
+        await kitchen.set_members(
+            player_ids_to_add=[study.player_id, hallway.player_id, attic.player_id]
+        )
+
+    assert _pending_polls(timer_mass) == [_poll_id(study)]
+    attic.soco.join.assert_not_called()
+
+
+async def test_unjoin_failure_names_the_speaker_that_refused(
+    timer_mass: MusicAssistant,
+) -> None:
+    """A speaker that refuses to leave a group is named in the failure, not the group leader."""
+    kitchen = _make_player(timer_mass, "RINCON_000E58AAAAAA01400", "Kitchen")
+    study = _make_player(timer_mass, "RINCON_000E58BBBBBB01400", "Study")
+    cast("MagicMock", timer_mass.players).get_player.side_effect = {study.player_id: study}.get
+    study.soco.unjoin.side_effect = SoCoException("the speaker refused to leave")
+
+    with pytest.raises(PlayerCommandFailed, match="Study") as exc_info:
+        await kitchen.set_members(player_ids_to_remove=[study.player_id])
+
+    assert "Kitchen" not in str(exc_info.value)
 
 
 async def test_unload_cancels_the_pending_poll(timer_mass: MusicAssistant) -> None:


### PR DESCRIPTION
# What does this implement/fix?

When grouping Sonos S1 speakers fails, the log named the wrong speaker. Grouping is driven from the group leader, but it joins and unjoins the *other* speakers, so a speaker refusing to join was reported against the leader:

`Error calling SonosPlayer.set_members on Kitchen: <error>` — while Study was the one that actually refused.

Only the server log is affected; the error shown in the UI is unchanged.

- Join and unjoin now run as their own methods on the speaker being (un)grouped, so the error names that speaker.
- Added tests covering both the join and unjoin failure paths.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
