### PR TITLE
Support casting the Music Quiz dashboard

### DIFF
--- a/music_assistant/controllers/dashboard/controller.py
+++ b/music_assistant/controllers/dashboard/controller.py
@@ -403,7 +403,9 @@ class DashboardController(CoreController):
                 raise InvalidCommand(msg)
             return f"/now-playing?{urlencode({'player': player_id}, safe=ROUTE_SAFE_CHARS)}"
         if dashboard == DashboardType.MUSIC_QUIZ:
-            return "/music-quiz"
+            # the viewer-only kiosk view: the host page needs USERS_INVITE, which a
+            # dashboard viewer never has
+            return "/music-quiz/dashboard"
         msg = f"Unsupported dashboard type: {dashboard}"
         raise InvalidCommand(msg)
 

--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -36,7 +36,11 @@ DASHBOARD_CONNECT_TIMEOUT = 10.0
 DASHBOARD_CONNECTION_LOSS_GRACE = 60.0
 
 # Dashboard types the chromecast receiver app has routes for.
-SUPPORTED_DASHBOARD_TYPES = {DashboardType.PARTY, DashboardType.NOW_PLAYING}
+SUPPORTED_DASHBOARD_TYPES = {
+    DashboardType.PARTY,
+    DashboardType.NOW_PLAYING,
+    DashboardType.MUSIC_QUIZ,
+}
 
 
 @dataclass

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -246,6 +246,9 @@ class MusicQuizPlugin(PluginProvider):
         self._warm_next_track_task: asyncio.Task[None] | None = None
         self._reveal_playback_task: asyncio.Task[None] | None = None
         self._unregister_handles: list[Callable[[], None]] = []
+        # public state is broadcast from sync code paths that cannot await the join URL,
+        # and the guest-scope getter must not mint a join code as a side effect
+        self._join_url: str | None = None
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
@@ -421,6 +424,9 @@ class MusicQuizPlugin(PluginProvider):
             )
         )
         quiz_type_class.validate_config(game_config)
