### PR TITLE
Don't resolve a filesystem image path that points at a directory

### DIFF
--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -24,7 +24,7 @@ import aiofiles
 import aiofiles.os
 from aiohttp.client_exceptions import ClientError
 from music_assistant_models.enums import ProviderIconVariant
-from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
 from PIL import Image, UnidentifiedImageError
 
 from music_assistant.constants import APPLICATION_NAME
@@ -405,10 +405,12 @@ async def _fetch_and_cache_source_image(
 
     try:
         img_data, disk_cacheable = await _fetch_source_image(mass, path_or_url, provider, depth)
-    except FileNotFoundError as err:
+    except (FileNotFoundError, MediaNotFoundError) as err:
         # remember the failure briefly and log it once, concisely: every
         # thumbnail/palette/metadata request for this source would otherwise
         # retry the origin and log the same error over and over
+        # a provider signals a missing source with MediaNotFoundError, which is not an
+        # OSError and would otherwise bypass this negative cache entirely
         _store_failed_source(cache_key, str(err))
         LOGGER.warning("%s (not retrying for %s seconds)", err, _FAILED_SOURCE_TTL)
         raise

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -1008,6 +1008,10 @@ class LocalFileSystemProvider(MusicProvider):
             # the referenced image file was removed from disk; surface a typed
             # not-found so the image layer treats it as a missing image
             raise MediaNotFoundError(f"Image not found: {path}") from err
+        if file_item.is_dir:
+            # handing the path back would have the image layer run an ffmpeg
+            # embedded-artwork extraction on the directory before giving up
+            raise MediaNotFoundError(f"Image path is a directory: {path}")
         return file_item.absolute_path
 
     async def check_write_access(self) -> None:

--- a/tests/helpers/test_images.py
+++ b/tests/helpers/test_images.py
@@ -18,6 +18,7 @@ from aiohttp import ClientSession, web
 from aiohttp.client_exceptions import ClientError
 from aiohttp.test_utils import TestServer
 from music_assistant_models.enums import ImageType, ProviderIconVariant
+from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import MediaItemImage
 from PIL import Image
 
@@ -33,6 +34,7 @@ from music_assistant.helpers.images import (
     load_provider_icon,
 )
 from music_assistant.models.metadata_provider import MetadataProvider
+from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.player_provider import PlayerProvider
 from tests.common import collect_loop_errors
 
@@ -378,6 +380,34 @@ async def test_failing_source_fails_fast_with_single_warning(
         await get_image_thumb(mass_minimal, remote_url, 256, "builtin")
 
     assert len(fetch_calls) == 1
+    warnings = [rec for rec in caplog.records if rec.name == "music_assistant.helpers.images"]
+    assert len(warnings) == 1
+    assert "not retrying" in warnings[0].getMessage()
+
+
+async def test_provider_reported_missing_image_fails_fast_with_single_warning(
+    mass_minimal: MusicAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    fetch_calls: list[tuple[str, str]],
+) -> None:
+    """A provider reporting a missing image is asked once, then fails fast without new logs."""
+    fake_provider = MagicMock(spec=MusicProvider)
+    fake_provider.resolve_image = AsyncMock(
+        side_effect=MediaNotFoundError("Image path is a directory: Some Artist")
+    )
+    monkeypatch.setattr(mass_minimal, "get_provider", lambda _prov: fake_provider)
+    caplog.set_level(logging.WARNING, logger="music_assistant.helpers.images")
+
+    with pytest.raises(MediaNotFoundError, match="Some Artist"):
+        await get_image_data(mass_minimal, "Some Artist", "filesystem_local--1")
+    # follow-up requests (a thumbnail, a palette) fail fast from the negative cache,
+    # without asking the provider again and without logging again
+    with pytest.raises(FileNotFoundError, match="Some Artist"):
+        await get_image_data(mass_minimal, "Some Artist", "filesystem_local--1")
+
+    assert len(fetch_calls) == 1
+    assert fake_provider.resolve_image.await_count == 1
     warnings = [rec for rec in caplog.records if rec.name == "music_assistant.helpers.images"]
     assert len(warnings) == 1
     assert "not retrying" in warnings[0].getMessage()

--- a/tests/providers/filesystem/test_versioned_image_path.py
+++ b/tests/providers/filesystem/test_versioned_image_path.py
@@ -1,5 +1,6 @@
 """Tests for LocalFileSystemProvider cover image cache-busting."""
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -43,7 +44,7 @@ class TestVersionedImagePath:
         provider = _create_provider()
         versioned = LocalFileSystemProvider._versioned_image_path("Moby Dick/folder.jpg", "123")
         with patch.object(provider, "resolve", new_callable=AsyncMock) as mock_resolve:
-            mock_resolve.return_value = MagicMock(absolute_path="/music/folder.jpg")
+            mock_resolve.return_value = MagicMock(absolute_path="/music/folder.jpg", is_dir=False)
             await provider.resolve_image(versioned)
         mock_resolve.assert_awaited_once_with("Moby Dick/folder.jpg")
 
@@ -52,9 +53,18 @@ class TestVersionedImagePath:
         """A plain path without a suffix is resolved unchanged."""
         provider = _create_provider()
         with patch.object(provider, "resolve", new_callable=AsyncMock) as mock_resolve:
-            mock_resolve.return_value = MagicMock(absolute_path="/music/track.flac")
+            mock_resolve.return_value = MagicMock(absolute_path="/music/track.flac", is_dir=False)
             await provider.resolve_image("Moby Dick/track.flac")
         mock_resolve.assert_awaited_once_with("Moby Dick/track.flac")
+
+    @pytest.mark.asyncio
+    async def test_resolve_image_directory_raises_media_not_found(self, tmp_path: Path) -> None:
+        """A folder path is rejected instead of being resolved as an image."""
+        provider = _create_provider()
+        provider.base_path = str(tmp_path)
+        (tmp_path / "Some Artist").mkdir()
+        with pytest.raises(MediaNotFoundError):
+            await provider.resolve_image("Some Artist")
 
     @pytest.mark.asyncio
     async def test_resolve_image_missing_file_raises_media_not_found(self) -> None:


### PR DESCRIPTION
# What does this implement/fix?

An image path pointing at a directory was resolved and handed to the image layer as if it were a file. A missing image reported by a provider also bypassed the source-image negative cache, so it was retried and logged again on every request.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
