### PR TITLE
Universal Players no longer come back as a brand new player

### DIFF
--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -623,6 +623,12 @@ async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
     if _migrate_orphaned_disabled_protocol_configs(data):
         changed = True
 
+    # Clear the stored name of players that were never renamed, so an updated default
+    # name is no longer shadowed by the auto-generated name stored at creation time.
+    # TODO: remove after 2.12 release
+    if _migrate_unrenamed_player_names(data):
+        changed = True
+
     return changed
 
 
@@ -1413,6 +1419,31 @@ def _migrate_bluesound_http_profile(data: dict[str, Any]) -> bool:
             changed = True
     if changed:
         LOGGER.info("Restored the required HTTP profile on the Bluesound player configuration(s)")
+    return changed
+
+
+def _migrate_unrenamed_player_names(data: dict[str, Any]) -> bool:
+    """
+    Clear the stored name of player configs that hold the default name verbatim.
+
+    Player configs used to store the name a player was created with as both the custom
+    and the default name, which makes a never-renamed player indistinguishable from a
+    renamed one and lets the creation-time name shadow every later default name.
+    """
+    all_player_configs = data.get(CONF_PLAYERS, {})
+    if not isinstance(all_player_configs, dict):
+        return False
+    changed = False
+    for player_cfg in all_player_configs.values():
+        if not isinstance(player_cfg, dict):
+            continue
+        # a config without a default name would be left without any name at all
+        if not (default_name := player_cfg.get("default_name")):
+            continue
+        if player_cfg.get("name") != default_name:
+            continue
+        player_cfg["name"] = None
+        changed = True
     return changed
 
 

--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -544,14 +544,8 @@ class PlayerConfigMixin:
         """Set (or update) the default name for a player."""
         # skip if the player config root no longer exists, otherwise the
         # nested set would resurrect a partial entry (missing player_id etc).
-        if not (existing_conf := self.get(f"{CONF_PLAYERS}/{player_id}")):
+        if not self.get(f"{CONF_PLAYERS}/{player_id}"):
             return
-        # a stored name equal to the default name was never renamed by the user, so
-        # move it along with the new default name; otherwise the stale auto-generated
-        # name would read as a user rename and keep shadowing the new default name
-        stored_name = existing_conf.get("name")
-        if stored_name and stored_name == existing_conf.get("default_name"):
-            self.set(f"{CONF_PLAYERS}/{player_id}/name", default_name)
         conf_key = f"{CONF_PLAYERS}/{player_id}/default_name"
         self.set(conf_key, default_name)
 
@@ -581,21 +575,23 @@ class PlayerConfigMixin:
         """
         # return early if the config already exists
         if existing_conf := self.get(f"{CONF_PLAYERS}/{player_id}"):
-            # update default name if needed (keeps an untouched name in sync as well)
+            # update default name if needed
             if name and name != existing_conf.get("default_name"):
-                self.set_player_default_name(player_id, name)
+                self.set(f"{CONF_PLAYERS}/{player_id}/default_name", name)
             # deliberately do NOT update player_type here: this is called from
             # Player.__init__ where the type can still be a transient class default.
             # Genuine type changes are persisted by update_state after registration.
             return
-        # config does not yet exist, create a default one
+        # config does not yet exist, create a default one.
+        # the name is stored as the default name only: a stored (custom) name means
+        # the user renamed the player and must keep shadowing the default name.
         conf_key = f"{CONF_PLAYERS}/{player_id}"
         default_conf = PlayerConfig(
             values={},
             provider=provider,
             player_id=player_id,
             enabled=enabled,
-            name=name,
+            name=None,
             default_name=name,
             player_type=player_type,
         )

--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -544,8 +544,14 @@ class PlayerConfigMixin:
         """Set (or update) the default name for a player."""
         # skip if the player config root no longer exists, otherwise the
         # nested set would resurrect a partial entry (missing player_id etc).
-        if not self.get(f"{CONF_PLAYERS}/{player_id}"):
+        if not (existing_conf := self.get(f"{CONF_PLAYERS}/{player_id}")):
             return
+        # a stored name equal to the default name was never renamed by the user, so
+        # move it along with the new default name; otherwise the stale auto-generated
+        # name would read as a user rename and keep shadowing the new default name
+        stored_name = existing_conf.get("name")
+        if stored_name and stored_name == existing_conf.get("default_name"):
+            self.set(f"{CONF_PLAYERS}/{player_id}/name", default_name)
         conf_key = f"{CONF_PLAYERS}/{player_id}/default_name"
         self.set(conf_key, default_name)
 
@@ -575,9 +581,9 @@ class PlayerConfigMixin:
         """
         # return early if the config already exists
         if existing_conf := self.get(f"{CONF_PLAYERS}/{player_id}"):
-            # update default name if needed
+            # update default name if needed (keeps an untouched name in sync as well)
             if name and name != existing_conf.get("default_name"):
-                self.set(f"{CONF_PLAYERS}/{player_id}/default_name", name)
+                self.set_player_default_name(player_id, name)
             # deliberately do NOT update player_type here: this is called from
             # Player.__init__ where the type can still be a transient class default.
             # Genuine type changes are persisted by update_state after registration.

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1093,7 +1093,7 @@ class ProtocolLinkingMixin:
 
         # only carry an actual user rename, not the auto-generated default name;
         # likewise a name on the native player only counts as a user override when
-        # it differs from the default name (fresh configs store name == default_name)
+        # it differs from the default name
         custom_name = source_raw.get("name")
         target_name = target_raw.get("name")
         target_has_custom_name = bool(target_name) and target_name != target_raw.get("default_name")

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -733,8 +733,8 @@ class ProtocolLinkingMixin:
         from a different protocol (e.g., DLNA-based universal player now matches
         AirPlay-based universal player because they share the same MAC address).
 
-        The universal player with more protocol links absorbs the other one. Only one merge
-        is performed per call; re-evaluation will catch cascading merges.
+        The oldest universal player absorbs the other one. Only one merge is performed
+        per call; re-evaluation will catch cascading merges.
         """
         if not (match := self._find_mergeable_universal_player(universal_player)):
             return
@@ -801,7 +801,7 @@ class ProtocolLinkingMixin:
         """
         Return which of the two universal players absorbs the other, as (keeper, absorbed).
 
-        The player with the most protocol links wins, on a tie the oldest one.
+        The oldest player wins, on a tie the one with the most protocol links.
 
         :param universal_player: The universal player the merge was triggered for.
         :param other_player: The universal player it matched with.
@@ -815,13 +815,21 @@ class ProtocolLinkingMixin:
         return other_player, universal_player
 
     def _merge_rank(self, universal_player: Player) -> tuple[int, int, str]:
-        """Return the sort key of a universal player in a merge, lowest wins."""
+        """
+        Return the sort key of a universal player in a merge, lowest wins.
+
+        Age comes first because the keeper's player id is the one that survives, and the
+        oldest player is the one API consumers have been bound to the longest. The links
+        of the absorbed player move over either way, so nothing is lost by keeping the
+        smaller one. A player from before player ids were minted has no stored moment and
+        counts as the oldest, which is exactly what it is.
+        """
         created_at = self.mass.config.get(
             f"{CONF_PLAYERS}/{universal_player.player_id}/values/{CONF_CREATED_AT}", 0
         )
         return (
-            -len(universal_player.linked_output_protocols),
             created_at if isinstance(created_at, int) else 0,
+            -len(universal_player.linked_output_protocols),
             universal_player.player_id,
         )
 

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -45,6 +45,7 @@ from music_assistant.helpers.util import (
     is_locally_administered_mac,
     is_valid_mac_address,
     normalize_mac_for_matching,
+    strong_identifiers_match,
 )
 from music_assistant.models.player import LinkedOutputProtocol, Player
 from music_assistant.providers.sync_group.constants import CONF_ALLOWED_MEMBERS
@@ -1636,51 +1637,31 @@ class ProtocolLinkingMixin:
         identifiers_a = player_a.device_info.identifiers
         identifiers_b = player_b.device_info.identifiers
 
-        # Check identifiers in order of reliability
-        # MAC_ADDRESS > SERIAL_NUMBER > UUID > CAST_UUID > AIRPLAY_ID
-        for conn_type in (
-            IdentifierType.MAC_ADDRESS,
-            IdentifierType.SERIAL_NUMBER,
-            IdentifierType.UUID,
-            IdentifierType.CAST_UUID,
-            IdentifierType.AIRPLAY_ID,
-        ):
-            val_a = identifiers_a.get(conn_type)
-            val_b = identifiers_b.get(conn_type)
+        # Strong identifiers (checked in order of reliability:
+        # MAC_ADDRESS > SERIAL_NUMBER > UUID > CAST_UUID > AIRPLAY_ID).
+        # The comparison rules are shared with the stored device key lookup
+        # of the universal player provider.
+        if strong_identifiers_match(identifiers_a, identifiers_b):
+            return True
 
-            if not val_a or not val_b:
-                continue
-
-            # Filter out invalid MAC addresses (00:00:00:00:00:00, ff:ff:ff:ff:ff:ff)
-            if conn_type == IdentifierType.MAC_ADDRESS:
-                if not is_valid_mac_address(val_a) or not is_valid_mac_address(val_b):
-                    self.logger.log(
-                        VERBOSE_LOG_LEVEL,
-                        "Skipping invalid MAC address for matching: %s=%s, %s=%s",
-                        player_a.display_name,
-                        val_a,
-                        player_b.display_name,
-                        val_b,
-                    )
-                    continue
-
-            # Normalize values for comparison
-            if conn_type == IdentifierType.MAC_ADDRESS:
-                # Use MAC normalization that handles locally-administered bit differences
-                # Some protocols (like AirPlay) report a locally-administered MAC variant
-                # where bit 1 of the first octet is set (e.g., 54:78:... vs 56:78:...)
-                val_a_norm = normalize_mac_for_matching(val_a)
-                val_b_norm = normalize_mac_for_matching(val_b)
-
-                # Direct match on current MAC
-                if val_a_norm == val_b_norm:
-                    return True
-
+        val_a = identifiers_a.get(IdentifierType.MAC_ADDRESS)
+        val_b = identifiers_b.get(IdentifierType.MAC_ADDRESS)
+        if val_a and val_b:
+            if not is_valid_mac_address(val_a) or not is_valid_mac_address(val_b):
+                self.logger.log(
+                    VERBOSE_LOG_LEVEL,
+                    "Skipping invalid MAC address for matching: %s=%s, %s=%s",
+                    player_a.display_name,
+                    val_a,
+                    player_b.display_name,
+                    val_b,
+                )
+            else:
                 # Multi-MAC matching: also check original reported MACs.
                 # Devices with multiple interfaces (WiFi + Ethernet) may have ARP
                 # resolve one MAC while the protocol reports a different one.
-                macs_a = {val_a_norm}
-                macs_b = {val_b_norm}
+                macs_a = {normalize_mac_for_matching(val_a)}
+                macs_b = {normalize_mac_for_matching(val_b)}
                 reported_a = player_a.extra_data.get("reported_mac")
                 reported_b = player_b.extra_data.get("reported_mac")
                 if reported_a and is_valid_mac_address(reported_a):
@@ -1688,24 +1669,6 @@ class ProtocolLinkingMixin:
                 if reported_b and is_valid_mac_address(reported_b):
                     macs_b.add(normalize_mac_for_matching(reported_b))
                 if macs_a & macs_b:
-                    return True
-
-                # No MAC match - continue to next identifier type
-                continue
-
-            val_a_norm = val_a.lower().replace(":", "").replace("-", "")
-            val_b_norm = val_b.lower().replace(":", "").replace("-", "")
-
-            # Direct match
-            if val_a_norm == val_b_norm:
-                return True
-
-            # Special case: Sonos UUID matching with DLNA _MR suffix
-            # Sonos uses RINCON_xxx, DLNA uses RINCON_xxx_MR for Media Renderer
-            if conn_type == IdentifierType.UUID:
-                if val_b_norm.endswith("_mr") and val_b_norm[:-3] == val_a_norm:
-                    return True
-                if val_a_norm.endswith("_mr") and val_a_norm[:-3] == val_b_norm:
                     return True
 
         # Last resort: IP-based matching.

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -45,12 +45,12 @@ from music_assistant.helpers.util import (
     is_locally_administered_mac,
     is_valid_mac_address,
     normalize_mac_for_matching,
-    strong_identifiers_match,
 )
 from music_assistant.models.player import LinkedOutputProtocol, Player
 from music_assistant.providers.sync_group.constants import CONF_ALLOWED_MEMBERS
 from music_assistant.providers.universal_player import UniversalPlayer, UniversalPlayerProvider
 from music_assistant.providers.universal_player.constants import (
+    CONF_CREATED_AT,
     CONF_DEVICE_IDENTIFIERS,
     CONF_DEVICE_INFO,
 )
@@ -549,7 +549,7 @@ class ProtocolLinkingMixin:
     def _find_matching_universal_player(self, protocol_player: Player) -> Player | None:
         """Find an existing universal player that matches this protocol player."""
         for player in self._players.values():
-            if player.provider.domain != "universal_player":
+            if not isinstance(player, UniversalPlayer):
                 continue
             if self._identifiers_match(protocol_player, player, ""):
                 return player
@@ -799,25 +799,29 @@ class ProtocolLinkingMixin:
         """
         Return which of the two universal players absorbs the other, as (keeper, absorbed).
 
-        The player with the most protocol links wins.
+        The player with the most protocol links wins, on a tie the oldest one.
 
         :param universal_player: The universal player the merge was triggered for.
         :param other_player: The universal player it matched with.
         """
-        len_u = len(universal_player.linked_output_protocols)
-        len_p = len(other_player.linked_output_protocols)
-        if len_u > len_p:
-            return universal_player, other_player
-        if len_u < len_p:
-            return other_player, universal_player
-        # On ties, fall back to a deterministic tiebreaker on player_id so the merge outcome
-        # is stable across server restarts. Without this, which UniversalPlayer "wins" depends
-        # on iteration order of self._players.values(), which can shift between runs and causes
-        # downstream player_id reshuffling (and broken entity bindings in consumers like the
-        # Home Assistant MA integration).
-        if universal_player.player_id < other_player.player_id:
+        # The outcome must be stable across server restarts. Without that, which
+        # UniversalPlayer "wins" depends on iteration order of self._players.values(),
+        # which can shift between runs and causes downstream player_id reshuffling
+        # (and broken entity bindings in consumers like the Home Assistant MA integration).
+        if self._merge_rank(universal_player) <= self._merge_rank(other_player):
             return universal_player, other_player
         return other_player, universal_player
