### PR TITLE
Fix missing artists on Apple Music playlist tracks

### DIFF
--- a/music_assistant/providers/apple_music/constants.py
+++ b/music_assistant/providers/apple_music/constants.py
@@ -41,7 +41,5 @@ BLOBSTORE_DOMAIN = "blobstore.apple.com"
 # blobstore artwork URLs are presigned with a ~24h expiry, so resolved artwork
 # URLs may only be cached well below that lifetime
 ARTWORK_CACHE_EXPIRATION = 12 * 60 * 60
-# bust cached api responses that were parsed before artwork tokens existed
-# (they carry now-expired signed artwork URLs); bump when the parsed image
-# representation changes again
+# Bump to re-parse cached api responses whenever the parsed representation changes
 PARSED_ITEM_CACHE_CHECKSUM = "artist_fallback_v1"

--- a/music_assistant/providers/apple_music/constants.py
+++ b/music_assistant/providers/apple_music/constants.py
@@ -44,4 +44,4 @@ ARTWORK_CACHE_EXPIRATION = 12 * 60 * 60
 # bust cached api responses that were parsed before artwork tokens existed
 # (they carry now-expired signed artwork URLs); bump when the parsed image
 # representation changes again
-PARSED_ITEM_CACHE_CHECKSUM = "artwork_tokens_v1"
+PARSED_ITEM_CACHE_CHECKSUM = "artist_fallback_v1"

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -261,9 +261,9 @@ def parse_track(
     if track_number := attributes.get("trackNumber"):
         track.track_number = track_number
     # Prefer catalog information over library information for artists.
-    if "artists" in relationships:
-        artists = relationships["artists"]
-        track.artists = UniqueList([parse_artist(provider, artist) for artist in artists["data"]])
+    # The artists relationship is empty when the artists are not in the user's library.
+    if artists_data := relationships.get("artists", {}).get("data"):
+        track.artists = UniqueList([parse_artist(provider, artist) for artist in artists_data])
     elif artist_name := normalize_unicode(
         attributes.get("artistName") or raw_attributes.get("artistName")
     ):

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -304,6 +304,42 @@ def test_parse_track_library_song_uses_library_album_name_fallback() -> None:
     assert result.album.name == "Album From Library"
 
 
+def test_parse_track_empty_artists_relationship_uses_artist_name() -> None:
+    """An artists relationship without data should fall back to artistName."""
+    provider = _create_provider_mock()
+    track_obj = {
+        "id": "i.librarytrack1",
+        "type": "library-songs",
+        "attributes": {
+            "name": "Mr. Brightside",
+            "artistName": "The Killers",
+            "durationInMillis": 222000,
+            "playParams": {"catalogId": "1526194192"},
+        },
+        "relationships": {
+            "artists": {"data": []},
+            "catalog": {
+                "data": [
+                    {
+                        "id": "1526194192",
+                        "attributes": {
+                            "name": "Mr. Brightside",
+                            "artistName": "The Killers",
+                            "durationInMillis": 222000,
+                            "playParams": {"id": "1526194192"},
+                        },
+                    }
+                ]
+            },
+        },
+    }
+
+    result = parse_track(provider, track_obj)
+
+    assert len(result.artists) == 1
+    assert result.artists[0].name == "The Killers"
+
+
 @pytest.mark.asyncio
 async def test_media_manager_get_playlist_applies_can_edit_hint() -> None:
     """Catalog playlist fetch should honor library editability hint when provided."""


### PR DESCRIPTION
# What does this implement/fix?

Tracks of an Apple Music library playlist lose their artists when those artists are not in the user's library: Apple returns the `artists` relationship with empty `data`, the parser took that branch and never fell back to the `artistName` attribute. Downstream this broke the Music Quiz (guess-the-song rounds intermittently failed with "Not enough distractors to build suggestions" because the artistless source pool was discarded), but it affects any consumer of these tracks.

- Fall back to `artistName` when the artists relationship carries no data
- Bump `PARSED_ITEM_CACHE_CHECKSUM` so cached artistless tracks are re-parsed
- Add a regression test for the empty-relationship shape

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.