### PR TITLE
Use expanded_options for sendspin pairing method

### DIFF
--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -445,8 +445,8 @@ class SendspinBasePlayer(Player):
                         key=CONF_PAIRING_METHOD,
                         type=ConfigEntryType.STRING,
                         required=True,
-                        default_value=options[0],
                         options=[ConfigValueOption(value=option) for option in options],
+                        expanded_options=True,
                     )
                 ],
                 step_id="select_method",

--- a/tests/providers/sendspin/test_setup_flow.py
+++ b/tests/providers/sendspin/test_setup_flow.py
@@ -296,6 +296,9 @@ async def test_select_method_pin_gesture_submit_success() -> None:
         PAIR_METHOD_PIN,
         PAIR_METHOD_TOKEN,
     }
+    # the method is rendered as an expanded (radio) list with nothing preselected
+    assert step.entries[0].expanded_options is True
+    assert step.entries[0].default_value is None
     session.handle_submit({CONF_PAIRING_METHOD: PAIR_METHOD_PIN})
 
     await _wait_step(session, step_type=FlowStepType.PROGRESS, step_id="awaiting_gesture")


### PR DESCRIPTION
# What does this implement/fix?

Use `expanded_options` for sendspin pairing method.

Related:
- related frontend PR https://github.com/music-assistant/frontend/pull/2401
- related models PR https://github.com/music-assistant/models/pull/358

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
