### PR TITLE
Clear the AirPlay session a crashed stream leaves on the device

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -206,6 +206,13 @@ AIRPLAY_LATE_JOIN_RING_MAX_BYTES: Final[int] = 6 * 1024 * 1024
 # Staged retries can be reintroduced by adding entries to the tuple.
 AIRPLAY_REJOIN_ATTEMPT_DELAYS: Final[tuple[int, ...]] = (5,)
 
+# Delays (seconds) between attempts to clear a session left behind on a device
+# whose cliairplay process died without a clean teardown. Apple receivers keep
+# the session armed and audibly pop until a new session displaces it, so a
+# short-lived connect/disconnect forces the drop. The increasing delays cover
+# both a brief network blip and a longer outage.
+AIRPLAY_SESSION_CLEANUP_ATTEMPT_DELAYS: Final[tuple[int, ...]] = (10, 60, 300)
+
 # Cover art is rendered to a local JPEG for the binary to embed (the binary
 # does not fetch URLs). 512px keeps the SET_PARAMETER payload small while still
 # looking sharp on speaker apps and the Apple TV now-playing screen.

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -34,6 +34,7 @@ from .constants import (
     AIRPLAY_HIRES_SAMPLE_RATES,
     AIRPLAY_PCM_FORMAT,
     AIRPLAY_REJOIN_ATTEMPT_DELAYS,
+    AIRPLAY_SESSION_CLEANUP_ATTEMPT_DELAYS,
     ATV_PASSWORD_BIT,
     BASE_PLAYER_FEATURES,
     CONF_AIRPLAY_CREDENTIALS,
@@ -64,6 +65,7 @@ from .helpers import (
     player_id_to_mac_address,
     supports_airplay2,
 )
+from .stream import AirPlayStream
 from .stream_session import AirPlayStreamSession
 
 if TYPE_CHECKING:
@@ -73,7 +75,6 @@ if TYPE_CHECKING:
 
     from .pairing import AirPlayPairing
     from .provider import AirPlayProvider
-    from .stream import AirPlayStream
 
 # Docker bridge subnet, sometimes wrongly advertised via mDNS by containerized devices.
 _DOCKER_SUBNET = ipaddress.ip_network("172.16.0.0/12")
@@ -108,6 +109,7 @@ class AirPlayPlayer(Player):
         self._lock = asyncio.Lock()
         self._transitioning = False  # Set during stream replacement to ignore stale DACP messages
         self._rejoin_task: asyncio.Task[None] | None = None
+        self._session_cleanup_task: asyncio.Task[None] | None = None
         # Set (static) player attributes
         self._attr_name = display_name
         self._attr_available = True
@@ -447,8 +449,10 @@ class AirPlayPlayer(Player):
     async def play_media(self, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA on given player."""
         # the player is being (re)purposed on purpose: drop any pending
-        # automatic re-join left over from an unexpected stream loss
+        # automatic re-join left over from an unexpected stream loss (the new
+        # session also displaces any leaked device session)
         self.cancel_group_rejoin()
+        self.cancel_device_session_cleanup()
         async with self._lock:
             if self.synced_to:
                 # this should not happen, but guard anyways
@@ -808,6 +812,7 @@ class AirPlayPlayer(Player):
         """Handle logic when the player is unloaded from the Player controller."""
         await super().on_unload()
         self.cancel_group_rejoin()
+        self.cancel_device_session_cleanup()
         if self.stream:
             # remove this player from the stream session if it is running
             if self.stream.running and self.stream.session:
@@ -845,6 +850,24 @@ class AirPlayPlayer(Player):
         # session (re)start paths that call this to clear stale schedules
         if rejoin_task and not rejoin_task.done() and rejoin_task is not asyncio.current_task():
             rejoin_task.cancel()
+
+    def schedule_device_session_cleanup(self) -> None:
+        """
+        Schedule bounded attempts to clear a session left behind on the device.
+
+        Call after the stream process died without a clean teardown. The
+        attempts stand down once a live stream owns the player again and are
+        cancelled by any deliberate use of the player.
+        """
+        self.cancel_device_session_cleanup()
+        self._session_cleanup_task = self.mass.create_task(self._device_session_cleanup_attempts())
+
+    def cancel_device_session_cleanup(self) -> None:
+        """Cancel any pending device session cleanup attempts for this player."""
+        cleanup_task = self._session_cleanup_task
+        self._session_cleanup_task = None
+        if cleanup_task and not cleanup_task.done() and cleanup_task is not asyncio.current_task():
+            cleanup_task.cancel()
 
     def _volume_control_routes_to_self(self, volume_control: str) -> bool:
         """Return True if the given (resolved) volume control routes volume to this player."""
@@ -1321,6 +1344,60 @@ class AirPlayPlayer(Player):
                 continue
             return candidate
         return None
+
+    async def _device_session_cleanup_attempts(self) -> None:
+        """Connect and cleanly disconnect to clear a session leaked on the device."""
+        # Let a scheduled re-join resolve first: a successful re-join already
+        # displaces the leaked session. asyncio.wait never propagates the
+        # task's outcome, so a failed re-join cannot end the cleanup with it.
+        if (rejoin_task := self._rejoin_task) is not None:
+            await asyncio.wait({rejoin_task})
+        max_attempts = len(AIRPLAY_SESSION_CLEANUP_ATTEMPT_DELAYS)
+        for attempt, delay in enumerate(AIRPLAY_SESSION_CLEANUP_ATTEMPT_DELAYS, start=1):
+            await asyncio.sleep(delay)
+            if self.stream and self.stream.running:
+                # a live session owns the device again; it displaced the leak
+                return
+            if not self.available:
+                # device offline; a later attempt may reach it
+                continue
+            # This stream never becomes self.stream: its state reports are
+            # ignored (set_state_from_stream validates the sender) and a real
+            # session starting meanwhile simply displaces it.
+            cleanup_stream = AirPlayStream(self)
+            try:
+                await cleanup_stream.connect()
+                await cleanup_stream.wait_for_connection()
+            except Exception as err:
+                self.logger.debug(
+                    "Device session cleanup for %s could not connect (attempt %d/%d): %s",
+                    self.display_name,
+                    attempt,
+                    max_attempts,
+                    err,
+                )
+                with contextlib.suppress(Exception):
+                    await cleanup_stream.stop(force=True)
+                continue
+            try:
+                await cleanup_stream.stop()
+            except Exception as err:
+                self.logger.debug(
+                    "Device session cleanup for %s failed to disconnect: %s",
+                    self.display_name,
+                    err,
+                )
+                continue
+            self.logger.info(
+                "Cleared a leftover AirPlay session on %s after unexpected stream loss",
+                self.display_name,
+            )
+            return
+        self.logger.debug(
+            "Device session cleanup for %s gave up after %d attempt(s)",
+            self.display_name,
+            max_attempts,
+        )
 
     def _store_device_password(self, password: str) -> None:
         """

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -1292,6 +1292,10 @@ class AirPlayStream:
                         # the group (or its successor) may still be playing:
                         # schedule bounded attempts to re-join it
                         player.schedule_group_rejoin(rejoin_candidates)
+                    # The dead process never delivered a teardown, so the
+                    # receiver may still hold the armed session and audibly
+                    # pop on it. If no new session lands, this clears it.
+                    player.schedule_device_session_cleanup()
                     if was_leader:
                         return
                 player.set_state_from_stream(state=PlaybackState.IDLE, elapsed_time=0, stream=self)

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1342,6 +1342,148 @@ async def test_stop_cancels_pending_rejoin() -> None:
         assert rejoin_task.cancelled()
 
 
+# --- Device session cleanup after unexpected stream loss ---
+
+
+_NO_CLEANUP_DELAYS = (
+    "music_assistant.providers.airplay.player.AIRPLAY_SESSION_CLEANUP_ATTEMPT_DELAYS"
+)
+_CLEANUP_STREAM_CLS = "music_assistant.providers.airplay.player.AirPlayStream"
+
+
+def _make_cleanup_stream() -> MagicMock:
+    """Create a mock cleanup stream that connects and disconnects successfully."""
+    stream = MagicMock()
+    stream.connect = AsyncMock()
+    stream.wait_for_connection = AsyncMock()
+    stream.stop = AsyncMock()
+    return stream
+
+
+@pytest.mark.asyncio
+async def test_session_cleanup_connects_and_cleanly_disconnects() -> None:
+    """The cleanup lands one session on the device and tears it down again."""
+    player = _make_idle_player()
+    cleanup_stream = _make_cleanup_stream()
+
+    with (
+        patch(_NO_CLEANUP_DELAYS, (0,)),
+        patch(_CLEANUP_STREAM_CLS, return_value=cleanup_stream) as stream_cls,
+    ):
+        await player._device_session_cleanup_attempts()
+
+    stream_cls.assert_called_once_with(player)
+    cleanup_stream.connect.assert_awaited_once()
+    cleanup_stream.wait_for_connection.assert_awaited_once()
+    # a graceful stop delivers the teardown that clears the leaked session
+    cleanup_stream.stop.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_session_cleanup_stands_down_when_a_session_owns_the_device() -> None:
+    """A live stream on the player means the leak was displaced: no cleanup connect."""
+    player = _make_idle_player()
+    _attach_running_session(player, [player])
+
+    with (
+        patch(_NO_CLEANUP_DELAYS, (0,)),
+        patch(_CLEANUP_STREAM_CLS) as stream_cls,
+    ):
+        await player._device_session_cleanup_attempts()
+
+    stream_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_session_cleanup_retries_a_failed_connect() -> None:
+    """A connect failure (device still riding out the blackout) is retried."""
+    player = _make_idle_player()
+    failing_stream = _make_cleanup_stream()
+    failing_stream.wait_for_connection = AsyncMock(side_effect=TimeoutError("no connection"))
+    succeeding_stream = _make_cleanup_stream()
+
+    with (
+        patch(_NO_CLEANUP_DELAYS, (0, 0)),
+        patch(_CLEANUP_STREAM_CLS, side_effect=[failing_stream, succeeding_stream]),
+    ):
+        await player._device_session_cleanup_attempts()
+
+    # the failed attempt only ever kills its own process
+    failing_stream.stop.assert_awaited_once_with(force=True)
+    succeeding_stream.stop.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_session_cleanup_gives_up_after_all_attempts() -> None:
+    """An unreachable device exhausts the ladder without further effect."""
+    player = _make_idle_player()
+    streams = [_make_cleanup_stream() for _ in range(3)]
+    for stream in streams:
+        stream.connect = AsyncMock(side_effect=TimeoutError("unreachable"))
+
+    with (
+        patch(_NO_CLEANUP_DELAYS, (0, 0, 0)),
+        patch(_CLEANUP_STREAM_CLS, side_effect=streams) as stream_cls,
+    ):
+        await player._device_session_cleanup_attempts()
+
+    assert stream_cls.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_session_cleanup_skips_attempts_while_device_is_offline() -> None:
+    """An offline device is never dialed; attempts wait for it to come back."""
+    player = _make_idle_player()
+    player._attr_available = False
+
+    with (
+        patch(_NO_CLEANUP_DELAYS, (0, 0)),
+        patch(_CLEANUP_STREAM_CLS) as stream_cls,
+    ):
+        await player._device_session_cleanup_attempts()
+
+    stream_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_session_cleanup_waits_for_the_rejoin_to_resolve_first() -> None:
+    """A successful re-join displaces the leak itself, so the cleanup stands down."""
+    player = _make_idle_player()
+
+    async def rejoin() -> None:
+        _attach_running_session(player, [player])
+
+    rejoin_task = asyncio.get_running_loop().create_task(rejoin())
+    player._rejoin_task = rejoin_task
+
+    with (
+        patch(_NO_CLEANUP_DELAYS, (0,)),
+        patch(_CLEANUP_STREAM_CLS) as stream_cls,
+    ):
+        await player._device_session_cleanup_attempts()
+
+    assert rejoin_task.done()
+    stream_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_play_media_cancels_pending_session_cleanup() -> None:
+    """A new playback owns the device and displaces any leak: the cleanup is dropped."""
+    player = _make_idle_player()
+    cast("MagicMock", player.mass).create_task = lambda coro: (
+        asyncio.get_running_loop().create_task(coro)
+    )
+
+    with patch(_NO_CLEANUP_DELAYS, (60,)):
+        player.schedule_device_session_cleanup()
+        cleanup_task = player._session_cleanup_task
+        assert cleanup_task is not None
+        player.cancel_device_session_cleanup()
+        assert player._session_cleanup_task is None
+        await asyncio.sleep(0)
+        assert cleanup_task.cancelled()
+
+
 # --- Group membership and the leader's stream session ---
 
 

--- a/tests/providers/airplay/test_protocol_crash.py
+++ b/tests/providers/airplay/test_protocol_crash.py
@@ -67,6 +67,9 @@ async def test_crash_on_sync_leader_defers_idle_and_ungroups() -> None:
 
     mass.players.cmd_ungroup.assert_called_once_with(player.player_id)
     mass.create_task.assert_called_once()
+    # The dead process never delivered a teardown: the device-side session
+    # cleanup must be scheduled so the receiver cannot keep popping on it.
+    player.schedule_device_session_cleanup.assert_called_once()
     # Leader must NOT be forced idle here — that would dissolve the group.
     player.set_state_from_stream.assert_not_called()
 
@@ -80,6 +83,7 @@ async def test_crash_on_member_idles_and_ungroups() -> None:
 
     mass.players.cmd_ungroup.assert_called_once_with(player.player_id)
     mass.create_task.assert_called_once()
+    player.schedule_device_session_cleanup.assert_called_once()
     # Members / standalone players are reflected idle right away.
     player.set_state_from_stream.assert_called_once()
     _, kwargs = player.set_state_from_stream.call_args


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

When a cliairplay process dies without delivering a teardown (typically after a network blackout outlives the keepalive tolerance), the receiver still holds the armed audio session. Apple receivers audibly pop on that session's starving queue and keep doing so until a new session displaces it. A user report shows exactly this: a HomePod popping for hours overnight until it was power cycled, right after such a crash where the automatic re-join also failed and MA logged it could not stop the player.

After an unexpected stream loss the player now schedules bounded attempts to connect a short-lived stream to the device and cleanly disconnect, which forces the receiver to drop the leaked session.

This hasn't been tested locally, but the receiver behavior is documented in cliairplay.c: "a receiver whose queue underruns while the session stays armed pops audibly (the end-of-playback burst on Apple receivers)". The remedy is therefore established, what was missing is anyone to deliver it after a crash. The fix uses only the existing connect and disconnect paths that every normal playback start and stop already exercises, so no new device-facing protocol code is introduced; the new code is scheduling logic only, and that is what the unit tests cover. Risk is bounded, the attempts stand down whenever a real session owns the player, skip offline devices, are cancelled by any user action, and give up after three tries, so the worst case is identical to current behavior. Success is logged at INFO ("Cleared a leftover AirPlay session on...") so field confirmation from the reporter's next incident is directly visible in their log.

**Related issue (if applicable):**

- related issue Reported here https://github.com/orgs/music-assistant/discussions/5982#discussioncomment-17945050 and maybe also here https://github.com/music-assistant/support/issues/5279#issuecomment-5234779452

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