+        # resolved before the game goes live so every public-state broadcast, including
+        # the very first lobby one a cast dashboard renders its QR from, carries it
+        self._join_url = await self._get_join_url()
         async with self._game_lock:
             if self._game is not None and self._game.phase in (
                 MusicQuizPhase.ANSWERING,
@@ -617,7 +623,7 @@ class MusicQuizPlugin(PluginProvider):
             self._signal_game_updated()
             return {
                 "player_id": player.player_id,
-                "state": _player_state(game, player, answer_type),
+                "state": _player_state(game, player, answer_type, self._join_url),
             }
 
     async def get_player_state(self, player_id: str) -> dict[str, Any]:
@@ -630,7 +636,7 @@ class MusicQuizPlugin(PluginProvider):
             game, _, answer_type = self._require_game_strategies()
             player = _get_player(game, player_id)
             self._refresh_player_presence(player)
-            return _player_state(game, player, answer_type)
+            return _player_state(game, player, answer_type, self._join_url)
 
     async def get_public_state(self) -> dict[str, Any] | None:
         """
@@ -646,7 +652,7 @@ class MusicQuizPlugin(PluginProvider):
             if self._game is None:
                 return None
             game, _, answer_type = self._require_game_strategies()
-            return _public_state(game, answer_type)
+            return _public_state(game, answer_type, self._join_url)
 
     async def heartbeat(self, player_id: str) -> bool:
         """
@@ -716,14 +722,14 @@ class MusicQuizPlugin(PluginProvider):
             # a repeat ready is a no-op: it cannot newly satisfy the all-ready
             # check, so return current state without re-broadcasting
             if game.phase != MusicQuizPhase.REVEAL or player.ready:
-                return _player_state(game, player, answer_type)
+                return _player_state(game, player, answer_type, self._join_url)
             mark_player_ready(game, player.player_id)
             # advance early when every player is ready for the next round
             if are_active_players_ready(game):
                 await self._advance_from_reveal()
             else:
                 self._signal_game_updated()
-            return _player_state(game, player, answer_type)
+            return _player_state(game, player, answer_type, self._join_url)
 
     async def listen_in(self, web_player_id: str) -> None:
         """
@@ -837,7 +843,7 @@ class MusicQuizPlugin(PluginProvider):
             self._do_reveal(completed=True)
         else:
             self._signal_game_updated()
-        return _player_state(game, player, answer_type)
+        return _player_state(game, player, answer_type, self._join_url)
 
     async def _host_state(self) -> dict[str, Any]:
         """Return the host-visible state of the current game."""
@@ -867,7 +873,7 @@ class MusicQuizPlugin(PluginProvider):
             return
         game, _, answer_type = self._require_game_strategies()
         self.signal_provider_event(
-            {"event": "game_updated", "state": _public_state(game, answer_type)}
+            {"event": "game_updated", "state": _public_state(game, answer_type, self._join_url)}
         )
 
     async def _resolve_sources(self, source_uris: list[str]) -> list[MusicQuizSource]:
@@ -2117,7 +2123,11 @@ def _host_round(
     }
 
 
-def _public_state(game: MusicQuizGame, answer_type: QuizAnswerType) -> dict[str, Any]:
+def _public_state(
+    game: MusicQuizGame,
+    answer_type: QuizAnswerType,
+    join_url: str | None = None,
+) -> dict[str, Any]:
     """Return the guest-safe public game state (see the module docstring)."""
     current_round = (
         game.rounds[game.current_round_index] if game.current_round_index is not None else None
@@ -2148,6 +2158,8 @@ def _public_state(game: MusicQuizGame, answer_type: QuizAnswerType) -> dict[str,
         "answer_duration": game.config.answer_duration,
         "auto_start_at": game.auto_start_at,
         "preparing": game.preparing,
+        # omitted rather than empty while unresolved, so a display can hide its join QR
+        **({"join_url": join_url} if join_url else {}),
         **answer_type.serialize_game_config(game),
         **get_quiz_type(game.quiz_type).serialize_game_config(game),
         "players": players,
@@ -2192,6 +2204,7 @@ def _player_state(
     game: MusicQuizGame,
     player: MusicQuizPlayer,
     answer_type: QuizAnswerType,
+    join_url: str | None = None,
 ) -> dict[str, Any]:
     """Return the personalized (still guest-safe) game state for a player."""
     current_round = (
@@ -2210,4 +2223,4 @@ def _player_state(
             revealed=revealed,
         ),
     }
-    return {**_public_state(game, answer_type), "you": you}
+    return {**_public_state(game, answer_type, join_url), "you": you}

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -425,15 +425,15 @@ class MusicQuizPlugin(PluginProvider):
             )
         )
         quiz_type_class.validate_config(game_config)
-        # resolved before the game goes live so every public-state broadcast, including
-        # the very first lobby one a cast dashboard renders its QR from, carries it
-        self._join_url = await self._get_join_url()
         async with self._game_lock:
             if self._game is not None and self._game.phase in (
                 MusicQuizPhase.ANSWERING,
                 MusicQuizPhase.REVEAL,
             ):
                 raise MusicQuizGameActiveError("A Music Quiz game is already in progress")
+            # resolved before the game goes live so every public-state broadcast, including
+            # the very first lobby one a cast dashboard renders its QR from, carries it
+            self._join_url = await self._get_join_url()
             game = MusicQuizGame(
                 config=game_config,
                 quiz_type=quiz_type,

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -29,7 +29,8 @@ The public game state is guest-safe by construction. Common state contains:
   ``include_similar_music`` and public player progress. ``auto_start_at`` contains
   the authoritative replay deadline while a lobby countdown is active.
   ``preparing`` is true while a reset loads the sources and first round of the
-  next run. Private player IDs never appear in broadcasts. Trivia additionally
+  next run. ``join_url`` is included once resolved and omitted until then.
+  Private player IDs never appear in broadcasts. Trivia additionally
   exposes its canonical ``language`` and ``play_reveal_audio`` setting.
 - answering rounds expose common timing and question fields plus a strategy
   fragment. Multiple-choice exposes opaque ``suggestions``. Timeline exposes
@@ -623,7 +624,7 @@ class MusicQuizPlugin(PluginProvider):
             self._signal_game_updated()
             return {
                 "player_id": player.player_id,
-                "state": _player_state(game, player, answer_type, self._join_url),
+                "state": _player_state(game, player, answer_type, join_url=self._join_url),
             }
 
     async def get_player_state(self, player_id: str) -> dict[str, Any]:
@@ -636,7 +637,7 @@ class MusicQuizPlugin(PluginProvider):
             game, _, answer_type = self._require_game_strategies()
             player = _get_player(game, player_id)
             self._refresh_player_presence(player)
-            return _player_state(game, player, answer_type, self._join_url)
+            return _player_state(game, player, answer_type, join_url=self._join_url)
 
     async def get_public_state(self) -> dict[str, Any] | None:
         """
@@ -652,7 +653,7 @@ class MusicQuizPlugin(PluginProvider):
             if self._game is None:
                 return None
             game, _, answer_type = self._require_game_strategies()
-            return _public_state(game, answer_type, self._join_url)
+            return _public_state(game, answer_type, join_url=self._join_url)
 
     async def heartbeat(self, player_id: str) -> bool:
         """
@@ -722,14 +723,14 @@ class MusicQuizPlugin(PluginProvider):
             # a repeat ready is a no-op: it cannot newly satisfy the all-ready
             # check, so return current state without re-broadcasting
             if game.phase != MusicQuizPhase.REVEAL or player.ready:
-                return _player_state(game, player, answer_type, self._join_url)
+                return _player_state(game, player, answer_type, join_url=self._join_url)
             mark_player_ready(game, player.player_id)
             # advance early when every player is ready for the next round
             if are_active_players_ready(game):
                 await self._advance_from_reveal()
             else:
                 self._signal_game_updated()
-            return _player_state(game, player, answer_type, self._join_url)
+            return _player_state(game, player, answer_type, join_url=self._join_url)
 
     async def listen_in(self, web_player_id: str) -> None:
         """
@@ -843,7 +844,7 @@ class MusicQuizPlugin(PluginProvider):
             self._do_reveal(completed=True)
         else:
             self._signal_game_updated()
-        return _player_state(game, player, answer_type, self._join_url)
+        return _player_state(game, player, answer_type, join_url=self._join_url)
 
     async def _host_state(self) -> dict[str, Any]:
         """Return the host-visible state of the current game."""
@@ -852,7 +853,7 @@ class MusicQuizPlugin(PluginProvider):
             **_public_state(game, answer_type),
             "created_at": game.created_at,
             "sources": [source.to_dict() for source in game.sources],
-            "join_url": await self._get_join_url(),
+            "join_url": self._join_url or await self._get_join_url(),
             "rounds": [_host_round(game_round, answer_type) for game_round in game.rounds],
             "playback": _playback_summary(game),
         }
