### PR TITLE
Only return the Phish artist when the query matches its name

### DIFF
--- a/music_assistant/providers/phishin/helpers.py
+++ b/music_assistant/providers/phishin/helpers.py
@@ -414,7 +414,7 @@ def parse_search_results(
 
         return song_title
 
-    artists: list[Artist] = _parse_artists(provider, media_types)
+    artists: list[Artist] = _parse_artists(provider, media_types, search_term)
     albums: list[Album] = _parse_albums(provider, search_data, media_types, contains_search_term)
     tracks: list[Track] = _parse_tracks(
         provider, search_data, media_types, contains_search_term, strip_performance_indicators
@@ -426,10 +426,14 @@ def parse_search_results(
     return artists, albums, tracks, playlists
 
 
-def _parse_artists(provider: MusicProvider, media_types: list[MediaType]) -> list[Artist]:
+def _parse_artists(
+    provider: MusicProvider, media_types: list[MediaType], search_term: str
+) -> list[Artist]:
     """Parse artists from search results."""
     artists: list[Artist] = []
-    if MediaType.ARTIST in media_types:
+    # Phish.in hosts a single artist and its api has no artist search, so only
+    # claim a match when the query is the start of its name.
+    if MediaType.ARTIST in media_types and PHISH_ARTIST_NAME.lower().startswith(search_term):
         metadata = MediaItemMetadata(
             images=UniqueList(
                 [


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The Phish.in provider hosts a single artist, but returned it for every artist search regardless of the query. Only return it when the search query is a front-anchored substring of "Phish".

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
