### PR TITLE
Show dashboards on Fully Kiosk displays

### DIFF
--- a/music_assistant/providers/fully_kiosk/dashboard.py
+++ b/music_assistant/providers/fully_kiosk/dashboard.py
@@ -1,0 +1,132 @@
+"""Dashboard support for the Fully Kiosk Browser provider."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+from typing import TYPE_CHECKING
+
+from aiohttp import ClientError
+from fullykiosk.exceptions import FullyKioskError
+from music_assistant_models.dashboard import DashboardDevice
+from music_assistant_models.enums import DashboardType
+from music_assistant_models.errors import PlayerCommandFailed, PlayerUnavailableError
+
+from .player import FullyKioskPlayer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .provider import FullyKioskProvider
+
+# Fully Kiosk's webview can show any dashboard route, so all types are supported.
+SUPPORTED_DASHBOARD_TYPES = {
+    DashboardType.NOW_PLAYING,
+    DashboardType.PARTY,
+    DashboardType.MUSIC_QUIZ,
+}
+
+
+class FullyKioskDashboards:
+    """Registers connected Fully Kiosk devices as dashboard endpoints and drives their webview."""
+
+    def __init__(self, provider: FullyKioskProvider) -> None:
+        """
+        Initialize dashboard handling for a Fully Kiosk provider.
+
+        :param provider: The Fully Kiosk provider owning the managed devices.
+        """
+        self.provider = provider
+        self.mass = provider.mass
+        self.logger = provider.logger.getChild("dashboard")
+        self._unregister_callbacks: dict[str, Callable[[], None]] = {}
+        self._unloaded = False
+
+    def register(self, player: FullyKioskPlayer) -> None:
+        """
+        Register (or refresh) a connected player as a dashboard endpoint.
+
+        A no-op once the provider has unloaded or the player itself is gone,
+        closing a race with a late connect resolving after unload or removal.
+
+        :param player: The connected Fully Kiosk player to register.
+        """
+        if self._unloaded:
+            return
+        # a connect awaiting the device response may resolve after the player was
+        # removed; never resurrect an endpoint for it
+        if self.mass.players.get_player(player.player_id) is not player:
+            return
+        device = DashboardDevice(
+            dashboard_id=player.player_id,
+            name=player.display_name,
+            supported_types=set(SUPPORTED_DASHBOARD_TYPES),
+            provider_domain_hint=self.provider.domain,
+        )
+        self._unregister_callbacks[player.player_id] = (
+            self.mass.dashboard.register_dashboard_handler(
+                device,
+                functools.partial(self._on_show, player.player_id),
+                functools.partial(self._on_hide, player.player_id),
+            )
+        )
+
+    def unregister(self, player_id: str) -> None:
+        """
+        Drop a player's dashboard registration.
+
+        :param player_id: The player whose registration to drop.
+        """
+        if unregister_callback := self._unregister_callbacks.pop(player_id, None):
+            unregister_callback()
+
+    async def unload(self) -> None:
+        """Unregister all dashboard endpoints owned by this provider."""
+        self._unloaded = True
+        for unregister_callback in list(self._unregister_callbacks.values()):
+            unregister_callback()
+        self._unregister_callbacks.clear()
+
+    async def _on_show(
+        self, player_id: str, dashboard: DashboardType, target_player_id: str | None
+    ) -> None:
+        """Wake a Fully Kiosk device and load a Music Assistant dashboard in its webview."""
+        player = self.mass.players.get_player(player_id)
+        if not isinstance(player, FullyKioskPlayer) or player.fully_kiosk is None:
+            raise PlayerUnavailableError(f"Fully Kiosk device {player_id} is no longer available")
+        client = player.fully_kiosk
+        url = await self.mass.dashboard.resolve_dashboard_url(
+            dashboard, target_player_id, prefer_local=True
+        )
+        # never log the resolved url: it embeds a one-time viewer code
+        self.logger.debug("Showing %s dashboard on %s", dashboard.value, player.display_name)
+        try:
+            async with asyncio.timeout(15):
+                await client.screenOn()
+                await client.stopScreensaver()
+                await client.toForeground()
+                await client.loadUrl(url)
+        except FullyKioskError, ClientError, TimeoutError:
+            # never chain the caught error: its repr may embed the request url with the password
+            raise PlayerUnavailableError(
+                f"Unable to show the dashboard on {player.display_name}",
+                translation_key="show_dashboard_failed",
+                translation_owner=self.provider.translation_owner,
+                translation_args=[player.display_name],
+            ) from None
+
+    async def _on_hide(self, player_id: str) -> None:
+        """Return a Fully Kiosk device's webview to its configured start page."""
+        player = self.mass.players.get_player(player_id)
+        if not isinstance(player, FullyKioskPlayer) or player.fully_kiosk is None:
+            # nothing connected to this device: it can't be showing a dashboard
+            return
+        client = player.fully_kiosk
+        try:
+            async with asyncio.timeout(15):
+                await client.loadStartUrl()
+        except FullyKioskError, ClientError, TimeoutError:
+            # never chain the caught error: its repr may embed the request url with the password
+            raise PlayerCommandFailed(
+                f"Unable to hide the dashboard on {player.display_name}"
+            ) from None

