### PR TITLE
Keep protocol players working when their parent player is removed

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1642,8 +1642,10 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         Only wipes the stored configuration, the player itself is not unregistered.
         The config of a linked protocol player is wiped along with it, so the device
         returns as a brand new player once it is discovered again. Protocol players that
-        are still registered or that already moved to another parent keep their config.
+        are still registered or that already moved to another parent keep their config;
+        registered ones are detached from the removed player and re-evaluated.
         """
+        self._detach_protocol_children(player_id)
         player_ids = [
             protocol_id
             for protocol_id in self.mass.config.get(CONF_PLAYERS, {})

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1549,14 +1549,12 @@ class ProtocolLinkingMixin:
                 if protocol_player := self.get_player(protocol_id):
                     # Protocol player is available: clear parent and schedule re-evaluation
                     # so it can be matched to a new parent or a new universal player
-                    protocol_player.set_protocol_parent_id(None)
-                    protocol_player.refresh_state()
                     self.logger.debug(
                         "Player %s removed - scheduling evaluation for protocol %s",
                         player.player_id,
                         protocol_id,
                     )
-                    self._schedule_protocol_evaluation(protocol_player)
+                    self._detach_protocol_child(protocol_player)
                 else:
                     # Protocol player is not registered yet — it may still be
                     # mid-discovery (e.g., DLNA connecting via SSDP). Don't delete
@@ -1568,6 +1566,40 @@ class ProtocolLinkingMixin:
                         player.player_id,
                         protocol_id,
                     )
+
+    def _detach_protocol_children(self, parent_id: str) -> None:
+        """
+        Detach the registered protocol players of a parent player that is going away.
+
+        Covers the removal paths that don't unregister the parent first (e.g. its
+        provider is unloaded), where the parent is not around anymore to enumerate
+        its protocol players.
+
+        :param parent_id: Player id of the parent that is being removed.
+        """
+        for protocol_player in list(self._players.values()):
+            if protocol_player.state.type != PlayerType.PROTOCOL:
+                continue
+            # a protocol player waiting for a parent that never registered only has
+            # the link in its config, so match on both the live and the cached parent
+            if parent_id not in (
+                protocol_player.protocol_parent_id,
+                self._get_cached_protocol_parent_id(protocol_player.player_id),
+            ):
+                continue
+            self.logger.debug(
+                "Player %s removed - scheduling evaluation for protocol %s",
+                parent_id,
+                protocol_player.player_id,
+            )
+            self._detach_protocol_child(protocol_player)
+
+    def _detach_protocol_child(self, protocol_player: Player) -> None:
+        """Clear a protocol player's parent link and schedule a fresh evaluation."""
+        self._clear_protocol_parent_id(protocol_player.player_id)
+        protocol_player.set_protocol_parent_id(None)
+        protocol_player.refresh_state()
+        self._schedule_protocol_evaluation(protocol_player)
 
     def _identifiers_match(
         self, player_a: Player, player_b: Player, protocol_domain: str = ""

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1543,9 +1543,6 @@ class ProtocolLinkingMixin:
             # since disabled/inactive protocols may only exist in the cached parent data.
             all_protocol_ids = set(self._get_known_protocol_ids(player))
             for protocol_id in all_protocol_ids:
-                # Clear cached parent ID in config so protocol won't try to
-                # restore a link to the deleted player on next restart
-                self._clear_protocol_parent_id(protocol_id)
                 if protocol_player := self.get_player(protocol_id):
                     # Protocol player is available: clear parent and schedule re-evaluation
                     # so it can be matched to a new parent or a new universal player
@@ -1556,6 +1553,9 @@ class ProtocolLinkingMixin:
                     )
                     self._detach_protocol_child(protocol_player)
                 else:
+                    # Clear cached parent ID in config so protocol won't try to
+                    # restore a link to the deleted player on next restart
+                    self._clear_protocol_parent_id(protocol_id)
                     # Protocol player is not registered yet — it may still be
                     # mid-discovery (e.g., DLNA connecting via SSDP). Don't delete
                     # its config as that would cause a KeyError when it finishes
