### PR TITLE
Keep sync group playing when the lead speaker is removed

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -631,6 +631,19 @@ class Player(ABC):
         return self._attr_group_members
 
     @property
+    def live_session_members(self) -> list[str]:
+        """
+        Return the id's of the players that take part in this player's live playback session.
+
+        Defaults to :attr:`group_members`, which is the right answer where grouping and
+        the playback session are the same thing. Providers where the two drift apart
+        (a member the session dropped, one that never managed to join it, or no session
+        at all) should override this and answer from the session itself, so callers can
+        tell actual playback partners from tracked group membership.
+        """
+        return self.group_members
+
+    @property
     def can_group_with(self) -> set[str]:
         """
         Return the id's of players this player can group with.

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -277,6 +277,17 @@ class AirPlayPlayer(Player):
         """Return True: members are attached to this player's own stream session."""
         return True
 
+    @property
+    def live_session_members(self) -> list[str]:
+        """Return the id's of the players the running stream session feeds."""
+        # group membership is bookkeeping that outlives the session: a member can be
+        # dropped from the session (write failures) or never make it in (a refused
+        # late join) while still being listed as part of the group, and without a
+        # session there is nobody to render with at all
+        if self.stream and self.stream.running and self.stream.session:
+            return [x.player_id for x in self.stream.session.sync_clients]
+        return []
+
     async def get_config_entries(self) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the given player (if any)."""
         # Pairing/credentials are no longer config entries: they are collected by the

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -967,7 +967,9 @@ class SyncGroupPlayer(Player):
         if session_player is None:
             return
         # the provider's own group_members, not state.group_members: the latter is
-        # set-derived for non-protocol players and loses the member order
+        # set-derived for non-protocol players and loses the member order. Not
+        # live_session_members either: that answers who is in the session, not in
+        # which order, and a provider may derive it without preserving any.
         session_order = [
             x
             for x in self._translate_to_parent_ids(session_player.group_members)
@@ -1057,38 +1059,21 @@ class SyncGroupPlayer(Player):
 
     def _is_player_in_session(self, player: Player, session_player: Player | None) -> bool:
         """
-        Return True if ``player`` is already a sync_client of the live session.
+        Return True if ``player`` already takes part in the live session.
 