+
+    def _merge_rank(self, universal_player: Player) -> tuple[int, int, str]:
+        """Return the sort key of a universal player in a merge, lowest wins."""
+        created_at = self.mass.config.get(
+            f"{CONF_PLAYERS}/{universal_player.player_id}/values/{CONF_CREATED_AT}", 0
+        )
+        return (
+            -len(universal_player.linked_output_protocols),
+            created_at if isinstance(created_at, int) else 0,
+            universal_player.player_id,
+        )
 
     def _merge_universal_players(self, keep: UniversalPlayer, remove: UniversalPlayer) -> None:
         """
@@ -914,33 +918,24 @@ class ProtocolLinkingMixin:
             return
 
         # Delegate to provider - it handles locking, create/update decision, etc.
-        universal_player = await universal_provider.ensure_universal_player_for_protocols(
+        # It reports which universal player each protocol player belongs to, as a
+        # device with several instances of one protocol domain gets more than one.
+        assignments = await universal_provider.ensure_universal_players_for_protocols(
             protocol_players
         )
 
-        if not universal_player:
-            return
+        # Link the protocols to their universal player (the controller manages
+        # cross-provider state), skipping players that were linked in the meantime.
+        by_universal_player: dict[str, list[Player]] = {}
+        for player in protocol_players:
+            if player.protocol_parent_id:
+                continue
+            if universal_player := assignments.get(player.player_id):
+                by_universal_player.setdefault(universal_player.player_id, []).append(player)
 
-        # Link the protocols to the universal player (controller manages cross-provider state)
-        # Filter out players that were already linked
-        # (e.g., via _add_protocol_to_existing_universal)
-        unlinked_players = [p for p in protocol_players if not p.protocol_parent_id]
-
-        # Split unlinked players: those that can join the main universal player
-        # vs those that got separate universal players (domain-duplicates)
-        for player in list(unlinked_players):
-            # Check if a separate universal player was created for this player
-            fallback_key = player.player_id.replace(":", "").replace("-", "").lower()
-            separate_id = f"up{fallback_key}"
-            if separate_up := self.get_player(separate_id):
-                # Link to the separate universal player instead
-                self._add_protocol_link(separate_up, player, player.provider.domain)
-                player.refresh_state()
-                separate_up.refresh_state()
-                unlinked_players.remove(player)
-
-        self._link_protocols_to_universal(universal_player, unlinked_players)
-        universal_player.refresh_state()
+        for universal_player_id, players in by_universal_player.items():
+            if universal_player := self.get_player(universal_player_id):
+                self._link_protocols_to_universal(universal_player, players)
 
     def _try_link_protocols_to_native(self, native_player: Player) -> None:
         """Try to link protocol players to a native player."""
@@ -1543,13 +1538,17 @@ class ProtocolLinkingMixin:
                         parent_player.provider.domain == "universal_player"
                         and len(parent_player.linked_output_protocols) == 0
                     ):
-                        # No protocols left - remove universal player
+                        # No protocols left - the universal player has nothing to play
+                        # on. Its config is deliberately kept: the player id is opaque
+                        # and cannot be recreated, so deleting it here would orphan the
+                        # entities API consumers bound to it. Only an explicit removal
+                        # by the user deletes a universal player for good.
                         self.logger.info(
-                            "Universal player %s has no protocols left, removing",
+                            "Universal player %s has no protocols left",
                             parent_id,
                         )
                         self.mass.create_task(
-                            self.mass.players.unregister(parent_id, permanent=True)
+                            self.mass.players.unregister(parent_id, permanent=False)
                         )
                     else:
                         parent_player.refresh_state()
@@ -1637,31 +1636,51 @@ class ProtocolLinkingMixin:
         identifiers_a = player_a.device_info.identifiers
         identifiers_b = player_b.device_info.identifiers
 
-        # Strong identifiers (checked in order of reliability:
-        # MAC_ADDRESS > SERIAL_NUMBER > UUID > CAST_UUID > AIRPLAY_ID).
-        # The comparison rules are shared with the stored device key lookup
-        # of the universal player provider.
-        if strong_identifiers_match(identifiers_a, identifiers_b):
-            return True
+        # Check identifiers in order of reliability
+        # MAC_ADDRESS > SERIAL_NUMBER > UUID > CAST_UUID > AIRPLAY_ID
+        for conn_type in (
+            IdentifierType.MAC_ADDRESS,
+            IdentifierType.SERIAL_NUMBER,
+            IdentifierType.UUID,
+            IdentifierType.CAST_UUID,
+            IdentifierType.AIRPLAY_ID,
+        ):
+            val_a = identifiers_a.get(conn_type)
+            val_b = identifiers_b.get(conn_type)
 
-        val_a = identifiers_a.get(IdentifierType.MAC_ADDRESS)
-        val_b = identifiers_b.get(IdentifierType.MAC_ADDRESS)
-        if val_a and val_b:
-            if not is_valid_mac_address(val_a) or not is_valid_mac_address(val_b):
-                self.logger.log(
-                    VERBOSE_LOG_LEVEL,
-                    "Skipping invalid MAC address for matching: %s=%s, %s=%s",
-                    player_a.display_name,
-                    val_a,
-                    player_b.display_name,
-                    val_b,
-                )
-            else:
+            if not val_a or not val_b:
+                continue
+
+            # Filter out invalid MAC addresses (00:00:00:00:00:00, ff:ff:ff:ff:ff:ff)
+            if conn_type == IdentifierType.MAC_ADDRESS:
+                if not is_valid_mac_address(val_a) or not is_valid_mac_address(val_b):
+                    self.logger.log(
+                        VERBOSE_LOG_LEVEL,
+                        "Skipping invalid MAC address for matching: %s=%s, %s=%s",
+                        player_a.display_name,
+                        val_a,
+                        player_b.display_name,
+                        val_b,
+                    )
+                    continue
+
+            # Normalize values for comparison
+            if conn_type == IdentifierType.MAC_ADDRESS:
+                # Use MAC normalization that handles locally-administered bit differences
+                # Some protocols (like AirPlay) report a locally-administered MAC variant
+                # where bit 1 of the first octet is set (e.g., 54:78:... vs 56:78:...)
+                val_a_norm = normalize_mac_for_matching(val_a)
+                val_b_norm = normalize_mac_for_matching(val_b)
+
+                # Direct match on current MAC
+                if val_a_norm == val_b_norm:
+                    return True
+
                 # Multi-MAC matching: also check original reported MACs.
                 # Devices with multiple interfaces (WiFi + Ethernet) may have ARP
                 # resolve one MAC while the protocol reports a different one.
-                macs_a = {normalize_mac_for_matching(val_a)}
-                macs_b = {normalize_mac_for_matching(val_b)}
+                macs_a = {val_a_norm}
+                macs_b = {val_b_norm}
                 reported_a = player_a.extra_data.get("reported_mac")
                 reported_b = player_b.extra_data.get("reported_mac")
                 if reported_a and is_valid_mac_address(reported_a):
@@ -1669,6 +1688,24 @@ class ProtocolLinkingMixin:
                 if reported_b and is_valid_mac_address(reported_b):
                     macs_b.add(normalize_mac_for_matching(reported_b))
                 if macs_a & macs_b:
+                    return True
+
+                # No MAC match - continue to next identifier type
+                continue
+
+            val_a_norm = val_a.lower().replace(":", "").replace("-", "")
+            val_b_norm = val_b.lower().replace(":", "").replace("-", "")
+
+            # Direct match
+            if val_a_norm == val_b_norm:
+                return True
+
+            # Special case: Sonos UUID matching with DLNA _MR suffix
+            # Sonos uses RINCON_xxx, DLNA uses RINCON_xxx_MR for Media Renderer
+            if conn_type == IdentifierType.UUID:
+                if val_b_norm.endswith("_mr") and val_b_norm[:-3] == val_a_norm:
+                    return True
+                if val_a_norm.endswith("_mr") and val_a_norm[:-3] == val_b_norm:
                     return True
 
         # Last resort: IP-based matching.

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -64,8 +64,9 @@ if TYPE_CHECKING:
     from music_assistant import MusicAssistant
 
 # Config value keys that are bookkeeping of the universal player wrapper itself
-# (protocol links and device-identity caches) and must never be carried over
-# when a native player replaces a universal player.
+# (protocol links, device-identity caches and its creation moment) and must never
+# be carried over when a native player replaces a universal player, or when one
+# universal player absorbs another.
 UNIVERSAL_PLAYER_INTERNAL_CONF_KEYS = (
     CONF_LINKED_PROTOCOL_IDS,
     CONF_PROTOCOL_PARENT_ID,
@@ -74,6 +75,7 @@ UNIVERSAL_PLAYER_INTERNAL_CONF_KEYS = (
     CONF_DEVICE_INFO,
     CONF_CACHED_ARP_MAC,
     CONF_REPORTED_MAC,
+    CONF_CREATED_AT,
 )
 
 

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -20,7 +20,7 @@ import unicodedata
 import urllib.error
 import urllib.request
 import weakref
-from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Coroutine
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Coroutine, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from importlib.metadata import PackageNotFoundError
@@ -1801,6 +1801,58 @@ def is_valid_mac_address(mac_address: str | None) -> bool:
         return True
     except ValueError:
         return False
+
+
+# Identifier types considered proof of device identity, in order of reliability.
+STRONG_IDENTIFIER_TYPES = (
+    IdentifierType.MAC_ADDRESS,
+    IdentifierType.SERIAL_NUMBER,
+    IdentifierType.UUID,
+    IdentifierType.CAST_UUID,
+    IdentifierType.AIRPLAY_ID,
+)
+
+
+def strong_identifiers_match(
+    identifiers_a: Mapping[IdentifierType, str],
+    identifiers_b: Mapping[IdentifierType, str],
+) -> bool:
+    """
+    Check if two identifier mappings share a strong device identifier.
+
+    Only the strong identifier types are compared; weak identifiers such as IP
+    addresses are ignored. Invalid MAC addresses (e.g. 00:00:00:00:00:00) never match.
+
+    :param identifiers_a: Device identifiers of the first device.
+    :param identifiers_b: Device identifiers of the second device.
+    """
+    for conn_type in STRONG_IDENTIFIER_TYPES:
+        val_a = identifiers_a.get(conn_type)
+        val_b = identifiers_b.get(conn_type)
+        if not val_a or not val_b:
+            continue
+        if conn_type == IdentifierType.MAC_ADDRESS:
+            # Filter out invalid MAC addresses (00:00:00:00:00:00, ff:ff:ff:ff:ff:ff)
+            if not is_valid_mac_address(val_a) or not is_valid_mac_address(val_b):
+                continue
+            # Use MAC normalization that handles locally-administered bit differences
+            # Some protocols (like AirPlay) report a locally-administered MAC variant
+            # where bit 1 of the first octet is set (e.g., 54:78:... vs 56:78:...)
+            if normalize_mac_for_matching(val_a) == normalize_mac_for_matching(val_b):
+                return True
+            continue
+        val_a_norm = val_a.lower().replace(":", "").replace("-", "")
+        val_b_norm = val_b.lower().replace(":", "").replace("-", "")
+        if val_a_norm == val_b_norm:
+            return True
+        # Special case: Sonos UUID matching with DLNA _MR suffix
+        # Sonos uses RINCON_xxx, DLNA uses RINCON_xxx_MR for Media Renderer
+        if conn_type == IdentifierType.UUID:
+            if val_b_norm.endswith("_mr") and val_b_norm[:-3] == val_a_norm:
+                return True
+            if val_a_norm.endswith("_mr") and val_a_norm[:-3] == val_b_norm:
+                return True
+    return False
 
 
 def normalize_ip_address(ip_address: str | None) -> str | None:

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -20,7 +20,7 @@ import unicodedata
 import urllib.error
 import urllib.request
 import weakref
-from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Coroutine, Mapping
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Coroutine
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from importlib.metadata import PackageNotFoundError
@@ -1801,58 +1801,6 @@ def is_valid_mac_address(mac_address: str | None) -> bool:
         return True
     except ValueError:
         return False
-
-
-# Identifier types considered proof of device identity, in order of reliability.
-STRONG_IDENTIFIER_TYPES = (
-    IdentifierType.MAC_ADDRESS,
-    IdentifierType.SERIAL_NUMBER,
-    IdentifierType.UUID,
-    IdentifierType.CAST_UUID,
-    IdentifierType.AIRPLAY_ID,
-)
-
-
-def strong_identifiers_match(
-    identifiers_a: Mapping[IdentifierType, str],
-    identifiers_b: Mapping[IdentifierType, str],
-) -> bool:
-    """
-    Check if two identifier mappings share a strong device identifier.
-
-    Only the strong identifier types are compared; weak identifiers such as IP
-    addresses are ignored. Invalid MAC addresses (e.g. 00:00:00:00:00:00) never match.
-
-    :param identifiers_a: Device identifiers of the first device.
-    :param identifiers_b: Device identifiers of the second device.
-    """
-    for conn_type in STRONG_IDENTIFIER_TYPES:
-        val_a = identifiers_a.get(conn_type)
-        val_b = identifiers_b.get(conn_type)
-        if not val_a or not val_b:
-            continue
-        if conn_type == IdentifierType.MAC_ADDRESS:
-            # Filter out invalid MAC addresses (00:00:00:00:00:00, ff:ff:ff:ff:ff:ff)
-            if not is_valid_mac_address(val_a) or not is_valid_mac_address(val_b):
-                continue
-            # Use MAC normalization that handles locally-administered bit differences
-            # Some protocols (like AirPlay) report a locally-administered MAC variant
-            # where bit 1 of the first octet is set (e.g., 54:78:... vs 56:78:...)
-            if normalize_mac_for_matching(val_a) == normalize_mac_for_matching(val_b):
-                return True
-            continue
-        val_a_norm = val_a.lower().replace(":", "").replace("-", "")
-        val_b_norm = val_b.lower().replace(":", "").replace("-", "")
-        if val_a_norm == val_b_norm:
-            return True
-        # Special case: Sonos UUID matching with DLNA _MR suffix
-        # Sonos uses RINCON_xxx, DLNA uses RINCON_xxx_MR for Media Renderer
-        if conn_type == IdentifierType.UUID:
-            if val_b_norm.endswith("_mr") and val_b_norm[:-3] == val_a_norm:
-                return True
-            if val_a_norm.endswith("_mr") and val_a_norm[:-3] == val_b_norm:
-                return True
-    return False
 
 
 def normalize_ip_address(ip_address: str | None) -> str | None:

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -54,7 +54,9 @@ class SyncGroupPlayer(Player):
     ) -> None:
         """Initialize SyncGroupPlayer instance."""
         super().__init__(provider, player_id)
-        self._attr_name = self.config.name or self.config.default_name or f"SyncGroup {player_id}"
+        # the default name, not the custom one: display_name already prefers the
+        # custom name, while update_state persists this one as the default name
+        self._attr_name = self.config.default_name or self.config.name or f"SyncGroup {player_id}"
         self._attr_available = True
         self._attr_device_info = DeviceInfo(model=provider.name, manufacturer=APPLICATION_NAME)
         # Group players default to "no opinion" on power. The session lifecycle

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -75,7 +75,11 @@ class UniversalGroupPlayer(Player):
         """Initialize UniversalGroupPlayer instance."""
         super().__init__(provider, player_id)
         self.stream: UGPStream | None = None
-        self._attr_name = self.config.name or f"Universal Group {player_id}"
+        # the default name, not the custom one: display_name already prefers the
+        # custom name, while update_state persists this one as the default name
+        self._attr_name = (
+            self.config.default_name or self.config.name or f"Universal Group {player_id}"
+        )
         self._attr_available = True
         # See SyncGroupPlayer: groups have no opinion on power by default; the
         # session lifecycle is what governs activity. Fake power control is the

--- a/music_assistant/providers/universal_player/README.md
+++ b/music_assistant/providers/universal_player/README.md
@@ -92,8 +92,10 @@ made it shift whenever a different set of protocol players was registered - from
 MAC-based to a UUID-based id, for example - which orphaned the consumer's entity.
 
 As a consequence a universal player config is only ever deleted when the user removes
-the player, or when a native player takes over the device. When the protocol players
-of a universal player disappear it becomes unavailable but keeps its config, because
+the player, when a native player takes over the device, or when it is absorbed by
+another universal player of the same device in a merge. The latter two carry its
+settings over to the player that replaces it first. When the protocol players of a
+universal player merely disappear it becomes unavailable but keeps its config, because
 an opaque id cannot be recreated from the device.
 
 ### File Structure

--- a/music_assistant/providers/universal_player/README.md
+++ b/music_assistant/providers/universal_player/README.md
@@ -78,14 +78,23 @@ If a native provider is later installed (e.g., Denon integration), the Universal
 
 ## Technical Details
 
-### Player ID Format
+### Player ID
 
-Universal players use the format: `up{device_key}`
+Universal players use the format `up{random}`, minted once when the device is first
+wrapped. The id carries no device information and is never recomputed.
 
-Where `device_key` is typically the normalized MAC address.
-If no stable MAC is available, the provider falls back to UUID-like identifiers and finally the first protocol player's ID.
+This matters because the player id is the identity API consumers (e.g. the Home
+Assistant integration) bind their entities to, so it has to stay stable for the
+lifetime of the device. A universal player is therefore always resolved through the
+`protocol_parent_id` that each of its protocol players persists, never by deriving an
+id from the identifiers that happen to be available at that moment. Deriving the id
+made it shift whenever a different set of protocol players was registered - from a
+MAC-based to a UUID-based id, for example - which orphaned the consumer's entity.
 
-The player id is the identity API consumers (e.g. the Home Assistant integration) bind entities to, so it must stay stable for the lifetime of the device. When a universal player is (re)created for a device that already has a stored universal player config (matched via its stored protocol player memberships or device identifiers), the stored device key is reused, even if the identifiers available at that moment would compute a different key.
+As a consequence a universal player config is only ever deleted when the user removes
+the player, or when a native player takes over the device. When the protocol players
+of a universal player disappear it becomes unavailable but keeps its config, because
+an opaque id cannot be recreated from the device.
 
 ### File Structure
 

--- a/music_assistant/providers/universal_player/README.md
+++ b/music_assistant/providers/universal_player/README.md
@@ -85,6 +85,8 @@ Universal players use the format: `up{device_key}`
 Where `device_key` is typically the normalized MAC address.
 If no stable MAC is available, the provider falls back to UUID-like identifiers and finally the first protocol player's ID.
 
+The player id is the identity API consumers (e.g. the Home Assistant integration) bind entities to, so it must stay stable for the lifetime of the device. When a universal player is (re)created for a device that already has a stored universal player config (matched via its stored protocol player memberships or device identifiers), the stored device key is reused, even if the identifiers available at that moment would compute a different key.
+
 ### File Structure
 
 ```

--- a/music_assistant/providers/universal_player/constants.py
+++ b/music_assistant/providers/universal_player/constants.py
@@ -12,8 +12,9 @@ CONF_DEVICE_IDENTIFIERS: Final[str] = "device_identifiers"
 # Config key for storing device info (model, manufacturer)
 CONF_DEVICE_INFO: Final[str] = "device_info"
 
-# Config key for the (unix timestamp) moment a universal player was created,
-# used to let the older player win when two of them merge.
+# Config key for the moment a universal player was created, as a nanosecond
+# timestamp so players created in the same second still order, used to let the
+# older player win when two of them merge.
 CONF_CREATED_AT: Final[str] = "created_at"
 
 # Protocols where external sources (e.g. Spotify Connect) can play

--- a/music_assistant/providers/universal_player/constants.py
+++ b/music_assistant/providers/universal_player/constants.py
@@ -12,6 +12,10 @@ CONF_DEVICE_IDENTIFIERS: Final[str] = "device_identifiers"
 # Config key for storing device info (model, manufacturer)
 CONF_DEVICE_INFO: Final[str] = "device_info"
 
+# Config key for the (unix timestamp) moment a universal player was created,
+# used to let the older player win when two of them merge.
+CONF_CREATED_AT: Final[str] = "created_at"
+
 # Protocols where external sources (e.g. Spotify Connect) can play
 # independently of Music Assistant.
 EXTERNAL_SOURCE_PROTOCOLS = {"chromecast", "dlna"}

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -120,7 +120,7 @@ class UniversalPlayerProvider(PlayerProvider):
             enabled=True,
             values={
                 CONF_LINKED_PROTOCOL_IDS: protocol_player_ids,
-                CONF_CREATED_AT: int(time.time()),
+                CONF_CREATED_AT: time.time_ns(),
             },
         )
 

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -21,7 +21,7 @@ from music_assistant.constants import (
     CONF_PLAYERS,
     CONF_PROTOCOL_PARENT_ID,
 )
-from music_assistant.helpers.util import is_valid_mac_address, normalize_mac_for_matching
+from music_assistant.helpers.util import normalize_mac_for_matching, strong_identifiers_match
 from music_assistant.models.player import DeviceInfo
 from music_assistant.models.player_provider import PlayerProvider
 
@@ -32,16 +32,6 @@ if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigEntry
 
     from music_assistant.models.player import Player
-
-# Identifier types considered proof of device identity, kept in sync with the
-# type order used by the player controller's _identifiers_match.
-MATCHABLE_IDENTIFIER_TYPES = (
-    IdentifierType.MAC_ADDRESS,
-    IdentifierType.SERIAL_NUMBER,
-    IdentifierType.UUID,
-    IdentifierType.CAST_UUID,
-    IdentifierType.AIRPLAY_ID,
-)
 
 
 class UniversalPlayerProvider(PlayerProvider):
@@ -597,62 +587,73 @@ class UniversalPlayerProvider(PlayerProvider):
         all_player_configs = self.mass.config.get(CONF_PLAYERS, {})
         if not isinstance(all_player_configs, dict):
             return None
-        protocol_ids = {player.player_id for player in protocol_players}
-        identifiers: set[tuple[str, str]] = set()
+
+        def get_stored_parent_id(child_id: str) -> str | None:
+            child_conf = all_player_configs.get(child_id)
+            child_values = child_conf.get("values") if isinstance(child_conf, dict) else None
+            parent_id = (
+                child_values.get(CONF_PROTOCOL_PARENT_ID)
+                if isinstance(child_values, dict)
+                else None
+            )
+            return parent_id if isinstance(parent_id, str) and parent_id else None
+
+        def get_own_universal_config(player_id: str) -> dict[str, Any] | None:
+            # the "up" prefix alone is not enough, a native player id could
+            # coincidentally carry it, so require our own provider as well
+            if not player_id.startswith(UNIVERSAL_PLAYER_PREFIX):
+                return None
+            raw_conf = all_player_configs.get(player_id)
+            if not isinstance(raw_conf, dict) or raw_conf.get("provider") != self.instance_id:
+                return None
+            return raw_conf
+
+        # The parent link persisted on the protocol player itself is the canonical
+        # side of the relation and wins over any reverse membership below.
         for player in protocol_players:
-            for id_type, value in player.device_info.identifiers.items():
-                if normalized := self._normalize_identifier(id_type, value):
-                    identifiers.add((id_type.value, normalized))
+            parent_id = get_stored_parent_id(player.player_id)
+            if parent_id and get_own_universal_config(parent_id):
+                return parent_id.removeprefix(UNIVERSAL_PLAYER_PREFIX)
+
+        protocol_ids = {player.player_id for player in protocol_players}
         identifier_match: str | None = None
         for player_id in sorted(all_player_configs):
-            if not isinstance(player_id, str) or not player_id.startswith(UNIVERSAL_PLAYER_PREFIX):
+            if not isinstance(player_id, str):
                 continue
-            raw_conf = all_player_configs[player_id]
-            if not isinstance(raw_conf, dict):
+            if (raw_conf := get_own_universal_config(player_id)) is None:
                 continue
             values = raw_conf.get("values")
             values = values if isinstance(values, dict) else {}
-            # a protocol player that was already a member is the strongest match
+            # a protocol player that was already a member is a strong match, unless
+            # its own (canonical) parent link contradicts the stored membership
             stored_protocol_ids = values.get(CONF_LINKED_PROTOCOL_IDS)
-            if isinstance(stored_protocol_ids, list) and protocol_ids.intersection(
-                stored_protocol_ids
-            ):
-                return player_id.removeprefix(UNIVERSAL_PLAYER_PREFIX)
+            stored_protocol_ids = (
+                stored_protocol_ids if isinstance(stored_protocol_ids, list) else []
+            )
+            for child_id in protocol_ids.intersection(stored_protocol_ids):
+                if get_stored_parent_id(child_id) in (None, player_id):
+                    return player_id.removeprefix(UNIVERSAL_PLAYER_PREFIX)
             if identifier_match is not None:
                 continue
             # otherwise match on the persisted device identifiers, which also covers
-            # players that were never a member (e.g. a re-keyed bridge player)
+            # players that were never a member (e.g. a re-keyed bridge player).
+            # An unrecognized stored key maps to IdentifierType.UNKNOWN, which is
+            # not a strong identifier and therefore never matches.
             stored_identifiers = values.get(CONF_DEVICE_IDENTIFIERS)
             stored_identifiers = stored_identifiers if isinstance(stored_identifiers, dict) else {}
-            for id_type_str, value in stored_identifiers.items():
-                if not isinstance(value, str):
-                    continue
-                # an unrecognized stored key maps to IdentifierType.UNKNOWN,
-                # which _normalize_identifier rejects
-                id_type = IdentifierType(id_type_str)
-                if (normalized := self._normalize_identifier(id_type, value)) and (
-                    id_type.value,
-                    normalized,
-                ) in identifiers:
-                    identifier_match = player_id
-                    break
+            parsed_identifiers = {
+                IdentifierType(id_type_str): value
+                for id_type_str, value in stored_identifiers.items()
+                if isinstance(id_type_str, str) and isinstance(value, str)
+            }
+            if any(
+                strong_identifiers_match(player.device_info.identifiers, parsed_identifiers)
+                for player in protocol_players
+            ):
+                identifier_match = player_id
         if identifier_match is None:
             return None
         return identifier_match.removeprefix(UNIVERSAL_PLAYER_PREFIX)
-
-    @staticmethod
-    def _normalize_identifier(id_type: IdentifierType, value: str) -> str | None:
-        """Normalize a device identifier value for matching, or None if unusable."""
-        # restricted to the same identifier types _identifiers_match uses, so both
-        # apply the same notion of device identity. This notably excludes IP
-        # addresses (change with DHCP, shared by multi-instance hosts) and UNKNOWN.
-        if not value or id_type not in MATCHABLE_IDENTIFIER_TYPES:
-            return None
-        if id_type == IdentifierType.MAC_ADDRESS:
-            if not is_valid_mac_address(value):
-                return None
-            return normalize_mac_for_matching(value)
-        return value.replace("-", "").replace(":", "").replace("_", "").lower()
 
     def _get_device_key_from_players(self, protocol_players: list[Player]) -> str | None:
         """

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -12,7 +12,9 @@ interface while delegating actual playback to the underlying protocol player(s).
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from music_assistant_models.enums import IdentifierType, PlayerType
 
