### PR TITLE
Update strings for radio stations settings for OpenSubsonic Provider

### DIFF
--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -242,7 +242,7 @@ class OpenSonicProvider(MusicProvider):
             self.logger.info("Failed to query server for OpenSubsonic extensions")
 
         self._enable_podcasts = bool(self.config.get_value(CONF_ENABLE_PODCASTS))
-        self._enable_radio_stations = bool(self.config.get_value(CONF_ENABLE_RADIO_STATIONS, True))
+        self._enable_radio_stations = bool(self.config.get_value(CONF_ENABLE_RADIO_STATIONS))
         self._show_faves = bool(self.config.get_value(CONF_RECO_FAVES))
         self._show_new = bool(self.config.get_value(CONF_NEW_ALBUMS))
         self._show_played = bool(self.config.get_value(CONF_PLAYED_ALBUMS))

--- a/music_assistant/providers/opensubsonic/strings.json
+++ b/music_assistant/providers/opensubsonic/strings.json
@@ -28,6 +28,10 @@
       "label": "Enable Podcasts",
       "description": "Should the provider query for podcasts as well as music?"
     },
+    "enable_radio_stations": {
+      "label": "Enable Radio Stations",
+      "description": "Should the provider query for radio stations?"
+    },
     "enable_legacy_auth": {
       "label": "Enable Legacy Auth",
       "description": "Enable OpenSubsonic \"legacy\" auth support"

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1669,6 +1669,8 @@
   "provider.opensubsonic.config_entries.enable_legacy_auth.label": "Enable Legacy Auth",
   "provider.opensubsonic.config_entries.enable_podcasts.description": "Should the provider query for podcasts as well as music?",
   "provider.opensubsonic.config_entries.enable_podcasts.label": "Enable Podcasts",
+  "provider.opensubsonic.config_entries.enable_radio_stations.description": "Should the provider query for radio stations?",
+  "provider.opensubsonic.config_entries.enable_radio_stations.label": "Enable Radio Stations",
   "provider.opensubsonic.config_entries.pagination_size.description": "When enumerating items from the server, how many should be in each request. Smaller will require more requests but is better for low bandwidth connections. The Open Subsonic spec says the max value for this is 500 items.",
   "provider.opensubsonic.config_entries.pagination_size.label": "Number of items included per server request.",
   "provider.opensubsonic.config_entries.password.description": "The password associated with the username. Not required when using an API key.",


### PR DESCRIPTION
# What does this implement/fix?

- Add missing strings for the new radio stations settings for OpenSubsonic radios
- Cleanup passing default boolean in favor of default like other lines

**Related issue (if applicable):**

- related issue: https://github.com/music-assistant/server/pull/5150

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
