### PR TITLE
Keep bridged AirPlay speakers in sync after a seek or track change

### DIFF
--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -13,8 +13,8 @@ import logging
 import os
 
 # if TYPE_CHECKING:
-from collections.abc import AsyncGenerator
-from contextlib import suppress
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager, suppress
 from signal import SIGINT
 from types import TracebackType
 from typing import Self
@@ -182,43 +182,32 @@ class AsyncProcess:
             self.proc.stdin.write(data)
             await self.proc.stdin.drain()
 
-    async def drain_stdin(self, timeout: float = 5.0) -> bool:
+    @asynccontextmanager
+    async def stdin_quiesced(self, timeout: float = 5.0) -> AsyncIterator[bool]:
         """
-        Wait until every byte handed to stdin has reached the pipe.
+        Hold stdin quiet for a block, with what was already written seen through to the pipe.
 
         :meth:`write` only waits while the transport is paused, which it is only
-        above the high-water mark, so it returns with up to that much still
-        queued locally (64 KiB by default). A caller that needs the process to
-        have been handed everything it was sent -- rather than to have merely
-        accepted it for later -- waits here first. The bytes are then in the
-        kernel pipe, which is as far as this can guarantee: whether the process
-        has read them is its own business.
+        above the high-water mark, so it returns with up to that much still queued
+        locally (64 KiB by default). This first sees those bytes through to the
+        kernel pipe -- as far as it can guarantee; whether the process has read
+        them is its own business -- and then keeps the write lock for the body, so
+        no :meth:`write` or :meth:`write_eof` can interleave. For a caller telling
+        the process something about the bytes it has been handed -- out of band,
+        and in a sequence the process must not see a write inside -- that turns
+        "we happen to have stopped writing" into something the block enforces.
+
+        Yields True when stdin was emptied, False when it could not be: the
+        process is then still owed bytes, so a caller whose message depends on it
+        having received everything must give up rather than send it.
 
         :param timeout: Seconds to wait for the buffer to empty.
-        :return: True once the buffer is empty, False when the wait timed out.
         """
         if self._close_called or self.proc is None or self.proc.stdin is None:
-            return True
+            yield True
+            return
         async with self._stdin_lock:
-            transport = self.proc.stdin.transport
-            low, high = transport.get_write_buffer_limits()
-            try:
-                # Pausing the transport at a zero high-water mark is what makes
-                # drain() resolve only once the buffer is completely empty: it
-                # otherwise resolves as soon as the transport is not paused.
-                transport.set_write_buffer_limits(high=0)
-                await asyncio.wait_for(self.proc.stdin.drain(), timeout)
-            except TimeoutError:
-                return False
-            except BrokenPipeError, RuntimeError, ConnectionResetError:
-                # already exited, race condition: nothing is left to arrive
-                return True
-            finally:
-                # Restore what this process was configured with rather than the
-                # asyncio defaults a bare call would reinstate.
-                with suppress(RuntimeError):
-                    transport.set_write_buffer_limits(high=high, low=low)
-        return True
+            yield await self._drain_stdin_locked(timeout)
 
     async def write_eof(self) -> None:
         """Write end of file to to process stdin."""
@@ -453,6 +442,35 @@ class AsyncProcess:
     def attach_stderr_reader(self, task: asyncio.Task[None]) -> None:
         """Attach a stderr reader task to this process."""
         self._stderr_reader_task = task