@@ -21,11 +23,15 @@ from music_assistant.constants import (
     CONF_PLAYERS,
     CONF_PROTOCOL_PARENT_ID,
 )
-from music_assistant.helpers.util import normalize_mac_for_matching, strong_identifiers_match
 from music_assistant.models.player import DeviceInfo
 from music_assistant.models.player_provider import PlayerProvider
 
-from .constants import CONF_DEVICE_IDENTIFIERS, CONF_DEVICE_INFO, UNIVERSAL_PLAYER_PREFIX
+from .constants import (
+    CONF_CREATED_AT,
+    CONF_DEVICE_IDENTIFIERS,
+    CONF_DEVICE_INFO,
+    UNIVERSAL_PLAYER_PREFIX,
+)
 from .player import UniversalPlayer
 
 if TYPE_CHECKING:
@@ -52,8 +58,9 @@ class UniversalPlayerProvider(PlayerProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        # Lock to prevent race conditions during universal player creation
-        self._universal_player_locks: dict[str, asyncio.Lock] = {}
+        # Serializes resolving, restoring and creating universal players, so a device
+        # can never end up with two of them (and thus two player ids).
+        self._lock = asyncio.Lock()
 
     async def discover_players(self) -> None:
         """
@@ -63,17 +70,17 @@ class UniversalPlayerProvider(PlayerProvider):
         not through discovery. However, we restore previously created
         universal players from config.
         """
-        for player_conf in await self.mass.config.get_player_configs(
-            self.instance_id, include_unavailable=True, include_disabled=True
-        ):
-            if player_conf.player_id.startswith(UNIVERSAL_PLAYER_PREFIX):
+        async with self._lock:
+            for player_conf in await self.mass.config.get_player_configs(
+                self.instance_id, include_unavailable=True, include_disabled=True
+            ):
                 # Restore universal player from config
                 # The stored protocol IDs enable fast matching when protocols register
                 await self._restore_player(player_conf.player_id)
 
     async def create_universal_player(
         self,
-        device_key: str,
+        player_id: str,
         name: str,
         device_info: DeviceInfo,
         protocol_player_ids: list[str],
@@ -84,15 +91,12 @@ class UniversalPlayerProvider(PlayerProvider):
         Called by the PlayerController when multiple protocol players are
         detected for a device without a native player.
 
-        :param device_key: Unique device key (typically MAC address).
+        :param player_id: Player id for the new player, as minted by `mint_player_id`.
         :param name: Display name for the player.
         :param device_info: Aggregated device information.
         :param protocol_player_ids: List of protocol player IDs to link.
         :return: The created UniversalPlayer instance.
         """
-        # Generate player_id from device_key
-        player_id = f"{UNIVERSAL_PLAYER_PREFIX}{device_key}"
-
         # Check if player already exists
         if existing := self.mass.players.get_player(player_id):
             # Update existing player with new protocol players
@@ -116,6 +120,7 @@ class UniversalPlayerProvider(PlayerProvider):
             enabled=True,
             values={
                 CONF_LINKED_PROTOCOL_IDS: protocol_player_ids,
+                CONF_CREATED_AT: int(time.time()),
             },
         )
 
@@ -177,88 +182,86 @@ class UniversalPlayerProvider(PlayerProvider):
         """
         await self.mass.players.unregister(player_id, permanent=True)
 
-    async def ensure_universal_player_for_protocols(
+    async def ensure_universal_players_for_protocols(
         self, protocol_players: list[Player]
-    ) -> Player | None:
+    ) -> dict[str, Player]:
         """
-        Ensure a universal player exists for a set of protocol players.
+        Ensure a universal player exists for a set of protocol players of one device.
 
-        This method handles the orchestration of creating or updating a universal player
-        for the given protocol players. It uses per-device locking to prevent race
-        conditions when multiple protocols for the same device register simultaneously.
+        A device keeps the universal player it already belongs to, so its player id -
+        the identity API consumers (such as the Home Assistant integration) bind to -
+        stays the same for the lifetime of the device. Only a device that was never
+        wrapped before gets a newly minted id.
 
-        When a second instance of the same protocol domain tries to join an existing
-        universal player (e.g., two AirPlay instances on the same host), the duplicate
-        is separated out and given its own universal player with a player_id-based key.
+        A protocol domain the universal player already serves means a second device
+        behind the same identifiers (e.g. two AirPlay instances on one host); such a
+        player gets a universal player of its own.
 
         :param protocol_players: List of protocol players for the same device.
-        :return: The created or updated universal player, or None if operation failed.
+        :return: The universal player per protocol player id, keyed by protocol player id.
         """
-        device_key = self._get_device_key_from_players(protocol_players)
-        if not device_key:
-            return None
-
-        # Prefer the device key stored by an earlier universal player for this device.
-        # The player id derived from it is the identity API consumers (such as the
-        # Home Assistant integration) bind to, while the computed key varies with
-        # whichever protocol players happen to be registered at (re)creation time.
-        device_key = self._get_stored_device_key(protocol_players) or device_key
-
-        universal_player_id = f"{UNIVERSAL_PLAYER_PREFIX}{device_key}"
-
-        # Use a per-device lock to prevent race conditions
-        if device_key not in self._universal_player_locks:
-            self._universal_player_locks[device_key] = asyncio.Lock()
-
-        async with self._universal_player_locks[device_key]:
+        async with self._lock:
             # Re-check - another task may have already handled these players
             # Filter out players that are already linked to a parent
             protocol_players = [p for p in protocol_players if not p.protocol_parent_id]
             if not protocol_players:
-                return None
+                return {}
 
-            # Check if universal player already exists
-            if existing := self.mass.players.get_player(universal_player_id):
-                if isinstance(existing, UniversalPlayer):
-                    # Separate players into those that can join vs those that are
-                    # domain-duplicates (a domain already active on the universal player)
-                    active_domains: set[str] = set()
-                    for link in existing.linked_output_protocols:
-                        if not link.protocol_domain:
-                            continue
-                        # A registered player occupies this domain slot even if unavailable
-                        if self.mass.players.get_player(link.output_protocol_id):
-                            active_domains.add(link.protocol_domain)
-                    can_join = [
-                        p for p in protocol_players if p.provider.domain not in active_domains
-                    ]
-                    rejected = [p for p in protocol_players if p.provider.domain in active_domains]
+            # The parent link persisted on the protocol player is the canonical side
+            # of the relation: it names the universal player this device belongs to.
+            assignments: dict[str, Player] = {}
+            unassigned: list[Player] = []
+            for player in protocol_players:
+                if universal_player := await self._resolve_stored_universal_player(player):
+                    assignments[player.player_id] = universal_player
+                else:
+                    unassigned.append(player)
 
-                    # Add players that can join to the existing universal player
-                    for player in can_join:
-                        await self.add_protocol_to_universal_player(
-                            universal_player_id, player.player_id
-                        )
+            target = next(iter(assignments.values()), None)
+            served_domains: set[str] = set()
+            if target is None:
+                # this device was never wrapped before: create one universal player
+                # for it, taking a single protocol player per domain
+                members = self._first_player_per_domain(unassigned)
+                target = await self.create_universal_player(
+                    player_id=self.mint_player_id(),
+                    name=self._get_clean_player_name(members),
+                    device_info=self._aggregate_device_info(members),
+                    protocol_player_ids=[p.player_id for p in members],
+                )
+                for player in members:
+                    assignments[player.player_id] = target
+                    served_domains.add(player.provider.domain)
+                unassigned = [p for p in unassigned if p.player_id not in assignments]
+            else:
+                served_domains = self._served_domains(target)
+                served_domains.update(
+                    player.provider.domain
+                    for player in protocol_players
+                    if assignments.get(player.player_id) is target
+                )
 
-                    # Create separate universal players for rejected (domain-duplicate)
-                    # players using player_id-based device keys
-                    for player in rejected:
-                        fallback_key = player.player_id.replace(":", "").replace("-", "").lower()
-                        await self._create_separate_universal_player(fallback_key, player)
+            for player in unassigned:
+                if player.provider.domain in served_domains:
+                    assignments[player.player_id] = await self._create_separate_universal_player(
+                        player
+                    )
+                    continue
+                served_domains.add(player.provider.domain)
+                await self.add_protocol_to_universal_player(target.player_id, player.player_id)
+                assignments[player.player_id] = target
 
-                return existing
+            return assignments
 
-            # Create new universal player
-            device_info = self._aggregate_device_info(protocol_players)
-            name = self._get_clean_player_name(protocol_players)
-            protocol_player_ids = [p.player_id for p in protocol_players]
-
-            return await self.create_universal_player(
-                device_key=device_key,
-                name=name,
-                device_info=device_info,
-                protocol_player_ids=protocol_player_ids,
-            )
+    def mint_player_id(self) -> str:
+        """Return an unused player id for a new universal player."""
+        while True:
+            player_id = f"{UNIVERSAL_PLAYER_PREFIX}{uuid4().hex[:8]}"
+            if self.mass.players.get_player(player_id):
+                continue
+            if self.mass.config.get(f"{CONF_PLAYERS}/{player_id}"):
+                continue
+            return player_id
 
     def get_universal_player(self, player_id: str) -> UniversalPlayer | None:
         """Get a UniversalPlayer by ID if it exists and is managed by this provider."""
@@ -292,6 +295,11 @@ class UniversalPlayerProvider(PlayerProvider):
         register - they can be linked immediately without waiting for identifier matching.
         Device identifiers are also restored to enable matching new protocol players.
         """
+        if self.get_universal_player(player_id):
+            # a restore replaces the player instance, which would drop the output
+            # protocol links of the registered one while its members still point here
+            return
+
         # Get stored config values
         config = self.mass.config.get(f"{CONF_PLAYERS}/{player_id}")
         if not config:
@@ -307,8 +315,8 @@ class UniversalPlayerProvider(PlayerProvider):
 
         # When nothing links to the stored universal player config (anymore),
         # keep it - it holds user customizations - and simply skip restoring:
-        # the config is picked up again when protocol players return, as
-        # universal player ids are derived from the device.
+        # the config is picked up again once a protocol player that stored this
+        # player as its parent registers.
         if not valid_protocol_ids:
             self.logger.debug(
                 "Not restoring universal player %s - no linked protocol players remain",
@@ -391,7 +399,9 @@ class UniversalPlayerProvider(PlayerProvider):
                     "Unknown identifier type %s for player %s", id_type_str, player_id
                 )
 
-        name = config.get("name", f"Universal Player {player_id}")
+        # the default name, not the custom one: display_name already prefers the
+        # custom name, while update_state persists this one as the default name
+        name = config.get("default_name") or config.get("name") or f"Universal Player {player_id}"
 
         self.logger.debug(
             "Restoring universal player %s with %d protocol IDs and %d identifiers",
@@ -545,143 +555,67 @@ class UniversalPlayerProvider(PlayerProvider):
             len(player.device_info.identifiers),
         )
 
-    async def _create_separate_universal_player(
-        self, device_key: str, protocol_player: Player
-    ) -> Player | None:
+    async def _create_separate_universal_player(self, protocol_player: Player) -> Player:
         """
         Create a separate universal player for a protocol player that was rejected.
 
         Used when a second instance of the same protocol domain (e.g., two AirPlay
-        instances on the same host) cannot join the existing universal player.
-        A unique device_key derived from the player_id ensures no collision.
+        instances on the same host) cannot join the universal player of the device.
 
-        :param device_key: Unique device key for this player (player_id-based).
         :param protocol_player: The protocol player that needs its own universal player.
         """
-        universal_player_id = f"{UNIVERSAL_PLAYER_PREFIX}{device_key}"
-
-        # Check if this separate universal player already exists
-        if existing := self.mass.players.get_player(universal_player_id):
-            if isinstance(existing, UniversalPlayer):
-                await self.add_protocol_to_universal_player(
-                    universal_player_id, protocol_player.player_id
-                )
-            return existing
-
-        device_info = self._aggregate_device_info([protocol_player])
-        name = self._get_clean_player_name([protocol_player])
-
         return await self.create_universal_player(
-            device_key=device_key,
-            name=name,
-            device_info=device_info,
+            player_id=self.mint_player_id(),
+            name=self._get_clean_player_name([protocol_player]),
+            device_info=self._aggregate_device_info([protocol_player]),
             protocol_player_ids=[protocol_player.player_id],
         )
 
-    def _get_stored_device_key(self, protocol_players: list[Player]) -> str | None:
+    async def _resolve_stored_universal_player(
+        self, protocol_player: Player
+    ) -> UniversalPlayer | None:
         """
-        Return the stored device key of an earlier universal player for the same device.
+        Return the universal player a protocol player is persistently linked to, if any.
 
-        :param protocol_players: The protocol players a universal player is (re)created for.
+        :param protocol_player: The protocol player to resolve the universal player of.
         """
-        all_player_configs = self.mass.config.get(CONF_PLAYERS, {})
-        if not isinstance(all_player_configs, dict):
+        parent_id = self.mass.config.get(
+            f"{CONF_PLAYERS}/{protocol_player.player_id}/values/{CONF_PROTOCOL_PARENT_ID}"
+        )
+        if not isinstance(parent_id, str) or not parent_id:
             return None
-
-        def get_stored_parent_id(child_id: str) -> str | None:
-            child_conf = all_player_configs.get(child_id)
-            child_values = child_conf.get("values") if isinstance(child_conf, dict) else None
-            parent_id = (
-                child_values.get(CONF_PROTOCOL_PARENT_ID)
-                if isinstance(child_values, dict)
-                else None
-            )
-            return parent_id if isinstance(parent_id, str) and parent_id else None
-
-        def get_own_universal_config(player_id: str) -> dict[str, Any] | None:
-            # the "up" prefix alone is not enough, a native player id could
-            # coincidentally carry it, so require our own provider as well
-            if not player_id.startswith(UNIVERSAL_PLAYER_PREFIX):
-                return None
-            raw_conf = all_player_configs.get(player_id)
-            if not isinstance(raw_conf, dict) or raw_conf.get("provider") != self.instance_id:
-                return None
-            return raw_conf
-
-        # The parent link persisted on the protocol player itself is the canonical
-        # side of the relation and wins over any reverse membership below.
-        for player in protocol_players:
-            parent_id = get_stored_parent_id(player.player_id)
-            if parent_id and get_own_universal_config(parent_id):
-                return parent_id.removeprefix(UNIVERSAL_PLAYER_PREFIX)
-
-        protocol_ids = {player.player_id for player in protocol_players}
-        identifier_match: str | None = None
-        for player_id in sorted(all_player_configs):
-            if not isinstance(player_id, str):
-                continue
-            if (raw_conf := get_own_universal_config(player_id)) is None:
-                continue
-            values = raw_conf.get("values")
-            values = values if isinstance(values, dict) else {}
-            # a protocol player that was already a member is a strong match, unless
-            # its own (canonical) parent link contradicts the stored membership
-            stored_protocol_ids = values.get(CONF_LINKED_PROTOCOL_IDS)
-            stored_protocol_ids = (
-                stored_protocol_ids if isinstance(stored_protocol_ids, list) else []
-            )
-            for child_id in protocol_ids.intersection(stored_protocol_ids):
-                if get_stored_parent_id(child_id) in (None, player_id):
-                    return player_id.removeprefix(UNIVERSAL_PLAYER_PREFIX)
-            if identifier_match is not None:
-                continue
-            # otherwise match on the persisted device identifiers, which also covers
-            # players that were never a member (e.g. a re-keyed bridge player).
-            # An unrecognized stored key maps to IdentifierType.UNKNOWN, which is
-            # not a strong identifier and therefore never matches.
-            stored_identifiers = values.get(CONF_DEVICE_IDENTIFIERS)
-            stored_identifiers = stored_identifiers if isinstance(stored_identifiers, dict) else {}
-            parsed_identifiers = {
-                IdentifierType(id_type_str): value
-                for id_type_str, value in stored_identifiers.items()
-                if isinstance(id_type_str, str) and isinstance(value, str)
-            }
-            if any(
-                strong_identifiers_match(player.device_info.identifiers, parsed_identifiers)
-                for player in protocol_players
-            ):
-                identifier_match = player_id
-        if identifier_match is None:
+        if existing := self.get_universal_player(parent_id):
+            return existing
+        raw_conf = self.mass.config.get(f"{CONF_PLAYERS}/{parent_id}")
+        # the "up" prefix alone is not enough, a native player id could
+        # coincidentally carry it, so require our own provider as well
+        if not isinstance(raw_conf, dict) or raw_conf.get("provider") != self.instance_id:
             return None
-        return identifier_match.removeprefix(UNIVERSAL_PLAYER_PREFIX)
+        if not raw_conf.get("enabled", True):
+            # the user turned this device off, bringing it back would defeat that intent
+            return None
+        await self._restore_player(parent_id)
+        return self.get_universal_player(parent_id)
 
-    def _get_device_key_from_players(self, protocol_players: list[Player]) -> str | None:
-        """
-        Generate a device key from protocol players' identifiers.
+    def _served_domains(self, universal_player: Player) -> set[str]:
+        """Return the protocol domains that are occupied on a universal player."""
+        return {
+            link.protocol_domain
+            for link in universal_player.linked_output_protocols
+            # a registered player occupies this domain slot even if unavailable
+            if link.protocol_domain and self.mass.players.get_player(link.output_protocol_id)
+        }
 
-        Prefers MAC address (most stable), falls back to UUID, then player_id.
-        IP address is not used as it can change with DHCP and cause incorrect matches.
-        """
-        uuid_key: str | None = None
+    def _first_player_per_domain(self, protocol_players: list[Player]) -> list[Player]:
+        """Return the first protocol player of every distinct protocol domain."""
+        seen: set[str] = set()
+        members: list[Player] = []
         for player in protocol_players:
-            identifiers = player.device_info.identifiers
-            # Prefer MAC address (most reliable)
-            # Use normalize_mac_for_matching to handle locally-administered MAC variants
-            # Some protocols (like AirPlay) report a variant where bit 1 of the first octet
-            # is set (e.g., 54:78:... vs 56:78:...), but they represent the same device
-            if mac := identifiers.get(IdentifierType.MAC_ADDRESS):
-                return normalize_mac_for_matching(mac)
-            # Fall back to UUID (reliable for DLNA, Chromecast)
-            if not uuid_key and (uuid := identifiers.get(IdentifierType.UUID)):
-                # Normalize UUID: remove special characters, lowercase
-                uuid_key = uuid.replace("-", "").replace(":", "").replace("_", "").lower()
-        if uuid_key:
-            return uuid_key
-        # Last resort: use player_id as device key for protocol players without identifiers
-        # (e.g., Sendspin players that don't expose IP/MAC)
-        if protocol_players:
-            return protocol_players[0].player_id.replace(":", "").replace("-", "").lower()
-        return None
+            if player.provider.domain in seen:
+                continue
+            seen.add(player.provider.domain)
+            members.append(player)
+        return members
 
     def _aggregate_device_info(self, protocol_players: list[Player]) -> DeviceInfo:
         """Aggregate device info from protocol players."""

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -198,6 +198,12 @@ class UniversalPlayerProvider(PlayerProvider):
         if not device_key:
             return None
 
+        # Prefer the device key stored by an earlier universal player for this device.
+        # The player id derived from it is the identity API consumers (such as the
+        # Home Assistant integration) bind to, while the computed key varies with
+        # whichever protocol players happen to be registered at (re)creation time.
+        device_key = self._get_stored_device_key(protocol_players) or device_key
+
         universal_player_id = f"{UNIVERSAL_PLAYER_PREFIX}{device_key}"
 
         # Use a per-device lock to prevent race conditions
@@ -571,6 +577,71 @@ class UniversalPlayerProvider(PlayerProvider):
             device_info=device_info,
             protocol_player_ids=[protocol_player.player_id],
         )
+
+    def _get_stored_device_key(self, protocol_players: list[Player]) -> str | None:
+        """
+        Return the stored device key of an earlier universal player for the same device.
+
+        :param protocol_players: The protocol players a universal player is (re)created for.
+        """
+        all_player_configs = self.mass.config.get(CONF_PLAYERS, {})
+        if not isinstance(all_player_configs, dict):
+            return None
+        protocol_ids = {player.player_id for player in protocol_players}
+        identifiers: set[tuple[str, str]] = set()
+        for player in protocol_players:
+            for id_type, value in player.device_info.identifiers.items():
+                if normalized := self._normalize_identifier(id_type, value):
+                    identifiers.add((id_type.value, normalized))
+        identifier_match: str | None = None
+        for player_id in sorted(all_player_configs):
+            if not isinstance(player_id, str) or not player_id.startswith(UNIVERSAL_PLAYER_PREFIX):
+                continue
+            raw_conf = all_player_configs[player_id]
+            if not isinstance(raw_conf, dict):
+                continue
+            values = raw_conf.get("values")
+            values = values if isinstance(values, dict) else {}
+            # a protocol player that was already a member is the strongest match
+            stored_protocol_ids = values.get(CONF_LINKED_PROTOCOL_IDS)
+            if isinstance(stored_protocol_ids, list) and protocol_ids.intersection(
+                stored_protocol_ids
+            ):
+                return player_id.removeprefix(UNIVERSAL_PLAYER_PREFIX)
+            if identifier_match is not None:
+                continue
+            # otherwise match on the persisted device identifiers, which also covers
+            # players that were never a member (e.g. a re-keyed bridge player)
+            stored_identifiers = values.get(CONF_DEVICE_IDENTIFIERS)
+            stored_identifiers = stored_identifiers if isinstance(stored_identifiers, dict) else {}
+            for id_type_str, value in stored_identifiers.items():
+                try:
+                    id_type = IdentifierType(id_type_str)
+                except ValueError:
+                    continue
+                if not isinstance(value, str):
+                    continue
+                if (normalized := self._normalize_identifier(id_type, value)) and (
+                    id_type.value,
+                    normalized,
+                ) in identifiers:
+                    identifier_match = player_id
+                    break
+        if identifier_match is None:
+            return None
+        return identifier_match.removeprefix(UNIVERSAL_PLAYER_PREFIX)
+
+    @staticmethod
+    def _normalize_identifier(id_type: IdentifierType, value: str) -> str | None:
+        """Normalize a device identifier value for matching, or None if unusable."""
+        if not value:
+            return None
+        if id_type == IdentifierType.IP_ADDRESS:
+            # IP addresses change with DHCP and are shared by multi-instance hosts
+            return None
+        if id_type == IdentifierType.MAC_ADDRESS:
+            return normalize_mac_for_matching(value)
+        return value.replace("-", "").replace(":", "").replace("_", "").lower()
 
     def _get_device_key_from_players(self, protocol_players: list[Player]) -> str | None:
         """

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -21,7 +21,7 @@ from music_assistant.constants import (
     CONF_PLAYERS,
     CONF_PROTOCOL_PARENT_ID,
 )
-from music_assistant.helpers.util import normalize_mac_for_matching
+from music_assistant.helpers.util import is_valid_mac_address, normalize_mac_for_matching
 from music_assistant.models.player import DeviceInfo
 from music_assistant.models.player_provider import PlayerProvider
 
@@ -32,6 +32,16 @@ if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigEntry
 
     from music_assistant.models.player import Player
+
+# Identifier types considered proof of device identity, kept in sync with the
+# type order used by the player controller's _identifiers_match.
+MATCHABLE_IDENTIFIER_TYPES = (
+    IdentifierType.MAC_ADDRESS,
+    IdentifierType.SERIAL_NUMBER,
+    IdentifierType.UUID,
+    IdentifierType.CAST_UUID,
+    IdentifierType.AIRPLAY_ID,
+)
 
 
 class UniversalPlayerProvider(PlayerProvider):
@@ -615,12 +625,11 @@ class UniversalPlayerProvider(PlayerProvider):
             stored_identifiers = values.get(CONF_DEVICE_IDENTIFIERS)
             stored_identifiers = stored_identifiers if isinstance(stored_identifiers, dict) else {}
             for id_type_str, value in stored_identifiers.items():
-                try:
-                    id_type = IdentifierType(id_type_str)
-                except ValueError:
-                    continue
                 if not isinstance(value, str):
                     continue
+                # an unrecognized stored key maps to IdentifierType.UNKNOWN,
+                # which _normalize_identifier rejects
+                id_type = IdentifierType(id_type_str)
                 if (normalized := self._normalize_identifier(id_type, value)) and (
                     id_type.value,
                     normalized,
@@ -634,12 +643,14 @@ class UniversalPlayerProvider(PlayerProvider):
     @staticmethod
     def _normalize_identifier(id_type: IdentifierType, value: str) -> str | None:
         """Normalize a device identifier value for matching, or None if unusable."""
-        if not value:
-            return None
-        if id_type == IdentifierType.IP_ADDRESS:
-            # IP addresses change with DHCP and are shared by multi-instance hosts
+        # restricted to the same identifier types _identifiers_match uses, so both
+        # apply the same notion of device identity. This notably excludes IP
+        # addresses (change with DHCP, shared by multi-instance hosts) and UNKNOWN.
+        if not value or id_type not in MATCHABLE_IDENTIFIER_TYPES:
             return None
         if id_type == IdentifierType.MAC_ADDRESS:
+            if not is_valid_mac_address(value):
+                return None
             return normalize_mac_for_matching(value)
         return value.replace("-", "").replace(":", "").replace("_", "").lower()
 

--- a/tests/controllers/config/test_default_player_config.py
+++ b/tests/controllers/config/test_default_player_config.py
@@ -42,3 +42,39 @@ async def test_existing_default_name_still_updated(mass_minimal: MusicAssistant)
         PLAYER_ID, "squeezelite", PlayerType.PROTOCOL, "new-name"
     )
     assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/default_name") == "new-name"
+
+
+async def test_untouched_name_follows_default_name(mass_minimal: MusicAssistant) -> None:
+    """
+    A name the user never changed moves along with the default name.
+
+    Regression test for music-assistant/support#5888: fresh configs store
+    name == default_name. A default name update that leaves the untouched name
+    behind makes the stale auto-generated name read as a user rename, which
+    shadows the new default name and gets carried over to any replacement
+    player, producing duplicated friendly names.
+    """
+    mass_minimal.config.create_default_player_config(
+        PLAYER_ID, "squeezelite", PlayerType.PROTOCOL, "old-name"
+    )
+    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/name") == "old-name"
+
+    mass_minimal.config.set_player_default_name(PLAYER_ID, "new-name")
+
+    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/default_name") == "new-name"
+    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/name") == "new-name"
+
+
+async def test_user_renamed_name_preserved_on_default_name_update(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A real user rename is never overwritten by a default name update."""
+    mass_minimal.config.create_default_player_config(
+        PLAYER_ID, "squeezelite", PlayerType.PROTOCOL, "old-name"
+    )
+    mass_minimal.config.set(f"{CONF_PLAYERS}/{PLAYER_ID}/name", "My Custom Name")
+
+    mass_minimal.config.set_player_default_name(PLAYER_ID, "new-name")
+
+    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/default_name") == "new-name"
+    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/name") == "My Custom Name"

--- a/tests/controllers/config/test_default_player_config.py
+++ b/tests/controllers/config/test_default_player_config.py
@@ -44,25 +44,25 @@ async def test_existing_default_name_still_updated(mass_minimal: MusicAssistant)
     assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/default_name") == "new-name"
 
 
-async def test_untouched_name_follows_default_name(mass_minimal: MusicAssistant) -> None:
+async def test_creation_name_is_stored_as_default_name_only(mass_minimal: MusicAssistant) -> None:
     """
-    A name the user never changed moves along with the default name.
+    The name a player is created with is stored as its default name only.
 
-    Regression test for music-assistant/support#5888: fresh configs store
-    name == default_name. A default name update that leaves the untouched name
-    behind makes the stale auto-generated name read as a user rename, which
-    shadows the new default name and gets carried over to any replacement
-    player, producing duplicated friendly names.
+    Regression test for music-assistant/support#5888: a stored name used to be
+    written for fresh configs as well, which is indistinguishable from a user
+    rename. It kept shadowing every later default name and was carried over to
+    any replacement player, producing duplicated friendly names.
     """
     mass_minimal.config.create_default_player_config(
         PLAYER_ID, "squeezelite", PlayerType.PROTOCOL, "old-name"
     )
-    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/name") == "old-name"
+    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/name") is None
+    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/default_name") == "old-name"
 
     mass_minimal.config.set_player_default_name(PLAYER_ID, "new-name")
 
     assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/default_name") == "new-name"
-    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/name") == "new-name"
+    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/name") is None
 
 
 async def test_user_renamed_name_preserved_on_default_name_update(

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -25,6 +25,7 @@ from music_assistant.controllers.config.migrations import (
     _migrate_output_limiter,
     _migrate_player_icons,
     _migrate_player_setup_data,
+    _migrate_unrenamed_player_names,
     migrate_hass_engine_selection,
     migrate_nfs_subfolder_into_export_path,
     migrate_provider_setup_data,
@@ -1178,3 +1179,23 @@ def test_migrate_orphaned_disabled_protocol_configs_tolerates_malformed_data() -
     }
     assert _migrate_orphaned_disabled_protocol_configs(data) is False
     assert len(data["players"]) == 3
+
+
+def test_migrate_unrenamed_player_names() -> None:
+    """A stored name that merely repeats the default name is cleared, real renames stay."""
+    data: dict[str, Any] = {
+        "players": {
+            "never_renamed": {"name": "Living Room", "default_name": "Living Room"},
+            "user_renamed": {"name": "Bathroom", "default_name": "solarium-bath-sl"},
+            # without a default name, clearing the name would leave no name at all
+            "without_default_name": {"name": "Kitchen"},
+            "not_a_dict": "malformed",
+        }
+    }
+
+    assert _migrate_unrenamed_player_names(data) is True
+    assert data["players"]["never_renamed"]["name"] is None
+    assert data["players"]["user_renamed"]["name"] == "Bathroom"
+    assert data["players"]["without_default_name"]["name"] == "Kitchen"
+    # the cleared name must not be picked up again on the next start
+    assert _migrate_unrenamed_player_names(data) is False

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -7776,6 +7776,32 @@ class TestEndToEndUniversalPlayerId:
         assert universal_id in controller._players
         assert store[CONF_PLAYERS]["ap_1"]["values"][CONF_PROTOCOL_PARENT_ID] == universal_id
 
+    async def test_wrappers_created_in_one_second_still_order(self, mock_mass: MagicMock) -> None:
+        """
+        Two wrappers created back to back get distinct creation timestamps.
+
+        A merge between them must be able to keep the older one, which it cannot do
+        when both carry the same timestamp and the tiebreak falls back to the id.
+        """
+        controller, store = self._setup_controller(mock_mass)
+        players = [
+            self._make_airplay_player(
+                mock_mass, f"ap_{index}", f"Speaker {index}", {IdentifierType.MAC_ADDRESS: mac}
+            )
+            for index, mac in enumerate(("54:78:C9:E6:0D:A0", "AA:BB:CC:DD:EE:FF"), start=1)
+        ]
+        controller._players = {player.player_id: player for player in players}
+
+        for player in players:
+            await controller._delayed_protocol_evaluation(player.player_id)
+
+        created = [
+            store[CONF_PLAYERS][player.protocol_parent_id]["values"][CONF_CREATED_AT]
+            for player in players
+        ]
+        assert all(isinstance(value, int) for value in created)
+        assert created[0] < created[1]
+
     async def test_new_devices_get_distinct_minted_ids(self, mock_mass: MagicMock) -> None:
         """Devices that were never wrapped before each get their own minted id."""
         controller, _ = self._setup_controller(mock_mass)

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -849,6 +849,153 @@ class TestGetDeviceKeyFromPlayers:
         assert device_key == "sendspindeviceabc"
 
 
+class TestGetStoredDeviceKey:
+    """
+    Tests for reusing the stored device key of an earlier universal player.
+
+    Regression tests for music-assistant/support#5888: re-creating a universal
+    player must not change its player id, even when a different set of protocol
+    players or identifiers is available at re-creation time. Consumers such as
+    the Home Assistant integration bind entities to that id.
+    """
+
+    def test_stored_key_reused_via_linked_protocol_ids(self, mock_mass: MagicMock) -> None:
+        """A protocol player that was a member before yields the stored key."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        mock_mass.config.get = MagicMock(
+            return_value={
+                "up5478c9e60da0": {
+                    "player_id": "up5478c9e60da0",
+                    "provider": "universal_player",
+                    "values": {"linked_protocol_ids": ["ap_123456", "sendspin_bridge_1"]},
+                },
+            }
+        )
+        provider = MockProvider("sendspin")
+        # the returning member has no MAC identifier at all this time
+        player = MockPlayer(
+            provider,
+            "sendspin_bridge_1",
+            "Test Player",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.UUID: "12345678-1234-1234-1234-123456789abc"},
+        )
+
+        assert universal_provider._get_stored_device_key([player]) == "5478c9e60da0"
+        # sanity: the freshly computed key would have differed
+        assert universal_provider._get_device_key_from_players([player]) != "5478c9e60da0"
+
+    def test_stored_key_reused_via_identifiers(self, mock_mass: MagicMock) -> None:
+        """A never-before-seen protocol player of a known device yields the stored key."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        mock_mass.config.get = MagicMock(
+            return_value={
+                "upuuid12345678": {
+                    "player_id": "upuuid12345678",
+                    "provider": "universal_player",
+                    "values": {
+                        "linked_protocol_ids": ["dlna_123456"],
+                        "device_identifiers": {"mac_address": "54:78:C9:E6:0D:A0"},
+                    },
+                },
+            }
+        )
+        provider = MockProvider("airplay")
+        # re-keyed player: unknown id, locally-administered MAC variant of the same device
+        player = MockPlayer(
+            provider,
+            "ap_999999",
+            "Test Player",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "56:78:C9:E6:0D:A0"},
+        )
+
+        assert universal_provider._get_stored_device_key([player]) == "uuid12345678"
+
+    def test_stored_key_never_matches_on_ip_address(self, mock_mass: MagicMock) -> None:
+        """IP addresses are not identity: no stored key may be derived from them."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        mock_mass.config.get = MagicMock(
+            return_value={
+                "upaabbccddeeff": {
+                    "player_id": "upaabbccddeeff",
+                    "provider": "universal_player",
+                    "values": {
+                        "linked_protocol_ids": ["dlna_123456"],
+                        "device_identifiers": {"ip_address": "192.168.1.100"},
+                    },
+                },
+            }
+        )
+        provider = MockProvider("airplay")
+        player = MockPlayer(
+            provider,
+            "ap_999999",
+            "Test Player",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.IP_ADDRESS: "192.168.1.100"},
+        )
+
+        assert universal_provider._get_stored_device_key([player]) is None
+
+    def test_no_stored_key_for_unrelated_device(self, mock_mass: MagicMock) -> None:
+        """A device without an earlier universal player yields no stored key."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        mock_mass.config.get = MagicMock(
+            return_value={
+                "upaabbccddeeff": {
+                    "player_id": "upaabbccddeeff",
+                    "provider": "universal_player",
+                    "values": {
+                        "linked_protocol_ids": ["ap_123456"],
+                        "device_identifiers": {"mac_address": "AA:BB:CC:DD:EE:FF"},
+                    },
+                },
+            }
+        )
+        provider = MockProvider("airplay")
+        player = MockPlayer(
+            provider,
+            "ap_999999",
+            "Test Player",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "11:22:33:44:55:66"},
+        )
+
+        assert universal_provider._get_stored_device_key([player]) is None
+
+    async def test_ensure_universal_player_reuses_stored_key(self, mock_mass: MagicMock) -> None:
+        """Re-creating a universal player keeps the stored device key (and thus its id)."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        mock_mass.config.get = MagicMock(
+            return_value={
+                "up5478c9e60da0": {
+                    "player_id": "up5478c9e60da0",
+                    "provider": "universal_player",
+                    "values": {"linked_protocol_ids": ["sendspin_bridge_1"]},
+                },
+            }
+        )
+        mock_mass.players.get_player = MagicMock(return_value=None)
+        universal_provider.create_universal_player = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+        provider = MockProvider("sendspin")
+        player = MockPlayer(
+            provider,
+            "sendspin_bridge_1",
+            "Test Player",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.UUID: "12345678-1234-1234-1234-123456789abc"},
+        )
+
+        await universal_provider.ensure_universal_player_for_protocols([player])
+
+        universal_provider.create_universal_player.assert_awaited_once()
+        await_args = universal_provider.create_universal_player.await_args
+        assert await_args is not None
+        assert await_args.kwargs["device_key"] == "5478c9e60da0"
+
+
 class TestGetCleanPlayerName:
     """Tests for player name selection."""
 

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -6317,6 +6317,37 @@ class TestUniversalPlayerMerging:
         # non-conflicting values still migrate
         assert config_store["players/up_keep/values/flow_mode"] is True
 
