### PR TITLE
Clean up library items left behind without a provider

### DIFF
--- a/music_assistant/controllers/music/database.py
+++ b/music_assistant/controllers/music/database.py
@@ -59,7 +59,9 @@ if TYPE_CHECKING:
     from music_assistant import MusicAssistant
     from music_assistant.controllers.music.media.albums import AlbumsController
     from music_assistant.controllers.music.media.artists import ArtistsController
+    from music_assistant.controllers.music.media.audiobooks import AudiobooksController
     from music_assistant.controllers.music.media.playlists import PlaylistController
+    from music_assistant.controllers.music.media.podcasts import PodcastsController
     from music_assistant.controllers.music.media.radio import RadioController
     from music_assistant.controllers.music.media.tracks import TracksController
 
@@ -79,7 +81,8 @@ class MusicDatabaseSetupMixin:
     - mass: MusicAssistant instance
     - logger: logging.Logger instance
     - database: the active DatabaseConnection
-    - the per-media-type controllers (albums, artists, tracks, playlists, radio, genres)
+    - the per-media-type controllers (albums, artists, tracks, playlists, radio,
+      podcasts, audiobooks, genres)
     - close() and start_sync() methods
     """
 
@@ -93,6 +96,8 @@ class MusicDatabaseSetupMixin:
         tracks: TracksController
         playlists: PlaylistController
         radio: RadioController
+        podcasts: PodcastsController
+        audiobooks: AudiobooksController
         genres: GenreController
 
         @property
@@ -121,6 +126,8 @@ class MusicDatabaseSetupMixin:
             self.tracks,
             self.playlists,
             self.radio,
+            self.podcasts,
+            self.audiobooks,
         ):
             update_current_task_progress_text(f"Cleaning {ctrl.media_type.value} library records")
             # Provider mappings where the db item is removed

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -1091,6 +1091,19 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             # edge case: already deleted / race condition
             return
 
+        remaining_mappings = {
+            x
+            for x in library_item.provider_mappings
+            if not (x.provider_instance == provider_instance_id and x.item_id == provider_item_id)
+        }
+        if not remaining_mappings:
+            # this was the last mapping, so remove the entire library item, which also
+            # clears its provider mapping rows. Dropping those rows up front would leave
+            # the item behind without any mappings if the removal itself fails.
+            with suppress(MediaNotFoundError):
+                await self.remove_item_from_library(db_id)
+            return
+
         # update provider_mappings table
         await self.mass.music.database.delete(
             DB_TABLE_PROVIDER_MAPPINGS,
@@ -1110,33 +1123,24 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 "provider": provider_instance_id,
             },
         )
-        library_item.provider_mappings = {
-            x
-            for x in library_item.provider_mappings
-            if not (x.provider_instance == provider_instance_id and x.item_id == provider_item_id)
-        }
-        if library_item.provider_mappings:
-            # if this was the last mapping for the provider instance, strip any artwork
-            # that belonged to it (e.g. local file paths that are no longer resolvable)
-            images_changed = not any(
-                x.provider_instance == provider_instance_id for x in library_item.provider_mappings
-            ) and await self._remove_provider_images(db_id, provider_instance_id)
-            self.logger.debug(
-                "removed provider_mapping %s/%s from item id %s",
-                provider_instance_id,
-                provider_item_id,
-                db_id,
-            )
-            # the removed provider mapping is itself a change to the item, so always notify
-            # (unless suppressed during a bulk cleanup); re-fetch first when images were
-            # stripped so the event payload stays accurate
-            if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
-                event_item = await self.get_library_item(db_id) if images_changed else library_item
-                self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, event_item.uri, event_item)
-        else:
-            # remove item if it has no more providers
-            with suppress(AssertionError):
-                await self.remove_item_from_library(db_id)
+        library_item.provider_mappings = remaining_mappings
+        # if this was the last mapping for the provider instance, strip any artwork
+        # that belonged to it (e.g. local file paths that are no longer resolvable)
+        images_changed = not any(
+            x.provider_instance == provider_instance_id for x in remaining_mappings
+        ) and await self._remove_provider_images(db_id, provider_instance_id)
+        self.logger.debug(
+            "removed provider_mapping %s/%s from item id %s",
+            provider_instance_id,
+            provider_item_id,
+            db_id,
+        )
+        # the removed provider mapping is itself a change to the item, so always notify
+        # (unless suppressed during a bulk cleanup); re-fetch first when images were
+        # stripped so the event payload stays accurate
+        if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
+            event_item = await self.get_library_item(db_id) if images_changed else library_item
+            self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, event_item.uri, event_item)
 
     @final
     async def remove_provider_mappings(self, item_id: str | int, provider_instance_id: str) -> None:
@@ -1145,8 +1149,28 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         try:
             library_item = await self.get_library_item(db_id)
         except MediaNotFoundError:
-            # edge case: already deleted / race condition
-            library_item = None
+            # edge case: already deleted / race condition, just drop any leftover rows
+            await self.mass.music.database.delete(
+                DB_TABLE_PROVIDER_MAPPINGS,
+                {
+                    "media_type": self.media_type.value,
+                    "item_id": db_id,
+                    "provider_instance": provider_instance_id,
+                },
+            )
+            return
+
+        remaining_mappings = {
+            x for x in library_item.provider_mappings if x.provider_instance != provider_instance_id
+        }
+        if not remaining_mappings:
+            # these were the last mappings, so remove the entire library item, which also
+            # clears its provider mapping rows. Dropping those rows up front would leave
+            # the item behind without any mappings if the removal itself fails.
+            with suppress(MediaNotFoundError):
+                await self.remove_item_from_library(db_id)
+            return
+
         # update provider_mappings table
         await self.mass.music.database.delete(
             DB_TABLE_PROVIDER_MAPPINGS,
@@ -1156,32 +1180,22 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 "provider_instance": provider_instance_id,
             },
         )
-        if library_item is None:
-            return
-        # update the item's provider mappings (and check if we still have any)
-        library_item.provider_mappings = {
-            x for x in library_item.provider_mappings if x.provider_instance != provider_instance_id
-        }
-        if library_item.provider_mappings:
-            # the item is kept (it still has other providers), but it may carry artwork
-            # that belonged to the removed provider (e.g. local file paths that are no
-            # longer resolvable), so strip those images from the stored metadata
-            images_changed = await self._remove_provider_images(db_id, provider_instance_id)
-            self.logger.debug(
-                "removed all provider mappings for provider %s from item id %s",
-                provider_instance_id,
-                db_id,
-            )
-            # the removed provider mapping(s) are themselves a change to the item, so
-            # always notify (unless suppressed during a bulk cleanup); re-fetch first when
-            # images were stripped so the event payload stays accurate
-            if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
-                event_item = await self.get_library_item(db_id) if images_changed else library_item
-                self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, event_item.uri, event_item)
-        else:
-            # remove item if it has no more providers
-            with suppress(AssertionError):
-                await self.remove_item_from_library(db_id)
+        library_item.provider_mappings = remaining_mappings
+        # the item is kept (it still has other providers), but it may carry artwork
+        # that belonged to the removed provider (e.g. local file paths that are no
+        # longer resolvable), so strip those images from the stored metadata
+        images_changed = await self._remove_provider_images(db_id, provider_instance_id)
+        self.logger.debug(
+            "removed all provider mappings for provider %s from item id %s",
+            provider_instance_id,
+            db_id,
+        )
+        # the removed provider mapping(s) are themselves a change to the item, so
+        # always notify (unless suppressed during a bulk cleanup); re-fetch first when
+        # images were stripped so the event payload stays accurate
+        if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
+            event_item = await self.get_library_item(db_id) if images_changed else library_item
+            self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, event_item.uri, event_item)
 
     @final
     async def set_provider_mappings(
@@ -1853,6 +1867,12 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
     @final
     def _select_provider_id(self, library_item: ItemCls) -> tuple[str, str]:
         """Select the correct provider id to use for fetching the item."""
+        if not library_item.provider_mappings:
+            msg = (
+                f"{self.media_type.value} {library_item.item_id} "
+                "is no longer available on any provider"
+            )
+            raise MediaNotFoundError(msg)
         user = get_current_user()
         user_provider_filter = user.provider_filter if user and user.provider_filter else None
         if not user_provider_filter:

--- a/tests/controllers/music/test_provider_cleanup.py
+++ b/tests/controllers/music/test_provider_cleanup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -9,6 +10,7 @@ from music_assistant_models.enums import EventType, ImageType
 from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
 from music_assistant_models.media_items import (
     Artist,
+    Audiobook,
     MediaItemImage,
     Playlist,
     Podcast,
@@ -17,6 +19,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.constants import DB_TABLE_PROVIDER_MAPPINGS
+from music_assistant.controllers.music.media.base import MediaControllerBase
 from music_assistant.mass import MusicAssistant
 
 FS_INSTANCE = "filesystem_local--AbCd"
@@ -270,9 +273,53 @@ async def test_failed_item_removal_keeps_provider_mapping(mass: MusicAssistant) 
     assert {pm.provider_instance for pm in updated.provider_mappings} == {FS_INSTANCE}
 
 
+async def test_failed_item_removal_keeps_single_provider_mapping(mass: MusicAssistant) -> None:
+    """The same applies when the item's last individual mapping is removed."""
+    artists = mass.music.artists
+    fs_only = Artist(
+        item_id="fsonly",
+        provider=FS_INSTANCE,
+        name="Filesystem Only Artist",
+        provider_mappings={
+            ProviderMapping(
+                item_id="fsonly",
+                provider_domain="filesystem_local",
+                provider_instance=FS_INSTANCE,
+            )
+        },
+    )
+    db_artist = await artists.add_item_to_library(fs_only)
+    db_id = int(db_artist.item_id)
+
+    with (
+        patch.object(
+            artists, "remove_item_from_library", AsyncMock(side_effect=MusicAssistantError("boom"))
+        ),
+        pytest.raises(MusicAssistantError),
+    ):
+        await artists.remove_provider_mapping(db_id, FS_INSTANCE, "fsonly")
+
+    updated = await artists.get_library_item(db_id)
+    assert {pm.provider_instance for pm in updated.provider_mappings} == {FS_INSTANCE}
+
+
+async def _assert_orphan_is_pruned(
+    mass: MusicAssistant, controller: MediaControllerBase[Any], db_id: int
+) -> None:
+    """Strip an item's provider mapping rows and assert the periodic cleanup removes it."""
+    await mass.music.database.delete(
+        DB_TABLE_PROVIDER_MAPPINGS,
+        {"media_type": controller.media_type.value, "item_id": db_id},
+    )
+
+    await mass.music._cleanup_database()
+
+    with pytest.raises(MediaNotFoundError):
+        await controller.get_library_item(db_id)
+
+
 async def test_database_cleanup_removes_orphaned_podcasts(mass: MusicAssistant) -> None:
