### PR TITLE
Resolve OpenSubsonic search and top tracks without per-track lyrics fetches

### DIFF
--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -385,8 +385,11 @@ class OpenSonicProvider(MusicProvider):
             tr = []
             for entry in answer.song:
                 self._set_loudness(entry)
-                lyrics: tuple[str, bool] | None = await self.get_track_lyrics(entry)
-                tr.append(parse_track(self.logger, self.instance_id, entry, lyrics=lyrics))
+                # No per-track lyrics fetch here: lyrics are resolved on demand via
+                # get_track when a track is actually opened or played. Fetching them
+                # per result turned one search3 call into a serial getLyricsBySongId
+                # per hit, which dominates search time on a remote server.
+                tr.append(parse_track(self.logger, self.instance_id, entry))
         else:
             tr = []
 
@@ -720,8 +723,10 @@ class OpenSonicProvider(MusicProvider):
         tracks = []
         for entry in songs:
             self._set_loudness(entry)
-            lyrics: tuple[str, bool] | None = await self.get_track_lyrics(entry)
-            tracks.append(parse_track(self.logger, self.instance_id, entry, lyrics=lyrics))
+            # As in search: lyrics come from get_track on demand, so opening an
+            # artist costs one getTopSongs call rather than one extra request per
+            # track returned.
+            tracks.append(parse_track(self.logger, self.instance_id, entry))
         return tracks
 
     @use_cache(3600 * 3)  # cache for 3 hours

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -385,10 +385,6 @@ class OpenSonicProvider(MusicProvider):
             tr = []
             for entry in answer.song:
                 self._set_loudness(entry)
-                # No per-track lyrics fetch here: lyrics are resolved on demand via
-                # get_track when a track is actually opened or played. Fetching them
-                # per result turned one search3 call into a serial getLyricsBySongId
-                # per hit, which dominates search time on a remote server.
                 tr.append(parse_track(self.logger, self.instance_id, entry))
         else:
             tr = []
@@ -723,9 +719,6 @@ class OpenSonicProvider(MusicProvider):
         tracks = []
         for entry in songs:
             self._set_loudness(entry)
-            # As in search: lyrics come from get_track on demand, so opening an
-            # artist costs one getTopSongs call rather than one extra request per
-            # track returned.
             tracks.append(parse_track(self.logger, self.instance_id, entry))
         return tracks
 