@@ -1581,11 +1581,11 @@ class ProtocolLinkingMixin:
             if protocol_player.state.type != PlayerType.PROTOCOL:
                 continue
             # a protocol player waiting for a parent that never registered only has
-            # the link in its config, so match on both the live and the cached parent
-            if parent_id not in (
-                protocol_player.protocol_parent_id,
-                self._get_cached_protocol_parent_id(protocol_player.player_id),
-            ):
+            # the link in its config, so fall back to the cached parent
+            linked_parent_id = protocol_player.protocol_parent_id or (
+                self._get_cached_protocol_parent_id(protocol_player.player_id)
+            )
+            if linked_parent_id != parent_id:
                 continue
             self.logger.debug(
                 "Player %s removed - scheduling evaluation for protocol %s",

--- a/tests/controllers/config/test_remove_player_config.py
+++ b/tests/controllers/config/test_remove_player_config.py
@@ -5,15 +5,57 @@ Reproduces the case where a player is first disabled and then removed: disabling
 cascades to the linked protocol players, so none of them is registered anymore when
 the removal comes in. The leftover (disabled) protocol config is not shown anywhere
 and keeps the device from ever registering again.
+
+Also covers the mirrored case where the player being removed is not registered (e.g.
+its provider was unloaded) while one of its protocol players still is: that protocol
+player must be detached from the removed player instead of keeping a dead parent link.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+from music_assistant_models.enums import PlayerType
 
 from music_assistant.constants import CONF_PLAYER_DSP, CONF_PLAYERS, CONF_PROTOCOL_PARENT_ID
 from music_assistant.mass import MusicAssistant
 
 PARENT_ID = "up_esp32"
 PROTOCOL_ID = "spb_esp32"
+
+
+class StubProtocolPlayer:
+    """Minimal stand-in for a registered protocol player."""
+
+    def __init__(self, parent_id: str | None) -> None:
+        """Initialize the stub with the given (live) protocol parent."""
+        self.player_id = PROTOCOL_ID
+        self.state = SimpleNamespace(type=PlayerType.PROTOCOL)
+        self.protocol_parent_id = parent_id
+        self.refreshed = False
+        self.sleep_timer_expires_at = None
+
+    def set_protocol_parent_id(self, parent_id: str | None) -> None:
+        """Set the live protocol parent."""
+        self.protocol_parent_id = parent_id
+
+    def refresh_state(self) -> None:
+        """Record that the state was refreshed."""
+        self.refreshed = True
+
+
+def _register_protocol_player(mass: MusicAssistant, parent_id: str | None) -> StubProtocolPlayer:
+    """Register a stub protocol player on the player controller."""
+    protocol_player = StubProtocolPlayer(parent_id)
+    mass.players._players[PROTOCOL_ID] = protocol_player  # type: ignore[assignment]
+    return protocol_player
+
+
+def _pop_scheduled_evaluation(mass: MusicAssistant) -> bool:
+    """Return True if a protocol evaluation is pending for the protocol player."""
+    if handle := mass.players._pending_protocol_evaluations.pop(PROTOCOL_ID, None):
+        handle.cancel()
+        return True
+    return False
 
 
 def _store_configs(mass: MusicAssistant, enabled: bool) -> None:
@@ -85,3 +127,48 @@ async def test_remove_keeps_registered_protocol_configs(mass: MusicAssistant) ->
     assert mass.config.get(f"{CONF_PLAYERS}/{PARENT_ID}") is None
     assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}") is not None
     assert mass.config.get(f"{CONF_PLAYER_DSP}/{PROTOCOL_ID}") is not None
