### PR TITLE
Fix sync group not re-forming after a leader switch

### DIFF
--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -758,23 +758,31 @@ class SyncGroupPlayer(Player):
         self._cancel_reform_timer()
         self._playback_start_at = float("-inf")
         if sync_leader := self.sync_leader:
-            # dissolve the temporary syncgroup from the sync leader
+            # dissolve the temporary syncgroup from the player that holds the members:
+            # ungrouping from a leader that no longer holds them is a no-op and would
+            # leave the members grouped and streaming with no way back
+            group_leader = self._protocol_group_leader(sync_leader)
             sync_children = [
-                x for x in sync_leader.state.group_members if x != sync_leader.player_id
+                x for x in group_leader.state.group_members if x != group_leader.player_id
             ]
             if sync_children:
                 # wait for the leader's state to reflect the ungroup
                 # use _handle_set_members directly to avoid the redirect loop
                 # (cmd_set_members redirects sync-leader targets back to this syncgroup)
                 async with (
-                    self.mass.players.wait_for_player_update(sync_leader.player_id, timeout=5),
+                    self.mass.players.wait_for_player_update(group_leader.player_id, timeout=5),
                     self.mass.players.get_player_lock(
-                        sync_leader.player_id, PlayerLockPurpose.PLAYBACK
+                        group_leader.player_id, PlayerLockPurpose.PLAYBACK
                     ),
                 ):
                     await self.mass.players._handle_set_members(
-                        sync_leader, player_ids_to_remove=sync_children
+                        group_leader, player_ids_to_remove=sync_children
                     )
+            if group_leader is not sync_leader:
+                # our callers only ever stop the leader we track, so a provider-promoted
+                # one would keep streaming on its own once the members are released
+                await self.mass.players._handle_cmd_stop(group_leader.player_id)
+                self.mass.players.schedule_active_output_protocol_clear(group_leader)
         # Clear the leader's active protocol once it stops playing; the controller's
         # clearing in _handle_cmd_stop is skipped for a still-grouped protocol player.
         if sync_leader:
@@ -850,6 +858,9 @@ class SyncGroupPlayer(Player):
     #     (_member_supports_protocol_domain / _select_sync_leader)
     #   - downshift to the native protocol when the last protocol-requiring
     #     member is gone (_any_member_requires_protocol_domain)
+    #   - stay aligned with the protocol's own view of the group, both in member
+    #     order (_align_members_with_session) and in who leads it
+    #     (_protocol_group_leader)
     # The helpers below cover those needs. Composition decisions (which protocol
     # to use given the current member mix) intentionally live in the group:
     # individual protocol providers don't have visibility into the rest of the
@@ -941,6 +952,62 @@ class SyncGroupPlayer(Player):
         ):
             return protocol_player
         return self.sync_leader
+
+    def _align_members_with_session(self, session_player: Player | None) -> None:
+        """
+        Re-order the tracked members to match the live session's member order.
+
+        Members that are not part of the live session keep their relative order at
+        the end of the list.
+
+        :param session_player: The player that owns the live sync session.
+        """
+        if session_player is None:
+            return
+        # the provider's own group_members, not state.group_members: the latter is
+        # set-derived for non-protocol players and loses the member order
+        session_order = [
+            x
+            for x in self._translate_to_parent_ids(session_player.group_members)
+            if x in self._attr_group_members
+        ]
+        if not session_order:
+            return
+        self._attr_group_members = [
+            *session_order,
+            *[x for x in self._attr_group_members if x not in session_order],
+        ]
+
+    def _protocol_group_leader(self, sync_leader: Player) -> Player:
+        """
+        Return the member that currently holds the protocol-level group.
+
+        This is normally the sync leader itself, but a provider may have promoted a
+        different member at the protocol level. Falls back to the sync leader when no
+        member reports holding others.
+
+        :param sync_leader: The sync leader tracked by this group.
+        """
+        if sync_leader.state.group_members:
+            return sync_leader
+        for member_id in self._attr_group_members:
+            if member_id == sync_leader.player_id:
+                continue
+            member = self.mass.players.get_player(member_id)
+            if member is None or not member.state.available:
+                continue
+            # a leader always lists itself alongside its members; only adopt one that
+            # holds members of this group, never a group formed outside of MA
+            held = [x for x in member.state.group_members if x != member_id]
+            if held and not set(held).isdisjoint(self._attr_group_members):
+                self.logger.warning(
+                    "Syncgroup %s tracks %s as leader but %s holds the group members",
+                    self.display_name,
+                    sync_leader.display_name,
+                    member.display_name,
+                )
+                return member
+        return sync_leader
 
     def _update_attributes(self) -> None:
         """Update dynamic attributes."""
