### PR TITLE
Start playback at the saved position on Media Station X players

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1398,6 +1398,9 @@ class StreamsController(CoreController):
             inner_stream = self.audio.get_queue_item_stream(
                 queue_item=queue_item,
                 pcm_format=pcm_format,
+                seek_position=(
+                    int(queue_item.streamdetails.seek_position) if queue_item.streamdetails else 0
+                ),
                 playback_speed=cast(
                     "float", queue_item.extra_attributes.get("playback_speed", 1.0)
                 ),

--- a/tests/controllers/streams/test_direct_pcm_stream.py
+++ b/tests/controllers/streams/test_direct_pcm_stream.py
@@ -1,0 +1,90 @@
+"""Tests for the direct-PCM stream helper on the streams controller."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.player import PlayerMedia
+from music_assistant_models.queue_item import QueueItem
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.controllers.streams.controller import StreamsController
+
+PCM_FORMAT = AudioFormat(
+    content_type=ContentType.PCM_S16LE,
+    sample_rate=44100,
+    bit_depth=16,
+    channels=2,
+)
+
+QUEUE_ID = "player-1"
+QUEUE_ITEM_ID = "item-1"
+
+
+def _queue_item(seek_position: int) -> QueueItem:
+    """Build an audiobook queue item whose streamdetails carry the given seek position."""
+    return QueueItem(
+        queue_id=QUEUE_ID,
+        queue_item_id=QUEUE_ITEM_ID,
+        name="Some Audiobook",
+        duration=7200,
+        streamdetails=StreamDetails(
+            provider="builtin",
+            item_id="book-1",
+            audio_format=PCM_FORMAT,
+            media_type=MediaType.AUDIOBOOK,
+            stream_type=StreamType.HTTP,
+            path="http://example.com/book.mp3",
+            duration=7200,
+            can_seek=True,
+            allow_seek=True,
+            queue_id=QUEUE_ID,
+            seek_position=seek_position,
+        ),
+    )
+
+
+def _controller(queue_item: QueueItem) -> tuple[StreamsController, dict[str, Any]]:
+    """
+    Build a streams controller that records the kwargs of the single item stream call.
+
+    The queue itself is absent, which keeps the request on the non-flow (single item)
+    branch: crossfade and audio overlay both need a queue to force flow mode.
+    """
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
+    mass.player_queues.get.return_value = None
+    mass.player_queues.get_item.return_value = queue_item
+    controller = StreamsController(mass)
+    call_kwargs: dict[str, Any] = {}
+
+    def _record(**kwargs: Any) -> object:
+        call_kwargs.update(kwargs)
+        return object()
+
+    controller.audio = MagicMock()
+    controller.audio.get_queue_item_stream.side_effect = _record
+    return controller, call_kwargs
+
+
+@pytest.mark.parametrize("seek_position", [1800, 0])
+def test_single_item_stream_starts_at_the_seek_position(seek_position: int) -> None:
+    """A resumed (or seeked) item is served from its seek position, not from the start."""
+    queue_item = _queue_item(seek_position)
+    controller, call_kwargs = _controller(queue_item)
+
+    controller.get_stream(
+        PlayerMedia(
+            uri="library://audiobook/1",
+            media_type=MediaType.AUDIOBOOK,
+            source_id=QUEUE_ID,
+            queue_item_id=QUEUE_ITEM_ID,
+        ),
+        PCM_FORMAT,
+    )
+
+    assert call_kwargs["seek_position"] == seek_position

--- a/tests/controllers/streams/test_direct_pcm_stream.py
+++ b/tests/controllers/streams/test_direct_pcm_stream.py
@@ -54,6 +54,8 @@ def _controller(queue_item: QueueItem) -> tuple[StreamsController, dict[str, Any
 
     The queue itself is absent, which keeps the request on the non-flow (single item)
     branch: crossfade and audio overlay both need a queue to force flow mode.
+
+    :param queue_item: The item the controller resolves the stream request to.
     """
     mass = MagicMock()
     mass.config.get_raw_core_config_value.return_value = "GLOBAL"
@@ -72,8 +74,8 @@ def _controller(queue_item: QueueItem) -> tuple[StreamsController, dict[str, Any
 
 
 @pytest.mark.parametrize("seek_position", [1800, 0])
-def test_single_item_stream_starts_at_the_seek_position(seek_position: int) -> None:
-    """A resumed (or seeked) item is served from its seek position, not from the start."""
+def test_single_item_stream_forwards_the_seek_position(seek_position: int) -> None:
+    """A resumed (or seeked) item is streamed from its seek position, not from the start."""
     queue_item = _queue_item(seek_position)
     controller, call_kwargs = _controller(queue_item)
 


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant can hand raw audio straight to a player instead of serving it over HTTP. On that route the saved position was dropped, so an audiobook or podcast picked up where it was left off — and any seek — started over from the very beginning.

In practice this only affects Media Station X players — on every other player a saved position was already handled correctly.

Changes:

- Pass the playback position along when handing a single item to a player directly, matching what the HTTP route already does.
- Added a test covering it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

