### PR TITLE
Remove an unused internal helper from the music controller

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -104,7 +104,7 @@ from music_assistant.helpers.datetime import (
 from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.helpers.tags import split_artists
 from music_assistant.helpers.uri import parse_uri
-from music_assistant.helpers.util import TaskManager, parse_optional_bool, parse_title_and_version
+from music_assistant.helpers.util import parse_optional_bool, parse_title_and_version
 from music_assistant.models.core_controller import CoreController
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.plugin import PluginProvider
@@ -1201,16 +1201,6 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         # perform full metadata scan
         await self.mass.metadata.update_metadata(library_item, overwrite_existing)
         return library_item
-
-    async def refresh_items(self, items: list[MediaItemType]) -> None:
-        """
-        Refresh MediaItems to force retrieval of full info and matches.
-
-        Creates background tasks to process the action.
-        """
-        async with TaskManager(self.mass) as tg:
-            for media_item in items:
-                tg.create_task(self.refresh_item(media_item))
 
     @api_command("music/refresh_item", required_scope=Scope.LIBRARY_MANAGE)
     async def refresh_item(  # noqa: PLR0915


### PR DESCRIPTION
# What does this implement/fix?

`MusicController.refresh_items` was never called from anywhere and was not exposed as an API command, so it could not be reached at all. Removing it keeps the music controller easier to reason about — in particular it was the only place that fanned out over the media matching paths without any concurrency limit, which made reasoning about those paths harder than it needed to be.

Verified unreachable before removing: no call sites anywhere in the repo, no `@api_command` decorator (API commands are registered by decorator scan only, and the music controller registers nothing by hand), no dynamic/name-based dispatch, and no references in the bundled frontend — which uses the singular `music/refresh_item` instead. That command stays exactly as it was.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Removed the unused `refresh_items` helper from the music controller.
- Dropped the now-unused `TaskManager` import from that module.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
