### PR TITLE
Fix a brief audio hiccup on the first playback after starting the server

### DIFF
--- a/music_assistant/helpers/database.py
+++ b/music_assistant/helpers/database.py
@@ -88,14 +88,13 @@ class _LoopStallTracker:
 
     def release(self) -> None:
         """Stop sampling once the last user has released the tracker."""
-        if not ENABLE_DEBUG:
-            return
         self._users = max(0, self._users - 1)
         if self._users == 0 and self._task is not None:
             self._task.cancel()
             self._task = None
 
     async def _sample(self) -> None:
+        """Record how late each wake-up is, which is the time the loop was unavailable."""
         loop = asyncio.get_running_loop()
         while True:
             await asyncio.sleep(_STALL_SAMPLE_INTERVAL)
@@ -123,9 +122,11 @@ async def debug_query(
         LOGGER.error(f"{err}\n{sql_query}")
         raise
     finally:
-        # queries run on aiosqlite's connection thread, so the awaited wall time also covers
-        # any stretch the loop was blocked elsewhere and could not deliver the result. Discount
-        # that, otherwise an unrelated blocking callback reports as a slow query.
+        # queries run on aiosqlite's connection thread, so the awaited wall time also covers any
+        # stretch the loop was blocked elsewhere and could not deliver the result. Discounting
+        # that keeps an unrelated blocking callback from reporting as a slow query; a stall that
+        # overlaps a genuinely slow query is discounted too, so this under-reports rather than
+        # points at the wrong culprit.
         process_time = time.monotonic() - time_start - _loop_stalls.stalled_since(stalled_start)
         if process_time > SLOW_QUERY_THRESHOLD:
             # log slow queries
@@ -217,6 +218,7 @@ class DatabaseConnection:
         self._deferred_commit_depth: ContextVar[int] = ContextVar(
             "deferred_commit_depth", default=0
         )
+        self._tracking_loop_stalls = False
 
     async def setup(
         self,
@@ -252,13 +254,18 @@ class DatabaseConnection:
         await self.execute(f"PRAGMA cache_size = -{cache_size_kib};")
         await self.commit()
         _loop_stalls.acquire()
+        self._tracking_loop_stalls = True
 
     async def close(self) -> None:
         """Close db connection on exit."""
-        _loop_stalls.release()
         await self.execute("PRAGMA optimize;")
         await self.commit()
         await self._db.close()
+        # mirror the acquire in setup() exactly, so a connection that failed to set up or is
+        # closed twice cannot release a slot that belongs to one of the other connections
+        if self._tracking_loop_stalls:
+            self._tracking_loop_stalls = False
+            _loop_stalls.release()
 
     async def get_rows(
         self,

--- a/music_assistant/helpers/database.py
+++ b/music_assistant/helpers/database.py
@@ -47,6 +47,65 @@ UNSET: _UnsetType = _UnsetType()
 
 ENABLE_DEBUG = os.environ.get("PYTHONDEVMODE") == "1"
 
+SLOW_QUERY_THRESHOLD = 0.5
+_STALL_SAMPLE_INTERVAL = 0.05
+
+
+class _LoopStallTracker:
+    """Samples how long the event loop spends unavailable, so query timings can discount it."""
+
+    def __init__(self) -> None:
+        """Initialize class."""
+        self._total = 0.0
+        self._last_tick = 0.0
+        self._task: asyncio.Task[None] | None = None
+        self._users = 0
+
+    @property
+    def total(self) -> float:
+        """Return the stall time recorded so far, to pass to `stalled_since` later on."""
+        return self._total
+
+    def stalled_since(self, total: float) -> float:
+        """Return how long the event loop was unavailable since the given `total`."""
+        if self._task is None:
+            return 0.0
+        # a stall that is still in progress cannot have been sampled yet: the loop only frees
+        # up at its end and hands the awaiting query its result first, so the time the sampler
+        # is currently overdue by counts towards this window as well
+        overdue = asyncio.get_running_loop().time() - self._last_tick - _STALL_SAMPLE_INTERVAL
+        return self._total - total + max(0.0, overdue)
+
+    def acquire(self) -> None:
+        """Start sampling (if not already running) on behalf of one more user."""
+        if not ENABLE_DEBUG:
+            return
+        self._users += 1
+        if self._task is None:
+            loop = asyncio.get_running_loop()
+            self._last_tick = loop.time()
+            self._task = loop.create_task(self._sample())
+
+    def release(self) -> None:
+        """Stop sampling once the last user has released the tracker."""
+        if not ENABLE_DEBUG:
+            return
+        self._users = max(0, self._users - 1)
+        if self._users == 0 and self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    async def _sample(self) -> None:
+        loop = asyncio.get_running_loop()
+        while True:
+            await asyncio.sleep(_STALL_SAMPLE_INTERVAL)
+            now = loop.time()
+            self._total += max(0.0, now - self._last_tick - _STALL_SAMPLE_INTERVAL)
+            self._last_tick = now
+
+
+_loop_stalls = _LoopStallTracker()
+
 
 @asynccontextmanager
 async def debug_query(
@@ -56,15 +115,19 @@ async def debug_query(
     if not ENABLE_DEBUG:
         yield
         return
-    time_start = time.time()
+    time_start = time.monotonic()
+    stalled_start = _loop_stalls.total
     try:
         yield
     except OperationalError as err:
         LOGGER.error(f"{err}\n{sql_query}")
         raise
     finally:
-        process_time = time.time() - time_start
-        if process_time > 0.5:
+        # queries run on aiosqlite's connection thread, so the awaited wall time also covers
+        # any stretch the loop was blocked elsewhere and could not deliver the result. Discount
+        # that, otherwise an unrelated blocking callback reports as a slow query.
+        process_time = time.monotonic() - time_start - _loop_stalls.stalled_since(stalled_start)
+        if process_time > SLOW_QUERY_THRESHOLD:
             # log slow queries
             for key, value in (query_params or {}).items():
                 sql_query = sql_query.replace(f":{key}", repr(value))
@@ -188,9 +251,11 @@ class DatabaseConnection:
         await self.execute(f"PRAGMA mmap_size = {mmap_size_bytes};")
         await self.execute(f"PRAGMA cache_size = -{cache_size_kib};")
         await self.commit()
+        _loop_stalls.acquire()
 
     async def close(self) -> None:
         """Close db connection on exit."""
+        _loop_stalls.release()
         await self.execute("PRAGMA optimize;")
         await self.commit()
         await self._db.close()

--- a/music_assistant/helpers/database.py
+++ b/music_assistant/helpers/database.py
@@ -73,15 +73,16 @@ class _LoopStallTracker:
         overdue = asyncio.get_running_loop().time() - self._last_tick - _STALL_SAMPLE_INTERVAL
         return self._total + max(0.0, overdue)
 
-    def acquire(self) -> None:
-        """Start sampling (if not already running) on behalf of one more user."""
+    def acquire(self) -> bool:
+        """Start sampling on behalf of one more user; False when there is nothing to sample."""
         if not ENABLE_DEBUG:
-            return
+            return False
         self._users += 1
         if self._task is None:
             loop = asyncio.get_running_loop()
             self._last_tick = loop.time()
             self._task = loop.create_task(self._sample())
+        return True
 
     def release(self) -> None:
         """Stop sampling once the last user has released the tracker."""
@@ -250,8 +251,7 @@ class DatabaseConnection:
         await self.execute(f"PRAGMA mmap_size = {mmap_size_bytes};")
         await self.execute(f"PRAGMA cache_size = -{cache_size_kib};")
         await self.commit()
-        _loop_stalls.acquire()
-        self._tracking_loop_stalls = True
+        self._tracking_loop_stalls = _loop_stalls.acquire()
 
     async def close(self) -> None:
         """Close db connection on exit."""

--- a/music_assistant/helpers/database.py
+++ b/music_assistant/helpers/database.py
@@ -62,19 +62,16 @@ class _LoopStallTracker:
         self._users = 0
 
     @property
-    def total(self) -> float:
-        """Return the stall time recorded so far, to pass to `stalled_since` later on."""
-        return self._total
-
-    def stalled_since(self, total: float) -> float:
-        """Return how long the event loop was unavailable since the given `total`."""
+    def stalled(self) -> float:
+        """Return the total time the event loop was unavailable, to compare two readings of."""
         if self._task is None:
             return 0.0
-        # a stall that is still in progress cannot have been sampled yet: the loop only frees
-        # up at its end and hands the awaiting query its result first, so the time the sampler
-        # is currently overdue by counts towards this window as well
+        # the sampler can only record a stall once the loop frees up again, and it hands any
+        # awaiting query its result first, so a stall in progress lives in how overdue the
+        # sampler currently is. Counting it here as well keeps this reading continuous, which
+        # is what lets two readings bracket exactly the stalls that fall between them
         overdue = asyncio.get_running_loop().time() - self._last_tick - _STALL_SAMPLE_INTERVAL
-        return self._total - total + max(0.0, overdue)
+        return self._total + max(0.0, overdue)
 
     def acquire(self) -> None:
         """Start sampling (if not already running) on behalf of one more user."""
@@ -115,7 +112,7 @@ async def debug_query(
         yield
         return
     time_start = time.monotonic()
-    stalled_start = _loop_stalls.total
+    stalled_start = _loop_stalls.stalled
     try:
         yield
     except OperationalError as err:
@@ -127,7 +124,7 @@ async def debug_query(
         # that keeps an unrelated blocking callback from reporting as a slow query; a stall that
         # overlaps a genuinely slow query is discounted too, so this under-reports rather than
         # points at the wrong culprit.
-        process_time = time.monotonic() - time_start - _loop_stalls.stalled_since(stalled_start)
+        process_time = time.monotonic() - time_start - (_loop_stalls.stalled - stalled_start)
         if process_time > SLOW_QUERY_THRESHOLD:
             # log slow queries
             for key, value in (query_params or {}).items():

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -21,6 +21,7 @@ from music_assistant.constants import CONF_OUTPUT_CHANNELS
 from music_assistant.controllers.streams.audio_processing import get_media_session_id
 from music_assistant.helpers.audio import iter_pcm_slices
 from music_assistant.helpers.ffmpeg import FFMpeg
+from music_assistant.helpers.util import import_module_in_thread
 from music_assistant.models.player import PlayerMedia
 from music_assistant.providers.sendspin.bridge_role import (
     BRIDGE_BIT_DEPTH,
@@ -727,6 +728,11 @@ class SendspinPlaybackSession:
         Sendspin push stream, and commits audio continuously. Supports dynamic group
         membership changes and late-join historical backfill while running.
         """
+        # aiosendspin resamples and encodes with PyAV, which it imports lazily on first use -
+        # from inside commit_audio(), on the event loop. Pull that import forward to a thread,
+        # before the play timeline exists, so its cost can neither stall audio production nor
+        # push the timeline into a forward rebase.
+        await import_module_in_thread("av")
         # refresh the session PCM format from the leader's preferred output before
         # building any pipelines; member ffmpeg pipelines and pre-computed filter
         # params depend on this rate so the cache must also be cleared

--- a/tests/helpers/test_database_connection.py
+++ b/tests/helpers/test_database_connection.py
@@ -1,14 +1,17 @@
 """Tests for the DatabaseConnection helper."""
 
 import asyncio
+import logging
 import os
 import pathlib
+import time
 from collections.abc import AsyncGenerator
 from sqlite3 import OperationalError
 from typing import Any
 
 import pytest
 
+from music_assistant.helpers import database
 from music_assistant.helpers.database import (
     DatabaseConnection,
     get_sqlite_memory_settings,
@@ -27,6 +30,20 @@ TEMP_STORE_MEMORY = 2
 async def db_connection(tmp_path: pathlib.Path) -> AsyncGenerator[DatabaseConnection]:
     """Return an initialized DatabaseConnection backed by a temp file."""
     db = DatabaseConnection(str(tmp_path / "test.db"))
+    await db.setup()
+    yield db
+    await db.close()
+
+
+@pytest.fixture
+async def debug_db(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> AsyncGenerator[DatabaseConnection]:
+    """Return an initialized DatabaseConnection with slow query logging enabled."""
+    monkeypatch.setattr(database, "ENABLE_DEBUG", True)
+    # a fresh tracker per test so neither its sampler task nor its totals outlive this loop
+    monkeypatch.setattr(database, "_loop_stalls", database._LoopStallTracker())
+    db = DatabaseConnection(str(tmp_path / "debug.db"))
     await db.setup()
     yield db
     await db.close()
@@ -362,3 +379,32 @@ def test_query_params_leaves_prefixed_placeholders_untouched() -> None:
     )
     assert query == "SELECT * FROM items WHERE id IN (:_param_0) AND other = :ids_extra"
     assert params == {"_param_0": 1, "ids_extra": 2}
+
+
+async def test_slow_query_warning_ignores_event_loop_stalls(
+    debug_db: DatabaseConnection, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a query awaited across a blocked event loop is not reported as slow."""
+    monkeypatch.setattr(database, "SLOW_QUERY_THRESHOLD", 0.1)
+    with caplog.at_level(logging.WARNING, logger="music_assistant.database"):
+        query = asyncio.create_task(debug_db.get_rows_from_query("SELECT 1", limit=0))
+        # let the statement reach the connection thread, then hog the loop so its result
+        # cannot be delivered - exactly what a CPU-bound callback elsewhere would do
+        await asyncio.sleep(0)
+        time.sleep(0.5)  # noqa: ASYNC251  # blocking the loop is what is under test here
+        await query
+    assert "SQL Query took" not in caplog.text
+
+
+async def test_slow_query_warning_still_reports_a_slow_query(
+    debug_db: DatabaseConnection, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a query which genuinely keeps sqlite busy is still reported as slow."""
+    monkeypatch.setattr(database, "SLOW_QUERY_THRESHOLD", 0.02)
+    with caplog.at_level(logging.WARNING, logger="music_assistant.database"):
+        await debug_db.get_rows_from_query(
+            "WITH RECURSIVE cnt(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM cnt WHERE x < 2000000) "
+            "SELECT count(*) FROM cnt",
+            limit=0,
+        )
+    assert "SQL Query took" in caplog.text

--- a/tests/helpers/test_database_connection.py
+++ b/tests/helpers/test_database_connection.py
@@ -385,7 +385,7 @@ async def test_slow_query_warning_ignores_event_loop_stalls(
     debug_db: DatabaseConnection, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that a query awaited across a blocked event loop is not reported as slow."""
-    monkeypatch.setattr(database, "SLOW_QUERY_THRESHOLD", 0.1)
+    monkeypatch.setattr(database, "SLOW_QUERY_THRESHOLD", 0.2)
     with caplog.at_level(logging.WARNING, logger="music_assistant.database"):
         query = asyncio.create_task(debug_db.get_rows_from_query("SELECT 1", limit=0))
         # let the statement reach the connection thread, then hog the loop so its result

--- a/tests/helpers/test_database_connection.py
+++ b/tests/helpers/test_database_connection.py
@@ -25,6 +25,12 @@ GIB = 1024**3
 TEMP_STORE_FILE = 1
 TEMP_STORE_MEMORY = 2
 
+# keeps sqlite busy for well over the threshold the slow query tests set, without touching a table
+_SLOW_QUERY = (
+    "WITH RECURSIVE cnt(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM cnt WHERE x < 2000000) "
+    "SELECT count(*) FROM cnt"
+)
+
 
 @pytest.fixture
 async def db_connection(tmp_path: pathlib.Path) -> AsyncGenerator[DatabaseConnection]:
@@ -402,9 +408,18 @@ async def test_slow_query_warning_still_reports_a_slow_query(
     """Test that a query which genuinely keeps sqlite busy is still reported as slow."""
     monkeypatch.setattr(database, "SLOW_QUERY_THRESHOLD", 0.02)
     with caplog.at_level(logging.WARNING, logger="music_assistant.database"):
-        await debug_db.get_rows_from_query(
-            "WITH RECURSIVE cnt(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM cnt WHERE x < 2000000) "
-            "SELECT count(*) FROM cnt",
-            limit=0,
-        )
+        await debug_db.get_rows_from_query(_SLOW_QUERY, limit=0)
+    assert "SQL Query took" in caplog.text
+
+
+async def test_slow_query_warning_survives_a_stall_that_precedes_it(
+    debug_db: DatabaseConnection, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a stall ending before a query starts is not discounted from that query."""
+    monkeypatch.setattr(database, "SLOW_QUERY_THRESHOLD", 0.02)
+    with caplog.at_level(logging.WARNING, logger="music_assistant.database"):
+        # the sampler only books this stall once it next wakes, which is after the query below
+        # has already started and taken its own reading
+        time.sleep(0.5)  # noqa: ASYNC251  # stalling the loop is what is under test here
+        await debug_db.get_rows_from_query(_SLOW_QUERY, limit=0)
     assert "SQL Query took" in caplog.text


### PR DESCRIPTION
# What does this implement/fix?

The first time a Sendspin stream starts in a running server, the audio library it uses for
resampling and encoding was loaded on the event loop, right in the middle of producing the
first audio. That froze audio production for up to half a second, which left a hole in the
play timeline — bridged players reported it as a ~560ms realign, and every other player type
would be affected the same way. It only happens once per server run, on the first play.

Loading it up front, off the event loop, removes the hiccup. Second and later playbacks were
already fine and are unchanged.

While tracking this down, the "slow SQL query" debug warning turned out to be misleading: it
timed how long the server *waited* for a query, not how long the query took. Any unrelated
freeze got reported as a slow query, which is exactly what sent the first diagnosis down the
wrong path — the query it blamed actually runs in 0.05ms. It now discounts time the server
spent blocked elsewhere.

**Related issue (if applicable):**

- n/a — found while diagnosing the bridged AirPlay sync work in #5570

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Load PyAV in a thread when a Sendspin playback session starts, before the play timeline exists.
- Slow-query logging now subtracts time the event loop was blocked, so it only flags genuinely slow queries.
- Tests covering both directions of the slow-query warning.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