@@ -872,9 +873,8 @@ class MusicQuizPlugin(PluginProvider):
         if self._game is None:
             return
         game, _, answer_type = self._require_game_strategies()
-        self.signal_provider_event(
-            {"event": "game_updated", "state": _public_state(game, answer_type, self._join_url)}
-        )
+        state = _public_state(game, answer_type, join_url=self._join_url)
+        self.signal_provider_event({"event": "game_updated", "state": state})
 
     async def _resolve_sources(self, source_uris: list[str]) -> list[MusicQuizSource]:
         """Resolve configured source URIs into host-visible source metadata."""
@@ -2126,6 +2126,7 @@ def _host_round(
 def _public_state(
     game: MusicQuizGame,
     answer_type: QuizAnswerType,
+    *,
     join_url: str | None = None,
 ) -> dict[str, Any]:
     """Return the guest-safe public game state (see the module docstring)."""
@@ -2204,6 +2205,7 @@ def _player_state(
     game: MusicQuizGame,
     player: MusicQuizPlayer,
     answer_type: QuizAnswerType,
+    *,
     join_url: str | None = None,
 ) -> dict[str, Any]:
     """Return the personalized (still guest-safe) game state for a player."""
@@ -2223,4 +2225,4 @@ def _player_state(
             revealed=revealed,
         ),
     }
-    return {**_public_state(game, answer_type, join_url), "you": you}
+    return {**_public_state(game, answer_type, join_url=join_url), "you": you}

