### PR TITLE
Fix Spotify playback authorization

### DIFF
--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -17,7 +17,14 @@ from aiofiles.os import wrap
 from music_assistant_models.api import ServerInfoMessage
 from music_assistant_models.auth import UserRole
 from music_assistant_models.enums import CoreState, EventType, ProviderFeature, ProviderType
-from music_assistant_models.errors import MusicAssistantError, SetupFailedError
+from music_assistant_models.errors import (
+    AuthenticationFailed,
+    AuthenticationRequired,
+    InvalidToken,
+    LoginFailed,
+    MusicAssistantError,
+    SetupFailedError,
+)
 from music_assistant_models.event import MassEvent
 from music_assistant_models.helpers import set_global_cache_values
 from music_assistant_models.provider import ProviderManifest
@@ -86,6 +93,10 @@ LOGGER = logging.getLogger(MASS_LOGGER_NAME)
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 PROVIDERS_PATH = os.path.join(BASE_DIR, "providers")
+
+# authentication failures require the user to reconfigure the provider, so retrying on a
+# timer never resolves them and only spams the log every 120 seconds
+NON_RETRYABLE_ERRORS = (AuthenticationRequired, AuthenticationFailed, LoginFailed, InvalidToken)
 
 _R = TypeVar("_R")
 _ProviderT = TypeVar("_ProviderT", bound=ProviderInstanceType)
@@ -776,7 +787,13 @@ class MusicAssistant:
 
             # auto schedule a retry if the (re)load failed with a handled exception
             # unhandled exceptions (e.g. ValueError) are likely bugs that won't resolve themselves