+
+    async def _drain_stdin_locked(self, timeout: float) -> bool:
+        """
+        Empty the stdin write buffer, with the write lock already held.
+
+        :param timeout: Seconds to wait for the buffer to empty.
+        :return: True once the buffer is empty, False when the wait timed out.
+        """
+        assert self.proc is not None  # for type checking
+        assert self.proc.stdin is not None  # for type checking
+        transport = self.proc.stdin.transport
+        low, high = transport.get_write_buffer_limits()
+        try:
+            # Pausing the transport at a zero high-water mark is what makes
+            # drain() resolve only once the buffer is completely empty: it
+            # otherwise resolves as soon as the transport is not paused.
+            transport.set_write_buffer_limits(high=0)
+            await asyncio.wait_for(self.proc.stdin.drain(), timeout)
+        except TimeoutError:
+            return False
+        except BrokenPipeError, RuntimeError, ConnectionResetError:
+            # already exited, race condition: nothing is left to arrive
+            return True
+        finally:
+            # Restore what this process was configured with rather than the
+            # asyncio defaults a bare call would reinstate.
+            with suppress(RuntimeError):
+                transport.set_write_buffer_limits(high=high, low=low)
+        return True
 
 
 async def check_output(

--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -184,12 +184,15 @@ class AsyncProcess:
 
     async def drain_stdin(self, timeout: float = 5.0) -> bool:
         """
-        Wait until every byte handed to stdin has left the local write buffer.
+        Wait until every byte handed to stdin has reached the pipe.
 
-        :meth:`write` resolves as soon as the buffer falls below asyncio's
-        low-water mark, so it can leave bytes still queued for the pipe. A caller
-        that needs the process to have actually received everything it was sent
-        -- rather than merely to have accepted it -- waits here first.
+        :meth:`write` only waits while the transport is paused, which it is only
+        above the high-water mark, so it returns with up to that much still
+        queued locally (64 KiB by default). A caller that needs the process to
+        have been handed everything it was sent -- rather than to have merely
+        accepted it for later -- waits here first. The bytes are then in the
+        kernel pipe, which is as far as this can guarantee: whether the process
+        has read them is its own business.
 
         :param timeout: Seconds to wait for the buffer to empty.
         :return: True once the buffer is empty, False when the wait timed out.
@@ -198,25 +201,23 @@ class AsyncProcess:
             return True
         async with self._stdin_lock:
             transport = self.proc.stdin.transport
+            low, high = transport.get_write_buffer_limits()
             try:
-                # Pausing the protocol at a zero high-water mark is what makes
-                # drain() resolve only once the buffer is completely empty
-                # instead of at the default low-water mark.
+                # Pausing the transport at a zero high-water mark is what makes
+                # drain() resolve only once the buffer is completely empty: it
+                # otherwise resolves as soon as the transport is not paused.
                 transport.set_write_buffer_limits(high=0)
                 await asyncio.wait_for(self.proc.stdin.drain(), timeout)
             except TimeoutError:
                 return False
-            except (
-                AttributeError,
-                BrokenPipeError,
-                RuntimeError,
-                ConnectionResetError,
-            ):
+            except BrokenPipeError, RuntimeError, ConnectionResetError:
                 # already exited, race condition: nothing is left to arrive
                 return True
             finally:
-                with suppress(AttributeError, RuntimeError):
-                    transport.set_write_buffer_limits()
+                # Restore what this process was configured with rather than the
+                # asyncio defaults a bare call would reinstate.
+                with suppress(RuntimeError):
+                    transport.set_write_buffer_limits(high=high, low=low)
         return True
 
     async def write_eof(self) -> None:

--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -182,6 +182,43 @@ class AsyncProcess:
             self.proc.stdin.write(data)
             await self.proc.stdin.drain()
 
+    async def drain_stdin(self, timeout: float = 5.0) -> bool:
+        """
+        Wait until every byte handed to stdin has left the local write buffer.
+
+        :meth:`write` resolves as soon as the buffer falls below asyncio's
+        low-water mark, so it can leave bytes still queued for the pipe. A caller
+        that needs the process to have actually received everything it was sent
+        -- rather than merely to have accepted it -- waits here first.
+
+        :param timeout: Seconds to wait for the buffer to empty.
+        :return: True once the buffer is empty, False when the wait timed out.
+        """
+        if self._close_called or self.proc is None or self.proc.stdin is None:
+            return True
+        async with self._stdin_lock:
+            transport = self.proc.stdin.transport
+            try:
+                # Pausing the protocol at a zero high-water mark is what makes
+                # drain() resolve only once the buffer is completely empty
+                # instead of at the default low-water mark.
+                transport.set_write_buffer_limits(high=0)
+                await asyncio.wait_for(self.proc.stdin.drain(), timeout)
+            except TimeoutError:
+                return False
+            except (
+                AttributeError,
+                BrokenPipeError,
+                RuntimeError,
+                ConnectionResetError,
+            ):
+                # already exited, race condition: nothing is left to arrive
+                return True
+            finally:
+                with suppress(AttributeError, RuntimeError):
+                    transport.set_write_buffer_limits()
+        return True
+
     async def write_eof(self) -> None:
         """Write end of file to to process stdin."""
         if self._close_called or self.proc is None:

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -845,14 +845,17 @@ class SendspinAirPlayBridge:
 
         # The writer stays gated until this anchor is settled, so the bridge has
         # written nothing for this stream and anything the binary reports pending
-        # is left over from the previous one. The START would anchor that as its
+        # was left behind by an earlier one. The START would anchor that as its
         # first sample and leave every chunk after it late by the same amount,
-        # which no later realignment can see: the cursor below counts only what
-        # the bridge queued itself.
+        # which no later realignment can see: the cursor counts only what the
+        # bridge queued itself. Reported rather than acted on, because the reading
+        # is best effort -- it depends on the status line having been parsed by
+        # now -- so falling back to a cold restart on it would trade a fault that
+        # should no longer happen for one that would.
         if stream.audio_pending_ms:
             self.logger.warning(
-                "%s still had %d ms of the previous stream's audio pending when its "
-                "anchor was commanded; its content will play that late",
+                "%s still had %d ms of earlier audio pending when its anchor was "
+                "commanded; its content will play that late",
                 self.airplay_player.display_name,
                 stream.audio_pending_ms,
             )

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -843,6 +843,20 @@ class SendspinAirPlayBridge:
                 )
         commanded_ms = anchor_ms + adjust_ms
 
+        # The writer stays gated until this anchor is settled, so the bridge has
+        # written nothing for this stream and anything the binary reports pending
+        # is left over from the previous one. The START would anchor that as its
+        # first sample and leave every chunk after it late by the same amount,
+        # which no later realignment can see: the cursor below counts only what
+        # the bridge queued itself.
+        if stream.audio_pending_ms:
+            self.logger.warning(
+                "%s still had %d ms of the previous stream's audio pending when its "
+                "anchor was commanded; its content will play that late",
+                self.airplay_player.display_name,
+                stream.audio_pending_ms,
+            )
+
         # Always a join: the Sendspin timeline is the group's, never the bridge's
         # to set, so the binary must hold its ack until the receiver clock
         # verification resolves and report the instant it really scheduled.

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -413,8 +413,9 @@ class AirPlayStream:
         receiver, discards its input ring and drains stdin, then reports
         ``[STATUS] flushed`` while keeping the connection and stdin reader alive.
         The caller must have stopped feeding old audio before calling this; what
-        it already wrote is seen through to the binary here, so the drain removes
-        exactly the pre-flush bytes.
+        it already wrote is seen through to the binary here, and stdin is held
+        quiet until the flush is acknowledged, so the drain removes exactly the
+        pre-flush bytes and nothing lands behind it.
 
         :param timeout: Seconds to wait for the flushed acknowledgement.
         :return: True once the flush is acknowledged; False when audio we already
@@ -424,31 +425,36 @@ class AirPlayStream:
         """
         if not self.running or not self.connected:
             return False
+        if (cli_proc := self._cli_proc) is None:
+            return False
         # The FLUSH travels on the command pipe while audio travels on stdin, so
         # the binary can run its drain while bytes we already handed to stdin are
-        # still in flight. Those would land after the drain and become the first
-        # pending sample the next START anchors, putting the new content late by
-        # their duration for the rest of the stream. Emptying our own buffer first
-        # is what makes the drain remove every pre-flush byte.
-        if self._cli_proc and not await self._cli_proc.drain_stdin(_STDIN_DRAIN_TIMEOUT):
-            self.player.logger.warning(
-                "Queued audio for %s did not clear within %.1fs, so a flush could not "
-                "remove all of it; falling back to a cold restart",
-                self.player.display_name,
-                _STDIN_DRAIN_TIMEOUT,
-            )
-            return False
-        self._arm_flush_answer()
-        # The flush drain re-arms the binary's one-shot audio signal; the next
-        # [STATUS] audio belongs to the new track.
-        self._audio_present.clear()
-        self.audio_pending_ms = 0
-        if not await self._write_cli_command("ACTION=FLUSH"):
-            return False
-        try:
-            await asyncio.wait_for(self._flushed.wait(), timeout)
-        except TimeoutError:
-            return False
+        # still in flight, and can read a write issued after it. Either would land
+        # behind the drain and become the first pending sample the next START
+        # anchors, putting the new content late by its duration for the rest of the
+        # stream. Emptying our buffer and then holding stdin shut for the whole
+        # exchange is what makes the drain remove every pre-flush byte and keeps
+        # the binary's idea of "pending" empty until it answers.
+        async with cli_proc.stdin_quiesced(_STDIN_DRAIN_TIMEOUT) as quiesced:
+            if not quiesced:
+                self.player.logger.warning(
+                    "Queued audio for %s did not clear within %.1fs, so a flush could not "
+                    "remove all of it; falling back to a cold restart",
+                    self.player.display_name,
+                    _STDIN_DRAIN_TIMEOUT,
+                )
+                return False
+            self._arm_flush_answer()
+            # The flush drain re-arms the binary's one-shot audio signal; the next
+            # [STATUS] audio belongs to the new track.
+            self._audio_present.clear()
+            self.audio_pending_ms = 0
+            if not await self._write_cli_command("ACTION=FLUSH"):
+                return False
+            try:
+                await asyncio.wait_for(self._flushed.wait(), timeout)
+            except TimeoutError:
+                return False
         if (error := self._flush_error) is not None:
             self.player.logger.warning(
                 "cliairplay rejected the flush for %s (%s); falling back to a cold restart",

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -79,8 +79,10 @@ _CLI_ERROR_DETAIL_RE = re.compile(r'\bdetail="([^"]*)"')
 _COMMAND_PIPE_READER_TIMEOUT: Final[float] = 2.0
 
 # Seconds to wait for our own queued stdin audio to reach the binary before a
-# flush. Only the bytes already accepted for the pipe are left to move, which the
-# binary keeps reading, so this covers a stalled reader rather than a real wait.
+# flush. At most the write buffer's high-water mark is left to move (64 KiB, a
+# third of a second of PCM) and the binary reads continuously, so reaching this
+# means its reader has stalled -- for which the cold restart it falls back to is
+# the right answer anyway.
 _STDIN_DRAIN_TIMEOUT: Final[float] = 2.0
 
 
@@ -410,13 +412,15 @@ class AirPlayStream:
         Sends ``ACTION=FLUSH`` — the binary stops sending audio, flushes the
         receiver, discards its input ring and drains stdin, then reports
         ``[STATUS] flushed`` while keeping the connection and stdin reader alive.
-        The caller must have stopped feeding old audio before calling this so the
-        drain removes exactly the pre-flush bytes.
+        The caller must have stopped feeding old audio before calling this; what
+        it already wrote is seen through to the binary here, so the drain removes
+        exactly the pre-flush bytes.
 
         :param timeout: Seconds to wait for the flushed acknowledgement.
-        :return: True once the flush is acknowledged; False on a delivery
-            failure, a flush the binary reports it rejected, or a timeout, so
-            the caller can fall back to a cold restart.
+        :return: True once the flush is acknowledged; False when audio we already
+            wrote cannot be cleared, on a delivery failure, on a flush the binary
+            reports it rejected, or on a timeout, so the caller can fall back to a
+            cold restart.
         """
         if not self.running or not self.connected:
             return False
@@ -1416,6 +1420,8 @@ class AirPlayStream:
                     self.audio_pending_ms = int(line.split("buffered_ms=")[1].split(maxsplit=1)[0])
                 except ValueError, IndexError:
                     self.audio_pending_ms = 0
+            else:
+                self.audio_pending_ms = 0
             self._audio_present.set()
         elif "[STATUS] mrp" in line:
             # The artwork reports arrive on stderr; the now-playing push

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -78,6 +78,11 @@ _CLI_ERROR_DETAIL_RE = re.compile(r'\bdetail="([^"]*)"')
 # the connection is reported, so this only bridges the reader thread starting up.
 _COMMAND_PIPE_READER_TIMEOUT: Final[float] = 2.0
 
+# Seconds to wait for our own queued stdin audio to reach the binary before a
+# flush. Only the bytes already accepted for the pipe are left to move, which the
+# binary keeps reading, so this covers a stalled reader rather than a real wait.
+_STDIN_DRAIN_TIMEOUT: Final[float] = 2.0
+
 
 @dataclass
 class CliError:
@@ -93,6 +98,11 @@ class AirPlayStream:
 
     _cli_proc: AsyncProcess | None
     session: AirPlayStreamSession | None = None
+    # Audio (ms) the binary last reported pending on its stdin for the current
+    # start cycle, 0 until it reports any. A caller that has written nothing since
+    # the last flush can read this as audio left over from the previous stream,
+    # which a START would anchor as if it were the new first sample.
+    audio_pending_ms: int = 0
 
     def __init__(self, player: AirPlayPlayer, pcm_format: AudioFormat | None = None) -> None:
         """
@@ -410,10 +420,25 @@ class AirPlayStream:
         """
         if not self.running or not self.connected:
             return False
+        # The FLUSH travels on the command pipe while audio travels on stdin, so
+        # the binary can run its drain while bytes we already handed to stdin are
+        # still in flight. Those would land after the drain and become the first
+        # pending sample the next START anchors, putting the new content late by
+        # their duration for the rest of the stream. Emptying our own buffer first
+        # is what makes the drain remove every pre-flush byte.
+        if self._cli_proc and not await self._cli_proc.drain_stdin(_STDIN_DRAIN_TIMEOUT):
+            self.player.logger.warning(
+                "Queued audio for %s did not clear within %.1fs, so a flush could not "
+                "remove all of it; falling back to a cold restart",
+                self.player.display_name,
+                _STDIN_DRAIN_TIMEOUT,
+            )
+            return False
         self._arm_flush_answer()
         # The flush drain re-arms the binary's one-shot audio signal; the next
         # [STATUS] audio belongs to the new track.
         self._audio_present.clear()
+        self.audio_pending_ms = 0
         if not await self._write_cli_command("ACTION=FLUSH"):
             return False
         try:
@@ -503,6 +528,9 @@ class AirPlayStream:
         # the previous anchor (this also covers the warm-seek FLUSH->refill->START
         # path) to keep the server and binary baselines aligned.
         self.reset_reanchor_shift()
+        # Whatever was pending belongs to the anchor being replaced here; a later
+        # report describes what this start cycle was handed.
+        self.audio_pending_ms = 0
         self._start_position = position_ms / 1000
         # This base is absolute, so a cut still outstanding against the previous
         # anchor is no longer part of it and must not be reconciled into it.
@@ -1383,6 +1411,11 @@ class AirPlayStream:
             self._flush_error = None
             self._flushed.set()
         elif "[STATUS] audio " in line:
+            if "buffered_ms=" in line:
+                try:
+                    self.audio_pending_ms = int(line.split("buffered_ms=")[1].split(maxsplit=1)[0])
+                except ValueError, IndexError:
+                    self.audio_pending_ms = 0
             self._audio_present.set()
         elif "[STATUS] mrp" in line:
             # The artwork reports arrive on stderr; the now-playing push

--- a/tests/helpers/test_process.py
+++ b/tests/helpers/test_process.py
@@ -37,6 +37,9 @@ async def piped_process_fixture() -> AsyncGenerator[tuple[AsyncProcess, int]]:
         yield proc, read_fd
     finally:
         transport.abort()
+        # abort() only schedules the callback that closes the write side, so let
+        # it run before the loop goes away rather than relying on the ordering.
+        await asyncio.sleep(0)
         os.close(read_fd)
 
 

--- a/tests/helpers/test_process.py
+++ b/tests/helpers/test_process.py
@@ -1,0 +1,112 @@
+"""Tests for the AsyncProcess helper."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock
+
+import pytest
+
+from music_assistant.helpers.process import AsyncProcess
+
+# Comfortably beyond the OS pipe capacity plus asyncio's default high-water mark,
+# so the bytes are guaranteed to still be queued in our own write buffer.
+_MORE_THAN_THE_PIPE_HOLDS = b"\x00" * (4 * 1024 * 1024)
+
+
+@pytest.fixture(name="piped_process")
+async def piped_process_fixture() -> AsyncGenerator[tuple[AsyncProcess, int]]:
+    """
+    Yield an AsyncProcess writing to a real pipe, plus its unread read end.
+
+    The write side is a genuine asyncio pipe transport, so the flow control
+    drain_stdin relies on behaves exactly as it does against a real process, while
+    nothing consumes the read end until a test chooses to.
+    """
+    read_fd, write_fd = os.pipe()
+    loop = asyncio.get_running_loop()
+    transport, protocol = await loop.connect_write_pipe(
+        asyncio.streams.FlowControlMixin, os.fdopen(write_fd, "wb", 0)
+    )
+    writer = asyncio.StreamWriter(transport, protocol, None, loop)
+    proc = AsyncProcess(["cat"], stdin=True)
+    proc.proc = MagicMock(stdin=writer)
+    try:
+        yield proc, read_fd
+    finally:
+        transport.abort()
+        os.close(read_fd)
+
+
+def _queue_without_waiting(proc: AsyncProcess, data: bytes) -> None:
+    """
+    Hand data to stdin without awaiting it, leaving it in the write buffer.
+
+    ``write`` would block on its own drain while the pipe is unread, which is the
+    state these tests need to set up rather than something to wait through.
+    """
+    assert proc.proc is not None
+    assert proc.proc.stdin is not None
+    proc.proc.stdin.write(data)
+
+
+async def _consume(read_fd: int, total: int) -> None:
+    """Read `total` bytes off the pipe so the write buffer can empty."""
+    remaining = total
+    while remaining > 0:
+        remaining -= len(await asyncio.to_thread(os.read, read_fd, 65536))
+
+
+@pytest.mark.asyncio
+async def test_drain_stdin_waits_for_the_write_buffer_to_empty(
+    piped_process: tuple[AsyncProcess, int],
+) -> None:
+    """The drain resolves only once every queued byte has reached the reader."""
+    proc, read_fd = piped_process
+    _queue_without_waiting(proc, _MORE_THAN_THE_PIPE_HOLDS)
+    assert proc.proc is not None
+    assert proc.proc.stdin is not None
+    assert proc.proc.stdin.transport.get_write_buffer_size() > 0
+    reader = asyncio.create_task(_consume(read_fd, len(_MORE_THAN_THE_PIPE_HOLDS)))
+
+    assert await proc.drain_stdin() is True
+
+    assert proc.proc.stdin.transport.get_write_buffer_size() == 0
+    await reader
+
+
+@pytest.mark.asyncio
+async def test_drain_stdin_reports_a_reader_that_never_catches_up(
+    piped_process: tuple[AsyncProcess, int],
+) -> None:
+    """A reader that never consumes the pipe fails the drain instead of hanging."""
+    proc, _ = piped_process
+    _queue_without_waiting(proc, _MORE_THAN_THE_PIPE_HOLDS)
+
+    assert await proc.drain_stdin(timeout=0.2) is False
+
+
+@pytest.mark.asyncio
+async def test_drain_stdin_restores_normal_writing(
+    piped_process: tuple[AsyncProcess, int],
+) -> None:
+    """Writing carries on unaffected after a drain, on the restored buffer limits."""
+    proc, read_fd = piped_process
+    reader = asyncio.create_task(_consume(read_fd, len(b"first") + len(b"second")))
+    await proc.write(b"first")
+    assert await proc.drain_stdin() is True
+
+    await proc.write(b"second")
+
+    assert await proc.drain_stdin() is True
+    await reader
+
+
+@pytest.mark.asyncio
+async def test_drain_stdin_is_a_noop_without_a_process() -> None:
+    """A drain on a process that was never started succeeds rather than raising."""
+    proc = AsyncProcess(["cat"], stdin=True)
+
+    assert await proc.drain_stdin() is True

--- a/tests/helpers/test_process.py
+++ b/tests/helpers/test_process.py
@@ -22,8 +22,8 @@ async def piped_process_fixture() -> AsyncGenerator[tuple[AsyncProcess, int]]:
     Yield an AsyncProcess writing to a real pipe, plus its unread read end.
 
     The write side is a genuine asyncio pipe transport, so the flow control
-    drain_stdin relies on behaves exactly as it does against a real process, while
-    nothing consumes the read end until a test chooses to.
+    stdin_quiesced relies on behaves exactly as it does against a real process,
+    while nothing consumes the read end until a test chooses to.
     """
     read_fd, write_fd = os.pipe()
     loop = asyncio.get_running_loop()
@@ -63,10 +63,10 @@ async def _consume(read_fd: int, total: int) -> None:
 
 
 @pytest.mark.asyncio
-async def test_drain_stdin_waits_for_the_write_buffer_to_empty(
+async def test_stdin_quiesced_waits_for_the_write_buffer_to_empty(
     piped_process: tuple[AsyncProcess, int],
 ) -> None:
-    """The drain resolves only once every queued byte has reached the reader."""
+    """The block is entered only once every queued byte has reached the reader."""
     proc, read_fd = piped_process
     _queue_without_waiting(proc, _MORE_THAN_THE_PIPE_HOLDS)
     assert proc.proc is not None
@@ -74,42 +74,77 @@ async def test_drain_stdin_waits_for_the_write_buffer_to_empty(
     assert proc.proc.stdin.transport.get_write_buffer_size() > 0
     reader = asyncio.create_task(_consume(read_fd, len(_MORE_THAN_THE_PIPE_HOLDS)))
 
-    assert await proc.drain_stdin() is True
+    async with proc.stdin_quiesced() as quiesced:
+        assert quiesced is True
+        assert proc.proc.stdin.transport.get_write_buffer_size() == 0
 
-    assert proc.proc.stdin.transport.get_write_buffer_size() == 0
     await reader
 
 
 @pytest.mark.asyncio
-async def test_drain_stdin_reports_a_reader_that_never_catches_up(
+async def test_stdin_quiesced_reports_a_reader_that_never_catches_up(
     piped_process: tuple[AsyncProcess, int],
 ) -> None:
-    """A reader that never consumes the pipe fails the drain instead of hanging."""
+    """A reader that never consumes the pipe reports failure instead of hanging."""
     proc, _ = piped_process
     _queue_without_waiting(proc, _MORE_THAN_THE_PIPE_HOLDS)
 
-    assert await proc.drain_stdin(timeout=0.2) is False
+    async with proc.stdin_quiesced(timeout=0.2) as quiesced:
+        assert quiesced is False
 
 
 @pytest.mark.asyncio
-async def test_drain_stdin_restores_normal_writing(
+async def test_stdin_quiesced_keeps_writes_out_of_the_block(
     piped_process: tuple[AsyncProcess, int],
 ) -> None:
-    """Writing carries on unaffected after a drain, on the restored buffer limits."""
+    """
+    No write can land while the block runs, so nothing queues up behind a drain.
+
+    This is the guarantee the block exists for: a caller telling the process
+    something about the bytes it has been handed needs stdin to stay as it left it
+    until the process has answered.
+    """
     proc, read_fd = piped_process
-    reader = asyncio.create_task(_consume(read_fd, len(b"first") + len(b"second")))
-    await proc.write(b"first")
-    assert await proc.drain_stdin() is True
+    reader = asyncio.create_task(_consume(read_fd, len(b"late")))
 
-    await proc.write(b"second")
+    async with proc.stdin_quiesced() as quiesced:
+        assert quiesced is True
+        writing = asyncio.create_task(proc.write(b"late"))
+        await asyncio.sleep(0)
 
-    assert await proc.drain_stdin() is True
+        assert not writing.done()
+        assert proc.proc is not None
+        assert proc.proc.stdin is not None
+        assert proc.proc.stdin.transport.get_write_buffer_size() == 0
+
+    await writing
     await reader
 
 
 @pytest.mark.asyncio
-async def test_drain_stdin_is_a_noop_without_a_process() -> None:
-    """A drain on a process that was never started succeeds rather than raising."""
+async def test_stdin_quiesced_restores_normal_writing(
+    piped_process: tuple[AsyncProcess, int],
+) -> None:
+    """Writing carries on unaffected afterwards, on the restored buffer limits."""
+    proc, read_fd = piped_process
+    assert proc.proc is not None
+    assert proc.proc.stdin is not None
+    limits = proc.proc.stdin.transport.get_write_buffer_limits()
+    reader = asyncio.create_task(_consume(read_fd, len(b"first") + len(b"second")))
+    await proc.write(b"first")
+
+    async with proc.stdin_quiesced() as quiesced:
+        assert quiesced is True
+
+    assert proc.proc.stdin.transport.get_write_buffer_limits() == limits
+    await proc.write(b"second")
+    await reader
+
+
+@pytest.mark.asyncio
+async def test_stdin_quiesced_is_a_noop_without_a_process() -> None:
+    """A process that was never started quiesces trivially rather than raising."""
     proc = AsyncProcess(["cat"], stdin=True)
 
-    assert await proc.drain_stdin() is True
+    async with proc.stdin_quiesced() as quiesced:
+        assert quiesced is True

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -744,10 +744,11 @@ async def test_anchor_reports_leftover_audio_pending_on_stdin() -> None:
     """
     Audio still pending when the anchor is commanded is named as the offset it causes.
 
-    The writer is gated until the anchor settles, so anything pending belongs to
-    the previous stream and the START anchors it as this one's first sample. The
-    cursor only counts what the bridge queued itself, so no later realignment can
-    see the resulting offset -- this warning is the only signal it happened.
+    The writer is gated until the anchor settles, so anything pending was left
+    behind by an earlier stream and the START anchors it as this one's first
+    sample. The cursor only counts what the bridge queued itself, so no later
+    realignment can see the resulting offset, which leaves this warning as the
+    one place it surfaces.
     """
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     stream = _make_anchor_stream(audio_pending_ms=92)
@@ -770,7 +771,7 @@ async def test_anchor_stays_quiet_when_stdin_was_left_empty() -> None:
     with patch.object(bridge.logger, "warning") as warning:
         assert await _anchor(bridge, stream, warm=True) is True
 
-    assert not [call for call in warning.call_args_list if "pending" in str(call)]
+    assert not [call for call in warning.call_args_list if "pending" in call.args[0]]
 
 
 async def test_anchor_follows_the_clock_ready_projection() -> None:

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -470,14 +470,16 @@ def _make_anchor_stream(
     ack: int | None = None,
     warm_lead_ms: int = 0,
     flushed_head_unix_ms: int = 0,
+    audio_pending_ms: int = 0,
 ) -> MagicMock:
     """
     Build an AirPlayStream mock the anchor math can run against.
 
     The bridge reads these off the stream and does arithmetic on them, so they
     must be real numbers: the anchor compares ``warm_lead_ms`` /
-    ``flushed_head_unix_ms`` with ``> 0`` and the shift fold subtracts
-    ``cumulative_shift_seconds``, none of which a bare MagicMock can answer.
+    ``flushed_head_unix_ms`` / ``audio_pending_ms`` with ``> 0`` and the shift
+    fold subtracts ``cumulative_shift_seconds``, none of which a bare MagicMock
+    can answer (every one of them is truthy).
 
     :param ack: Instant the binary acks the START at. None acks the commanded
         instant, as a feasible one is.
@@ -496,6 +498,7 @@ def _make_anchor_stream(
     stream.start = AsyncMock(side_effect=_ack_start)
     stream.warm_lead_ms = warm_lead_ms
     stream.flushed_head_unix_ms = flushed_head_unix_ms
+    stream.audio_pending_ms = audio_pending_ms
     return stream
 
 
@@ -735,6 +738,39 @@ async def test_anchor_floors_at_the_join_headroom() -> None:
     assert await _anchor(bridge, stream) is True
 
     assert _commanded_instant(stream) == UNIX_NOW_MS + AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS
+
+
+async def test_anchor_reports_leftover_audio_pending_on_stdin() -> None:
+    """
+    Audio still pending when the anchor is commanded is named as the offset it causes.
+
+    The writer is gated until the anchor settles, so anything pending belongs to
+    the previous stream and the START anchors it as this one's first sample. The
+    cursor only counts what the bridge queued itself, so no later realignment can
+    see the resulting offset -- this warning is the only signal it happened.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    stream = _make_anchor_stream(audio_pending_ms=92)
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=WARM_LEAD_MS)
+
+    with patch.object(bridge.logger, "warning") as warning:
+        assert await _anchor(bridge, stream, warm=True) is True
+
+    pending = [call for call in warning.call_args_list if "pending" in call.args[0]]
+    assert len(pending) == 1
+    assert pending[0].args[2] == 92
+
+
+async def test_anchor_stays_quiet_when_stdin_was_left_empty() -> None:
+    """An anchor commanded against empty stdin reports nothing."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    stream = _make_anchor_stream()
+    _prepare_anchor(bridge, stream, first_chunk_lead_ms=WARM_LEAD_MS)
+
+    with patch.object(bridge.logger, "warning") as warning:
+        assert await _anchor(bridge, stream, warm=True) is True
+
+    assert not [call for call in warning.call_args_list if "pending" in str(call)]
 
 
 async def test_anchor_follows_the_clock_ready_projection() -> None:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -36,6 +36,11 @@ START_UNIX_MS = 1_750_000_000_000
 AP2_FEATURES = "0x4A7FDFD5,0x3C177FDE"
 
 
+def _make_cli_proc() -> MagicMock:
+    """Build a mock cliairplay process that answers its awaited calls."""
+    return MagicMock(closed=False, drain_stdin=AsyncMock(return_value=True))
+
+
 def _make_player() -> MagicMock:
     """Build a mock AirPlay player with both discovery records present."""
     player = MagicMock()
@@ -1129,7 +1134,7 @@ async def test_cli_command_updates_timestamp_after_successful_delivery() -> None
     player = _make_player()
     player.last_command_sent = 10.0
     stream = AirPlayStream(player)
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
 
     with (
         patch.object(stream.commands_pipe, "write", new=AsyncMock(return_value=True)),
@@ -1146,7 +1151,7 @@ async def test_cli_command_preserves_timestamp_when_delivery_fails() -> None:
     player = _make_player()
     player.last_command_sent = 10.0
     stream = AirPlayStream(player)
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
 
     with patch.object(stream.commands_pipe, "write", new=AsyncMock(return_value=False)):
         assert await stream.send_cli_command("ACTION=STANDBY") is False
@@ -1160,7 +1165,7 @@ async def test_cli_command_preserves_timestamp_when_delivery_raises() -> None:
     player = _make_player()
     player.last_command_sent = 10.0
     stream = AirPlayStream(player)
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
 
     with (
         patch.object(
@@ -1247,7 +1252,7 @@ async def test_start_sends_command_and_stamps_position() -> None:
     """START is delivered over the command pipe and stamps the media position."""
     player = _make_player()
     stream = AirPlayStream(player)
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
 
     with patch.object(
@@ -1268,7 +1273,7 @@ async def test_start_join_marks_the_command() -> None:
     """A late-join START carries START_JOIN=1 so the binary enforces clock readiness."""
     player = _make_player()
     stream = AirPlayStream(player)
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
 
     with patch.object(
@@ -1294,7 +1299,7 @@ async def test_start_transition_artwork_settled_or_retried(complete_before_start
     """START keeps already-delivered transition artwork settled and retries a superseded render."""
     player = _make_player()
     stream = AirPlayStream(player)
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
     metadata = MagicMock(
         corrected_elapsed_time=0,
@@ -1373,7 +1378,7 @@ async def test_start_transition_artwork_settled_or_retried(complete_before_start
 async def test_start_requires_connected_process() -> None:
     """START is rejected without a connected cliairplay process."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     # not connected: _connected event never set
 
     with (
@@ -1389,7 +1394,7 @@ async def test_start_requires_connected_process() -> None:
 async def test_flush_sends_command_and_awaits_ack() -> None:
     """FLUSH is delivered and resolves once the binary reports it flushed."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
 
     with patch.object(
@@ -1407,7 +1412,7 @@ async def test_flush_sends_command_and_awaits_ack() -> None:
 async def test_flush_times_out_without_ack() -> None:
     """FLUSH returns False when the binary never acknowledges it."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
 
     with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True):
@@ -1418,7 +1423,7 @@ async def test_flush_times_out_without_ack() -> None:
 async def test_flush_returns_false_when_command_not_delivered() -> None:
     """FLUSH reports failure when the command cannot be delivered."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
 
     with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=False):
@@ -1429,7 +1434,7 @@ async def test_flush_returns_false_when_command_not_delivered() -> None:
 async def test_start_raises_when_command_not_delivered() -> None:
     """A dropped START surfaces as an error so the caller can fall back cold."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
 
     with (
@@ -1443,7 +1448,7 @@ async def test_start_raises_when_command_not_delivered() -> None:
 async def test_start_fails_fast_on_reported_start_failure() -> None:
     """A reported start failure ends the ack wait at once instead of timing out."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
 
     with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True):
@@ -1463,7 +1468,7 @@ async def test_start_fails_fast_on_reported_start_failure() -> None:
 async def test_flush_fails_fast_on_reported_flush_failure() -> None:
     """A reported flush failure resolves the ack wait as a failure, not a timeout."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
 
     with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True):
@@ -1481,7 +1486,7 @@ async def test_flush_fails_fast_on_reported_flush_failure() -> None:
 async def test_start_failure_does_not_outlive_its_command() -> None:
     """A failed START leaves no error behind that would fail the next one."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
     stream._handle_status_line("[STATUS] error code=start_failed")
 
@@ -1498,7 +1503,7 @@ async def test_start_failure_does_not_outlive_its_command() -> None:
 async def test_start_returns_the_instant_the_binary_scheduled() -> None:
     """A corrected ack, not the commanded instant, is what the caller maps content onto."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
     corrected = START_UNIX_MS + 700
 
@@ -1515,7 +1520,7 @@ async def test_start_returns_the_instant_the_binary_scheduled() -> None:
 async def test_start_fails_when_the_ack_never_arrives() -> None:
     """An unacknowledged START fails: nothing may be mapped onto an unconfirmed instant."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
 
     with (
@@ -1534,7 +1539,7 @@ async def test_start_fails_when_the_ack_never_arrives() -> None:
 async def test_start_accepts_a_malformed_ack_as_the_commanded_instant() -> None:
     """An ack that cannot be parsed still answered the START, so the commanded instant stands."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
 
     with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True):
@@ -1548,7 +1553,7 @@ async def test_start_accepts_a_malformed_ack_as_the_commanded_instant() -> None:
 async def test_start_treats_a_missing_scheduled_instant_as_malformed() -> None:
     """An ack without at_unix_ms parses cleanly to 0, which must never be returned."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
 
     with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True):
@@ -1570,7 +1575,7 @@ async def test_start_treats_a_missing_scheduled_instant_as_malformed() -> None:
 async def test_start_ack_window_matches_the_arm(join: bool, expected_timeout: float) -> None:
     """A join's ack is held for clock verification, so it waits far longer than a plain start."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
     timeouts: list[float] = []
 
@@ -1596,7 +1601,7 @@ async def test_start_ack_window_matches_the_arm(join: bool, expected_timeout: fl
 async def test_flush_returns_false_when_not_connected() -> None:
     """FLUSH is a no-op returning False before the device connects."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     # not connected
 
     with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
@@ -1613,6 +1618,89 @@ def test_flushed_status_sets_flush_event() -> None:
     assert stream._handle_status_line("[STATUS] flushed") is False
 
     assert stream._flushed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_flush_drains_queued_audio_before_commanding_the_flush() -> None:
+    """
+    Queued stdin audio is cleared before FLUSH, so the binary's drain removes it.
+
+    The command travels on a pipe of its own, so audio still in flight when the
+    binary drains would survive to be anchored as the next start's first sample.
+    """
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = _make_cli_proc()
+    stream._connected.set()
+    calls: list[str] = []
+
+    async def _record_drain(*_args: object) -> bool:
+        calls.append("drain")
+        return True
+
+    async def _record_command(command: str) -> bool:
+        calls.append(command)
+        return True
+
+    stream._cli_proc.drain_stdin = AsyncMock(side_effect=_record_drain)
+
+    with patch.object(stream, "_write_cli_command", side_effect=_record_command):
+        flush_task = asyncio.create_task(stream.flush())
+        await asyncio.sleep(0)
+        assert stream._handle_status_line("[STATUS] flushed") is False
+        assert await flush_task is True
+
+    assert calls == ["drain", "ACTION=FLUSH"]
+
+
+@pytest.mark.asyncio
+async def test_flush_fails_when_queued_audio_cannot_be_cleared() -> None:
+    """A drain that never completes fails the flush instead of anchoring stale audio."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = _make_cli_proc()
+    stream._connected.set()
+    stream._cli_proc.drain_stdin = AsyncMock(return_value=False)
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
+        assert await stream.flush() is False
+
+    write_command.assert_not_awaited()
+
+
+def test_audio_status_records_the_pending_stdin_depth() -> None:
+    """The [STATUS] audio line reports how much audio is pending on the binary's stdin."""
+    stream = AirPlayStream(_make_player())
+    assert stream.audio_pending_ms == 0
+
+    assert stream._handle_status_line("[STATUS] audio buffered_ms=92") is False
+
+    assert stream.audio_pending_ms == 92
+
+
+def test_unparsable_audio_status_reports_no_pending_audio() -> None:
+    """A malformed depth reports none rather than carrying the previous value."""
+    stream = AirPlayStream(_make_player())
+    stream._handle_status_line("[STATUS] audio buffered_ms=92")
+
+    assert stream._handle_status_line("[STATUS] audio buffered_ms=nonsense") is False
+
+    assert stream.audio_pending_ms == 0
+
+
+@pytest.mark.asyncio
+async def test_flush_clears_the_pending_stdin_depth() -> None:
+    """A flush drops the previous cycle's depth so the next report describes the new one."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = _make_cli_proc()
+    stream._connected.set()
+    stream._handle_status_line("[STATUS] audio buffered_ms=92")
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True):
+        flush_task = asyncio.create_task(stream.flush())
+        await asyncio.sleep(0)
+        stream._handle_status_line("[STATUS] flushed")
+        assert await flush_task is True
+
+    assert stream.audio_pending_ms == 0
 
 
 @pytest.mark.asyncio
@@ -1812,7 +1900,7 @@ def test_reanchor_status_ignores_line_without_total() -> None:
 async def test_start_resets_reanchor_shift() -> None:
     """A START re-anchors from scratch, clearing the accumulated shift."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
     stream.cumulative_shift_seconds = 3.078
 
@@ -1858,7 +1946,7 @@ async def test_initial_metadata_skips_artwork() -> None:
     """The pre-connect metadata push cannot delay setup on artwork rendering."""
     player = _make_player()
     stream = AirPlayStream(player)
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     metadata = MagicMock(
         title="Track",
         artist="Artist",
@@ -1969,7 +2057,7 @@ async def test_wait_for_connection_fails_on_an_unread_command_pipe() -> None:
     player.volume_muted = False
     stream = AirPlayStream(player)
     stream._connected.set()
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
 
     with (
         patch.object(
@@ -1993,7 +2081,7 @@ async def test_wait_for_connection_stays_quiet_about_a_stopped_stream() -> None:
     player.volume_muted = False
     stream = AirPlayStream(player)
     stream._connected.set()
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._stopping = True
 
     with (
@@ -2349,7 +2437,7 @@ async def test_artwork_url_form_change_does_not_resend_artwork() -> None:
     """Alternating URL forms of the same imageproxy image send artwork only once."""
     player = _make_player()
     stream = AirPlayStream(player)
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
 
     def make_metadata(image_url: str) -> MagicMock:
         return MagicMock(
@@ -2566,7 +2654,7 @@ async def test_send_metadata_passes_cached_artwork_path_to_binary() -> None:
 async def test_track_change_bundles_ready_artwork_into_a_single_push() -> None:
     """A track change whose artwork renders within budget lands as ONE bundled write."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     metadata = MagicMock(
         queue_item_id="item-1",
         duration=180,
@@ -2597,7 +2685,7 @@ async def test_track_change_bundles_ready_artwork_into_a_single_push() -> None:
 async def test_track_change_artwork_missing_the_budget_follows_as_artwork_command() -> None:
     """A render missing the bundling budget still delivers via ARTWORK once it completes."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     metadata = MagicMock(
         queue_item_id="item-1",
         duration=180,
@@ -2642,7 +2730,7 @@ async def test_pending_start_interrupts_the_artwork_wait() -> None:
     """A pending START releases the bounded artwork wait instead of queueing behind it."""
     player = _make_player()
     stream = AirPlayStream(player)
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     stream._connected.set()
     metadata = MagicMock(
         queue_item_id="item-1",
@@ -2689,7 +2777,7 @@ async def test_pending_start_interrupts_the_artwork_wait() -> None:
 async def test_track_change_starting_mid_track_sends_a_progress_correction() -> None:
     """A track change landing mid-position corrects the timeline after the bundle."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = MagicMock(closed=False)
+    stream._cli_proc = _make_cli_proc()
     metadata = MagicMock(
         queue_item_id="item-1",
         duration=180,

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -6,8 +6,8 @@ import logging
 import os
 import select
 import threading
-from collections.abc import AsyncGenerator, Callable, Coroutine
-from contextlib import suppress
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -36,9 +36,21 @@ START_UNIX_MS = 1_750_000_000_000
 AP2_FEATURES = "0x4A7FDFD5,0x3C177FDE"
 
 
-def _make_cli_proc() -> MagicMock:
-    """Build a mock cliairplay process that answers its awaited calls."""
-    return MagicMock(closed=False, drain_stdin=AsyncMock(return_value=True))
+def _make_cli_proc(*, quiesced: bool = True, calls: list[str] | None = None) -> MagicMock:
+    """
+    Build a mock cliairplay process that answers its awaited calls.
+
+    :param quiesced: What holding stdin quiet reports about emptying the buffer.
+    :param calls: Records "quiesce" as stdin is held, for ordering assertions.
+    """
+
+    @asynccontextmanager
+    async def _stdin_quiesced(*_args: object) -> AsyncIterator[bool]:
+        if calls is not None:
+            calls.append("quiesce")
+        yield quiesced
+
+    return MagicMock(closed=False, stdin_quiesced=_stdin_quiesced)
 
 
 def _make_player() -> MagicMock:
@@ -1621,27 +1633,21 @@ def test_flushed_status_sets_flush_event() -> None:
 
 
 @pytest.mark.asyncio
-async def test_flush_drains_queued_audio_before_commanding_the_flush() -> None:
+async def test_flush_holds_stdin_quiet_before_commanding_the_flush() -> None:
     """
     Queued stdin audio is cleared before FLUSH, so the binary's drain removes it.
 
     The command travels on a pipe of its own, so audio still in flight when the
     binary drains would survive to be anchored as the next start's first sample.
     """
-    stream = AirPlayStream(_make_player())
-    stream._cli_proc = _make_cli_proc()
-    stream._connected.set()
     calls: list[str] = []
-
-    async def _record_drain(*_args: object) -> bool:
-        calls.append("drain")
-        return True
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = _make_cli_proc(calls=calls)
+    stream._connected.set()
 
     async def _record_command(command: str) -> bool:
         calls.append(command)
         return True
-
-    stream._cli_proc.drain_stdin = AsyncMock(side_effect=_record_drain)
 
     with patch.object(stream, "_write_cli_command", side_effect=_record_command):
         flush_task = asyncio.create_task(stream.flush())
@@ -1649,16 +1655,15 @@ async def test_flush_drains_queued_audio_before_commanding_the_flush() -> None:
         assert stream._handle_status_line("[STATUS] flushed") is False
         assert await flush_task is True
 
-    assert calls == ["drain", "ACTION=FLUSH"]
+    assert calls == ["quiesce", "ACTION=FLUSH"]
 
 
 @pytest.mark.asyncio
 async def test_flush_fails_when_queued_audio_cannot_be_cleared() -> None:
     """A drain that never completes fails the flush instead of anchoring stale audio."""
     stream = AirPlayStream(_make_player())
-    stream._cli_proc = _make_cli_proc()
+    stream._cli_proc = _make_cli_proc(quiesced=False)
     stream._connected.set()
-    stream._cli_proc.drain_stdin = AsyncMock(return_value=False)
 
     with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
         assert await stream.flush() is False

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -1686,6 +1686,16 @@ def test_unparsable_audio_status_reports_no_pending_audio() -> None:
     assert stream.audio_pending_ms == 0
 
 
+def test_audio_status_without_a_depth_reports_no_pending_audio() -> None:
+    """A line omitting the depth reports none rather than carrying the previous value."""
+    stream = AirPlayStream(_make_player())
+    stream._handle_status_line("[STATUS] audio buffered_ms=92")
+
+    assert stream._handle_status_line("[STATUS] audio ") is False
+
+    assert stream.audio_pending_ms == 0
+
+
 @pytest.mark.asyncio
 async def test_flush_clears_the_pending_stdin_depth() -> None:
     """A flush drops the previous cycle's depth so the next report describes the new one."""


### PR DESCRIPTION
# What does this implement/fix?

When an AirPlay speaker plays through a Sendspin sync group (mixed with Sendspin speakers), starting playback was in sync but a **seek or next-track** left the AirPlay speaker audibly late — up to ~90ms behind the rest of the group — for the remainder of the stream. Native AirPlay playback was unaffected.

A seek or track change flushes the AirPlay binary in place and re-anchors it instead of reconnecting. The flush command travels on its own pipe while audio travels on stdin, so audio already handed to stdin was still in flight when the binary ran its drain. Those bytes arrived just after it, and the new anchor mapped them as the first sample of the new track — shifting all of the new content late by their duration. Nothing detected it: the bridge only counts the bytes it queues after the anchor, so no realignment could see the offset.

`write()` only waits while the transport is paused, which happens above the high-water mark, so it can return with up to 64 KiB queued — a third of a second of PCM. The ~90ms observed in the logs is the steady state under continuous writing, not the worst case.

Verified against debug logs from a reporter and a local reproduction: on a warm seek the binary reports audio already pending on its stdin *before* the start is commanded, whereas on a cold start it reports it *after*. The amount matches how much was queued when the previous track stopped being fed.

**Related issue (if applicable):**

- n/a — reported on Discord with debug logs

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Empty our own stdin buffer before commanding a flush, so the binary's drain really removes every pre-flush byte — as `flush()` already documented its caller must ensure. This covers the native path too, which had the same exposure.
- Add `AsyncProcess.stdin_quiesced()`: it sees queued bytes through to the pipe and then holds the write lock for the block, so no write can land behind the binary's drain while the flush is in flight. `write()` only waits while the transport is paused, which is what let bytes slip through.
- Fall back to a cold restart when queued audio cannot be cleared, rather than anchoring onto stale audio. This costs nothing in practice: the residue is at most 64 KiB and the binary reads continuously, so reaching the 2s timeout means its reader has stalled — in which case the flush ack would have timed out and forced the same cold restart anyway.
- Warn when the binary still reports pending audio as a bridge anchor is commanded, so this can never go silent again.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.