--- a/tests/providers/opensubsonic/test_provider.py
+++ b/tests/providers/opensubsonic/test_provider.py
@@ -401,3 +401,77 @@ async def test_get_playlist_tracks_avoids_per_track_metadata_fetch(
     provider.conn.get_album_info2.assert_not_awaited()
     provider.conn.get_lyrics.assert_not_awaited()
     provider.conn.get_lyrics_by_song_id.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# search / get_artist_toptracks
+# ---------------------------------------------------------------------------
+
+
+def _force_cache_miss(provider: OpenSonicProvider) -> list[asyncio.Future[Any]]:
+    """Make a @use_cache method run its body, capturing the background store task."""
+    tasks, task_mock = _make_task_capturer()
+    provider.mass.cache.get_with_freshness = AsyncMock(  # type: ignore[method-assign]
+        return_value=(None, False, False)
+    )
+    provider.mass.cache.set = AsyncMock()  # type: ignore[method-assign]
+    provider.mass.create_task = task_mock  # type: ignore[method-assign]
+    return tasks
+
+
+@pytest.mark.asyncio
+async def test_search_avoids_per_track_lyrics_fetch(
+    provider: OpenSonicProvider, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Searching must not fetch lyrics per hit (avoids N+1 requests)."""
+    answer = Mock()
+    answer.artist = None
+    answer.album = None
+    answer.song = [_make_sonic_item(item_id=f"tr-{i}") for i in range(3)]
+
+    provider.conn = Mock()
+    provider.conn.search3 = AsyncMock(return_value=answer)
+    provider.conn.get_lyrics = AsyncMock()
+    provider.conn.get_lyrics_by_song_id = AsyncMock()
+
+    tasks = _force_cache_miss(provider)
+    monkeypatch.setattr(
+        "music_assistant.providers.opensubsonic.sonic_provider.parse_track",
+        _parse_track_stub,
+    )
+
+    result = await provider.search("query", [MediaType.TRACK], limit=3)
+    await asyncio.gather(*tasks)
+
+    assert len(result.tracks) == 3
+    provider.conn.search3.assert_awaited_once()
+    provider.conn.get_lyrics.assert_not_awaited()
+    provider.conn.get_lyrics_by_song_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_artist_toptracks_avoids_per_track_lyrics_fetch(
+    provider: OpenSonicProvider, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Opening an artist must not fetch lyrics per top track."""
+    provider.conn = Mock()
+    provider.conn.get_artist = AsyncMock(return_value=Mock(name="an-artist"))
+    provider.conn.get_top_songs = AsyncMock(
+        return_value=[_make_sonic_item(item_id=f"tr-{i}") for i in range(3)]
+    )
+    provider.conn.get_lyrics = AsyncMock()
+    provider.conn.get_lyrics_by_song_id = AsyncMock()
+
+    tasks = _force_cache_miss(provider)
+    monkeypatch.setattr(
+        "music_assistant.providers.opensubsonic.sonic_provider.parse_track",
+        _parse_track_stub,
+    )
+
+    result = await provider.get_artist_toptracks("ar-1")
+    await asyncio.gather(*tasks)
+
+    assert len(result) == 3
+    provider.conn.get_top_songs.assert_awaited_once()
+    provider.conn.get_lyrics.assert_not_awaited()
+    provider.conn.get_lyrics_by_song_id.assert_not_awaited()

--- a/tests/providers/opensubsonic/test_provider.py
+++ b/tests/providers/opensubsonic/test_provider.py
@@ -30,6 +30,17 @@ def _make_task_capturer() -> tuple[list[asyncio.Future[Any]], Mock]:
     return tasks, Mock(side_effect=_schedule)
 
 
+def _force_cache_miss(provider: OpenSonicProvider) -> list[asyncio.Future[Any]]:
+    """Make a @use_cache method run its body, capturing the background store task."""
+    tasks, task_mock = _make_task_capturer()
+    provider.mass.cache.get_with_freshness = AsyncMock(  # type: ignore[method-assign]
+        return_value=(None, False, False)
+    )
+    provider.mass.cache.set = AsyncMock()  # type: ignore[method-assign]
+    provider.mass.create_task = task_mock  # type: ignore[method-assign]
+    return tasks
+
+
 def _make_sonic_item(
     *,
     item_id: str = "tr-1",
@@ -376,14 +387,7 @@ async def test_get_playlist_tracks_avoids_per_track_metadata_fetch(
     provider.conn.get_lyrics = AsyncMock()
     provider.conn.get_lyrics_by_song_id = AsyncMock()
 
-    # force a cache miss so the real method body runs, and capture the background
-    # store task so its coroutine is awaited rather than left pending
-    tasks, task_mock = _make_task_capturer()
-    provider.mass.cache.get_with_freshness = AsyncMock(  # type: ignore[method-assign]
-        return_value=(None, False, False)
-    )
-    provider.mass.cache.set = AsyncMock()  # type: ignore[method-assign]
-    provider.mass.create_task = task_mock  # type: ignore[method-assign]
+    tasks = _force_cache_miss(provider)
 
     # parse_track has its own coverage in test_parsers; isolate the fetch behaviour here
     monkeypatch.setattr(
@@ -406,17 +410,6 @@ async def test_get_playlist_tracks_avoids_per_track_metadata_fetch(
 # ---------------------------------------------------------------------------
 # search / get_artist_toptracks
 # ---------------------------------------------------------------------------
-
-
-def _force_cache_miss(provider: OpenSonicProvider) -> list[asyncio.Future[Any]]:
-    """Make a @use_cache method run its body, capturing the background store task."""
-    tasks, task_mock = _make_task_capturer()
-    provider.mass.cache.get_with_freshness = AsyncMock(  # type: ignore[method-assign]
-        return_value=(None, False, False)
-    )
-    provider.mass.cache.set = AsyncMock()  # type: ignore[method-assign]
-    provider.mass.create_task = task_mock  # type: ignore[method-assign]
-    return tasks
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

`search` and `get_artist_toptracks` fetch lyrics for every entry inside the
enumeration loop, so a single `search3` or `getTopSongs` response fans out into a
serial `getLyricsBySongId` per result. On a server reached over a WAN this
dominates the call: a search matching a full page of songs takes around four
seconds longer than one that matches nothing.

Open Subsonic lyric support (#3424) added the fetch to every path that builds a
Track, `get_track` included. `MetadataController._get_track_lyrics` falls back to
`get_track` when a track carries no lyrics and the provider declares
`ProviderFeature.LYRICS`, which this provider does, so lyrics still resolve at the
point they are displayed. No other music provider fetches lyrics during search.

Follows #5359, applying the same change to the two remaining list paths that pass
only `lyrics=` and no `album=`. The paths that also pass an album are left alone.

**Related issue (if applicable):**

- none

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

Present in `stable` as well.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