-            will_retry = allow_retry and isinstance(exc, MusicAssistantError)
+            # authentication errors need the user to reconfigure the provider, so retrying
+            # on a timer would never resolve them
+            will_retry = (
+                allow_retry
+                and isinstance(exc, MusicAssistantError)
+                and not isinstance(exc, NON_RETRYABLE_ERRORS)
+            )
             if will_retry:
                 self.call_later(
                     120,

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -94,10 +94,6 @@ LOGGER = logging.getLogger(MASS_LOGGER_NAME)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 PROVIDERS_PATH = os.path.join(BASE_DIR, "providers")
 
-# authentication failures require the user to reconfigure the provider, so retrying on a
-# timer never resolves them and only spams the log every 120 seconds
-NON_RETRYABLE_ERRORS = (AuthenticationRequired, AuthenticationFailed, LoginFailed, InvalidToken)
-
 _R = TypeVar("_R")
 _ProviderT = TypeVar("_ProviderT", bound=ProviderInstanceType)
 
@@ -787,12 +783,13 @@ class MusicAssistant:
 
             # auto schedule a retry if the (re)load failed with a handled exception
             # unhandled exceptions (e.g. ValueError) are likely bugs that won't resolve themselves
-            # authentication errors need the user to reconfigure the provider, so retrying
-            # on a timer would never resolve them
             will_retry = (
                 allow_retry
                 and isinstance(exc, MusicAssistantError)
-                and not isinstance(exc, NON_RETRYABLE_ERRORS)
+                and not isinstance(
+                    exc,
+                    (AuthenticationRequired, AuthenticationFailed, LoginFailed, InvalidToken),
+                )
             )
             if will_retry:
                 self.call_later(

--- a/music_assistant/providers/spotify/__init__.py
+++ b/music_assistant/providers/spotify/__init__.py
@@ -411,8 +411,8 @@ async def get_config_entries(
             key=CONF_ACTION_AUTH_PLAYBACK,
             type=ConfigEntryType.ACTION,
             label="Authorize playback with the Spotify app",
-            description="Advertises Music Assistant in the Spotify app for a few minutes, "
-            "so you can select it there to authorize playback.",
+            description=f"Advertises '{PAIRING_DEVICE_NAME}' in the Spotify app for a few "
+            "minutes, so you can select it there to authorize playback.",
             action=CONF_ACTION_AUTH_PLAYBACK,
             action_label="Authorize playback",
             required=False,
@@ -424,7 +424,7 @@ async def get_config_entries(
             type=ConfigEntryType.ACTION,
             label="Authorize playback with a web browser",
             description="Opens Spotify in a new browser tab to authorize playback. Use this "
-            "when Music Assistant does not appear in the Spotify app.",
+            f"when '{PAIRING_DEVICE_NAME}' does not appear in the Spotify app.",
             action=CONF_ACTION_AUTH_PLAYBACK_BROWSER,
             action_label="Authorize in browser",
             required=False,

--- a/music_assistant/providers/spotify/__init__.py
+++ b/music_assistant/providers/spotify/__init__.py
@@ -175,7 +175,7 @@ async def _handle_playback_auth_actions(
 
 async def _pair_with_spotify_app(librespot_bin: str) -> str:
     """
-    Advertise Music Assistant to the Spotify app and return the credential once it is selected.
+    Advertise the temporary pairing device to the Spotify app and return the selected credential.
 
     A still-running attempt is cancelled first, so pressing the button again restarts pairing
     instead of advertising a second device under the same name.

--- a/music_assistant/providers/spotify/constants.py
+++ b/music_assistant/providers/spotify/constants.py
@@ -35,8 +35,10 @@ LIBRESPOT_REDIRECT_PORT = 5588
 LIBRESPOT_REDIRECT_PATH = "/login"
 LIBRESPOT_REDIRECT_URI = f"http://127.0.0.1:{LIBRESPOT_REDIRECT_PORT}{LIBRESPOT_REDIRECT_PATH}"
 LOOPBACK_WAIT_TIMEOUT = 30  # seconds before offering the manual paste instead
-# name advertised to the Spotify app while pairing; also shown in the instructions
-PAIRING_DEVICE_NAME = "Music Assistant"
+# name advertised to the Spotify app while pairing; also shown in the instructions.
+# Must differ from the Spotify Connect player's own "Music Assistant" name, or picking the
+# existing player in the Spotify app leaves the playback credential empty.
+PAIRING_DEVICE_NAME = "Music Assistant Pairing"
 PAIRING_TIMEOUT = 120  # seconds the pairing action waits for the user to pick the device
 CHECK_AUTH_TIMEOUT = 30  # seconds
 CREDENTIALS_FILE = "credentials.json"

--- a/music_assistant/providers/spotify/helpers.py
+++ b/music_assistant/providers/spotify/helpers.py
@@ -339,9 +339,17 @@ async def pkce_auth_flow(
 
 async def _log_pairing_output(librespot_proc: AsyncProcess) -> None:
     """Log the pairing daemon's output so a failure to advertise is diagnosable."""
+    # librespot repeats identical warnings (e.g. libmdns "No route to host") on every
+    # advertisement retry even when pairing succeeds, so only the first occurrence of a
+    # given line is logged as a warning; exact repeats are demoted to debug
+    seen_warnings: set[str] = set()
     async for line in librespot_proc.iter_stderr():
         if "ERROR" in line or "WARN" in line:
-            LOGGER.warning("[librespot-pairing] %s", line)
+            if line in seen_warnings:
+                LOGGER.debug("[librespot-pairing] %s", line)
+            else:
+                seen_warnings.add(line)
+                LOGGER.warning("[librespot-pairing] %s", line)
         else:
             LOGGER.debug("[librespot-pairing] %s", line)
 

--- a/music_assistant/providers/spotify/helpers.py
+++ b/music_assistant/providers/spotify/helpers.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import platform
+import re
 import tempfile
 import time
 from typing import TYPE_CHECKING, Any
@@ -35,6 +36,11 @@ if TYPE_CHECKING:
     from music_assistant import MusicAssistant
 
 LOGGER = logging.getLogger(__name__)
+
+# matches the leading "[<timestamp> " librespot's env_logger output starts each line with,
+# e.g. "[2026-08-12T01:02:42Z WARN  libmdns::fsm] ..."; used to drop the (ever-changing)
+# timestamp from the pairing log dedupe key while keeping the level, target and message
+_LIBRESPOT_TIMESTAMP = re.compile(r"^\[\S+ ")
 
 LOOPBACK_RESPONSE_HTML = """
 <html>
@@ -340,15 +346,19 @@ async def pkce_auth_flow(
 async def _log_pairing_output(librespot_proc: AsyncProcess) -> None:
     """Log the pairing daemon's output so a failure to advertise is diagnosable."""
     # librespot repeats identical warnings (e.g. libmdns "No route to host") on every
-    # advertisement retry even when pairing succeeds, so only the first occurrence of a
-    # given line is logged as a warning; exact repeats are demoted to debug
+    # advertisement retry even when pairing succeeds. Its lines are timestamped
+    # (e.g. "[2026-08-12T01:02:42Z WARN  libmdns::fsm] ..."), so the timestamp is
+    # stripped from the dedupe key while the level, target and message are kept:
+    # only the first occurrence of an otherwise identical line is logged as a
+    # warning, exact repeats are demoted to debug
     seen_warnings: set[str] = set()
     async for line in librespot_proc.iter_stderr():
         if "ERROR" in line or "WARN" in line:
-            if line in seen_warnings:
+            dedupe_key = _LIBRESPOT_TIMESTAMP.sub("[", line, count=1)
+            if dedupe_key in seen_warnings:
                 LOGGER.debug("[librespot-pairing] %s", line)
             else:
-                seen_warnings.add(line)
+                seen_warnings.add(dedupe_key)
                 LOGGER.warning("[librespot-pairing] %s", line)
         else:
             LOGGER.debug("[librespot-pairing] %s", line)

--- a/music_assistant/providers/spotify/helpers.py
+++ b/music_assistant/providers/spotify/helpers.py
@@ -36,11 +36,9 @@ if TYPE_CHECKING:
     from music_assistant import MusicAssistant
 
 LOGGER = logging.getLogger(__name__)
-
-# matches the leading "[<timestamp> " librespot's env_logger output starts each line with,
-# e.g. "[2026-08-12T01:02:42Z WARN  libmdns::fsm] ..."; used to drop the (ever-changing)
-# timestamp from the pairing log dedupe key while keeping the level, target and message
-_LIBRESPOT_TIMESTAMP = re.compile(r"^\[\S+ ")
+# strips librespot's leading timestamp (e.g. "[2026-08-12T01:02:42Z ") so identical
+# WARN/ERROR lines are recognized as repeats regardless of when each one was logged
+PAIRING_LOG_TIMESTAMP = re.compile(r"^\[\d{4}-\d{2}-\d{2}T[^ ]+ ")
 
 LOOPBACK_RESPONSE_HTML = """
 <html>
@@ -345,21 +343,12 @@ async def pkce_auth_flow(
 
 async def _log_pairing_output(librespot_proc: AsyncProcess) -> None:
     """Log the pairing daemon's output so a failure to advertise is diagnosable."""
-    # librespot repeats identical warnings (e.g. libmdns "No route to host") on every
-    # advertisement retry even when pairing succeeds. Its lines are timestamped
-    # (e.g. "[2026-08-12T01:02:42Z WARN  libmdns::fsm] ..."), so the timestamp is
-    # stripped from the dedupe key while the level, target and message are kept:
-    # only the first occurrence of an otherwise identical line is logged as a
-    # warning, exact repeats are demoted to debug
-    seen_warnings: set[str] = set()
+    reported_warnings: set[str] = set()
     async for line in librespot_proc.iter_stderr():
-        if "ERROR" in line or "WARN" in line:
-            dedupe_key = _LIBRESPOT_TIMESTAMP.sub("[", line, count=1)
-            if dedupe_key in seen_warnings:
-                LOGGER.debug("[librespot-pairing] %s", line)
-            else:
-                seen_warnings.add(dedupe_key)
-                LOGGER.warning("[librespot-pairing] %s", line)
+        warning_key = PAIRING_LOG_TIMESTAMP.sub("[", line, count=1)
+        if ("ERROR" in line or "WARN" in line) and warning_key not in reported_warnings:
+            reported_warnings.add(warning_key)
+            LOGGER.warning("[librespot-pairing] %s", line)
         else:
             LOGGER.debug("[librespot-pairing] %s", line)
 

--- a/tests/core/test_provider_load_retry.py
+++ b/tests/core/test_provider_load_retry.py
@@ -1,0 +1,67 @@
+"""
+Regression tests for automatic provider (re)load retries.
+
+``load_provider`` scheduled a retry 120 seconds later for any handled
+``MusicAssistantError``, including authentication failures. Those require the user to
+reconfigure the provider, so retrying on a timer never resolved them and only spammed
+the log every 120 seconds. Authentication-class errors must not be retried, while other
+handled errors keep retrying as before.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from music_assistant_models.config_entries import ProviderConfig
+from music_assistant_models.enums import ProviderType
+from music_assistant_models.errors import (
+    AuthenticationFailed,
+    AuthenticationRequired,
+    InvalidToken,
+    LoginFailed,
+    ProviderUnavailableError,
+)
+
+from music_assistant.mass import MusicAssistant
+
+INSTANCE_ID = "spotify--test"
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        AuthenticationRequired("token expired"),
+        AuthenticationFailed("bad credentials"),
+        LoginFailed("login failed"),
+        InvalidToken("token invalid"),
+    ],
+)
+async def test_authentication_errors_are_not_retried(
+    mass_minimal: MusicAssistant, exc: Exception
+) -> None:
+    """An authentication-class load failure does not schedule a retry timer."""
+    await _load_provider_and_raise(mass_minimal, exc)
+    assert f"load_provider_{INSTANCE_ID}" not in mass_minimal._tracked_timers
+
+
+async def test_transient_error_still_retries(mass_minimal: MusicAssistant) -> None:
+    """A genuinely transient handled error still schedules a retry timer."""
+    await _load_provider_and_raise(mass_minimal, ProviderUnavailableError("temporarily down"))
+    assert f"load_provider_{INSTANCE_ID}" in mass_minimal._tracked_timers
+
+
+async def _load_provider_and_raise(mass_minimal: MusicAssistant, exc: Exception) -> None:
+    """Run load_provider(allow_retry=True) with load_provider_config raising the given error."""
+    prov_conf = ProviderConfig(
+        values={},
+        type=ProviderType.MUSIC,
+        domain="spotify",
+        instance_id=INSTANCE_ID,
+        enabled=True,
+    )
+    with (
+        patch.object(mass_minimal.config, "get_provider_config", AsyncMock(return_value=prov_conf)),
+        patch.object(mass_minimal, "load_provider_config", AsyncMock(side_effect=exc)),
+    ):
+        await mass_minimal.load_provider(INSTANCE_ID, allow_retry=True)

--- a/tests/providers/spotify/test_pairing_log_dedup.py
+++ b/tests/providers/spotify/test_pairing_log_dedup.py
@@ -2,9 +2,11 @@
 Tests for logging output from librespot's pairing (Spotify Connect advertisement) process.
 
 librespot repeats identical WARN/ERROR lines (most commonly libmdns' "No route to host") on
-every advertisement retry, even when pairing itself succeeds. Only the first occurrence of a
-given line is logged as a warning so a real (distinct) problem stays visible without flooding
-the log; exact repeats are demoted to debug.
+every advertisement retry, even when pairing itself succeeds. Each line is prefixed with a
+timestamp that changes on every repeat (e.g. "[2026-08-12T01:02:42Z WARN  libmdns::fsm] ...")
+so repeats are recognized by their level, target and message, ignoring the timestamp. Only the
+first occurrence of an otherwise identical line is logged as a warning so a real (distinct)
+problem stays visible without flooding the log; exact repeats are demoted to debug.
 """
 
 from __future__ import annotations
@@ -16,15 +18,26 @@ import pytest
 
 from music_assistant.providers.spotify.helpers import _log_pairing_output
 
+_MDNS_WARNING = (
+    "[{timestamp} WARN  libmdns::fsm] error sending packet "
+    'Os {{ code: 65, kind: HostUnreachable, message: "No route to host" }}'
+)
+_AUTH_ERROR = "[{timestamp} ERROR librespot_core::session] failed to authenticate"
+
 
 async def test_duplicate_warning_lines_are_demoted_after_first(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A repeated warning line is logged as a warning only once; repeats become debug."""
+    """
+    A warning repeated at different timestamps is logged as a warning only once.
+
+    librespot's timestamp changes on every repeat, so the dedupe key must ignore it or every
+    repeat would still be logged as a fresh warning.
+    """
     lines = [
-        "WARN libmdns: No route to host (os error 65)",
-        "WARN libmdns: No route to host (os error 65)",
-        "WARN libmdns: No route to host (os error 65)",
+        _MDNS_WARNING.format(timestamp="2026-08-12T01:02:42Z"),
+        _MDNS_WARNING.format(timestamp="2026-08-12T01:02:43Z"),
+        _MDNS_WARNING.format(timestamp="2026-08-12T01:02:44Z"),
     ]
     await _log_pairing_output(_fake_process(lines))
 
@@ -39,8 +52,8 @@ async def test_distinct_warning_lines_all_stay_warnings(
 ) -> None:
     """Different warning lines are each surfaced, since they may point at different problems."""
     lines = [
-        "WARN libmdns: No route to host (os error 65)",
-        "ERROR librespot: failed to authenticate",
+        _MDNS_WARNING.format(timestamp="2026-08-12T01:02:42Z"),
+        _AUTH_ERROR.format(timestamp="2026-08-12T01:02:43Z"),
     ]
     await _log_pairing_output(_fake_process(lines))
 

--- a/tests/providers/spotify/test_pairing_log_dedup.py
+++ b/tests/providers/spotify/test_pairing_log_dedup.py
@@ -1,0 +1,60 @@
+"""
+Tests for logging output from librespot's pairing (Spotify Connect advertisement) process.
+
+librespot repeats identical WARN/ERROR lines (most commonly libmdns' "No route to host") on
+every advertisement retry, even when pairing itself succeeds. Only the first occurrence of a
+given line is logged as a warning so a real (distinct) problem stays visible without flooding
+the log; exact repeats are demoted to debug.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from music_assistant.providers.spotify.helpers import _log_pairing_output
+
+
+async def test_duplicate_warning_lines_are_demoted_after_first(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A repeated warning line is logged as a warning only once; repeats become debug."""
+    lines = [
+        "WARN libmdns: No route to host (os error 65)",
+        "WARN libmdns: No route to host (os error 65)",
+        "WARN libmdns: No route to host (os error 65)",
+    ]
+    await _log_pairing_output(_fake_process(lines))
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    debugs = [r for r in caplog.records if r.levelname == "DEBUG"]
+    assert len(warnings) == 1
+    assert len(debugs) == 2
+
+
+async def test_distinct_warning_lines_all_stay_warnings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Different warning lines are each surfaced, since they may point at different problems."""
+    lines = [
+        "WARN libmdns: No route to host (os error 65)",
+        "ERROR librespot: failed to authenticate",
+    ]
+    await _log_pairing_output(_fake_process(lines))
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 2
+
+
+def _fake_process(lines: list[str]) -> MagicMock:
+    """Return a mock AsyncProcess whose iter_stderr yields the given lines."""
+
+    async def _iter_stderr() -> AsyncIterator[str]:
+        for line in lines:
+            yield line
+
+    proc = MagicMock()
+    proc.iter_stderr = _iter_stderr
+    return proc

--- a/tests/providers/spotify/test_playback_auth.py
+++ b/tests/providers/spotify/test_playback_auth.py
@@ -30,6 +30,8 @@ from music_assistant.providers.spotify.constants import (
     CONF_PLAYBACK_CALLBACK_URL,
     CONF_REFRESH_TOKEN_GLOBAL,
     CREDENTIALS_FILE,
+    PAIRING_DEVICE_NAME,
+    PAIRING_TIMEOUT,
 )
 from music_assistant.providers.spotify.helpers import authorization_code_from_url
 from music_assistant.providers.spotify.provider import SpotifyProvider
@@ -74,11 +76,12 @@ async def test_missing_credential_fails_the_load(tmp_path: Path) -> None:
 
 
 async def test_pairing_action_stores_the_credential(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Selecting Music Assistant in the Spotify app stores the credential for playback."""
+    """Selecting the pairing device in the Spotify app stores the credential for playback."""
     _patch_librespot(monkeypatch)
+    pairing_mock = AsyncMock(return_value=STORED_CREDENTIALS)
     monkeypatch.setattr(
         "music_assistant.providers.spotify.librespot_credentials_via_pairing",
-        AsyncMock(return_value=STORED_CREDENTIALS),
+        pairing_mock,
     )
     values = _authenticated_values()
 
@@ -88,6 +91,28 @@ async def test_pairing_action_stores_the_credential(monkeypatch: pytest.MonkeyPa
     # with playback authorized, the authorize buttons make way for the clear action
     assert _entry(entries, CONF_ACTION_AUTH_PLAYBACK).hidden
     assert not _entry(entries, CONF_ACTION_CLEAR_AUTH_PLAYBACK).hidden
+
+
+async def test_pairing_advertises_the_non_colliding_device_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The pairing action advertises a name distinct from the Spotify Connect player.
+
+    Both previously advertised as "Music Assistant", so selecting the existing Spotify
+    Connect player in the Spotify app left the playback credential empty.
+    """
+    _patch_librespot(monkeypatch)
+    pairing_mock = AsyncMock(return_value=STORED_CREDENTIALS)
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.librespot_credentials_via_pairing",
+        pairing_mock,
+    )
+
+    await _get_entries(action=CONF_ACTION_AUTH_PLAYBACK, values=_authenticated_values())
+
+    pairing_mock.assert_awaited_once_with("/bin/librespot", PAIRING_DEVICE_NAME, PAIRING_TIMEOUT)
+    assert PAIRING_DEVICE_NAME != "Music Assistant"
 
 
 async def test_pairing_timeout_points_at_the_browser_option(


### PR DESCRIPTION
# What does this implement/fix?

Fixes three related Spotify authentication problems:

- When Spotify login failed (e.g. a revoked token), Music Assistant kept retrying every 2 minutes even though re-authenticating requires the user to reconnect their account manually. This just spammed the log.
- The temporary pairing device used to authorize playback advertised itself as "Music Assistant", the same name as the existing Spotify Connect player. Selecting that existing player in the Spotify app left the playback credential empty, so the Save button stayed disabled.
- The pairing process also repeated the same harmless warning (e.g. libmdns "No route to host") many times, even when pairing succeeded.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6052

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
