### PR TITLE
Fix sync group breaking up when the leader is removed during playback

### DIFF
--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -568,8 +568,8 @@ class SyncGroupPlayer(Player):
             # just a regular member(s) added/removed action,
             # we can simply update the syncgroup members on the sync leader.
             # `active_protocol_domain` is derived from live state, so the
-            # group will naturally downshift on the next leader selection if
-            # the last protocol-requiring member was removed.
+            # group will naturally downshift once it re-forms if the last
+            # protocol-requiring member was removed.
             # use _handle_set_members directly to avoid the redirect loop
             # (cmd_set_members redirects sync-leader targets back to this syncgroup)
             async with self.mass.players.get_player_lock(
@@ -615,6 +615,10 @@ class SyncGroupPlayer(Player):
         non-native protocol — in which case the group should downshift and
         this returns the leader's native provider domain. Always computed
         from live state so it cannot drift from reality.
+
+        Because of that downshift this is a hint for the next leader selection,
+        not an address for the live session: use ``_active_session_player()``
+        to reach the players that are carrying the stream right now.
         """
         session_player = self._active_session_player()
         if session_player is None or self.sync_leader is None:
@@ -802,10 +806,8 @@ class SyncGroupPlayer(Player):
         :param new_members: Optional list of newly added member ids to consider
             when no current/static members are available.
         :param preferred_protocol_domain: If provided, prefer members that
-            support this protocol domain so the live session can keep playing
-            on the same protocol. Typically a snapshot of
-            :attr:`active_protocol_domain` taken before the old leader is
-            cleared.
+            support this protocol domain so playback keeps using the same
+            protocol.
         """
         if self.group_members and self.sync_leader and self.sync_leader.state.available:
             # current leader is still available, no need to select a new one
@@ -1228,6 +1230,10 @@ class SyncGroupPlayer(Player):
         # handoff-eligibility check.
         preferred_domain = self.active_protocol_domain
         session_player = self._active_session_player()
+        # The domain the live session actually runs on. It differs from
+        # `preferred_domain` once the group is due to downshift to native, and
+        # a seamless handoff must stay on the protocol carrying the stream.
+        session_domain = session_player.provider.domain if session_player else None
 
         # Remove the old leader from our group members list
         if old_leader_id in self._attr_group_members:
@@ -1241,7 +1247,7 @@ class SyncGroupPlayer(Player):
         # Pick a new leader preferring one that supports the currently active
         # protocol so the session continuation is seamless.
         self.sync_leader = None
-        new_leader = self._select_sync_leader(preferred_protocol_domain=preferred_domain)
+        new_leader = self._select_sync_leader(preferred_protocol_domain=session_domain)
 
         if not new_leader:
             # No remaining members to take over — stop the old leader's
@@ -1292,17 +1298,17 @@ class SyncGroupPlayer(Player):
 
         # Hand off at the protocol level. We already know:
         # - the old session player (the protocol player that owns the live session)
-        # - the active protocol domain
+        # - the domain that session runs on
         # - the new leader (a parent player whose protocol player is in the session)
         # So we can talk to the protocol players directly and skip the controller's
         # protocol-translation overhead in cmd_set_members.
-        new_target = self._resolve_session_target(new_leader, preferred_domain)
+        new_target = self._resolve_session_target(new_leader, session_domain)
         remaining_protocol_ids: list[str] = []
         for member_id in self._attr_group_members:
             if member_id == new_leader.player_id:
                 continue
             if member := self.mass.players.get_player(member_id):
-                if target := self._resolve_session_target(member, preferred_domain):
+                if target := self._resolve_session_target(member, session_domain):
                     remaining_protocol_ids.append(target.player_id)
 
         # 1. Old leader's session protocol player steps out of the session.

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -70,6 +70,9 @@ def _make_mock_player(
     player.active_output_protocol = active_output_protocol
     player.playback_state = playback_state
     player.protocol_parent_id = None
+    # stated explicitly: it decides whether the player's own domain counts as a
+    # playback path, which drives the protocol downshift
+    player.is_native_player = True
     player.provider = MagicMock()
     player.provider.domain = provider_domain
 
@@ -551,6 +554,120 @@ class TestDynamicLeaderSwitch:
         assert sgp._attr_group_members == ["bathroom", "living_room"]
         old_leader.set_members.assert_any_await(player_ids_to_remove=["old_leader"])
         bathroom.set_members.assert_any_await(player_ids_to_add=["living_room"])
+
+    @pytest.mark.asyncio
+    async def test_handoff_stays_on_live_protocol_after_downshift(self) -> None:
+        """
+        A pending downshift must not redirect the handoff to the native players.
+
+        Once no member requires the non-native protocol anymore,
+        active_protocol_domain reports the native domain while the stream is
+        still carried by the protocol players, so the handoff has to keep
+        addressing the latter.
+        """
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        old_leader = _make_mock_player(
+            "old_leader",
+            provider_domain="sonos",
+            protocol_domains=["airplay"],
+            active_output_protocol="ap_old",
+        )
+        kitchen = _make_mock_player(
+            "kitchen",
+            provider_domain="sonos",
+            protocol_domains=["airplay"],
+            active_output_protocol="ap_kitchen",
+        )
+        kitchen.linked_output_protocols[0].output_protocol_id = "ap_kitchen"
+        bathroom = _make_mock_player(
+            "bathroom",
+            provider_domain="sonos",
+            protocol_domains=["airplay"],
+            active_output_protocol="ap_bathroom",
+        )
+        bathroom.linked_output_protocols[0].output_protocol_id = "ap_bathroom"
+
+        ap_old = _make_mock_player("ap_old", provider_domain="airplay")
+        ap_kitchen = _make_mock_player("ap_kitchen", provider_domain="airplay")
+        ap_bathroom = _make_mock_player("ap_bathroom", provider_domain="airplay")
+        mock_session = MagicMock()
+        mock_session.sync_clients = [ap_old, ap_kitchen, ap_bathroom]
+        ap_old.stream = MagicMock()
+        ap_old.stream.session = mock_session
+
+        mass.players.get_player = _player_lookup(
+            {
+                "old_leader": old_leader,
+                "kitchen": kitchen,
+                "bathroom": bathroom,
+                "ap_old": ap_old,
+                "ap_kitchen": ap_kitchen,
+                "ap_bathroom": ap_bathroom,
+            }
+        )
+
+        sgp.sync_leader = old_leader
+        sgp._attr_group_members = ["old_leader", "kitchen", "bathroom"]
+        # all remaining members can play natively, so the group is due to downshift
+        assert sgp.active_protocol_domain == "sonos"
+
+        with patch.object(sgp, "update_state"):
+            await sgp._dynamic_leader_switch("old_leader")
+
+        assert sgp.sync_leader == kitchen
+        ap_old.set_members.assert_any_await(player_ids_to_remove=["ap_old"])
+        ap_kitchen.set_members.assert_any_await(player_ids_to_add=["ap_bathroom"])
+        # a native grouping command would regroup speakers that stream over AirPlay
+        kitchen.set_members.assert_not_awaited()
+        bathroom.set_members.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_leader_selection_prefers_the_live_protocol_after_downshift(self) -> None:
+        """The new leader comes from the live session, not from the downshifted domain."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        old_leader = _make_mock_player(
+            "old_leader",
+            provider_domain="sonos",
+            protocol_domains=["airplay"],
+            active_output_protocol="ap_old",
+        )
+        # AirPlay device that is also reachable over its Sendspin bridge, so it
+        # does not count as requiring AirPlay and the group is due to downshift
+        apple_tv = _make_mock_player(
+            "apple_tv", provider_domain="airplay", protocol_domains=["sendspin"]
+        )
+        # native-only member that never joined the live session
+        spare = _make_mock_player("spare", provider_domain="sonos")
+
+        ap_old = _make_mock_player("ap_old", provider_domain="airplay")
+        mock_session = MagicMock()
+        mock_session.sync_clients = [ap_old, apple_tv]
+        ap_old.stream = MagicMock()
+        ap_old.stream.session = mock_session
+
+        mass.players.get_player = _player_lookup(
+            {
+                "old_leader": old_leader,
+                "apple_tv": apple_tv,
+                "spare": spare,
+                "ap_old": ap_old,
+            }
+        )
+
+        sgp.sync_leader = old_leader
+        sgp._attr_group_members = ["old_leader", "apple_tv", "spare"]
+        assert sgp.active_protocol_domain == "sonos"
+
+        with patch.object(sgp, "update_state"):
+            await sgp._dynamic_leader_switch("old_leader")
+
+        # picking the native-only spare would have cost a dissolve + reform
+        assert sgp.sync_leader == apple_tv
+        ap_old.set_members.assert_any_await(player_ids_to_remove=["ap_old"])
 
     def test_align_members_translates_protocol_ids_and_keeps_outsiders_last(self) -> None:
         """A protocol session player's order maps onto the parent members that we track."""


### PR DESCRIPTION
# What does this implement/fix?

Removing the leader from a playing sync group could hand the group over to the wrong speakers.

A sync group switches to another streaming protocol (for example AirPlay) when one of its members can only be reached that way. Once that member leaves, the group notes that it may go back to native streaming on the next start — but the audio keeps running over the original protocol until then. Removing the leader at that moment made the group hand the running session over to the native side of the remaining speakers, so a speaker could drop out of the group while it was still playing, or a grouping command was sent to speakers that were streaming over another protocol.

The handoff now always addresses the speakers that are actually carrying the audio.

- Resolve the new leader and the handoff targets from the player that owns the live session instead of from the "may go back to native" hint
- Keep that hint for the dissolve + re-form path, where it is meant to be used
- Added tests covering a leader removal while the group is still streaming over a non-native protocol

**Related issue (if applicable):**

- n/a — found while reviewing #5595

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
