### PR TITLE
Clean up player settings when a player provider is removed

### DIFF
--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -328,7 +328,7 @@ class ProviderConfigMixin:
                 if not isinstance(player_conf, dict):
                     continue
                 if player_conf.get("provider") == instance_id:
-                    self.remove(f"{CONF_PLAYERS}/{player_conf.get('player_id') or key}")
+                    self.mass.players.delete_player_config(player_conf.get("player_id") or key)
 
     async def remove_provider_config_value(self, instance_id: str, key: str) -> None:
         """Remove/reset single Provider config value."""

--- a/tests/controllers/config/test_remove_player_config.py
+++ b/tests/controllers/config/test_remove_player_config.py
@@ -47,11 +47,11 @@ from music_assistant.models.player import DeviceInfo, Player
 PARENT_ID = "up_esp32"
 PROTOCOL_ID = "spb_esp32"
 PLAYER_ID = "test_player_1"
-# a real, non-builtin player provider domain with no config entries of its own,
-# so a raw provider config can be stored without going through the setup flow
+# a real, non-builtin player provider with no config entries of its own, so a raw
+# provider config can be stored without going through the setup flow; it is
+# single-instance, so its instance id equals its domain
 PLAYER_PROVIDER_DOMAIN = "dlna"
-PLAYER_PROVIDER_INSTANCE_ID = "dlna"
-OTHER_PLAYER_PROVIDER_INSTANCE_ID = "chromecast"
+OTHER_PROVIDER_INSTANCE_ID = "other_provider"
 
 
 class StubProtocolPlayer:
@@ -71,6 +71,7 @@ class StubProtocolPlayer:
         self.needs_poll = False
         self.protocol_parent_id = parent_id
         self.refreshed = False
+        self.provider = SimpleNamespace(instance_id="sendspin")
 
     def set_protocol_parent_id(self, parent_id: str | None) -> None:
         """Set the live protocol parent."""
@@ -149,14 +150,14 @@ def _store_player_config(
     )
 
 
-def _store_provider_config(mass: MusicAssistant, instance_id: str) -> None:
-    """Store a raw provider config, mirroring the shape ProviderConfig.to_raw() produces."""
+def _store_provider_config(mass: MusicAssistant) -> None:
+    """Store a raw config for the player provider under test."""
     mass.config.set(
-        f"{CONF_PROVIDERS}/{instance_id}",
+        f"{CONF_PROVIDERS}/{PLAYER_PROVIDER_DOMAIN}",
         {
             "type": "player",
             "domain": PLAYER_PROVIDER_DOMAIN,
-            "instance_id": instance_id,
+            "instance_id": PLAYER_PROVIDER_DOMAIN,
             "enabled": True,
             "name": "DLNA",
             "values": {},
@@ -413,12 +414,12 @@ async def test_remove_provider_config_wipes_unregistered_player_config(
     mass: MusicAssistant,
 ) -> None:
     """Removing a provider also wipes the DSP/queue settings of its unregistered players."""
-    _store_provider_config(mass, PLAYER_PROVIDER_INSTANCE_ID)
-    _store_player_config(mass, PLAYER_ID, provider=PLAYER_PROVIDER_INSTANCE_ID)
+    _store_provider_config(mass)
+    _store_player_config(mass, PLAYER_ID, provider=PLAYER_PROVIDER_DOMAIN)
     mass.config.set(f"{CONF_PLAYER_DSP}/{PLAYER_ID}", {"enabled": True})
     await _store_queue_cache(mass, PLAYER_ID)
 
-    await mass.config.remove_provider_config(PLAYER_PROVIDER_INSTANCE_ID)
+    await mass.config.remove_provider_config(PLAYER_PROVIDER_DOMAIN)
 
     assert mass.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}") is None
     assert mass.config.get(f"{CONF_PLAYER_DSP}/{PLAYER_ID}") is None
@@ -430,15 +431,51 @@ async def test_remove_provider_config_keeps_other_providers_player_config(
     mass: MusicAssistant,
 ) -> None:
     """A player belonging to a different provider keeps its config untouched."""
-    _store_provider_config(mass, PLAYER_PROVIDER_INSTANCE_ID)
-    _store_player_config(mass, PLAYER_ID, provider=OTHER_PLAYER_PROVIDER_INSTANCE_ID)
+    _store_provider_config(mass)
+    _store_player_config(mass, PLAYER_ID, provider=OTHER_PROVIDER_INSTANCE_ID)
+    mass.config.set(f"{CONF_PLAYER_DSP}/{PLAYER_ID}", {"enabled": True})
     await _store_queue_cache(mass, PLAYER_ID)
 
-    await mass.config.remove_provider_config(PLAYER_PROVIDER_INSTANCE_ID)
+    await mass.config.remove_provider_config(PLAYER_PROVIDER_DOMAIN)
 
     assert mass.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}") is not None
