### PR TITLE
Better default player icons

### DIFF
--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -652,6 +652,13 @@ class PlayerConfigMixin:
             # only audio/protocol specific ones
             return []
 
+        icon_entry = deepcopy(
+            CONF_ENTRY_PLAYER_ICON_GROUP
+            if player.state.type == PlayerType.GROUP
+            else CONF_ENTRY_PLAYER_ICON
+        )
+        icon_entry.default_value = player.default_icon
+
         # some base entries for all player types
         # note that these may NOT be playback/audio related
         entries += [
@@ -687,12 +694,12 @@ class PlayerConfigMixin:
         # group-player config entries
         if player.state.type == PlayerType.GROUP:
             entries += [
-                CONF_ENTRY_PLAYER_ICON_GROUP,
+                icon_entry,
             ]
             return entries
         # normal player (or stereo pair) config entries
         entries += [
-            CONF_ENTRY_PLAYER_ICON,
+            icon_entry,
             # add default entries for announce feature
             CONF_ENTRY_ANNOUNCE_VOLUME_STRATEGY,
             CONF_ENTRY_ANNOUNCE_VOLUME,

--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -54,6 +54,7 @@ from music_assistant.constants import (
     CONF_ENTRY_TTS_PRE_ANNOUNCE,
     CONF_EXPOSE_PLAYER_TO_HA,
     CONF_HIDE_IN_UI,
+    CONF_ICON,
     CONF_MUTE_CONTROL,
     CONF_PLAYER_DSP,
     CONF_PLAYERS,
@@ -98,6 +99,40 @@ def _first_enabled_control_value(options: list[ConfigValueOption]) -> ConfigValu
         if not option.disabled:
             return option.value
     return PLAYER_CONTROL_NONE
+
+
+def _reconcile_player_icon_value(
+    submitted_values: dict[str, ConfigValueType],
+    stored_values: dict[str, Any],
+    new_values: dict[str, ConfigValueType],
+) -> bool:
+    """Persist explicit icon selections while keeping None as automatic selection."""
+    stored_icon = stored_values.get(CONF_ICON)
+    has_explicit_icon = isinstance(stored_icon, str) and bool(stored_icon)
+    if CONF_ICON not in submitted_values:
+        if has_explicit_icon:
+            new_values[CONF_ICON] = stored_icon
+        else:
+            new_values.pop(CONF_ICON, None)
+        return False
+
+    submitted_icon = submitted_values[CONF_ICON]
+    if isinstance(submitted_icon, str) and submitted_icon:
+        new_values[CONF_ICON] = submitted_icon
+        return not has_explicit_icon or submitted_icon != stored_icon
+
+    new_values.pop(CONF_ICON, None)
+    return has_explicit_icon
+
+
+def _apply_raw_player_icon_value(
+    config: PlayerConfig,
+    raw_values: dict[str, Any],
+) -> None:
+    """Apply the stored icon value to a parsed player config."""
+    if icon_entry := config.values.get(CONF_ICON):
+        stored_icon = raw_values.get(CONF_ICON)
+        icon_entry.value = stored_icon if isinstance(stored_icon, str) and stored_icon else None
 
 
 class PlayerConfigMixin:
@@ -200,6 +235,7 @@ class PlayerConfigMixin:
                 raw_conf.setdefault("player_id", player_id)
 
             conf = cast("PlayerConfig", PlayerConfig.parse(config_entries, raw_conf))
+            _apply_raw_player_icon_value(conf, raw_conf.get("values", {}))
             # parse() stamps every entry with this player's owner; injected protocol entries
             # belong to their own protocol provider, so restore that owner for string resolution.
             for entry in conf.values.values():
@@ -438,17 +474,13 @@ class PlayerConfigMixin:
     ) -> PlayerConfig:
         """Save/update PlayerConfig."""
         values = await self._update_output_protocol_config(values)
-        config = await self.get_player_config(player_id)
-        changed_keys = config.update(values)
-        if not changed_keys:
-            # no changes
-            return config
-        # store updated config first (to prevent issues with enabling/disabling players)
         conf_key = f"{CONF_PLAYERS}/{player_id}"
-        # Get existing raw config to preserve values that don't have config entries.
-        # e.g. protocol links etc.
         existing_raw = self.get(conf_key) or {}
         existing_values = existing_raw.get("values", {})
+        if values.get(CONF_ICON) is None and CONF_ICON not in existing_values:
+            values = {key: value for key, value in values.items() if key != CONF_ICON}
+        config = await self.get_player_config(player_id)
+        changed_keys = config.update(values)
         new_raw = config.to_raw()
         new_values = new_raw.get("values", {})
         # Preserve values from storage that don't have config entries in current context.
@@ -462,6 +494,13 @@ class PlayerConfigMixin:
         new_values = {
             key: value for key, value in new_values.items() if CONF_PROTOCOL_KEY_SPLITTER not in key
         }
+        if _reconcile_player_icon_value(values, existing_values, new_values):
+            changed_keys.add(f"values/{CONF_ICON}")
+        _apply_raw_player_icon_value(config, new_values)
+        if not changed_keys:
+            # no changes
+            return config
+        # store updated config first (to prevent issues with enabling/disabling players)
         new_raw["values"] = new_values
         self.set(conf_key, new_raw)
         try:
@@ -658,6 +697,7 @@ class PlayerConfigMixin:
             else CONF_ENTRY_PLAYER_ICON
         )
         icon_entry.default_value = player.default_icon
+        icon_entry.value = self.get_raw_player_config_value(player.player_id, CONF_ICON)
 
         # some base entries for all player types
         # note that these may NOT be playback/audio related

--- a/music_assistant/helpers/player.py
+++ b/music_assistant/helpers/player.py
@@ -1,0 +1,74 @@
+"""Helpers for player behavior."""
+
+from music_assistant_models.enums import PlayerType
+
+_DEFAULT_ICONS_BY_PROVIDER = {
+    "airplay": "airplay",
+    "chromecast": "cast",
+    "fully_kiosk": "tablet",
+    "msx_bridge": "tv",
+    "roku_media_assistant": "tv",
+    "sonos": "sonos",
+    "sonos_s1": "sonos",
+    "wiim": "wiim",
+}
+
+_DEFAULT_ICONS_BY_PLAYER_TYPE = {
+    PlayerType.DISPLAY: "monitor",
+    PlayerType.LIGHT: "sun",
+    PlayerType.VISUALIZER: "monitor",
+}
+
+_DEFAULT_ICON_MATCHES = (
+    ("homepod-mini", ("homepod",)),
+    ("apple-tv", ("apple tv", "appletv")),
+    (
+        "google-nest",
+        ("google home", "google nest", "nest audio", "nest hub", "nest mini"),
+    ),
+    ("voice-pe", ("home assistant voice", "voice pe", "voice preview edition")),
+    ("sonos", ("sonos",)),
+    ("wiim", ("wiim",)),
+    ("soundbar", ("sound bar", "soundbar")),
+    ("tv", (" tv", "smarttv", "television")),
+    ("monitor", ("web browser",)),
+    ("laptop", ("laptop", "notebook")),
+    ("smartphone", ("iphone", "mobile application", "smartphone")),
+    ("tablet", ("ipad", "tablet")),
+    ("headphones", ("earbud", "headphone", "headset")),
+    ("bluetooth", ("bluetooth",)),
+    ("radio", ("radio",)),
+    ("car", ("carplay",)),
+)
+
+
+def get_default_player_icon(
+    player_type: PlayerType,
+    provider_domain: str,
+    manufacturer: str,
+    model: str,
+) -> str:
+    """
+    Return the most appropriate default icon for a player.
+
+    :param player_type: The player's functional type.
+    :param provider_domain: The domain of the player provider.
+    :param manufacturer: The device manufacturer reported by the provider.
+    :param model: The device model reported by the provider.
+    """
+    if player_type in (PlayerType.GROUP, PlayerType.STEREO_PAIR):
+        return "speakers"
+    if player_type_icon := _DEFAULT_ICONS_BY_PLAYER_TYPE.get(player_type):
+        return player_type_icon
+
+    if manufacturer.casefold().startswith("apple") and model.casefold().startswith(("imac", "mac")):
+        return "mac"
+
+    device_description = f"{manufacturer} {model}".casefold()
+    for icon, matches in _DEFAULT_ICON_MATCHES:
+        if any(match in device_description for match in matches):
+            return icon
+
+    if provider_icon := _DEFAULT_ICONS_BY_PROVIDER.get(provider_domain):
+        return provider_icon
+    return "speaker"

--- a/music_assistant/helpers/player.py
+++ b/music_assistant/helpers/player.py
@@ -45,8 +45,8 @@ _DEFAULT_ICON_MATCHES = (
 def get_default_player_icon(
     player_type: PlayerType,
     provider_domain: str,
-    manufacturer: str,
-    model: str,
+    manufacturer: str | None,
+    model: str | None,
 ) -> str:
     """
     Return the most appropriate default icon for a player.
@@ -61,10 +61,12 @@ def get_default_player_icon(
     if player_type_icon := _DEFAULT_ICONS_BY_PLAYER_TYPE.get(player_type):
         return player_type_icon
 
-    if manufacturer.casefold().startswith("apple") and model.casefold().startswith(("imac", "mac")):
+    manufacturer_name = (manufacturer or "").casefold()
+    model_name = (model or "").casefold()
+    if manufacturer_name.startswith("apple") and model_name.startswith(("imac", "mac")):
         return "mac"
 
-    device_description = f"{manufacturer} {model}".casefold()
+    device_description = f"{manufacturer_name} {model_name}"
     for icon, matches in _DEFAULT_ICON_MATCHES:
         if any(match in device_description for match in matches):
             return icon

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -132,7 +132,7 @@ MEDIA_IDENTITY_KEYS = frozenset(
 # config-derived cached properties (propcache keys in Player._cache); these are
 # only invalidated by set_config, all other cached properties (including those
 # defined by player implementations) are invalidated on every update_state call
-_CONFIG_CACHED_PROPS = frozenset({"icon", "hide_in_ui", "expose_to_ha"})
+_CONFIG_CACHED_PROPS = frozenset({"hide_in_ui", "expose_to_ha"})
 
 _DEFAULT_ICONS_BY_PROVIDER = {
     "airplay": "airplay",
@@ -163,7 +163,7 @@ _DEFAULT_ICON_MATCHES = (
     ("wiim", ("wiim",)),
     ("soundbar", ("sound bar", "soundbar")),
     ("tv", (" tv", "smarttv", "television")),
-    ("monitor", ("monitor", "web browser")),
+    ("monitor", ("web browser",)),
     ("laptop", ("laptop", "notebook")),
     ("smartphone", ("iphone", "mobile application", "smartphone")),
     ("tablet", ("ipad", "tablet")),
@@ -190,6 +190,8 @@ def _get_default_player_icon(
     """
     if player_type in (PlayerType.GROUP, PlayerType.STEREO_PAIR):
         return "speakers"
+    if player_type_icon := _DEFAULT_ICONS_BY_PLAYER_TYPE.get(player_type):
+        return player_type_icon
 
     if manufacturer.casefold().startswith("apple") and model.casefold().startswith(("imac", "mac")):
         return "mac"
@@ -201,7 +203,7 @@ def _get_default_player_icon(
 
     if provider_icon := _DEFAULT_ICONS_BY_PROVIDER.get(provider_domain):
         return provider_icon
-    return _DEFAULT_ICONS_BY_PLAYER_TYPE.get(player_type, "speaker")
+    return "speaker"
 
 
 def _reconcile_position_anchor(
@@ -1431,9 +1433,10 @@ class Player(ABC):
     @final
     def icon(self) -> str:
         """Return the player icon."""
-        # players without an icon config entry (e.g. protocol players) serve the fallback id
-        icon = self._config.get_value(CONF_ENTRY_PLAYER_ICON.key)
-        return cast("str", icon or self.default_icon)
+        icon = self.mass.config.get_raw_player_config_value(
+            self.player_id, CONF_ENTRY_PLAYER_ICON.key
+        )
+        return icon if isinstance(icon, str) and icon else self.default_icon
 
     @cached_property
     @final

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -134,6 +134,75 @@ MEDIA_IDENTITY_KEYS = frozenset(
 # defined by player implementations) are invalidated on every update_state call
 _CONFIG_CACHED_PROPS = frozenset({"icon", "hide_in_ui", "expose_to_ha"})
 
+_DEFAULT_ICONS_BY_PROVIDER = {
+    "airplay": "airplay",
+    "chromecast": "cast",
+    "fully_kiosk": "tablet",
+    "msx_bridge": "tv",
+    "roku_media_assistant": "tv",
+    "sonos": "sonos",
+    "sonos_s1": "sonos",
+    "wiim": "wiim",
+}
+
+_DEFAULT_ICONS_BY_PLAYER_TYPE = {
+    PlayerType.DISPLAY: "monitor",
+    PlayerType.LIGHT: "sun",
+    PlayerType.VISUALIZER: "monitor",
+}
+
+_DEFAULT_ICON_MATCHES = (
+    ("homepod-mini", ("homepod",)),
+    ("apple-tv", ("apple tv", "appletv")),
+    (
+        "google-nest",
+        ("google home", "google nest", "nest audio", "nest hub", "nest mini"),
+    ),
+    ("voice-pe", ("home assistant voice", "voice pe", "voice preview edition")),
+    ("sonos", ("sonos",)),
+    ("wiim", ("wiim",)),
+    ("soundbar", ("sound bar", "soundbar")),
+    ("tv", (" tv", "smarttv", "television")),
+    ("monitor", ("monitor", "web browser")),
+    ("laptop", ("laptop", "notebook")),
+    ("smartphone", ("iphone", "mobile application", "smartphone")),
+    ("tablet", ("ipad", "tablet")),
+    ("headphones", ("earbud", "headphone", "headset")),
+    ("bluetooth", ("bluetooth",)),
+    ("radio", ("radio",)),
+    ("car", ("carplay",)),
+)
+
+
+def _get_default_player_icon(
+    player_type: PlayerType,
+    provider_domain: str,
+    manufacturer: str,
+    model: str,
+) -> str:
+    """
+    Return the most appropriate default icon for a player.
+
+    :param player_type: The player's functional type.
+    :param provider_domain: The domain of the player provider.
+    :param manufacturer: The device manufacturer reported by the provider.
+    :param model: The device model reported by the provider.
+    """
+    if player_type in (PlayerType.GROUP, PlayerType.STEREO_PAIR):
+        return "speakers"
+
+    if manufacturer.casefold().startswith("apple") and model.casefold().startswith(("imac", "mac")):
+        return "mac"
+
+    device_description = f"{manufacturer} {model}".casefold()
+    for icon, matches in _DEFAULT_ICON_MATCHES:
+        if any(match in device_description for match in matches):
+            return icon
+
+    if provider_icon := _DEFAULT_ICONS_BY_PROVIDER.get(provider_domain):
+        return provider_icon
+    return _DEFAULT_ICONS_BY_PLAYER_TYPE.get(player_type, "speaker")
+
 
 def _reconcile_position_anchor(
     prev_position: float | None,
@@ -1206,6 +1275,17 @@ class Player(ABC):
         # default implementation will simply trigger an update for the state of the player
         self.mass.players.trigger_player_update(self.player_id)
 
+    @cached_property
+    @final
+    def default_icon(self) -> str:
+        """Return the default player icon."""
+        return _get_default_player_icon(
+            self.type,
+            self.provider.domain,
+            self.device_info.manufacturer,
+            self.device_info.model,
+        )
+
     def _on_player_media_updated(self) -> None:  # noqa: B027
         """Handle callback when the current media of the player is updated."""
         # optional callback for players that want to be informed when the final
@@ -1353,7 +1433,7 @@ class Player(ABC):
         """Return the player icon."""
         # players without an icon config entry (e.g. protocol players) serve the fallback id
         icon = self._config.get_value(CONF_ENTRY_PLAYER_ICON.key)
-        return cast("str", icon or CONF_ENTRY_PLAYER_ICON.default_value)
+        return cast("str", icon or self.default_icon)
 
     @cached_property
     @final

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -63,6 +63,7 @@ from music_assistant.constants import (
     PROTOCOL_FEATURES,
     PROTOCOL_PRIORITY,
 )
+from music_assistant.helpers.player import get_default_player_icon
 from music_assistant.helpers.util import html_to_markdown
 
 if TYPE_CHECKING:
@@ -133,77 +134,6 @@ MEDIA_IDENTITY_KEYS = frozenset(
 # only invalidated by set_config, all other cached properties (including those
 # defined by player implementations) are invalidated on every update_state call
 _CONFIG_CACHED_PROPS = frozenset({"hide_in_ui", "expose_to_ha"})
-
-_DEFAULT_ICONS_BY_PROVIDER = {
-    "airplay": "airplay",
-    "chromecast": "cast",
-    "fully_kiosk": "tablet",
-    "msx_bridge": "tv",
-    "roku_media_assistant": "tv",
-    "sonos": "sonos",
-    "sonos_s1": "sonos",
-    "wiim": "wiim",
-}
-
-_DEFAULT_ICONS_BY_PLAYER_TYPE = {
-    PlayerType.DISPLAY: "monitor",
-    PlayerType.LIGHT: "sun",
-    PlayerType.VISUALIZER: "monitor",
-}
-
-_DEFAULT_ICON_MATCHES = (
-    ("homepod-mini", ("homepod",)),
-    ("apple-tv", ("apple tv", "appletv")),
-    (
-        "google-nest",
-        ("google home", "google nest", "nest audio", "nest hub", "nest mini"),
-    ),
-    ("voice-pe", ("home assistant voice", "voice pe", "voice preview edition")),
-    ("sonos", ("sonos",)),
-    ("wiim", ("wiim",)),
-    ("soundbar", ("sound bar", "soundbar")),
-    ("tv", (" tv", "smarttv", "television")),
-    ("monitor", ("web browser",)),
-    ("laptop", ("laptop", "notebook")),
-    ("smartphone", ("iphone", "mobile application", "smartphone")),
-    ("tablet", ("ipad", "tablet")),
-    ("headphones", ("earbud", "headphone", "headset")),
-    ("bluetooth", ("bluetooth",)),
-    ("radio", ("radio",)),
-    ("car", ("carplay",)),
-)
-
-
-def _get_default_player_icon(
-    player_type: PlayerType,
-    provider_domain: str,
-    manufacturer: str,
-    model: str,
-) -> str:
-    """
-    Return the most appropriate default icon for a player.
-
-    :param player_type: The player's functional type.
-    :param provider_domain: The domain of the player provider.
-    :param manufacturer: The device manufacturer reported by the provider.
-    :param model: The device model reported by the provider.
-    """
-    if player_type in (PlayerType.GROUP, PlayerType.STEREO_PAIR):
-        return "speakers"
-    if player_type_icon := _DEFAULT_ICONS_BY_PLAYER_TYPE.get(player_type):
-        return player_type_icon
-
-    if manufacturer.casefold().startswith("apple") and model.casefold().startswith(("imac", "mac")):
-        return "mac"
-
-    device_description = f"{manufacturer} {model}".casefold()
-    for icon, matches in _DEFAULT_ICON_MATCHES:
-        if any(match in device_description for match in matches):
-            return icon
-
-    if provider_icon := _DEFAULT_ICONS_BY_PROVIDER.get(provider_domain):
-        return provider_icon
-    return "speaker"
 
 
 def _reconcile_position_anchor(
@@ -1281,7 +1211,7 @@ class Player(ABC):
     @final
     def default_icon(self) -> str:
         """Return the default player icon."""
-        return _get_default_player_icon(
+        return get_default_player_icon(
             self.type,
             self.provider.domain,
             self.device_info.manufacturer,

--- a/tests/models/test_player_icons.py
+++ b/tests/models/test_player_icons.py
@@ -1,0 +1,98 @@
+"""Tests for player icon defaults and overrides."""
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import PlayerType
+from music_assistant_models.player import DeviceInfo
+
+from music_assistant.constants import CONF_ICON
+from music_assistant.mass import MusicAssistant
+from tests.common import MockPlayer, MockProvider
+
+
+@pytest.mark.parametrize(
+    ("player_type", "provider_domain", "manufacturer", "model", "expected"),
+    [
+        (PlayerType.GROUP, "sonos", "Sonos", "Arc", "speakers"),
+        (PlayerType.STEREO_PAIR, "test", "Unknown", "Unknown", "speakers"),
+        (PlayerType.PLAYER, "sonos", "Unknown", "Unknown", "sonos"),
+        (PlayerType.PLAYER, "hass_players", "Sonos", "Era 100", "sonos"),
+        (PlayerType.PLAYER, "wiim", "Linkplay", "Unknown", "wiim"),
+        (PlayerType.PLAYER, "airplay", "Apple", "Apple TV 4K Gen2", "apple-tv"),
+        (PlayerType.PLAYER, "airplay", "Apple", "HomePod", "homepod-mini"),
+        (PlayerType.PLAYER, "airplay", "Apple", "Mac14,3", "mac"),
+        (
+            PlayerType.PLAYER,
+            "chromecast",
+            "Google Inc.",
+            "Google Nest Mini",
+            "google-nest",
+        ),
+        (PlayerType.PLAYER, "chromecast", "Google Inc.", "Chromecast Audio", "cast"),
+        (
+            PlayerType.PLAYER,
+            "hass_players",
+            "Nabu Casa",
+            "Home Assistant Voice Preview Edition",
+            "voice-pe",
+        ),
+        (PlayerType.PLAYER, "fully_kiosk", "Samsung", "SM-X700", "tablet"),
+        (PlayerType.PLAYER, "roku_media_assistant", "Roku", "Ultra", "tv"),
+        (PlayerType.PLAYER, "test", "Samsung", "HW-Q990 Soundbar", "soundbar"),
+        (PlayerType.PLAYER, "test", "Unknown", "Bluetooth Speaker", "bluetooth"),
+        (PlayerType.DISPLAY, "sendspin", "Unknown", "Unknown", "monitor"),
+        (PlayerType.VISUALIZER, "sendspin", "Unknown", "Unknown", "monitor"),
+        (PlayerType.LIGHT, "hue_entertainment", "Signify", "Hue", "sun"),
+        (PlayerType.PLAYER, "test", "Unknown", "Unknown", "speaker"),
+    ],
+)
+def test_default_player_icon(
+    player_type: PlayerType,
+    provider_domain: str,
+    manufacturer: str,
+    model: str,
+    expected: str,
+) -> None:
+    """The player type, provider, and device metadata select a useful default icon."""
+    player = MockPlayer(
+        MockProvider(provider_domain),
+        "test_player",
+        "Test Player",
+        player_type=player_type,
+    )
+    player._attr_device_info = DeviceInfo(manufacturer=manufacturer, model=model)
+    cast("MagicMock", player.config.get_value).return_value = None
+    player._cache.clear()
+
+    assert player.icon == expected
+
+
+def test_explicit_player_icon_overrides_default() -> None:
+    """An explicitly configured icon always wins over the computed default."""
+    player = MockPlayer(MockProvider("airplay"), "apple_tv", "Apple TV")
+    player._attr_device_info = DeviceInfo(manufacturer="Apple", model="Apple TV 4K")
+    cast("MagicMock", player.config.get_value).return_value = "living-room"
+    player._cache.clear()
+
+    assert player.icon == "living-room"
+
+
+async def test_unset_icon_config_uses_player_default(mass_minimal: MusicAssistant) -> None:
+    """An unset stored icon resolves to the player's computed config default."""
+    player = MagicMock()
+    player.state.type = PlayerType.PLAYER
+    player.default_icon = "sonos"
+    player.hidden_by_default = False
+    player.expose_to_ha_by_default = True
+    player.linked_output_protocols = []
+    player.supports_feature.return_value = False
+    mass_minimal.players = MagicMock()
+    mass_minimal.players.player_controls.return_value = []
+
+    entries = mass_minimal.config._get_default_player_config_entries(player)
+    icon_entry = next(entry for entry in entries if entry.key == CONF_ICON)
+
+    assert icon_entry.default_value == "sonos"
+    assert icon_entry.parse_value(None) == "sonos"

--- a/tests/models/test_player_icons.py
+++ b/tests/models/test_player_icons.py
@@ -8,6 +8,7 @@ from music_assistant_models.enums import PlayerType
 from music_assistant_models.player import DeviceInfo
 
 from music_assistant.constants import CONF_ICON, CONF_PLAYERS
+from music_assistant.helpers.player import get_default_player_icon
 from music_assistant.mass import MusicAssistant
 from tests.common import MockPlayer, MockProvider
 
@@ -69,6 +70,11 @@ def test_default_player_icon(
     player._cache.clear()
 
     assert player.icon == expected
+
+
+def test_default_player_icon_tolerates_missing_device_metadata() -> None:
+    """Missing metadata on restored players falls back safely."""
+    assert get_default_player_icon(PlayerType.PLAYER, "test", None, None) == "speaker"
 
 
 def test_explicit_player_icon_overrides_default() -> None:

--- a/tests/models/test_player_icons.py
+++ b/tests/models/test_player_icons.py
@@ -1,13 +1,13 @@
 """Tests for player icon defaults and overrides."""
 
 from typing import cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import PlayerType
 from music_assistant_models.player import DeviceInfo
 
-from music_assistant.constants import CONF_ICON
+from music_assistant.constants import CONF_ICON, CONF_PLAYERS
 from music_assistant.mass import MusicAssistant
 from tests.common import MockPlayer, MockProvider
 
@@ -42,6 +42,8 @@ from tests.common import MockPlayer, MockProvider
         (PlayerType.PLAYER, "roku_media_assistant", "Roku", "Ultra", "tv"),
         (PlayerType.PLAYER, "test", "Samsung", "HW-Q990 Soundbar", "soundbar"),
         (PlayerType.PLAYER, "test", "Unknown", "Bluetooth Speaker", "bluetooth"),
+        (PlayerType.PLAYER, "test", "Monitor Audio", "Creator 90", "speaker"),
+        (PlayerType.PLAYER, "test", "Unknown", "Studio Monitor", "speaker"),
         (PlayerType.DISPLAY, "sendspin", "Unknown", "Unknown", "monitor"),
         (PlayerType.VISUALIZER, "sendspin", "Unknown", "Unknown", "monitor"),
         (PlayerType.LIGHT, "hue_entertainment", "Signify", "Hue", "sun"),
@@ -63,7 +65,7 @@ def test_default_player_icon(
         player_type=player_type,
     )
     player._attr_device_info = DeviceInfo(manufacturer=manufacturer, model=model)
-    cast("MagicMock", player.config.get_value).return_value = None
+    cast("MagicMock", player.mass.config.get_raw_player_config_value).return_value = None
     player._cache.clear()
 
     assert player.icon == expected
@@ -73,15 +75,29 @@ def test_explicit_player_icon_overrides_default() -> None:
     """An explicitly configured icon always wins over the computed default."""
     player = MockPlayer(MockProvider("airplay"), "apple_tv", "Apple TV")
     player._attr_device_info = DeviceInfo(manufacturer="Apple", model="Apple TV 4K")
-    cast("MagicMock", player.config.get_value).return_value = "living-room"
+    cast("MagicMock", player.mass.config.get_raw_player_config_value).return_value = "living-room"
     player._cache.clear()
 
     assert player.icon == "living-room"
 
 
+def test_automatic_player_icon_refreshes_with_device_info() -> None:
+    """An automatic icon follows device information learned after initialization."""
+    player = MockPlayer(MockProvider("test"), "late_metadata", "Late metadata")
+    cast("MagicMock", player.mass.config.get_raw_player_config_value).return_value = None
+
+    assert player.icon == "speaker"
+
+    player._attr_device_info = DeviceInfo(manufacturer="Sonos", model="Era 100")
+    player.update_state(signal_event=False)
+
+    assert player.icon == "sonos"
+
+
 async def test_unset_icon_config_uses_player_default(mass_minimal: MusicAssistant) -> None:
     """An unset stored icon resolves to the player's computed config default."""
     player = MagicMock()
+    player.player_id = "test_player"
     player.state.type = PlayerType.PLAYER
     player.default_icon = "sonos"
     player.hidden_by_default = False
@@ -96,3 +112,121 @@ async def test_unset_icon_config_uses_player_default(mass_minimal: MusicAssistan
 
     assert icon_entry.default_value == "sonos"
     assert icon_entry.parse_value(None) == "sonos"
+
+
+async def test_unset_icon_config_exposes_automatic_state(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """An absent stored icon stays None while the computed default is provided separately."""
+    _set_up_config_player(mass_minimal)
+
+    config = await mass_minimal.config.get_player_config("test_player")
+
+    assert config.values[CONF_ICON].value is None
+    assert config.values[CONF_ICON].default_value == "sonos"
+
+
+async def test_explicit_default_icon_remains_explicit(mass_minimal: MusicAssistant) -> None:
+    """A stored icon remains explicit even when it equals the computed default."""
+    mass_minimal.config.set(
+        f"{CONF_PLAYERS}/test_player",
+        {
+            "player_id": "test_player",
+            "provider": "sonos",
+            "player_type": PlayerType.PLAYER,
+            "values": {CONF_ICON: "sonos"},
+        },
+    )
+    _set_up_config_player(mass_minimal)
+
+    config = await mass_minimal.config.get_player_config("test_player")
+
+    assert config.values[CONF_ICON].value == "sonos"
+    assert config.values[CONF_ICON].default_value == "sonos"
+
+    await mass_minimal.config.save_player_config(
+        "test_player",
+        {CONF_ICON: "sonos", "hide_in_ui": True},
+    )
+    stored_values = mass_minimal.config.get(f"{CONF_PLAYERS}/test_player/values")
+    assert stored_values[CONF_ICON] == "sonos"
+
+
+async def test_automatic_icon_stays_unset_on_unrelated_save(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A stale automatic icon cannot become an explicit choice during a config save."""
+    _set_up_config_player(mass_minimal)
+
+    await mass_minimal.config.save_player_config(
+        "test_player",
+        {CONF_ICON: None, "hide_in_ui": True},
+    )
+
+    stored_values = mass_minimal.config.get(f"{CONF_PLAYERS}/test_player/values")
+    assert CONF_ICON not in stored_values
+
+
+async def test_explicit_icon_lifecycle(mass_minimal: MusicAssistant) -> None:
+    """Explicit icons survive unrelated saves, can change to the default, and can reset."""
+    mass_minimal.config.set(
+        f"{CONF_PLAYERS}/test_player",
+        {
+            "player_id": "test_player",
+            "provider": "sonos",
+            "player_type": PlayerType.PLAYER,
+            "values": {CONF_ICON: "speaker"},
+        },
+    )
+    _set_up_config_player(mass_minimal)
+
+    await mass_minimal.config.save_player_config(
+        "test_player",
+        {CONF_ICON: "speaker", "hide_in_ui": True},
+    )
+    stored_values = mass_minimal.config.get(f"{CONF_PLAYERS}/test_player/values")
+    assert stored_values[CONF_ICON] == "speaker"
+
+    await mass_minimal.config.save_player_config("test_player", {CONF_ICON: "sonos"})
+    stored_values = mass_minimal.config.get(f"{CONF_PLAYERS}/test_player/values")
+    assert stored_values[CONF_ICON] == "sonos"
+
+    await mass_minimal.config.save_player_config("test_player", {CONF_ICON: None})
+    stored_values = mass_minimal.config.get(f"{CONF_PLAYERS}/test_player/values")
+    assert CONF_ICON not in stored_values
+    callback = cast("AsyncMock", mass_minimal.players.on_player_config_change)
+    assert callback.await_args is not None
+    callback_config = callback.await_args.args[0]
+    assert callback_config.values[CONF_ICON].value is None
+
+
+def _set_up_config_player(mass: MusicAssistant) -> None:
+    """Set up a player mock that drives the real player config parsing path."""
+    if not mass.config.get(f"{CONF_PLAYERS}/test_player"):
+        mass.config.set(
+            f"{CONF_PLAYERS}/test_player",
+            {
+                "player_id": "test_player",
+                "provider": "sonos",
+                "player_type": PlayerType.PLAYER,
+                "values": {},
+            },
+        )
+    player = MagicMock()
+    player.player_id = "test_player"
+    player.state.type = PlayerType.PLAYER
+    player.state.name = "Test Player"
+    player.provider.instance_id = "sonos"
+    player.translation_owner = "provider.sonos"
+    player.default_icon = "sonos"
+    player.hidden_by_default = False
+    player.expose_to_ha_by_default = True
+    player.linked_output_protocols = []
+    player.output_protocols = []
+    player.supported_features = set()
+    player.supports_feature.return_value = False
+    player.get_config_entries = AsyncMock(return_value=[])
+    mass.players = MagicMock()
+    mass.players.get_player.return_value = player
+    mass.players.player_controls.return_value = []
+    mass.players.on_player_config_change = AsyncMock()


### PR DESCRIPTION
# What does this implement/fix?

Players without a custom icon currently fall back to the same generic speaker icons.

- Pick recognizable defaults from the player type, provider, and device details.
- Apply the improved default when no icon is configured without replacing custom choices.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
