### PR TITLE
Date songs written for films by their soundtrack

### DIFF
--- a/music_assistant/providers/musicbrainz/provider.py
+++ b/music_assistant/providers/musicbrainz/provider.py
@@ -440,8 +440,9 @@ class MusicbrainzProvider(MetadataProvider):
         Get the year a song was first released, by artist and track name.
 
         Weaker evidence than :meth:`get_release_year_by_isrc`, which identifies the exact
-        recording: this matches on name and only counts studio albums and singles named
-        after the song, so an ambiguous or unknown name yields no year rather than a guess.
+        recording: this matches on name and only counts studio albums, soundtracks and
+        singles named after the song, so an ambiguous or unknown name yields no year
+        rather than a guess.
         Costs up to two MusicBrainz requests.
 
         :param artist_name: Name of the track's primary artist.
@@ -489,7 +490,7 @@ class MusicbrainzProvider(MetadataProvider):
         :param track_name: Track name to search for.
         :return: Tuple of (raw artist, release groups with their earliest release date sorted
             oldest first), or None when no recording matched. The release groups are empty
-            when the matched recordings carry no studio album or same-named single.
+            when the matched recordings carry no studio album, soundtrack or same-named single.
         """
         search_artist = re.sub(LUCENE_SPECIAL, r"\\\1", artist_name)
         search_track = re.sub(LUCENE_SPECIAL, r"\\\1", track_name)
@@ -599,7 +600,8 @@ class MusicbrainzProvider(MetadataProvider):
                 continue
             # A song written for a film or musical is first released on its soundtrack, which
             # MusicBrainz types as an album with a Soundtrack secondary type. Any other
-            # secondary type, alongside Soundtrack or not, is a rerelease of the song.
+            # secondary type, alongside Soundtrack or not, means the release group is not
+            # where the song came out.
             if secondary_types and secondary_types != ["Soundtrack"]:
                 continue
 

--- a/music_assistant/providers/musicbrainz/provider.py
+++ b/music_assistant/providers/musicbrainz/provider.py
@@ -558,8 +558,9 @@ class MusicbrainzProvider(MetadataProvider):
         """
         Collect release groups for a recording with their release dates.
 
-        Filters out secondary-type releases and compilations, including the ones credited
-        to Various Artists rather than tagged as such.
+        Filters out compilations, live and other rereleases, including the compilations
+        credited to Various Artists rather than tagged as such. Soundtracks are kept,
+        since a song written for a film is first released on one.
         For singles, only includes those where the title matches the track name.
         Returns list of (release_group, release_date) tuples for singles and studio albums.
 
@@ -596,7 +597,10 @@ class MusicbrainzProvider(MetadataProvider):
             # Only include singles and studio albums (no compilations, live, etc.)
             if primary_type not in ("Album", "Single"):
                 continue
-            if secondary_types:
+            # A song written for a film or musical is first released on its soundtrack, which
+            # MusicBrainz types as an album with a Soundtrack secondary type. Any other
+            # secondary type, alongside Soundtrack or not, is a rerelease of the song.
+            if secondary_types and secondary_types != ["Soundtrack"]:
                 continue
 
             # For singles, only include if the title matches the track name

--- a/tests/providers/musicbrainz/test_provider.py
+++ b/tests/providers/musicbrainz/test_provider.py
@@ -317,6 +317,27 @@ async def test_release_year_by_track_name_ignores_a_soundtrack_compilation() -> 
     assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") == 1975
 
 