@@ -1165,6 +1232,11 @@ class SyncGroupPlayer(Player):
         # Remove the old leader from our group members list
         if old_leader_id in self._attr_group_members:
             self._attr_group_members.remove(old_leader_id)
+
+        # A provider may hand the live session to its own first remaining member, so our
+        # member order has to match the session's before we pick from it — otherwise we
+        # end up tracking a different leader than the one that inherits the session.
+        self._align_members_with_session(session_player)
 
         # Pick a new leader preferring one that supports the currently active
         # protocol so the session continuation is seamless.

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -293,6 +293,84 @@ class TestActiveProtocolDomain:
         assert getattr(sgp, "sync_leader") is None  # noqa: B009
         mass.players.schedule_active_output_protocol_clear.assert_called_once_with(leader)
 
+    @pytest.mark.asyncio
+    async def test_dissolve_ungroups_from_the_member_holding_the_group(self) -> None:
+        """
+        Dissolve must ungroup from the member that actually holds the group members.
+
+        A provider can promote a different member to protocol leader than the one we
+        track; ungrouping from our leader would then be a no-op and leave the members
+        grouped and streaming with no way back.
+        """
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        # our tracked leader no longer holds any members
+        living_room = _make_mock_player("living_room", provider_domain="sendspin")
+        bathroom = _make_mock_player("bathroom", provider_domain="sendspin")
+        kitchen = _make_mock_player("kitchen", provider_domain="sendspin")
+        bathroom.state.group_members = ["bathroom", "living_room", "kitchen"]
+
+        mass.players.get_player = _player_lookup(
+            {"living_room": living_room, "bathroom": bathroom, "kitchen": kitchen}
+        )
+
+        sgp.sync_leader = living_room
+        sgp._attr_group_members = ["living_room", "bathroom", "kitchen"]
+
+        with patch.object(sgp, "update_state"):
+            await sgp._dissolve_syncgroup()
+
+        mass.players._handle_set_members.assert_awaited_once_with(
+            bathroom, player_ids_to_remove=["living_room", "kitchen"]
+        )
+        # the promoted owner must be stopped too, our callers only stop the tracked leader
+        mass.players._handle_cmd_stop.assert_awaited_once_with("bathroom")
+        assert getattr(sgp, "sync_leader") is None  # noqa: B009
+
+    @pytest.mark.asyncio
+    async def test_dissolve_keeps_using_the_sync_leader_when_it_holds_the_group(self) -> None:
+        """A leader that still holds its members must stay the dissolve target."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        leader = _make_mock_player("leader", provider_domain="sendspin")
+        member = _make_mock_player("member", provider_domain="sendspin")
+        leader.state.group_members = ["leader", "member"]
+
+        mass.players.get_player = _player_lookup({"leader": leader, "member": member})
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader", "member"]
+
+        with patch.object(sgp, "update_state"):
+            await sgp._dissolve_syncgroup()
+
+        mass.players._handle_set_members.assert_awaited_once_with(
+            leader, player_ids_to_remove=["member"]
+        )
+        mass.players._handle_cmd_stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dissolve_ignores_a_member_leading_an_unrelated_group(self) -> None:
+        """A member grouped outside of MA must never be adopted as the dissolve target."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        living_room = _make_mock_player("living_room", provider_domain="sendspin")
+        member = _make_mock_player("member", provider_domain="sendspin")
+        # member leads a group that shares no player with us
+        member.state.group_members = ["member", "outsider"]
+
+        mass.players.get_player = _player_lookup({"living_room": living_room, "member": member})
+        sgp.sync_leader = living_room
+        sgp._attr_group_members = ["living_room", "member"]
+
+        with patch.object(sgp, "update_state"):
+            await sgp._dissolve_syncgroup()
+
+        mass.players._handle_set_members.assert_not_awaited()
+        mass.players._handle_cmd_stop.assert_not_awaited()
+
 
 class TestControllerLockCategory:
     """Test that the controller's lock categories serialize correctly."""
@@ -431,6 +509,97 @@ class TestDynamicLeaderSwitch:
         ap_protocol.set_members.assert_not_awaited()
         mass.players.wait_for_player_update.assert_called()
         assert "old_leader" not in sgp._attr_group_members