-        A seamless leader handoff only works when the candidate's resolved
-        protocol player is already in the active ``AirPlayStreamSession`` (or
-        equivalent). If not (e.g. a freshly-added player that has never played
+        A seamless leader handoff only works when the candidate is already a member
+        of the session. If not (e.g. a freshly-added player that has never played
         anything), we must fall back to dissolve + reform.
 
         :param player: The candidate new leader.
-        :param session_player: The protocol player that owns the live session
-            (snapshot taken before the old leader was cleared via
-            ``_active_session_player()``).
+        :param session_player: The player that owns the live session (snapshot taken
+            before the old leader was cleared via ``_active_session_player()``).
         """
         if session_player is None:
             return False
-        session = getattr(getattr(session_player, "stream", None), "session", None)
-        if session is None:
-            # No session object (e.g. Snapcast, Sendspin) — assume handoff is
-            # safe if the provider declared support for it.
-            return True
-        sync_clients = getattr(session, "sync_clients", None)
-        if sync_clients is None:
-            # Session exists but doesn't expose sync_clients — same assumption.
-            return True
-        # Resolve player to the protocol player that would own the session
-        target: Player = player
-        if (
-            player.active_output_protocol
-            and player.active_output_protocol != "native"
-            and (p := self.mass.players.get_player(player.active_output_protocol))
-        ):
-            target = p
-        return target in sync_clients
+        return player.player_id in self._translate_to_parent_ids(
+            session_player.live_session_members
+        )
 
     async def _dissolve_and_reform(
         self,

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1361,6 +1361,26 @@ async def test_set_members_adds_the_child_to_the_running_session() -> None:
     assert leader.group_members == ["leader", "child"]
 
 
+def test_live_session_members_reports_who_the_session_actually_feeds() -> None:
+    """Group membership outlives the session, so only the session itself can answer."""
+    leader = _make_playing_leader()
+    leader._attr_group_members = ["leader", "child"]
+    # the session dropped the child (e.g. its receiver never answered our clock)
+    _attach_running_session(leader, [leader])
+
+    assert leader.live_session_members == ["leader"]
+
+    # no session means nobody is being rendered with, whatever the group says
+    stream = cast("MagicMock", leader.stream)
+    stream.running = False
+    assert leader.live_session_members == []
+    stream.running = True
+    stream.session = None
+    assert leader.live_session_members == []
+    leader.stream = None
+    assert leader.live_session_members == []
+
+
 @pytest.mark.asyncio
 async def test_set_members_warns_when_the_leader_has_no_session(
     caplog: pytest.LogCaptureFixture,

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -88,6 +88,11 @@ def _make_mock_player(
     player.linked_output_protocols = protocols
 
     # State mock
+    # real lists, so a test that needs members has to say so instead of silently
+    # getting an empty auto-attribute
+    player.group_members = []
+    player.live_session_members = []
+
     player.state = MagicMock()
     player.state.available = available
     player.state.playback_state = playback_state
@@ -424,13 +429,13 @@ class TestDynamicLeaderSwitch:
         ap_only.linked_output_protocols[0].output_protocol_id = "ap_only_proto"
         # ap_only's airplay protocol player needs to exist for the protocol-id resolution
         ap_only_proto = _make_mock_player("ap_only_proto", provider_domain="airplay")
+        ap_new.protocol_parent_id = "new_leader"
+        ap_only_proto.protocol_parent_id = "ap_only"
 
         ap_protocol = _make_mock_player("ap_old", provider_domain="airplay")
-        # Set up the live session with new_leader's protocol player in sync_clients
-        mock_session = MagicMock()
-        mock_session.sync_clients = [ap_protocol, ap_new, ap_only]
-        ap_protocol.stream = MagicMock()
-        ap_protocol.stream.session = mock_session
+        # the live session holds new_leader's protocol player, so it can take over
+        ap_protocol.group_members = ["ap_old", "ap_new", "ap_only_proto"]
+        ap_protocol.live_session_members = ["ap_old", "ap_new", "ap_only_proto"]
 
         mass.players.get_player = _player_lookup(
             {
@@ -485,12 +490,8 @@ class TestDynamicLeaderSwitch:
         fresh_player = _make_mock_player(
             "fresh_player", provider_domain="sonos", protocol_domains=["airplay"]
         )
+        # the old leader was streaming on its own, so its session holds nobody else
         ap_protocol = _make_mock_player("ap_old", provider_domain="airplay")
-        # Session does NOT contain fresh_player's protocol player
-        mock_session = MagicMock()
-        mock_session.sync_clients = [ap_protocol]
-        ap_protocol.stream = MagicMock()
-        ap_protocol.stream.session = mock_session
 
         mass.players.get_player = _player_lookup(
             {
@@ -528,12 +529,11 @@ class TestDynamicLeaderSwitch:
         old_leader = _make_mock_player("old_leader", provider_domain="sendspin")
         living_room = _make_mock_player("living_room", provider_domain="sendspin")
         bathroom = _make_mock_player("bathroom", provider_domain="sendspin")
-        # no stream/session object (Sendspin, Snapcast) -> handoff is assumed safe
-        old_leader.stream = None
         # the live session hands over to bathroom, our own order says living_room.
         # state.group_members is deliberately left unordered: only the raw attribute
         # carries the provider's member order.
         old_leader.group_members = ["old_leader", "bathroom", "living_room"]
+        old_leader.live_session_members = ["old_leader", "bathroom", "living_room"]
         old_leader.state.group_members = ["old_leader", "living_room", "bathroom"]
 
         mass.players.get_player = _player_lookup(
@@ -592,10 +592,10 @@ class TestDynamicLeaderSwitch:
         ap_old = _make_mock_player("ap_old", provider_domain="airplay")
         ap_kitchen = _make_mock_player("ap_kitchen", provider_domain="airplay")
         ap_bathroom = _make_mock_player("ap_bathroom", provider_domain="airplay")
-        mock_session = MagicMock()
-        mock_session.sync_clients = [ap_old, ap_kitchen, ap_bathroom]
-        ap_old.stream = MagicMock()
-        ap_old.stream.session = mock_session
+        ap_kitchen.protocol_parent_id = "kitchen"
+        ap_bathroom.protocol_parent_id = "bathroom"
+        ap_old.group_members = ["ap_old", "ap_kitchen", "ap_bathroom"]
+        ap_old.live_session_members = ["ap_old", "ap_kitchen", "ap_bathroom"]
 
         mass.players.get_player = _player_lookup(
             {
@@ -644,10 +644,8 @@ class TestDynamicLeaderSwitch:
         spare = _make_mock_player("spare", provider_domain="sonos")
 
         ap_old = _make_mock_player("ap_old", provider_domain="airplay")
-        mock_session = MagicMock()
-        mock_session.sync_clients = [ap_old, apple_tv]
-        ap_old.stream = MagicMock()
-        ap_old.stream.session = mock_session
+        ap_old.group_members = ["ap_old", "apple_tv"]
+        ap_old.live_session_members = ["ap_old", "apple_tv"]
 
         mass.players.get_player = _player_lookup(
             {
@@ -668,6 +666,48 @@ class TestDynamicLeaderSwitch:
         # picking the native-only spare would have cost a dissolve + reform
         assert sgp.sync_leader == apple_tv
         ap_old.set_members.assert_any_await(player_ids_to_remove=["ap_old"])
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("provider_domain", "live_members"),
+        [
+            # a solo Sendspin leader still lists itself as its group's only client
+            ("sendspin", ["old_leader"]),
+            # Snapcast reports no members at all while it leads nobody
+            ("snapcast", []),
+        ],
+    )
+    async def test_dynamic_leader_switch_dissolves_when_member_never_joined_session(
+        self, provider_domain: str, live_members: list[str]
+    ) -> None:
+        """A member that never joined the live session cannot inherit it, whatever the provider."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        old_leader = _make_mock_player("old_leader", provider_domain=provider_domain)
+        old_leader.group_members = live_members
+        old_leader.live_session_members = live_members
+        # added to the group in the same call that removed the leader, so it was
+        # never synced at the protocol level
+        fresh_player = _make_mock_player("fresh_player", provider_domain=provider_domain)
+
+        mass.players.get_player = _player_lookup(
+            {"old_leader": old_leader, "fresh_player": fresh_player}
+        )
+
+        sgp.sync_leader = old_leader
+        sgp._attr_group_members = ["old_leader", "fresh_player"]
+
+        with patch.object(sgp, "update_state"):
+            await sgp._dynamic_leader_switch("old_leader")
+
+        # no protocol-level handoff was attempted; the group stopped and dissolved
+        # with a re-form scheduled so playback resumes on the new member
+        old_leader.set_members.assert_not_awaited()
+        mass.players._handle_cmd_stop.assert_awaited_with("old_leader")
+        assert sgp._attr_group_members == ["fresh_player"]
+        assert sgp._reform_task is not None
+        assert sgp.sync_leader is None
 
     def test_align_members_translates_protocol_ids_and_keeps_outsiders_last(self) -> None:
         """A protocol session player's order maps onto the parent members that we track."""


### PR DESCRIPTION
# What does this implement/fix?

When you remove the speaker that leads a sync group while it's playing, the group tries to hand the running stream to one of the remaining speakers. That only works if the chosen speaker is already part of the live session — otherwise the group has to stop and restart to keep the music going.

The check for "is this speaker part of the session?" only understood AirPlay. For Sendspin and Snapcast it always answered yes, so a speaker that had just been added (and was never actually connected to the stream) could be handed a session that doesn't exist, leaving the group silent.

Players now answer that question themselves: AirPlay answers from its live stream session, everyone else from their group members.

**Related issue (if applicable):**

- follow-up on #5595

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
