### PR TITLE
Keep the full duration of an audiobook when resuming mid-book

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -451,6 +451,9 @@ class StreamsAudio:
         logger = self.logger.getChild("media_stream")
         logger.log(VERBOSE_LOG_LEVEL, "Starting media stream for %s", streamdetails.uri)
         extra_input_args = streamdetails.extra_input_args or []
+        # the branches below zero out seek_position where the seek is delegated to the
+        # source itself, so keep the requested position for the duration writeback
+        requested_seek_position = seek_position
 
         # work out audio source for these streamdetails
         audio_source: str | AsyncGenerator[bytes]
@@ -641,8 +644,9 @@ class StreamsAudio:
             # determine how many seconds we've received
             # for pcm output we can calculate this easily
             seconds_received = bytes_sent / pcm_format.pcm_sample_size if bytes_sent else 0
-            # store accurate duration
-            if finished and not seek_position and seconds_received:
+            # store accurate duration, but only for a playthrough from the very start:
+            # a seeked stream yields the remaining audio, not the item's full length
+            if finished and not requested_seek_position and seconds_received:
                 streamdetails.duration = int(seconds_received)
 
             logger.log(

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 from music_assistant_models.enums import ContentType, MediaType, StreamType
 from music_assistant_models.media_items import AudioFormat
-from music_assistant_models.streamdetails import StreamDetails
+from music_assistant_models.streamdetails import MultiPartPath, StreamDetails
 
 import music_assistant.controllers.streams.audio as audio_mod
 from music_assistant.controllers.streams.audio import StreamsAudio
@@ -25,9 +25,11 @@ class _FakeFFMpeg:
         *,
         audio_input: object,
         input_format: AudioFormat,
+        extra_input_args: list[str] | None = None,
         **_kwargs: Any,
     ) -> None:
         self.audio_input = audio_input
+        self.extra_input_args = extra_input_args
         # Mirror the real FFMpeg, which mutates this object's codec_type after probe.
         # Tests inspect the original `input_format` AudioFormat passed in to confirm
         # which one the controller picked.
@@ -60,6 +62,14 @@ def patch_ffmpeg(monkeypatch: pytest.MonkeyPatch) -> type[_FakeFFMpeg]:
     _FakeFFMpeg.last_instance = None
     monkeypatch.setattr(audio_mod, "FFMpeg", _FakeFFMpeg)
     return _FakeFFMpeg
+
+
+@pytest.fixture
+def patch_two_minute_ffmpeg(monkeypatch: pytest.MonkeyPatch) -> type[_TwoMinuteFFMpeg]:
+    """Swap the real FFMpeg for the fake that emits a fixed amount of audio."""
+    _TwoMinuteFFMpeg.last_instance = None
+    monkeypatch.setattr(audio_mod, "FFMpeg", _TwoMinuteFFMpeg)
+    return _TwoMinuteFFMpeg
 
 
 def _make_audio_controller() -> StreamsAudio:
@@ -96,9 +106,63 @@ def _make_streamdetails(
     )
 
 
+_PCM_SAMPLE_SIZE = _make_pcm_format().pcm_sample_size
+
+
 async def _drain(gen: AsyncGenerator[bytes]) -> None:
     async for _ in gen:
         pass
+
+
+def _recording_multi_file_stream() -> tuple[Any, list[int]]:
+    """
+    Build a stand-in for the concat stream plus the list of seek positions it received.
+
+    Avoids a real ffmpeg process and temp file while still proving the seek was
+    handed off to the source rather than applied through the -ss argument.
+    """
+    received_seeks: list[int] = []
+
+    async def _empty_stream() -> AsyncGenerator[bytes]:
+        yield b""
+
+    # record on call rather than on first iteration: the FFMpeg double never
+    # consumes the generator it is handed, so its body would never run
+    def _fake_stream(
+        _streamdetails: StreamDetails, seek_position: int = 0
+    ) -> AsyncGenerator[bytes]:
+        received_seeks.append(seek_position)
+        return _empty_stream()
+
+    return _fake_stream, received_seeks
+
+
+class _TwoMinuteFFMpeg(_FakeFFMpeg):
+    """FFMpeg double that emits exactly two minutes of PCM at the format below."""
+
+    seconds_emitted = 120
+
+    async def iter_chunked(self, _chunk_size: int) -> AsyncGenerator[bytes]:
+        for _ in range(self.seconds_emitted):
+            yield b"\x00" * _PCM_SAMPLE_SIZE
+
+
+def _multi_part_streamdetails() -> StreamDetails:
+    """Build StreamDetails for a multi-file audiobook of two 30 minute parts."""
+    return StreamDetails(
+        provider="test_provider",
+        item_id="audiobook-1",
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        media_type=MediaType.AUDIOBOOK,
+        stream_type=StreamType.HTTP,
+        path=[
+            MultiPartPath(path="http://test.invalid/part-1.mp3", duration=1800),
+            MultiPartPath(path="http://test.invalid/part-2.mp3", duration=1800),
+        ],
+        duration=3600,
+        can_seek=True,
+        allow_seek=True,
+    )
 
 
 @pytest.mark.asyncio