+
+
+async def test_remove_detaches_registered_protocol_player(mass: MusicAssistant) -> None:
+    """Removing an unregistered parent detaches its still registered protocol player."""
+    _store_configs(mass, enabled=True)
+    protocol_player = _register_protocol_player(mass, parent_id=PARENT_ID)
+
+    await mass.config.remove_player_config(PARENT_ID)
+
+    assert mass.config.get(f"{CONF_PLAYERS}/{PARENT_ID}") is None
+    assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}") is not None
+    assert protocol_player.protocol_parent_id is None
+    assert protocol_player.refreshed
+    assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}/values/{CONF_PROTOCOL_PARENT_ID}") is None
+    assert _pop_scheduled_evaluation(mass)
+
+
+async def test_remove_detaches_protocol_player_waiting_for_its_parent(
+    mass: MusicAssistant,
+) -> None:
+    """A protocol player that only has the parent link in its config is detached too."""
+    _store_configs(mass, enabled=True)
+    protocol_player = _register_protocol_player(mass, parent_id=None)
+
+    await mass.config.remove_player_config(PARENT_ID)
+
+    assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}/values/{CONF_PROTOCOL_PARENT_ID}") is None
+    assert protocol_player.protocol_parent_id is None
+    assert _pop_scheduled_evaluation(mass)
+
+
+async def test_remove_leaves_unrelated_protocol_player_alone(mass: MusicAssistant) -> None:
+    """A protocol player of another parent keeps its link when a player is removed."""
+    _store_configs(mass, enabled=True)
+    mass.config.set(f"{CONF_PLAYERS}/{PROTOCOL_ID}/values/{CONF_PROTOCOL_PARENT_ID}", "cast_1")
+    protocol_player = _register_protocol_player(mass, parent_id="cast_1")
+
+    mass.players.delete_player_config(PARENT_ID)
+
+    assert protocol_player.protocol_parent_id == "cast_1"
+    assert (
+        mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}/values/{CONF_PROTOCOL_PARENT_ID}")
+        == "cast_1"
+    )
+    assert not _pop_scheduled_evaluation(mass)

