### PR TITLE
Never leave a library item without a playable source

### DIFF
--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -1206,13 +1206,6 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
     ) -> None:
         """Update the provider_items table for the media item."""
         db_id = int(item_id)  # ensure integer
-        if overwrite:
-            # on overwrite, clear the provider_mappings table first
-            # this is done for filesystem provider changing the path (and thus item_id)
-            await self.mass.music.database.delete(
-                DB_TABLE_PROVIDER_MAPPINGS,
-                {"media_type": self.media_type.value, "item_id": db_id},
-            )
         prov_map_objs: list[dict[str, Any]] = []
         for provider_mapping in provider_mappings:
             prov_map_obj = {
@@ -1228,6 +1221,23 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 if (value := getattr(provider_mapping, key, None)) is not None:
                     prov_map_obj[key] = value
             prov_map_objs.append(prov_map_obj)
+        if not prov_map_objs:
+            # an item without any provider mapping can not be played or resolved,
+            # so never wipe the existing rows when there is nothing to replace them with
+            if overwrite:
+                self.logger.warning(
+                    "Ignoring request to clear all provider mappings of %s %s",
+                    self.media_type.value,
+                    db_id,
+                )
+            return
+        if overwrite:
+            # on overwrite, clear the provider_mappings table first
+            # this is done for filesystem provider changing the path (and thus item_id)
+            await self.mass.music.database.delete(
+                DB_TABLE_PROVIDER_MAPPINGS,
+                {"media_type": self.media_type.value, "item_id": db_id},
+            )
         await self.mass.music.database.upsert_many(
             DB_TABLE_PROVIDER_MAPPINGS,
             prov_map_objs,

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -1204,7 +1204,12 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         provider_mappings: Iterable[ProviderMapping],
         overwrite: bool = False,
     ) -> None:
-        """Update the provider_items table for the media item."""
+        """
+        Update the provider_mappings table for the media item.
+
+        An empty set of mappings never clears the stored rows: an item without any
+        mapping can not be played or resolved.
+        """
         db_id = int(item_id)  # ensure integer
         prov_map_objs: list[dict[str, Any]] = []
         for provider_mapping in provider_mappings:
@@ -1222,11 +1227,11 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                     prov_map_obj[key] = value
             prov_map_objs.append(prov_map_obj)
         if not prov_map_objs:
-            # an item without any provider mapping can not be played or resolved,
-            # so never wipe the existing rows when there is nothing to replace them with
             if overwrite:
+                # a caller asking to replace all mappings with none is a bug,
+                # so keep the stored rows and make the attempt visible
                 self.logger.warning(
-                    "Ignoring request to clear all provider mappings of %s %s",
+                    "Ignoring request to clear all provider mappings of %s item id %s",
                     self.media_type.value,
                     db_id,
                 )

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -847,6 +847,20 @@ async def test_set_provider_mappings_overwrite_keeps_existing_when_empty(
 
     mock_controller.mass.music.database.delete.assert_not_called()
     mock_controller.mass.music.database.upsert_many.assert_not_called()
+    mock_controller.logger.warning.assert_called_once()
+
+
+async def test_set_provider_mappings_no_mappings_is_noop(mock_controller: Mock) -> None:
+    """
+    Test that an empty mappings set without overwrite writes nothing.
+
+    :param mock_controller: Mock MediaControllerBase instance.
+    """
+    await mock_controller.set_provider_mappings(1, [], overwrite=False)
+
+    mock_controller.mass.music.database.delete.assert_not_called()
+    mock_controller.mass.music.database.upsert_many.assert_not_called()
+    mock_controller.logger.warning.assert_not_called()
 
 
 async def test_set_provider_mappings_upsert_preserves_null_in_library(

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -811,6 +811,7 @@ def mock_controller() -> Mock:
     """Create a mock MediaControllerBase for set_provider_mappings tests."""
     ctrl = Mock(spec=MediaControllerBase)
     ctrl.media_type = MediaType.ALBUM
+    ctrl.logger = Mock()
     ctrl.mass = Mock()
     ctrl.mass.music.database.delete = AsyncMock()
     ctrl.mass.music.database.upsert_many = AsyncMock()
@@ -832,6 +833,20 @@ async def test_set_provider_mappings_overwrite_deletes_and_reinserts(
 
     mock_controller.mass.music.database.delete.assert_called_once()
     mock_controller.mass.music.database.upsert_many.assert_called_once()
+
+
+async def test_set_provider_mappings_overwrite_keeps_existing_when_empty(
+    mock_controller: Mock,
+) -> None:
+    """
+    Test that overwrite=True with no mappings leaves the existing mappings untouched.
+
+    :param mock_controller: Mock MediaControllerBase instance.
+    """
+    await mock_controller.set_provider_mappings(1, [], overwrite=True)
+
+    mock_controller.mass.music.database.delete.assert_not_called()
+    mock_controller.mass.music.database.upsert_many.assert_not_called()
 
 
 async def test_set_provider_mappings_upsert_preserves_null_in_library(


### PR DESCRIPTION
# What does this implement/fix?

Every library item needs at least one provider mapping to be playable. When an item update is
saved with the "overwrite" flag, the stored mappings are cleared first and then replaced by
the ones supplied with the update. If that update happens to carry no mappings at all, the
item was left behind with none — present in the library, but impossible to play.

No shipped client does this today — the app always sends the item's existing mappings back —
but nothing on the server side guaranteed it. Follow-up on #5522, which closed the same hole
in the mapping-removal paths.

- Keep the existing provider mappings instead of wiping them when an overwrite comes in with
  none, and log a warning
- Added test coverage

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
