### PR TITLE
Fix smart playlist shortcut recognition from recommendation rows

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -318,8 +318,29 @@ class SmartPlaylistProvider(PluginProvider):
         items: UniqueList[MediaItemType | ItemMapping | BrowseFolder] = UniqueList()
         if item_id != "smart_playlists":
             return items
+
+        library_mappings: dict[str, str] = {}
+        for pid in self._rules_store:
+            try:
+                lib_item = await self.mass.music.playlists.get_library_item_by_prov_id(
+                    pid, self.instance_id
+                )
+                if lib_item:
+                    library_mappings[pid] = str(lib_item.item_id)
+            except Exception as err:
+                self.logger.debug("Could not get library item for %s: %s", pid, err)
+
         for pid, rules in self._rules_store.items():
-            items.append(await self._build_playlist(pid, rules))
+            playlist = await self._build_playlist(pid, rules)
+            if pid in library_mappings:
+                playlist.provider_mappings.add(
+                    ProviderMapping(
+                        item_id=library_mappings[pid],
+                        provider_domain="library",
+                        provider_instance="library",
+                    )
+                )
+            items.append(playlist)
         return items
 
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
@@ -329,8 +350,24 @@ class SmartPlaylistProvider(PluginProvider):
             msg = f"Smart playlist {prov_playlist_id} not found"
             raise MediaNotFoundError(msg)
 
-        # Build playlist from rules
-        return await self._build_playlist(resolved_id, rules)
+        playlist = await self._build_playlist(resolved_id, rules)
+
+        try:
+            lib_item = await self.mass.music.playlists.get_library_item_by_prov_id(
+                resolved_id, self.instance_id
+            )
+            if lib_item:
+                playlist.provider_mappings.add(
+                    ProviderMapping(
+                        item_id=str(lib_item.item_id),
+                        provider_domain="library",
+                        provider_instance="library",
+                    )
+                )
+        except Exception as err:
+            self.logger.debug("Could not get library item for %s: %s", resolved_id, err)
+
+        return playlist
 
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
         """

--- a/tests/providers/smart_playlist/test_recommendations.py
+++ b/tests/providers/smart_playlist/test_recommendations.py
@@ -64,8 +64,8 @@ async def test_get_recommendation_items_builds_playlists() -> None:
     assert [item.item_id for item in result] == ["abc", "def"]
     assert all(isinstance(item, Playlist) for item in result)
     assert [item.name for item in result] == ["Playlist A", "Playlist B"]
-    # the per-playlist artwork lookup ran for each built playlist
-    assert mass.music.playlists.get_library_item_by_prov_id.await_count == 2
+    # library mapping lookup + artwork lookup for each playlist
+    assert mass.music.playlists.get_library_item_by_prov_id.await_count == 4
 
 
 async def test_get_recommendation_items_unknown_id_returns_empty() -> None:
@@ -77,3 +77,44 @@ async def test_get_recommendation_items_unknown_id_returns_empty() -> None:
 
     assert list(result) == []
     mass.music.playlists.get_library_item_by_prov_id.assert_not_awaited()
+
+
+async def test_get_recommendation_items_adds_library_mappings() -> None:
+    """Recommendation items include library provider_mappings for shortcut recognition."""
+    plugin, mass = _make_plugin()
+    plugin._rules_store["abc"] = SmartPlaylistRules(limit=10)
+    plugin._names_store["abc"] = "Test Playlist"
+
+    lib_playlist = MagicMock()
+    lib_playlist.item_id = 123
+    mass.music.playlists.get_library_item_by_prov_id = AsyncMock(return_value=lib_playlist)
+
+    result = await plugin.get_recommendation_items("smart_playlists")
+
+    assert len(result) == 1
+    playlist = result[0]
+    assert isinstance(playlist, Playlist)
+
+    library_mappings = [m for m in playlist.provider_mappings if m.provider_domain == "library"]
+    assert len(library_mappings) == 1
+    assert library_mappings[0].item_id == "123"
+    assert library_mappings[0].provider_instance == "library"
+
+
+async def test_get_playlist_adds_library_mapping() -> None:
+    """get_playlist includes library provider_mapping for shortcut recognition."""
+    plugin, mass = _make_plugin()
+    plugin._rules_store["abc"] = SmartPlaylistRules(limit=10)
+    plugin._names_store["abc"] = "Test Playlist"
+
+    lib_playlist = MagicMock()
+    lib_playlist.item_id = 456
+    mass.music.playlists.get_library_item_by_prov_id = AsyncMock(return_value=lib_playlist)
+
+    result = await plugin.get_playlist("abc")
+
+    assert isinstance(result, Playlist)
+    library_mappings = [m for m in result.provider_mappings if m.provider_domain == "library"]
+    assert len(library_mappings) == 1
+    assert library_mappings[0].item_id == "456"
+    assert library_mappings[0].provider_instance == "library"

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -1277,10 +1277,9 @@ async def test_get_playlist_loads_library_artwork(
     assert playlist.metadata.images[0].path == "generated_artwork.jpg"
     assert playlist.metadata.images[0].provider == "playlist_art"
 
-    # Verify library lookup was called
-    mass.music.playlists.get_library_item_by_prov_id.assert_awaited_once_with(
-        "abc", plugin.instance_id
-    )
+    # Library lookup called twice: once for provider_mapping, once for artwork
+    assert mass.music.playlists.get_library_item_by_prov_id.await_count == 2
+    mass.music.playlists.get_library_item_by_prov_id.assert_awaited_with("abc", plugin.instance_id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Fixes smart playlists pinned from recommendation rows not appearing in the sidebar. The issue was introduced in #4487 when recommendation loading was changed to on-demand.

When a user pins a smart playlist from a recommendation row, the frontend saves a URI like `smart_playlist--1://playlist/abc`. When the shortcut system loads this URI via `getItemByUri()`, the server returns a playlist without library provider_mappings. This prevents the frontend from matching it with already-pinned library versions, causing the shortcut to not appear in the sidebar even though it's correctly saved in preferences.

**Solution:**
Add library provider_mappings to smart playlists when loaded via:
- `get_recommendation_items()` - for recommendation row items (batch lookup for performance)
- `get_playlist()` - when loading by URI

This enables frontend identity matching to work correctly.

**Related issue (if applicable):**

- Reported by user in nightly testing

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: music-assistant/frontend#[PR_NUMBER]
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.