### PR TITLE
Fix Spotify playback

### DIFF
--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -415,15 +415,30 @@ class AsyncProcess:
         self._stderr_reader_task = task
 
 
-async def check_output(*args: str, env: dict[str, str] | None = None) -> tuple[int, bytes]:
-    """Run subprocess and return returncode and output."""
+async def check_output(
+    *args: str, env: dict[str, str] | None = None, timeout: float | None = None
+) -> tuple[int, bytes]:
+    """
+    Run subprocess and return returncode and output.
+
+    :param env: Optional environment overrides for the subprocess.
+    :param timeout: Maximum seconds to wait for the process to exit. On expiry the
+        process is killed and TimeoutError is raised; None (default) waits forever.
+    """
     proc = await asyncio.create_subprocess_exec(
         *args,
         stderr=asyncio.subprocess.STDOUT,
         stdout=asyncio.subprocess.PIPE,
         env=get_subprocess_env(env),
     )
-    stdout, _ = await proc.communicate()
+    try:
+        async with asyncio.timeout(timeout):
+            stdout, _ = await proc.communicate()
+    except TimeoutError:
+        proc.kill()
+        with suppress(ProcessLookupError):
+            await proc.wait()
+        raise
     assert proc.returncode is not None  # for type checking
     return (proc.returncode, stdout)
 

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -172,8 +172,12 @@ class Provider:
         return self.manifest.stage
 
     def unload_with_error(self, error: str) -> None:
-        """Unload provider with error message."""
-        self.mass.call_later(1, self.mass.unload_provider, self.instance_id, error)
+        """
+        Unload this provider and record an error for the user to act on.
+
+        :param error: Error message to show to the user.
+        """
+        self.mass.call_later(1, self.mass.unload_provider_with_error, self.instance_id, error)
 
     def to_dict(self) -> dict[str, Any]:
         """Return Provider(instance) as serializable dict."""

--- a/music_assistant/providers/spotify/__init__.py
+++ b/music_assistant/providers/spotify/__init__.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+from contextlib import suppress
 from typing import TYPE_CHECKING, cast
 
+import pkce
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
-from music_assistant_models.enums import ConfigEntryType, ProviderFeature
+from music_assistant_models.enums import ConfigEntryType, EventType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError, LoginFailed
 
 from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
@@ -15,16 +18,37 @@ from .constants import (
     CALLBACK_REDIRECT_URL,
     CONF_ACTION_AUTH,
     CONF_ACTION_AUTH_DEV,
+    CONF_ACTION_AUTH_PLAYBACK,
+    CONF_ACTION_AUTH_PLAYBACK_BROWSER,
+    CONF_ACTION_AUTH_PLAYBACK_SUBMIT,
     CONF_ACTION_CLEAR_AUTH,
     CONF_ACTION_CLEAR_AUTH_DEV,
+    CONF_ACTION_CLEAR_AUTH_PLAYBACK,
     CONF_CLIENT_ID,
+    CONF_LIBRESPOT_CREDENTIALS,
+    CONF_PLAYBACK_CALLBACK_URL,
     CONF_REFRESH_TOKEN_DEPRECATED,
     CONF_REFRESH_TOKEN_DEV,
     CONF_REFRESH_TOKEN_GLOBAL,
     CONF_SYNC_AUDIOBOOK_PROGRESS,
     CONF_SYNC_PODCAST_PROGRESS,
+    LIBRESPOT_REDIRECT_PATH,
+    LIBRESPOT_REDIRECT_PORT,
+    LOOPBACK_WAIT_TIMEOUT,
+    PAIRING_DEVICE_NAME,
+    PAIRING_TIMEOUT,
 )
-from .helpers import pkce_auth_flow
+from .helpers import (
+    authorization_code_from_params,
+    authorization_code_from_url,
+    await_loopback_authorization,
+    get_librespot_binary,
+    keymaster_access_token,
+    keymaster_authorize_url,
+    librespot_credentials_via_pairing,
+    librespot_credentials_via_token,
+    pkce_auth_flow,
+)
 from .provider import SpotifyProvider
 
 if TYPE_CHECKING:
@@ -54,6 +78,14 @@ SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_PODCASTS_EDIT,
 }
 