+async def test_release_year_by_track_name_ignores_a_various_artists_soundtrack() -> None:
+    """Never date a song by a film compilation credited to Various Artists."""
+    provider, _ = _provider(
+        _search_result(
+            _recording(
+                # most film soundtracks are compilations of several artists, and the credit
+                # filter is what keeps them out now that soundtracks are allowed through
+                _release(
+                    "1968-10-26",
+                    title="Music From the Motion Picture",
+                    secondary_types=["Soundtrack"],
+                    credit=_credit("Various Artists", VARIOUS_ARTISTS_MBID),
+                ),
+                _release("1975-11-21", credit=_credit("Queen", "artist-1")),
+            )
+        )
+    )
+
+    assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") == 1975
+
+
 async def test_release_year_by_track_name_ignores_a_various_artists_release() -> None:
     """Never date a song by a hits compilation that carries no Compilation type."""
     provider, _ = _provider(

--- a/tests/providers/musicbrainz/test_provider.py
+++ b/tests/providers/musicbrainz/test_provider.py
@@ -277,6 +277,46 @@ async def test_release_year_by_track_name_ignores_untrustworthy_releases() -> No
     assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") == 1975
 
 
+async def test_release_year_by_track_name_dates_a_song_by_its_soundtrack() -> None:
+    """Date a song written for a film by that film's soundtrack."""
+    provider, _ = _provider(
+        _search_result(
+            _recording(
+                _release(
+                    "1994-05-31",
+                    title="The Lion King: Original Motion Picture Soundtrack",
+                    secondary_types=["Soundtrack"],
+                ),
+                _release("2013-09-13", title="The Diving Board"),
+                title="Circle of Life",
+                artist="Elton John",
+            )
+        )
+    )
+
+    assert await provider.get_release_year_by_track_name("Elton John", "Circle of Life") == 1994
+
+
+async def test_release_year_by_track_name_ignores_a_soundtrack_compilation() -> None:
+    """Never date a song by a film compilation of songs released before it."""
+    provider, _ = _provider(
+        _search_result(
+            _recording(
+                # the compilation predates the studio album, so the secondary type filter
+                # has to hold on its own for the studio year to win
+                _release(
+                    "1968-10-26",
+                    title="Music From the Motion Picture",
+                    secondary_types=["Compilation", "Soundtrack"],
+                ),
+                _release("1975-11-21"),
+            )
+        )
+    )
+
+    assert await provider.get_release_year_by_track_name("Queen", "Bohemian Rhapsody") == 1975
+
+
 async def test_release_year_by_track_name_ignores_a_various_artists_release() -> None:
     """Never date a song by a hits compilation that carries no Compilation type."""
     provider, _ = _provider(
@@ -343,6 +383,31 @@ async def test_release_group_by_track_name_drops_a_various_artists_release() -> 
     artist, release_groups = result
     assert artist.name == "Queen"
     assert release_groups == []
+
+
+async def test_release_group_by_track_name_offers_a_soundtrack_as_artwork() -> None:
+    """Offer the soundtrack of a song written for a film as an artwork candidate."""
+    provider, _ = _provider(
+        _search_result(
+            _recording(
+                _release(
+                    "1994-05-31",
+                    title="The Lion King: Original Motion Picture Soundtrack",
+                    secondary_types=["Soundtrack"],
+                ),
+                title="Circle of Life",
+                artist="Elton John",
+            )
+        )
+    )
+
+    result = await provider.get_release_group_by_track_name("Elton John", "Circle of Life")
+
+    assert result is not None
+    _, release_groups = result
+    assert [rg.title for rg in release_groups] == [
+        "The Lion King: Original Motion Picture Soundtrack"
+    ]
 
 
 async def test_release_year_by_track_name_ignores_an_undated_release_group() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Songs written for a film or musical were dated by the wrong release. MusicBrainz files a
soundtrack as an album with a "Soundtrack" secondary type, and our release group filter
dropped anything carrying a secondary type — so the song's original album was thrown away
and the year (and radio artwork) came from an unrelated later release instead.

Elton John's "Circle of Life" was dated 2013 instead of 1994, and The Beatles' "Ticket To
Ride" 1993 instead of 1965. Soundtracks are now kept, unless they carry another secondary
type as well (a "Compilation, Soundtrack" is still a compilation).

Measured against a hand-dated sample of my own library, drawn blind:

- 1530 library tracks scanned; the change touches 5.7% of them.
- On a soundtrack-heavy sample of 100 hand-dated tracks: 8 songs went from no year at all
  to the right year, 6 got a better year, none got worse and none lost their year.
- On a random 330-track sample (252 hand-dated): 2 new correct years, 2 corrected years,
  and 1 song that now picks up a wrong year from a much later soundtrack it was licensed to.
- Radio artwork: 16 songs gained a cover where it previously fell back to artist art, 10
  moved to a more fitting cover, none lost one.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