--- a/music_assistant/providers/fully_kiosk/player.py
+++ b/music_assistant/providers/fully_kiosk/player.py
@@ -33,6 +33,7 @@ from music_assistant.models.setup_flow import SetupFlowError
 if TYPE_CHECKING:
     from music_assistant.models.setup_flow import SetupSession
 
+    from .dashboard import FullyKioskDashboards
     from .provider import FullyKioskProvider
 
 AUDIOMANAGER_STREAM_MUSIC = 3
@@ -134,6 +135,7 @@ class FullyKioskPlayer(Player):
             self._attr_needs_setup = True
             self._attr_setup_reason = "password_required"
             self._attr_available = False
+            self._dashboards.unregister(self.player_id)
             self.update_state()
             return
         await self._connect()
@@ -169,6 +171,7 @@ class FullyKioskPlayer(Player):
             )
             self._attr_available = False
             self.fully_kiosk = None
+            self._dashboards.unregister(self.player_id)
             self.update_state()
             return
         self._sync_state()
@@ -207,6 +210,11 @@ class FullyKioskPlayer(Player):
         self._attr_playback_state = PlaybackState.PLAYING
         self.update_state()
 
+    async def on_unload(self) -> None:
+        """Handle logic when the player is unloaded from the Player controller."""
+        await super().on_unload()
+        self._dashboards.unregister(self.player_id)
+
     async def _connect(self) -> None:
         """Establish a connection to the Fully Kiosk device."""
         password = cast("str | None", self.get_setup_value(CONF_PASSWORD) or None)
@@ -215,42 +223,17 @@ class FullyKioskPlayer(Player):
             self._attr_setup_reason = "password_required"
             self._attr_available = False
             self.fully_kiosk = None
+            self._dashboards.unregister(self.player_id)
             self.update_state()
             return
 
-        use_ssl = bool(self.config.get_value(CONF_USE_SSL))
-        fingerprint_value = self.config.get_value(CONF_SSL_FINGERPRINT)
-        fingerprint_raw = fingerprint_value.strip() if isinstance(fingerprint_value, str) else ""
-        if fingerprint_raw and not use_ssl:
-            self.logger.warning(
-                "Fully Kiosk %s: fingerprint validation requires HTTPS to be enabled",
-                self.host,
-            )
+        session_info = self._resolve_http_session()
+        if session_info is None:
             self._attr_available = False
+            self._dashboards.unregister(self.player_id)
             self.update_state()
             return
