### PR TITLE
Clean up queue settings when a player is removed

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1288,23 +1288,23 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         self.mass.cancel_task(f"save_queue_cache_{player_id}")
         self._set_transitioning(player_id, False)
         if permanent:
-            # if the player is permanently removed, we also remove the cached queue data
-            self.mass.create_task(
-                self.mass.cache.delete(
-                    key=player_id,
-                    provider=self.domain,
-                    category=CACHE_CATEGORY_PLAYER_QUEUE_STATE,
-                )
-            )
-            self.mass.create_task(
-                self.mass.cache.delete(
-                    key=player_id,
-                    provider=self.domain,
-                    category=CACHE_CATEGORY_PLAYER_QUEUE_ITEMS,
-                )
-            )
+            self.purge_saved_queue(player_id)
         self._queue_data.pop(player_id, None)
         self._managed_pool.forget(player_id)
+
+    def purge_saved_queue(self, queue_id: str) -> None:
+        """Delete the persisted state and items of the given queue."""
+        for category in (CACHE_CATEGORY_PLAYER_QUEUE_STATE, CACHE_CATEGORY_PLAYER_QUEUE_ITEMS):
+            # a removal runs both the player teardown and the config cleanup, so keep the
+            # delete to one task per category instead of one per caller
+            self.mass.create_task(
+                self.mass.cache.delete(
+                    key=queue_id,
+                    provider=self.domain,
+                    category=category,
+                ),
+                task_id=f"purge_saved_queue_{queue_id}_{category}",
+            )
 
     async def load_next_queue_item(
         self,

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -84,6 +84,7 @@ from music_assistant.constants import (
     CONF_MUTE_CONTROL,
     CONF_PLAY_MEDIA_OVERRIDES_GROUP,
     CONF_PLAYER_DSP,
+    CONF_PLAYER_QUEUES,
     CONF_PLAYERS,
     CONF_POWER_CONTROL,
     CONF_PROTOCOL_PARENT_ID,
@@ -1637,9 +1638,11 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
     def delete_player_config(self, player_id: str) -> None:
         """
-        Permanently delete a player's configuration.
+        Permanently delete a player's configuration, including its DSP and queue settings.
 
-        Only wipes the stored configuration, the player itself is not unregistered.
+        The saved queue of a player that is no longer registered is dropped along with it,
+        so a device that returns under the same id starts out fresh. The player itself is
+        not unregistered.
         The config of a linked protocol player is wiped along with it, so the device
         returns as a brand new player once it is discovered again. Protocol players that
         are still registered or that already moved to another parent keep their config;
@@ -1654,8 +1657,14 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         ]
         player_ids.append(player_id)
         for pid in player_ids:
-            for key in (f"{CONF_PLAYERS}/{pid}", f"{CONF_PLAYER_DSP}/{pid}"):
+            for key in (
+                f"{CONF_PLAYERS}/{pid}",
+                f"{CONF_PLAYER_DSP}/{pid}",
+                f"{CONF_PLAYER_QUEUES}/{pid}",
+            ):
                 self.mass.config.remove(key)
+            if self.get_player(pid) is None:
+                self.mass.player_queues.purge_saved_queue(pid)
 
     def scale_volume_to_device(self, player_id: str, logical_volume: int) -> int:
         """Scale logical volume (0-100) to device volume (min_volume-max_volume)."""

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1116,8 +1116,7 @@ class ProtocolLinkingMixin:
         """
         Move the per-queue settings of a replaced universal player to its replacement.
 
-        Queue ids equal player ids. The queue config is not covered by the
-        permanent unregister cleanup, so the source entry is removed here.
+        Queue ids equal player ids, so the source entry is removed once it is carried over.
 
         :param universal_id: Player id of the obsolete universal player.
         :param native_id: Player id of the native player that replaces it.

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -358,7 +358,6 @@ class UniversalPlayerProvider(PlayerProvider):
                 self.mass.players._migrate_universal_player_config(player_id, default_parent)
                 self.mass.players._repoint_group_memberships(player_id, default_parent)
                 self.mass.players.delete_player_config(player_id)
-                self.mass.player_queues.on_player_remove(player_id, permanent=True)
             return
 
         stored_protocol_ids = valid_protocol_ids

--- a/tests/controllers/config/test_remove_player_config.py
+++ b/tests/controllers/config/test_remove_player_config.py
@@ -1,27 +1,47 @@
 """
-Regression tests for removing a player config with linked protocol players.
+Regression tests for the cleanup that runs when a player is removed.
 
 Reproduces the case where a player is first disabled and then removed: disabling
 cascades to the linked protocol players, so none of them is registered anymore when
 the removal comes in. The leftover (disabled) protocol config is not shown anywhere
-and keeps the device from ever registering again.
+and keeps the device from ever registering again, and the leftover queue settings and
+queue state are silently inherited by a device that returns under the same player id.
 
 Also covers the mirrored case where the player being removed is not registered (e.g.
 its provider was unloaded) while one of its protocol players still is: that protocol
 player must be detached from the removed player instead of keeping a dead parent link.
 """
 
+import logging
 from collections.abc import Callable, Generator
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
-from music_assistant_models.enums import PlaybackState, PlayerType
+from music_assistant_models.enums import (
+    PlaybackState,
+    PlayerFeature,
+    PlayerType,
+    ProviderFeature,
+    ProviderType,
+)
 
-from music_assistant.constants import CONF_PLAYER_DSP, CONF_PLAYERS, CONF_PROTOCOL_PARENT_ID
+from music_assistant.constants import (
+    CONF_PLAYER_DSP,
+    CONF_PLAYER_QUEUES,
+    CONF_PLAYERS,
+    CONF_PROTOCOL_PARENT_ID,
+)
+from music_assistant.controllers.player_queues.constants import (
+    CACHE_CATEGORY_PLAYER_QUEUE_ITEMS,
+    CACHE_CATEGORY_PLAYER_QUEUE_STATE,
+)
 from music_assistant.mass import MusicAssistant
+from music_assistant.models.player import DeviceInfo, Player
 
 PARENT_ID = "up_esp32"
 PROTOCOL_ID = "spb_esp32"
+PLAYER_ID = "test_player_1"
 
 
 class StubProtocolPlayer:
@@ -97,6 +117,91 @@ def _store_configs(mass: MusicAssistant, enabled: bool) -> None:
         },
     )
     mass.config.set(f"{CONF_PLAYER_DSP}/{PROTOCOL_ID}", {"enabled": True})