--- a/tests/controllers/config/test_remove_player_config.py
+++ b/tests/controllers/config/test_remove_player_config.py
@@ -11,10 +11,11 @@ its provider was unloaded) while one of its protocol players still is: that prot
 player must be detached from the removed player instead of keeping a dead parent link.
 """
 
+from collections.abc import Callable, Generator
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
-from music_assistant_models.enums import PlayerType
+import pytest
+from music_assistant_models.enums import PlaybackState, PlayerType
 
 from music_assistant.constants import CONF_PLAYER_DSP, CONF_PLAYERS, CONF_PROTOCOL_PARENT_ID
 from music_assistant.mass import MusicAssistant
@@ -29,10 +30,17 @@ class StubProtocolPlayer:
     def __init__(self, parent_id: str | None) -> None:
         """Initialize the stub with the given (live) protocol parent."""
         self.player_id = PROTOCOL_ID
-        self.state = SimpleNamespace(type=PlayerType.PROTOCOL)
+        # a registered player is looked up and polled by the running server,
+        # so carry the state fields those paths read
+        self.state = SimpleNamespace(
+            type=PlayerType.PROTOCOL,
+            playback_state=PlaybackState.IDLE,
+            available=True,
+            enabled=True,
+        )
+        self.needs_poll = False
         self.protocol_parent_id = parent_id
         self.refreshed = False
-        self.sleep_timer_expires_at = None
 
     def set_protocol_parent_id(self, parent_id: str | None) -> None:
         """Set the live protocol parent."""
@@ -43,11 +51,19 @@ class StubProtocolPlayer:
         self.refreshed = True
 
 
-def _register_protocol_player(mass: MusicAssistant, parent_id: str | None) -> StubProtocolPlayer:
-    """Register a stub protocol player on the player controller."""
-    protocol_player = StubProtocolPlayer(parent_id)
-    mass.players._players[PROTOCOL_ID] = protocol_player  # type: ignore[assignment]
-    return protocol_player
+@pytest.fixture(name="register_protocol_player")
+def register_protocol_player_fixture(
+    mass: MusicAssistant,
+) -> Generator[Callable[[str | None], StubProtocolPlayer]]:
+    """Register a stub protocol player on the player controller for the test."""
+
+    def _register(parent_id: str | None) -> StubProtocolPlayer:
+        protocol_player = StubProtocolPlayer(parent_id)
+        mass.players._players[PROTOCOL_ID] = protocol_player  # type: ignore[assignment]
+        return protocol_player
+
+    yield _register
+    mass.players._players.pop(PROTOCOL_ID, None)
 
 
 def _pop_scheduled_evaluation(mass: MusicAssistant) -> bool:
@@ -117,22 +133,29 @@ async def test_remove_keeps_reparented_protocol_configs(mass: MusicAssistant) ->
     assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}") is not None
 
 
-async def test_remove_keeps_registered_protocol_configs(mass: MusicAssistant) -> None:
+async def test_remove_keeps_registered_protocol_configs(
+    mass: MusicAssistant,
+    register_protocol_player: Callable[[str | None], StubProtocolPlayer],
+) -> None:
     """A protocol player that is still registered keeps its config to be re-parented."""
     _store_configs(mass, enabled=True)
-    mass.players._players[PROTOCOL_ID] = MagicMock()
+    register_protocol_player(PARENT_ID)
 
     mass.players.delete_player_config(PARENT_ID)
 
     assert mass.config.get(f"{CONF_PLAYERS}/{PARENT_ID}") is None
     assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}") is not None
     assert mass.config.get(f"{CONF_PLAYER_DSP}/{PROTOCOL_ID}") is not None
+    _pop_scheduled_evaluation(mass)
 
 
-async def test_remove_detaches_registered_protocol_player(mass: MusicAssistant) -> None:
+async def test_remove_detaches_registered_protocol_player(
+    mass: MusicAssistant,
+    register_protocol_player: Callable[[str | None], StubProtocolPlayer],
+) -> None:
     """Removing an unregistered parent detaches its still registered protocol player."""
     _store_configs(mass, enabled=True)
-    protocol_player = _register_protocol_player(mass, parent_id=PARENT_ID)
+    protocol_player = register_protocol_player(PARENT_ID)
 
     await mass.config.remove_player_config(PARENT_ID)
 
@@ -146,10 +169,11 @@ async def test_remove_detaches_registered_protocol_player(mass: MusicAssistant) 
 
 async def test_remove_detaches_protocol_player_waiting_for_its_parent(
     mass: MusicAssistant,
+    register_protocol_player: Callable[[str | None], StubProtocolPlayer],
 ) -> None:
     """A protocol player that only has the parent link in its config is detached too."""
     _store_configs(mass, enabled=True)
-    protocol_player = _register_protocol_player(mass, parent_id=None)
+    protocol_player = register_protocol_player(None)
 
     await mass.config.remove_player_config(PARENT_ID)
 
@@ -158,17 +182,15 @@ async def test_remove_detaches_protocol_player_waiting_for_its_parent(
     assert _pop_scheduled_evaluation(mass)
 
 
-async def test_remove_leaves_unrelated_protocol_player_alone(mass: MusicAssistant) -> None:
+async def test_remove_leaves_unrelated_protocol_player_alone(
+    mass: MusicAssistant,
+    register_protocol_player: Callable[[str | None], StubProtocolPlayer],
+) -> None:
     """A protocol player of another parent keeps its link when a player is removed."""
     _store_configs(mass, enabled=True)
-    mass.config.set(f"{CONF_PLAYERS}/{PROTOCOL_ID}/values/{CONF_PROTOCOL_PARENT_ID}", "cast_1")
-    protocol_player = _register_protocol_player(mass, parent_id="cast_1")
+    protocol_player = register_protocol_player("cast_1")
 
     mass.players.delete_player_config(PARENT_ID)
 
     assert protocol_player.protocol_parent_id == "cast_1"
-    assert (
-        mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}/values/{CONF_PROTOCOL_PARENT_ID}")
-        == "cast_1"
-    )
     assert not _pop_scheduled_evaluation(mass)

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -8011,6 +8011,73 @@ class TestCleanupProtocolLinks:
         mock_schedule.assert_called_once_with(protocol_player)
 
 
+class TestDetachProtocolChildren:
+    """Tests for detaching protocol players of a removed player that is not registered."""
+
+    @staticmethod
+    def _setup(
+        mock_mass: MagicMock, live_parent_id: str | None
+    ) -> tuple[PlayerController, MockPlayer, dict[str, object]]:
+        """Set up a registered protocol player whose (unregistered) parent is sonos_1."""
+        controller = PlayerController(mock_mass)
+
+        config_store: dict[str, object] = {
+            "players": {"sonos_1": {}, "airplay_live": {}},
+            "players/sonos_1": {"enabled": True},
+            "players/airplay_live": {"enabled": True},
+            "players/airplay_live/values/protocol_parent_id": "sonos_1",
+        }
+
+        mock_mass.config.get = MagicMock(
+            side_effect=lambda key, default=None: config_store.get(key, default)
+        )
+        mock_mass.config.set = MagicMock(
+            side_effect=lambda key, value: config_store.__setitem__(key, value)
+        )
+
+        protocol_player = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "airplay_live",
+            "AirPlay Test",
+            player_type=PlayerType.PROTOCOL,
+        )
+        protocol_player.set_protocol_parent_id(live_parent_id)
+        controller._players = {"airplay_live": protocol_player}
+        return controller, protocol_player, config_store
+
+    def test_detach_on_removal_of_an_unregistered_parent(self, mock_mass: MagicMock) -> None:
+        """Removing a player that is no longer registered detaches its protocol player."""
+        controller, protocol_player, config_store = self._setup(mock_mass, "sonos_1")
+
+        with patch.object(controller, "_schedule_protocol_evaluation") as mock_schedule:
+            controller.delete_player_config("sonos_1")
+
+        assert protocol_player.protocol_parent_id is None
+        assert config_store["players/airplay_live/values/protocol_parent_id"] is None
+        mock_schedule.assert_called_once_with(protocol_player)
+
+    def test_detach_of_a_protocol_player_waiting_for_its_parent(self, mock_mass: MagicMock) -> None:
+        """A protocol player that only has the parent link in its config is detached too."""
+        controller, protocol_player, config_store = self._setup(mock_mass, None)
+
+        with patch.object(controller, "_schedule_protocol_evaluation") as mock_schedule:
+            controller.delete_player_config("sonos_1")
+
+        assert config_store["players/airplay_live/values/protocol_parent_id"] is None
+        mock_schedule.assert_called_once_with(protocol_player)
+
+    def test_detach_skips_a_protocol_player_of_another_parent(self, mock_mass: MagicMock) -> None:
+        """A protocol player that already moved to another parent keeps its link."""
+        controller, protocol_player, config_store = self._setup(mock_mass, "cast_1")
+
+        with patch.object(controller, "_schedule_protocol_evaluation") as mock_schedule:
+            controller.delete_player_config("sonos_1")
+
+        assert protocol_player.protocol_parent_id == "cast_1"
+        assert config_store["players/airplay_live/values/protocol_parent_id"] == "sonos_1"
+        mock_schedule.assert_not_called()
+
+
 class TestStaleConfigMigration:
     """Tests for protocol parent link repair on startup."""
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up on #5525. When a player is removed while it is not registered anymore (for example because its provider was unloaded or failed to load), the AirPlay/DLNA/Sendspin endpoints of that same device that _are_ still registered kept pointing at the removed player. Nothing cleared that link or triggered a new evaluation, so those endpoints stayed hidden until the server was restarted.

Removing a player now also detaches its protocol players and re-evaluates them, so they get linked to another player or wrapped in a new one right away.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- `delete_player_config` now detaches the still registered protocol players of the player being removed and schedules a fresh protocol evaluation for them.
- The parent link is cleared both live and in the stored config, so it also covers a protocol player that was only waiting for a parent that never registered.
- Shared the detach logic with the existing permanent-removal cleanup instead of duplicating it.
- Added tests for removing a player that is no longer registered while its protocol player still is.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