@@ -203,3 +267,68 @@ async def test_get_media_stream_writes_back_codec_when_no_decoded_format() -> No
     # decoded format that AudioFormat is the same object as streamdetails.audio_format,
     # so the controller's writeback path is exercised end-to-end.
     assert streamdetails.audio_format.codec_type is ContentType.FLAC
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_stores_measured_duration_for_full_playthrough(
+    monkeypatch: pytest.MonkeyPatch,
+    patch_two_minute_ffmpeg: type[_TwoMinuteFFMpeg],
+) -> None:
+    """A multi-file item streamed from the start gets its measured duration stored."""
+    streamdetails = _multi_part_streamdetails()
+    audio = _make_audio_controller()
+    fake_stream, _ = _recording_multi_file_stream()
+    monkeypatch.setattr(audio, "get_multi_file_stream", fake_stream)
+
+    await _drain(audio.get_media_stream(streamdetails, _make_pcm_format()))
+
+    assert streamdetails.duration == patch_two_minute_ffmpeg.seconds_emitted
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_keeps_duration_when_multi_file_seek_is_delegated(
+    monkeypatch: pytest.MonkeyPatch,
+    patch_two_minute_ffmpeg: type[_TwoMinuteFFMpeg],
+) -> None:
+    """Resuming a multi-file audiobook must not shrink its duration to the remainder."""
+    streamdetails = _multi_part_streamdetails()
+    audio = _make_audio_controller()
+    fake_stream, received_seeks = _recording_multi_file_stream()
+    monkeypatch.setattr(audio, "get_multi_file_stream", fake_stream)
+
+    await _drain(audio.get_media_stream(streamdetails, _make_pcm_format(), seek_position=1800))
+
+    # the concat stream consumes the seek itself, which clears the local seek
+    # position before the duration writeback runs at the end of the stream
+    assert received_seeks == [1800]
+    assert patch_two_minute_ffmpeg.last_instance is not None
+    assert "-ss" not in (patch_two_minute_ffmpeg.last_instance.extra_input_args or [])
+    assert streamdetails.duration == 3600
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_keeps_duration_when_provider_seek_is_delegated(
+    patch_two_minute_ffmpeg: type[_TwoMinuteFFMpeg],
+) -> None:
+    """A seekable provider stream must not shrink its duration to the remainder either."""
+    streamdetails = StreamDetails(
+        provider="test_provider",
+        item_id="track-1",
+        audio_format=AudioFormat(content_type=ContentType.OGG),
+        media_type=MediaType.TRACK,
+        stream_type=StreamType.CUSTOM,
+        duration=240,
+        can_seek=True,
+        allow_seek=True,
+    )
+    audio = _make_audio_controller()
+    provider = cast("MagicMock", audio.mass).get_provider.return_value
+
+    await _drain(audio.get_media_stream(streamdetails, _make_pcm_format(), seek_position=90))
+
+    # a provider that can seek receives the position and the local one is cleared,
+    # so only the remaining audio reaches ffmpeg
+    provider.get_audio_stream.assert_called_once_with(streamdetails, seek_position=90)
+    assert patch_two_minute_ffmpeg.last_instance is not None
+    assert "-ss" not in (patch_two_minute_ffmpeg.last_instance.extra_input_args or [])
+    assert streamdetails.duration == 240


### PR DESCRIPTION
# What does this implement/fix?

Manual backport of #5524 — the automatic cherry-pick conflicted because the surrounding code has moved on in `dev`.

Resuming a multi-file audiobook part-way through would shrink the book's stored duration to just the part that was left to play. Progress reporting then used that shortened length, so a book could be marked as finished while there was still plenty left. The same applies to normal tracks from providers that seek themselves (Spotify, for example): seeking past the first minute could get a track marked as played, and scrobbled, well before it actually ended.

Changes:

- Remember the position that was originally asked for, and only store a newly measured duration when the item really did play from the start.
- Added tests for both cases: a multi-file book, and a provider stream that handles its own seeking.

**Related issue (if applicable):**

- backport of #5524

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes. (ruff check + ruff format run directly; the pre-commit hook envs would not build in this worktree, so leaving this to CI)
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
