### PR TITLE
Improve live source playback compatibility

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -171,6 +171,7 @@ CONF_UNDERLYING_PLAYER_ID: Final[str] = (
 CONF_CACHED_ARP_MAC: Final[str] = "cached_arp_mac"  # cached ARP-resolved MAC for fast restart
 CONF_REPORTED_MAC: Final[str] = "reported_mac"  # original MAC reported by provider (before ARP)
 CONF_OUTPUT_CODEC: Final[str] = "output_codec"
+CONF_PREFER_WAV_FOR_LIVE_SOURCES: Final[str] = "prefer_wav_for_live_sources"
 CONF_ALLOW_AUDIO_CACHE: Final[str] = "allow_audio_cache"
 CONF_SMART_FADES_MODE: Final[str] = "smart_fades_mode"  # legacy; consumed by one-time migration
 CONF_CROSSFADE_MODE: Final[str] = "crossfade_mode"
@@ -500,6 +501,18 @@ CONF_ENTRY_OUTPUT_CODEC_HIDDEN = ConfigEntry.from_dict(
 )
 CONF_ENTRY_OUTPUT_CODEC_ENFORCE_FLAC = ConfigEntry.from_dict(
     {**CONF_ENTRY_OUTPUT_CODEC.to_dict(), "default_value": "flac", "hidden": True}
+)
+
+CONF_ENTRY_PREFER_WAV_FOR_LIVE_SOURCES = ConfigEntry(
+    key=CONF_PREFER_WAV_FOR_LIVE_SOURCES,
+    type=ConfigEntryType.BOOLEAN,
+    default_value=False,
+    category="protocol_generic",
+    advanced=True,
+    requires_reload=True,
+)
+CONF_ENTRY_PREFER_WAV_FOR_LIVE_SOURCES_DEFAULT_ENABLED = ConfigEntry.from_dict(
+    {**CONF_ENTRY_PREFER_WAV_FOR_LIVE_SOURCES.to_dict(), "default_value": True}
 )
 
 

--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -50,6 +50,7 @@ from music_assistant.constants import (
     CONF_ENTRY_PLAY_MEDIA_OVERRIDES_GROUP,
     CONF_ENTRY_PLAYER_ICON,
     CONF_ENTRY_PLAYER_ICON_GROUP,
+    CONF_ENTRY_PREFER_WAV_FOR_LIVE_SOURCES,
     CONF_ENTRY_SAMPLE_RATES,
     CONF_ENTRY_TTS_PRE_ANNOUNCE,
     CONF_EXPOSE_PLAYER_TO_HA,
@@ -655,6 +656,7 @@ class PlayerConfigMixin:
                 # for http based players we can add the http streaming related entries
                 default_entries += [
                     CONF_ENTRY_OUTPUT_CODEC,
+                    CONF_ENTRY_PREFER_WAV_FOR_LIVE_SOURCES,
                     CONF_ENTRY_HTTP_PROFILE,
                     CONF_ENTRY_ENABLE_ICY_METADATA,
                 ]

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -52,6 +52,7 @@ from music_assistant.constants import (
     CONF_HTTP_PROFILE,
     CONF_OUTPUT_CODEC,
     CONF_PLAYER_QUEUES,
+    CONF_PREFER_WAV_FOR_LIVE_SOURCES,
     CONF_PUBLISH_IP,
     CONF_VALUE_AUTO,
     CONF_VOLUME_NORMALIZATION_FIXED_GAIN_RADIO,
@@ -508,19 +509,25 @@ class StreamsController(CoreController):
         if media.media_type in (MediaType.ANNOUNCEMENT, MediaType.FLOW_STREAM):
             return media.uri
         protocol_player = self.mass.players.get_player(player_id)
-        # AudioSource is realtime: serve as WAV (PCM + header) so the encode
-        # step is a no-op passthrough — drops a whole ffmpeg from the
-        # consumer-side pipeline and the latency that comes with it.
-        if media.media_type == MediaType.AUDIO_SOURCE:
-            output_codec = ContentType.WAV
-        else:
-            conf_output_codec = cast(
-                "str",
-                protocol_player.config.get_value(CONF_OUTPUT_CODEC, default="flac")
-                if protocol_player
-                else "flac",
+        conf_output_codec = cast(
+            "str",
+            protocol_player.config.get_value(CONF_OUTPUT_CODEC, default="flac")
+            if protocol_player
+            else "flac",
+        )
+        prefer_wav_for_live_sources = (
+            media.media_type == MediaType.AUDIO_SOURCE
+            and protocol_player is not None
+            and cast(
+                "bool",
+                protocol_player.config.get_value(CONF_PREFER_WAV_FOR_LIVE_SOURCES, default=False),
             )
-            output_codec = ContentType.try_parse(conf_output_codec)
+        )
+        output_codec = (
+            ContentType.WAV
+            if prefer_wav_for_live_sources
+            else ContentType.try_parse(conf_output_codec)
+        )
         fmt = output_codec.value
         # handle raw pcm without exact format specifiers
         if output_codec.is_pcm() and ";" not in fmt:

--- a/music_assistant/providers/chromecast/constants.py
+++ b/music_assistant/providers/chromecast/constants.py
@@ -9,6 +9,7 @@ from music_assistant.constants import (
     CONF_ENTRY_FLOW_MODE,
     CONF_ENTRY_HTTP_PROFILE_DEFAULT_3,
     CONF_ENTRY_OUTPUT_CODEC,
+    CONF_ENTRY_PREFER_WAV_FOR_LIVE_SOURCES_DEFAULT_ENABLED,
     create_sample_rates_config_entry,
 )
 
@@ -40,6 +41,7 @@ SENDSPIN_CAST_BLOCKLIST: set[tuple[str, str]] = {
 
 CAST_PLAYER_CONFIG_ENTRIES = (
     CONF_ENTRY_OUTPUT_CODEC,
+    CONF_ENTRY_PREFER_WAV_FOR_LIVE_SOURCES_DEFAULT_ENABLED,
     CONF_ENTRY_HTTP_PROFILE_DEFAULT_3,
     # enable flow mode by default as cast devices handle a continuous
     # flow stream more reliably than enqueueing individual tracks

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -32,6 +32,7 @@ from music_assistant_models.player import OutputProtocol, PlayerMedia
 
 from music_assistant.constants import (
     CONF_ENTRY_HTTP_PROFILE_DEFAULT_2,
+    CONF_ENTRY_PREFER_WAV_FOR_LIVE_SOURCES_DEFAULT_ENABLED,
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.helpers.util import is_valid_mac_address
@@ -193,6 +194,7 @@ class SonosPlayer(Player):
         """Return all (provider/player specific) Config Entries for the player."""
         return [
             CONF_ENTRY_HTTP_PROFILE_DEFAULT_2,
+            CONF_ENTRY_PREFER_WAV_FOR_LIVE_SOURCES_DEFAULT_ENABLED,
         ]
 
     async def on_unload(self) -> None:

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -20,7 +20,10 @@ from soco import SoCoException
 from soco.core import MUSIC_SRC_RADIO, SoCo
 from soco.data_structures import DidlAudioBroadcast
 
-from music_assistant.constants import VERBOSE_LOG_LEVEL
+from music_assistant.constants import (
+    CONF_ENTRY_PREFER_WAV_FOR_LIVE_SOURCES_DEFAULT_ENABLED,
+    VERBOSE_LOG_LEVEL,
+)
 from music_assistant.helpers.upnp import create_didl_metadata
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 
@@ -47,6 +50,7 @@ from .constants import (
 from .helpers import SonosUpdateError, soco_error
 
 if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ConfigEntry
     from soco.events_base import Event as SonosEvent
     from soco.events_base import SubscriptionBase
 
@@ -120,6 +124,10 @@ class SonosPlayer(Player):
         await asyncio.to_thread(_read_speaker_state)
         await self.subscribe()
         await self.mass.players.register_or_update(self)
+
+    async def get_config_entries(self) -> list[ConfigEntry]:
+        """Return all provider-specific configuration entries for the player."""
+        return [CONF_ENTRY_PREFER_WAV_FOR_LIVE_SOURCES_DEFAULT_ENABLED]
 
     async def offline(self) -> None:
         """Handle removal of speaker when unavailable."""

--- a/music_assistant/strings.json
+++ b/music_assistant/strings.json
@@ -234,6 +234,10 @@
         "wav": "Lossless but uncompressed — highest bandwidth. Only needed for players that can't handle FLAC."
       }
     },
+    "prefer_wav_for_live_sources": {
+      "label": "Prefer low-latency WAV for live sources",
+      "description": "Send live sources such as Spotify Connect and AirPlay Receiver as uncompressed WAV to reduce playback delay. Disable this if the player cannot play continuous WAV streams; Music Assistant will use the configured output codec instead."
+    },
     "play_media_overrides_group": {
       "label": "Play Media overrides active group",
       "description": "When this player is currently captured by an active group or sync session, an explicit Play Media command (e.g. starting a new playlist or track from Home Assistant) will release this player from the group/sync and play the new media directly on this player. Disable this to keep the legacy behavior where Play Media is redirected to the group leader. Other commands (next/prev/pause/resume) are always forwarded to the group leader as they act on the existing playback."

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -200,6 +200,8 @@
   "common.config_entries.power_control.options.none": "None",
   "common.config_entries.pre_announcement_chime_url.description": "URL to a custom audio file to play before announcements.\nLeave empty to use the default chime.\nSupports http:// and https:// URLs pointing to audio files (.mp3, .wav, .flac, .ogg, .m4a, .aac).\nExample: http://homeassistant.local:8123/local/audio/custom_chime.mp3",
   "common.config_entries.pre_announcement_chime_url.label": "Custom (pre)announcement chime URL",
+  "common.config_entries.prefer_wav_for_live_sources.description": "Send live sources such as Spotify Connect and AirPlay Receiver as uncompressed WAV to reduce playback delay. Disable this if the player cannot play continuous WAV streams; Music Assistant will use the configured output codec instead.",
+  "common.config_entries.prefer_wav_for_live_sources.label": "Prefer low-latency WAV for live sources",
   "common.config_entries.preferred_output_protocol.description": "Select the preferred protocol for audio playback to this device.",
   "common.config_entries.preferred_output_protocol.disabled_reasons.needs_setup": "This output must be set up before it can be used.",
   "common.config_entries.preferred_output_protocol.disabled_reasons.turned_off": "This output is turned off.",

--- a/tests/controllers/config/test_config_protocol_defaults.py
+++ b/tests/controllers/config/test_config_protocol_defaults.py
@@ -23,6 +23,7 @@ from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import (
     CONF_FLOW_MODE_SAMPLE_RATE,
+    CONF_PREFER_WAV_FOR_LIVE_SOURCES,
     CONF_PROTOCOL_KEY_SPLITTER,
     FLOW_MODE_SAMPLE_RATE_BIT_PERFECT,
     FLOW_MODE_SAMPLE_RATE_SMART,
@@ -228,3 +229,27 @@ async def test_player_entries_resolve_under_their_own_provider(mass: MusicAssist
 
     assert own_entries
     assert {entry.translation_owner for entry in own_entries} == {"provider.sonos"}
+
+
+async def test_live_source_wav_preference_is_only_exposed_for_http_players(
+    mass: MusicAssistant,
+) -> None:
+    """Only HTTP player protocols expose the live source WAV preference."""
+    await _setup_parent_with_protocol_child(mass)
+    parent_entries = await mass.config.get_player_config_entries(PARENT_ID)
+    dlna_key = f"{CHILD_ID}{CONF_PROTOCOL_KEY_SPLITTER}{CONF_PREFER_WAV_FOR_LIVE_SOURCES}"
+    assert next(entry for entry in parent_entries if entry.key == dlna_key).default_value is False
+
+    sendspin_provider = _TestProvider(mass, "sendspin")
+    mass._providers[sendspin_provider.instance_id] = sendspin_provider  # type: ignore[assignment]
+    mass._provider_manifests[sendspin_provider.domain] = sendspin_provider.manifest
+    sendspin_player = _TestPlayer(
+        sendspin_provider,
+        "sendspin_1",
+        "Sendspin Player",
+        PlayerType.PROTOCOL,
+    )
+
+    entries = await mass.config._get_player_config_entries(sendspin_player)
+
+    assert CONF_PREFER_WAV_FOR_LIVE_SOURCES not in {entry.key for entry in entries}

--- a/tests/controllers/streams/test_live_source_codec.py
+++ b/tests/controllers/streams/test_live_source_codec.py
@@ -1,0 +1,103 @@
+"""Tests for player-specific live source output codec selection."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import MediaType
+from music_assistant_models.player import PlayerMedia
+
+from music_assistant.constants import (
+    CONF_OUTPUT_CODEC,
+    CONF_PREFER_WAV_FOR_LIVE_SOURCES,
+)
+from music_assistant.controllers.streams import StreamsController
+from music_assistant.providers.chromecast.constants import CAST_PLAYER_CONFIG_ENTRIES
+from music_assistant.providers.sonos.player import SonosPlayer
+from music_assistant.providers.sonos_s1.player import SonosPlayer as SonosS1Player
+
+
+def _controller(output_codec: str, prefer_wav_for_live_sources: bool) -> StreamsController:
+    """Return a streams controller with one configured HTTP player."""
+    controller = StreamsController.__new__(StreamsController)
+    controller._base_url = "http://mass:8097"
+    controller.mass = mass = MagicMock()
+    player = MagicMock()
+    values = {
+        CONF_OUTPUT_CODEC: output_codec,
+        CONF_PREFER_WAV_FOR_LIVE_SOURCES: prefer_wav_for_live_sources,
+    }
+    player.config.get_value.side_effect = lambda key, default=None: values.get(key, default)
+    player.flow_mode = False
+    player.supports_gapless = True
+    mass.players.get_player.return_value = player
+    mass.player_queues.get.return_value = SimpleNamespace(
+        crossfade_enabled=False,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
+    return controller
+
+
+def _media(media_type: MediaType) -> PlayerMedia:
+    """Return queue media with the data needed to resolve its stream URL."""
+    return PlayerMedia(
+        uri="fake_plugin://audio_source/main",
+        media_type=media_type,
+        source_id="queue-1",
+        queue_item_id="item-1",
+        custom_data={"session_id": "session-1"},
+    )
+
+
+@pytest.mark.parametrize(
+    ("prefer_wav_for_live_sources", "expected_extension"),
+    [(False, "mp3"), (True, "wav")],
+)
+async def test_audio_source_url_respects_wav_preference(
+    prefer_wav_for_live_sources: bool,
+    expected_extension: str,
+) -> None:
+    """Live sources use WAV only when the player opts into the low-latency path."""
+    controller = _controller("mp3", prefer_wav_for_live_sources)
+
+    url = await controller.resolve_stream_url("player-1", _media(MediaType.AUDIO_SOURCE))
+
+    assert url == (
+        f"http://mass:8097/single/session-1/queue-1/item-1/player-1.{expected_extension}"
+    )
+
+
+async def test_wav_preference_does_not_change_regular_tracks() -> None:
+    """The live source preference leaves regular output codec selection unchanged."""
+    controller = _controller("aac", True)
+
+    url = await controller.resolve_stream_url("player-1", _media(MediaType.TRACK))
+
+    assert url == "http://mass:8097/single/session-1/queue-1/item-1/player-1.aac"
+
+
+def test_chromecast_prefers_wav_for_live_sources_by_default() -> None:
+    """Cast players default to the known-compatible low-latency WAV path."""
+    entry = next(
+        entry
+        for entry in CAST_PLAYER_CONFIG_ENTRIES
+        if entry.key == CONF_PREFER_WAV_FOR_LIVE_SOURCES
+    )
+
+    assert entry.default_value is True
+
+
+@pytest.mark.parametrize("player_class", [SonosPlayer, SonosS1Player])
+async def test_sonos_prefers_wav_for_live_sources_by_default(
+    player_class: type[SonosPlayer | SonosS1Player],
+) -> None:
+    """Sonos players default to the known-compatible low-latency WAV path."""
+    player = player_class.__new__(player_class)
+
+    entries = await player.get_config_entries()
+    entry = next(entry for entry in entries if entry.key == CONF_PREFER_WAV_FOR_LIVE_SOURCES)
+
+    assert entry.default_value is True


### PR DESCRIPTION
# What does this implement/fix?

Live sources such as Spotify Connect always used WAV, which leaves some HTTP players silent even when their configured codec works.

- Use the player's configured codec by default for live sources
- Add an advanced low-latency WAV preference
- Keep WAV enabled by default for Cast and Sonos players

**Related issue (if applicable):**

- Related to music-assistant/support#6033

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.