### PR TITLE
Play announcements over the music on AirPlay players

### DIFF
--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -229,23 +229,32 @@ class AnnouncementsMixin:
             # determine if the player has native announcements support
             # or if any linked protocol has announcement support
             announce_player: Player | None
-            if PlayerFeature.PLAY_ANNOUNCEMENT in player.supported_features:
-                # The player's own native support always wins over a linked
-                # protocol: e.g. a Sonos overlays the clip on whatever source
-                # is playing (audioClip), which beats interrupting that
-                # playback by routing the announcement to its AirPlay child.
+            if announce_player := self._get_control_target(
+                player,
+                required_feature=PlayerFeature.PLAY_ANNOUNCEMENT,
+                require_active=True,
+            ):
+                # The output that is ACTIVELY rendering can announce: the
+                # announcement rides the same audio path as the music (e.g. a
+                # Sonos playing through its AirPlay child gets the clip mixed
+                # into that live stream, in sync with the rest of the group)
+                # instead of a second mechanism firing beside the playback.
+                pass
+            elif PlayerFeature.PLAY_ANNOUNCEMENT in player.supported_features:
+                # Not playing through an announce-capable output: the player's
+                # own native support (e.g. Sonos audioClip, which overlays the
+                # clip on whatever source is playing) is the next-best path.
                 announce_player = player
-            else:
+            elif player.state.playback_state != PlaybackState.PLAYING:
+                # An idle player may announce through any linked protocol. A
+                # PLAYING player deliberately gets no such fallback: routing to
+                # an idle linked protocol (e.g. the AirPlay child of a WiiM
+                # playing natively) would seize the device from the active
+                # output, with nothing restoring that playback afterwards.
                 announce_player = self._get_control_target(
                     player,
                     required_feature=PlayerFeature.PLAY_ANNOUNCEMENT,
-                    # A playing player only announces natively through the
-                    # output that is actually rendering: routing to an idle
-                    # linked protocol (e.g. the AirPlay child of a WiiM playing
-                    # natively) would seize the device from the active output,
-                    # with nothing restoring that playback afterwards. An idle
-                    # player may announce through any linked protocol.
-                    require_active=player.state.playback_state == PlaybackState.PLAYING,
+                    require_active=False,
                 )
             native_announce_support = announce_player is not None
             if announce_player is None:

--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -228,14 +228,27 @@ class AnnouncementsMixin:
             )
             # determine if the player has native announcements support
             # or if any linked protocol has announcement support
-            native_announce_support = False
-            if announce_player := self._get_control_target(
-                player,
-                required_feature=PlayerFeature.PLAY_ANNOUNCEMENT,
-                require_active=False,
-            ):
-                native_announce_support = True
+            announce_player: Player | None
+            if PlayerFeature.PLAY_ANNOUNCEMENT in player.supported_features:
+                # The player's own native support always wins over a linked
+                # protocol: e.g. a Sonos overlays the clip on whatever source
+                # is playing (audioClip), which beats interrupting that
+                # playback by routing the announcement to its AirPlay child.
+                announce_player = player
             else:
+                announce_player = self._get_control_target(
+                    player,
+                    required_feature=PlayerFeature.PLAY_ANNOUNCEMENT,
+                    # A playing player only announces natively through the
+                    # output that is actually rendering: routing to an idle
+                    # linked protocol (e.g. the AirPlay child of a WiiM playing
+                    # natively) would seize the device from the active output,
+                    # with nothing restoring that playback afterwards. An idle
+                    # player may announce through any linked protocol.
+                    require_active=player.state.playback_state == PlaybackState.PLAYING,
+                )
+            native_announce_support = announce_player is not None
+            if announce_player is None:
                 announce_player = player
             # create a PlayerMedia object for the announcement so
             # we can send a regular play-media call downstream

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -408,7 +408,7 @@ def _live_members(player: AirPlayPlayer) -> list[AirPlayPlayer]:
         if bridge is not None and bridge.owns_airplay_stream:
             return [player]
         return []
-    if player.state.active_group:
+    if _owning_group_entity(player):
         # A group ENTITY (e.g. a syncgroup) owns this session, and that entity
         # is the whole-group announcement handle: this player addressed
         # individually announces alone, even as the session's sync leader.
