### PR TITLE
Fix player not coming back after disabling and removing it

### DIFF
--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -1418,15 +1418,24 @@ def _migrate_bluesound_http_profile(data: dict[str, Any]) -> bool:
 
 def _migrate_orphaned_disabled_protocol_configs(data: dict[str, Any]) -> bool:
     """
-    Remove disabled protocol player configs that no longer have a parent player.
+    Remove disabled protocol player configs that no longer belong to a player.
 
-    A protocol player is only ever presented as part of its parent player, so a disabled
-    config that outlived its parent keeps the device from registering again while offering
-    no way to enable it.
+    A protocol player is only ever presented as part of the player that owns it, so a
+    disabled config that outlived its owner keeps the device from registering again while
+    offering no way to enable it.
     """
     all_player_configs = data.get(CONF_PLAYERS, {})
     if not isinstance(all_player_configs, dict):
         return False
+    linked_ids: set[str] = set()
+    for player_cfg in all_player_configs.values():
+        if not isinstance(player_cfg, dict):
+            continue
+        player_values = player_cfg.get("values")
+        if not isinstance(player_values, dict):
+            continue
+        if isinstance(cached_ids := player_values.get(CONF_LINKED_PROTOCOL_IDS), list):
+            linked_ids.update(cached_ids)
     orphaned: list[str] = []
     for player_id, player_cfg in all_player_configs.items():
         if not isinstance(player_cfg, dict):
@@ -1435,11 +1444,14 @@ def _migrate_orphaned_disabled_protocol_configs(data: dict[str, Any]) -> bool:
             continue
         if player_cfg.get("enabled", True):
             continue
-        player_values = player_cfg.get("values")
-        if not isinstance(player_values, dict):
+        # a player owns a protocol player from either side of the link
+        if player_id in linked_ids:
             continue