--- a/tests/controllers/dashboard/test_controller.py
+++ b/tests/controllers/dashboard/test_controller.py
@@ -616,7 +616,8 @@ async def test_show_dashboard_api_path_now_playing_requires_player_id() -> None:
     [
         (DashboardType.PARTY, None, "/party"),
         (DashboardType.NOW_PLAYING, "player1", "/now-playing?player=player1"),
-        (DashboardType.MUSIC_QUIZ, None, "/music-quiz"),
+        # the viewer-only kiosk view, not the host page (which needs USERS_INVITE)
+        (DashboardType.MUSIC_QUIZ, None, "/music-quiz/dashboard"),
     ],
 )
 def test_dashboard_route_resolves_expected_path(

--- a/tests/providers/chromecast/test_dashboard_commands.py
+++ b/tests/providers/chromecast/test_dashboard_commands.py
@@ -77,7 +77,11 @@ def test_register_video_capable_device() -> None:
     assert device == DashboardDevice(
         dashboard_id=f"chromecast_{uuid}",
         name="Living Room TV",
-        supported_types={DashboardType.PARTY, DashboardType.NOW_PLAYING},
+        supported_types={
+            DashboardType.PARTY,
+            DashboardType.NOW_PLAYING,
+            DashboardType.MUSIC_QUIZ,
+        },
         provider_domain_hint="chromecast",
     )
 

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -5014,6 +5014,19 @@ async def test_create_game_rejected_while_game_active() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_game_rejected_while_active_does_not_resolve_join_url() -> None:
+    """A rejected create_game call must not rotate the join code of the running game."""
+    plugin = _create_plugin()
+    await _create_started_game(plugin)
+    cast("AsyncMock", plugin._get_join_url).reset_mock()
+
+    with pytest.raises(MusicQuizGameActiveError):
+        await plugin.create_game(source_uris=["library://playlist/2"])
+
+    cast("AsyncMock", plugin._get_join_url).assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_create_game_replaces_finished_game() -> None:
     """Creating a new game over a finished one starts fresh."""
     plugin = _create_plugin()

--- a/tests/providers/music_quiz/test_plugin.py
+++ b/tests/providers/music_quiz/test_plugin.py
@@ -312,6 +312,7 @@ def _create_plugin(
     plugin._warm_next_track_task = None
     plugin._reveal_playback_task = None
     plugin._unregister_handles = []
+    plugin._join_url = None
     plugin.mass.cache.get = AsyncMock(return_value=None)
     plugin.mass.cache.set = AsyncMock()
     sendspin_provider = MagicMock()
@@ -3716,6 +3717,7 @@ async def test_public_state_redacts_answer_data_before_reveal() -> None:
         "include_similar_music",
         "auto_start_at",
         "preparing",
+        "join_url",
         "players",
         "current_round",
     }
@@ -3947,6 +3949,37 @@ async def test_public_state_exposes_full_state_for_non_participant() -> None:
     # a participant's personal state is this same public state plus their own "you" view
     personal_state = await plugin.get_player_state(player_ids["Alice"])
     assert set(personal_state) == {*state, "you"}
+
+
+@pytest.mark.asyncio
+async def test_public_state_exposes_join_url_for_the_dashboard() -> None:
+    """A cast dashboard renders its lobby join QR from the guest-safe state."""
+    plugin = _create_plugin()
+    await _create_started_game(plugin)
+
+    state = await plugin.get_public_state()
+
+    assert state is not None
+    assert state["join_url"] == "http://ma/join"
+    # the broadcast payload a dashboard follows carries the same value
+    broadcast = cast("MagicMock", plugin.signal_provider_event).call_args.args[0]["state"]
+    assert broadcast["join_url"] == "http://ma/join"
+    host_state = await plugin.get_game()
+    assert host_state is not None
+    assert host_state["join_url"] == state["join_url"]
+
+
+@pytest.mark.asyncio
+async def test_public_state_omits_join_url_when_unresolved() -> None:
+    """Without a resolved join URL the key is absent, so a client hides its QR."""
+    plugin = _create_plugin()
+    await _create_started_game(plugin)
+    plugin._join_url = None
+
+    state = await plugin.get_public_state()
+
+    assert state is not None
+    assert "join_url" not in state
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Casting the Music Quiz to a Chromecast (or opening it on a wall tablet) currently shows the host page, which guest viewer sessions cannot load. This adds the two server-side pieces for the new viewer-only quiz dashboard:

- The guest-safe `music_quiz/public_state` payload (and the broadcast game state) now includes the `join_url`, so a TV lobby can show the join QR code. It is resolved once at game creation and never minted from guest-scoped calls.
- Music Quiz dashboard casts now open `/music-quiz/dashboard` (the new viewer-only page) instead of `/music-quiz` (the host page).

Companion frontend PR: music-assistant/frontend#2352 (contains the actual dashboard view; best merged first or in the same release).

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