-
-        verify_ssl = bool(self.config.get_value(CONF_VERIFY_SSL)) if use_ssl else False
-        http_session: ClientSession | _FingerprintSessionWrapper
-        if use_ssl:
-            if fingerprint_raw:
-                try:
-                    fingerprint = _build_fingerprint(fingerprint_raw)
-                except ValueError as err:
-                    self.logger.warning(
-                        "Fully Kiosk %s: invalid TLS fingerprint configured: %s", self.host, err
-                    )
-                    self._attr_available = False
-                    self.update_state()
-                    return
-                http_session = _FingerprintSessionWrapper(self.mass.http_session, fingerprint)
-                verify_ssl = True
-            else:
-                http_session = (
-                    self.mass.http_session if verify_ssl else self.mass.http_session_no_ssl
-                )
-        else:
-            http_session = self.mass.http_session_no_ssl
+        http_session, use_ssl, verify_ssl = session_info
 
         client = FullyKiosk(
             http_session,
@@ -273,6 +256,7 @@ class FullyKioskPlayer(Player):
             )
             self.fully_kiosk = None
             self._attr_available = False
+            self._dashboards.unregister(self.player_id)
             self.update_state()
             return
 
@@ -288,7 +272,36 @@ class FullyKioskPlayer(Player):
         self._attr_setup_reason = None
         self._attr_available = True
         self._sync_state()
+        self._dashboards.register(self)
         self.update_state()
+
+    def _resolve_http_session(
+        self,
+    ) -> tuple[ClientSession | _FingerprintSessionWrapper, bool, bool] | None:
+        """Resolve (http_session, use_ssl, verify_ssl) from config, or None if misconfigured."""
+        use_ssl = bool(self.config.get_value(CONF_USE_SSL))
+        fingerprint_value = self.config.get_value(CONF_SSL_FINGERPRINT)
+        fingerprint_raw = fingerprint_value.strip() if isinstance(fingerprint_value, str) else ""
+        if fingerprint_raw and not use_ssl:
+            self.logger.warning(
+                "Fully Kiosk %s: fingerprint validation requires HTTPS to be enabled",
+                self.host,
+            )
+            return None
+        verify_ssl = bool(self.config.get_value(CONF_VERIFY_SSL)) if use_ssl else False
+        if not use_ssl:
+            return self.mass.http_session_no_ssl, use_ssl, verify_ssl
+        if fingerprint_raw:
+            try:
+                fingerprint = _build_fingerprint(fingerprint_raw)
+            except ValueError as err:
+                self.logger.warning(
+                    "Fully Kiosk %s: invalid TLS fingerprint configured: %s", self.host, err
+                )
+                return None
+            return _FingerprintSessionWrapper(self.mass.http_session, fingerprint), use_ssl, True
+        session = self.mass.http_session if verify_ssl else self.mass.http_session_no_ssl
+        return session, use_ssl, verify_ssl
 
     def _sync_state(self) -> None:
         """Refresh player attributes from the latest deviceInfo."""
@@ -303,3 +316,8 @@ class FullyKioskPlayer(Player):
                 break
         if not device_info.get("soundUrlPlaying"):
             self._attr_playback_state = PlaybackState.IDLE
+
+    @property
+    def _dashboards(self) -> FullyKioskDashboards:
+        """Return the owning provider's dashboard adapter."""
+        return cast("FullyKioskProvider", self.provider).dashboards

--- a/music_assistant/providers/fully_kiosk/provider.py
+++ b/music_assistant/providers/fully_kiosk/provider.py
@@ -11,6 +11,7 @@ from music_assistant_models.enums import ConfigEntryType
 from music_assistant.constants import CONF_ENTRY_MANUAL_DISCOVERY_IPS, VERBOSE_LOG_LEVEL
 from music_assistant.models.player_provider import PlayerProvider
 
+from .dashboard import FullyKioskDashboards
 from .player import DEFAULT_PORT, FullyKioskPlayer
 
 CONF_MANUAL_IPS = CONF_ENTRY_MANUAL_DISCOVERY_IPS.key