+    def test_merge_does_not_carry_over_the_creation_moment(self, mock_mass: MagicMock) -> None:
+        """
+        The absorbed player's creation moment stays behind.
+
+        It is bookkeeping of that wrapper alone; copying it onto the keeper would let a
+        later merge discard the keeper's older - and therefore established - player id.
+        """
+        config_store: dict[str, Any] = {
+            "players/up_keep": {
+                "enabled": True,
+                "name": "Keep (Universal)",
+                "default_name": "Keep (Universal)",
+                "values": {},
+            },
+            "players/up_remove": {
+                "enabled": True,
+                "name": "Remove (Universal)",
+                "default_name": "Remove (Universal)",
+                "values": {CONF_CREATED_AT: 5000},
+            },
+            "players/ap_keep": {"enabled": True},
+            "players/dlna_live": {"enabled": True},
+        }
+        controller, keep, _ = self._setup_merge_scenario(mock_mass, config_store)
+
+        with patch.object(controller, "_save_universal_player_data"):
+            controller._check_merge_universal_players(keep)
+
+        assert f"players/up_keep/values/{CONF_CREATED_AT}" not in config_store
+        assert CONF_CREATED_AT not in config_store["players/up_keep"]["values"]
+
     def test_merge_repoints_group_memberships(self, mock_mass: MagicMock) -> None:
         """Merge re-points group memberships from the removed wrapper to the keeper."""
         config_store: dict[str, Any] = {

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -5736,7 +5736,7 @@ class TestUniversalPlayerMerging:
         assert "up_2" in controller._players
 
     def test_merge_keeps_player_with_more_protocols(self, mock_mass: MagicMock) -> None:
-        """Test that the universal player with more protocol links absorbs the other."""
+        """Test that of two equally old universal players, the one with more links wins."""
         controller = PlayerController(mock_mass)
         up_provider = create_mock_universal_provider(mock_mass)
 
@@ -5824,6 +5824,70 @@ class TestUniversalPlayerMerging:
 
         # up1 should have no more links
         assert len(up1.linked_output_protocols) == 0
+
+    def test_merge_keeps_the_older_player_with_fewer_protocols(self, mock_mass: MagicMock) -> None:
+        """
+        The oldest universal player wins even when it serves fewer protocols.
+
+        Its player id is the one API consumers have been bound to the longest, and the
+        links of the absorbed player move over anyway. A player stored before ids were
+        minted has no creation moment at all, which must count as the oldest of the two.
+        """
+        controller = PlayerController(mock_mass)
+        up_provider = create_mock_universal_provider(mock_mass)
+        _wire_nested_config(
+            mock_mass,
+            {
+                CONF_PLAYERS: {
+                    # the established player, from before player ids were minted
+                    "up_old": {"player_id": "up_old", "enabled": True, "values": {}},
+                    "up_new": {
+                        "player_id": "up_new",
+                        "enabled": True,
+                        "values": {CONF_CREATED_AT: 9000},
+                    },
+                }
+            },
+        )
+
+        players: dict[str, UniversalPlayer] = {}
+        for player_id, protocol_ids in (("up_old", ["dlna_1"]), ("up_new", ["ap_1", "spb_1"])):
+            player = UniversalPlayer(
+                provider=up_provider,
+                player_id=player_id,
+                name=player_id,
+                device_info=DeviceInfo(model="Test", manufacturer="Test"),
+                protocol_player_ids=protocol_ids,
+            )
+            player._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, "AA:BB:CC:DD:EE:FF")
+            player._cache.clear()
+            player.update_state(signal_event=False)
+            player.set_initialized()
+            players[player_id] = player
+
+        protocol_players: dict[str, MockPlayer] = {}
+        for protocol_id, domain in (("dlna_1", "dlna"), ("ap_1", "airplay"), ("spb_1", "sendspin")):
+            protocol_player = MockPlayer(
+                MockProvider(domain, mass=mock_mass),
+                protocol_id,
+                domain,
+                player_type=PlayerType.PROTOCOL,
+                identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+            )
+            protocol_player.set_initialized()
+            protocol_players[protocol_id] = protocol_player
+
+        controller._players = {**players, **protocol_players}
+        controller._add_protocol_link(players["up_old"], protocol_players["dlna_1"], "dlna")
+        controller._add_protocol_link(players["up_new"], protocol_players["ap_1"], "airplay")
+        controller._add_protocol_link(players["up_new"], protocol_players["spb_1"], "sendspin")
+
+        controller._check_merge_universal_players(players["up_new"])
+
+        domains = {link.protocol_domain for link in players["up_old"].linked_output_protocols}
+        assert domains == {"dlna", "airplay", "sendspin"}
+        assert protocol_players["ap_1"].protocol_parent_id == "up_old"
+        assert len(players["up_new"].linked_output_protocols) == 0
 
     @staticmethod
     def _setup_merge_tiebreak(

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -938,6 +938,60 @@ class TestGetStoredDeviceKey:
 
         assert universal_provider._get_stored_device_key([player]) is None
 
+    def test_stored_key_never_matches_on_invalid_mac(self, mock_mass: MagicMock) -> None:
+        """An all-zero MAC is not identity: it must not match across devices."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        mock_mass.config.get = MagicMock(
+            return_value={
+                "upaabbccddeeff": {
+                    "player_id": "upaabbccddeeff",
+                    "provider": "universal_player",
+                    "values": {
+                        "linked_protocol_ids": ["dlna_123456"],
+                        "device_identifiers": {"mac_address": "00:00:00:00:00:00"},
+                    },
+                },
+            }
+        )
+        provider = MockProvider("airplay")
+        player = MockPlayer(
+            provider,
+            "ap_999999",
+            "Test Player",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "00:00:00:00:00:00"},
+        )
+
+        assert universal_provider._get_stored_device_key([player]) is None
+
+    def test_stored_key_never_matches_on_unknown_identifier_type(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A stored garbage identifier key coerces to UNKNOWN and must not match."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        mock_mass.config.get = MagicMock(
+            return_value={
+                "upaabbccddeeff": {
+                    "player_id": "upaabbccddeeff",
+                    "provider": "universal_player",
+                    "values": {
+                        "linked_protocol_ids": ["dlna_123456"],
+                        "device_identifiers": {"some_unknown_key": "same-value"},
+                    },
+                },
+            }
+        )
+        provider = MockProvider("airplay")
+        player = MockPlayer(
+            provider,
+            "ap_999999",
+            "Test Player",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.UNKNOWN: "same-value"},
+        )
+
+        assert universal_provider._get_stored_device_key([player]) is None
+
     def test_no_stored_key_for_unrelated_device(self, mock_mass: MagicMock) -> None:
         """A device without an earlier universal player yields no stored key."""
         universal_provider = create_mock_universal_provider(mock_mass)

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -1,9 +1,12 @@
 """Tests for protocol player linking and universal player creation."""
 
+import asyncio
 import logging
+import re
 from collections.abc import Awaitable
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
 
 import pytest
 from music_assistant_models.config_entries import PlayerConfig
@@ -22,6 +25,7 @@ from music_assistant.constants import (
     CONF_PLAYER_QUEUES,
     CONF_PLAYERS,
     CONF_PREFERRED_OUTPUT_PROTOCOL,
+    CONF_PROTOCOL_PARENT_ID,
 )
 from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.config.migrations import migrate
@@ -29,6 +33,7 @@ from music_assistant.controllers.players import PlayerController
 from music_assistant.helpers.util import enrich_device_mac_address
 from music_assistant.models.player import DeviceInfo, LinkedOutputProtocol, Player
 from music_assistant.models.player_provider import PlayerProvider
+from music_assistant.providers.universal_player.constants import CONF_CREATED_AT
 from music_assistant.providers.universal_player.player import UniversalPlayer
 from music_assistant.providers.universal_player.provider import UniversalPlayerProvider
 
@@ -58,9 +63,78 @@ def create_mock_universal_provider(mock_mass: MagicMock) -> UniversalPlayerProvi
     config.instance_id = "universal_player"
     config.name = None
     provider.config = config
-    # Initialize the locks dict that would normally be set in handle_async_init
-    provider._universal_player_locks = {}
+    # Initialize the lock that would normally be set in handle_async_init
+    provider._lock = asyncio.Lock()
     return provider
+
+
+# Player id of the universal player a device was wrapped in earlier, as minted once
+# by UniversalPlayerProvider.mint_player_id.
+STORED_UNIVERSAL_ID = "up1a2b3c4d"
+
+
+def _wire_nested_config(mock_mass: MagicMock, store: dict[str, Any]) -> None:
+    """Wire mass.config get/set/remove to a nested, path-addressable store."""
+
+    def _get(key: str, default: object = None) -> object:
+        node: Any = store
+        for part in key.split("/"):
+            if not isinstance(node, dict) or part not in node:
+                return default
+            node = node[part]
+        return node
+
+    def _set(key: str, value: object) -> None:
+        parts = key.split("/")
+        node: dict[str, Any] = store
+        for part in parts[:-1]:
+            node = node.setdefault(part, {})
+        node[parts[-1]] = value
+
+    def _remove(key: str) -> None:
+        parts = key.split("/")
+        node: Any = store
+        for part in parts[:-1]:
+            node = node.get(part) if isinstance(node, dict) else None
+            if node is None:
+                return
+        if isinstance(node, dict):
+            node.pop(parts[-1], None)
+
+    mock_mass.config.get = MagicMock(side_effect=_get)
+    mock_mass.config.set = MagicMock(side_effect=_set)
+    mock_mass.config.remove = MagicMock(side_effect=_remove)
+
+
+def _fake_create_default_player_config(
+    store: dict[str, Any],
+    player_id: str,
+    provider: str,
+    player_type: PlayerType,
+    name: str | None = None,
+    enabled: bool = True,
+    values: dict[str, Any] | None = None,
+) -> None:
+    """
+    Mirror ConfigController.create_default_player_config against a plain dict store.
+
+    Only the parts the universal player flows depend on: a fresh config keeps the
+    creation-time name as the default name only, an existing config keeps its type.
+    """
+    players: dict[str, Any] = store.setdefault(CONF_PLAYERS, {})
+    if existing := players.get(player_id):
+        if name and name != existing.get("default_name"):
+            existing["default_name"] = name
+        return
+    players[player_id] = {
+        "player_id": player_id,
+        "provider": provider,
+        "player_type": player_type.value,
+        "enabled": enabled,
+        "name": None,
+        "default_name": name,
+        "values": dict(values or {}),
+    }
 
 
 class MockProvider:
@@ -225,6 +299,26 @@ class TestIdentifiersMatch:
             "player_b",
             "Player B",
             identifiers={IdentifierType.MAC_ADDRESS: "11:22:33:44:55:66"},
+        )
+
+        assert controller._identifiers_match(player_a, player_b) is False
+
+    def test_invalid_mac_address_no_match(self, mock_mass: MagicMock) -> None:
+        """Test that an all-zero MAC is not identity and never matches across devices."""
+        controller = PlayerController(mock_mass)
+
+        provider = MockProvider("test")
+        player_a = MockPlayer(
+            provider,
+            "player_a",
+            "Player A",
+            identifiers={IdentifierType.MAC_ADDRESS: "00:00:00:00:00:00"},
+        )
+        player_b = MockPlayer(
+            provider,
+            "player_b",
+            "Player B",
+            identifiers={IdentifierType.MAC_ADDRESS: "00:00:00:00:00:00"},
         )
 
         assert controller._identifiers_match(player_a, player_b) is False
@@ -731,415 +825,202 @@ class TestFindMatchingProtocolPlayers:
         assert snapcast_player_2 not in matches
 
 
-class TestGetDeviceKeyFromPlayers:
-    """Tests for device key generation."""
-
-    def test_device_key_from_mac(self, mock_mass: MagicMock) -> None:
-        """
-        Test device key generation from MAC address.
-
-        Note: Device keys are normalized to clear the locally-administered bit
-        (bit 1 of first octet) to ensure consistent keys across protocols.
-        """
-        universal_provider = create_mock_universal_provider(mock_mass)
-
-        provider = MockProvider("airplay")
-        # Use a MAC without locally-administered bit set for cleaner test
-        # 00:BB:CC:DD:EE:FF has first byte 0x00, bit 1 = 0
-        player = MockPlayer(
-            provider,
-            "ap_123456",
-            "Test Player",
-            identifiers={IdentifierType.MAC_ADDRESS: "00:BB:CC:DD:EE:FF"},
-        )
-
-        device_key = universal_provider._get_device_key_from_players([player])
-
-        assert device_key == "00bbccddeeff"
-
-    def test_device_key_normalizes_locally_administered_mac(self, mock_mass: MagicMock) -> None:
-        """
-        Test that device key normalizes locally-administered MACs.
-
-        A device with hardware MAC 54:78:C9:E6:0D:A0 and AirPlay MAC 56:78:C9:E6:0D:A0
-        should generate the same device key, allowing them to be merged into
-        the same universal player.
-        """
-        universal_provider = create_mock_universal_provider(mock_mass)
-
-        provider_dlna = MockProvider("dlna")
-        provider_airplay = MockProvider("airplay")
-
-        # DLNA player with real hardware MAC
-        player_dlna = MockPlayer(
-            provider_dlna,
-            "dlna_123456",
-            "WiiM Pro (DLNA)",
-            identifiers={IdentifierType.MAC_ADDRESS: "54:78:C9:E6:0D:A0"},
-        )
-
-        # AirPlay player with locally-administered MAC (bit 1 set)
-        player_airplay = MockPlayer(
-            provider_airplay,
-            "ap_123456",
-            "WiiM Pro (AirPlay)",
-            identifiers={IdentifierType.MAC_ADDRESS: "56:78:C9:E6:0D:A0"},
-        )
-
-        # Both should generate the same device key
-        key_dlna = universal_provider._get_device_key_from_players([player_dlna])
-        key_airplay = universal_provider._get_device_key_from_players([player_airplay])
-
-        # Keys should be identical (both normalized to clear locally-administered bit)
-        assert key_dlna == key_airplay
-        # The normalized MAC should have bit 1 cleared (0x54 not 0x56)
-        assert key_dlna == "5478c9e60da0"
-
-    def test_device_key_from_uuid_fallback(self, mock_mass: MagicMock) -> None:
-        """Test device key generation falls back to UUID when no MAC available."""
-        universal_provider = create_mock_universal_provider(mock_mass)
-
-        provider = MockProvider("dlna")
-        player = MockPlayer(
-            provider,
-            "dlna_123456",
-            "Test Player",
-            identifiers={IdentifierType.UUID: "uuid:12345678-1234-1234-1234-123456789abc"},
-        )
-
-        device_key = universal_provider._get_device_key_from_players([player])
-
-        assert device_key == "uuid12345678123412341234123456789abc"
-
-    def test_device_key_from_ip_falls_back_to_player_id(self, mock_mass: MagicMock) -> None:
-        """Test that device key falls back to player_id for IP-only players (IP not used)."""
-        universal_provider = create_mock_universal_provider(mock_mass)
-
-        provider = MockProvider("airplay")
-        player = MockPlayer(
-            provider,
-            "ap_123456",
-            "Test Player",
-            identifiers={IdentifierType.IP_ADDRESS: "192.168.1.100"},
-        )
-
-        device_key = universal_provider._get_device_key_from_players([player])
-
-        # IP address is not used for device key - falls back to player_id
-        # This allows protocol players without MAC/UUID to still get a UniversalPlayer
-        assert device_key == "ap_123456"
-
-    def test_device_key_from_no_identifiers_falls_back_to_player_id(
-        self, mock_mass: MagicMock
-    ) -> None:
-        """Test that device key falls back to player_id when no identifiers at all."""
-        universal_provider = create_mock_universal_provider(mock_mass)
-
-        provider = MockProvider("sendspin")
-        player = MockPlayer(
-            provider,
-            "sendspin-device-abc",
-            "Test Player",
-            # No identifiers at all (like Sendspin protocol players)
-        )
-
-        device_key = universal_provider._get_device_key_from_players([player])
-
-        # Falls back to player_id when no MAC/UUID identifiers
-        assert device_key == "sendspindeviceabc"
-
-
-class TestGetStoredDeviceKey:
+class TestResolveStoredUniversalPlayer:
     """
-    Tests for reusing the stored device key of an earlier universal player.
+    Tests for resolving the universal player a protocol player is persistently linked to.
 
-    Regression tests for music-assistant/support#5888: re-creating a universal
-    player must not change its player id, even when a different set of protocol
-    players or identifiers is available at re-creation time. Consumers such as
-    the Home Assistant integration bind entities to that id.
+    Regression tests for music-assistant/support#5888: the universal player id is
+    minted once and a device is always routed back to the wrapper its protocol
+    players point at, so the id API consumers (such as the Home Assistant
+    integration) bind their entities to stays put.
     """
 
-    def test_stored_key_reused_via_linked_protocol_ids(self, mock_mass: MagicMock) -> None:
-        """A protocol player that was a member before yields the stored key."""
-        universal_provider = create_mock_universal_provider(mock_mass)
-        mock_mass.config.get = MagicMock(
-            return_value={
-                "up5478c9e60da0": {
-                    "player_id": "up5478c9e60da0",
-                    "provider": "universal_player",
-                    "values": {"linked_protocol_ids": ["ap_123456", "sendspin_bridge_1"]},
-                },
-            }
-        )
-        provider = MockProvider("sendspin")
-        # the returning member has no MAC identifier at all this time
-        player = MockPlayer(
-            provider,
-            "sendspin_bridge_1",
-            "Test Player",
-            player_type=PlayerType.PROTOCOL,
-            identifiers={IdentifierType.UUID: "12345678-1234-1234-1234-123456789abc"},
-        )
+    @staticmethod
+    def _stored_universal_config(**overrides: Any) -> dict[str, Any]:
+        """Return the stored config of a universal player wrapping the ap_123456 device."""
+        return {
+            "player_id": STORED_UNIVERSAL_ID,
+            "provider": "universal_player",
+            "player_type": "player",
+            "enabled": True,
+            "default_name": "Living Room",
+            "values": {
+                "linked_protocol_ids": ["ap_123456"],
+                "device_identifiers": {"mac_address": "54:78:C9:E6:0D:A0"},
+                "device_info": {"model": "WiiM Pro", "manufacturer": "Linkplay"},
+            },
+        } | overrides
 
-        assert universal_provider._get_stored_device_key([player]) == "5478c9e60da0"
-        # sanity: the freshly computed key would have differed
-        assert universal_provider._get_device_key_from_players([player]) != "5478c9e60da0"
-
-    def test_stored_key_reused_via_identifiers(self, mock_mass: MagicMock) -> None:
-        """A never-before-seen protocol player of a known device yields the stored key."""
-        universal_provider = create_mock_universal_provider(mock_mass)
-        mock_mass.config.get = MagicMock(
-            return_value={
-                "upuuid12345678": {
-                    "player_id": "upuuid12345678",
-                    "provider": "universal_player",
-                    "values": {
-                        "linked_protocol_ids": ["dlna_123456"],
-                        "device_identifiers": {"mac_address": "54:78:C9:E6:0D:A0"},
-                    },
-                },
-            }
-        )
-        provider = MockProvider("airplay")
-        # re-keyed player: unknown id, locally-administered MAC variant of the same device
-        player = MockPlayer(
-            provider,
-            "ap_999999",
-            "Test Player",
-            player_type=PlayerType.PROTOCOL,
-            identifiers={IdentifierType.MAC_ADDRESS: "56:78:C9:E6:0D:A0"},
-        )
-
-        assert universal_provider._get_stored_device_key([player]) == "uuid12345678"
-
-    def test_stored_key_never_matches_on_ip_address(self, mock_mass: MagicMock) -> None:
-        """IP addresses are not identity: no stored key may be derived from them."""
-        universal_provider = create_mock_universal_provider(mock_mass)
-        mock_mass.config.get = MagicMock(
-            return_value={
-                "upaabbccddeeff": {
-                    "player_id": "upaabbccddeeff",
-                    "provider": "universal_player",
-                    "values": {
-                        "linked_protocol_ids": ["dlna_123456"],
-                        "device_identifiers": {"ip_address": "192.168.1.100"},
-                    },
-                },
-            }
-        )
-        provider = MockProvider("airplay")
-        player = MockPlayer(
-            provider,
-            "ap_999999",
-            "Test Player",
-            player_type=PlayerType.PROTOCOL,
-            identifiers={IdentifierType.IP_ADDRESS: "192.168.1.100"},
-        )
-
-        assert universal_provider._get_stored_device_key([player]) is None
-
-    def test_canonical_parent_wins_over_stale_membership(self, mock_mass: MagicMock) -> None:
+    @staticmethod
+    def _wire_config(
+        mock_mass: MagicMock,
+        parent_id: str | None,
+        parent_config: dict[str, Any] | None = None,
+    ) -> None:
         """
-        A stale config listing the same member must not win from the canonical parent.
+        Wire a config store holding the ap_123456 protocol player and its parent.
 
-        Lifecycle scenario: an obsolete universal player config from before a re-key
-        still lists the protocol player as a member, while the protocol player's own
-        persisted parent link points at the current universal player. The current
-        one must be picked, so the id (and with it the stored settings) stays put.
+        :param mock_mass: The mocked MusicAssistant instance to wire.
+        :param parent_id: Parent link persisted on the protocol player, if any.
+        :param parent_config: Stored config of the parent player, when it (still) exists.
         """
-        universal_provider = create_mock_universal_provider(mock_mass)
-        mock_mass.config.get = MagicMock(
-            return_value={
-                # obsolete config, deliberately sorting before the current one
-                "up1111stale": {
-                    "player_id": "up1111stale",
-                    "provider": "universal_player",
-                    "values": {"linked_protocol_ids": ["ap_123456"]},
-                },
-                "up5478c9e60da0": {
-                    "player_id": "up5478c9e60da0",
-                    "provider": "universal_player",
-                    "values": {"linked_protocol_ids": ["ap_123456"]},
-                },
-                "ap_123456": {
-                    "player_id": "ap_123456",
-                    "provider": "airplay",
-                    "player_type": "protocol",
-                    "values": {"protocol_parent_id": "up5478c9e60da0"},
-                },
+        players: dict[str, Any] = {
+            "ap_123456": {
+                "player_id": "ap_123456",
+                "provider": "airplay",
+                "player_type": "protocol",
+                "enabled": True,
+                "values": {"protocol_parent_id": parent_id},
             }
+        }
+        if parent_config is not None:
+            players[parent_config["player_id"]] = parent_config
+        _wire_nested_config(mock_mass, {CONF_PLAYERS: players})
+
+    @staticmethod
+    def _wire_players(mock_mass: MagicMock, registry: dict[str, Player]) -> None:
+        """Wire mass.players so registrations land in the given registry."""
+
+        async def _register(player: Player) -> None:
+            registry[player.player_id] = player
+            player.set_initialized()
+
+        mock_mass.players = MagicMock()
+        mock_mass.players.get_player = MagicMock(
+            side_effect=lambda pid, *_args, **_kwargs: registry.get(pid)
         )
-        provider = MockProvider("airplay")
+        mock_mass.players.register_or_update = AsyncMock(side_effect=_register)
+
+    @staticmethod
+    def _make_protocol_player(mock_mass: MagicMock) -> MockPlayer:
+        """Return the unlinked AirPlay protocol player of the wrapped device."""
         player = MockPlayer(
-            provider,
+            MockProvider("airplay", mass=mock_mass),
             "ap_123456",
             "Test Player",
             player_type=PlayerType.PROTOCOL,
             identifiers={IdentifierType.MAC_ADDRESS: "54:78:C9:E6:0D:A0"},
         )
+        player.set_initialized()
+        return player
 
-        assert universal_provider._get_stored_device_key([player]) == "5478c9e60da0"
-
-    def test_up_prefixed_config_of_other_provider_ignored(self, mock_mass: MagicMock) -> None:
-        """A config whose id merely starts with "up" must not be treated as universal."""
-        universal_provider = create_mock_universal_provider(mock_mass)
-        mock_mass.config.get = MagicMock(
-            return_value={
-                # a native player of another provider whose id happens to start with "up"
-                "upnp_media_renderer": {
-                    "player_id": "upnp_media_renderer",
-                    "provider": "some_native_provider",
-                    "values": {"linked_protocol_ids": ["ap_123456"]},
-                },
-            }
-        )
-        provider = MockProvider("airplay")
-        player = MockPlayer(
-            provider,
-            "ap_123456",
-            "Test Player",
-            player_type=PlayerType.PROTOCOL,
-            identifiers={IdentifierType.MAC_ADDRESS: "54:78:C9:E6:0D:A0"},
-        )
-
-        assert universal_provider._get_stored_device_key([player]) is None
-
-    def test_stored_key_reused_via_sonos_uuid_variant(self, mock_mass: MagicMock) -> None:
-        """The Sonos RINCON/_MR uuid equivalence applies to stored identifiers as well."""
-        universal_provider = create_mock_universal_provider(mock_mass)
-        mock_mass.config.get = MagicMock(
-            return_value={
-                "uprincon123": {
-                    "player_id": "uprincon123",
-                    "provider": "universal_player",
-                    "values": {
-                        "linked_protocol_ids": ["dlna_123456"],
-                        "device_identifiers": {"uuid": "RINCON_ABC123"},
-                    },
-                },
-            }
-        )
-        provider = MockProvider("dlna")
-        player = MockPlayer(
-            provider,
-            "dlna_999999",
-            "Test Player",
-            player_type=PlayerType.PROTOCOL,
-            identifiers={IdentifierType.UUID: "RINCON_ABC123_MR"},
-        )
-
-        assert universal_provider._get_stored_device_key([player]) == "rincon123"
-
-    def test_stored_key_never_matches_on_invalid_mac(self, mock_mass: MagicMock) -> None:
-        """An all-zero MAC is not identity: it must not match across devices."""
-        universal_provider = create_mock_universal_provider(mock_mass)
-        mock_mass.config.get = MagicMock(
-            return_value={
-                "upaabbccddeeff": {
-                    "player_id": "upaabbccddeeff",
-                    "provider": "universal_player",
-                    "values": {
-                        "linked_protocol_ids": ["dlna_123456"],
-                        "device_identifiers": {"mac_address": "00:00:00:00:00:00"},
-                    },
-                },
-            }
-        )
-        provider = MockProvider("airplay")
-        player = MockPlayer(
-            provider,
-            "ap_999999",
-            "Test Player",
-            player_type=PlayerType.PROTOCOL,
-            identifiers={IdentifierType.MAC_ADDRESS: "00:00:00:00:00:00"},
-        )
-
-        assert universal_provider._get_stored_device_key([player]) is None
-
-    def test_stored_key_never_matches_on_unknown_identifier_type(
+    async def test_registered_parent_resolves_to_its_universal_player(
         self, mock_mass: MagicMock
     ) -> None:
-        """A stored garbage identifier key coerces to UNKNOWN and must not match."""
+        """The stored parent link resolves to the universal player it names."""
         universal_provider = create_mock_universal_provider(mock_mass)
-        mock_mass.config.get = MagicMock(
-            return_value={
-                "upaabbccddeeff": {
-                    "player_id": "upaabbccddeeff",
-                    "provider": "universal_player",
-                    "values": {
-                        "linked_protocol_ids": ["dlna_123456"],
-                        "device_identifiers": {"some_unknown_key": "same-value"},
-                    },
-                },
-            }
+        self._wire_config(mock_mass, STORED_UNIVERSAL_ID, self._stored_universal_config())
+        registry: dict[str, Player] = {}
+        self._wire_players(mock_mass, registry)
+        universal = _create_universal_player(
+            mock_mass, STORED_UNIVERSAL_ID, "Living Room", protocol_player_ids=["ap_123456"]
         )
-        provider = MockProvider("airplay")
-        player = MockPlayer(
-            provider,
-            "ap_999999",
-            "Test Player",
-            player_type=PlayerType.PROTOCOL,
-            identifiers={IdentifierType.UNKNOWN: "same-value"},
-        )
+        registry[STORED_UNIVERSAL_ID] = universal
+        player = self._make_protocol_player(mock_mass)
 
-        assert universal_provider._get_stored_device_key([player]) is None
+        assert await universal_provider._resolve_stored_universal_player(player) is universal
+        mock_mass.players.register_or_update.assert_not_awaited()
 
-    def test_no_stored_key_for_unrelated_device(self, mock_mass: MagicMock) -> None:
-        """A device without an earlier universal player yields no stored key."""
+    async def test_unregistered_parent_is_restored_from_its_config(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A stored parent that is not registered is restored under its own player id."""
         universal_provider = create_mock_universal_provider(mock_mass)
-        mock_mass.config.get = MagicMock(
-            return_value={
-                "upaabbccddeeff": {
-                    "player_id": "upaabbccddeeff",
-                    "provider": "universal_player",
-                    "values": {
-                        "linked_protocol_ids": ["ap_123456"],
-                        "device_identifiers": {"mac_address": "AA:BB:CC:DD:EE:FF"},
-                    },
-                },
-            }
-        )
-        provider = MockProvider("airplay")
-        player = MockPlayer(
-            provider,
-            "ap_999999",
-            "Test Player",
-            player_type=PlayerType.PROTOCOL,
-            identifiers={IdentifierType.MAC_ADDRESS: "11:22:33:44:55:66"},
-        )
+        self._wire_config(mock_mass, STORED_UNIVERSAL_ID, self._stored_universal_config())
+        registry: dict[str, Player] = {}
+        self._wire_players(mock_mass, registry)
+        player = self._make_protocol_player(mock_mass)
 
-        assert universal_provider._get_stored_device_key([player]) is None
+        resolved = await universal_provider._resolve_stored_universal_player(player)
 
-    async def test_ensure_universal_player_reuses_stored_key(self, mock_mass: MagicMock) -> None:
-        """Re-creating a universal player keeps the stored device key (and thus its id)."""
+        assert resolved is not None
+        assert resolved.player_id == STORED_UNIVERSAL_ID
+        assert resolved._protocol_player_ids == ["ap_123456"]
+        assert registry[STORED_UNIVERSAL_ID] is resolved
+
+    async def test_parent_config_of_another_provider_is_ignored(self, mock_mass: MagicMock) -> None:
+        """A parent config owned by another provider is never ours to resolve to."""
         universal_provider = create_mock_universal_provider(mock_mass)
-        mock_mass.config.get = MagicMock(
-            return_value={
-                "up5478c9e60da0": {
-                    "player_id": "up5478c9e60da0",
-                    "provider": "universal_player",
-                    "values": {"linked_protocol_ids": ["sendspin_bridge_1"]},
-                },
-            }
+        # a native player whose id merely happens to start with the universal player prefix
+        self._wire_config(
+            mock_mass,
+            "upnp_media_renderer",
+            {
+                "player_id": "upnp_media_renderer",
+                "provider": "some_native_provider",
+                "enabled": True,
+                "values": {"linked_protocol_ids": ["ap_123456"]},
+            },
         )
-        mock_mass.players.get_player = MagicMock(return_value=None)
-        universal_provider.create_universal_player = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        registry: dict[str, Player] = {}
+        self._wire_players(mock_mass, registry)
+        player = self._make_protocol_player(mock_mass)
 
-        provider = MockProvider("sendspin")
-        player = MockPlayer(
-            provider,
-            "sendspin_bridge_1",
-            "Test Player",
-            player_type=PlayerType.PROTOCOL,
-            identifiers={IdentifierType.UUID: "12345678-1234-1234-1234-123456789abc"},
+        assert await universal_provider._resolve_stored_universal_player(player) is None
+        mock_mass.players.register_or_update.assert_not_awaited()
+
+    async def test_disabled_parent_config_is_ignored(self, mock_mass: MagicMock) -> None:
+        """A disabled universal player stays off: the user turned this device off."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        self._wire_config(
+            mock_mass, STORED_UNIVERSAL_ID, self._stored_universal_config(enabled=False)
         )
+        registry: dict[str, Player] = {}
+        self._wire_players(mock_mass, registry)
+        player = self._make_protocol_player(mock_mass)
 
-        await universal_provider.ensure_universal_player_for_protocols([player])
+        assert await universal_provider._resolve_stored_universal_player(player) is None
+        mock_mass.players.register_or_update.assert_not_awaited()
 
-        universal_provider.create_universal_player.assert_awaited_once()
-        await_args = universal_provider.create_universal_player.await_args
-        assert await_args is not None
-        assert await_args.kwargs["device_key"] == "5478c9e60da0"
+    async def test_stored_parent_without_a_config_is_ignored(self, mock_mass: MagicMock) -> None:
+        """A parent link left dangling by a deleted config resolves to nothing."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        self._wire_config(mock_mass, STORED_UNIVERSAL_ID)
+        registry: dict[str, Player] = {}
+        self._wire_players(mock_mass, registry)
+        player = self._make_protocol_player(mock_mass)
+
+        assert await universal_provider._resolve_stored_universal_player(player) is None
+        mock_mass.players.register_or_update.assert_not_awaited()
+
+    async def test_without_a_stored_parent_link_nothing_resolves(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A protocol player that was never wrapped resolves to no universal player."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        self._wire_config(mock_mass, None)
+        registry: dict[str, Player] = {}
+        self._wire_players(mock_mass, registry)
+        player = self._make_protocol_player(mock_mass)
+
+        assert await universal_provider._resolve_stored_universal_player(player) is None
+
+
+class TestMintPlayerId:
+    """Tests for minting the opaque player id of a new universal player."""
+
+    def test_minted_id_is_free_as_a_player_and_as_a_config(self, mock_mass: MagicMock) -> None:
+        """A minted id is never one that is already taken."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        _wire_nested_config(
+            mock_mass,
+            {CONF_PLAYERS: {"upbbbbbbbb": {"player_id": "upbbbbbbbb", "enabled": False}}},
+        )
+        registered = {"upaaaaaaaa": MagicMock()}
+        mock_mass.players = MagicMock()
+        mock_mass.players.get_player = MagicMock(
+            side_effect=lambda pid, *_args, **_kwargs: registered.get(pid)
+        )
+        candidates = [
+            UUID("aaaaaaaa-0000-0000-0000-000000000000"),  # taken by a registered player
+            UUID("bbbbbbbb-0000-0000-0000-000000000000"),  # taken by a (stale) config
+            UUID("cccccccc-0000-0000-0000-000000000000"),
+        ]
+
+        with patch(
+            "music_assistant.providers.universal_player.provider.uuid4", side_effect=candidates
+        ):
+            assert universal_provider.mint_player_id() == "upcccccccc"
 
 
 class TestGetCleanPlayerName:
@@ -5944,12 +5825,33 @@ class TestUniversalPlayerMerging:
         # up1 should have no more links
         assert len(up1.linked_output_protocols) == 0
 
-    def test_merge_deterministic_tiebreaker_on_equal_link_counts(
-        self, mock_mass: MagicMock
-    ) -> None:
-        """Test that equal-link-count merges resolve to the lex-smaller player_id."""
+    @staticmethod
+    def _setup_merge_tiebreak(
+        mock_mass: MagicMock, created_at: dict[str, int]
+    ) -> tuple[PlayerController, UniversalPlayer, UniversalPlayer, MockPlayer, MockPlayer]:
+        """
+        Set up two universal players of one device, each with a single protocol link.
+
+        :param mock_mass: The mocked MusicAssistant instance to wire.
+        :param created_at: Stored creation timestamp per universal player id.
+        :return: Tuple of (controller, up_aaa, up_bbb, its DLNA player, its AirPlay player).
+        """
         controller = PlayerController(mock_mass)
         up_provider = create_mock_universal_provider(mock_mass)
+        _wire_nested_config(
+            mock_mass,
+            {
+                CONF_PLAYERS: {
+                    player_id: {
+                        "player_id": player_id,
+                        "provider": "universal_player",
+                        "enabled": True,
+                        "values": {CONF_CREATED_AT: timestamp},
+                    }
+                    for player_id, timestamp in created_at.items()
+                }
+            },
+        )
 
         # up_a: lex-smaller player_id, one protocol link (DLNA)
         up_a = UniversalPlayer(
@@ -6008,6 +5910,16 @@ class TestUniversalPlayerMerging:
         controller._add_protocol_link(up_a, dlna_player, "dlna")
         controller._add_protocol_link(up_b, ap_player, "airplay")
 
+        return controller, up_a, up_b, dlna_player, ap_player
+
+    def test_merge_deterministic_tiebreaker_on_equal_link_counts(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Test that merges of equally old players resolve to the lex-smaller player_id."""
+        controller, up_a, up_b, _, ap_player = self._setup_merge_tiebreak(
+            mock_mass, {"up_aaa": 1000, "up_bbb": 1000}
+        )
+
         # Call merge from the lex-larger side. Under the old non-deterministic
         # behavior the caller (up_b) would have won. With the tiebreaker the
         # lex-smaller player_id (up_a) wins regardless of which side calls.
@@ -6015,14 +5927,29 @@ class TestUniversalPlayerMerging:
 
         # up_a (lex-smaller) should have absorbed up_b's AirPlay link
         protocol_domains = {link.protocol_domain for link in up_a.linked_output_protocols}
-        assert "dlna" in protocol_domains
-        assert "airplay" in protocol_domains
+        assert protocol_domains == {"dlna", "airplay"}
 
         # AirPlay player should now point to up_aaa
         assert ap_player.protocol_parent_id == "up_aaa"
 
         # up_b should have no more links
         assert len(up_b.linked_output_protocols) == 0
+
+    def test_merge_tiebreaker_prefers_the_older_universal_player(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Test that the player that has been around longest absorbs the other one."""
+        controller, up_a, up_b, dlna_player, _ = self._setup_merge_tiebreak(
+            mock_mass, {"up_aaa": 2000, "up_bbb": 1000}
+        )
+
+        controller._check_merge_universal_players(up_a)
+
+        # up_b is older, so it wins despite its lex-larger player_id
+        protocol_domains = {link.protocol_domain for link in up_b.linked_output_protocols}
+        assert protocol_domains == {"dlna", "airplay"}
+        assert dlna_player.protocol_parent_id == "up_bbb"
+        assert len(up_a.linked_output_protocols) == 0
 
     async def test_merge_preserves_moved_protocols_during_parent_cleanup(
         self, mock_mass: MagicMock
@@ -7152,7 +7079,7 @@ class TestEndToEndDuplicateProtocol:
     End-to-end integration tests for duplicate protocol → separate universal player flow.
 
     These tests exercise the full async flow through _delayed_protocol_evaluation,
-    ensure_universal_player_for_protocols, and _create_separate_universal_player,
+    ensure_universal_players_for_protocols, and _create_separate_universal_player,
     verifying that a second instance of the same protocol domain on the same host
     results in a separate universal player.
     """
@@ -7255,7 +7182,7 @@ class TestEndToEndDuplicateProtocol:
         # ap2 should NOT be linked to the existing universal player
         assert ap2.protocol_parent_id != "up_aabbccddeeff"
 
-        # ap2 should have its own universal player (with player_id-based device key)
+        # ap2 should have its own (freshly minted) universal player
         assert ap2.protocol_parent_id is not None
         separate_up_id = ap2.protocol_parent_id
         assert separate_up_id in controller._players
@@ -7334,7 +7261,7 @@ class TestEndToEndDuplicateProtocol:
         self, mock_mass: MagicMock
     ) -> None:
         """
-        Path B: ensure_universal_player_for_protocols separates can_join vs rejected.
+        Path B: ensure_universal_players_for_protocols separates can_join vs rejected.
 
         Scenario: Two AirPlay players arrive simultaneously for delayed eval.
         Both are unlinked, both pass to _create_or_update_universal_player.
@@ -7379,7 +7306,7 @@ class TestEndToEndDuplicateProtocol:
         # _find_matching_universal_player will find the universal player by MAC
         # _add_protocol_to_existing_universal will refuse (duplicate domain)
         # _find_matching_protocol_players will skip ap1 (same domain)
-        # _create_or_update_universal_player → ensure_universal_player_for_protocols
+        # _create_or_update_universal_player → ensure_universal_players_for_protocols
         #   finds existing universal player, separates ap2 as rejected
         await controller._delayed_protocol_evaluation("ap_2")
 
@@ -7751,6 +7678,145 @@ class TestEndToEndDuplicateProtocol:
         shared_up = controller._players[shared_up_id]
         shared_domains = {link.protocol_domain for link in shared_up.linked_output_protocols}
         assert shared_domains == {"airplay", "dlna", "chromecast"}
+
+
+class TestEndToEndUniversalPlayerId:
+    """
+    End-to-end tests for the minted player id of a universal player.
+
+    Regression tests for music-assistant/support#5888: the id used to be derived from
+    whichever device identifiers happened to be available when the wrapper was created,
+    so a re-created wrapper could silently change id and orphan the entities API
+    consumers (such as the Home Assistant integration) bind to it. These tests drive
+    the real evaluation path against a config store that persists what the flow writes.
+    """
+
+    @staticmethod
+    def _setup_controller(
+        mock_mass: MagicMock,
+    ) -> tuple[PlayerController, dict[str, Any]]:
+        """
+        Wire a controller, the universal player provider and a persisting config store.
+
+        :param mock_mass: The mocked MusicAssistant instance to wire.
+        :return: Tuple of (controller, backing config store).
+        """
+        controller = PlayerController(mock_mass)
+        up_provider = create_mock_universal_provider(mock_mass)
+        mock_mass.get_providers = MagicMock(return_value=[up_provider])
+
+        store: dict[str, Any] = {CONF_PLAYERS: {}}
+        _wire_nested_config(mock_mass, store)
+        mock_mass.config.create_default_player_config = MagicMock(
+            side_effect=lambda *args, **kwargs: _fake_create_default_player_config(
+                store, *args, **kwargs
+            )
+        )
+        mock_mass.config.get_base_player_config.return_value = create_mock_config("Test")
+
+        async def fake_register_or_update(player: Player) -> None:
+            controller._players[player.player_id] = player
+            player.set_initialized()
+
+        mock_mass.players = MagicMock()
+        mock_mass.players.register_or_update = AsyncMock(side_effect=fake_register_or_update)
+        mock_mass.players.get_player = lambda pid, *_args, **_kwargs: controller._players.get(pid)
+        return controller, store
+
+    @staticmethod
+    def _make_airplay_player(
+        mock_mass: MagicMock, player_id: str, name: str, identifiers: dict[IdentifierType, str]
+    ) -> MockPlayer:
+        """Return an unlinked AirPlay protocol player."""
+        player = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            player_id,
+            name,
+            player_type=PlayerType.PROTOCOL,
+            identifiers=identifiers,
+        )
+        player.set_initialized()
+        return player
+
+    async def test_id_survives_recreation_with_other_identifiers(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A re-created wrapper keeps its id when a different set of identifiers is known.
+
+        The first evaluation only knows the device's MAC, the second only its UUID.
+        The derived key changed along with that, taking the player id with it.
+        """
+        controller, store = self._setup_controller(mock_mass)
+        first = self._make_airplay_player(
+            mock_mass, "ap_1", "Living Room", {IdentifierType.MAC_ADDRESS: "54:78:C9:E6:0D:A0"}
+        )
+        controller._players = {"ap_1": first}
+
+        await controller._delayed_protocol_evaluation("ap_1")
+
+        universal_id = first.protocol_parent_id
+        assert universal_id is not None
+        assert re.fullmatch(r"up[0-9a-f]{8}", universal_id)
+
+        # tear the wrapper down (its config is kept, as a non-permanent unregister does)
+        # and bring the device back with only a UUID to identify it by
+        del controller._players[universal_id]
+        second = self._make_airplay_player(
+            mock_mass,
+            "ap_1",
+            "Living Room",
+            {IdentifierType.UUID: "12345678-1234-1234-1234-123456789abc"},
+        )
+        controller._players = {"ap_1": second}
+
+        await controller._delayed_protocol_evaluation("ap_1")
+
+        assert second.protocol_parent_id == universal_id
+        assert universal_id in controller._players
+        assert store[CONF_PLAYERS]["ap_1"]["values"][CONF_PROTOCOL_PARENT_ID] == universal_id
+
+    async def test_new_devices_get_distinct_minted_ids(self, mock_mass: MagicMock) -> None:
+        """Devices that were never wrapped before each get their own minted id."""
+        controller, _ = self._setup_controller(mock_mass)
+        players = [
+            self._make_airplay_player(
+                mock_mass, f"ap_{index}", f"Speaker {index}", {IdentifierType.MAC_ADDRESS: mac}
+            )
+            for index, mac in enumerate(("54:78:C9:E6:0D:A0", "AA:BB:CC:DD:EE:FF"), start=1)
+        ]
+        controller._players = {player.player_id: player for player in players}
+
+        for player in players:
+            await controller._delayed_protocol_evaluation(player.player_id)
+
+        universal_ids = [player.protocol_parent_id for player in players]
+        assert all(pid and re.fullmatch(r"up[0-9a-f]{8}", pid) for pid in universal_ids)
+        assert len(set(universal_ids)) == len(players)
+
+    async def test_duplicate_domain_gets_a_second_wrapper_with_a_parent_link(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        Two players of one protocol domain end up on two wrappers, both linked.
+
+        The handoff must persist a parent link for the second player as well,
+        otherwise it silently stays unwrapped.
+        """
+        controller, store = self._setup_controller(mock_mass)
+        identifiers = {IdentifierType.MAC_ADDRESS: "54:78:C9:E6:0D:A0"}
+        ap1 = self._make_airplay_player(mock_mass, "ap_1", "Zone 1", identifiers)
+        ap2 = self._make_airplay_player(mock_mass, "ap_2", "Zone 2", identifiers)
+        controller._players = {"ap_1": ap1, "ap_2": ap2}
+
+        await controller._create_or_update_universal_player([ap1, ap2])
+
+        assert ap1.protocol_parent_id is not None
+        assert ap2.protocol_parent_id is not None
+        assert ap1.protocol_parent_id != ap2.protocol_parent_id
+        for player in (ap1, ap2):
+            stored = store[CONF_PLAYERS][player.player_id]["values"][CONF_PROTOCOL_PARENT_ID]
+            assert stored == player.protocol_parent_id
 
 
 class TestSiblingProtocolMatching:
@@ -8835,39 +8901,6 @@ class TestUniversalPlayerRestoreOrphanCleanup:
 
         mock_mass.config.get.side_effect = _get
 
-    @staticmethod
-    def _wire_nested_config(mock_mass: MagicMock, store: dict[str, Any]) -> None:
-        """Wire mass.config get/set/remove to a nested, path-addressable store."""
-
-        def _get(key: str, default: object = None) -> object:
-            node: Any = store
-            for part in key.split("/"):
-                if not isinstance(node, dict) or part not in node:
-                    return default
-                node = node[part]
-            return node
-
-        def _set(key: str, value: object) -> None:
-            parts = key.split("/")
-            node: dict[str, Any] = store
-            for part in parts[:-1]:
-                node = node.setdefault(part, {})
-            node[parts[-1]] = value
-
-        def _remove(key: str) -> None:
-            parts = key.split("/")
-            node: Any = store
-            for part in parts[:-1]:
-                node = node.get(part) if isinstance(node, dict) else None
-                if node is None:
-                    return
-            if isinstance(node, dict):
-                node.pop(parts[-1], None)
-
-        mock_mass.config.get = MagicMock(side_effect=_get)
-        mock_mass.config.set = MagicMock(side_effect=_set)
-        mock_mass.config.remove = MagicMock(side_effect=_remove)
-
     @pytest.mark.asyncio
     async def test_orphan_protocol_dropped_but_configs_kept(self, mock_mass: MagicMock) -> None:
         """Orphan protocol is dropped from membership without deleting any config."""
@@ -9288,7 +9321,7 @@ class TestUniversalPlayerRestoreOrphanCleanup:
                 universal_id: {"queue_id": universal_id, "values": {"crossfade_duration": 5}}
             },
         }
-        self._wire_nested_config(mock_mass, store)
+        _wire_nested_config(mock_mass, store)
         mock_mass.config.save_player_config = AsyncMock()
         scheduled_tasks: list[Awaitable[object]] = []
         mock_mass.create_task = MagicMock(
@@ -9372,7 +9405,7 @@ class TestUniversalPlayerRestoreOrphanCleanup:
                 native_id: {"queue_id": native_id, "values": {"crossfade_duration": 2}},
             },
         }
-        self._wire_nested_config(mock_mass, store)
+        _wire_nested_config(mock_mass, store)
         mock_mass.config.save_player_config = AsyncMock()
         scheduled_tasks: list[Awaitable[object]] = []
         mock_mass.create_task = MagicMock(

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -938,6 +938,98 @@ class TestGetStoredDeviceKey:
 
         assert universal_provider._get_stored_device_key([player]) is None
 
+    def test_canonical_parent_wins_over_stale_membership(self, mock_mass: MagicMock) -> None:
+        """
+        A stale config listing the same member must not win from the canonical parent.
+
+        Lifecycle scenario: an obsolete universal player config from before a re-key
+        still lists the protocol player as a member, while the protocol player's own
+        persisted parent link points at the current universal player. The current
+        one must be picked, so the id (and with it the stored settings) stays put.
+        """
+        universal_provider = create_mock_universal_provider(mock_mass)
+        mock_mass.config.get = MagicMock(
+            return_value={
+                # obsolete config, deliberately sorting before the current one
+                "up1111stale": {
+                    "player_id": "up1111stale",
+                    "provider": "universal_player",
+                    "values": {"linked_protocol_ids": ["ap_123456"]},
+                },
+                "up5478c9e60da0": {
+                    "player_id": "up5478c9e60da0",
+                    "provider": "universal_player",
+                    "values": {"linked_protocol_ids": ["ap_123456"]},
+                },
+                "ap_123456": {
+                    "player_id": "ap_123456",
+                    "provider": "airplay",
+                    "player_type": "protocol",
+                    "values": {"protocol_parent_id": "up5478c9e60da0"},
+                },
+            }
+        )
+        provider = MockProvider("airplay")
+        player = MockPlayer(
+            provider,
+            "ap_123456",
+            "Test Player",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "54:78:C9:E6:0D:A0"},
+        )
+
+        assert universal_provider._get_stored_device_key([player]) == "5478c9e60da0"
+
+    def test_up_prefixed_config_of_other_provider_ignored(self, mock_mass: MagicMock) -> None:
+        """A config whose id merely starts with "up" must not be treated as universal."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        mock_mass.config.get = MagicMock(
+            return_value={
+                # a native player of another provider whose id happens to start with "up"
+                "upnp_media_renderer": {
+                    "player_id": "upnp_media_renderer",
+                    "provider": "some_native_provider",
+                    "values": {"linked_protocol_ids": ["ap_123456"]},
+                },
+            }
+        )
+        provider = MockProvider("airplay")
+        player = MockPlayer(
+            provider,
+            "ap_123456",
+            "Test Player",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "54:78:C9:E6:0D:A0"},
+        )
+
+        assert universal_provider._get_stored_device_key([player]) is None
+
+    def test_stored_key_reused_via_sonos_uuid_variant(self, mock_mass: MagicMock) -> None:
+        """The Sonos RINCON/_MR uuid equivalence applies to stored identifiers as well."""
+        universal_provider = create_mock_universal_provider(mock_mass)
+        mock_mass.config.get = MagicMock(
+            return_value={
+                "uprincon123": {
+                    "player_id": "uprincon123",
+                    "provider": "universal_player",
+                    "values": {
+                        "linked_protocol_ids": ["dlna_123456"],
+                        "device_identifiers": {"uuid": "RINCON_ABC123"},
+                    },
+                },
+            }
+        )
+        provider = MockProvider("dlna")
+        player = MockPlayer(
+            provider,
+            "dlna_999999",
+            "Test Player",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.UUID: "RINCON_ABC123_MR"},
+        )
+
+        assert universal_provider._get_stored_device_key([player]) == "rincon123"
+
     def test_stored_key_never_matches_on_invalid_mac(self, mock_mass: MagicMock) -> None:
         """An all-zero MAC is not identity: it must not match across devices."""
         universal_provider = create_mock_universal_provider(mock_mass)

--- a/tests/providers/universal_player/test_player.py
+++ b/tests/providers/universal_player/test_player.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
@@ -49,7 +50,7 @@ def _make_universal_provider(mock_mass: MagicMock) -> UniversalPlayerProvider:
     config.instance_id = "universal_player"
     config.name = None
     provider.config = config
-    provider._universal_player_locks = {}
+    provider._lock = asyncio.Lock()
     return provider
 
 


### PR DESCRIPTION
# What does this implement/fix?

A Universal Player — the player Music Assistant creates for a device that has no native provider — took its player id from whichever device identifiers happened to be available at the moment it was created. Re-creating one could therefore give the same speaker a different id, for example switching from a MAC-based to a UUID-based one. Anything bound to that id then sees the player disappear and a brand new one show up: in Home Assistant the old entity is orphaned and automations referencing it stop working. A related problem made the replacement carry a stale automatically generated name, which showed up as a duplicated friendly name.

The id is now handed out once and never derived from the device again.

## Changes

- A Universal Player gets a random id the first time its device is wrapped, and that id is never recomputed
- A device's Universal Player is found through the link its protocol players store, and is restored from its configuration when it is not loaded yet — previously this case quietly created a second player
- Nothing looks a Universal Player up by rebuilding its id from the device any more
- A Universal Player keeps its settings when its protocol players disappear: it goes unavailable instead of being deleted, so the device returns as the same player. Only removing it yourself deletes it for good
- When two Universal Players for the same device merge, the one that has been around longest now wins, so the established player id is the one that survives
- A player no longer stores its automatically generated name as if you had renamed it, so a renamed device is no longer shadowed by its old name. Existing players are migrated

Existing Universal Players keep the id they already have — nothing is renumbered.

**Related issue:** https://github.com/music-assistant/support/issues/5888

<sub>Note for reviewers: the trigger in the report (changing the output protocol) could not be reproduced as a cause on either `dev` or 2.9.9 — that setting never tears a player down. The destructive path that did exist in 2.9.9 was on the startup restore and is already fixed on `dev` by #4643. What remains genuinely unstable is the derived id itself, which this PR removes. One case stays open by design: if a protocol player is permanently removed and its config deleted, a returning device has no stored link left and gets a new id.</sub>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