+# A browser sign-in that could not report back parks its PKCE verifier here, keyed by the config
+# dialog's session id, until the user pastes the address their browser ended up on. Kept in
+# memory only: the authorization code it belongs to expires within minutes anyway.
+_PENDING_BROWSER_AUTH: dict[str, str] = {}
+# The pairing daemon keeps advertising until it is selected or times out, so it is tracked to
+# make a second attempt replace the first one.
+_PAIRING_ATTEMPT: dict[str, asyncio.Task[str]] = {}
+
 
 async def _handle_auth_actions(
     mass: MusicAssistant,
@@ -69,6 +101,8 @@ async def _handle_auth_actions(
         values[CONF_REFRESH_TOKEN_GLOBAL] = refresh_token
         values[CONF_REFRESH_TOKEN_DEV] = None  # Clear dev token on new global auth
         values[CONF_CLIENT_ID] = None  # Clear client ID on new global auth
+        # the playback credential belongs to the account that was just replaced
+        _clear_playback_auth_values(values)
 
     elif action == CONF_ACTION_AUTH_DEV:
         custom_client_id = values.get(CONF_CLIENT_ID)
@@ -81,10 +115,152 @@ async def _handle_auth_actions(
 
     elif action == CONF_ACTION_CLEAR_AUTH:
         values[CONF_REFRESH_TOKEN_GLOBAL] = None
+        _clear_playback_auth_values(values)
 
     elif action == CONF_ACTION_CLEAR_AUTH_DEV:
         values[CONF_REFRESH_TOKEN_DEV] = None
         values[CONF_CLIENT_ID] = None
+
+
+async def _handle_playback_auth_actions(
+    mass: MusicAssistant,
+    action: str | None,
+    values: dict[str, ConfigValueType] | None,
+) -> None:
+    """
+    Handle the playback authorization actions for config entries.
+
+    :param mass: MusicAssistant instance.
+    :param action: Action key called from the config entries UI, if any.
+    :param values: The intermediate config values, updated in place with the result.
+    """
+    if values is None:
+        return
+
+    if action == CONF_ACTION_CLEAR_AUTH_PLAYBACK:
+        _clear_playback_auth_values(values)
+        return
+
+    if action not in (
+        CONF_ACTION_AUTH_PLAYBACK,
+        CONF_ACTION_AUTH_PLAYBACK_BROWSER,
+        CONF_ACTION_AUTH_PLAYBACK_SUBMIT,
+    ):
+        return
+
+    librespot_bin = await get_librespot_binary()
+    credentials: str | None
+    if action == CONF_ACTION_AUTH_PLAYBACK:
+        try:
+            credentials = await _pair_with_spotify_app(librespot_bin)
+        except TimeoutError as err:
+            raise LoginFailed(
+                f"'{PAIRING_DEVICE_NAME}' was not selected in the Spotify app in time. "
+                "Try again, or use the web browser option if it does not appear at all."
+            ) from err
+    elif action == CONF_ACTION_AUTH_PLAYBACK_BROWSER:
+        credentials = await _authorize_playback_via_browser(mass, values, librespot_bin)
+    else:
+        credentials = await _complete_playback_auth_via_browser(mass, values, librespot_bin)
+
+    if credentials is None:
+        # the browser could not report back, so the user pastes the address instead
+        return
+    _clear_playback_auth_values(values)
+    values[CONF_LIBRESPOT_CREDENTIALS] = credentials
+
+
+async def _pair_with_spotify_app(librespot_bin: str) -> str:
+    """
+    Advertise Music Assistant to the Spotify app and return the credential once it is selected.
+
+    A still-running attempt is cancelled first, so pressing the button again restarts pairing
+    instead of advertising a second device under the same name.
+
+    :param librespot_bin: Path to the librespot binary.
+    :raises TimeoutError: When the device was not selected within PAIRING_TIMEOUT.
+    """
+    if attempt := _PAIRING_ATTEMPT.pop("task", None):
+        attempt.cancel()
+        # wait for it to actually stop advertising before starting the replacement
+        with suppress(asyncio.CancelledError):
+            await attempt
+    attempt = asyncio.create_task(
+        librespot_credentials_via_pairing(librespot_bin, PAIRING_DEVICE_NAME, PAIRING_TIMEOUT)
+    )
+    _PAIRING_ATTEMPT["task"] = attempt
+    try:
+        return await attempt
+    finally:
+        if _PAIRING_ATTEMPT.get("task") is attempt:
+            del _PAIRING_ATTEMPT["task"]
+
+
+async def _authorize_playback_via_browser(
+    mass: MusicAssistant,
+    values: dict[str, ConfigValueType],
+    librespot_bin: str,
+) -> str | None:
+    """
+    Start the playback sign-in in the user's browser.
+
+    Returns the stored credential when the browser reported back to Music Assistant directly,
+    or None when the user has to paste the address their browser ended up on.
+
+    :param mass: MusicAssistant instance.
+    :param values: The intermediate config values, updated in place with the pending state.
+    :param librespot_bin: Path to the librespot binary.
+    """
+    session_id = cast("str", values["session_id"])
+    code_verifier, code_challenge = pkce.generate_pkce_pair()
+    # signalled directly instead of through AuthenticationHelper: Spotify only accepts a
+    # loopback redirect for this client id, so the helper's callback URL can never be reached.
+    # The frontend opens the URL right away, so the loopback target below is already served
+    # by the time the user approves.
+    mass.signal_event(EventType.AUTH_SESSION, session_id, keymaster_authorize_url(code_challenge))
+    try:
+        callback_params = await await_loopback_authorization(
+            LIBRESPOT_REDIRECT_PORT, LIBRESPOT_REDIRECT_PATH, LOOPBACK_WAIT_TIMEOUT
+        )
+    except TimeoutError, OSError:
+        # the loopback target is only reachable when the browser runs on this host; everyone
+        # else copies the address from their browser into the config instead
+        _clear_playback_auth_values(values)
+        _PENDING_BROWSER_AUTH[session_id] = code_verifier
+        return None
+
+    access_token = await keymaster_access_token(
+        mass.http_session, authorization_code_from_params(callback_params), code_verifier
+    )
+    return await librespot_credentials_via_token(librespot_bin, access_token)
+
+
+async def _complete_playback_auth_via_browser(
+    mass: MusicAssistant,
+    values: dict[str, ConfigValueType],
+    librespot_bin: str,
+) -> str:
+    """
+    Redeem the address the user pasted back after approving playback in their browser.
+
+    :param mass: MusicAssistant instance.
+    :param values: The intermediate config values holding the pasted address.
+    :param librespot_bin: Path to the librespot binary.
+    :raises InvalidDataError: When the browser sign-in was not started first.
+    """
+    code_verifier = _PENDING_BROWSER_AUTH.pop(cast("str", values["session_id"]), None)
+    if not code_verifier:
+        raise InvalidDataError("Start the browser authorization first")
+    code = authorization_code_from_url(str(values.get(CONF_PLAYBACK_CALLBACK_URL) or ""))
+    access_token = await keymaster_access_token(mass.http_session, code, code_verifier)
+    return await librespot_credentials_via_token(librespot_bin, access_token)
+
+
+def _clear_playback_auth_values(values: dict[str, ConfigValueType]) -> None:
+    """Reset the playback authorization values, including any half-finished browser sign-in."""
+    _PENDING_BROWSER_AUTH.clear()
+    values[CONF_LIBRESPOT_CREDENTIALS] = None
+    values[CONF_PLAYBACK_CALLBACK_URL] = None
 
 
 async def get_config_entries(
@@ -103,6 +279,7 @@ async def get_config_entries(
 
     # Handle any authentication actions
     await _handle_auth_actions(mass, action, values)
+    await _handle_playback_auth_actions(mass, action, values)
 
     # Determine authentication states from current values
     # Note: encrypted values are sent as placeholder text, which indicates value IS set
@@ -110,6 +287,9 @@ async def get_config_entries(
     dev_token = (values or {}).get(CONF_REFRESH_TOKEN_DEV)
     global_authenticated = global_token not in (None, "")
     dev_authenticated = dev_token not in (None, "")
+    playback_authorized = (values or {}).get(CONF_LIBRESPOT_CREDENTIALS) not in (None, "")
+    # a browser sign-in waiting to be finished is what reveals the paste field
+    browser_auth_pending = (values or {}).get("session_id") in _PENDING_BROWSER_AUTH
 
     # Build label text based on state - these are dynamic based on current values
     if not global_authenticated:
@@ -123,6 +303,35 @@ async def get_config_entries(
         label_text = "Authenticated to Spotify. Don't forget to save to complete setup."
     else:
         label_text = "Authenticated to Spotify. No further action required."
+
+    # Build playback authorization label text
+    if browser_auth_pending:
+        playback_label_text = (
+            "Approve playback in the browser tab that was just opened. Your browser then ends "
+            "up on a page that cannot be reached, which is expected.\n\n"
+            "Copy the full address of that page into the field below and press "
+            "'Complete authorization'."
+        )
+    elif not playback_authorized:
+        playback_label_text = (
+            "Spotify authorizes playback separately from the connection above, so one more "
+            "step is needed before Music Assistant can play your music.\n\n"
+            "1. Open the Spotify app on your phone, tablet or computer, signed in with this "
+            "same account.\n"
+            f"2. Press the button below, then pick '{PAIRING_DEVICE_NAME}' in the Spotify app, "
+            "the way you would pick a speaker.\n\n"
+            f"If '{PAIRING_DEVICE_NAME}' does not appear in the Spotify app, for example "
+            "because Music Assistant runs in a container without access to your home network, "
+            "use the web browser option instead."
+        )
+    elif action in (
+        CONF_ACTION_AUTH_PLAYBACK,
+        CONF_ACTION_AUTH_PLAYBACK_BROWSER,
+        CONF_ACTION_AUTH_PLAYBACK_SUBMIT,
+    ):
+        playback_label_text = "Playback authorized. Don't forget to save to complete setup."
+    else:
+        playback_label_text = "Playback is authorized. No further action required."
 
     # Build dev label text
     if action == CONF_ACTION_AUTH_DEV:
@@ -173,6 +382,81 @@ async def get_config_entries(
             required=False,
             # Show only when authenticated
             hidden=not global_authenticated,
+        ),
+        # Playback authorization section
+        ConfigEntry(
+            key="playback_label_text",
+            type=ConfigEntryType.LABEL,
+            label=playback_label_text,
+            # Show only when global auth is complete
+            hidden=not global_authenticated,
+        ),
+        ConfigEntry(
+            key=CONF_LIBRESPOT_CREDENTIALS,
+            type=ConfigEntryType.SECURE_STRING,
+            label=CONF_LIBRESPOT_CREDENTIALS,
+            hidden=True,
+            # required without a default keeps the config from being saved (and the provider
+            # from being loaded and failing) before playback has been authorized
+            required=True,
+            value=values.get(CONF_LIBRESPOT_CREDENTIALS) if values else None,
+        ),
+        ConfigEntry(
+            key=CONF_ACTION_AUTH_PLAYBACK,
+            type=ConfigEntryType.ACTION,
+            label="Authorize playback with the Spotify app",
+            description="Advertises Music Assistant in the Spotify app for a few minutes, "
+            "so you can select it there to authorize playback.",
+            action=CONF_ACTION_AUTH_PLAYBACK,
+            action_label="Authorize playback",
+            required=False,
+            # Show only when the account is connected but playback is not authorized yet
+            hidden=not global_authenticated or playback_authorized,
+        ),
+        ConfigEntry(
+            key=CONF_ACTION_AUTH_PLAYBACK_BROWSER,
+            type=ConfigEntryType.ACTION,
+            label="Authorize playback with a web browser",
+            description="Opens Spotify in a new browser tab to authorize playback. Use this "
+            "when Music Assistant does not appear in the Spotify app.",
+            action=CONF_ACTION_AUTH_PLAYBACK_BROWSER,
+            action_label="Authorize in browser",
+            required=False,
+            hidden=not global_authenticated or playback_authorized,
+        ),
+        ConfigEntry(
+            key=CONF_PLAYBACK_CALLBACK_URL,
+            type=ConfigEntryType.STRING,
+            label="Address from your browser",
+            description="After approving playback, your browser ends up on a page that cannot "
+            "be reached. That is expected: copy the full address of that page to here and press "
+            "the button below.",
+            required=False,
+            default_value="",
+            value=values.get(CONF_PLAYBACK_CALLBACK_URL, "") if values else "",
+            # Show only while a browser sign-in is waiting to be finished
+            hidden=not browser_auth_pending,
+        ),
+        ConfigEntry(
+            key=CONF_ACTION_AUTH_PLAYBACK_SUBMIT,
+            type=ConfigEntryType.ACTION,
+            label="Complete the browser authorization",
+            description="Finishes the authorization with the address you copied above.",
+            action=CONF_ACTION_AUTH_PLAYBACK_SUBMIT,
+            action_label="Complete authorization",
+            required=False,
+            hidden=not browser_auth_pending,
+        ),
+        ConfigEntry(
+            key=CONF_ACTION_CLEAR_AUTH_PLAYBACK,
+            type=ConfigEntryType.ACTION,
+            label="Clear playback authorization",
+            description="Clear the current playback authorization to authorize it again.",
+            action=CONF_ACTION_CLEAR_AUTH_PLAYBACK,
+            action_label="Clear playback authorization",
+            required=False,
+            # Show only when playback is authorized
+            hidden=not playback_authorized,
         ),
         # Developer API section
         ConfigEntry(

--- a/music_assistant/providers/spotify/__init__.py
+++ b/music_assistant/providers/spotify/__init__.py
@@ -83,7 +83,10 @@ SUPPORTED_FEATURES = {
 # memory only: the authorization code it belongs to expires within minutes anyway.
 _PENDING_BROWSER_AUTH: dict[str, str] = {}
 # The pairing daemon keeps advertising until it is selected or times out, so it is tracked to
-# make a second attempt replace the first one.
+# make a second attempt replace the first one. Deliberately one slot for the whole server, not
+# one per provider instance: every daemon advertises under the same name, so two at once would
+# show up as two identical devices in the Spotify app and the credential could end up on the
+# instance for the other account.
 _PAIRING_ATTEMPT: dict[str, asyncio.Task[str]] = {}
 
 
@@ -226,6 +229,9 @@ async def _authorize_playback_via_browser(
         # the loopback target is only reachable when the browser runs on this host; everyone
         # else copies the address from their browser into the config instead
         _clear_playback_auth_values(values)
+        # only one sign-in can be pending: a verifier is worthless once its code expires, so
+        # dropping any older one keeps abandoned attempts from piling up
+        _PENDING_BROWSER_AUTH.clear()
         _PENDING_BROWSER_AUTH[session_id] = code_verifier
         return None
 
@@ -257,8 +263,8 @@ async def _complete_playback_auth_via_browser(
 
 
 def _clear_playback_auth_values(values: dict[str, ConfigValueType]) -> None:
-    """Reset the playback authorization values, including any half-finished browser sign-in."""
-    _PENDING_BROWSER_AUTH.clear()
+    """Reset the playback authorization values, including this session's browser sign-in."""
+    _PENDING_BROWSER_AUTH.pop(str(values.get("session_id")), None)
     values[CONF_LIBRESPOT_CREDENTIALS] = None
     values[CONF_PLAYBACK_CALLBACK_URL] = None
 

--- a/music_assistant/providers/spotify/constants.py
+++ b/music_assistant/providers/spotify/constants.py
@@ -13,6 +13,37 @@ CONF_ACTION_CLEAR_AUTH = "clear_auth"
 CONF_ACTION_CLEAR_AUTH_DEV = "clear_auth_dev"
 CONF_SYNC_PODCAST_PROGRESS = "sync_podcast_progress"
 CONF_SYNC_AUDIOBOOK_PROGRESS = "sync_audiobook_progress"
+CONF_LIBRESPOT_CREDENTIALS = "librespot_credentials"  # librespot's reusable stored credential
+CONF_ACTION_AUTH_PLAYBACK = "auth_playback"
+CONF_ACTION_AUTH_PLAYBACK_BROWSER = "auth_playback_browser"
+CONF_ACTION_AUTH_PLAYBACK_SUBMIT = "auth_playback_submit"
+CONF_ACTION_CLEAR_AUTH_PLAYBACK = "clear_auth_playback"
+CONF_PLAYBACK_CALLBACK_URL = "playback_callback_url"
+
+# Librespot playback authorization
+#
+# Spotify's login5 endpoint only accepts a stored credential that was minted with the same
+# client id librespot presents, which is always Spotify's own "keymaster" id. A credential
+# minted with MA's (or a user's) client id is rejected, so the playback credential has to be
+# obtained separately from the Web API tokens.
+KEYMASTER_CLIENT_ID = "65b708073fc0480ea92a077233ca87bd"
+LIBRESPOT_SCOPE = ["streaming"]
+# keymaster accepts loopback redirect URIs only, so the browser flow cannot use MA's hosted
+# callback. Music Assistant serves the loopback target itself, which works when the browser
+# runs on the same host; otherwise the browser lands on a dead URL that the user pastes back.
+LIBRESPOT_REDIRECT_PORT = 5588
+LIBRESPOT_REDIRECT_PATH = "/login"
+LIBRESPOT_REDIRECT_URI = f"http://127.0.0.1:{LIBRESPOT_REDIRECT_PORT}{LIBRESPOT_REDIRECT_PATH}"
+LOOPBACK_WAIT_TIMEOUT = 30  # seconds before offering the manual paste instead
+# name advertised to the Spotify app while pairing; also shown in the instructions
+PAIRING_DEVICE_NAME = "Music Assistant"
+PAIRING_TIMEOUT = 120  # seconds the pairing action waits for the user to pick the device
+CHECK_AUTH_TIMEOUT = 30  # seconds
+CREDENTIALS_FILE = "credentials.json"
+PLAYBACK_AUTH_REQUIRED_ERROR = (
+    "Spotify playback authorization required: open the Spotify settings in Music Assistant "
+    "and authorize playback."
+)
 
 # OAuth Settings
 SCOPE = [

--- a/music_assistant/providers/spotify/helpers.py
+++ b/music_assistant/providers/spotify/helpers.py
@@ -3,24 +3,46 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import platform
+import tempfile
 import time
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import pkce
-from music_assistant_models.errors import LoginFailed
+from aiohttp import web
+from music_assistant_models.errors import InvalidDataError, LoginFailed
 
 from music_assistant.helpers.auth import AuthenticationHelper
-from music_assistant.helpers.process import check_output
+from music_assistant.helpers.json import json_loads
+from music_assistant.helpers.process import AsyncProcess, check_output
 
-from .constants import CALLBACK_REDIRECT_URL, SCOPE
+from .constants import (
+    CALLBACK_REDIRECT_URL,
+    CHECK_AUTH_TIMEOUT,
+    CREDENTIALS_FILE,
+    KEYMASTER_CLIENT_ID,
+    LIBRESPOT_REDIRECT_URI,
+    LIBRESPOT_SCOPE,
+    SCOPE,
+)
 
 if TYPE_CHECKING:
     import aiohttp
 
     from music_assistant import MusicAssistant
+
+LOGGER = logging.getLogger(__name__)
+
+LOOPBACK_RESPONSE_HTML = """
+<html>
+<body onload="window.close();">
+    Playback approved, you may now close this window and return to Music Assistant.
+</body>
+</html>
+"""
 
 
 async def get_librespot_binary() -> str:
@@ -46,6 +68,178 @@ async def get_librespot_binary() -> str:
 
     msg = f"Unable to locate Librespot for {system}/{architecture}"
     raise RuntimeError(msg)
+
+
+async def librespot_credentials_via_pairing(
+    librespot_bin: str, device_name: str, timeout: float
+) -> str:
+    """
+    Advertise a Spotify Connect device and return the credential librespot stores once paired.
+
+    :param librespot_bin: Path to the librespot binary.
+    :param device_name: Device name to advertise to the Spotify app.
+    :param timeout: Seconds to wait for the user to select the device.
+    :raises TimeoutError: When the device was not selected within the timeout.
+    """
+    with tempfile.TemporaryDirectory() as cache_dir:
+        args = [
+            librespot_bin,
+            "--cache",
+            cache_dir,
+            "--disable-audio-cache",
+            "--backend",
+            "pipe",
+            "--name",
+            device_name,
+        ]
+        # stdout carries decoded audio once the user hits play; discard it so the pairing
+        # daemon never blocks on a pipe nobody reads
+        async with AsyncProcess(
+            args, stdout=asyncio.subprocess.DEVNULL, stderr=True, name="librespot-pairing"
+        ) as librespot_proc:
+            # librespot advertises over mDNS, which fails silently in host-network-less
+            # containers; without its log the user would just watch the action time out
+            librespot_proc.attach_stderr_reader(
+                asyncio.create_task(_log_pairing_output(librespot_proc))
+            )
+            # bound the wait inside the context manager so the daemon is always reaped
+            async with asyncio.timeout(timeout):
+                return await _await_credentials_file(cache_dir)
+
+
+async def librespot_credentials_via_token(librespot_bin: str, access_token: str) -> str:
+    """
+    Exchange a keymaster access token for librespot's reusable stored credential.
+
+    :param librespot_bin: Path to the librespot binary.
+    :param access_token: Spotify access token minted with the keymaster client id.
+    :raises LoginFailed: When librespot could not turn the token into a stored credential.
+    """
+    with tempfile.TemporaryDirectory() as cache_dir:
+        returncode, output = await check_output(
+            librespot_bin,
+            "--cache",
+            cache_dir,
+            "--check-auth",
+            "--access-token",
+            access_token,
+            timeout=CHECK_AUTH_TIMEOUT,
+        )
+        if returncode != 0:
+            raise LoginFailed(
+                f"Librespot rejected the playback authorization: {output.decode().strip()}"
+            )
+        credentials_file = os.path.join(cache_dir, CREDENTIALS_FILE)
+        if not os.path.exists(credentials_file):
+            raise LoginFailed("Librespot did not store a playback credential")
+        return await asyncio.to_thread(_read_credentials_file, credentials_file)
+
+
+async def await_loopback_authorization(port: int, path: str, timeout: float) -> dict[str, str]:
+    """
+    Serve the loopback redirect target and return the OAuth params the browser arrives with.
+
+    Only reachable when the browser runs on the same host as Music Assistant; callers are
+    expected to offer a manual fallback for everyone else.
+
+    :param port: Loopback port to listen on.
+    :param path: Request path the redirect URI points at.
+    :param timeout: Seconds to wait for the browser to arrive.
+    :raises OSError: When the port cannot be bound.
+    :raises TimeoutError: When no browser arrived within the timeout.
+    """
+    received: asyncio.Future[dict[str, str]] = asyncio.get_running_loop().create_future()
+
+    async def handle(request: web.Request) -> web.Response:
+        if not received.done():
+            received.set_result(dict(request.query))
+        return web.Response(text=LOOPBACK_RESPONSE_HTML, content_type="text/html")
+
+    app = web.Application()
+    app.router.add_get(path, handle)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    try:
+        await web.TCPSite(runner, "127.0.0.1", port).start()
+        async with asyncio.timeout(timeout):
+            return await received
+    finally:
+        await runner.cleanup()
+
+
+def keymaster_authorize_url(code_challenge: str) -> str:
+    """
+    Return the Spotify authorize URL that grants a credential librespot can use for playback.
+
+    :param code_challenge: PKCE code challenge derived from the verifier kept for the exchange.
+    """
+    params = {
+        "response_type": "code",
+        "client_id": KEYMASTER_CLIENT_ID,
+        "scope": " ".join(LIBRESPOT_SCOPE),
+        "code_challenge_method": "S256",
+        "code_challenge": code_challenge,
+        "redirect_uri": LIBRESPOT_REDIRECT_URI,
+    }
+    return f"https://accounts.spotify.com/authorize?{urlencode(params)}"
+
+
+async def keymaster_access_token(
+    http_session: aiohttp.ClientSession, code: str, code_verifier: str
+) -> str:
+    """
+    Redeem an authorization code from the playback sign-in for an access token.
+
+    :param http_session: aiohttp client session.
+    :param code: Authorization code returned by Spotify.
+    :param code_verifier: PKCE code verifier belonging to the authorize request.
+    :raises LoginFailed: When Spotify refuses the code.
+    """
+    token_params = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": LIBRESPOT_REDIRECT_URI,
+        "client_id": KEYMASTER_CLIENT_ID,
+        "code_verifier": code_verifier,
+    }
+    async with http_session.post(
+        "https://accounts.spotify.com/api/token", data=token_params
+    ) as response:
+        if response.status != 200:
+            raise LoginFailed(f"Failed to get playback access token: {await response.text()}")
+        token_result: dict[str, Any] = await response.json()
+    if not (access_token := token_result.get("access_token")):
+        raise LoginFailed("Spotify returned no playback access token")
+    return str(access_token)
+
+
+def authorization_code_from_params(params: dict[str, str]) -> str:
+    """
+    Return the authorization code from the query params Spotify redirected with.
+
+    :param params: Query params as received on the redirect.
+    :raises InvalidDataError: When the params carry no usable authorization code.
+    """
+    if code := params.get("code"):
+        return code
+    error = params.get("error") or "no authorization code was returned"
+    raise InvalidDataError(f"Playback authorization failed: {error}")
+
+
+def authorization_code_from_url(url: str) -> str:
+    """
+    Return the authorization code from a redirect URL the user pasted back into the config.
+
+    Spotify only accepts a loopback redirect for the playback client id, so the browser cannot
+    reach Music Assistant and the user copies the URL it landed on instead.
+
+    :param url: The full redirect URL, as pasted by the user.
+    :raises InvalidDataError: When the URL carries no usable authorization code.
+    """
+    query = parse_qs(urlparse(url.strip()).query)
+    return authorization_code_from_params(
+        {key: values[0] for key, values in query.items() if values}
+    )
 
 
 async def get_spotify_token(
@@ -141,3 +335,35 @@ async def pkce_auth_flow(
         token_result = await response.json()
 
     return str(token_result["refresh_token"])
+
+
+async def _log_pairing_output(librespot_proc: AsyncProcess) -> None:
+    """Log the pairing daemon's output so a failure to advertise is diagnosable."""
+    async for line in librespot_proc.iter_stderr():
+        if "ERROR" in line or "WARN" in line:
+            LOGGER.warning("[librespot-pairing] %s", line)
+        else:
+            LOGGER.debug("[librespot-pairing] %s", line)
+
+
+async def _await_credentials_file(cache_dir: str) -> str:
+    """Poll librespot's cache directory until it holds a complete credential file."""
+    credentials_file = os.path.join(cache_dir, CREDENTIALS_FILE)
+    while True:
+        if os.path.exists(credentials_file):
+            try:
+                return await asyncio.to_thread(_read_credentials_file, credentials_file)
+            except OSError, ValueError:
+                # the file was caught mid-write; fall through and retry
+                pass
+        await asyncio.sleep(1)
+
+
+def _read_credentials_file(credentials_file: str) -> str:
+    """Read and validate librespot's credential file, returning its raw contents."""
+    with open(credentials_file, encoding="utf-8") as fileobj:
+        contents = fileobj.read()
+    if not json_loads(contents).get("auth_data"):
+        msg = "Incomplete librespot credential file"
+        raise ValueError(msg)
+    return contents

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 from collections.abc import AsyncGenerator
@@ -47,18 +48,20 @@ from orjson import JSONDecodeError
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
 from music_assistant.helpers.json import json_loads
-from music_assistant.helpers.process import check_output
 from music_assistant.helpers.throttle_retry import ThrottlerManager, throttle_with_retries
 from music_assistant.helpers.util import lock
 from music_assistant.models.music_provider import MusicProvider
 
 from .constants import (
     CONF_CLIENT_ID,
+    CONF_LIBRESPOT_CREDENTIALS,
     CONF_REFRESH_TOKEN_DEV,
     CONF_REFRESH_TOKEN_GLOBAL,
     CONF_SYNC_AUDIOBOOK_PROGRESS,
     CONF_SYNC_PODCAST_PROGRESS,
+    CREDENTIALS_FILE,
     LIKED_SONGS_FAKE_PLAYLIST_ID_PREFIX,
+    PLAYBACK_AUTH_REQUIRED_ERROR,
 )
 from .helpers import get_librespot_binary, get_spotify_token
 from .parsers import (
@@ -100,6 +103,8 @@ class SpotifyProvider(MusicProvider):
 
         # check if we have a librespot binary for this arch
         self._librespot_bin = await get_librespot_binary()
+        # playback authorization is independent of the Web API tokens
+        await self._setup_librespot_auth()
         # try login which will raise if it fails (logs in global session)
         await self.login()
 
@@ -127,6 +132,10 @@ class SpotifyProvider(MusicProvider):
                 "See https://support.spotify.com/us/authors/article/audiobooks-availability/ "
                 "for supported countries."
             )
+
+    def discard_playback_credentials(self) -> None:
+        """Forget the stored playback credential, so the settings ask to authorize again."""
+        self._update_config_value(CONF_LIBRESPOT_CREDENTIALS, None)
 
     @property
     def audiobooks_supported(self) -> bool:
@@ -889,11 +898,6 @@ class SpotifyProvider(MusicProvider):
             CONF_REFRESH_TOKEN_GLOBAL, auth_info["refresh_token"], encrypted=True
         )
 
-        # Setup librespot with global token only if dev token is not configured
-        # (if dev token exists, librespot will be set up in login_dev instead)
-        if not self.config.get_value(CONF_REFRESH_TOKEN_DEV):
-            await self._setup_librespot_auth(auth_info["access_token"])
-
         # get logged-in user info
         if not self._sp_user:
             self._sp_user = userinfo = await self._get_data(
@@ -948,41 +952,33 @@ class SpotifyProvider(MusicProvider):
             CONF_REFRESH_TOKEN_DEV, auth_info["refresh_token"], encrypted=True
         )
 
-        # Setup librespot with dev token (preferred over global token)
-        await self._setup_librespot_auth(auth_info["access_token"])
-
         self.logger.info("Successfully logged in to Spotify developer session")
         return auth_info
 
-    async def _setup_librespot_auth(self, access_token: str) -> None:
+    async def _setup_librespot_auth(self) -> None:
         """
-        Set up librespot authentication with the given access token.
+        Install the stored playback credential into librespot's cache directory.
 
-        :param access_token: Spotify access token to use for librespot authentication.
+        :raises LoginFailed: When no playback credential is configured, which requires the
+            user to authorize playback from the provider settings.
         """
         if self._librespot_bin is None:
             raise LoginFailed("Librespot binary not available")
+        credentials = self.config.get_value(CONF_LIBRESPOT_CREDENTIALS)
+        if not credentials:
+            # Spotify's login5 refuses credentials minted with any client id other than the one
+            # librespot presents, so installs predating the dedicated playback credential (and
+            # anything cached from before) cannot stream and must authorize playback again.
+            raise LoginFailed(PLAYBACK_AUTH_REQUIRED_ERROR)
+        await asyncio.to_thread(self._write_librespot_credentials, self.cache_dir, str(credentials))
 
-        args = [
-            self._librespot_bin,
-            "--cache",
-            self.cache_dir,
-            "--check-auth",
-        ]
-        ret_code, stdout = await check_output(*args)
-        if ret_code != 0:
-            # cached librespot creds are invalid, re-authenticate
-            # we can use the check-token option to send a new token to librespot
-            # librespot will then get its own token from spotify (somehow) and cache that.
-            args += [
-                "--access-token",
-                access_token,
-            ]
-            ret_code, stdout = await check_output(*args)
-            if ret_code != 0:
-                # this should not happen, but guard it just in case
-                err_str = stdout.decode("utf-8").strip()
-                raise LoginFailed(f"Failed to verify credentials on Librespot: {err_str}")
+    @staticmethod
+    def _write_librespot_credentials(cache_dir: str, credentials: str) -> None:
+        """Write the stored credential to librespot's cache, replacing any stale one."""
+        os.makedirs(cache_dir, exist_ok=True)
+        credentials_file = os.path.join(cache_dir, CREDENTIALS_FILE)
+        with open(credentials_file, "w", encoding="utf-8") as fileobj:
+            fileobj.write(credentials)
 
     async def _get_auth_info(self, use_global_session: bool = False) -> dict[str, Any]:
         """

--- a/music_assistant/providers/spotify/streaming.py
+++ b/music_assistant/providers/spotify/streaming.py
@@ -13,6 +13,8 @@ from music_assistant_models.errors import AudioError
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.process import AsyncProcess
 
+from .constants import PLAYBACK_AUTH_REQUIRED_ERROR
+
 if TYPE_CHECKING:
     from music_assistant_models.streamdetails import StreamDetails
 
@@ -81,6 +83,13 @@ class LibrespotStreamer:
                     log_history.append(line)
                     if "ERROR" in line or "WARNING" in line:
                         logger.warning("[librespot] %s", line)
+                        if "INVALID_CREDENTIALS" in line and self.provider.available:
+                            # Spotify refused the stored playback credential. Drop it and unload
+                            # with an error: the provider settings then offer to authorize
+                            # playback again, instead of claiming playback is still authorized
+                            # while every track fails.
+                            self.provider.discard_playback_credentials()
+                            self.provider.unload_with_error(PLAYBACK_AUTH_REQUIRED_ERROR)
                         if "unable to" in line.lower() or "skipping" in line.lower():
                             # if librespot reports a fatal error (e.g. unable to load
                             # or read audio), terminate the process to avoid hanging

--- a/tests/providers/spotify/__init__.py
+++ b/tests/providers/spotify/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spotify provider."""

--- a/tests/providers/spotify/test_playback_auth.py
+++ b/tests/providers/spotify/test_playback_auth.py
@@ -1,0 +1,280 @@
+"""
+Tests for the Spotify provider's playback (librespot) authorization.
+
+Spotify's login5 endpoint only accepts a stored credential minted with the same client id
+librespot presents, so the playback credential is collected separately from the Web API tokens
+and installed into librespot's cache directory on load. An install without one cannot stream
+and has to authorize playback from the provider settings.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
+from music_assistant_models.errors import InvalidDataError, LoginFailed
+
+from music_assistant.providers.spotify import _PENDING_BROWSER_AUTH, get_config_entries
+from music_assistant.providers.spotify.constants import (
+    CONF_ACTION_AUTH_PLAYBACK,
+    CONF_ACTION_AUTH_PLAYBACK_BROWSER,
+    CONF_ACTION_AUTH_PLAYBACK_SUBMIT,
+    CONF_ACTION_CLEAR_AUTH,
+    CONF_ACTION_CLEAR_AUTH_PLAYBACK,
+    CONF_LIBRESPOT_CREDENTIALS,
+    CONF_PLAYBACK_CALLBACK_URL,
+    CONF_REFRESH_TOKEN_GLOBAL,
+    CREDENTIALS_FILE,
+)
+from music_assistant.providers.spotify.helpers import authorization_code_from_url
+from music_assistant.providers.spotify.provider import SpotifyProvider
+
+STORED_CREDENTIALS = '{"username": "tester", "auth_type": 1, "auth_data": "blob"}'
+
+
+@pytest.fixture(autouse=True)
+def _clean_pending_browser_auth() -> Generator[None]:
+    """Keep the in-memory pending sign-in state from leaking between tests."""
+    _PENDING_BROWSER_AUTH.clear()
+    yield
+    _PENDING_BROWSER_AUTH.clear()
+
+
+async def test_stored_credential_is_installed_for_librespot(tmp_path: Path) -> None:
+    """The stored credential is written to librespot's cache so login5 accepts it."""
+    cache_dir = tmp_path / "cache"
+    prov = _make_provider(STORED_CREDENTIALS, str(cache_dir))
+    await prov._setup_librespot_auth()
+    written = json.loads((cache_dir / CREDENTIALS_FILE).read_text(encoding="utf-8"))
+    assert written["auth_data"] == "blob"
+
+
+async def test_stale_cached_credential_is_replaced(tmp_path: Path) -> None:
+    """A credential left in the cache from an earlier (now rejected) mint is overwritten."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    credentials_file = cache_dir / CREDENTIALS_FILE
+    credentials_file.write_text('{"username": "tester", "auth_data": "stale"}', encoding="utf-8")
+    prov = _make_provider(STORED_CREDENTIALS, str(cache_dir))
+    await prov._setup_librespot_auth()
+    written = json.loads(credentials_file.read_text(encoding="utf-8"))
+    assert written["auth_data"] == "blob"
+
+
+async def test_missing_credential_fails_the_load(tmp_path: Path) -> None:
+    """Without a stored credential the provider refuses to load, pointing at the settings."""
+    prov = _make_provider(None, str(tmp_path / "cache"))
+    with pytest.raises(LoginFailed, match="authorization required"):
+        await prov._setup_librespot_auth()
+
+
+async def test_pairing_action_stores_the_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Selecting Music Assistant in the Spotify app stores the credential for playback."""
+    _patch_librespot(monkeypatch)
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.librespot_credentials_via_pairing",
+        AsyncMock(return_value=STORED_CREDENTIALS),
+    )
+    values = _authenticated_values()
+
+    entries = await _get_entries(action=CONF_ACTION_AUTH_PLAYBACK, values=values)
+
+    assert values[CONF_LIBRESPOT_CREDENTIALS] == STORED_CREDENTIALS
+    # with playback authorized, the authorize buttons make way for the clear action
+    assert _entry(entries, CONF_ACTION_AUTH_PLAYBACK).hidden
+    assert not _entry(entries, CONF_ACTION_CLEAR_AUTH_PLAYBACK).hidden
+
+
+async def test_pairing_timeout_points_at_the_browser_option(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the device is never selected, the error names the fallback instead of just failing."""
+    _patch_librespot(monkeypatch)
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.librespot_credentials_via_pairing",
+        AsyncMock(side_effect=TimeoutError),
+    )
+
+    with pytest.raises(LoginFailed, match="web browser"):
+        await _get_entries(action=CONF_ACTION_AUTH_PLAYBACK, values=_authenticated_values())
+
+
+async def test_browser_action_falls_back_to_pasting_the_address(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the browser cannot reach Music Assistant, the paste field is revealed instead."""
+    _patch_librespot(monkeypatch)
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.await_loopback_authorization",
+        AsyncMock(side_effect=TimeoutError),
+    )
+    values = _authenticated_values()
+
+    entries = await _get_entries(action=CONF_ACTION_AUTH_PLAYBACK_BROWSER, values=values)
+
+    assert not values[CONF_LIBRESPOT_CREDENTIALS]
+    # the parked verifier is what keeps the pending sign-in redeemable on the next action
+    assert _PENDING_BROWSER_AUTH["session"]
+    assert not _entry(entries, CONF_PLAYBACK_CALLBACK_URL).hidden
+    assert not _entry(entries, CONF_ACTION_AUTH_PLAYBACK_SUBMIT).hidden
+
+
+async def test_browser_action_completes_on_the_same_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A browser on the Music Assistant host reports back, so no pasting is needed."""
+    _patch_librespot(monkeypatch)
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.await_loopback_authorization",
+        AsyncMock(return_value={"code": "abc123"}),
+    )
+    values = _authenticated_values()
+
+    entries = await _get_entries(action=CONF_ACTION_AUTH_PLAYBACK_BROWSER, values=values)
+
+    assert values[CONF_LIBRESPOT_CREDENTIALS] == STORED_CREDENTIALS
+    assert not _PENDING_BROWSER_AUTH
+    assert _entry(entries, CONF_PLAYBACK_CALLBACK_URL).hidden
+
+
+async def test_pasted_address_completes_the_authorization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The address copied from the browser is redeemed into a playback credential."""
+    access_token = _patch_librespot(monkeypatch)
+    values = _authenticated_values()
+    _PENDING_BROWSER_AUTH["session"] = "verifier"
+    values[CONF_PLAYBACK_CALLBACK_URL] = "http://127.0.0.1:5588/login?code=abc123"
+
+    await _get_entries(action=CONF_ACTION_AUTH_PLAYBACK_SUBMIT, values=values)
+
+    assert access_token.await_args is not None
+    assert access_token.await_args.args[1:] == ("abc123", "verifier")
+    assert values[CONF_LIBRESPOT_CREDENTIALS] == STORED_CREDENTIALS
+    # the redeemed sign-in leaves nothing behind to retry with
+    assert not _PENDING_BROWSER_AUTH
+    assert not values[CONF_PLAYBACK_CALLBACK_URL]
+
+
+async def test_submit_without_a_started_signin_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Completing an authorization that was never started reports what to do first."""
+    _patch_librespot(monkeypatch)
+    values = _authenticated_values()
+    values[CONF_PLAYBACK_CALLBACK_URL] = "http://127.0.0.1:5588/login?code=abc123"
+
+    with pytest.raises(InvalidDataError):
+        await _get_entries(action=CONF_ACTION_AUTH_PLAYBACK_SUBMIT, values=values)
+
+
+async def test_rejected_credential_is_discarded(tmp_path: Path) -> None:
+    """A credential Spotify refuses is dropped, so playback can be authorized again."""
+    prov = _make_provider(STORED_CREDENTIALS, str(tmp_path / "cache"))
+    prov.discard_playback_credentials()
+    set_raw_value = cast("MagicMock", prov.mass.config.set_raw_provider_config_value)
+    set_raw_value.assert_called_once_with(prov.instance_id, CONF_LIBRESPOT_CREDENTIALS, None, False)
+
+
+async def test_settings_offer_authorization_when_not_authorized() -> None:
+    """Without a credential the authorize buttons are shown and the clear action is not."""
+    values = _authenticated_values()
+
+    entries = await _get_entries(action=CONF_ACTION_CLEAR_AUTH_PLAYBACK, values=values)
+
+    assert not _entry(entries, CONF_ACTION_AUTH_PLAYBACK).hidden
+    assert not _entry(entries, CONF_ACTION_AUTH_PLAYBACK_BROWSER).hidden
+    assert _entry(entries, CONF_ACTION_CLEAR_AUTH_PLAYBACK).hidden
+
+
+async def test_clearing_account_auth_clears_playback_authorization() -> None:
+    """The credential belongs to the connected account, so it goes when that account does."""
+    values = _authenticated_values()
+    values[CONF_LIBRESPOT_CREDENTIALS] = STORED_CREDENTIALS
+
+    await _get_entries(action=CONF_ACTION_CLEAR_AUTH, values=values)
+
+    assert not values[CONF_LIBRESPOT_CREDENTIALS]
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("http://127.0.0.1:5588/login?code=abc123", "abc123"),
+        ("  http://127.0.0.1:5588/login?code=abc123&state=x  ", "abc123"),
+        ("https://127.0.0.1:5588/login?state=x&code=abc123", "abc123"),
+    ],
+)
+def test_authorization_code_from_url(url: str, expected: str) -> None:
+    """The code is recovered from the (dead) loopback URL the user pastes back."""
+    assert authorization_code_from_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:5588/login?error=access_denied",
+        "not a url at all",
+        "",
+    ],
+)
+def test_authorization_code_from_url_rejects_unusable(url: str) -> None:
+    """A denied, empty or malformed paste is reported instead of silently proceeding."""
+    with pytest.raises(InvalidDataError):
+        authorization_code_from_url(url)
+
+
+def _make_provider(credentials: str | None, cache_dir: str) -> SpotifyProvider:
+    """Return a SpotifyProvider (bypassing __init__) with the given stored credential."""
+    prov = object.__new__(SpotifyProvider)
+    config = MagicMock(instance_id="spotify--test")
+    config.get_value = MagicMock(
+        side_effect=lambda key, default=None: (
+            credentials if key == CONF_LIBRESPOT_CREDENTIALS else default
+        )
+    )
+    prov.config = config
+    prov.logger = MagicMock()
+    prov.cache_dir = cache_dir
+    prov._librespot_bin = "/bin/librespot"
+    prov.mass = MagicMock()
+    return prov
+
+
+def _patch_librespot(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Stub out the librespot binary and token exchange, returning the token exchange mock."""
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.get_librespot_binary",
+        AsyncMock(return_value="/bin/librespot"),
+    )
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.librespot_credentials_via_token",
+        AsyncMock(return_value=STORED_CREDENTIALS),
+    )
+    access_token = AsyncMock(return_value="access-token")
+    monkeypatch.setattr("music_assistant.providers.spotify.keymaster_access_token", access_token)
+    return access_token
+
+
+def _authenticated_values() -> dict[str, ConfigValueType]:
+    """Return config values for an instance whose account is connected."""
+    return {
+        "session_id": "session",
+        CONF_REFRESH_TOKEN_GLOBAL: "refresh-token",
+        CONF_LIBRESPOT_CREDENTIALS: None,
+        CONF_PLAYBACK_CALLBACK_URL: None,
+    }
+
+
+async def _get_entries(action: str, values: dict[str, ConfigValueType]) -> tuple[ConfigEntry, ...]:
+    """Run the provider's config entries for the given action."""
+    mass: Any = MagicMock()
+    return await get_config_entries(mass, instance_id="spotify--test", action=action, values=values)
+
+
+def _entry(entries: tuple[ConfigEntry, ...], key: str) -> ConfigEntry:
+    """Return the config entry with the given key."""
+    return next(entry for entry in entries if entry.key == key)


### PR DESCRIPTION
# What does this implement/fix?

Spotify playback stopped working for everyone on 10 August: browsing and artwork still load, but every track fails with "No playable item found to start playback".

Spotify changed what it accepts when authorizing playback. It now only accepts a playback credential that was created with Spotify's own built-in app identity, and rejects one created with Music Assistant's. Playback is therefore authorized separately from the rest of the Spotify connection, from the Spotify settings.

Two ways to do it, so it works on every kind of network:

- **Spotify app (recommended)** — select Music Assistant once in the Spotify app, the way you would pick a speaker.
- **Web browser** — for setups where Music Assistant does not show up in the Spotify app, for example a different network or a container without home-network access.

Everyone using Spotify has to do this once. Until then, Spotify reports that it needs attention.

This is the `stable` counterpart of #5568. It cannot be a backport: `dev` hooks the extra step into its setup flow, which does not exist on `stable`, so here it is done with buttons in the Spotify settings.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6043

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Added buttons to the Spotify settings to authorize playback, through the Spotify app or through a web browser.
- Playback credentials are stored with the provider config and installed for librespot on load, instead of being derived from the Web API token.
- The Spotify settings cannot be saved until playback is authorized, so an incomplete setup no longer throws away the connection you just made.
- A playback credential that Spotify rejects is dropped and reported as an authentication problem, so the settings offer to authorize again instead of every track appearing unplayable.
- Provider errors that need attention are recorded again, so the reason shows in the UI instead of the provider being treated as removed.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
