### PR TITLE
Fix music not resuming on WiiM speakers after a group change

### DIFF
--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -89,6 +89,7 @@ class WiimPlayer(Player):
 
         self._last_logged_sdk_uri: str | None = None
         self._last_logged_sdk_status: PlayingStatus | None = None
+        self._ma_stream_uri: str | None = None
 
     # --- Lifecycle ---
 
@@ -148,6 +149,9 @@ class WiimPlayer(Player):
             source_id=media.source_id,
             clear_all=True,
         )
+        self._attr_elapsed_time = 0
+        self._attr_elapsed_time_last_updated = time.time()
+        self._ma_stream_uri = stream_url
         try:
             await self.device.async_play(uri=stream_url, metadata=didl_metadata)
         except (WiimDeviceException, WiimRequestException) as err:
@@ -197,6 +201,7 @@ class WiimPlayer(Player):
         """Stop command."""
         self._attr_active_source = None
         self._attr_current_media = None
+        self._ma_stream_uri = None
         try:
             await self.device.async_stop()
         except (WiimDeviceException, WiimRequestException) as err:
@@ -501,7 +506,12 @@ class WiimPlayer(Player):
         except (WiimDeviceException, WiimRequestException) as err:
             self.logger.debug("Failed to sync position for %s: %s", self._attr_name, err)
             return
-        if (media := self.device.current_media) is not None and media.position is not None:
+        media = self.device.current_media
+        device_uri = media.uri if media else None
+        if device_uri and device_uri == self._ma_stream_uri:
+            self._ma_stream_uri = None
+        # The device reports its previous content's position until it loads our stream URI.
+        if self._ma_stream_uri is None and media is not None and media.position is not None:
             self._attr_elapsed_time = media.position
             self._attr_elapsed_time_last_updated = time.time()
         self._update_ma_state_from_sdk_cache()

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -155,6 +155,8 @@ class WiimPlayer(Player):
         try:
             await self.device.async_play(uri=stream_url, metadata=didl_metadata)
         except (WiimDeviceException, WiimRequestException) as err:
+            # The device never took our stream, so the guard must not outlive the attempt.
+            self._ma_stream_uri = None
             self._handle_command_error("play_media", err)
             return
         self._update_ma_state_from_sdk_cache()

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -7,6 +7,7 @@ from music_assistant_models.enums import PlaybackState, PlayerFeature
 from wiim import PlayingStatus
 from wiim.exceptions import WiimDeviceException, WiimRequestException
 
+from music_assistant.models.player import PlayerMedia
 from music_assistant.providers.wiim.constants import SOURCE_NETWORK
 from music_assistant.providers.wiim.player import SDK_TO_MA_STATE, WiimPlayer
 
@@ -340,3 +341,157 @@ class TestErrorHandling:
         await player.pause()
         assert player._attr_available is True
         player.update_state.assert_called()