+
+
+def _store_player_config(mass: MusicAssistant, player_id: str, enabled: bool = False) -> None:
+    """Store a plain player config with customised queue settings."""
+    mass.config.set(
+        f"{CONF_PLAYERS}/{player_id}",
+        {
+            "player_id": player_id,
+            "provider": "test_provider",
+            "player_type": "player",
+            "enabled": enabled,
+            "values": {},
+        },
+    )
+    mass.config.set(
+        f"{CONF_PLAYER_QUEUES}/{player_id}",
+        {"queue_id": player_id, "values": {"crossfade_duration": 9}},
+    )
+
+
+async def _store_queue_cache(mass: MusicAssistant, player_id: str) -> None:
+    """Store cached queue state and items for the given player."""
+    for category in (CACHE_CATEGORY_PLAYER_QUEUE_STATE, CACHE_CATEGORY_PLAYER_QUEUE_ITEMS):
+        await mass.cache.set(
+            key=player_id,
+            data={"queue_id": player_id},
+            provider="player_queues",
+            category=category,
+            persistent=True,
+        )
+
+
+async def _get_queue_cache(mass: MusicAssistant, player_id: str) -> list[object]:
+    """Return the cached queue state and items for the given player."""
+    return [
+        await mass.cache.get(key=player_id, provider="player_queues", category=category)
+        for category in (CACHE_CATEGORY_PLAYER_QUEUE_STATE, CACHE_CATEGORY_PLAYER_QUEUE_ITEMS)
+    ]
+
+
+class _TestProvider:
+    """Minimal PlayerProvider stand-in that supports removing its players."""
+
+    def __init__(self, mass: MusicAssistant) -> None:
+        """Initialize the test provider."""
+        self.mass = mass
+        self.domain = "test_provider"
+        self.instance_id = "test_provider"
+        self.name = "Test Provider"
+        self.available = True
+        self.logger = logging.getLogger("test.test_provider")
+        self.manifest = MagicMock()
+        self.manifest.domain = self.domain
+        self.manifest.name = self.name
+        self.manifest.type = ProviderType.PLAYER
+        self.type = ProviderType.PLAYER
+
+    def check_feature(self, feature: ProviderFeature) -> None:
+        """Accept every feature check."""
+
+    async def remove_player(self, player_id: str) -> None:
+        """Remove the player, like a real provider does."""
+        await self.mass.players.unregister(player_id, permanent=True)
+
+    async def unload(self, is_removed: bool = False) -> None:
+        """Unload the provider (nothing to clean up)."""
+
+
+class _TestPlayer(Player):
+    """Minimal player stand-in."""
+
+    def __init__(self, provider: _TestProvider, player_id: str) -> None:
+        """Initialize the test player."""
+        super().__init__(provider, player_id)  # type: ignore[arg-type]
+        self._attr_name = "Test Player"
+        self._attr_type = PlayerType.PLAYER
+        self._attr_available = True
+        self._attr_powered = True
+        self._attr_supported_features = {PlayerFeature.VOLUME_SET, PlayerFeature.PLAY_MEDIA}
+        self._attr_device_info = DeviceInfo(model="Test Model", manufacturer="Test Manufacturer")
+        self._cache.clear()
+        self.update_state(signal_event=False)
+
+    async def stop(self) -> None:
+        """Stop playback - required abstract method."""
 
 
 async def test_remove_wipes_unregistered_protocol_configs(mass: MusicAssistant) -> None:
@@ -194,3 +299,84 @@ async def test_remove_leaves_unrelated_protocol_player_alone(
 
     assert protocol_player.protocol_parent_id == "cast_1"
     assert not _pop_scheduled_evaluation(mass)
+
+
+async def test_remove_config_wipes_queue_config(mass: MusicAssistant) -> None:
+    """Removing the config of an unregistered player also wipes its queue settings."""
+    _store_player_config(mass, PLAYER_ID)
+    await _store_queue_cache(mass, PLAYER_ID)
+
+    await mass.config.remove_player_config(PLAYER_ID)
+
+    assert mass.config.get(f"{CONF_PLAYER_QUEUES}/{PLAYER_ID}") is None
+    assert await _get_queue_cache(mass, PLAYER_ID) == [None, None]
+
+
+async def test_remove_player_wipes_queue_config(mass: MusicAssistant) -> None:
+    """Removing an unregistered player also wipes its queue settings."""
+    _store_player_config(mass, PLAYER_ID)
+    await _store_queue_cache(mass, PLAYER_ID)
+
+    await mass.players.remove(PLAYER_ID)
+
+    assert mass.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}") is None
+    assert mass.config.get(f"{CONF_PLAYER_QUEUES}/{PLAYER_ID}") is None
+    assert await _get_queue_cache(mass, PLAYER_ID) == [None, None]
+
+
+async def test_remove_registered_player_wipes_queue_config(mass: MusicAssistant) -> None:
+    """Removing a registered player also wipes its queue settings and state."""
+    _store_player_config(mass, PLAYER_ID, enabled=True)
+    provider = _TestProvider(mass)
+    player = _TestPlayer(provider, PLAYER_ID)
+    mass.players._players[PLAYER_ID] = player
+    await mass.player_queues.on_player_register(player)
+    await _store_queue_cache(mass, PLAYER_ID)
+
+    await mass.config.remove_player_config(PLAYER_ID)
+
+    assert mass.players.get_player(PLAYER_ID) is None
+    assert mass.player_queues.get(PLAYER_ID) is None
+    assert mass.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}") is None
+    assert mass.config.get(f"{CONF_PLAYER_QUEUES}/{PLAYER_ID}") is None
+    assert await _get_queue_cache(mass, PLAYER_ID) == [None, None]
+
+
+async def test_remove_wipes_queue_config_of_linked_protocol_player(
+    mass: MusicAssistant,
+) -> None:
+    """The queue settings of a wiped protocol player config go along with it."""
+    _store_configs(mass, enabled=False)
+    mass.config.set(
+        f"{CONF_PLAYER_QUEUES}/{PROTOCOL_ID}",
+        {"queue_id": PROTOCOL_ID, "values": {"crossfade_duration": 9}},
+    )
+    await _store_queue_cache(mass, PROTOCOL_ID)
+
+    await mass.config.remove_player_config(PARENT_ID)
+
+    assert mass.config.get(f"{CONF_PLAYER_QUEUES}/{PROTOCOL_ID}") is None
+    assert await _get_queue_cache(mass, PROTOCOL_ID) == [None, None]
+
+
+async def test_remove_keeps_queue_config_of_registered_protocol_player(
+    mass: MusicAssistant,
+    register_protocol_player: Callable[[str | None], StubProtocolPlayer],
+) -> None:
+    """A protocol player that keeps its config also keeps its queue settings and state."""
+    _store_configs(mass, enabled=True)
+    mass.config.set(
+        f"{CONF_PLAYER_QUEUES}/{PROTOCOL_ID}",
+        {"queue_id": PROTOCOL_ID, "values": {"crossfade_duration": 9}},
+    )
+    await _store_queue_cache(mass, PROTOCOL_ID)
+    register_protocol_player(PARENT_ID)
+
+    mass.players.delete_player_config(PARENT_ID)
+
+    assert mass.config.get(f"{CONF_PLAYER_QUEUES}/{PROTOCOL_ID}") is not None
+    assert await _get_queue_cache(mass, PROTOCOL_ID) == [
+        {"queue_id": PROTOCOL_ID},
+        {"queue_id": PROTOCOL_ID},
+    ]
+    _pop_scheduled_evaluation(mass)

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -8523,9 +8523,6 @@ class TestUniversalPlayerRestoreOrphanCleanup:
             universal_id, native_parent_id
         )
         mock_mass.players.delete_player_config.assert_called_once_with(universal_id)