@@ -453,7 +453,10 @@ def _resolve_announce_instant(
     # prune settled plans so the registry cannot grow with announcement history
     for key in [key for key, at_ms in plans.items() if at_ms <= now_ms]:
         del plans[key]
-    plan_key = (player.state.active_group or player.synced_to or player.player_id, render_key)
+    plan_key = (
+        _owning_group_entity(player) or player.synced_to or player.player_id,
+        render_key,
+    )
     if (at_unix_ms := plans.get(plan_key)) is not None:
         return at_unix_ms
     # the instant must clear EVERY session member's span: the sibling calls of
@@ -475,6 +478,24 @@ def _shared_announce_instant(streams: Iterable[AirPlayStream]) -> int:
     """
     max_span_ms = max(_member_span_ms(stream) for stream in streams)
     return int(time.time() * 1000) + max_span_ms + AIRPLAY_ANNOUNCE_AT_MARGIN_MS
+
+
+def _owning_group_entity(player: AirPlayPlayer) -> str | None:
+    """
+    Return the id of the group ENTITY that owns this player's session, if any.
+
+    ``active_group`` only ever names a real group player (e.g. a syncgroup) -
+    but a protocol player never carries it itself: the model keeps the group
+    state on the device player it renders for, so the ownership is read
+    through the protocol parent when needed.
+    """
+    if player.state.active_group:
+        return player.state.active_group
+    if player.protocol_parent_id and (
+        parent := player.mass.players.get_player(player.protocol_parent_id)
+    ):
+        return parent.state.active_group
+    return None
 
 
 def _member_span_ms(stream: AirPlayStream) -> int:

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -8,6 +8,11 @@ member of the live session at one shared audible instant and tracks the per-memb
 outcome. Whenever there is no live playback to mix into (idle or parked player), the
 announcement runs as a dedicated stream session instead, leaving the player idle.
 
+Targeting semantics: the leader of an (ad-hoc) sync group represents the whole
+group - announcing to it plays on every member, exactly like playing media to it
+does. A synced member addressed individually announces alone, over its own ducked
+copy of the group's music, while the other rooms play on untouched.
+
 A group announcement is forwarded by the player controller to every member
 concurrently; the session leader's call runs one orchestration for the whole session
 and the members' calls coalesce onto it (see the provider's announce-task registry).
@@ -57,8 +62,10 @@ if TYPE_CHECKING:
     from .stream import AirPlayStream
 
 # Scheduled announcement-volume changes of one member: the previous level and
-# the timers that apply/restore the announcement volume around the clip.
-_VolumeSchedule = tuple["AirPlayPlayer", int, list[asyncio.TimerHandle]]
+# the timer task ids that apply/restore the announcement volume around the
+# clip (mass.call_later tracks its timers by task id, and only cancel_timer
+# releases a tracked entry that never fired).
+_VolumeSchedule = tuple["AirPlayPlayer", int, list[str]]
 
 # How a synced member's call looks for the leader task of a group announcement.
 # The controller forwards a group announcement to every member in one batch, so
@@ -345,9 +352,9 @@ async def _announce_over_live_session(
         # The scheduled volume changes belong to an announcement that is no
         # longer being tracked: cancel them and restore the previous levels
         # right away (a restore of an unchanged level is a harmless re-send).
-        for member, prev_volume, handles in volume_schedules:
-            for handle in handles:
-                handle.cancel()
+        for member, prev_volume, task_ids in volume_schedules:
+            for task_id in task_ids:
+                member.mass.cancel_timer(task_id)
             player.mass.create_task(member.volume_set(prev_volume))
         raise
     finally:
@@ -540,15 +547,21 @@ def _schedule_member_volume(
     # still sounding. The duck ramp (and the pre-announce chime) masks the
     # late bump; short clips cap the bias at their midpoint.
     bump_delay = delay + min(AIRPLAY_ANNOUNCE_VOLUME_BUMP_DELAY_MS / 1000, clip_seconds / 2)
-    handles = [
-        member.mass.call_later(bump_delay, member.volume_set, volume_level),
-        member.mass.call_later(
-            delay + clip_seconds + AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS / 1000,
-            member.volume_set,
-            prev_volume,
-        ),
+    # Deterministic task ids: cancel_timer is the only way to release a tracked
+    # timer that never fires, and reusing the ids also cancels stale timers of
+    # a replaced announcement on the same member.
+    task_ids = [
+        f"airplay_announce_volume_bump_{member.player_id}",
+        f"airplay_announce_volume_restore_{member.player_id}",
     ]
-    return (member, prev_volume, handles)
+    member.mass.call_later(bump_delay, member.volume_set, volume_level, task_id=task_ids[0])
+    member.mass.call_later(
+        delay + clip_seconds + AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS / 1000,
+        member.volume_set,
+        prev_volume,
+        task_id=task_ids[1],
+    )
+    return (member, prev_volume, task_ids)
 
 
 async def _render_clip_file(render: AnnouncementRender, pcm_format: AudioFormat) -> str:
@@ -595,4 +608,7 @@ async def _no_announce_ack() -> tuple[int, int] | None:
 
 def _format_key(pcm_format: AudioFormat) -> str:
     """Return the identity of a raw PCM stdin format for clip-file sharing."""
-    return f"{pcm_format.content_type.value}_{pcm_format.sample_rate}_{pcm_format.bit_depth}"
+    return (
+        f"{pcm_format.content_type.value}_{pcm_format.sample_rate}"
+        f"_{pcm_format.bit_depth}_{pcm_format.channels}"
+    )

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -5,9 +5,15 @@ The cliairplay binary mixes a raw-PCM clip over the outgoing music with the musi
 ducked underneath - no flush, no re-anchor, the group timeline stays untouched. This
 module renders the shared announcement clip once per member stdin format, arms every
 member of the live session at one shared audible instant and tracks the per-member
-outcome. Whenever there is no live playback to mix into (idle or parked player, or no
-member armed the clip), the announcement runs as a dedicated stream session instead,
-leaving the player idle.
+outcome. Whenever there is no live playback to mix into (idle or parked player), the
+announcement runs as a dedicated stream session instead, leaving the player idle.
+
+A group announcement is forwarded by the player controller to every member
+concurrently; the session leader's call runs one orchestration for the whole session
+and the members' calls coalesce onto it (see the provider's announce-task registry).
+Members of a Sendspin GROUP of bridged players each compute their own instant, so a
+group announcement there can be offset by tens of ms across rooms; cross-player
+coalescing for that case is future work.
 """
 
 from __future__ import annotations
@@ -18,7 +24,7 @@ import tempfile
 import time
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Final, cast
 
 from music_assistant_models.enums import PlaybackState
 from music_assistant_models.errors import PlayerCommandFailed
@@ -51,6 +57,16 @@ if TYPE_CHECKING:
 # the timers that apply/restore the announcement volume around the clip.
 _VolumeSchedule = tuple["AirPlayPlayer", int, list[asyncio.TimerHandle]]
 
+# How a synced member's call looks for the leader task of a group announcement.
+# The controller forwards a group announcement to every member in one batch, so
+# the leader registers within a scheduler tick or two of the members' first
+# check - a couple of short polls cover that ordering. Kept tight on purpose:
+# only the timeout tells a group-forwarded member call apart from a DIRECT
+# announcement to that member, which pays the full poll as dead latency before
+# it arms.
+_LEADER_TASK_POLL_INTERVAL_S: Final[float] = 0.1
+_LEADER_TASK_POLL_ATTEMPTS: Final[int] = 3
+
 
 async def play_announcement(
     player: AirPlayPlayer, announcement: PlayerMedia, volume_level: int | None
@@ -59,8 +75,10 @@ async def play_announcement(
     Play an announcement on the player (and the members it leads).
 
     A live playing session mixes the clip over the music without interrupting
-    it; a player that is idle or parked - or whose members could not mix the
-    clip - plays the announcement as a dedicated stream session and ends idle.
+    it; an idle player plays the announcement as a dedicated stream session and
+    ends idle. A group announcement (forwarded per member by the controller) is
+    orchestrated once by the session leader's call; the members' calls coalesce
+    onto that shared run.
 
     :param player: The player the announcement targets.
     :param announcement: The announcement to play.
@@ -71,24 +89,99 @@ async def play_announcement(
         raise PlayerCommandFailed(
             f"Announcement for {player.display_name} carries no announcement data"
         )
+    provider = cast("AirPlayProvider", player.provider)
     renderer = player.mass.streams.announcement_renderer
     render = renderer.acquire(announce_data)
     try:
-        # The whole clip is rendered up front: the live path hands the binary a
-        # complete file, and the exact duration bounds every wait below.
-        duration = await render.wait_finished()
-        if duration is None:
-            duration = render.duration
-        if duration <= 0:
-            player.logger.warning(
-                "Announcement for %s produced no audio; nothing to play", player.display_name
-            )
+        if player.synced_to:
+            if await _join_group_announcement(provider, player, render.key):
+                return
+            # no group announcement to coalesce onto: this is the deliberate
+            # announcement to just this member
+            await _run_announcement(player, announcement, render, volume_level)
             return
-        if await _announce_over_live_session(player, render, duration, volume_level):
-            return
-        await _announce_with_session(player, announcement, render, duration, volume_level)
+        # Leader/solo: publish the orchestration as a task so the concurrently
+        # forwarded member calls of a group announcement await it instead of
+        # arming their members a second time. Registered synchronously (no
+        # await between task creation and registration) so a member's lookup
+        # can never miss an in-flight run.
+        task = player.mass.create_task(
+            _run_announcement(player, announcement, render, volume_level)
+        )
+        provider._announce_tasks[player.player_id] = (render.key, task)
+        try:
+            await task
+        except asyncio.CancelledError:
+            # cancelling the caller must cancel the orchestration itself, so
+            # its cleanup (volume restore, clip files) runs
+            task.cancel()
+            raise
+        finally:
+            provider._announce_tasks.pop(player.player_id, None)
     finally:
         await renderer.release(render)
+
+
+async def _join_group_announcement(
+    provider: AirPlayProvider, player: AirPlayPlayer, render_key: str
+) -> bool:
+    """
+    Await the group announcement the player's sync leader runs, if there is one.
+
+    The leader's orchestration arms every member of the session - including
+    this player, and the announcement volume for all of them - so this call
+    only has to await that shared outcome (which also propagates its failure).
+
+    :param provider: The AirPlay provider holding the announce-task registry.
+    :param player: The synced member whose leader may run the announcement.
+    :param render_key: Identity of the announcement audio, to only ever join
+        the run of the SAME announcement.
+    :return: True when a matching group announcement was found and awaited;
+        False when none appeared (an announcement to just this member).
+    """
+    leader_id = player.synced_to
+    assert leader_id is not None  # only called for synced members
+    for attempt in range(_LEADER_TASK_POLL_ATTEMPTS):
+        entry = provider._announce_tasks.get(leader_id)
+        if entry is not None and entry[0] == render_key:
+            player.logger.debug(
+                "Announcement to %s coalesces onto the group announcement of its leader",
+                player.display_name,
+            )
+            await entry[1]
+            return True
+        if attempt < _LEADER_TASK_POLL_ATTEMPTS - 1:
+            await asyncio.sleep(_LEADER_TASK_POLL_INTERVAL_S)
+    return False
+
+
+async def _run_announcement(
+    player: AirPlayPlayer,
+    announcement: PlayerMedia,
+    render: AnnouncementRender,
+    volume_level: int | None,
+) -> None:
+    """
+    Render the clip, then mix it over live playback or play it as its own session.
+
+    :param player: The player the announcement targets.
+    :param announcement: The announcement to play.
+    :param render: The announcement render to play.
+    :param volume_level: Optional volume level for the announcement.
+    """
+    # The whole clip is rendered up front: the live path hands the binary a
+    # complete file, and the exact duration bounds every wait below.
+    duration = await render.wait_finished()
+    if duration is None:
+        duration = render.duration
+    if duration <= 0:
+        player.logger.warning(
+            "Announcement for %s produced no audio; nothing to play", player.display_name
+        )
+        return
+    if await _announce_over_live_session(player, render, duration, volume_level):
+        return
+    await _announce_with_session(player, announcement, render, duration, volume_level)
 
 
 async def _announce_over_live_session(
@@ -105,8 +198,11 @@ async def _announce_over_live_session(
     :param duration: Exact clip duration in seconds.
     :param volume_level: Optional volume level for the announcement.
     :return: True when at least one member played the clip; False when there is
-        no live playback or no member armed it, so the caller falls back to a
-        dedicated announcement session.
+        no live playback to mix into, so the caller runs the dedicated
+        announcement session instead.
+    :raises PlayerCommandFailed: If there was live playback but no member armed
+        the clip (tearing the playing session down for a fallback would trade
+        the user's music for the announcement).
     """
     clip_files: dict[str, str] = {}
     volume_schedules: list[_VolumeSchedule] = []
@@ -115,9 +211,13 @@ async def _announce_over_live_session(
         # same lock play_media holds to mutate the session - while the
         # multi-second clip waits below run outside it, so provider-internal
         # paths (DACP feedback, member removal on stream loss) are not blocked
-        # for the clip's duration. User-driven playback commands are already
-        # serialized against the whole announcement by the controller's
-        # per-player playback lock.
+        # for the clip's duration. The controller's per-player playback lock
+        # serializes this whole announcement against cmd_stop, cmd_resume,
+        # cmd_power, enqueue_next_media, play_media and other announcements,
+        # but NOT against cmd_play/cmd_pause/cmd_seek - those can land inside
+        # the waits, where the binary's own cancel semantics keep them safe: a
+        # pause or flush cancels the clip cleanly (done cancelled=1) and the
+        # announcement ends with a cancelled outcome instead of wedging.
         async with player._lock:
             members = _live_members(player)
             if not members:
@@ -170,11 +270,16 @@ async def _announce_over_live_session(
             if ack is not None
         }
         if not started:
-            player.logger.info(
-                "No member of %s armed the announcement; playing it as its own session",
-                player.display_name,
+            # Music keeps playing on every member, so falling back to a
+            # dedicated announcement session would stop the user's playback
+            # over a clip that could not be mixed anyway. Silently ignoring
+            # the unknown arm command is exactly what an outdated cliairplay
+            # build does.
+            raise PlayerCommandFailed(
+                f"No member of {player.display_name} armed the announcement; "
+                "the running cliairplay binary may not support announcements yet "
+                "(version mismatch)"
             )
-            return False
         if volume_level is not None:
             for member in members:
                 if (ack := started.get(member.player_id)) is None:
@@ -210,6 +315,19 @@ async def _announce_over_live_session(
                 player.display_name,
                 ", ".join(failed),
             )
+        # announce_done fires when the clip is fully MIXED at the delivery
+        # head - up to a member's span BEFORE it is audible. Returning then
+        # would let the caller restore mutes (and arm a follow-up
+        # announcement) over the audible tail, so hold the return until the
+        # latest audible end across the started members.
+        latest_end_unix_ms = max(
+            (ack_at or at_unix_ms) + (ack_duration or int(duration * 1000))
+            for ack_at, ack_duration in started.values()
+        )
+        await asyncio.sleep(
+            max(0.0, latest_end_unix_ms / 1000 - time.time())
+            + AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS / 1000
+        )
         return True
     except BaseException:
         # The scheduled volume changes belong to an announcement that is no
@@ -236,17 +354,44 @@ async def _announce_with_session(
     """
     Play the announcement as a dedicated stream session.
 
-    Any existing (parked) session is stopped first. The player ends idle - the
-    same end state the generic announcement flow leaves a non-playing player in;
-    the queue keeps its resume position server-side.
+    Any existing (parked) session led by this player is stopped first. The
+    player ends idle - the same end state the generic announcement flow leaves
+    a non-playing player in; the queue keeps its resume position server-side.
+
+    Known limitation: a synced member of a group without live playback is
+    refused here - its stream belongs to the leader's shared (parked) session,
+    which must not be torn down for a single-member announcement, so that
+    announcement simply does not play. Announcing over a parked session
+    without stopping it needs binary-side support (announce while in
+    STANDBY), which is the planned proper fix.
 
     :param player: The player the announcement targets.
     :param announcement: The announcement media, owning the session's metadata.
     :param render: The (finished) announcement render to play.
     :param duration: Exact clip duration in seconds.
     :param volume_level: Optional volume level for the announcement.
+    :raises PlayerCommandFailed: If the player is a synced group member or is
+        streamed to by its Sendspin bridge - both own no session this path may
+        replace.
     """
     provider = cast("AirPlayProvider", player.provider)
+    if player.synced_to:
+        # The controller's group-forward runs the member calls in a
+        # TaskManager, which does not cancel siblings on a failure, so raising
+        # here cannot take the leader's in-flight announcement down with it.
+        raise PlayerCommandFailed(
+            f"Cannot announce on {player.display_name}: a grouped AirPlay player "
+            "without live playback cannot announce natively"
+        )
+    if provider.bridge_manager.get_bridge(player.player_id) is not None:
+        # The device belongs to the bridge; a dedicated announcement session
+        # would seize it from the Sendspin side with nothing restoring that
+        # playback. Only reachable in a stream-ended race - an idle bridged
+        # player does not advertise the announcement feature at all.
+        raise PlayerCommandFailed(
+            f"Cannot announce on {player.display_name}: the player is driven by its "
+            "Sendspin bridge and has no live stream to mix the announcement into"
+        )
     prev_volumes: dict[AirPlayPlayer, int] = {}
     session: AirPlayStreamSession | None = None
     try:
@@ -278,6 +423,9 @@ async def _announce_with_session(
         player._transitioning = False
         if session is not None:
             await session.stop()
+            # like player.stop(): an idle player must not keep showing media
+            player._attr_current_media = None
+            player.update_state()
         for member, prev_volume in prev_volumes.items():
             await member.volume_set(prev_volume)
 
@@ -298,6 +446,12 @@ def _live_members(player: AirPlayPlayer) -> list[AirPlayPlayer]:
     if player.synced_to:
         return [player]
     if stream.session is None:
+        # A Sendspin-bridged player plays without a stream session, but its
+        # stream is a regular AirPlayStream the clip mixes into (self-only).
+        provider = cast("AirPlayProvider", player.provider)
+        bridge = provider.bridge_manager.get_bridge(player.player_id)
+        if bridge is not None and bridge.owns_airplay_stream:
+            return [player]
         return []
     return [
         member
@@ -367,13 +521,13 @@ async def _render_clip_file(render: AnnouncementRender, pcm_format: AudioFormat)
     :param render: The (finished) announcement render to read.
     :param pcm_format: The raw PCM format the file must carry.
     """
-    chunks: list[bytes] = []
+    clip = bytearray()
     async for chunk in render.get_stream(pcm_format):
-        chunks.append(chunk)
-    return await asyncio.to_thread(_write_clip_file, b"".join(chunks))
+        clip.extend(chunk)
+    return await asyncio.to_thread(_write_clip_file, clip)
 
 
-def _write_clip_file(data: bytes) -> str:
+def _write_clip_file(data: bytes | bytearray) -> str:
     """Write clip audio to a uniquely named temp file and return its path."""
     fd, path = tempfile.mkstemp(prefix="ma_airplay_announce_", suffix=".pcm")
     with os.fdopen(fd, "wb") as clip_file:

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -1,0 +1,391 @@
+"""
+Native AirPlay announcement orchestration.
+
+The cliairplay binary mixes a raw-PCM clip over the outgoing music with the music
+ducked underneath - no flush, no re-anchor, the group timeline stays untouched. This
+module renders the shared announcement clip once per member stdin format, arms every
+member of the live session at one shared audible instant and tracks the per-member
+outcome. Whenever there is no live playback to mix into (idle or parked player, or no
+member armed the clip), the announcement runs as a dedicated stream session instead,
+leaving the player idle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from music_assistant_models.enums import PlaybackState
+from music_assistant_models.errors import PlayerCommandFailed
+
+from .constants import (
+    AIRPLAY_ANNOUNCE_AT_MARGIN_MS,
+    AIRPLAY_ANNOUNCE_DONE_TIMEOUT_MS,
+    AIRPLAY_ANNOUNCE_DUCK_DB,
+    AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS,
+    AIRPLAY_ANNOUNCE_SESSION_DRAIN_S,
+    AIRPLAY_ANNOUNCE_STARTED_TIMEOUT_MS,
+    AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS,
+)
+from .stream_session import AirPlayStreamSession
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from music_assistant_models.media_items import AudioFormat
+    from music_assistant_models.player import PlayerMedia
+
+    from music_assistant.controllers.players.helpers import AnnounceData
+    from music_assistant.controllers.streams.announcements import AnnouncementRender
+
+    from .player import AirPlayPlayer
+    from .provider import AirPlayProvider
+    from .stream import AirPlayStream
+
+# Scheduled announcement-volume changes of one member: the previous level and
+# the timers that apply/restore the announcement volume around the clip.
+_VolumeSchedule = tuple["AirPlayPlayer", int, list[asyncio.TimerHandle]]
+
+
+async def play_announcement(
+    player: AirPlayPlayer, announcement: PlayerMedia, volume_level: int | None
+) -> None:
+    """
+    Play an announcement on the player (and the members it leads).
+
+    A live playing session mixes the clip over the music without interrupting
+    it; a player that is idle or parked - or whose members could not mix the
+    clip - plays the announcement as a dedicated stream session and ends idle.
+
+    :param player: The player the announcement targets.
+    :param announcement: The announcement to play.
+    :param volume_level: Optional volume level for the announcement.
+    """
+    announce_data = cast("AnnounceData | None", announcement.custom_data)
+    if not announce_data or "announcement_url" not in announce_data:
+        raise PlayerCommandFailed(
+            f"Announcement for {player.display_name} carries no announcement data"
+        )
+    renderer = player.mass.streams.announcement_renderer
+    render = renderer.acquire(announce_data)
+    try:
+        # The whole clip is rendered up front: the live path hands the binary a
+        # complete file, and the exact duration bounds every wait below.
+        duration = await render.wait_finished()
+        if duration is None:
+            duration = render.duration
+        if duration <= 0:
+            player.logger.warning(
+                "Announcement for %s produced no audio; nothing to play", player.display_name
+            )
+            return
+        if await _announce_over_live_session(player, render, duration, volume_level):
+            return
+        await _announce_with_session(player, announcement, render, duration, volume_level)
+    finally:
+        await renderer.release(render)
+
+
+async def _announce_over_live_session(
+    player: AirPlayPlayer,
+    render: AnnouncementRender,
+    duration: float,
+    volume_level: int | None,
+) -> bool:
+    """
+    Mix the clip over the live playing session.
+
+    :param player: The player the announcement targets.
+    :param render: The (finished) announcement render to play.
+    :param duration: Exact clip duration in seconds.
+    :param volume_level: Optional volume level for the announcement.
+    :return: True when at least one member played the clip; False when there is
+        no live playback or no member armed it, so the caller falls back to a
+        dedicated announcement session.
+    """
+    clip_files: dict[str, str] = {}
+    volume_schedules: list[_VolumeSchedule] = []
+    try:
+        # The dispatch decision and the arming run under the player lock - the
+        # same lock play_media holds to mutate the session - while the
+        # multi-second clip waits below run outside it, so provider-internal
+        # paths (DACP feedback, member removal on stream loss) are not blocked
+        # for the clip's duration. User-driven playback commands are already
+        # serialized against the whole announcement by the controller's
+        # per-player playback lock.
+        async with player._lock:
+            members = _live_members(player)
+            if not members:
+                return False
+            streams: dict[str, AirPlayStream] = {}
+            for member in members:
+                assert member.stream is not None  # guaranteed by _live_members
+                streams[member.player_id] = member.stream
+            # one clip file per distinct member stdin format, shared by all
+            # members on that format
+            for stream in streams.values():
+                clip_key = _format_key(stream.pcm_format)
+                if clip_key not in clip_files:
+                    clip_files[clip_key] = await _render_clip_file(render, stream.pcm_format)
+            # resolved only now: file rendering above must not eat into the
+            # margin the shared instant carries
+            at_unix_ms = _shared_announce_instant(streams.values())
+            delivered = await asyncio.gather(
+                *[
+                    stream.announce(
+                        clip_files[_format_key(stream.pcm_format)],
+                        at_unix_ms,
+                        AIRPLAY_ANNOUNCE_DUCK_DB,
+                    )
+                    for stream in streams.values()
+                ],
+                return_exceptions=True,
+            )
+        for member, sent in zip(members, delivered, strict=True):
+            if isinstance(sent, BaseException):
+                player.logger.debug(
+                    "Could not deliver the announcement arm to %s: %r",
+                    member.display_name,
+                    sent,
+                )
+        started_timeout = (
+            max(0.0, at_unix_ms / 1000 - time.time()) + AIRPLAY_ANNOUNCE_STARTED_TIMEOUT_MS / 1000
+        )
+        acks = await asyncio.gather(
+            *[
+                stream.wait_announce_started(started_timeout)
+                if sent is True
+                else _no_announce_ack()
+                for stream, sent in zip(streams.values(), delivered, strict=True)
+            ]
+        )
+        started: dict[str, tuple[int, int]] = {
+            member.player_id: ack
+            for member, ack in zip(members, acks, strict=True)
+            if ack is not None
+        }
+        if not started:
+            player.logger.info(
+                "No member of %s armed the announcement; playing it as its own session",
+                player.display_name,
+            )
+            return False
+        if volume_level is not None:
+            for member in members:
+                if (ack := started.get(member.player_id)) is None:
+                    continue
+                ack_at_unix_ms, ack_duration_ms = ack
+                if schedule := _schedule_member_volume(
+                    member,
+                    volume_level,
+                    ack_at_unix_ms or at_unix_ms,
+                    ack_duration_ms / 1000 if ack_duration_ms else duration,
+                ):
+                    volume_schedules.append(schedule)
+        done_results = await asyncio.gather(
+            *[
+                streams[member_id].wait_announce_done(
+                    max(0.0, (ack_at or at_unix_ms) / 1000 - time.time())
+                    + (ack_duration / 1000 if ack_duration else duration)
+                    + AIRPLAY_ANNOUNCE_DONE_TIMEOUT_MS / 1000
+                )
+                for member_id, (ack_at, ack_duration) in started.items()
+            ]
+        )
+        for member_id, done in zip(started, done_results, strict=True):
+            if not done:
+                player.logger.debug(
+                    "Announcement on member %s was cut short or its completion went unreported",
+                    member_id,
+                )
+        if failed := [m.display_name for m in members if m.player_id not in started]:
+            player.logger.warning(
+                "Announcement was not played on %d member(s) of %s: %s",
+                len(failed),
+                player.display_name,
+                ", ".join(failed),
+            )
+        return True
+    except BaseException:
+        # The scheduled volume changes belong to an announcement that is no
+        # longer being tracked: cancel them and restore the previous levels
+        # right away (a restore of an unchanged level is a harmless re-send).
+        for member, prev_volume, handles in volume_schedules:
+            for handle in handles:
+                handle.cancel()
+            player.mass.create_task(member.volume_set(prev_volume))
+        raise
+    finally:
+        for path in clip_files.values():
+            with suppress(OSError):
+                Path(path).unlink()
+
+
+async def _announce_with_session(
+    player: AirPlayPlayer,
+    announcement: PlayerMedia,
+    render: AnnouncementRender,
+    duration: float,
+    volume_level: int | None,
+) -> None:
+    """
+    Play the announcement as a dedicated stream session.
+
+    Any existing (parked) session is stopped first. The player ends idle - the
+    same end state the generic announcement flow leaves a non-playing player in;
+    the queue keeps its resume position server-side.
+
+    :param player: The player the announcement targets.
+    :param announcement: The announcement media, owning the session's metadata.
+    :param render: The (finished) announcement render to play.
+    :param duration: Exact clip duration in seconds.
+    :param volume_level: Optional volume level for the announcement.
+    """
+    provider = cast("AirPlayProvider", player.provider)
+    prev_volumes: dict[AirPlayPlayer, int] = {}
+    session: AirPlayStreamSession | None = None
+    try:
+        # Session teardown and setup mirror play_media's cold path, under the
+        # same player lock; the clip wait below runs outside it.
+        async with player._lock:
+            if player.stream and player.stream.running and player.stream.session:
+                player._transitioning = True
+                await player.stream.session.stop()
+                player.stream = None
+            sync_clients = player._get_sync_clients()
+            session_pcm_format = await player._get_session_pcm_format(sync_clients, announcement)
+            if volume_level is not None:
+                for member in sync_clients:
+                    prev_volume = member.volume_level
+                    if prev_volume is not None and prev_volume != volume_level:
+                        prev_volumes[member] = prev_volume
+                        await member.volume_set(volume_level)
+            session = AirPlayStreamSession(provider, sync_clients, session_pcm_format, announcement)
+            await session.start(render.get_stream(session_pcm_format))
+            player._transitioning = False
+        # The clip is anchored: wait out the start lead plus the clip and the
+        # receiver drain. The source ends after the clip, so the session
+        # usually ends cleanly on its own and the stop below is cleanup only.
+        await asyncio.sleep(
+            max(0.0, session.start_time - time.time()) + duration + AIRPLAY_ANNOUNCE_SESSION_DRAIN_S
+        )
+    finally:
+        player._transitioning = False
+        if session is not None:
+            await session.stop()
+        for member, prev_volume in prev_volumes.items():
+            await member.volume_set(prev_volume)
+
+
+def _live_members(player: AirPlayPlayer) -> list[AirPlayPlayer]:
+    """
+    Return the members a live announcement targets, or [] without live playback.
+
+    A synced member announced individually is just itself; a session leader
+    covers every member of its session. Only a PLAYING session can mix a clip -
+    a parked (paused) or idle player has no live timeline to mix into.
+    """
+    if player.playback_state != PlaybackState.PLAYING:
+        return []
+    stream = player.stream
+    if stream is None or not stream.running or not stream.connected:
+        return []
+    if player.synced_to:
+        return [player]
+    if stream.session is None:
+        return []
+    return [
+        member
+        for member in stream.session.sync_clients
+        if member.stream is not None and member.stream.running and member.stream.connected
+    ]
+
+
+def _shared_announce_instant(streams: Iterable[AirPlayStream]) -> int:
+    """
+    Return the shared audible instant (unix ms) for arming an announcement.
+
+    Every member must mix the clip into audio it has not delivered yet; its
+    span is how far ahead of the audible position that delivery head runs, so
+    the shared instant sits past the largest member span plus a fan-out margin.
+    """
+    max_span_ms = max(_member_span_ms(stream) for stream in streams)
+    return int(time.time() * 1000) + max_span_ms + AIRPLAY_ANNOUNCE_AT_MARGIN_MS
+
+
+def _member_span_ms(stream: AirPlayStream) -> int:
+    """Return how far a member's delivery head runs ahead of its audible position (ms)."""
+    if stream.warm_lead_ms > 0:
+        return stream.warm_lead_ms
+    if stream.latency_lead_ms > 0:
+        return stream.latency_lead_ms
+    return AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS
+
+
+def _schedule_member_volume(
+    member: AirPlayPlayer, volume_level: int, at_unix_ms: int, clip_seconds: float
+) -> _VolumeSchedule | None:
+    """
+    Schedule the announcement volume around one member's audible clip window.
+
+    Both changes are wall-clock timers on the acked instant: the done report
+    arrives when the clip is fully MIXED (at the delivery head), which is ahead
+    of it being heard, so neither change can key off it.
+
+    :param member: The member whose volume is bumped and restored.
+    :param volume_level: The announcement volume level.
+    :param at_unix_ms: The acked audible instant of the clip on this member.
+    :param clip_seconds: The clip duration in seconds.
+    :return: The schedule to track (None when there is nothing to change).
+    """
+    prev_volume = member.volume_level
+    if prev_volume is None or prev_volume == volume_level:
+        return None
+    delay = max(0.0, at_unix_ms / 1000 - time.time())
+    handles = [
+        member.mass.call_later(delay, member.volume_set, volume_level),
+        member.mass.call_later(
+            delay + clip_seconds + AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS / 1000,
+            member.volume_set,
+            prev_volume,
+        ),
+    ]
+    return (member, prev_volume, handles)
+
+
+async def _render_clip_file(render: AnnouncementRender, pcm_format: AudioFormat) -> str:
+    """
+    Render the announcement clip into a temp file of raw PCM in the given format.
+
+    The caller owns the file and removes it once every member is done with it.
+
+    :param render: The (finished) announcement render to read.
+    :param pcm_format: The raw PCM format the file must carry.
+    """
+    chunks: list[bytes] = []
+    async for chunk in render.get_stream(pcm_format):
+        chunks.append(chunk)
+    return await asyncio.to_thread(_write_clip_file, b"".join(chunks))
+
+
+def _write_clip_file(data: bytes) -> str:
+    """Write clip audio to a uniquely named temp file and return its path."""
+    fd, path = tempfile.mkstemp(prefix="ma_airplay_announce_", suffix=".pcm")
+    with os.fdopen(fd, "wb") as clip_file:
+        clip_file.write(data)
+    return path
+
+
+async def _no_announce_ack() -> tuple[int, int] | None:
+    """Stand in for the started-ack of a member whose arm was never delivered."""
+    return None
+
+
+def _format_key(pcm_format: AudioFormat) -> str:
+    """Return the identity of a raw PCM stdin format for clip-file sharing."""
+    return f"{pcm_format.content_type.value}_{pcm_format.sample_rate}_{pcm_format.bit_depth}"

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -383,14 +383,17 @@ async def _announce_with_session(
             f"Cannot announce on {player.display_name}: a grouped AirPlay player "
             "without live playback cannot announce natively"
         )
-    if provider.bridge_manager.get_bridge(player.player_id) is not None:
-        # The device belongs to the bridge; a dedicated announcement session
-        # would seize it from the Sendspin side with nothing restoring that
-        # playback. Only reachable in a stream-ended race - an idle bridged
-        # player does not advertise the announcement feature at all.
+    bridge = provider.bridge_manager.get_bridge(player.player_id)
+    if bridge is not None and bridge.owns_airplay_stream:
+        # The bridge is actively streaming to the device; a dedicated
+        # announcement session would seize it from the Sendspin side with
+        # nothing restoring that playback. Only reachable in a race (the live
+        # mix path handles a playing bridge stream). A bridge that is merely
+        # configured but idle is a bystander: the fallback then behaves
+        # exactly as it does for an unbridged player.
         raise PlayerCommandFailed(
-            f"Cannot announce on {player.display_name}: the player is driven by its "
-            "Sendspin bridge and has no live stream to mix the announcement into"
+            f"Cannot announce on {player.display_name}: the player is being streamed "
+            "to by its Sendspin bridge"
         )
     prev_volumes: dict[AirPlayPlayer, int] = {}
     session: AirPlayStreamSession | None = None

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -36,7 +36,9 @@ from .constants import (
     AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS,
     AIRPLAY_ANNOUNCE_SESSION_DRAIN_S,
     AIRPLAY_ANNOUNCE_STARTED_TIMEOUT_MS,
+    AIRPLAY_ANNOUNCE_VOLUME_BUMP_DELAY_MS,
     AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS,
+    AIRPLAY_VOLUME_DB_PER_POINT,
 )
 from .stream_session import AirPlayStreamSession
 
@@ -237,12 +239,12 @@ async def _announce_over_live_session(
             at_unix_ms = _shared_announce_instant(streams.values())
             delivered = await asyncio.gather(
                 *[
-                    stream.announce(
-                        clip_files[_format_key(stream.pcm_format)],
+                    streams[member.player_id].announce(
+                        clip_files[_format_key(streams[member.player_id].pcm_format)],
                         at_unix_ms,
-                        AIRPLAY_ANNOUNCE_DUCK_DB,
+                        _member_duck_db(member, volume_level),
                     )
-                    for stream in streams.values()
+                    for member in members
                 ],
                 return_exceptions=True,
             )
@@ -484,6 +486,25 @@ def _member_span_ms(stream: AirPlayStream) -> int:
     return AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS
 
 
+def _member_duck_db(member: AirPlayPlayer, volume_level: int | None) -> float:
+    """
+    Return the music duck (dB) for one member, compensated for its volume bump.
+
+    The announcement volume is applied as DEVICE volume, which raises the music
+    bed together with the clip. The AirPlay volume scale is linear dB (see
+    AIRPLAY_VOLUME_DB_PER_POINT), so that rise is exactly known and the duck is
+    deepened by the same amount - the music keeps its configured perceived duck
+    depth while the clip plays at the configured announcement loudness. A bump
+    DOWN (a night-mode announcement quieter than the music) symmetrically
+    shallows the duck, and the result never leaves the binary's usable range.
+    """
+    duck_db = float(AIRPLAY_ANNOUNCE_DUCK_DB)
+    if volume_level is None or member.volume_level is None:
+        return duck_db
+    bump_db = (volume_level - member.volume_level) * AIRPLAY_VOLUME_DB_PER_POINT
+    return min(0.0, max(-60.0, duck_db - bump_db))
+
+
 def _schedule_member_volume(
     member: AirPlayPlayer, volume_level: int, at_unix_ms: int, clip_seconds: float
 ) -> _VolumeSchedule | None:
@@ -504,8 +525,13 @@ def _schedule_member_volume(
     if prev_volume is None or prev_volume == volume_level:
         return None
     delay = max(0.0, at_unix_ms / 1000 - time.time())
+    # The bump is biased INTO the clip: a receiver that plays out later than
+    # the reported instant would otherwise get louder while the old music is
+    # still sounding. The duck ramp (and the pre-announce chime) masks the
+    # late bump; short clips cap the bias at their midpoint.
+    bump_delay = delay + min(AIRPLAY_ANNOUNCE_VOLUME_BUMP_DELAY_MS / 1000, clip_seconds / 2)
     handles = [
-        member.mass.call_later(delay, member.volume_set, volume_level),
+        member.mass.call_later(bump_delay, member.volume_set, volume_level),
         member.mass.call_later(
             delay + clip_seconds + AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS / 1000,
             member.volume_set,

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -8,17 +8,18 @@ member of the live session at one shared audible instant and tracks the per-memb
 outcome. Whenever there is no live playback to mix into (idle or parked player), the
 announcement runs as a dedicated stream session instead, leaving the player idle.
 
-Targeting semantics: the leader of an (ad-hoc) sync group represents the whole
-group - announcing to it plays on every member, exactly like playing media to it
-does. A synced member addressed individually announces alone, over its own ducked
-copy of the group's music, while the other rooms play on untouched.
+Targeting semantics: a player addressed individually announces alone - over its own
+ducked copy of the group's music, while the other rooms play on untouched - whenever
+a group ENTITY exists as the whole-group handle (a syncgroup member, even the one
+leading the underlying session). Only an ad-hoc sync leader, which has no entity
+above it, represents its whole group, exactly like playing media to it does.
 
-A group announcement is forwarded by the player controller to every member
-concurrently; the session leader's call runs one orchestration for the whole session
-and the members' calls coalesce onto it (see the provider's announce-task registry).
+A group-entity announcement is forwarded by the player controller to every member
+concurrently; each call arms its own member and they share one audible instant via
+the provider's announce-plan registry, so every room renders the clip in sync.
 Members of a Sendspin GROUP of bridged players each compute their own instant, so a
 group announcement there can be offset by tens of ms across rooms; cross-player
-coalescing for that case is future work.
+plan sharing for that case is future work.
 """
 
 from __future__ import annotations
@@ -29,7 +30,7 @@ import tempfile
 import time
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Final, cast
+from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.enums import ContentType, PlaybackState
 from music_assistant_models.errors import PlayerCommandFailed
@@ -67,28 +68,18 @@ if TYPE_CHECKING:
 # releases a tracked entry that never fired).
 _VolumeSchedule = tuple["AirPlayPlayer", int, list[str]]
 
-# How a synced member's call looks for the leader task of a group announcement.
-# The controller forwards a group announcement to every member in one batch, so
-# the leader registers within a scheduler tick or two of the members' first
-# check - a couple of short polls cover that ordering. Kept tight on purpose:
-# only the timeout tells a group-forwarded member call apart from a DIRECT
-# announcement to that member, which pays the full poll as dead latency before
-# it arms.
-_LEADER_TASK_POLL_INTERVAL_S: Final[float] = 0.1
-_LEADER_TASK_POLL_ATTEMPTS: Final[int] = 3
-
 
 async def play_announcement(
     player: AirPlayPlayer, announcement: PlayerMedia, volume_level: int | None
 ) -> None:
     """
-    Play an announcement on the player (and the members it leads).
+    Play an announcement on the player (and, for an ad-hoc leader, its members).
 
     A live playing session mixes the clip over the music without interrupting
     it; an idle player plays the announcement as a dedicated stream session and
-    ends idle. A group announcement (forwarded per member by the controller) is
-    orchestrated once by the session leader's call; the members' calls coalesce
-    onto that shared run.
+    ends idle. A group-entity announcement is forwarded per member by the
+    controller; the members share one audible instant through the provider's
+    announce-plan registry so every room renders the clip in sync.
 
     :param player: The player the announcement targets.
     :param announcement: The announcement to play.
@@ -99,70 +90,12 @@ async def play_announcement(
         raise PlayerCommandFailed(
             f"Announcement for {player.display_name} carries no announcement data"
         )
-    provider = cast("AirPlayProvider", player.provider)
     renderer = player.mass.streams.announcement_renderer
     render = renderer.acquire(announce_data)
     try:
-        if player.synced_to:
-            if await _join_group_announcement(provider, player, render.key):
-                return
-            # no group announcement to coalesce onto: this is the deliberate
-            # announcement to just this member
-            await _run_announcement(player, announcement, render, volume_level)
-            return
-        # Leader/solo: publish the orchestration as a task so the concurrently
-        # forwarded member calls of a group announcement await it instead of
-        # arming their members a second time. Registered synchronously (no
-        # await between task creation and registration) so a member's lookup
-        # can never miss an in-flight run.
-        task = player.mass.create_task(
-            _run_announcement(player, announcement, render, volume_level)
-        )
-        provider._announce_tasks[player.player_id] = (render.key, task)
-        try:
-            await task
-        except asyncio.CancelledError:
-            # cancelling the caller must cancel the orchestration itself, so
-            # its cleanup (volume restore, clip files) runs
-            task.cancel()
-            raise
-        finally:
-            provider._announce_tasks.pop(player.player_id, None)
+        await _run_announcement(player, announcement, render, volume_level)
     finally:
         await renderer.release(render)
-
-
-async def _join_group_announcement(
-    provider: AirPlayProvider, player: AirPlayPlayer, render_key: str
-) -> bool:
-    """
-    Await the group announcement the player's sync leader runs, if there is one.
-
-    The leader's orchestration arms every member of the session - including
-    this player, and the announcement volume for all of them - so this call
-    only has to await that shared outcome (which also propagates its failure).
-
-    :param provider: The AirPlay provider holding the announce-task registry.
-    :param player: The synced member whose leader may run the announcement.
-    :param render_key: Identity of the announcement audio, to only ever join
-        the run of the SAME announcement.
-    :return: True when a matching group announcement was found and awaited;
-        False when none appeared (an announcement to just this member).
-    """
-    leader_id = player.synced_to
-    assert leader_id is not None  # only called for synced members
-    for attempt in range(_LEADER_TASK_POLL_ATTEMPTS):
-        entry = provider._announce_tasks.get(leader_id)
-        if entry is not None and entry[0] == render_key:
-            player.logger.debug(
-                "Announcement to %s coalesces onto the group announcement of its leader",
-                player.display_name,
-            )
-            await entry[1]
-            return True
-        if attempt < _LEADER_TASK_POLL_ATTEMPTS - 1:
-            await asyncio.sleep(_LEADER_TASK_POLL_INTERVAL_S)
-    return False
 
 
 async def _run_announcement(
@@ -244,7 +177,7 @@ async def _announce_over_live_session(
                     clip_files[clip_key] = await _render_clip_file(render, stream.pcm_format)
             # resolved only now: file rendering above must not eat into the
             # margin the shared instant carries
-            at_unix_ms = _shared_announce_instant(streams.values())
+            at_unix_ms = _resolve_announce_instant(player, members, render.key)
             delivered = await asyncio.gather(
                 *[
                     streams[member.player_id].announce(
@@ -475,11 +408,61 @@ def _live_members(player: AirPlayPlayer) -> list[AirPlayPlayer]:
         if bridge is not None and bridge.owns_airplay_stream:
             return [player]
         return []
+    if player.state.active_group:
+        # A group ENTITY (e.g. a syncgroup) owns this session, and that entity
+        # is the whole-group announcement handle: this player addressed
+        # individually announces alone, even as the session's sync leader.
+        return [player]
+    # An ad-hoc leader has no entity above it, so it IS the group handle:
+    # announcing to it covers every member of its session.
     return [
         member
         for member in stream.session.sync_clients
         if member.stream is not None and member.stream.running and member.stream.connected
     ]
+
+
+def _resolve_announce_instant(
+    player: AirPlayPlayer, members: list[AirPlayPlayer], render_key: str
+) -> int:
+    """
+    Return the audible instant (unix ms) the announcement is armed for.
+
+    When the targets are only a part of a multi-member session (a group-entity
+    announcement is fanned out per member by the controller, each call arming
+    its own member), the instant is shared through the provider's plan
+    registry: the first call computes it from EVERY session member's span, the
+    concurrent sibling calls reuse it, and every room renders the clip in
+    sync. A call that arms its whole target set at once (ad-hoc leader, solo,
+    bridged) needs no plan.
+
+    :param player: The player this call targets.
+    :param members: The members this call arms.
+    :param render_key: Identity of the announcement audio; instants are only
+        ever shared between arms of the SAME announcement.
+    """
+    session = player.stream.session if player.stream else None
+    session_members = session.sync_clients if session else members
+    if len(members) >= len(session_members):
+        return _shared_announce_instant(
+            member.stream for member in members if member.stream is not None
+        )
+    provider = cast("AirPlayProvider", player.provider)
+    plans = provider._announce_plans
+    now_ms = int(time.time() * 1000)
+    # prune settled plans so the registry cannot grow with announcement history
+    for key in [key for key, at_ms in plans.items() if at_ms <= now_ms]:
+        del plans[key]
+    plan_key = (player.state.active_group or player.synced_to or player.player_id, render_key)
+    if (at_unix_ms := plans.get(plan_key)) is not None:
+        return at_unix_ms
+    # the instant must clear EVERY session member's span: the sibling calls of
+    # a group fan-out reuse it for their own members
+    at_unix_ms = _shared_announce_instant(
+        member.stream for member in session_members if member.stream is not None
+    )
+    plans[plan_key] = at_unix_ms
+    return at_unix_ms
 
 
 def _shared_announce_instant(streams: Iterable[AirPlayStream]) -> int:

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -26,13 +26,14 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Final, cast
 
-from music_assistant_models.enums import PlaybackState
+from music_assistant_models.enums import ContentType, PlaybackState
 from music_assistant_models.errors import PlayerCommandFailed
 
 from .constants import (
     AIRPLAY_ANNOUNCE_AT_MARGIN_MS,
     AIRPLAY_ANNOUNCE_DONE_TIMEOUT_MS,
     AIRPLAY_ANNOUNCE_DUCK_DB,
+    AIRPLAY_ANNOUNCE_DUCK_TAIL_S,
     AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS,
     AIRPLAY_ANNOUNCE_SESSION_DRAIN_S,
     AIRPLAY_ANNOUNCE_STARTED_TIMEOUT_MS,
@@ -287,18 +288,27 @@ async def _announce_over_live_session(
                 if (ack := started.get(member.player_id)) is None:
                     continue
                 ack_at_unix_ms, ack_duration_ms = ack
+                # The binary-reported duration includes the ducked silence
+                # tail appended to the clip file; the restore must land INSIDE
+                # that cushion, so it is timed on the content length alone.
+                content_seconds = (
+                    max(0.0, ack_duration_ms / 1000 - AIRPLAY_ANNOUNCE_DUCK_TAIL_S)
+                    if ack_duration_ms
+                    else duration
+                )
                 if schedule := _schedule_member_volume(
                     member,
                     volume_level,
                     ack_at_unix_ms or at_unix_ms,
-                    ack_duration_ms / 1000 if ack_duration_ms else duration,
+                    content_seconds,
                 ):
                     volume_schedules.append(schedule)
+        padded_duration = duration + AIRPLAY_ANNOUNCE_DUCK_TAIL_S
         done_results = await asyncio.gather(
             *[
                 streams[member_id].wait_announce_done(
                     max(0.0, (ack_at or at_unix_ms) / 1000 - time.time())
-                    + (ack_duration / 1000 if ack_duration else duration)
+                    + (ack_duration / 1000 if ack_duration else padded_duration)
                     + AIRPLAY_ANNOUNCE_DONE_TIMEOUT_MS / 1000
                 )
                 for member_id, (ack_at, ack_duration) in started.items()
@@ -323,7 +333,7 @@ async def _announce_over_live_session(
         # announcement) over the audible tail, so hold the return until the
         # latest audible end across the started members.
         latest_end_unix_ms = max(
-            (ack_at or at_unix_ms) + (ack_duration or int(duration * 1000))
+            (ack_at or at_unix_ms) + (ack_duration or int(padded_duration * 1000))
             for ack_at, ack_duration in started.values()
         )
         await asyncio.sleep(
@@ -545,6 +555,10 @@ async def _render_clip_file(render: AnnouncementRender, pcm_format: AudioFormat)
     """
     Render the announcement clip into a temp file of raw PCM in the given format.
 
+    A ducked-silence tail is appended: the binary holds the music duck for the
+    whole file, so the music stays ducked briefly past the announcement and the
+    volume restore has a safe window to land in.
+
     The caller owns the file and removes it once every member is done with it.
 
     :param render: The (finished) announcement render to read.
@@ -553,6 +567,16 @@ async def _render_clip_file(render: AnnouncementRender, pcm_format: AudioFormat)
     clip = bytearray()
     async for chunk in render.get_stream(pcm_format):
         clip.extend(chunk)
+    # Wire sizes come from the content type: at 24-bit the stdin carrier is
+    # s32le while bit_depth stays 24, so bit_depth-derived sizes are wrong.
+    bytes_per_sample = {
+        ContentType.PCM_S16LE: 2,
+        ContentType.PCM_S24LE: 3,
+        ContentType.PCM_S32LE: 4,
+        ContentType.PCM_F32LE: 4,
+    }.get(pcm_format.content_type, pcm_format.bit_depth // 8)
+    trail_frames = int(pcm_format.sample_rate * AIRPLAY_ANNOUNCE_DUCK_TAIL_S)
+    clip.extend(bytes(trail_frames * bytes_per_sample * pcm_format.channels))
     return await asyncio.to_thread(_write_clip_file, clip)
 
 

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -206,6 +206,38 @@ AIRPLAY_LATE_JOIN_RING_MAX_BYTES: Final[int] = 6 * 1024 * 1024
 # Staged retries can be reintroduced by adding entries to the tuple.
 AIRPLAY_REJOIN_ATTEMPT_DELAYS: Final[tuple[int, ...]] = (5,)
 
+# Shared audible instant for a native announcement over a live stream: now +
+# the largest member span + this margin. A member can only mix the clip into
+# audio it has not delivered yet, and its span (warm_lead_ms on the Apple
+# splice timeline, the reported lead_ms otherwise) is how far its delivery
+# head runs ahead of the audible position - so the earliest instant EVERY
+# member can honor lies one max-span out. The margin covers fanning the
+# command out over the pipes and the per-member arm processing, so one shared
+# instant stays feasible for all members.
+AIRPLAY_ANNOUNCE_AT_MARGIN_MS: Final[int] = 300
+# Span assumed for a member whose binary reported neither a warm lead nor a
+# device lead (both read 0 = unreported): the binary's own default playback
+# lead, which bounds how far its delivery head can run ahead.
+AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS: Final[int] = 2000
+# Music gain (dB) under the clip while it plays; the binary ramps the duck in
+# and out itself. <= -60 mutes the music entirely.
+AIRPLAY_ANNOUNCE_DUCK_DB: Final[int] = -12
+# On top of the lead to the commanded instant: how long to wait for a member's
+# announce_started before treating that member as not announcing. An outdated
+# binary silently ignores the unknown command, so this bounded wait is also
+# what detects that and routes the announcement to the fallback path.
+AIRPLAY_ANNOUNCE_STARTED_TIMEOUT_MS: Final[int] = 3000
+# On top of the clip's audible end: how long to wait for announce_done. The
+# wait stays bounded because a queue that ends mid-clip emits its eof, which
+# ends the status stream while the clip still plays out over the drain.
+AIRPLAY_ANNOUNCE_DONE_TIMEOUT_MS: Final[int] = 5000
+# Pad after the clip's audible end before the pre-announcement volume is
+# restored: covers the jitter between the acked instant and true audibility.
+AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS: Final[int] = 500
+# Drain margin for a dedicated announcement session: covers the receiver
+# playing out its buffered audio after the clip's last byte was fed.
+AIRPLAY_ANNOUNCE_SESSION_DRAIN_S: Final[float] = 2.0
+
 # Cover art is rendered to a local JPEG for the binary to embed (the binary
 # does not fetch URLs). 512px keeps the SET_PARAMETER payload small while still
 # looking sharp on speaker apps and the Apple TV now-playing screen.
@@ -258,6 +290,7 @@ AIRPLAY_HIRES_AUDIO_FORMATS: Final[int] = (1 << 19) | (1 << 21)
 
 BASE_PLAYER_FEATURES: Final[set[PlayerFeature]] = {
     PlayerFeature.PLAY_MEDIA,
+    PlayerFeature.PLAY_ANNOUNCEMENT,
     PlayerFeature.SET_MEMBERS,
     PlayerFeature.MULTI_DEVICE_DSP,
     PlayerFeature.VOLUME_SET,

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -234,6 +234,18 @@ AIRPLAY_ANNOUNCE_DONE_TIMEOUT_MS: Final[int] = 5000
 # Pad after the clip's audible end before the pre-announcement volume is
 # restored: covers the jitter between the acked instant and true audibility.
 AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS: Final[int] = 500
+# Delay of the announcement-volume bump past the clip's audible start: a bump
+# that lands early (a receiver playing out later than the reported instant)
+# raises the still-playing music, so it is biased into the clip where the duck
+# ramp masks it - the pre-announce chime covers the first moments anyway.
+AIRPLAY_ANNOUNCE_VOLUME_BUMP_DELAY_MS: Final[int] = 300
+# The AirPlay volume parameter is linear dB: 0..100 maps onto -30..0 dB on
+# every flow (libraop raopcl_float_volume, reused verbatim by the native AP2
+# SET_PARAMETER path), so one volume point is exactly 0.3 dB of output. This
+# makes the announcement volume bump's effect on the music bed computable, and
+# the duck is deepened by the same amount to keep the music's perceived level
+# at the configured duck depth.
+AIRPLAY_VOLUME_DB_PER_POINT: Final[float] = 0.3
 # Drain margin for a dedicated announcement session: covers the receiver
 # playing out its buffered audio after the clip's last byte was fed.
 AIRPLAY_ANNOUNCE_SESSION_DRAIN_S: Final[float] = 2.0

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -220,8 +220,15 @@ AIRPLAY_ANNOUNCE_AT_MARGIN_MS: Final[int] = 300
 # lead, which bounds how far its delivery head can run ahead.
 AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS: Final[int] = 2000
 # Music gain (dB) under the clip while it plays; the binary ramps the duck in
-# and out itself. <= -60 mutes the music entirely.
-AIRPLAY_ANNOUNCE_DUCK_DB: Final[int] = -12
+# and out itself. <= -60 mutes the music entirely. -18 dB puts the music
+# clearly in the background under speech (-12 was field-judged too shallow).
+AIRPLAY_ANNOUNCE_DUCK_DB: Final[int] = -18
+# Silence appended to every announcement clip file. The binary holds the duck
+# for the whole file, so this keeps the music ducked past the announcement -
+# the volume restore lands inside this cushion instead of racing the duck's
+# 200 ms tail ramp (a restore that lands after the ramp plays a moment of
+# full-level music at the still-bumped device volume).
+AIRPLAY_ANNOUNCE_DUCK_TAIL_S: Final[float] = 1.0
 # On top of the lead to the commanded instant: how long to wait for a member's
 # announce_started before treating that member as not announcing. An outdated
 # binary silently ignores the unknown command, so this bounded wait is also

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -28,6 +28,7 @@ from music_assistant.helpers.util import get_primary_ip_address_from_zeroconf, i
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 from music_assistant.models.setup_flow import AbortFlow
 
+from . import announce
 from .constants import (
     AIRPLAY_DISCOVERY_TYPE,
     AIRPLAY_HIRES_AUDIO_FORMATS,
@@ -258,7 +259,15 @@ class AirPlayPlayer(Player):
         # could fall through to a linked native player's pause (e.g. a Sonos acting as
         # an AirPlay receiver), which only pauses the sync leader while the other
         # members keep playing.
-        return {*BASE_PLAYER_FEATURES, PlayerFeature.PAUSE}
+        features = {*BASE_PLAYER_FEATURES, PlayerFeature.PAUSE}
+        # A Sendspin-bridged player's audio stream is owned by the bridge: there
+        # is no stream session to mix an announcement into, and the fallback
+        # would steal the device from a live bridge stream. Without the feature,
+        # announcements for these devices keep their existing routing.
+        prov = cast("AirPlayProvider", self.provider)
+        if prov.bridge_manager.get_bridge(self.player_id) is not None:
+            features.discard(PlayerFeature.PLAY_ANNOUNCEMENT)
+        return features
 
     @property
     def can_group_with(self) -> set[str]:
@@ -518,6 +527,20 @@ class AirPlayPlayer(Player):
             )
             await stream_session.start(audio_source)
             self._transitioning = False
+
+    async def play_announcement(
+        self, announcement: PlayerMedia, volume_level: int | None = None
+    ) -> None:
+        """
+        Play an announcement natively: mixed over live playback, or as its own session.
+
+        :param announcement: Details of the announcement that needs to be played.
+        :param volume_level: Optional volume level for the announcement.
+        """
+        # The lock windows live inside the orchestration: the dispatch decision
+        # and session mutations hold self._lock like play_media does, while the
+        # multi-second clip waits run outside it (see announce.py).
+        await announce.play_announcement(self, announcement, volume_level)
 
     async def volume_set(self, volume_level: int) -> None:
         """Send VOLUME_SET command to given player."""

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -260,15 +260,20 @@ class AirPlayPlayer(Player):
         # an AirPlay receiver), which only pauses the sync leader while the other
         # members keep playing.
         features = {*BASE_PLAYER_FEATURES, PlayerFeature.PAUSE}
-        # A Sendspin-bridged player advertises announcements only while the
-        # bridge actually streams to it: that stream is a regular AirPlayStream
-        # the clip mixes into. An IDLE bridged player must not advertise - its
-        # dedicated announcement session would fight the bridge for the device,
-        # so without the feature those announcements keep their existing
-        # routing (the generic flow via the Sendspin parent).
+        # A player with a Sendspin bridge CONFIGURED still announces natively
+        # whenever there is a stream to mix into: its own (session-backed)
+        # AirPlay stream, or the bridge's stream while Sendspin plays through
+        # it. Only a bridged player with neither hides the feature - a
+        # dedicated announcement session on it would race the bridge for the
+        # device, so those announcements keep their existing routing (the
+        # generic flow via the Sendspin parent).
         prov = cast("AirPlayProvider", self.provider)
         bridge = prov.bridge_manager.get_bridge(self.player_id)
-        if bridge is not None and not bridge.owns_airplay_stream:
+        if (
+            bridge is not None
+            and not bridge.owns_airplay_stream
+            and not (self.stream is not None and self.stream.running and self.stream.session)
+        ):
             features.discard(PlayerFeature.PLAY_ANNOUNCEMENT)
         return features
 

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -260,12 +260,15 @@ class AirPlayPlayer(Player):
         # an AirPlay receiver), which only pauses the sync leader while the other
         # members keep playing.
         features = {*BASE_PLAYER_FEATURES, PlayerFeature.PAUSE}
-        # A Sendspin-bridged player's audio stream is owned by the bridge: there
-        # is no stream session to mix an announcement into, and the fallback
-        # would steal the device from a live bridge stream. Without the feature,
-        # announcements for these devices keep their existing routing.
+        # A Sendspin-bridged player advertises announcements only while the
+        # bridge actually streams to it: that stream is a regular AirPlayStream
+        # the clip mixes into. An IDLE bridged player must not advertise - its
+        # dedicated announcement session would fight the bridge for the device,
+        # so without the feature those announcements keep their existing
+        # routing (the generic flow via the Sendspin parent).
         prov = cast("AirPlayProvider", self.provider)
-        if prov.bridge_manager.get_bridge(self.player_id) is not None:
+        bridge = prov.bridge_manager.get_bridge(self.player_id)
+        if bridge is not None and not bridge.owns_airplay_stream:
             features.discard(PlayerFeature.PLAY_ANNOUNCEMENT)
         return features
 

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -223,12 +223,13 @@ class AirPlayProvider(PlayerProvider):
         self._set_pyatv_log_level()
         self._companion_info_by_address: dict[str, AsyncServiceInfo] = {}
         self._mrp_info_by_address: dict[str, AsyncServiceInfo] = {}
-        # Native announcement orchestrations by session-leader player id ->
-        # (render key, task). The controller forwards a group announcement to
-        # every member concurrently; the members' calls use this registry to
-        # coalesce onto the leader's single orchestration instead of arming
-        # their members a second time (managed by announce.py).
-        self._announce_tasks: dict[str, tuple[str, asyncio.Task[None]]] = {}
+        # Shared audible instants for in-flight announcements, keyed by
+        # (group-or-leader player id, render key) -> unix ms. The controller
+        # forwards a group-entity announcement to every member concurrently;
+        # each call arms its own member and reuses the instant the first call
+        # planned, so all rooms render the clip in sync (managed by
+        # announce.py, pruned as plans pass).
+        self._announce_plans: dict[tuple[str, str], int] = {}
 
         # Initialize Sendspin bridge manager for protocol linking
         self._bridge_manager = SendspinBridgeManager(self)

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -223,6 +223,12 @@ class AirPlayProvider(PlayerProvider):
         self._set_pyatv_log_level()
         self._companion_info_by_address: dict[str, AsyncServiceInfo] = {}
         self._mrp_info_by_address: dict[str, AsyncServiceInfo] = {}
+        # Native announcement orchestrations by session-leader player id ->
+        # (render key, task). The controller forwards a group announcement to
+        # every member concurrently; the members' calls use this registry to
+        # coalesce onto the leader's single orchestration instead of arming
+        # their members a second time (managed by announce.py).
+        self._announce_tasks: dict[str, tuple[str, asyncio.Task[None]]] = {}
 
         # Initialize Sendspin bridge manager for protocol linking
         self._bridge_manager = SendspinBridgeManager(self)

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -477,7 +477,7 @@ class AirPlayStream:
             return False
         return True
 
-    async def announce(self, file_path: str, at_unix_ms: int, duck_db: int) -> bool:
+    async def announce(self, file_path: str, at_unix_ms: int, duck_db: float) -> bool:
         """
         Arm the binary's native announcement mixer with a clip file.
 

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -69,6 +69,7 @@ CLI_ERROR_AUTH_REQUIRED: Final[str] = "auth_required"
 CLI_ERROR_AUTH_FAILED: Final[str] = "auth_failed"
 CLI_ERROR_START_FAILED: Final[str] = "start_failed"
 CLI_ERROR_FLUSH_FAILED: Final[str] = "flush_failed"
+CLI_ERROR_ANNOUNCE_FAILED: Final[str] = "announce_failed"
 
 _CLI_ERROR_CODE_RE = re.compile(r"\bcode=(\S+)")
 _CLI_ERROR_HTTP_RE = re.compile(r"\bhttp=(\d+)")
@@ -106,7 +107,9 @@ class AirPlayStream:
     # which a START would anchor as if it were the new first sample.
     audio_pending_ms: int = 0
 
-    def __init__(self, player: AirPlayPlayer, pcm_format: AudioFormat | None = None) -> None:
+    def __init__(  # noqa: PLR0915
+        self, player: AirPlayPlayer, pcm_format: AudioFormat | None = None
+    ) -> None:
         """
         Initialize AirPlay stream.
 
@@ -164,6 +167,16 @@ class AirPlayStream:
         self._started = asyncio.Event()
         self._start_ack: tuple[int, int] | None = None
         self._start_error: CliError | None = None
+        # The binary's answers to an ANNOUNCE arm: announce_started carries the
+        # actual audible instant plus clip duration, a reported announce failure
+        # fills the error slot instead (each answer clears the other), and
+        # announce_done is set once the clip is fully mixed - with the cancelled
+        # flag when it was cut short (or never played at all).
+        self._announce_started = asyncio.Event()
+        self._announce_done = asyncio.Event()
+        self._announce_ack: tuple[int, int] | None = None
+        self._announce_error: CliError | None = None
+        self._announce_done_cancelled = False
         # Whether the last commanded START was a late-join start: routes the
         # post-commit correction log level (a corrected join is the routine
         # landing path, a corrected origin start is a loud signal).
@@ -463,6 +476,76 @@ class AirPlayStream:
             )
             return False
         return True
+
+    async def announce(self, file_path: str, at_unix_ms: int, duck_db: int) -> bool:
+        """
+        Arm the binary's native announcement mixer with a clip file.
+
+        The clip is mixed over the outgoing music with the music ducked
+        underneath - no flush, no re-anchor, the group timeline is untouched.
+        The binary requires an anchored, playing stream to accept the arm.
+
+        :param file_path: Raw headerless PCM clip in exactly this stream's
+            stdin format.
+        :param at_unix_ms: Unix epoch ms at which the clip must be audible
+            (0 = earliest feasible).
+        :param duck_db: Music gain in dB while the clip plays (<= -60 mutes).
+        :return: True when the command was delivered; the binary then answers
+            with announce_started/announce_done (or a reported announce
+            failure), awaited via :meth:`wait_announce_started` and
+            :meth:`wait_announce_done`.
+        """
+        if not self.running or not self.connected:
+            return False
+        self._arm_announce_answer()
+        return await self._write_cli_command(
+            f"ANNOUNCE_FILE={file_path}\n"
+            f"ANNOUNCE_AT_UNIX_MS={at_unix_ms}\n"
+            f"ANNOUNCE_DUCK_DB={duck_db}\n"
+            "ACTION=ANNOUNCE"
+        )
+
+    async def wait_announce_started(self, timeout: float) -> tuple[int, int] | None:
+        """
+        Wait for the binary to commit the armed clip's first sample.
+
+        :param timeout: Seconds to wait for the report.
+        :return: The ACTUAL audible instant (unix ms, possibly corrected later
+            than requested) and the clip duration (ms), either 0 when
+            unreported. None when the arm failed, the clip was cancelled before
+            it played, or nothing arrived in time (an outdated binary ignores
+            the command entirely).
+        """
+        # announce_done can be the only answer (cancelled before the clip ever
+        # played), so the wait watches both events instead of running out its
+        # timeout on a clip that is already settled.
+        waiters = [
+            asyncio.ensure_future(self._announce_started.wait()),
+            asyncio.ensure_future(self._announce_done.wait()),
+        ]
+        try:
+            await asyncio.wait(waiters, timeout=timeout, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            for waiter in waiters:
+                waiter.cancel()
+        if self._announce_error is not None or not self._announce_started.is_set():
+            return None
+        return self._announce_ack or (0, 0)
+
+    async def wait_announce_done(self, timeout: float) -> bool:
+        """
+        Wait for the armed clip (and its tail ramp) to be fully mixed.
+
+        :param timeout: Seconds to wait for the report.
+        :return: True for a completed clip; False when it was cancelled, the arm
+            failed, or nothing arrived in time (e.g. the status stream ended on
+            the eof of a queue that ran out mid-clip).
+        """
+        try:
+            await asyncio.wait_for(self._announce_done.wait(), timeout)
+        except TimeoutError:
+            return False
+        return self._announce_error is None and not self._announce_done_cancelled
 
     async def wait_audio_present(self, timeout: float = 5.0) -> bool:
         """
@@ -1247,9 +1330,12 @@ class AirPlayStream:
           [STATUS] playing elapsed_ms=<ms>
           [STATUS] paused
           [STATUS] eof
+          [STATUS] announce_started at_unix_ms=<ms> duration_ms=<ms>
+          [STATUS] announce_done [cancelled=1]
           [STATUS] error code=<slug> http=<int> detail="<short text>"
             (auth_required/auth_failed/connect_failed are terminal; the
-             start_failed/flush_failed command slugs answer a pending ack)
+             start_failed/flush_failed/announce_failed command slugs answer
+             a pending ack)
           [ERROR] <message>
         """
         player = self.player
@@ -1420,6 +1506,19 @@ class AirPlayStream:
                 self.flushed_head_unix_ms = 0
             self._flush_error = None
             self._flushed.set()
+        elif "[STATUS] announce_started" in line:
+            fields = dict(part.split("=", 1) for part in line.split() if "=" in part)
+            self._announce_ack = (
+                _status_int(fields, "at_unix_ms"),
+                _status_int(fields, "duration_ms"),
+            )
+            # The started report and a reported announce failure are the two
+            # mutually exclusive answers to one arm, so each clears the other.
+            self._announce_error = None
+            self._announce_started.set()
+        elif "[STATUS] announce_done" in line:
+            self._announce_done_cancelled = "cancelled=1" in line
+            self._announce_done.set()
         elif "[STATUS] audio " in line:
             if "buffered_ms=" in line:
                 try:
@@ -1586,6 +1685,14 @@ class AirPlayStream:
         self._flushed.clear()
         self._flush_error = None
 
+    def _arm_announce_answer(self) -> None:
+        """Clear the slots the binary answers an ANNOUNCE in, so only this one's answer is read."""
+        self._announce_started.clear()
+        self._announce_done.clear()
+        self._announce_ack = None
+        self._announce_error = None
+        self._announce_done_cancelled = False
+
     async def _write_cli_command(self, command: str) -> bool:
         """Write an interactive command regardless of stream teardown state."""
         if not self._cli_proc or self._cli_proc.closed:
@@ -1699,6 +1806,13 @@ class AirPlayStream:
         if error.code == CLI_ERROR_FLUSH_FAILED:
             self._flush_error = error
             self._flushed.set()
+            return
+        if error.code == CLI_ERROR_ANNOUNCE_FAILED:
+            # A rejected arm plays nothing, so both announce waits are answered
+            # at once - nothing else will ever answer them.
+            self._announce_error = error
+            self._announce_started.set()
+            self._announce_done.set()
             return
         self._connect_error = error
         if error.code in (CLI_ERROR_AUTH_FAILED, CLI_ERROR_AUTH_REQUIRED):

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -3202,22 +3202,58 @@ class TestNativeAnnouncementRouting:
         native_path.assert_awaited_once()
         assert native_path.call_args.args[1] is proto
 
-    async def test_own_native_support_beats_the_active_protocol_child(
+    async def test_active_protocol_child_beats_own_native_support(
         self, mock_mass: MagicMock
     ) -> None:
         """
-        A player's own announcement support wins over its rendering protocol child.
+        The output that is actively rendering wins over the player's own support.
 
-        E.g. a Sonos playing through its AirPlay child: its native announcement
-        overlays the clip on whatever source plays, which beats interrupting
-        the child's stream.
+        E.g. a Sonos playing through its AirPlay child: the announcement rides
+        the same audio path as the music (mixed into the live stream, in sync
+        with the rest of a group) instead of a second mechanism firing beside
+        the playback.
         """
-        controller, player, _proto, native_path, _generic_path = (
+        controller, _player, proto, native_path, _generic_path = (
             self._make_player_with_linked_child(
                 mock_mass,
                 PlaybackState.PLAYING,
                 parent_supports_announce=True,
                 active_protocol="proto_1",
+            )
+        )
+
+        await controller.play_announcement("player_1", "http://test/announcement.mp3")
+
+        native_path.assert_awaited_once()
+        assert native_path.call_args.args[1] is proto
+
+    async def test_own_native_support_wins_when_playing_natively(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player rendering through its own native output announces natively."""
+        controller, player, _proto, native_path, _generic_path = (
+            self._make_player_with_linked_child(
+                mock_mass,
+                PlaybackState.PLAYING,
+                parent_supports_announce=True,
+                active_protocol="native",
+            )
+        )
+
+        await controller.play_announcement("player_1", "http://test/announcement.mp3")
+
+        native_path.assert_awaited_once()
+        assert native_path.call_args.args[1] is player
+
+    async def test_idle_player_prefers_its_own_support_over_a_linked_child(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Without active playback the player's own announcement support wins."""
+        controller, player, _proto, native_path, _generic_path = (
+            self._make_player_with_linked_child(
+                mock_mass,
+                PlaybackState.IDLE,
+                parent_supports_announce=True,
             )
         )
 

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -3117,6 +3117,116 @@ class TestPlayAnnouncementCleanup:
         render.wait_finished.assert_not_awaited()
 
 
+class TestNativeAnnouncementRouting:
+    """Announcement routing respects the player's own support and its active output."""
+
+    def _make_player_with_linked_child(
+        self,
+        mock_mass: MagicMock,
+        playback_state: PlaybackState,
+        *,
+        parent_supports_announce: bool = False,
+        active_protocol: str | None = None,
+    ) -> tuple[PlayerController, MockPlayer, MockPlayer, AsyncMock, AsyncMock]:
+        """Create a controller, a player, its linked protocol child and the two path mocks."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        player._attr_playback_state = playback_state
+        if parent_supports_announce:
+            player._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)
+        proto_provider = MockProvider("airplay", mass=mock_mass)
+        proto = MockPlayer(
+            proto_provider, "proto_1", "AirPlay Child", player_type=PlayerType.PROTOCOL
+        )
+        proto._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)
+        controller._players = {"player_1": player, "proto_1": proto}
+        mock_mass.players = controller
+        player.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id="proto_1",
+                    name="AirPlay",
+                    protocol_domain="airplay",
+                    priority=40,
+                )
+            ]
+        )
+        if active_protocol is not None:
+            player.set_active_output_protocol(active_protocol)
+        render = MagicMock()
+        render.wait_ready = AsyncMock(return_value=True)
+        renderer = mock_mass.streams.announcement_renderer
+        renderer.register = MagicMock(return_value=render)
+        renderer.unregister = AsyncMock()
+        mock_mass.streams.get_announcement_url = MagicMock(
+            side_effect=lambda player_id, **_kwargs: f"http://ma/announcement/{player_id}.mp3"
+        )
+        proto.update_state(signal_event=False)
+        player.update_state(signal_event=False)
+        native_path = AsyncMock()
+        generic_path = AsyncMock()
+        controller._play_native_announcement = native_path  # type: ignore[method-assign]
+        controller._play_announcement = generic_path  # type: ignore[method-assign]
+        return controller, player, proto, native_path, generic_path
+
+    async def test_playing_player_does_not_route_to_an_idle_linked_child(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A player rendering through one output must not announce through another.
+
+        E.g. a WiiM playing natively with an idle linked AirPlay child: routing
+        the announcement to the child would seize the device from the native
+        output, with nothing restoring that playback afterwards.
+        """
+        controller, _player, _proto, native_path, generic_path = (
+            self._make_player_with_linked_child(
+                mock_mass, PlaybackState.PLAYING, active_protocol="native"
+            )
+        )
+
+        await controller.play_announcement("player_1", "http://test/announcement.mp3")
+
+        native_path.assert_not_awaited()
+        generic_path.assert_awaited_once()
+
+    async def test_idle_player_routes_to_the_linked_child(self, mock_mass: MagicMock) -> None:
+        """An idle player announces natively through any capable linked protocol."""
+        controller, _player, proto, native_path, _generic_path = (
+            self._make_player_with_linked_child(mock_mass, PlaybackState.IDLE)
+        )
+
+        await controller.play_announcement("player_1", "http://test/announcement.mp3")
+
+        native_path.assert_awaited_once()
+        assert native_path.call_args.args[1] is proto
+
+    async def test_own_native_support_beats_the_active_protocol_child(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A player's own announcement support wins over its rendering protocol child.
+
+        E.g. a Sonos playing through its AirPlay child: its native announcement
+        overlays the clip on whatever source plays, which beats interrupting
+        the child's stream.
+        """
+        controller, player, _proto, native_path, _generic_path = (
+            self._make_player_with_linked_child(
+                mock_mass,
+                PlaybackState.PLAYING,
+                parent_supports_announce=True,
+                active_protocol="proto_1",
+            )
+        )
+
+        await controller.play_announcement("player_1", "http://test/announcement.mp3")
+
+        native_path.assert_awaited_once()
+        assert native_path.call_args.args[1] is player
+
+
 @pytest.mark.usefixtures("running_background_tasks")
 class TestPlayAnnouncementRestore:
     """Test the state restore of the default (fallback) announcement implementation."""

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -84,17 +84,17 @@ def _make_player(player_id: str, stream: MagicMock | None = None) -> MagicMock:
     player.player_id = player_id
     player.display_name = player_id
     player.synced_to = None
+    player.state.active_group = None
     player.playback_state = PlaybackState.PLAYING
     player.volume_level = 30
     player.volume_set = AsyncMock()
     player.stream = stream
     player._lock = asyncio.Lock()
     player.logger = logging.getLogger("test.airplay.announce")
-    # the leader path wraps its orchestration in a mass-created task
     player.mass.create_task = MagicMock(
         side_effect=lambda coro, *_args, **_kwargs: asyncio.get_running_loop().create_task(coro)
     )
-    player.provider._announce_tasks = {}
+    player.provider._announce_plans = {}
     player.provider.bridge_manager.get_bridge = MagicMock(return_value=None)
     renderer = player.mass.streams.announcement_renderer
     renderer.acquire = MagicMock(return_value=_make_render())
@@ -385,8 +385,14 @@ async def test_session_path_stops_a_parked_session_first() -> None:
 
 
 @pytest.mark.asyncio
-async def test_group_forwarded_member_calls_coalesce_onto_the_leader() -> None:
-    """The controller's group-forward arms every member exactly once, via the leader."""
+async def test_group_entity_fanout_arms_each_member_at_one_shared_instant() -> None:
+    """
+    A group-entity fan-out arms each member once, at one shared instant.
+
+    The controller forwards a group-entity announcement per member; each call
+    arms only its OWN member, and all of them share one audible instant through
+    the provider's plan registry, so every room renders in sync.
+    """
     streams = [_make_stream(), _make_stream(), _make_stream()]
     members = _make_playing_group(*streams)
     leader, member_1, member_2 = members
@@ -394,9 +400,13 @@ async def test_group_forwarded_member_calls_coalesce_onto_the_leader() -> None:
     render = _make_render()
     for member in members:
         member.provider = provider
+        member.state.active_group = "syncgroup_1"
         if member is not leader:
             member.synced_to = leader.player_id
         member.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
+    # the second member reports a far larger span: the shared instant must
+    # clear it for every sibling arm
+    streams[1].latency_lead_ms = 2000
     announcement = _make_announcement()
 
     await asyncio.gather(
@@ -405,30 +415,47 @@ async def test_group_forwarded_member_calls_coalesce_onto_the_leader() -> None:
         announce.play_announcement(member_2, announcement, None),
     )
 
-    # one orchestration armed every member; the member calls awaited it
-    # instead of arming their own stream a second time
+    instants = set()
     for stream in streams:
         stream.announce.assert_awaited_once()
         stream.wait_announce_done.assert_awaited_once()
-    assert provider._announce_tasks == {}
-    for member in members:
-        member.mass.streams.announcement_renderer.release.assert_awaited_once()
+        instants.add(stream.announce.await_args.args[1])
+    assert len(instants) == 1
+    # the shared instant cleared the largest member span (2s + margin)
+    assert next(iter(instants)) >= int(time.time() * 1000) + 2000
 
 
 @pytest.mark.asyncio
-async def test_member_without_group_announcement_arms_itself() -> None:
-    """A direct announcement to one synced member still mixes on just that member."""
+async def test_group_entity_session_leader_announces_alone() -> None:
+    """
+    A group entity's session leader addressed individually announces alone.
+
+    The entity itself is the whole-group handle, so leading the underlying
+    session does not widen an individual announcement.
+    """
+    streams = [_make_stream(), _make_stream()]
+    members = _make_playing_group(*streams)
+    leader = members[0]
+    leader.state.active_group = "syncgroup_1"
+    members[1].synced_to = leader.player_id
+
+    await announce.play_announcement(leader, _make_announcement(), None)
+
+    streams[0].announce.assert_awaited_once()
+    streams[1].announce.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_member_announced_directly_arms_itself() -> None:
+    """A direct announcement to one synced member mixes on just that member."""
     stream = _make_stream()
     members = _make_playing_group(stream)
     member = members[0]
     member.synced_to = "some_leader"
 
-    with patch.object(announce, "_LEADER_TASK_POLL_INTERVAL_S", 0):
-        await announce.play_announcement(member, _make_announcement(), None)
+    await announce.play_announcement(member, _make_announcement(), None)
 
     stream.announce.assert_awaited_once()
-    # a member's own run is never published for others to join
-    assert member.provider._announce_tasks == {}
 
 
 @pytest.mark.asyncio
@@ -447,10 +474,7 @@ async def test_synced_member_without_live_playback_is_refused() -> None:
     parked_session = parked_stream.session
     parked_session.stop = AsyncMock()
 
-    with (
-        patch.object(announce, "_LEADER_TASK_POLL_INTERVAL_S", 0),
-        pytest.raises(PlayerCommandFailed, match="without live playback"),
-    ):
+    with pytest.raises(PlayerCommandFailed, match="without live playback"):
         await announce.play_announcement(member, _make_announcement(), None)
 
     parked_session.stop.assert_not_awaited()

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -276,10 +276,34 @@ async def test_volume_is_scheduled_on_the_acked_instant() -> None:
     bump, restore = scheduled
     assert bump.args[1:] == (member.volume_set, 55)
     assert restore.args[1:] == (member.volume_set, 30)
-    # the bump delay derives from the acked instant (~0.2s out), the restore
-    # follows it by the acked clip duration plus the (zeroed) pad
-    assert 0.0 < bump.args[0] <= 0.25
-    assert restore.args[0] - bump.args[0] == pytest.approx(0.1)
+    # the bump derives from the acked instant (~0.2s out) plus the into-the-clip
+    # bias (capped at half this 0.1s clip); the restore follows the acked clip
+    # duration plus the (zeroed) pad, measured from the instant itself
+    assert 0.0 < bump.args[0] <= 0.3
+    assert restore.args[0] - bump.args[0] == pytest.approx(0.05)
+
+
+def test_member_duck_compensates_the_volume_bump() -> None:
+    """
+    The duck deepens by exactly the device-volume bump so the music never rises.
+
+    38 -> 61 volume points is +6.9 dB on the AirPlay dB scale; the -12 dB duck
+    becomes -18.9 dB so the music's perceived level stays at the configured
+    duck depth (the regression heard as "the music was not ducked"). A bump
+    down shallows it symmetrically, and without a bump the base duck applies.
+    """
+    member = _make_player("m")
+    member.volume_level = 38
+    assert announce._member_duck_db(member, 61) == pytest.approx(-18.9)
+    assert announce._member_duck_db(member, 18) == pytest.approx(-6.0)
+    assert announce._member_duck_db(member, None) == pytest.approx(-12.0)
+    assert announce._member_duck_db(member, 38) == pytest.approx(-12.0)
+    # extreme bumps clamp to the binary's usable range (never boost the music)
+    member.volume_level = 0
+    assert announce._member_duck_db(member, 100) == pytest.approx(-42.0)
+    assert announce._member_duck_db(member, 0) == pytest.approx(-12.0)
+    member.volume_level = 100
+    assert announce._member_duck_db(member, 0) == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -85,6 +85,7 @@ def _make_player(player_id: str, stream: MagicMock | None = None) -> MagicMock:
     player.display_name = player_id
     player.synced_to = None
     player.state.active_group = None
+    player.protocol_parent_id = None
     player.playback_state = PlaybackState.PLAYING
     player.volume_level = 30
     player.volume_set = AsyncMock()
@@ -437,6 +438,31 @@ async def test_group_entity_session_leader_announces_alone() -> None:
     members = _make_playing_group(*streams)
     leader = members[0]
     leader.state.active_group = "syncgroup_1"
+    members[1].synced_to = leader.player_id
+
+    await announce.play_announcement(leader, _make_announcement(), None)
+
+    streams[0].announce.assert_awaited_once()
+    streams[1].announce.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_protocol_child_reads_group_ownership_from_its_parent() -> None:
+    """
+    A protocol child leading a syncgroup's session still announces alone.
+
+    Protocol players never carry active_group themselves - the model keeps the
+    group state on the device player they render for - so the whole-group
+    handle is found through the protocol parent (the regression heard as an
+    individual announcement playing on the whole syncgroup).
+    """
+    streams = [_make_stream(), _make_stream()]
+    members = _make_playing_group(*streams)
+    leader = members[0]
+    leader.protocol_parent_id = "milo_parent"
+    parent = MagicMock()
+    parent.state.active_group = "syncgroup_1"
+    leader.mass.players.get_player = MagicMock(return_value=parent)
     members[1].synced_to = leader.player_id
 
     await announce.play_announcement(leader, _make_announcement(), None)

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -29,6 +29,20 @@ ANNOUNCE_DATA = {
 HIRES_PCM_FORMAT = AudioFormat(content_type=ContentType.PCM_S32LE, sample_rate=48000, bit_depth=24)
 
 
+@pytest.fixture(autouse=True)
+def _zero_restore_pad() -> Iterator[None]:
+    """
+    Zero the audible-end pad for every test.
+
+    The live path holds its return (and the volume restore) until the clip's
+    audible end plus this pad; the streams below ack a long-past instant, so
+    only the pad would otherwise add real wall-clock time to every test. The
+    audible-end test overrides it with its own value.
+    """
+    with patch.object(announce, "AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS", 0):
+        yield
+
+
 def _make_render(duration: float = 1.5) -> MagicMock:
     """Build a mock announcement render that finished with the given duration."""
     render = MagicMock()
@@ -44,9 +58,14 @@ def _make_render(duration: float = 1.5) -> MagicMock:
 
 def _make_stream(
     pcm_format: AudioFormat = AIRPLAY_PCM_FORMAT,
-    ack: tuple[int, int] | None = (0, 0),
+    ack: tuple[int, int] | None = (1, 1),
 ) -> MagicMock:
-    """Build a mock member stream whose announce arm resolves with the given ack."""
+    """
+    Build a mock member stream whose announce arm resolves with the given ack.
+
+    The default ack reports a long-past audible instant, so the audible-end
+    hold at the end of the live path resolves without waiting.
+    """
     stream = MagicMock()
     stream.running = True
     stream.connected = True
@@ -71,6 +90,12 @@ def _make_player(player_id: str, stream: MagicMock | None = None) -> MagicMock:
     player.stream = stream
     player._lock = asyncio.Lock()
     player.logger = logging.getLogger("test.airplay.announce")
+    # the leader path wraps its orchestration in a mass-created task
+    player.mass.create_task = MagicMock(
+        side_effect=lambda coro, *_args, **_kwargs: asyncio.get_running_loop().create_task(coro)
+    )
+    player.provider._announce_tasks = {}
+    player.provider.bridge_manager.get_bridge = MagicMock(return_value=None)
     renderer = player.mass.streams.announcement_renderer
     renderer.acquire = MagicMock(return_value=_make_render())
     renderer.release = AsyncMock()
@@ -188,18 +213,30 @@ async def test_idle_player_takes_the_session_path() -> None:
 
 
 @pytest.mark.asyncio
-async def test_live_path_falls_back_when_no_member_started() -> None:
-    """When no member arms the clip (e.g. an outdated binary), the session path runs."""
+async def test_no_member_arming_fails_without_killing_the_music() -> None:
+    """
+    Live members that never arm the clip fail the announcement, not the music.
+
+    An outdated cliairplay silently ignores the arm command; a fallback session
+    would stop the user's playing session over a clip that could not be mixed.
+    """
     streams = [_make_stream(ack=None), _make_stream(ack=None)]
     members = _make_playing_group(*streams)
+    live_session = streams[0].session
+    live_session.stop = AsyncMock()
 
-    with patch.object(announce, "_announce_with_session", new_callable=AsyncMock) as session_path:
+    with (
+        patch.object(announce, "_announce_with_session", new_callable=AsyncMock) as session_path,
+        pytest.raises(PlayerCommandFailed, match="may not support announcements"),
+    ):
         await announce.play_announcement(members[0], _make_announcement(), None)
 
     for stream in streams:
         stream.announce.assert_awaited_once()
         stream.wait_announce_done.assert_not_awaited()
-    session_path.assert_awaited_once()
+    session_path.assert_not_awaited()
+    live_session.stop.assert_not_awaited()
+    members[0].mass.streams.announcement_renderer.release.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -225,8 +262,8 @@ async def test_partial_success_warns_and_does_not_fall_back(
 @pytest.mark.asyncio
 async def test_volume_is_scheduled_on_the_acked_instant() -> None:
     """The volume bump lands at the acked audible instant, the restore after the clip."""
-    ack_at_unix_ms = int(time.time() * 1000) + 1000
-    stream = _make_stream(ack=(ack_at_unix_ms, 800))
+    ack_at_unix_ms = int(time.time() * 1000) + 200
+    stream = _make_stream(ack=(ack_at_unix_ms, 100))
     members = _make_playing_group(stream)
     member = members[0]
     member.volume_level = 30
@@ -239,10 +276,10 @@ async def test_volume_is_scheduled_on_the_acked_instant() -> None:
     bump, restore = scheduled
     assert bump.args[1:] == (member.volume_set, 55)
     assert restore.args[1:] == (member.volume_set, 30)
-    # the bump delay derives from the acked instant (~1s out), the restore
-    # follows it by the acked clip duration plus the fixed pad
-    assert 0.5 <= bump.args[0] <= 1.05
-    assert restore.args[0] - bump.args[0] == pytest.approx(0.8 + 0.5)
+    # the bump delay derives from the acked instant (~0.2s out), the restore
+    # follows it by the acked clip duration plus the (zeroed) pad
+    assert 0.0 < bump.args[0] <= 0.25
+    assert restore.args[0] - bump.args[0] == pytest.approx(0.1)
 
 
 @pytest.mark.asyncio
@@ -288,6 +325,9 @@ async def test_session_path_plays_the_clip_and_restores_the_volume() -> None:
     session.stop.assert_awaited_once()
     # announcement volume before the session, previous level restored after
     assert [call.args for call in player.volume_set.await_args_list] == [(60,), (25,)]
+    # the player ends idle without still showing media (like player.stop())
+    assert player._attr_current_media is None
+    player.update_state.assert_called()
 
 
 @pytest.mark.asyncio
@@ -316,6 +356,131 @@ async def test_session_path_stops_a_parked_session_first() -> None:
     parked_session.stop.assert_awaited_once()
     assert player.stream is None
     session.start.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_group_forwarded_member_calls_coalesce_onto_the_leader() -> None:
+    """The controller's group-forward arms every member exactly once, via the leader."""
+    streams = [_make_stream(), _make_stream(), _make_stream()]
+    members = _make_playing_group(*streams)
+    leader, member_1, member_2 = members
+    provider = leader.provider
+    render = _make_render()
+    for member in members:
+        member.provider = provider
+        if member is not leader:
+            member.synced_to = leader.player_id
+        member.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
+    announcement = _make_announcement()
+
+    await asyncio.gather(
+        announce.play_announcement(leader, announcement, None),
+        announce.play_announcement(member_1, announcement, None),
+        announce.play_announcement(member_2, announcement, None),
+    )
+
+    # one orchestration armed every member; the member calls awaited it
+    # instead of arming their own stream a second time
+    for stream in streams:
+        stream.announce.assert_awaited_once()
+        stream.wait_announce_done.assert_awaited_once()
+    assert provider._announce_tasks == {}
+    for member in members:
+        member.mass.streams.announcement_renderer.release.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_member_without_group_announcement_arms_itself() -> None:
+    """A direct announcement to one synced member still mixes on just that member."""
+    stream = _make_stream()
+    members = _make_playing_group(stream)
+    member = members[0]
+    member.synced_to = "some_leader"
+
+    with patch.object(announce, "_LEADER_TASK_POLL_INTERVAL_S", 0):
+        await announce.play_announcement(member, _make_announcement(), None)
+
+    stream.announce.assert_awaited_once()
+    # a member's own run is never published for others to join
+    assert member.provider._announce_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_synced_member_without_live_playback_is_refused() -> None:
+    """
+    A parked group member must not announce by tearing down the shared session.
+
+    Its stream belongs to the leader's parked session; stopping that for a
+    single-member announcement would silence every room in the group.
+    """
+    parked_stream = _make_stream()
+    members = _make_playing_group(parked_stream)
+    member = members[0]
+    member.synced_to = "some_leader"
+    member.playback_state = PlaybackState.PAUSED
+    parked_session = parked_stream.session
+    parked_session.stop = AsyncMock()
+
+    with (
+        patch.object(announce, "_LEADER_TASK_POLL_INTERVAL_S", 0),
+        pytest.raises(PlayerCommandFailed, match="without live playback"),
+    ):
+        await announce.play_announcement(member, _make_announcement(), None)
+
+    parked_session.stop.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_return_holds_until_the_audible_end() -> None:
+    """
+    The call returns only once the clip is audibly over, not when it is mixed.
+
+    announce_done reports MIX completion at the delivery head - ahead of
+    audibility - and the caller re-mutes muted players the moment this returns.
+    """
+    now_unix_ms = int(time.time() * 1000)
+    stream = _make_stream(ack=(now_unix_ms + 250, 100))
+    members = _make_playing_group(stream)
+
+    with patch.object(announce, "AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS", 100):
+        started = time.monotonic()
+        await announce.play_announcement(members[0], _make_announcement(), None)
+        elapsed = time.monotonic() - started
+
+    # audible end = acked instant + clip duration (0.35s out) + the 0.1s pad
+    assert elapsed >= 0.4
+
+
+@pytest.mark.asyncio
+async def test_bridged_player_with_live_stream_arms_itself() -> None:
+    """A Sendspin-bridged player mixes the clip into the bridge-owned stream."""
+    stream = _make_stream()
+    stream.session = None
+    player = _make_player("bridged", stream=stream)
+    bridge = MagicMock(owns_airplay_stream=True)
+    player.provider.bridge_manager.get_bridge = MagicMock(return_value=bridge)
+
+    await announce.play_announcement(player, _make_announcement(), None)
+
+    stream.announce.assert_awaited_once()
+    stream.wait_announce_done.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_bridged_player_never_runs_a_session_fallback() -> None:
+    """A bridged player without a live stream fails instead of seizing the device."""
+    player = _make_player("bridged")
+    player.playback_state = PlaybackState.IDLE
+    bridge = MagicMock(owns_airplay_stream=False)
+    player.provider.bridge_manager.get_bridge = MagicMock(return_value=bridge)
+
+    with (
+        patch.object(announce, "AirPlayStreamSession") as session_cls,
+        pytest.raises(PlayerCommandFailed, match="Sendspin bridge"),
+    ):
+        await announce.play_announcement(player, _make_announcement(), None)
+
+    session_cls.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -263,7 +263,8 @@ async def test_partial_success_warns_and_does_not_fall_back(
 async def test_volume_is_scheduled_on_the_acked_instant() -> None:
     """The volume bump lands at the acked audible instant, the restore after the clip."""
     ack_at_unix_ms = int(time.time() * 1000) + 200
-    stream = _make_stream(ack=(ack_at_unix_ms, 100))
+    # the acked duration includes the 1s ducked-silence tail: 2s of content
+    stream = _make_stream(ack=(ack_at_unix_ms, 3000))
     members = _make_playing_group(stream)
     member = members[0]
     member.volume_level = 30
@@ -276,32 +277,33 @@ async def test_volume_is_scheduled_on_the_acked_instant() -> None:
     bump, restore = scheduled
     assert bump.args[1:] == (member.volume_set, 55)
     assert restore.args[1:] == (member.volume_set, 30)
-    # the bump derives from the acked instant (~0.2s out) plus the into-the-clip
-    # bias (capped at half this 0.1s clip); the restore follows the acked clip
-    # duration plus the (zeroed) pad, measured from the instant itself
-    assert 0.0 < bump.args[0] <= 0.3
-    assert restore.args[0] - bump.args[0] == pytest.approx(0.05)
+    # the bump derives from the acked instant (~0.2s out) plus the 0.3s
+    # into-the-clip bias; the restore follows the CONTENT length (the acked
+    # duration minus the silence tail) plus the (zeroed) pad, so it lands
+    # inside the ducked cushion - 1.7s after the bump here
+    assert 0.2 < bump.args[0] <= 0.5
+    assert restore.args[0] - bump.args[0] == pytest.approx(1.7)
 
 
 def test_member_duck_compensates_the_volume_bump() -> None:
     """
     The duck deepens by exactly the device-volume bump so the music never rises.
 
-    38 -> 61 volume points is +6.9 dB on the AirPlay dB scale; the -12 dB duck
-    becomes -18.9 dB so the music's perceived level stays at the configured
+    38 -> 61 volume points is +6.9 dB on the AirPlay dB scale; the -18 dB duck
+    becomes -24.9 dB so the music's perceived level stays at the configured
     duck depth (the regression heard as "the music was not ducked"). A bump
     down shallows it symmetrically, and without a bump the base duck applies.
     """
     member = _make_player("m")
     member.volume_level = 38
-    assert announce._member_duck_db(member, 61) == pytest.approx(-18.9)
-    assert announce._member_duck_db(member, 18) == pytest.approx(-6.0)
-    assert announce._member_duck_db(member, None) == pytest.approx(-12.0)
-    assert announce._member_duck_db(member, 38) == pytest.approx(-12.0)
+    assert announce._member_duck_db(member, 61) == pytest.approx(-24.9)
+    assert announce._member_duck_db(member, 18) == pytest.approx(-12.0)
+    assert announce._member_duck_db(member, None) == pytest.approx(-18.0)
+    assert announce._member_duck_db(member, 38) == pytest.approx(-18.0)
     # extreme bumps clamp to the binary's usable range (never boost the music)
     member.volume_level = 0
-    assert announce._member_duck_db(member, 100) == pytest.approx(-42.0)
-    assert announce._member_duck_db(member, 0) == pytest.approx(-12.0)
+    assert announce._member_duck_db(member, 100) == pytest.approx(-48.0)
+    assert announce._member_duck_db(member, 0) == pytest.approx(-18.0)
     member.volume_level = 100
     assert announce._member_duck_db(member, 0) == pytest.approx(0.0)
 

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -1,0 +1,346 @@
+"""Unit tests for the native AirPlay announcement orchestration."""
+
+import asyncio
+import logging
+import time
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.enums import ContentType, PlaybackState
+from music_assistant_models.errors import PlayerCommandFailed
+from music_assistant_models.media_items import AudioFormat
+
+from music_assistant.providers.airplay import announce
+from music_assistant.providers.airplay.constants import (
+    AIRPLAY_ANNOUNCE_AT_MARGIN_MS,
+    AIRPLAY_ANNOUNCE_DUCK_DB,
+    AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS,
+    AIRPLAY_PCM_FORMAT,
+)
+
+ANNOUNCE_DATA = {
+    "announcement_url": "http://ma.local/tts.mp3",
+    "pre_announce": True,
+    "pre_announce_url": "http://ma.local/chime.mp3",
+    "announce_player_id": None,
+}
+HIRES_PCM_FORMAT = AudioFormat(content_type=ContentType.PCM_S32LE, sample_rate=48000, bit_depth=24)
+
+
+def _make_render(duration: float = 1.5) -> MagicMock:
+    """Build a mock announcement render that finished with the given duration."""
+    render = MagicMock()
+    render.duration = duration
+    render.wait_finished = AsyncMock(return_value=duration)
+
+    async def get_stream(_output_format: Any) -> AsyncGenerator[bytes]:
+        yield b"\x00" * 64
+
+    render.get_stream = get_stream
+    return render
+
+
+def _make_stream(
+    pcm_format: AudioFormat = AIRPLAY_PCM_FORMAT,
+    ack: tuple[int, int] | None = (0, 0),
+) -> MagicMock:
+    """Build a mock member stream whose announce arm resolves with the given ack."""
+    stream = MagicMock()
+    stream.running = True
+    stream.connected = True
+    stream.pcm_format = pcm_format
+    stream.warm_lead_ms = 0
+    stream.latency_lead_ms = 0
+    stream.announce = AsyncMock(return_value=True)
+    stream.wait_announce_started = AsyncMock(return_value=ack)
+    stream.wait_announce_done = AsyncMock(return_value=True)
+    return stream
+
+
+def _make_player(player_id: str, stream: MagicMock | None = None) -> MagicMock:
+    """Build a mock AirPlay player for announcement orchestration tests."""
+    player = MagicMock()
+    player.player_id = player_id
+    player.display_name = player_id
+    player.synced_to = None
+    player.playback_state = PlaybackState.PLAYING
+    player.volume_level = 30
+    player.volume_set = AsyncMock()
+    player.stream = stream
+    player._lock = asyncio.Lock()
+    player.logger = logging.getLogger("test.airplay.announce")
+    renderer = player.mass.streams.announcement_renderer
+    renderer.acquire = MagicMock(return_value=_make_render())
+    renderer.release = AsyncMock()
+    return player
+
+
+def _make_playing_group(*streams: MagicMock) -> list[MagicMock]:
+    """Build a playing session of one member per given stream; first one leads."""
+    members = [_make_player(f"member_{i}", stream=stream) for i, stream in enumerate(streams)]
+    session = MagicMock()
+    session.sync_clients = members
+    for member in members:
+        member.stream.session = session
+    return members
+
+
+def _make_announcement() -> MagicMock:
+    """Build the announcement PlayerMedia handed down by the player controller."""
+    return MagicMock(custom_data=dict(ANNOUNCE_DATA))
+
+
+def test_member_span_prefers_the_warm_lead() -> None:
+    """A splice-timeline member's span is its warm lead, not the device lead."""
+    stream = _make_stream()
+    stream.warm_lead_ms = 600
+    stream.latency_lead_ms = 1900
+
+    assert announce._member_span_ms(stream) == 600
+
+
+def test_member_span_uses_the_device_lead_without_a_warm_lead() -> None:
+    """Without a warm lead, the reported device lead bounds the delivery head."""
+    stream = _make_stream()
+    stream.latency_lead_ms = 1900
+
+    assert announce._member_span_ms(stream) == 1900
+
+
+def test_member_span_falls_back_when_nothing_was_reported() -> None:
+    """Both leads at 0 mean unreported: assume the binary's default playback lead."""
+    assert announce._member_span_ms(_make_stream()) == AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS
+
+
+def test_shared_instant_covers_the_slowest_member() -> None:
+    """The shared instant sits past the LARGEST member span plus the fan-out margin."""
+    fast = _make_stream()
+    fast.warm_lead_ms = 600
+    slow = _make_stream()
+    slow.latency_lead_ms = 1900
+    unreported = _make_stream()
+
+    before_ms = int(time.time() * 1000)
+    at_unix_ms = announce._shared_announce_instant([fast, slow, unreported])
+    after_ms = time.time() * 1000
+
+    # the unreported member's fallback span (2000) is the largest of the three
+    expected_lead = AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS + AIRPLAY_ANNOUNCE_AT_MARGIN_MS
+    assert before_ms + expected_lead <= at_unix_ms <= after_ms + expected_lead
+
+
+@pytest.mark.asyncio
+async def test_live_announcement_arms_every_member_at_one_shared_instant() -> None:
+    """A playing session arms every member with the same instant, duck and clip file."""
+    streams = [_make_stream(), _make_stream()]
+    members = _make_playing_group(*streams)
+    leader = members[0]
+
+    with patch.object(announce, "_announce_with_session", new_callable=AsyncMock) as session_path:
+        await announce.play_announcement(leader, _make_announcement(), None)
+
+    session_path.assert_not_awaited()
+    arms = [stream.announce.call_args for stream in streams]
+    for arm in arms:
+        assert arm is not None
+    # one shared instant and the default duck for every member
+    assert len({arm.args[1] for arm in arms}) == 1
+    assert {arm.args[2] for arm in arms} == {AIRPLAY_ANNOUNCE_DUCK_DB}
+    # both members share one stdin format, so they share one clip file
+    assert len({arm.args[0] for arm in arms}) == 1
+    assert arms[0].args[0].endswith(".pcm")
+    for stream in streams:
+        stream.wait_announce_done.assert_awaited_once()
+    leader.mass.streams.announcement_renderer.release.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_live_announcement_renders_one_clip_per_distinct_format() -> None:
+    """Members on different stdin formats each get a clip in exactly their format."""
+    streams = [_make_stream(), _make_stream(pcm_format=HIRES_PCM_FORMAT)]
+    members = _make_playing_group(*streams)
+
+    with patch.object(announce, "_announce_with_session", new_callable=AsyncMock):
+        await announce.play_announcement(members[0], _make_announcement(), None)
+
+    clip_paths = {stream.announce.call_args.args[0] for stream in streams}
+    assert len(clip_paths) == 2
+
+
+@pytest.mark.asyncio
+async def test_idle_player_takes_the_session_path() -> None:
+    """Without live playback the announcement runs as its own stream session."""
+    player = _make_player("solo")
+    player.playback_state = PlaybackState.IDLE
+    announcement = _make_announcement()
+
+    with patch.object(announce, "_announce_with_session", new_callable=AsyncMock) as session_path:
+        await announce.play_announcement(player, announcement, 40)
+
+    session_path.assert_awaited_once()
+    args = session_path.call_args.args
+    assert args[0] is player
+    assert args[1] is announcement
+    assert args[3] == 1.5  # the render's exact duration bounds the session waits
+    assert args[4] == 40
+
+
+@pytest.mark.asyncio
+async def test_live_path_falls_back_when_no_member_started() -> None:
+    """When no member arms the clip (e.g. an outdated binary), the session path runs."""
+    streams = [_make_stream(ack=None), _make_stream(ack=None)]
+    members = _make_playing_group(*streams)
+
+    with patch.object(announce, "_announce_with_session", new_callable=AsyncMock) as session_path:
+        await announce.play_announcement(members[0], _make_announcement(), None)
+
+    for stream in streams:
+        stream.announce.assert_awaited_once()
+        stream.wait_announce_done.assert_not_awaited()
+    session_path.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_partial_success_warns_and_does_not_fall_back(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One member playing the clip is a success; the members that did not are named."""
+    streams = [_make_stream(), _make_stream(ack=None)]
+    members = _make_playing_group(*streams)
+
+    with (
+        patch.object(announce, "_announce_with_session", new_callable=AsyncMock) as session_path,
+        caplog.at_level(logging.WARNING),
+    ):
+        await announce.play_announcement(members[0], _make_announcement(), None)
+
+    session_path.assert_not_awaited()
+    assert "member_1" in caplog.text
+    streams[0].wait_announce_done.assert_awaited_once()
+    streams[1].wait_announce_done.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_volume_is_scheduled_on_the_acked_instant() -> None:
+    """The volume bump lands at the acked audible instant, the restore after the clip."""
+    ack_at_unix_ms = int(time.time() * 1000) + 1000
+    stream = _make_stream(ack=(ack_at_unix_ms, 800))
+    members = _make_playing_group(stream)
+    member = members[0]
+    member.volume_level = 30
+
+    with patch.object(announce, "_announce_with_session", new_callable=AsyncMock):
+        await announce.play_announcement(member, _make_announcement(), 55)
+
+    scheduled = member.mass.call_later.call_args_list
+    assert len(scheduled) == 2
+    bump, restore = scheduled
+    assert bump.args[1:] == (member.volume_set, 55)
+    assert restore.args[1:] == (member.volume_set, 30)
+    # the bump delay derives from the acked instant (~1s out), the restore
+    # follows it by the acked clip duration plus the fixed pad
+    assert 0.5 <= bump.args[0] <= 1.05
+    assert restore.args[0] - bump.args[0] == pytest.approx(0.8 + 0.5)
+
+
+@pytest.mark.asyncio
+async def test_no_volume_level_leaves_the_volume_alone() -> None:
+    """Without an announcement volume nothing is scheduled on any member."""
+    members = _make_playing_group(_make_stream())
+
+    with patch.object(announce, "_announce_with_session", new_callable=AsyncMock):
+        await announce.play_announcement(members[0], _make_announcement(), None)
+
+    members[0].mass.call_later.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_session_path_plays_the_clip_and_restores_the_volume() -> None:
+    """The dedicated session serves the clip to the configured group at the given volume."""
+    player = _make_player("solo")
+    player.playback_state = PlaybackState.IDLE
+    player.volume_level = 25
+    player._get_sync_clients = MagicMock(return_value=[player])
+    player._get_session_pcm_format = AsyncMock(return_value=AIRPLAY_PCM_FORMAT)
+    announcement = _make_announcement()
+    render = _make_render(duration=0.01)
+    player.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
+
+    with (
+        patch.object(announce, "AirPlayStreamSession") as session_cls,
+        patch.object(announce, "AIRPLAY_ANNOUNCE_SESSION_DRAIN_S", 0.0),
+    ):
+        session = session_cls.return_value
+        session.start = AsyncMock()
+        session.stop = AsyncMock()
+        session.start_time = 0.0
+        await announce.play_announcement(player, announcement, 60)
+
+    assert session_cls.call_args.args == (
+        player.provider,
+        [player],
+        AIRPLAY_PCM_FORMAT,
+        announcement,
+    )
+    session.start.assert_awaited_once()
+    session.stop.assert_awaited_once()
+    # announcement volume before the session, previous level restored after
+    assert [call.args for call in player.volume_set.await_args_list] == [(60,), (25,)]
+
+
+@pytest.mark.asyncio
+async def test_session_path_stops_a_parked_session_first() -> None:
+    """A parked (paused) session is stopped before the dedicated announcement session."""
+    parked_stream = _make_stream()
+    player = _make_player("solo", stream=parked_stream)
+    player.playback_state = PlaybackState.PAUSED
+    player._get_sync_clients = MagicMock(return_value=[player])
+    player._get_session_pcm_format = AsyncMock(return_value=AIRPLAY_PCM_FORMAT)
+    parked_session = parked_stream.session
+    parked_session.stop = AsyncMock()
+    render = _make_render(duration=0.01)
+    player.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
+
+    with (
+        patch.object(announce, "AirPlayStreamSession") as session_cls,
+        patch.object(announce, "AIRPLAY_ANNOUNCE_SESSION_DRAIN_S", 0.0),
+    ):
+        session = session_cls.return_value
+        session.start = AsyncMock()
+        session.stop = AsyncMock()
+        session.start_time = 0.0
+        await announce.play_announcement(player, _make_announcement(), None)
+
+    parked_session.stop.assert_awaited_once()
+    assert player.stream is None
+    session.start.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_announcement_without_data_is_refused() -> None:
+    """An announcement without its announce data cannot be rendered."""
+    player = _make_player("solo")
+
+    with pytest.raises(PlayerCommandFailed, match="carries no announcement data"):
+        await announce.play_announcement(player, MagicMock(custom_data=None), None)
+
+
+@pytest.mark.asyncio
+async def test_announcement_without_audio_plays_nothing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A render that produced no audio is skipped, releasing the render regardless."""
+    stream = _make_stream()
+    members = _make_playing_group(stream)
+    player = members[0]
+    render = _make_render(duration=0.0)
+    player.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
+
+    with caplog.at_level(logging.WARNING):
+        await announce.play_announcement(player, _make_announcement(), None)
+
+    stream.announce.assert_not_awaited()
+    assert "produced no audio" in caplog.text
+    player.mass.streams.announcement_renderer.release.assert_awaited_once()

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -467,11 +467,30 @@ async def test_bridged_player_with_live_stream_arms_itself() -> None:
 
 
 @pytest.mark.asyncio
-async def test_bridged_player_never_runs_a_session_fallback() -> None:
-    """A bridged player without a live stream fails instead of seizing the device."""
+async def test_bridge_configured_player_mixes_over_its_own_session() -> None:
+    """
+    A bridge that is merely configured never blocks the live mix.
+
+    The regression this pins: a player with a Sendspin bridge set up but
+    playing its own (session-backed) AirPlay stream mixes the clip like any
+    unbridged player - the idle bridge is a bystander.
+    """
+    (member,) = _make_playing_group(_make_stream())
+    bridge = MagicMock(owns_airplay_stream=False)
+    member.provider.bridge_manager.get_bridge = MagicMock(return_value=bridge)
+
+    await announce.play_announcement(member, _make_announcement(), None)
+
+    member.stream.announce.assert_awaited_once()
+    member.stream.wait_announce_done.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_bridge_streaming_player_never_runs_a_session_fallback() -> None:
+    """A player whose bridge owns the live stream fails instead of seizing the device."""
     player = _make_player("bridged")
     player.playback_state = PlaybackState.IDLE
-    bridge = MagicMock(owns_airplay_stream=False)
+    bridge = MagicMock(owns_airplay_stream=True)
     player.provider.bridge_manager.get_bridge = MagicMock(return_value=bridge)
 
     with (

--- a/tests/providers/airplay/test_control_player.py
+++ b/tests/providers/airplay/test_control_player.py
@@ -1064,6 +1064,9 @@ async def test_late_companion_discovery_never_changes_player_model() -> None:
     provider.config = MagicMock()
     provider.config.instance_id = "airplay"
     provider._companion_info_by_address = {}
+    # a bare provider (built via __new__) lacks the bridge manager that
+    # supported_features consults; a real one exists before any player does
+    provider._bridge_manager = MagicMock(get_bridge=MagicMock(return_value=None))
     generic_player = GenericAirPlayPlayer(
         provider=provider,
         player_id=PLAYER_ID,

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -902,6 +902,11 @@ def test_bridged_player_advertises_announcements_only_while_streaming(
     idle_bridge = MagicMock(owns_airplay_stream=False)
     with patch.object(bridge_manager, "get_bridge", return_value=idle_bridge):
         assert PlayerFeature.PLAY_ANNOUNCEMENT not in airplay_player.supported_features
+        # ... but a configured-yet-idle bridge never hides the feature while the
+        # player runs its own session-backed stream (playing over AirPlay itself)
+        airplay_player.stream = MagicMock(running=True, session=MagicMock())
+        assert PlayerFeature.PLAY_ANNOUNCEMENT in airplay_player.supported_features
+        airplay_player.stream = None
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -882,20 +882,25 @@ def test_supported_features_always_includes_pause(airplay_player: AirPlayPlayer)
     assert PlayerFeature.PAUSE in airplay_player.supported_features
 
 
-def test_bridged_player_does_not_advertise_announcements(
+def test_bridged_player_advertises_announcements_only_while_streaming(
     airplay_player: AirPlayPlayer,
 ) -> None:
     """
-    A Sendspin-bridged player must not advertise PLAY_ANNOUNCEMENT.
+    A Sendspin-bridged player advertises PLAY_ANNOUNCEMENT only while streaming.
 
-    The bridge owns the audio stream, so there is no stream session to mix a
-    clip into - and the fallback path would steal the device from a live bridge
-    stream. Without the feature, announcement routing stays as it was.
+    The bridge's live stream is a regular AirPlayStream the clip mixes into, so
+    the feature stays available then. An idle bridged player must not advertise
+    it - a dedicated announcement session would fight the bridge for the
+    device, so those announcements keep their existing routing.
     """
     bridge_manager = cast("AirPlayProvider", airplay_player.provider).bridge_manager
     with patch.object(bridge_manager, "get_bridge", return_value=None):
         assert PlayerFeature.PLAY_ANNOUNCEMENT in airplay_player.supported_features
-    with patch.object(bridge_manager, "get_bridge", return_value=object()):
+    streaming_bridge = MagicMock(owns_airplay_stream=True)
+    with patch.object(bridge_manager, "get_bridge", return_value=streaming_bridge):
+        assert PlayerFeature.PLAY_ANNOUNCEMENT in airplay_player.supported_features
+    idle_bridge = MagicMock(owns_airplay_stream=False)
+    with patch.object(bridge_manager, "get_bridge", return_value=idle_bridge):
         assert PlayerFeature.PLAY_ANNOUNCEMENT not in airplay_player.supported_features
 
 

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -35,6 +35,7 @@ from music_assistant.providers.airplay.constants import (
     StreamingProtocol,
 )
 from music_assistant.providers.airplay.player import AirPlayPlayer
+from music_assistant.providers.airplay.provider import AirPlayProvider
 
 # _airplay._tcp features bitmask with the AirPlay 2 feature bits set (bit 38/48).
 AP2_FEATURES = "0x4A7FDFD5,0x3C177FDE"
@@ -879,6 +880,23 @@ def test_supported_features_always_includes_pause(airplay_player: AirPlayPlayer)
     # sync leader: still advertises PAUSE
     airplay_player._attr_group_members = ["test_player", "child"]
     assert PlayerFeature.PAUSE in airplay_player.supported_features
+
+
+def test_bridged_player_does_not_advertise_announcements(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """
+    A Sendspin-bridged player must not advertise PLAY_ANNOUNCEMENT.
+
+    The bridge owns the audio stream, so there is no stream session to mix a
+    clip into - and the fallback path would steal the device from a live bridge
+    stream. Without the feature, announcement routing stays as it was.
+    """
+    bridge_manager = cast("AirPlayProvider", airplay_player.provider).bridge_manager
+    with patch.object(bridge_manager, "get_bridge", return_value=None):
+        assert PlayerFeature.PLAY_ANNOUNCEMENT in airplay_player.supported_features
+    with patch.object(bridge_manager, "get_bridge", return_value=object()):
+        assert PlayerFeature.PLAY_ANNOUNCEMENT not in airplay_player.supported_features
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -1718,6 +1718,191 @@ async def test_flush_clears_the_pending_stdin_depth() -> None:
     assert stream.audio_pending_ms == 0
 
 
+def test_announce_started_status_records_instant_and_duration() -> None:
+    """The started report carries the ACTUAL audible instant and the clip duration."""
+    stream = AirPlayStream(_make_player())
+    assert not stream._announce_started.is_set()
+
+    assert (
+        stream._handle_status_line(
+            f"[STATUS] announce_started at_unix_ms={START_UNIX_MS} duration_ms=1800"
+        )
+        is False
+    )
+
+    assert stream._announce_started.is_set()
+    assert stream._announce_ack == (START_UNIX_MS, 1800)
+
+
+def test_announce_started_status_with_unusable_values_reports_zeroes() -> None:
+    """Unusable fields land on 0 (unreported) instead of failing the whole answer."""
+    stream = AirPlayStream(_make_player())
+
+    stream._handle_status_line("[STATUS] announce_started at_unix_ms=nonsense")
+
+    assert stream._announce_started.is_set()
+    assert stream._announce_ack == (0, 0)
+
+
+@pytest.mark.parametrize(
+    ("line", "cancelled"),
+    [
+        ("[STATUS] announce_done", False),
+        ("[STATUS] announce_done cancelled=1", True),
+    ],
+    ids=["completed", "cancelled"],
+)
+def test_announce_done_status_sets_done_and_cancelled(line: str, cancelled: bool) -> None:
+    """The done report releases the done wait, carrying whether the clip was cut short."""
+    stream = AirPlayStream(_make_player())
+    assert not stream._announce_done.is_set()
+
+    assert stream._handle_status_line(line) is False
+
+    assert stream._announce_done.is_set()
+    assert stream._announce_done_cancelled is cancelled
+
+
+def test_announce_failed_is_routed_to_the_announce_waiter() -> None:
+    """A rejected arm answers both announce waits at once and stays off the connect error."""
+    stream = AirPlayStream(_make_player())
+
+    stream._handle_status_line('[STATUS] error code=announce_failed http=0 detail="not playing"')
+
+    assert stream._announce_started.is_set()
+    assert stream._announce_done.is_set()
+    assert stream._announce_error is not None
+    assert stream._announce_error.detail == "not playing"
+    # a command failure must not poison how a NEW connection is reported
+    assert stream._connect_error is None
+
+
+@pytest.mark.asyncio
+async def test_announce_sends_the_arm_command() -> None:
+    """ANNOUNCE is delivered as the four-line arm the binary expects."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = _make_cli_proc()
+    stream._connected.set()
+
+    with patch.object(
+        stream, "_write_cli_command", new_callable=AsyncMock, return_value=True
+    ) as write_command:
+        assert await stream.announce("/fake/clip.pcm", START_UNIX_MS, -12) is True
+
+    write_command.assert_awaited_once_with(
+        f"ANNOUNCE_FILE=/fake/clip.pcm\nANNOUNCE_AT_UNIX_MS={START_UNIX_MS}\n"
+        "ANNOUNCE_DUCK_DB=-12\nACTION=ANNOUNCE"
+    )
+
+
+@pytest.mark.asyncio
+async def test_announce_resets_the_previous_answer() -> None:
+    """Arming clears every slot so only this arm's answer is read."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = _make_cli_proc()
+    stream._connected.set()
+    stream._handle_status_line("[STATUS] announce_started at_unix_ms=5 duration_ms=6")
+    stream._handle_status_line("[STATUS] announce_done cancelled=1")
+    stream._handle_status_line("[STATUS] error code=announce_failed")
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock, return_value=True):
+        assert await stream.announce("/fake/clip.pcm", 0, -12) is True
+
+    assert not stream._announce_started.is_set()
+    assert not stream._announce_done.is_set()
+    assert stream._announce_ack is None
+    assert stream._announce_error is None
+    assert stream._announce_done_cancelled is False
+
+
+@pytest.mark.asyncio
+async def test_announce_requires_a_running_connected_stream() -> None:
+    """An arm on a stream that is not up is refused without touching the pipe."""
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = _make_cli_proc()
+    # not connected
+
+    with patch.object(stream, "_write_cli_command", new_callable=AsyncMock) as write_command:
+        assert await stream.announce("/fake/clip.pcm", 0, -12) is False
+
+    write_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wait_announce_started_returns_the_ack() -> None:
+    """The started wait hands back the acked instant and duration."""
+    stream = AirPlayStream(_make_player())
+
+    wait_task = asyncio.create_task(stream.wait_announce_started(1.0))
+    await asyncio.sleep(0)
+    stream._handle_status_line(
+        f"[STATUS] announce_started at_unix_ms={START_UNIX_MS} duration_ms=900"
+    )
+
+    assert await wait_task == (START_UNIX_MS, 900)
+
+
+@pytest.mark.asyncio
+async def test_wait_announce_started_resolves_on_done_without_started() -> None:
+    """A done (cancelled) without a start means the clip never played: None, right away."""
+    stream = AirPlayStream(_make_player())
+
+    wait_task = asyncio.create_task(stream.wait_announce_started(30.0))
+    await asyncio.sleep(0)
+    stream._handle_status_line("[STATUS] announce_done cancelled=1")
+
+    assert await wait_task is None
+
+
+@pytest.mark.asyncio
+async def test_wait_announce_started_times_out_on_a_silent_binary() -> None:
+    """An outdated binary ignores the arm entirely; the bounded wait returns None."""
+    stream = AirPlayStream(_make_player())
+
+    assert await stream.wait_announce_started(0) is None
+
+
+@pytest.mark.asyncio
+async def test_wait_announce_started_returns_none_on_reported_failure() -> None:
+    """A reported announce failure answers the started wait as a failure, not a timeout."""
+    stream = AirPlayStream(_make_player())
+
+    wait_task = asyncio.create_task(stream.wait_announce_started(30.0))
+    await asyncio.sleep(0)
+    stream._handle_status_line("[STATUS] error code=announce_failed")
+
+    assert await wait_task is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("[STATUS] announce_done", True),
+        ("[STATUS] announce_done cancelled=1", False),
+        ("[STATUS] error code=announce_failed", False),
+    ],
+    ids=["completed", "cancelled", "failed"],
+)
+async def test_wait_announce_done_outcomes(line: str, expected: bool) -> None:
+    """Only a completed clip resolves the done wait as True."""
+    stream = AirPlayStream(_make_player())
+
+    wait_task = asyncio.create_task(stream.wait_announce_done(1.0))
+    await asyncio.sleep(0)
+    stream._handle_status_line(line)
+
+    assert await wait_task is expected
+
+
+@pytest.mark.asyncio
+async def test_wait_announce_done_times_out() -> None:
+    """The done wait stays bounded (eof can end the status stream mid-clip)."""
+    stream = AirPlayStream(_make_player())
+
+    assert await stream.wait_announce_done(0) is False
+
+
 @pytest.mark.asyncio
 async def test_clock_ready_projection_resolves_the_wait() -> None:
     """A probing receiver reports when its clock becomes usable, from its first probe."""


### PR DESCRIPTION
# What does this implement/fix?

Announcements on AirPlay players no longer interrupt the music. The cliairplay binary (v0.4.14) mixes the announcement clip directly into the live stream with the music ducked underneath - no stop, no restart, and a sync group keeps playing in perfect sync while every room renders the announcement at the same instant. Validated on real hardware (solo players, ad-hoc sync, syncgroups, Sonos-via-AirPlay).

- New `announce.py` orchestration in the AirPlay provider: renders the clip once per member audio format, arms the targets at one shared audible instant and tracks per-member results
- Targeting semantics: a syncgroup member addressed individually announces alone (even the one leading the audio session); the syncgroup entity announces on all members in sync; an ad-hoc sync leader represents its whole group, its synced members announce alone
- The music ducks -18 dB under the clip and stays ducked briefly past it; the announcement volume is compensated into the duck (the AirPlay volume scale is linear dB) so the music never gets louder during an announcement, and volume changes are timed on the actual audible window
- Announcement routing now prefers the output that is actively rendering (e.g. a Sonos playing through its AirPlay child gets the clip mixed into that stream, in sync with the group); native support (Sonos audioClip) is used when idle or playing natively, and a playing device is never seized through an idle linked protocol
- Players that are idle or paused play the announcement as a short dedicated session (ending idle, like the generic flow); Sendspin-bridged players mix natively whenever there is a live stream to mix into
- Bumps cliairplay to v0.4.14 (the release that adds the ANNOUNCE command)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