+
+
+class TestStalePositionOnNewStream:
+    """A new stream handed to the device must not inherit the previous position."""
+
+    def _make_player(self, provider: MagicMock, device: MagicMock) -> WiimPlayer:
+        player = WiimPlayer(provider=provider, player_id="uuid:test", device=device)
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+        return player
+
+    @pytest.mark.asyncio
+    async def test_play_media_resets_elapsed_time(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """play_media() must clear the stale elapsed_time anchor from prior content."""
+        stream_url = "http://192.168.1.80:8097/single/abc/queue/item/uuid:test.flac"
+        mock_provider.mass.streams.resolve_stream_url = AsyncMock(return_value=stream_url)
+        player = self._make_player(mock_provider, mock_wiim_device)
+        player._attr_elapsed_time = 273
+        player._attr_elapsed_time_last_updated = 1000.0
+
+        await player.play_media(PlayerMedia(uri="library://track/1", title="Some Track"))
+
+        assert player._attr_elapsed_time == 0
+        assert player._attr_elapsed_time_last_updated is not None
+        assert player._attr_elapsed_time_last_updated > 1000.0
+
+    @pytest.mark.asyncio
+    async def test_play_media_then_sync_position_end_to_end(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """
+        The device still reports the previous AirPlay content after play_media.
+
+        Its metadata makes MA rebuild _attr_current_media from the device's own
+        uri, so the position guard must not key off _attr_current_media.
+        """
+        stream_url = "http://192.168.1.80:8097/single/abc/queue/item/uuid:test.flac"
+        mock_provider.mass.streams.resolve_stream_url = AsyncMock(return_value=stream_url)
+
+        device_media = MagicMock()
+        device_media.uri = "wiimu_airplay"
+        device_media.title = "Previous Song"
+        device_media.artist = "Previous Artist"
+        device_media.album = "Previous Album"
+        device_media.position = 273
+        mock_wiim_device.play_mode = SOURCE_NETWORK
+        mock_wiim_device.current_media = device_media
+        mock_wiim_device.playing_status = PlayingStatus.PLAYING
+
+        player = self._make_player(mock_provider, mock_wiim_device)
+        player._attr_elapsed_time = 273
+
+        await player.play_media(PlayerMedia(uri="library://track/1", title="New Track"))
+        assert player._attr_elapsed_time == 0
+
+        await player._sync_position()
+
+        assert player._attr_elapsed_time == 0
+
+    @pytest.mark.asyncio
+    async def test_sync_position_ignores_position_reported_without_uri(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """The device clears its uri mid-handover while still reporting the old position."""
+        stream_url = "http://192.168.1.80:8097/single/abc/queue/item/uuid:test.flac"
+        mock_provider.mass.streams.resolve_stream_url = AsyncMock(return_value=stream_url)
+
+        device_media = MagicMock()
+        device_media.uri = None
+        device_media.title = None
+        device_media.artist = None
+        device_media.album = None
+        device_media.position = 273
+        mock_wiim_device.play_mode = SOURCE_NETWORK
+        mock_wiim_device.current_media = device_media
+
+        player = self._make_player(mock_provider, mock_wiim_device)
+
+        await player.play_media(PlayerMedia(uri="library://track/1", title="New Track"))
+        await player._sync_position()
+
+        assert player._attr_elapsed_time == 0
+
+    @pytest.mark.asyncio
+    async def test_sync_position_ignores_foreign_uri(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """The device's position is rejected while it hasn't loaded MA's stream uri."""
+        stream_uri = "http://192.168.1.80:8097/single/abc/queue/item/uuid:test.flac"
+        player = self._make_player(mock_provider, mock_wiim_device)
+        player._ma_stream_uri = stream_uri
+        player._attr_elapsed_time = 0
+        player._attr_elapsed_time_last_updated = 1000.0
+
+        device_media = MagicMock()
+        device_media.uri = "wiimu_airplay"
+        device_media.position = 273
+        mock_wiim_device.current_media = device_media
+
+        await player._sync_position()
+
+        assert player._attr_elapsed_time == 0
+        assert player._attr_elapsed_time_last_updated == 1000.0
+
+    @pytest.mark.asyncio
+    async def test_sync_position_accepts_matching_uri_and_clears_guard(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """Once the device reports MA's own uri, its position is trusted and the guard lifts."""
+        stream_uri = "http://192.168.1.80:8097/single/abc/queue/item/uuid:test.flac"
+        mock_provider.mass.streams.resolve_stream_url = AsyncMock(return_value=stream_uri)
+        player = self._make_player(mock_provider, mock_wiim_device)
+
+        device_media = MagicMock()
+        device_media.uri = stream_uri
+        device_media.position = 12
+        mock_wiim_device.current_media = device_media
+
+        await player.play_media(PlayerMedia(uri="library://track/1", title="New Track"))
+        player._attr_elapsed_time_last_updated = 1000.0
+
+        await player._sync_position()
+
+        assert player._attr_elapsed_time == 12
+        assert player._attr_elapsed_time_last_updated > 1000.0
+        assert player._ma_stream_uri is None
+
+        # A later switch to an external source must not be blocked by a stale guard.
+        device_media.uri = "wiimu_airplay"
+        device_media.position = 55
+        await player._sync_position()
+
+        assert player._attr_elapsed_time == 55
+
+    @pytest.mark.asyncio
+    async def test_sync_position_accepts_device_when_ma_not_driving_playback(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """With no stream handed over by MA (external source), the device's position is authoritative."""
+        player = self._make_player(mock_provider, mock_wiim_device)
+        player._ma_stream_uri = None
+        player._attr_elapsed_time = 0
+        player._attr_elapsed_time_last_updated = 1000.0
+
+        device_media = MagicMock()
+        device_media.uri = "wiimu_airplay"
+        device_media.position = 42
+        mock_wiim_device.current_media = device_media
+
+        await player._sync_position()
+
+        assert player._attr_elapsed_time == 42
+        assert player._attr_elapsed_time_last_updated > 1000.0

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -402,6 +402,27 @@ class TestStalePositionOnNewStream:
         assert player._attr_elapsed_time == 0
 
     @pytest.mark.asyncio
+    async def test_failed_play_media_releases_the_guard(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """A device that never took our stream must not stay guarded against its own position."""
+        stream_url = "http://192.168.1.80:8097/single/abc/queue/item/uuid:test.flac"
+        mock_provider.mass.streams.resolve_stream_url = AsyncMock(return_value=stream_url)
+        mock_wiim_device.async_play = AsyncMock(side_effect=WiimDeviceException("boom"))
+        player = self._make_player(mock_provider, mock_wiim_device)
+
+        await player.play_media(PlayerMedia(uri="library://track/1", title="New Track"))
+
+        device_media = MagicMock()
+        device_media.uri = "wiimu_airplay"
+        device_media.position = 42
+        mock_wiim_device.current_media = device_media
+
+        await player._sync_position()
+
+        assert player._attr_elapsed_time == 42
+
+    @pytest.mark.asyncio
     async def test_sync_position_ignores_position_reported_without_uri(
         self, mock_provider: MagicMock, mock_wiim_device: MagicMock
     ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Music did not resume on a WiiM speaker after the speakers were regrouped: the now-playing screen froze with the progress running past the end of the track (7:20 on a 4:21 track), and playback only recovered minutes later on the next group change, by then on a different song.

`WiimPlayer` only ever learned a position by copying whatever the device reported in `_sync_position()`. Nothing invalidated that position when Music Assistant handed the device a *new* stream, so the player kept reporting the position of the content the device was playing before. The queue's playback tracker adds the item's `streamdetails.seek_position` on top of the player position, so the two compounded:

- resume at 167s (correct, the stored resume point)
- plus a stale 273s still held from the previous AirPlay session
- = `elapsed_time` of 440s on a 261s track

A second play command then arrived while the queue was marked playing, so `resume()` took its `corrected_elapsed_time` branch and resumed at 440s. Seeking past the end of the track produced a stream with no audio, the device sat in `TRANSITIONING`, and the reported progress kept climbing past the duration.

Two things make the fix work:

- `play_media()` resets the position anchor and records the stream URL it handed over.
- `_sync_position()` ignores the device's reported position until the device confirms that exact URL, then clears the guard so a later switch to an external source (AirPlay, Spotify, line-in) still reports its own position normally.

The guard deliberately does not key off `_attr_current_media`: `_update_ma_state_from_sdk_cache()` rebuilds that from the device's own reported media, so it equals the device URI by construction and cannot tell us what MA handed over. It also rejects positions reported with an empty URI, which is a real state during the handover.

**Related issue (if applicable):**

- none; diagnosed from a production server log

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes. — ruff lint/format and mypy pass on both changed files; the only failures locally are ~35 pre-existing `mypy` errors in `providers/sendspin` from a local `aiosendspin` older than dev's pin, untouched by this PR.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. — n/a
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. — n/a
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. — n/a, no documented behaviour changes

## Tests

`tests/providers/wiim/test_player.py` gains `TestStalePositionOnNewStream` (5 cases): the anchor reset, the end-to-end handover that reproduces the wedge, a position reported with no URI, a foreign URI, and the guard clearing once the device confirms MA's URI so an external-source switch is not blocked.

All 5 fail with `assert 273 == 0` against the unmodified provider. With the fix, 27 passed, 1 skipped (the skip is pre-existing, pending wiim-sdk 0.1.5+).