-        mock_mass.player_queues.on_player_remove.assert_called_once_with(
-            universal_id, permanent=True
-        )
 
         # Each protocol's parent_id is restored to the disabled native parent
         parent_restorations = {
@@ -8620,9 +8617,6 @@ class TestUniversalPlayerRestoreOrphanCleanup:
             universal_id, "native_a"
         )
         mock_mass.players.delete_player_config.assert_called_once_with(universal_id)
-        mock_mass.player_queues.on_player_remove.assert_called_once_with(
-            universal_id, permanent=True
-        )
 
     @pytest.mark.asyncio
     async def test_restore_native_claims_carries_config_and_deletes_wrapper(
@@ -8712,9 +8706,7 @@ class TestUniversalPlayerRestoreOrphanCleanup:
         # the wrapper's own config entries are all gone
         assert universal_id not in players_tree
         # cached queue state of the wrapper is purged as well
-        mock_mass.player_queues.on_player_remove.assert_called_once_with(
-            universal_id, permanent=True
-        )
+        mock_mass.player_queues.purge_saved_queue.assert_called_once_with(universal_id)
         # the wrapper itself is not registered as a player
         assert universal_id not in controller._players
         for task in scheduled_tasks:


### PR DESCRIPTION
# What does this implement/fix?

Removing a player left its queue settings (crossfade, autoplay, smart shuffle, ...) and its saved queue behind in the settings. They were never shown anywhere, but if a device ever came back with the same id, it silently picked up those old settings and the old queue instead of starting fresh.

This was worst for a player that was disabled before it was removed: nothing was cleaned up for it at all, since it was no longer registered at that point.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Deleting a player's config now also deletes its queue settings and its saved queue, for the player itself and for the linked protocol players that are wiped along with it
- This now happens for a player that was no longer registered too, which was the case that cleaned up nothing at all
- Tests for both removal entry points, for a registered and an unregistered player

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