+    assert mass.config.get(f"{CONF_PLAYER_DSP}/{PLAYER_ID}") is not None
     assert mass.config.get(f"{CONF_PLAYER_QUEUES}/{PLAYER_ID}") is not None
     assert await _get_queue_cache(mass, PLAYER_ID) == [
         {"queue_id": PLAYER_ID},
         {"queue_id": PLAYER_ID},
     ]
+
+
+async def test_remove_provider_config_wipes_linked_protocol_config(
+    mass: MusicAssistant,
+) -> None:
+    """The config of an unregistered protocol player goes along with its parent's provider."""
+    _store_provider_config(mass)
+    _store_configs(mass, enabled=False)
+    mass.config.set(f"{CONF_PLAYERS}/{PARENT_ID}/provider", PLAYER_PROVIDER_DOMAIN)
+
+    await mass.config.remove_provider_config(PLAYER_PROVIDER_DOMAIN)
+
+    assert mass.config.get(f"{CONF_PLAYERS}/{PARENT_ID}") is None
+    assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}") is None
+    assert mass.config.get(f"{CONF_PLAYER_DSP}/{PROTOCOL_ID}") is None
+
+
+async def test_remove_provider_config_detaches_registered_protocol_player(
+    mass: MusicAssistant,
+    register_protocol_player: Callable[[str | None], StubProtocolPlayer],
+) -> None:
+    """A still registered protocol player of another provider is detached, not wiped."""
+    _store_provider_config(mass)
+    _store_configs(mass, enabled=True)
+    mass.config.set(f"{CONF_PLAYERS}/{PARENT_ID}/provider", PLAYER_PROVIDER_DOMAIN)
+    protocol_player = register_protocol_player(PARENT_ID)
+
+    await mass.config.remove_provider_config(PLAYER_PROVIDER_DOMAIN)
+
+    assert mass.config.get(f"{CONF_PLAYERS}/{PARENT_ID}") is None
+    assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}") is not None
+    assert protocol_player.protocol_parent_id is None
+    assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}/values/{CONF_PROTOCOL_PARENT_ID}") is None
+    assert _pop_scheduled_evaluation(mass)

--- a/tests/controllers/config/test_remove_player_config.py
+++ b/tests/controllers/config/test_remove_player_config.py
@@ -1,5 +1,5 @@
 """
-Regression tests for the cleanup that runs when a player is removed.
+Regression tests for the cleanup that runs when a player (or its provider) is removed.
 
 Reproduces the case where a player is first disabled and then removed: disabling
 cascades to the linked protocol players, so none of them is registered anymore when
@@ -10,6 +10,10 @@ queue state are silently inherited by a device that returns under the same playe
 Also covers the mirrored case where the player being removed is not registered (e.g.
 its provider was unloaded) while one of its protocol players still is: that protocol
 player must be detached from the removed player instead of keeping a dead parent link.
+
+Also covers removing a whole player provider: its unregistered players must have their
+DSP/queue settings and persisted queue cache wiped along with their player config,
+while players of other providers are left untouched.
 """
 
 import logging