-        parent_id = player_values.get(CONF_PROTOCOL_PARENT_ID)
-        if not parent_id or parent_id in all_player_configs:
+        player_values = player_cfg.get("values")
+        parent_id = (
+            player_values.get(CONF_PROTOCOL_PARENT_ID) if isinstance(player_values, dict) else None
+        )
+        if parent_id in all_player_configs:
             continue
         orphaned.append(player_id)
     dsp_configs = data.get(CONF_PLAYER_DSP)

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -7,7 +7,7 @@ from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.constants import PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_NONE
-from music_assistant_models.enums import CrossfadeMode, PlayerType
+from music_assistant_models.enums import CrossfadeMode
 from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.constants import (
@@ -1431,7 +1431,7 @@ def _migrate_orphaned_disabled_protocol_configs(data: dict[str, Any]) -> bool:
     for player_id, player_cfg in all_player_configs.items():
         if not isinstance(player_cfg, dict):
             continue
-        if player_cfg.get("player_type") != PlayerType.PROTOCOL:
+        if player_cfg.get("player_type") != "protocol":
             continue
         if player_cfg.get("enabled", True):
             continue

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -7,7 +7,7 @@ from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.constants import PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_NONE
-from music_assistant_models.enums import CrossfadeMode
+from music_assistant_models.enums import CrossfadeMode, PlayerType
 from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.constants import (
@@ -614,6 +614,13 @@ async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
     # because BluOS only plays back correctly on the forced content length profile.
     # TODO: remove after 2.12 release
     if _migrate_bluesound_http_profile(data):
+        changed = True
+
+    # Drop disabled protocol player configs that lost their parent player: the device they
+    # belong to can never register again while such a config lingers, and it is not shown
+    # in the UI so there is no way to enable it again.
+    # TODO: remove after 2.12 release
+    if _migrate_orphaned_disabled_protocol_configs(data):
         changed = True
 
     return changed
@@ -1407,6 +1414,41 @@ def _migrate_bluesound_http_profile(data: dict[str, Any]) -> bool:
     if changed:
         LOGGER.info("Restored the required HTTP profile on the Bluesound player configuration(s)")
     return changed
+
+
+def _migrate_orphaned_disabled_protocol_configs(data: dict[str, Any]) -> bool:
+    """
+    Remove disabled protocol player configs that no longer have a parent player.
+
+    A protocol player is only ever presented as part of its parent player, so a disabled
+    config that outlived its parent keeps the device from registering again while offering
+    no way to enable it.
+    """
+    all_player_configs = data.get(CONF_PLAYERS, {})
+    if not isinstance(all_player_configs, dict):
+        return False
+    orphaned: list[str] = []
+    for player_id, player_cfg in all_player_configs.items():
+        if not isinstance(player_cfg, dict):
+            continue
+        if player_cfg.get("player_type") != PlayerType.PROTOCOL:
+            continue
+        if player_cfg.get("enabled", True):
+            continue
+        player_values = player_cfg.get("values")
+        if not isinstance(player_values, dict):
+            continue
+        parent_id = player_values.get(CONF_PROTOCOL_PARENT_ID)
+        if not parent_id or parent_id in all_player_configs:
+            continue
+        orphaned.append(player_id)
+    dsp_configs = data.get(CONF_PLAYER_DSP)
+    for player_id in orphaned:
+        del all_player_configs[player_id]
+        if isinstance(dsp_configs, dict):
+            dsp_configs.pop(player_id, None)
+        LOGGER.warning("Removed orphaned player configuration %s", player_id)
+    return bool(orphaned)
 
 
 def _migrate_bose_soundtouch_presets(data: dict[str, Any]) -> bool:

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -1435,7 +1435,7 @@ def _migrate_orphaned_disabled_protocol_configs(data: dict[str, Any]) -> bool:
         if not isinstance(player_values, dict):
             continue
         if isinstance(cached_ids := player_values.get(CONF_LINKED_PROTOCOL_IDS), list):
-            linked_ids.update(cached_ids)
+            linked_ids.update(pid for pid in cached_ids if isinstance(pid, str))
     orphaned: list[str] = []
     for player_id, player_cfg in all_player_configs.items():
         if not isinstance(player_cfg, dict):

--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -56,7 +56,6 @@ from music_assistant.constants import (
     CONF_HIDE_IN_UI,
     CONF_ICON,
     CONF_MUTE_CONTROL,
-    CONF_PLAYER_DSP,
     CONF_PLAYERS,
     CONF_POWER_CONTROL,
     CONF_PRE_ANNOUNCE_CHIME_URL,
@@ -523,7 +522,6 @@ class PlayerConfigMixin:
     async def remove_player_config(self, player_id: str) -> None:
         """Remove PlayerConfig."""
         conf_key = f"{CONF_PLAYERS}/{player_id}"
-        dsp_conf_key = f"{CONF_PLAYER_DSP}/{player_id}"
         player_config = self.get(conf_key)
         if not player_config:
             msg = f"Player configuration for {player_id} does not exist"
@@ -538,10 +536,8 @@ class PlayerConfigMixin:
             # tell the player manager to remove the player if its lingering around
             # set permanent to false otherwise we end up in an infinite loop
             await self.mass.players.unregister(player_id, permanent=False)
-        # remove the actual config if all of the above passed
-        self.remove(conf_key)
-        # Also remove the DSP config if it exists
-        self.remove(dsp_conf_key)
+        # all of the above passed, so wipe the config (incl. DSP and linked protocol players)
+        self.mass.players.delete_player_config(player_id)
 
     def set_player_default_name(self, player_id: str, default_name: str) -> None:
         """Set (or update) the default name for a player."""

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1646,9 +1646,9 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         """
         player_ids = [
             protocol_id
-            for protocol_id in self._get_cached_protocol_ids(player_id)
-            if self.get_player(protocol_id) is None
-            and self._get_cached_protocol_parent_id(protocol_id) == player_id
+            for protocol_id in self.mass.config.get(CONF_PLAYERS, {})
+            if self._get_cached_protocol_parent_id(protocol_id) == player_id
+            and self.get_player(protocol_id) is None
         ]
         player_ids.append(player_id)
         for pid in player_ids:

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1639,7 +1639,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         """
         Permanently delete a player's configuration.
 
-        Should only be called for players that are not registered by the player controller.
+        Only wipes the stored configuration, the player itself is not unregistered.
         The config of a linked protocol player is wiped along with it, so the device
         returns as a brand new player once it is discovered again. Protocol players that
         are still registered or that already moved to another parent keep their config.

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1640,12 +1640,20 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         Permanently delete a player's configuration.
 
         Should only be called for players that are not registered by the player controller.
+        The config of a linked protocol player is wiped along with it, so the device
+        returns as a brand new player once it is discovered again. Protocol players that
+        are still registered or that already moved to another parent keep their config.
         """
-        # we simply permanently delete the player by wiping its config
-        conf_key = f"{CONF_PLAYERS}/{player_id}"
-        dsp_conf_key = f"{CONF_PLAYER_DSP}/{player_id}"
-        for key in (conf_key, dsp_conf_key):
-            self.mass.config.remove(key)
+        player_ids = [
+            protocol_id
+            for protocol_id in self._get_cached_protocol_ids(player_id)
+            if self.get_player(protocol_id) is None
+            and self._get_cached_protocol_parent_id(protocol_id) == player_id
+        ]
+        player_ids.append(player_id)
+        for pid in player_ids:
+            for key in (f"{CONF_PLAYERS}/{pid}", f"{CONF_PLAYER_DSP}/{pid}"):
+                self.mass.config.remove(key)
 
     def scale_volume_to_device(self, player_id: str, logical_volume: int) -> int:
         """Scale logical volume (0-100) to device volume (min_volume-max_volume)."""

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -1109,6 +1109,29 @@ def _orphaned_protocol_data() -> dict[str, Any]:
                 "enabled": False,
                 "values": {"protocol_parent_id": "up_kitchen"},
             },
+            # only the parent side of the link survived
+            "ap_office": {
+                "player_id": "ap_office",
+                "provider": "airplay",
+                "player_type": "protocol",
+                "enabled": False,
+                "values": {},
+            },
+            "cast_office": {
+                "player_id": "cast_office",
+                "provider": "chromecast",
+                "player_type": "player",
+                "enabled": True,
+                "values": {"linked_protocol_ids": ["ap_office"]},
+            },
+            # neither side of the link survived
+            "ap_ghost": {
+                "player_id": "ap_ghost",
+                "provider": "airplay",
+                "player_type": "protocol",
+                "enabled": False,
+                "values": {},
+            },
             "up_kitchen": {
                 "player_id": "up_kitchen",
                 "provider": "universal_player",
@@ -1127,9 +1150,11 @@ def test_migrate_orphaned_disabled_protocol_configs() -> None:
     assert _migrate_orphaned_disabled_protocol_configs(data) is True
     assert "spb_esp32" not in data["players"]
     assert "spb_esp32" not in data["player_dsp"]
-    # the protocol player that still has its (disabled) parent is left alone
+    assert "ap_ghost" not in data["players"]
+    # protocol players that are still owned by a player are left alone
     assert "spb_kitchen" in data["players"]
     assert "spb_kitchen" in data["player_dsp"]
+    assert "ap_office" in data["players"]
     assert _migrate_orphaned_disabled_protocol_configs(data) is False
 
 
@@ -1137,6 +1162,7 @@ def test_migrate_orphaned_disabled_protocol_configs_keeps_enabled_players() -> N
     """An enabled protocol player is kept: it can register and find a new parent."""
     data = _orphaned_protocol_data()
     data["players"]["spb_esp32"]["enabled"] = True
+    data["players"]["ap_ghost"]["enabled"] = True
     assert _migrate_orphaned_disabled_protocol_configs(data) is False
     assert "spb_esp32" in data["players"]
 
@@ -1146,7 +1172,7 @@ def test_migrate_orphaned_disabled_protocol_configs_tolerates_malformed_data() -
     data: dict[str, Any] = {
         "players": {
             "p1": "not-a-dict",
-            "p2": {"player_id": "p2", "player_type": "protocol", "enabled": False, "values": None},
+            "p2": {"player_id": "p2", "player_type": "player", "enabled": False, "values": None},
             "p3": {"player_id": "p3", "player_type": "player", "enabled": False, "values": {}},
         }
     }

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -21,6 +21,7 @@ from music_assistant.controllers.config.migrations import (
     _migrate_airplay_receiver_ghost_players,
     _migrate_bluesound_http_profile,
     _migrate_bose_soundtouch_presets,
+    _migrate_orphaned_disabled_protocol_configs,
     _migrate_output_limiter,
     _migrate_player_icons,
     _migrate_player_setup_data,
@@ -1088,3 +1089,66 @@ def test_migrate_player_icons_tolerates_malformed_data() -> None:
     assert _migrate_player_icons(data) is False
     assert data["players"]["p3"]["values"]["icon"] is None
     assert data["players"]["p4"]["values"]["icon"] == 123
+
+
+def _orphaned_protocol_data() -> dict[str, Any]:
+    """Build a config store with a disabled protocol player whose parent was removed."""
+    return {
+        "players": {
+            "spb_esp32": {
+                "player_id": "spb_esp32",
+                "provider": "sendspin",
+                "player_type": "protocol",
+                "enabled": False,
+                "values": {"protocol_parent_id": "up_esp32"},
+            },
+            "spb_kitchen": {
+                "player_id": "spb_kitchen",
+                "provider": "sendspin",
+                "player_type": "protocol",
+                "enabled": False,
+                "values": {"protocol_parent_id": "up_kitchen"},
+            },
+            "up_kitchen": {
+                "player_id": "up_kitchen",
+                "provider": "universal_player",
+                "player_type": "player",
+                "enabled": False,
+                "values": {"linked_protocol_ids": ["spb_kitchen"]},
+            },
+        },
+        "player_dsp": {"spb_esp32": {"enabled": True}, "spb_kitchen": {"enabled": True}},
+    }
+
+
+def test_migrate_orphaned_disabled_protocol_configs() -> None:
+    """A disabled protocol player without a parent config is dropped, others are kept."""
+    data = _orphaned_protocol_data()
+    assert _migrate_orphaned_disabled_protocol_configs(data) is True
+    assert "spb_esp32" not in data["players"]
+    assert "spb_esp32" not in data["player_dsp"]
+    # the protocol player that still has its (disabled) parent is left alone
+    assert "spb_kitchen" in data["players"]
+    assert "spb_kitchen" in data["player_dsp"]
+    assert _migrate_orphaned_disabled_protocol_configs(data) is False
+
+
+def test_migrate_orphaned_disabled_protocol_configs_keeps_enabled_players() -> None:
+    """An enabled protocol player is kept: it can register and find a new parent."""
+    data = _orphaned_protocol_data()
+    data["players"]["spb_esp32"]["enabled"] = True
+    assert _migrate_orphaned_disabled_protocol_configs(data) is False
+    assert "spb_esp32" in data["players"]
+
+
+def test_migrate_orphaned_disabled_protocol_configs_tolerates_malformed_data() -> None:
+    """Non-dict player configs/values and non-protocol players are skipped."""
+    data: dict[str, Any] = {
+        "players": {
+            "p1": "not-a-dict",
+            "p2": {"player_id": "p2", "player_type": "protocol", "enabled": False, "values": None},
+            "p3": {"player_id": "p3", "player_type": "player", "enabled": False, "values": {}},
+        }
+    }
+    assert _migrate_orphaned_disabled_protocol_configs(data) is False
+    assert len(data["players"]) == 3

--- a/tests/controllers/config/test_remove_player_config.py
+++ b/tests/controllers/config/test_remove_player_config.py
@@ -1,0 +1,75 @@
+"""
+Regression tests for removing a player config with linked protocol players.
+
+Reproduces the case where a player is first disabled and then removed: disabling
+cascades to the linked protocol players, so none of them is registered anymore when
+the removal comes in. The leftover (disabled) protocol config is not shown anywhere
+and keeps the device from ever registering again.
+"""
+
+from unittest.mock import MagicMock
+
+from music_assistant.constants import CONF_PLAYER_DSP, CONF_PLAYERS
+from music_assistant.mass import MusicAssistant
+
+PARENT_ID = "up_esp32"
+PROTOCOL_ID = "spb_esp32"
+
+
+def _store_configs(mass: MusicAssistant, enabled: bool) -> None:
+    """Store a universal player config with a single linked protocol player."""
+    mass.config.set(
+        f"{CONF_PLAYERS}/{PARENT_ID}",
+        {
+            "player_id": PARENT_ID,
+            "provider": "universal_player",
+            "player_type": "player",
+            "enabled": enabled,
+            "values": {"linked_protocol_ids": [PROTOCOL_ID]},
+        },
+    )
+    mass.config.set(
+        f"{CONF_PLAYERS}/{PROTOCOL_ID}",
+        {
+            "player_id": PROTOCOL_ID,
+            "provider": "sendspin",
+            "player_type": "protocol",
+            "enabled": enabled,
+            "values": {"protocol_parent_id": PARENT_ID},
+        },
+    )
+    mass.config.set(f"{CONF_PLAYER_DSP}/{PROTOCOL_ID}", {"enabled": True})
+
+
+async def test_remove_wipes_unregistered_protocol_configs(mass: MusicAssistant) -> None:
+    """Removing a disabled player also wipes the config of its linked protocol player."""
+    _store_configs(mass, enabled=False)
+
+    await mass.config.remove_player_config(PARENT_ID)
+
+    assert mass.config.get(f"{CONF_PLAYERS}/{PARENT_ID}") is None
+    assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}") is None
+    assert mass.config.get(f"{CONF_PLAYER_DSP}/{PROTOCOL_ID}") is None
+
+
+async def test_remove_keeps_reparented_protocol_configs(mass: MusicAssistant) -> None:
+    """A protocol player that already moved to another parent keeps its config."""
+    _store_configs(mass, enabled=True)
+    mass.config.set(f"{CONF_PLAYERS}/{PROTOCOL_ID}/values/protocol_parent_id", "cast_1")
+
+    mass.players.delete_player_config(PARENT_ID)
+
+    assert mass.config.get(f"{CONF_PLAYERS}/{PARENT_ID}") is None
+    assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}") is not None
+
+
+async def test_remove_keeps_registered_protocol_configs(mass: MusicAssistant) -> None:
+    """A protocol player that is still registered keeps its config to be re-parented."""
+    _store_configs(mass, enabled=True)
+    mass.players._players[PROTOCOL_ID] = MagicMock()
+
+    mass.players.delete_player_config(PARENT_ID)
+
+    assert mass.config.get(f"{CONF_PLAYERS}/{PARENT_ID}") is None
+    assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}") is not None
+    assert mass.config.get(f"{CONF_PLAYER_DSP}/{PROTOCOL_ID}") is not None

--- a/tests/controllers/config/test_remove_player_config.py
+++ b/tests/controllers/config/test_remove_player_config.py
@@ -9,7 +9,7 @@ and keeps the device from ever registering again.
 
 from unittest.mock import MagicMock
 
-from music_assistant.constants import CONF_PLAYER_DSP, CONF_PLAYERS
+from music_assistant.constants import CONF_PLAYER_DSP, CONF_PLAYERS, CONF_PROTOCOL_PARENT_ID
 from music_assistant.mass import MusicAssistant
 
 PARENT_ID = "up_esp32"
@@ -35,7 +35,7 @@ def _store_configs(mass: MusicAssistant, enabled: bool) -> None:
             "provider": "sendspin",
             "player_type": "protocol",
             "enabled": enabled,
-            "values": {"protocol_parent_id": PARENT_ID},
+            "values": {CONF_PROTOCOL_PARENT_ID: PARENT_ID},
         },
     )
     mass.config.set(f"{CONF_PLAYER_DSP}/{PROTOCOL_ID}", {"enabled": True})
@@ -52,10 +52,22 @@ async def test_remove_wipes_unregistered_protocol_configs(mass: MusicAssistant) 
     assert mass.config.get(f"{CONF_PLAYER_DSP}/{PROTOCOL_ID}") is None
 
 
+async def test_remove_wipes_protocol_configs_with_a_half_broken_link(
+    mass: MusicAssistant,
+) -> None:
+    """A protocol player is wiped by its own parent reference, not by the parent's list."""
+    _store_configs(mass, enabled=False)
+    mass.config.set(f"{CONF_PLAYERS}/{PARENT_ID}/values/linked_protocol_ids", [])
+
+    await mass.config.remove_player_config(PARENT_ID)
+
+    assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}") is None
+
+
 async def test_remove_keeps_reparented_protocol_configs(mass: MusicAssistant) -> None:
     """A protocol player that already moved to another parent keeps its config."""
     _store_configs(mass, enabled=True)
-    mass.config.set(f"{CONF_PLAYERS}/{PROTOCOL_ID}/values/protocol_parent_id", "cast_1")
+    mass.config.set(f"{CONF_PLAYERS}/{PROTOCOL_ID}/values/{CONF_PROTOCOL_PARENT_ID}", "cast_1")
 
     mass.players.delete_player_config(PARENT_ID)
 


### PR DESCRIPTION
# What does this implement/fix?

Disabling a player and then removing it made the player disappear for good: it never came back, not even after a server restart or re-flashing the device.

Disabling a player also disables the protocol player(s) that belong to the same device, but removing the player only wiped its own configuration. The disabled protocol configuration stayed behind, which blocks the device from ever showing up again - and since those entries are never shown in the UI, there was no way to undo it other than hand-editing `settings.json`.

- removing a player now also wipes the configuration of the protocol players that belong to it
- protocol players that are still in use or already moved to another player keep their settings
- leftover entries from before this fix are cleaned up on startup, so affected devices return by themselves

**Related issue (if applicable):**

- reported on Discord

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
