### PR TITLE
Enrich matched playlist entries with provider metadata during import

### DIFF
--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -636,7 +636,12 @@ class BuiltinProvider(MusicProvider):
 
             matched_uri = await self._match_track_by_metadata(item, match_providers=match_providers)
             if matched_uri:
-                item.path = matched_uri
+                # enrich the entry with full metadata (#EXTPROV etc.) so it resolves to a
+                # playable item - just storing the URI leaves it without provider mappings
+                try:
+                    parsed_items[index] = await self._build_m3u_entry_from_uri(matched_uri)
+                except MediaNotFoundError, InvalidDataError, ProviderUnavailableError:
+                    item.path = matched_uri
                 changed = True
                 matched_count += 1
             else:

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 from music_assistant_models.enums import ExternalID, ImageType, MediaType
+from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import (
     Artist,
     ItemMapping,
@@ -304,6 +305,66 @@ async def test_import_playlist_preserves_playlist_image() -> None:
     assert args[3] == "https://img.example.com/cover.jpg"
     assert result.image is not None
     assert result.image.path == "https://img.example.com/cover.jpg"
+
+
+async def test_match_imported_tracks_enriches_matched_entries() -> None:
+    """Test that a matched entry is enriched with provider metadata, not just its URI."""
+    prov = _make_provider()
+    prov_any = cast("Any", prov)
+    prov_any._read_m3u_file = AsyncMock(
+        return_value=(
+            "#EXTM3U\n"
+            "#PLAYLIST:Imported\n"
+            "#EXTMA:media_type=track||name=Song||mbid=a1b2c3d4-e5f6-7890-abcd-ef1234567890\n"
+            "#EXTINF:294,Artist - Song\n"
+            "track-1\n"
+        )
+    )
+    matched_uri = "opensubsonic--abc123://track/xyz789"
+    enriched_entry = PlaylistItem(
+        path=matched_uri,
+        title="Artist - Song",
+        length="294",
+        metadata={"media_type": "track", "name": "Song"},
+        providers=[
+            ProviderMappingInfo(
+                domain="opensubsonic", item_id="xyz789", instance_id="opensubsonic--abc123"
+            )
+        ],
+    )
+    prov_any._match_track_by_metadata = AsyncMock(return_value=matched_uri)
+    prov_any._build_m3u_entry_from_uri = AsyncMock(return_value=enriched_entry)
+    prov_any.get_playlist = AsyncMock(return_value=_make_playlist("Imported"))
+    prov_any._write_m3u_file = AsyncMock()
+
+    await prov.match_imported_playlist_tracks("playlist_1")
+
+    prov_any._build_m3u_entry_from_uri.assert_awaited_once_with(matched_uri)
+    assert prov_any._write_m3u_file.await_args is not None
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert written_items == [enriched_entry]
+    assert written_items[0].providers
+
+
+async def test_match_imported_tracks_falls_back_to_uri_when_enrich_fails() -> None:
+    """Test that the matched URI is still stored when enrichment fails."""
+    prov = _make_provider()
+    prov_any = cast("Any", prov)
+    prov_any._read_m3u_file = AsyncMock(
+        return_value="#EXTM3U\n#PLAYLIST:Imported\n#EXTINF:294,Artist - Song\ntrack-1\n"
+    )
+    matched_uri = "opensubsonic--abc123://track/xyz789"
+    prov_any._match_track_by_metadata = AsyncMock(return_value=matched_uri)
+    prov_any._build_m3u_entry_from_uri = AsyncMock(side_effect=MediaNotFoundError("gone"))
+    prov_any.get_playlist = AsyncMock(return_value=_make_playlist("Imported"))
+    prov_any._write_m3u_file = AsyncMock()
+
+    await prov.match_imported_playlist_tracks("playlist_1")
+
+    assert prov_any._write_m3u_file.await_args is not None
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert written_items[0].path == matched_uri
+    assert not written_items[0].providers
 
 
 async def test_remove_playlist_tracks_preserves_playlist_image() -> None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

When importing a plain M3U playlist without #EXTPROV tags, the track matcher only rewrote the entry's path to the matched URI without storing any provider mappings. Resolving such an entry then produced a track with an empty provider_mappings set, leaving it unplayable until the startup migration repaired it on the next restart.

Build the full M3U entry (provider mappings, artists, album, images) from the matched URI right away, falling back to storing just the URI when the item can't be fetched.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6036

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