@@ -31,6 +35,7 @@ from music_assistant.constants import (
     CONF_PLAYER_QUEUES,
     CONF_PLAYERS,
     CONF_PROTOCOL_PARENT_ID,
+    CONF_PROVIDERS,
 )
 from music_assistant.controllers.player_queues.constants import (
     CACHE_CATEGORY_PLAYER_QUEUE_ITEMS,
@@ -42,6 +47,11 @@ from music_assistant.models.player import DeviceInfo, Player
 PARENT_ID = "up_esp32"
 PROTOCOL_ID = "spb_esp32"
 PLAYER_ID = "test_player_1"
+# a real, non-builtin player provider domain with no config entries of its own,
+# so a raw provider config can be stored without going through the setup flow
+PLAYER_PROVIDER_DOMAIN = "dlna"
+PLAYER_PROVIDER_INSTANCE_ID = "dlna"
+OTHER_PLAYER_PROVIDER_INSTANCE_ID = "chromecast"
 
 
 class StubProtocolPlayer:
@@ -119,13 +129,15 @@ def _store_configs(mass: MusicAssistant, enabled: bool) -> None:
     mass.config.set(f"{CONF_PLAYER_DSP}/{PROTOCOL_ID}", {"enabled": True})
 
 
-def _store_player_config(mass: MusicAssistant, player_id: str, enabled: bool = False) -> None:
+def _store_player_config(
+    mass: MusicAssistant, player_id: str, enabled: bool = False, provider: str = "test_provider"
+) -> None:
     """Store a plain player config with customised queue settings."""
     mass.config.set(
         f"{CONF_PLAYERS}/{player_id}",
         {
             "player_id": player_id,
-            "provider": "test_provider",
+            "provider": provider,
             "player_type": "player",
             "enabled": enabled,
             "values": {},
@@ -134,6 +146,21 @@ def _store_player_config(mass: MusicAssistant, player_id: str, enabled: bool = F
     mass.config.set(
         f"{CONF_PLAYER_QUEUES}/{player_id}",
         {"queue_id": player_id, "values": {"crossfade_duration": 9}},
+    )
+
+
+def _store_provider_config(mass: MusicAssistant, instance_id: str) -> None:
+    """Store a raw provider config, mirroring the shape ProviderConfig.to_raw() produces."""
+    mass.config.set(
+        f"{CONF_PROVIDERS}/{instance_id}",
+        {
+            "type": "player",
+            "domain": PLAYER_PROVIDER_DOMAIN,
+            "instance_id": instance_id,
+            "enabled": True,
+            "name": "DLNA",
+            "values": {},
+        },
     )
 
 
@@ -380,3 +407,38 @@ async def test_remove_keeps_queue_config_of_registered_protocol_player(
         {"queue_id": PROTOCOL_ID},
     ]
     _pop_scheduled_evaluation(mass)
+
+
+async def test_remove_provider_config_wipes_unregistered_player_config(
+    mass: MusicAssistant,
+) -> None:
+    """Removing a provider also wipes the DSP/queue settings of its unregistered players."""
+    _store_provider_config(mass, PLAYER_PROVIDER_INSTANCE_ID)
+    _store_player_config(mass, PLAYER_ID, provider=PLAYER_PROVIDER_INSTANCE_ID)
+    mass.config.set(f"{CONF_PLAYER_DSP}/{PLAYER_ID}", {"enabled": True})
+    await _store_queue_cache(mass, PLAYER_ID)
+
+    await mass.config.remove_provider_config(PLAYER_PROVIDER_INSTANCE_ID)
+
+    assert mass.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}") is None
+    assert mass.config.get(f"{CONF_PLAYER_DSP}/{PLAYER_ID}") is None
+    assert mass.config.get(f"{CONF_PLAYER_QUEUES}/{PLAYER_ID}") is None
+    assert await _get_queue_cache(mass, PLAYER_ID) == [None, None]
+
+
+async def test_remove_provider_config_keeps_other_providers_player_config(
+    mass: MusicAssistant,
+) -> None:
+    """A player belonging to a different provider keeps its config untouched."""
+    _store_provider_config(mass, PLAYER_PROVIDER_INSTANCE_ID)
+    _store_player_config(mass, PLAYER_ID, provider=OTHER_PLAYER_PROVIDER_INSTANCE_ID)
+    await _store_queue_cache(mass, PLAYER_ID)
+
+    await mass.config.remove_provider_config(PLAYER_PROVIDER_INSTANCE_ID)
+
+    assert mass.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}") is not None
+    assert mass.config.get(f"{CONF_PLAYER_QUEUES}/{PLAYER_ID}") is not None
+    assert await _get_queue_cache(mass, PLAYER_ID) == [
+        {"queue_id": PLAYER_ID},
+        {"queue_id": PLAYER_ID},
+    ]


### PR DESCRIPTION
# What does this implement/fix?

Removing a player provider left settings behind for its players that were not registered at that moment (e.g. players that were disabled or offline). Their audio (DSP) settings, queue settings and saved queue stayed in the config forever, and would silently come back if the same device ever returned.

Registered players were already cleaned up properly - this makes the leftovers follow the same path.

- Removing a player provider now wipes the DSP settings, queue settings and saved queue of all of its players, not just the ones that were still registered
- Added tests covering provider removal for unregistered players, and a guard that players of other providers are left alone

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