-    """Podcasts and audiobooks without any provider mapping are cleaned up."""
-    podcasts = mass.music.podcasts
+    """A podcast without any provider mapping is cleaned up."""
     podcast = Podcast(
         item_id="show1",
         provider=FS_INSTANCE,
@@ -283,18 +330,24 @@ async def test_database_cleanup_removes_orphaned_podcasts(mass: MusicAssistant) 
             )
         },
     )
-    db_podcast = await podcasts.add_item_to_library(podcast)
-    db_id = int(db_podcast.item_id)
-    # simulate an item that lost its provider mapping rows without being removed
-    await mass.music.database.delete(
-        DB_TABLE_PROVIDER_MAPPINGS,
-        {"media_type": podcasts.media_type.value, "item_id": db_id},
+    db_item = await mass.music.podcasts.add_item_to_library(podcast)
+    await _assert_orphan_is_pruned(mass, mass.music.podcasts, int(db_item.item_id))
+
+
+async def test_database_cleanup_removes_orphaned_audiobooks(mass: MusicAssistant) -> None:
+    """An audiobook without any provider mapping is cleaned up."""
+    audiobook = Audiobook(
+        item_id="book1",
+        provider=FS_INSTANCE,
+        name="Orphaned Book",
+        provider_mappings={
+            ProviderMapping(
+                item_id="book1", provider_domain="filesystem_local", provider_instance=FS_INSTANCE
+            )
+        },
     )
-
-    await mass.music._cleanup_database()
-
-    with pytest.raises(MediaNotFoundError):
-        await podcasts.get_library_item(db_id)
+    db_item = await mass.music.audiobooks.add_item_to_library(audiobook)
+    await _assert_orphan_is_pruned(mass, mass.music.audiobooks, int(db_item.item_id))
 
 
 async def test_item_without_provider_mappings_raises_media_not_found(

--- a/tests/controllers/music/test_provider_cleanup.py
+++ b/tests/controllers/music/test_provider_cleanup.py
@@ -6,14 +6,17 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from music_assistant_models.enums import EventType, ImageType
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
 from music_assistant_models.media_items import (
     Artist,
     MediaItemImage,
+    Playlist,
+    Podcast,
     ProviderMapping,
     UniqueList,
 )
 
+from music_assistant.constants import DB_TABLE_PROVIDER_MAPPINGS
 from music_assistant.mass import MusicAssistant
 
 FS_INSTANCE = "filesystem_local--AbCd"
@@ -234,3 +237,90 @@ async def test_remove_provider_mappings_emits_event_without_image_changes(
     # payload reflects the removed mapping
     assert len(events) == 1
     assert {pm.provider_instance for pm in events[0].provider_mappings} == {STREAM_INSTANCE}
+
+
+async def test_failed_item_removal_keeps_provider_mapping(mass: MusicAssistant) -> None:
+    """A failing library removal must not leave the item behind without any providers."""
+    artists = mass.music.artists
+    fs_only = Artist(
+        item_id="fsonly",
+        provider=FS_INSTANCE,
+        name="Filesystem Only Artist",
+        provider_mappings={
+            ProviderMapping(
+                item_id="fsonly",
+                provider_domain="filesystem_local",
+                provider_instance=FS_INSTANCE,
+            )
+        },
+    )
+    db_artist = await artists.add_item_to_library(fs_only)
+    db_id = int(db_artist.item_id)
+
+    with (
+        patch.object(
+            artists, "remove_item_from_library", AsyncMock(side_effect=MusicAssistantError("boom"))
+        ),
+        pytest.raises(MusicAssistantError),
+    ):
+        await artists.remove_provider_mappings(db_id, FS_INSTANCE)
+
+    # the item survives *with* its mapping, so the removal can be retried
+    updated = await artists.get_library_item(db_id)
+    assert {pm.provider_instance for pm in updated.provider_mappings} == {FS_INSTANCE}
+
+
+async def test_database_cleanup_removes_orphaned_podcasts(mass: MusicAssistant) -> None:
+    """Podcasts and audiobooks without any provider mapping are cleaned up."""
+    podcasts = mass.music.podcasts
+    podcast = Podcast(
+        item_id="show1",
+        provider=FS_INSTANCE,
+        name="Orphaned Show",
+        provider_mappings={
+            ProviderMapping(
+                item_id="show1", provider_domain="filesystem_local", provider_instance=FS_INSTANCE
+            )
+        },
+    )
+    db_podcast = await podcasts.add_item_to_library(podcast)
+    db_id = int(db_podcast.item_id)
+    # simulate an item that lost its provider mapping rows without being removed
+    await mass.music.database.delete(
+        DB_TABLE_PROVIDER_MAPPINGS,
+        {"media_type": podcasts.media_type.value, "item_id": db_id},
+    )
+
+    await mass.music._cleanup_database()
+
+    with pytest.raises(MediaNotFoundError):
+        await podcasts.get_library_item(db_id)
+
+
+async def test_item_without_provider_mappings_raises_media_not_found(
+    mass: MusicAssistant,
+) -> None:
+    """An item that lost all its providers reports a clean 'not found' error."""
+    playlists = mass.music.playlists
+    playlist = Playlist(
+        item_id="pl1",
+        provider=FS_INSTANCE,
+        name="Orphaned Playlist",
+        owner="tester",
+        is_editable=False,
+        provider_mappings={
+            ProviderMapping(
+                item_id="pl1", provider_domain="filesystem_local", provider_instance=FS_INSTANCE
+            )
+        },
+    )
+    db_playlist = await playlists.add_item_to_library(playlist)
+    db_id = int(db_playlist.item_id)
+    await mass.music.database.delete(
+        DB_TABLE_PROVIDER_MAPPINGS,
+        {"media_type": playlists.media_type.value, "item_id": db_id},
+    )
+
+    with pytest.raises(MediaNotFoundError):
+        async for _ in playlists.tracks(str(db_id), "library"):
+            pass


### PR DESCRIPTION
# What does this implement/fix?

When a music provider is removed, its items are stripped from the library one by one. The provider mapping rows were deleted *before* the library item itself, so if removing the item then failed, the item stayed behind with no provider attached to it. Such an item can never be played and is not picked up by the retry, because that retry only looks at the (already deleted) mapping rows.

On top of that, the daily cleanup that removes these leftovers never covered podcasts and audiobooks, so those stayed in the library forever. Opening one resulted in a confusing internal error instead of a clear "not found" message.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Remove the library item first and let that clear its provider mappings, so a failed removal leaves the item intact and can simply be retried.
- Include podcasts and audiobooks in the periodic cleanup of leftover library items.
- Report a clear "not found" error for a library item that has no provider left, instead of an internal error.
- As a side effect, play history and audio analysis records belonging to the removed provider are now properly cleaned up too.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
