### PR TITLE
Stop dating songs from hits compilations

### DIFF
--- a/music_assistant/providers/musicbrainz/provider.py
+++ b/music_assistant/providers/musicbrainz/provider.py
@@ -558,8 +558,8 @@ class MusicbrainzProvider(MetadataProvider):
         """
         Collect release groups for a recording with their release dates.
 
-        Filters out compilations, whether tagged as such or credited to Various Artists,
-        and other secondary-type releases.
+        Filters out secondary-type releases and compilations, including the ones credited
+        to Various Artists rather than tagged as such.
         For singles, only includes those where the title matches the track name.
         Returns list of (release_group, release_date) tuples for singles and studio albums.
 

--- a/music_assistant/providers/musicbrainz/provider.py
+++ b/music_assistant/providers/musicbrainz/provider.py
@@ -13,6 +13,7 @@ from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import MediaItemLink, MediaItemMetadata, UniqueList
 from music_assistant_models.media_items.metadata import LifeSpan
 
+from music_assistant.constants import VARIOUS_ARTISTS_MBID
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.compare import compare_strings
 from music_assistant.helpers.util import parse_title_and_version
@@ -557,7 +558,8 @@ class MusicbrainzProvider(MetadataProvider):
         """
         Collect release groups for a recording with their release dates.
 
-        Filters out compilations and other secondary-type releases.
+        Filters out compilations, whether tagged as such or credited to Various Artists,
+        and other secondary-type releases.
         For singles, only includes those where the title matches the track name.
         Returns list of (release_group, release_date) tuples for singles and studio albums.
 
@@ -575,6 +577,12 @@ class MusicbrainzProvider(MetadataProvider):
             # Skip bootleg and pseudo-releases
             release_status = release.get("status", "")
             if release_status in ("Bootleg", "Pseudo-Release"):
+                continue
+
+            # Plenty of hits compilations carry no Compilation secondary type, so they pass
+            # for studio albums. Their releases are credited to Various Artists, which an
+            # album or single of one artist never is.
+            if _is_various_artists_release(release):
                 continue
 
             rg = release.get("release-group", {})
@@ -639,6 +647,20 @@ class MusicbrainzProvider(MetadataProvider):
             if (year := _release_year(release_group.get("first-release-date") or "")) is not None
         ]
         return min(years, default=None)
+
+
+def _is_various_artists_release(release: dict[str, Any]) -> bool:
+    """
+    Return whether a MusicBrainz release is credited to Various Artists.
+
+    :param release: MusicBrainz release dict from a recording search.
+    """
+    # MusicBrainz always credits the Various Artists entity by id, while its display name is
+    # localized and other artists are named after it, so only the id identifies it.
+    return any(
+        (credit.get("artist") or {}).get("id") == VARIOUS_ARTISTS_MBID
+        for credit in release.get("artist-credit") or ()
+    )
 
 
 def _release_year(release_date: str) -> int | None:

--- a/tests/providers/musicbrainz/test_provider.py
+++ b/tests/providers/musicbrainz/test_provider.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.errors import RateLimited
 
+from music_assistant.constants import VARIOUS_ARTISTS_MBID
 from music_assistant.providers.musicbrainz.provider import MusicbrainzProvider
 
 # ---------------------------------------------------------------------------
@@ -181,6 +182,11 @@ async def test_recordings_by_isrc_rejects_a_malformed_isrc() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _credit(name: str, artist_id: str) -> dict[str, Any]:
+    """Return one artist credit of a release."""
+    return {"name": name, "artist": {"id": artist_id, "name": name, "sort-name": name}}
+
+
 def _release(
     date: str,
     *,
@@ -188,6 +194,7 @@ def _release(
     primary_type: str = "Album",
     secondary_types: list[str] | None = None,
     status: str = "Official",
+    credit: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Return one release of a searched recording."""
     release: dict[str, Any] = {
@@ -203,6 +210,8 @@ def _release(
     }
     if secondary_types:
         release["release-group"]["secondary-types"] = secondary_types
+    if credit is not None:
+        release["artist-credit"] = [credit]
     return release
 
 
@@ -266,6 +275,74 @@ async def test_release_year_by_track_name_ignores_untrustworthy_releases() -> No
     )
 
     assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") == 1975
+
+
+async def test_release_year_by_track_name_ignores_a_various_artists_release() -> None:
+    """Never date a song by a hits compilation that carries no Compilation type."""
+    provider, _ = _provider(
+        _search_result(
+            _recording(
+                # the compilation predates the studio album, so the credit filter has to
+                # hold on its own for the studio year to win
+                _release(
+                    "1968-10-26",
+                    title="Hits of the 60s",
+                    credit=_credit("Various Artists", VARIOUS_ARTISTS_MBID),
+                ),
+                _release("1975-11-21", credit=_credit("Queen", "artist-1")),
+            )
+        )
+    )
+
+    assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") == 1975
+
+
+async def test_release_year_by_track_name_identifies_various_artists_by_id() -> None:
+    """
+    Recognise the Various Artists entity by its id rather than by its name.
+
+    MusicBrainz localizes the name it credits that entity under, and unrelated artists
+    are named after it.
+    """
+    provider, _ = _provider(
+        _search_result(
+            _recording(
+                _release(
+                    "1968-10-26",
+                    title="Artisti Vari Compilation",
+                    credit=_credit("Artisti Vari", VARIOUS_ARTISTS_MBID),
+                ),
+                _release(
+                    "1975-11-21",
+                    credit=_credit("Various Artist", "artist-named-like-various"),
+                ),
+            )
+        )
+    )
+
+    assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") == 1975
+
+
+async def test_release_group_by_track_name_drops_a_various_artists_release() -> None:
+    """Offer no artwork candidate when a song is only listed on a hits compilation."""
+    provider, _ = _provider(
+        _search_result(
+            _recording(
+                _release(
+                    "1981-10-26",
+                    title="Hits of the 80s",
+                    credit=_credit("Various Artists", VARIOUS_ARTISTS_MBID),
+                )
+            )
+        )
+    )
+
+    result = await provider.get_release_group_by_track_name("Queen", "Bohemian Rhapsody")
+
+    assert result is not None
+    artist, release_groups = result
+    assert artist.name == "Queen"
+    assert release_groups == []
 
 
 async def test_release_year_by_track_name_ignores_an_undated_release_group() -> None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Music Timeline and Trivia ask MusicBrainz when a song was first released, and radio
artwork asks it which album to take a cover from. Both skip compilations — but plenty of
hits compilations are not tagged as compilations in MusicBrainz, so they passed as studio
albums. Johnny Cash's Ring of Fire was dated 2013 from "Fetenhits: Rock Classics" and
Marvin Gaye's Sexual Healing 1999 from a Benetton promo album.

Those releases are credited to Various Artists, which an album or single of one artist
never is, so we now skip them.

Measured on the same hand-dated songs as #5442, dated blind before any lookup ran. Of the
607 albums and singles the search accepted, the 91 that now drop out are all compilations —
no real album is lost. Over 700 songs the answer is unchanged for 689 of them, 9 stop being
dated by a compilation that was the only thing to go on (Ring of Fire was dated 2013 and
Sexual Healing 1999, so reporting no year is the better answer — the Timeline then leaves
the song out instead of placing it decades off), and 2 move to the right album and become
exactly right: I Gotta Feeling 2008 → 2009 and Always On The Run 1988 → 1991.

Radio artwork loses the compilation covers as candidates and falls back to the original
album, or to the artist image when nothing else is left. A station that announces a
compilation as the album no longer gets that cover matched.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
