### PR TITLE
Make failing background tasks fail the announcement tests

### DIFF
--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
-from collections.abc import AsyncIterator, Callable, Iterator
+from collections.abc import AsyncIterator, Callable, Coroutine, Iterator
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -116,6 +116,32 @@ def _volume_step_config(step: int | None) -> CoreConfig:
             )
         },
     )
+
+
+@contextlib.contextmanager
+def _running_background_tasks(mock_mass: MagicMock) -> Iterator[None]:
+    """
+    Let ``mass.create_task`` actually run its coroutine on the running event loop.
+
+    :param mock_mass: The mocked MusicAssistant instance to patch.
+    """
+    errors: list[BaseException] = []
+
+    def _collect_exception(task: asyncio.Task[Any]) -> None:
+        # the real helper retrieves the exception of every task it creates, so a failing
+        # background task must fail the test instead of only warning at collection time
+        if not task.cancelled() and (err := task.exception()) is not None:
+            errors.append(err)
+
+    def _create_task(coro: Coroutine[Any, Any, Any], **_kwargs: Any) -> asyncio.Task[Any]:
+        task = asyncio.ensure_future(coro)
+        task.add_done_callback(_collect_exception)
+        return task
+
+    mock_mass.create_task = MagicMock(side_effect=_create_task)
+    yield
+    if errors:
+        raise errors[0]
 
 
 def _mute_natively(player: MockPlayer) -> AsyncMock:
@@ -3089,6 +3115,12 @@ class TestPlayAnnouncementCleanup:
 class TestPlayAnnouncementRestore:
     """Test the state restore of the default (fallback) announcement implementation."""
 
+    @pytest.fixture(autouse=True)
+    def _background_tasks(self, mock_mass: MagicMock) -> Iterator[None]:
+        """Run the (temporary and restored) volume commands the TaskManager dispatches."""
+        with _running_background_tasks(mock_mass):
+            yield
+
     def _make_player(
         self, mock_mass: MagicMock, prev_media: PlayerMedia
     ) -> tuple[PlayerController, MockPlayer, AsyncMock]:
@@ -3101,11 +3133,7 @@ class TestPlayAnnouncementRestore:
         player._cache.clear()
         controller._players = {"player_1": player}
         mock_mass.players = controller
-        # the (temporary and restored) volume commands are dispatched through the
-        # TaskManager, so background tasks must actually run in these tests
-        mock_mass.create_task = MagicMock(
-            side_effect=lambda coro, **_kwargs: asyncio.ensure_future(coro)
-        )
+        mock_mass.player_queues.get = MagicMock(return_value=None)
         resume_mock = AsyncMock()
         controller._handle_cmd_resume = resume_mock  # type: ignore[method-assign]
         controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
@@ -3454,6 +3482,12 @@ class TestPlayAnnouncementRestore:
 class TestPlayNativeAnnouncement:
     """Test the mute handling around an announcement that a player plays natively."""
 
+    @pytest.fixture(autouse=True)
+    def _background_tasks(self, mock_mass: MagicMock) -> Iterator[None]:
+        """Run the mute commands the TaskManager dispatches."""
+        with _running_background_tasks(mock_mass):
+            yield
+
     def _make_player(self, mock_mass: MagicMock) -> tuple[PlayerController, MockPlayer, AsyncMock]:
         """Create a controller and a player with native announcement support."""
         controller = PlayerController(mock_mass)
@@ -3463,11 +3497,7 @@ class TestPlayNativeAnnouncement:
         player._cache.clear()
         controller._players = {"player_1": player}
         mock_mass.players = controller
-        # the mute commands are dispatched through the TaskManager,
-        # so background tasks must actually run in these tests
-        mock_mass.create_task = MagicMock(
-            side_effect=lambda coro, **_kwargs: asyncio.ensure_future(coro)
-        )
+        mock_mass.player_queues.get = MagicMock(return_value=None)
         controller.get_announcement_volume = MagicMock(return_value=None)  # type: ignore[method-assign]
         announce_mock = AsyncMock()
         player.play_announcement = announce_mock  # type: ignore[method-assign]

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -126,22 +126,23 @@ def running_background_tasks(mock_mass: MagicMock) -> Iterator[None]:
     The real implementation only logs the exception of a background task, which would
     leave a test that dispatches its work through the TaskManager passing regardless.
     """
-    errors: list[BaseException] = []
+    tasks: list[asyncio.Task[Any]] = []
     use_real_create_task(mock_mass)
     real_create_task = mock_mass.create_task
-
-    def _collect_exception(task: asyncio.Task[Any]) -> None:
-        if not task.cancelled() and (err := task.exception()) is not None:
-            errors.append(err)
 
     def _create_task(target: Any, *args: Any, **kwargs: Any) -> Any:
         task = real_create_task(target, *args, **kwargs)
         if isinstance(task, asyncio.Task):
-            task.add_done_callback(_collect_exception)
+            tasks.append(task)
         return task
 
     mock_mass.create_task = MagicMock(side_effect=_create_task)
     yield
+    errors = [
+        err
+        for task in tasks
+        if task.done() and not task.cancelled() and (err := task.exception()) is not None
+    ]
     if len(errors) == 1:
         raise errors[0]
     if errors:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
-from collections.abc import AsyncIterator, Callable, Coroutine, Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
@@ -57,7 +57,7 @@ from music_assistant.constants import (
 from music_assistant.controllers.players import PlayerController
 from music_assistant.controllers.webserver.helpers.auth_middleware import current_user
 from music_assistant.models.player_provider import PlayerProvider
-from tests.common import MockPlayer, MockProvider, create_mock_config
+from tests.common import MockPlayer, MockProvider, create_mock_config, use_real_create_task
 
 
 def _player_config_stub(
@@ -118,30 +118,34 @@ def _volume_step_config(step: int | None) -> CoreConfig:
     )
 
 
-@contextlib.contextmanager
-def _running_background_tasks(mock_mass: MagicMock) -> Iterator[None]:
+@pytest.fixture
+def running_background_tasks(mock_mass: MagicMock) -> Iterator[None]:
     """