+
+    @pytest.mark.asyncio
+    async def test_dynamic_leader_switch_follows_live_session_order(self) -> None:
+        """
+        The new leader must be the member that inherits the live session.
+
+        Providers promote their own first remaining member, so a leader picked from a
+        drifted member order would leave the group tracking a different player than the
+        one actually holding the session.
+        """
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        old_leader = _make_mock_player("old_leader", provider_domain="sendspin")
+        living_room = _make_mock_player("living_room", provider_domain="sendspin")
+        bathroom = _make_mock_player("bathroom", provider_domain="sendspin")
+        # no stream/session object (Sendspin, Snapcast) -> handoff is assumed safe
+        old_leader.stream = None
+        # the live session hands over to bathroom, our own order says living_room.
+        # state.group_members is deliberately left unordered: only the raw attribute
+        # carries the provider's member order.
+        old_leader.group_members = ["old_leader", "bathroom", "living_room"]
+        old_leader.state.group_members = ["old_leader", "living_room", "bathroom"]
+
+        mass.players.get_player = _player_lookup(
+            {
+                "old_leader": old_leader,
+                "living_room": living_room,
+                "bathroom": bathroom,
+            }
+        )
+
+        sgp.sync_leader = old_leader
+        sgp._attr_group_members = ["old_leader", "living_room", "bathroom"]
+
+        with patch.object(sgp, "update_state"):
+            await sgp._dynamic_leader_switch("old_leader")
+
+        assert sgp.sync_leader == bathroom
+        assert sgp._attr_group_members == ["bathroom", "living_room"]
+        old_leader.set_members.assert_any_await(player_ids_to_remove=["old_leader"])
+        bathroom.set_members.assert_any_await(player_ids_to_add=["living_room"])
+
+    def test_align_members_translates_protocol_ids_and_keeps_outsiders_last(self) -> None:
+        """A protocol session player's order maps onto the parent members that we track."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        living_room = _make_mock_player("living_room")
+        bathroom = _make_mock_player("bathroom")
+        # tracked but not part of the live session
+        offline = _make_mock_player("offline")
+        ap_living_room = _make_mock_player("ap_living_room", provider_domain="airplay")
+        ap_bathroom = _make_mock_player("ap_bathroom", provider_domain="airplay")
+        ap_living_room.protocol_parent_id = "living_room"
+        ap_bathroom.protocol_parent_id = "bathroom"
+
+        session_player = _make_mock_player("ap_old", provider_domain="airplay")
+        session_player.group_members = ["ap_old", "ap_bathroom", "ap_living_room"]
+
+        mass.players.get_player = _player_lookup(
+            {
+                "living_room": living_room,
+                "bathroom": bathroom,
+                "offline": offline,
+                "ap_living_room": ap_living_room,
+                "ap_bathroom": ap_bathroom,
+                "ap_old": session_player,
+            }
+        )
+        sgp._attr_group_members = ["living_room", "bathroom", "offline"]
+
+        sgp._align_members_with_session(session_player)
+
+        assert sgp._attr_group_members == ["bathroom", "living_room", "offline"]
+
+    def test_align_members_leaves_order_untouched_without_a_live_session(self) -> None:
+        """Without a session (or with one holding none of our members) the order stands."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        stranger = _make_mock_player("stranger", provider_domain="airplay")
+        stranger.group_members = ["stranger"]
+        mass.players.get_player = _player_lookup({"stranger": stranger})
+        sgp._attr_group_members = ["living_room", "bathroom"]
+
+        sgp._align_members_with_session(None)
+        assert sgp._attr_group_members == ["living_room", "bathroom"]
+
+        sgp._align_members_with_session(stranger)
+        assert sgp._attr_group_members == ["living_room", "bathroom"]
 
 
 class TestPowerLifecycle:


### PR DESCRIPTION
# What does this implement/fix?

After a sync group switched to a new leader, the group could end up broken: Music Assistant would report one speaker as the leader while the audio session had actually moved to a different one. From that point the group could never be dissolved or re-formed, speakers kept repeating "can not be grouped with", and only a restart of Music Assistant fixed it.

This happened because the sync group picked the new leader from its own member order, while the speaker protocol hands the session to its own first remaining member. Those two orders can drift apart over time, and once they disagree the group and the actual session were out of sync for good.

- Keep the group's member order aligned with the live session, so the new leader is the speaker that actually takes over the session
- Dissolve the group from the speaker that really holds the members, instead of a leader that no longer holds any (which silently did nothing before)
- Stop a speaker that the protocol promoted on its own, so it doesn't keep playing after the group is dissolved
- Added tests covering the leader switch and both dissolve paths

**Related issue (if applicable):**

- reported on 2.10.0b14 with 5 Sendspin speakers in one sync group with dynamic members enabled

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
