### PR TITLE
Let dependency bump merges trigger the stale-PR refresh

### DIFF
--- a/.github/workflows/auto-merge-dependency-updates.yml
+++ b/.github/workflows/auto-merge-dependency-updates.yml
@@ -14,6 +14,8 @@ on:
     paths:
       - pyproject.toml
       - requirements_all.txt
+  # Manual escape hatch to drain a stranded bump PR without a human merge commit
+  workflow_dispatch:
 
 env:
   EXPECTED_APP_BOT_LOGIN: musicassistant-bot[bot]
@@ -278,12 +280,37 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # The merge must be enabled with the App token: the merge actor is whoever
+      # enabled auto-merge, and GitHub never triggers workflows for pushes made by
+      # GITHUB_TOKEN, so the discover-stale job below would not run on the merge.
+      - name: Create merge token
+        id: merge_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.MUSIC_ASSISTANT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.MUSIC_ASSISTANT_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Verify GitHub App identity
+        env:
+          APP_SLUG: ${{ steps.merge_token.outputs.app-slug }}
+          INSTALLATION_ID: ${{ steps.merge_token.outputs.installation-id }}
+        run: |
+          if [ "$APP_SLUG" != "$EXPECTED_APP_SLUG" ] || \
+             [ "$INSTALLATION_ID" != "$EXPECTED_APP_INSTALLATION_ID" ]; then
+            echo "Unexpected GitHub App installation: $APP_SLUG/$INSTALLATION_ID" >&2
+            exit 1
+          fi
+
       # Enable auto-merge with squash
       - name: Enable auto-merge
         run: |
           gh pr merge "${{ steps.pr.outputs.number }}" -R "${{ github.repository }}" --auto --squash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.merge_token.outputs.token }}
 
       - name: Comment on success
         if: success()
@@ -295,7 +322,7 @@ jobs:
   # Re-cutting raises a synchronize event, which puts the PR back through the job above.
   discover-stale:
     name: Find stale dependency PRs
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
# What does this implement/fix?

#5499 added a `push`-on-`dev` trigger that re-cuts dependency bump PRs stranded by a merge conflict. It never fires: auto-merge is enabled with `GITHUB_TOKEN`, so the merge actor is `github-actions`, and GitHub suppresses workflow triggers for events caused by `GITHUB_TOKEN`. The workflow has zero `push`-event runs, and #5528 sat in conflict after #5527 merged.

- Enable auto-merge with a `musicassistant-bot` App token (same minting + identity check as `refresh-stale`), so the merge push triggers the refresh. Approval stays on `GITHUB_TOKEN` since the App cannot approve its own PR.
- Add a `workflow_dispatch` trigger as a manual drain for already-stranded PRs, and accept it in the `discover-stale` gate.

Note: bump merges to `dev` now also trigger the other `push` workflows (test, release drafter), which `GITHUB_TOKEN` merges silently suppressed.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