@@ -49,6 +50,8 @@ class FullyKioskProvider(PlayerProvider):
     optional SSL options) are configured on the player itself.
     """
 
+    dashboards: FullyKioskDashboards
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
         return (
@@ -63,6 +66,7 @@ class FullyKioskProvider(PlayerProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
+        self.dashboards = FullyKioskDashboards(self)
         if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
             logging.getLogger("fullykiosk").setLevel(logging.DEBUG)
         else:
@@ -114,3 +118,8 @@ class FullyKioskProvider(PlayerProvider):
             if new_entries != entries:
                 self._update_config_value(CONF_MANUAL_IPS, new_entries)
         await self.mass.players.unregister(player_id, True)
+
+    async def unload(self, is_removed: bool = False) -> None:
+        """Handle unload/close of the provider."""
+        await self.dashboards.unload()
+        await super().unload(is_removed)

--- a/music_assistant/providers/fully_kiosk/strings.json
+++ b/music_assistant/providers/fully_kiosk/strings.json
@@ -20,6 +20,9 @@
       "description": "Optional SHA-256 hex fingerprint. When provided it must match the device certificate and overrides the verify setting."
     }
   },
+  "errors": {
+    "show_dashboard_failed": "Failed to show the dashboard on {0}."
+  },
   "manifest": {
     "description": "Play audio on Fully Kiosk-enabled displays or Android devices."
   },

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1305,6 +1305,7 @@
   "provider.fully_kiosk.config_entries.use_ssl.label": "Use HTTPS when connecting to the Fully Kiosk API.",
   "provider.fully_kiosk.config_entries.verify_ssl.description": "Disabling verification trusts any certificate (no validation).",
   "provider.fully_kiosk.config_entries.verify_ssl.label": "Verify HTTPS certificates (recommended).",
+  "provider.fully_kiosk.errors.show_dashboard_failed": "Failed to show the dashboard on {0}.",
   "provider.fully_kiosk.manifest.description": "Play audio on Fully Kiosk-enabled displays or Android devices.",
   "provider.fully_kiosk.setup_flow.user.description": "Enter the password configured for the Fully Kiosk REST API on this device.",
   "provider.fully_kiosk.setup_flow.user.title": "Connect to Fully Kiosk",

--- a/tests/common.py
+++ b/tests/common.py
@@ -232,6 +232,7 @@ class MockProvider:
         self.manifest = MagicMock()
         self.manifest.name = f"Mock {domain} Provider"
         self.mass = mass or MagicMock()
+        self.dashboards = MagicMock()
         self.logger = logging.getLogger(f"test.{domain}")
 
 

--- a/tests/providers/fully_kiosk/test_dashboard.py
+++ b/tests/providers/fully_kiosk/test_dashboard.py
@@ -1,0 +1,404 @@
+"""Tests for the Fully Kiosk provider's dashboard registration and display control."""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fullykiosk.exceptions import FullyKioskError
+from music_assistant_models.enums import DashboardType
+from music_assistant_models.errors import PlayerCommandFailed, PlayerUnavailableError
+
+from music_assistant.constants import CONF_SSL_FINGERPRINT, CONF_USE_SSL, CONF_VERIFY_SSL
+from music_assistant.providers.fully_kiosk.dashboard import FullyKioskDashboards
+from music_assistant.providers.fully_kiosk.player import FullyKioskPlayer
+from music_assistant.providers.fully_kiosk.provider import FullyKioskProvider
+from tests.common import MockProvider, create_mock_config
+
+PLAYER_ID = "fully_kiosk_10.0.0.5_2323"
+
+
+def _make_dashboards(player: FullyKioskPlayer | None = None) -> FullyKioskDashboards:
+    """Build a FullyKioskDashboards instance whose mocked players controller returns player."""
+    provider = MagicMock()
+    provider.domain = "fully_kiosk"
+    provider.translation_owner = "provider.fully_kiosk"
+    provider.mass.players.get_player.return_value = player
+    provider.mass.dashboard.register_dashboard_handler.return_value = MagicMock()
+    return FullyKioskDashboards(provider)
+
+
+def _make_player(
+    *,
+    player_id: str = PLAYER_ID,
+    display_name: str = "Living Room Kiosk",
+    connected: bool = True,
+) -> FullyKioskPlayer:
+    """Build a real FullyKioskPlayer, optionally with a connected client mock."""
+    provider = MockProvider("fully_kiosk", instance_id="fully_kiosk--1")
+    provider.mass.config.get_base_player_config.return_value = create_mock_config(display_name)
+    player = FullyKioskPlayer(provider=provider, player_id=player_id, host="10.0.0.5")  # type: ignore[arg-type]
+    player._attr_name = display_name
+    if connected:
+        client = MagicMock()
+        client.screenOn = AsyncMock()
+        client.stopScreensaver = AsyncMock()
+        client.toForeground = AsyncMock()
+        client.loadUrl = AsyncMock()
+        client.loadStartUrl = AsyncMock()
+        player.fully_kiosk = client
+    return player
+
+
+def _make_connectable_player(*, player_id: str = PLAYER_ID) -> tuple[FullyKioskPlayer, MagicMock]:
+    """Build a real player with a mocked provider.dashboards, ready to drive _connect()/poll()."""
+    provider = MockProvider("fully_kiosk", instance_id="fully_kiosk--1")
+    provider.dashboards = MagicMock()
+    provider.mass.config.get_base_player_config.return_value = create_mock_config("Kiosk")
+    player = FullyKioskPlayer(provider=provider, player_id=player_id, host="10.0.0.5")  # type: ignore[arg-type]
+    player.get_setup_value = MagicMock(return_value="secret")  # type: ignore[method-assign]
+    ssl_config = {CONF_USE_SSL: False, CONF_VERIFY_SSL: True, CONF_SSL_FINGERPRINT: ""}
+    player.config.get_value = MagicMock(side_effect=ssl_config.get)  # type: ignore[method-assign]
+    return player, provider.dashboards
+
+
+def _make_client(*, fails: bool = False) -> MagicMock:
+    """Build a FullyKiosk client stub for patching into player._connect()."""
+    client = MagicMock()
+    client.getDeviceInfo = AsyncMock(
+        side_effect=FullyKioskError("Error", "boom") if fails else None
+    )
+    client.deviceInfo = {}
+    return client
+
+
+def _client_of(player: FullyKioskPlayer) -> MagicMock:
+    """Return a connected player's client mock, narrowing away the FullyKiosk | None type."""
+    assert player.fully_kiosk is not None
+    return cast("MagicMock", player.fully_kiosk)
+
+
+### Player connect/poll wiring
+
+
+async def test_connect_registers_dashboard_endpoint() -> None:
+    """A successful connect registers the player as a dashboard endpoint."""
+    player, dashboards = _make_connectable_player()
+    client = _make_client()
+    with patch("music_assistant.providers.fully_kiosk.player.FullyKiosk", return_value=client):
+        await player._connect()
+
+    assert player.available is True
+    dashboards.register.assert_called_once_with(player)
+
+
+async def test_connect_registers_dashboard_endpoint_with_synced_name() -> None:
+    """A successful connect registers under the device's synced name, not the placeholder."""
+    player, dashboards = _make_connectable_player()
+    client = _make_client()
+    client.deviceInfo = {"deviceName": "Kitchen Tablet"}
+    captured_names: list[str] = []
+    dashboards.register.side_effect = lambda registered_player: captured_names.append(
+        registered_player.display_name
+    )
+    # a real config change (e.g. the password being set) clears the cached display_name
+    # via set_config() before on_config_updated()/_connect() runs; mirror that here
+    player.set_config(player.config)
+    with patch("music_assistant.providers.fully_kiosk.player.FullyKiosk", return_value=client):
+        await player._connect()
+
+    assert captured_names == ["Kitchen Tablet"]
+
+
+async def test_connect_fingerprint_without_ssl_unregisters_dashboard_endpoint() -> None:
+    """A config change to a fingerprint without SSL drops any existing dashboard endpoint."""
+    player, dashboards = _make_connectable_player()
+    client = _make_client()
+    with patch("music_assistant.providers.fully_kiosk.player.FullyKiosk", return_value=client):
+        await player._connect()
+    dashboards.reset_mock()
+
+    ssl_config = {CONF_USE_SSL: False, CONF_VERIFY_SSL: True, CONF_SSL_FINGERPRINT: "aa:bb"}
+    player.config.get_value = MagicMock(side_effect=ssl_config.get)  # type: ignore[method-assign]
+
+    await player._connect()
+
+    assert player.available is False
+    dashboards.unregister.assert_called_once_with(PLAYER_ID)
+
+
+async def test_poll_failure_unregisters_then_reconnect_reregisters() -> None:
+    """A poll failure drops the dashboard endpoint; a subsequent reconnect re-registers it."""
+    player, dashboards = _make_connectable_player()
+    client = _make_client()
+    with patch("music_assistant.providers.fully_kiosk.player.FullyKiosk", return_value=client):
+        await player._connect()
+        dashboards.reset_mock()
+
+        client.getDeviceInfo.side_effect = FullyKioskError("Error", "boom")
+        await player.poll()
+        unavailable = player.available
+        assert unavailable is False
+        dashboards.unregister.assert_called_once_with(PLAYER_ID)
+
+        client.getDeviceInfo.side_effect = None
+        await player.poll()  # fully_kiosk is None, so poll() reconnects
+
+    reconnected = player.available
+    assert reconnected is True
+    dashboards.register.assert_called_once_with(player)
+
+
+async def test_connect_failure_unregisters_dashboard_endpoint() -> None:
+    """A failed (re)connect drops any existing dashboard endpoint registration."""
+    player, dashboards = _make_connectable_player()
+    client = _make_client(fails=True)
+    with patch("music_assistant.providers.fully_kiosk.player.FullyKiosk", return_value=client):
+        await player._connect()
+
+    assert player.available is False
+    dashboards.unregister.assert_called_once_with(PLAYER_ID)
+
+
+async def test_password_cleared_unregisters_dashboard_endpoint() -> None:
+    """Clearing the password drops the dashboard endpoint without a network call."""
+    player, dashboards = _make_connectable_player()
+    client = _make_client()
+    with patch("music_assistant.providers.fully_kiosk.player.FullyKiosk", return_value=client):
+        await player._connect()
+    dashboards.reset_mock()
+
+    player.get_setup_value = MagicMock(return_value=None)  # type: ignore[method-assign]
+    await player.on_config_updated()
+
+    assert player.available is False
+    dashboards.unregister.assert_called_once_with(PLAYER_ID)
+
+
+async def test_on_unload_unregisters_dashboard_endpoint() -> None:
+    """Unloading the player drops its dashboard endpoint registration."""
+    player, dashboards = _make_connectable_player()
+
+    await player.on_unload()
+
+    dashboards.unregister.assert_called_once_with(PLAYER_ID)
+
+
+### Provider unload
+
+
+async def test_provider_unload_awaits_dashboards_unload() -> None:
+    """Provider unload tears down every dashboard endpoint it registered."""
+    provider = FullyKioskProvider.__new__(FullyKioskProvider)
+    provider.dashboards = AsyncMock()
+
+    await provider.unload()
+
+    provider.dashboards.unload.assert_awaited_once()
+
+
+### Registration lifecycle
+
+
+def test_register_creates_dashboard_endpoint_with_all_types() -> None:
+    """A connected player registers a dashboard endpoint supporting all three types."""
+    player = _make_player()
+    dashboards = _make_dashboards(player)
+
+    dashboards.register(player)
+
+    handler = dashboards.mass.dashboard.register_dashboard_handler
+    handler.assert_called_once()  # type: ignore[attr-defined]
+    device = handler.call_args[0][0]  # type: ignore[attr-defined]
+    assert device.dashboard_id == PLAYER_ID
+    assert device.name == "Living Room Kiosk"
+    assert device.supported_types == {
+        DashboardType.NOW_PLAYING,
+        DashboardType.PARTY,
+        DashboardType.MUSIC_QUIZ,
+    }
+    assert device.provider_domain_hint == "fully_kiosk"
+    assert PLAYER_ID in dashboards._unregister_callbacks
+
+
+def test_register_is_noop_after_unload() -> None:
+    """A late register call after unload must not resurrect an endpoint."""
+    player = _make_player()
+    dashboards = _make_dashboards(player)
+    dashboards._unloaded = True
+
+    dashboards.register(player)
+
+    dashboards.mass.dashboard.register_dashboard_handler.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize("other_player", [False, True])
+def test_register_is_noop_for_removed_player(other_player: bool) -> None:
+    """A register call for a player the players controller no longer knows about is a no-op."""
+    player = _make_player()
+    current: FullyKioskPlayer | None = _make_player() if other_player else None
+    dashboards = _make_dashboards(current)
+
+    dashboards.register(player)
+
+    dashboards.mass.dashboard.register_dashboard_handler.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_unregister_calls_callback_and_reregister_creates_new_one() -> None:
+    """Connection loss unregisters the endpoint; a subsequent reconnect re-registers it."""
+    player = _make_player()
+    dashboards = _make_dashboards(player)
+    unregister = MagicMock()
+    dashboards.mass.dashboard.register_dashboard_handler.return_value = unregister  # type: ignore[attr-defined]
+    dashboards.register(player)
+    assert PLAYER_ID in dashboards._unregister_callbacks
+
+    dashboards.unregister(PLAYER_ID)
+
+    unregister.assert_called_once()
+    assert PLAYER_ID not in dashboards._unregister_callbacks
+
+    # reconnect re-registers a fresh endpoint
+    dashboards.register(player)
+    assert PLAYER_ID in dashboards._unregister_callbacks
+    assert dashboards.mass.dashboard.register_dashboard_handler.call_count == 2  # type: ignore[attr-defined]
+
+
+def test_unregister_unknown_player_is_noop() -> None:
+    """Unregistering a player id that was never registered does nothing."""
+    dashboards = _make_dashboards()
+
+    dashboards.unregister(PLAYER_ID)  # must not raise
+
+
+async def test_unload_unregisters_all_endpoints() -> None:
+    """Unload unregisters every endpoint and blocks further registration."""
+    player = _make_player()
+    dashboards = _make_dashboards(player)
+    unregister = MagicMock()
+    dashboards.mass.dashboard.register_dashboard_handler.return_value = unregister  # type: ignore[attr-defined]
+    dashboards.register(player)
+
+    await dashboards.unload()
+
+    unregister.assert_called_once()
+    assert dashboards._unloaded
+    assert not dashboards._unregister_callbacks
+
+    dashboards.register(player)
+    dashboards.mass.dashboard.register_dashboard_handler.assert_called_once()  # type: ignore[attr-defined]
+
+
+### on_show
+
+
+async def test_on_show_wakes_and_loads_url_in_order() -> None:
+    """on_show resolves the local url and drives the device in the documented order."""
+    dashboards = _make_dashboards()
+    player = _make_player()
+    dashboards.mass.players.get_player.return_value = player  # type: ignore[attr-defined]
+    target = "http://192.168.1.10:8095/?dashboard=ABC123&path=%2Fparty"
+    dashboards.mass.dashboard.resolve_dashboard_url = AsyncMock(return_value=target)  # type: ignore[method-assign]
+    client = _client_of(player)
+    order = MagicMock()
+    order.attach_mock(client.screenOn, "screen_on")
+    order.attach_mock(client.stopScreensaver, "stop_screensaver")
+    order.attach_mock(client.toForeground, "to_foreground")
+    order.attach_mock(client.loadUrl, "load_url")
+
+    await dashboards._on_show(PLAYER_ID, DashboardType.PARTY, None)
+
+    dashboards.mass.dashboard.resolve_dashboard_url.assert_awaited_once_with(
+        DashboardType.PARTY, None, prefer_local=True
+    )
+    assert [call[0] for call in order.mock_calls] == [
+        "screen_on",
+        "stop_screensaver",
+        "to_foreground",
+        "load_url",
+    ]
+    client.loadUrl.assert_awaited_once_with(target)
+
+
+async def test_on_show_missing_player_raises_unavailable() -> None:
+    """on_show for a player that vanished raises PlayerUnavailableError."""
+    dashboards = _make_dashboards()
+    dashboards.mass.players.get_player.return_value = None  # type: ignore[attr-defined]
+
+    with pytest.raises(PlayerUnavailableError):
+        await dashboards._on_show(PLAYER_ID, DashboardType.PARTY, None)
+
+
+async def test_on_show_disconnected_player_raises_unavailable() -> None:
+    """on_show for a player without an active client connection raises PlayerUnavailableError."""
+    dashboards = _make_dashboards()
+    player = _make_player(connected=False)
+    dashboards.mass.players.get_player.return_value = player  # type: ignore[attr-defined]
+
+    with pytest.raises(PlayerUnavailableError):
+        await dashboards._on_show(PLAYER_ID, DashboardType.PARTY, None)
+
+
+async def test_on_show_device_error_raises_translated_unavailable_without_leaking_url() -> None:
+    """A device-side failure surfaces as a translated error that never echoes the url."""
+    dashboards = _make_dashboards()
+    player = _make_player(display_name="Living Room Kiosk")
+    dashboards.mass.players.get_player.return_value = player  # type: ignore[attr-defined]
+    target = "http://192.168.1.10:8095/?dashboard=SECRETCODE&path=%2Fparty"
+    dashboards.mass.dashboard.resolve_dashboard_url = AsyncMock(return_value=target)  # type: ignore[method-assign]
+    _client_of(player).toForeground.side_effect = FullyKioskError("Error", "boom")
+
+    with pytest.raises(PlayerUnavailableError) as exc_info:
+        await dashboards._on_show(PLAYER_ID, DashboardType.PARTY, None)
+
+    assert exc_info.value.translation_key == "show_dashboard_failed"
+    assert exc_info.value.translation_owner == "provider.fully_kiosk"
+    assert exc_info.value.translation_args == ["Living Room Kiosk"]
+    assert "SECRETCODE" not in str(exc_info.value)
+    assert target not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+
+
+### on_hide
+
+
+async def test_on_hide_loads_start_url() -> None:
+    """on_hide returns the kiosk to its configured start page."""
+    dashboards = _make_dashboards()
+    player = _make_player()
+    dashboards.mass.players.get_player.return_value = player  # type: ignore[attr-defined]
+
+    await dashboards._on_hide(PLAYER_ID)
+
+    _client_of(player).loadStartUrl.assert_awaited_once()
+
+
+async def test_on_hide_disconnected_player_is_noop() -> None:
+    """on_hide for an already-disconnected player is a graceful no-op."""
+    dashboards = _make_dashboards()
+    player = _make_player(connected=False)
+    dashboards.mass.players.get_player.return_value = player  # type: ignore[attr-defined]
+
+    await dashboards._on_hide(PLAYER_ID)  # must not raise
+
+
+async def test_on_hide_missing_player_is_noop() -> None:
+    """on_hide for a player that vanished is a graceful no-op."""
+    dashboards = _make_dashboards()
+    dashboards.mass.players.get_player.return_value = None  # type: ignore[attr-defined]
+
+    await dashboards._on_hide(PLAYER_ID)  # must not raise
+
+
+async def test_on_hide_device_error_raises_command_failed() -> None:
+    """A device-side failure while hiding surfaces as PlayerCommandFailed."""
+    dashboards = _make_dashboards()
+    player = _make_player()
+    dashboards.mass.players.get_player.return_value = player  # type: ignore[attr-defined]
+    _client_of(player).loadStartUrl.side_effect = FullyKioskError("Error", "boom")
+
+    with pytest.raises(PlayerCommandFailed) as exc_info:
+        await dashboards._on_hide(PLAYER_ID)
+
+    assert exc_info.value.__cause__ is None


### PR DESCRIPTION
# What does this implement/fix?

Fully Kiosk devices can now be used as dashboard displays, next to playing audio. Every connected Fully Kiosk device is registered as a dashboard endpoint, so the party, now-playing and music quiz dashboards can be cast to it from the UI. The dashboard loads directly in the kiosk's browser over the local network; audio playback on the device keeps running while it shows.

- Register each connected Fully Kiosk device as a dashboard endpoint (dropped again when the connection is lost)
- Showing a dashboard wakes the screen, brings the kiosk app to the foreground and loads the dashboard URL
- Hiding it returns the kiosk to its configured start page
- Tests for the registration lifecycle and show/hide behavior

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