-    Let ``mass.create_task`` actually run its coroutine on the running event loop.
+    Really run the tasks that ``mass.create_task`` is handed, and raise what they raise.
 
-    :param mock_mass: The mocked MusicAssistant instance to patch.
+    The real implementation only logs the exception of a background task, which would
+    leave a test that dispatches its work through the TaskManager passing regardless.
     """
     errors: list[BaseException] = []
+    use_real_create_task(mock_mass)
+    real_create_task = mock_mass.create_task
 
     def _collect_exception(task: asyncio.Task[Any]) -> None:
-        # the real helper retrieves the exception of every task it creates, so a failing
-        # background task must fail the test instead of only warning at collection time
         if not task.cancelled() and (err := task.exception()) is not None:
             errors.append(err)
 
-    def _create_task(coro: Coroutine[Any, Any, Any], **_kwargs: Any) -> asyncio.Task[Any]:
-        task = asyncio.ensure_future(coro)
-        task.add_done_callback(_collect_exception)
+    def _create_task(target: Any, *args: Any, **kwargs: Any) -> Any:
+        task = real_create_task(target, *args, **kwargs)
+        if isinstance(task, asyncio.Task):
+            task.add_done_callback(_collect_exception)
         return task
 
     mock_mass.create_task = MagicMock(side_effect=_create_task)
     yield
-    if errors:
+    if len(errors) == 1:
         raise errors[0]
+    if errors:
+        raise BaseExceptionGroup("background tasks failed", errors)
 
 
 def _mute_natively(player: MockPlayer) -> AsyncMock:
@@ -3112,14 +3116,9 @@ class TestPlayAnnouncementCleanup:
         render.wait_finished.assert_not_awaited()
 
 
+@pytest.mark.usefixtures("running_background_tasks")
 class TestPlayAnnouncementRestore:
     """Test the state restore of the default (fallback) announcement implementation."""
-
-    @pytest.fixture(autouse=True)
-    def _background_tasks(self, mock_mass: MagicMock) -> Iterator[None]:
-        """Run the (temporary and restored) volume commands the TaskManager dispatches."""
-        with _running_background_tasks(mock_mass):
-            yield
 
     def _make_player(
         self, mock_mass: MagicMock, prev_media: PlayerMedia
@@ -3479,14 +3478,9 @@ class TestPlayAnnouncementRestore:
         assert player.extra_data[ATTR_PREVIOUS_VOLUME] == 40
 
 
+@pytest.mark.usefixtures("running_background_tasks")
 class TestPlayNativeAnnouncement:
     """Test the mute handling around an announcement that a player plays natively."""
-
-    @pytest.fixture(autouse=True)
-    def _background_tasks(self, mock_mass: MagicMock) -> Iterator[None]:
-        """Run the mute commands the TaskManager dispatches."""
-        with _running_background_tasks(mock_mass):
-            yield
 
     def _make_player(self, mock_mass: MagicMock) -> tuple[PlayerController, MockPlayer, AsyncMock]:
         """Create a controller and a player with native announcement support."""


### PR DESCRIPTION
# What does this implement/fix?

The two announcement test classes each carried their own copy of a `mass.create_task` stub. That stub never looked at the result of the tasks it started, so a background task that blew up only produced an asyncio warning instead of failing the test.

Both now share one fixture, built on the `use_real_create_task` helper the rest of the test suite already uses. Letting it re-raise immediately surfaced a stray artwork lookup that had been failing unnoticed in two of those tests.

- Replaced the duplicated stub with a single shared fixture that runs background tasks for real and raises whatever they raise.
- Stopped the two announcement test classes from handing the player a stand-in queue, which was triggering an unrelated (and failing) artwork colour lookup.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
