### PR TITLE
Keep sync groups on the right protocol when a speaker can't play natively

### DIFF
--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -625,8 +625,8 @@ class SyncGroupPlayer(Player):
             return None
         domain = session_player.provider.domain
         native_domain = self.sync_leader.provider.domain
-        # A non-native protocol stays "active" for leader-selection purposes as
-        # long as at least one member cannot be reached on the leader's native domain.
+        # Keep a non-native protocol "active" for leader-selection purposes unless
+        # the whole group can be reached on the leader's native domain.
         if domain != native_domain and self._all_members_can_play_on_domain(native_domain):
             return native_domain
         return domain
@@ -903,14 +903,14 @@ class SyncGroupPlayer(Player):
 
     def _all_members_can_play_on_domain(self, domain: str) -> bool:
         """
-        Return True if every current member has an available playback path on the given domain.
+        Return True if every current member has a playback path on the given domain.
 
         A playback path is a member's own native playback or one of its
         available linked output protocols. Members that are unavailable or
         expose no playback path at all are ignored, so they never hold the
         group on a protocol.
 
-        :param domain: The protocol domain string (e.g. "airplay", "sonos").
+        :param domain: The playback path domain to check (e.g. "airplay", "sonos").
         """
         for member_id in self._attr_group_members:
             member = self.mass.players.get_player(member_id)

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -568,8 +568,8 @@ class SyncGroupPlayer(Player):
             # just a regular member(s) added/removed action,
             # we can simply update the syncgroup members on the sync leader.
             # `active_protocol_domain` is derived from live state, so the
-            # group will naturally downshift once it re-forms if the last
-            # protocol-requiring member was removed.
+            # group will naturally downshift once it re-forms if every
+            # remaining member can play on the leader's native protocol.
             # use _handle_set_members directly to avoid the redirect loop
             # (cmd_set_members redirects sync-leader targets back to this syncgroup)
             async with self.mass.players.get_player_lock(
@@ -611,10 +611,10 @@ class SyncGroupPlayer(Player):
         Derive the active protocol domain for this sync group on the fly.
 
         Returns the domain of the protocol currently carrying the live stream
-        session, EXCEPT when no remaining member actually requires that
-        non-native protocol — in which case the group should downshift and
-        this returns the leader's native provider domain. Always computed
-        from live state so it cannot drift from reality.
+        session, EXCEPT when every remaining member can also play on the
+        leader's native domain — in which case the group should downshift and
+        this returns that native domain. Always computed from live state so it
+        cannot drift from reality.
 
         Because of that downshift this is a hint for the next leader selection,
         not an address for the live session: use ``_active_session_player()``
@@ -625,9 +625,9 @@ class SyncGroupPlayer(Player):
             return None
         domain = session_player.provider.domain
         native_domain = self.sync_leader.provider.domain
-        # If a non-native protocol is in use, only keep it as "active" for
-        # leader-selection purposes when some member still requires it.
-        if domain != native_domain and not self._any_member_requires_protocol_domain(domain):
+        # A non-native protocol stays "active" for leader-selection purposes as
+        # long as at least one member cannot be reached on the leader's native domain.
+        if domain != native_domain and self._all_members_can_play_on_domain(native_domain):
             return native_domain
         return domain
 
@@ -858,8 +858,8 @@ class SyncGroupPlayer(Player):
     #     the right object
     #   - choose new leaders that keep protocol continuity
     #     (_member_supports_protocol_domain / _select_sync_leader)
-    #   - downshift to the native protocol when the last protocol-requiring
-    #     member is gone (_any_member_requires_protocol_domain)
+    #   - downshift to the native protocol once every remaining member can play
+    #     on it (_all_members_can_play_on_domain)
     #   - stay aligned with the protocol's own view of the group, both in member
     #     order (_align_members_with_session) and in who leads it
     #     (_protocol_group_leader)
@@ -901,17 +901,14 @@ class SyncGroupPlayer(Player):
                 return True
         return False
 
-    def _any_member_requires_protocol_domain(self, domain: str) -> bool:
+    def _all_members_can_play_on_domain(self, domain: str) -> bool:
         """
-        Return True if any current member can only play via the given protocol domain.
+        Return True if every current member has an available playback path on the given domain.
 
-        A member "requires" the protocol when all of its available playback
-        paths are on that domain — i.e. it has no native playback path outside
-        this domain AND no linked output protocol outside this domain. This
-        covers plain protocol-domain players (e.g. AirPlay) as well as
-        UniversalPlayer wrappers whose native ``provider.domain`` is
-        ``universal_player`` but which can still only play via a single
-        linked protocol.
+        A playback path is a member's own native playback or one of its
+        available linked output protocols. Members that are unavailable or
+        expose no playback path at all are ignored, so they never hold the
+        group on a protocol.
 
         :param domain: The protocol domain string (e.g. "airplay", "sonos").
         """
@@ -920,18 +917,18 @@ class SyncGroupPlayer(Player):
             if member is None or not member.state.available:
                 continue
             # Collect the set of available playback path domains for this member.
+            # UniversalPlayer wrappers have no native path of their own: their
+            # ``provider.domain`` is ``universal_player``, which is never a
+            # domain the group can play on.
             paths: set[str] = set()
             if member.is_native_player:
                 paths.add(member.provider.domain)
             for protocol in member.linked_output_protocols:
                 if protocol.available:
                     paths.add(protocol.protocol_domain)
-            if not paths:
-                # nothing available at all, skip rather than force a protocol
-                continue
-            if paths == {domain}:
-                return True
-        return False
+            if paths and domain not in paths:
+                return False
+        return True
 
     def _active_session_player(self) -> Player | None:
         """

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -267,23 +267,23 @@ class TestActiveProtocolDomain:
         assert sgp.active_protocol_domain == "sonos"
 
     def test_bridged_airplay_member_keeps_the_protocol(self) -> None:
-        """An AirPlay speaker holds the group on AirPlay despite its Sendspin bridge."""
+        """An AirPlay device holds the group on AirPlay despite its Sendspin bridge."""
         mass = _make_mock_mass()
         sgp = _make_sync_group(mass)
         leader = _make_mock_player(
             "leader", provider_domain="sonos", active_output_protocol="ap_leader"
         )
         ap_protocol = _make_mock_player("ap_leader", provider_domain="airplay")
-        # every AirPlay player gets a Sendspin bridge, so its playback paths are
-        # airplay + sendspin - neither of which can reach the leader's native domain
-        ap_speaker = _make_mock_player(
-            "ap_speaker", provider_domain="airplay", protocol_domains=["sendspin"]
+        # an Apple TV plays AirPlay natively and carries a Sendspin bridge on top,
+        # so its playback paths are airplay + sendspin - neither reaches sonos
+        apple_tv = _make_mock_player(
+            "apple_tv", provider_domain="airplay", protocol_domains=["sendspin"]
         )
         mass.players.get_player = _player_lookup(
-            {"leader": leader, "ap_leader": ap_protocol, "ap_speaker": ap_speaker}
+            {"leader": leader, "ap_leader": ap_protocol, "apple_tv": apple_tv}
         )
         sgp.sync_leader = leader
-        sgp._attr_group_members = ["leader", "ap_speaker"]
+        sgp._attr_group_members = ["leader", "apple_tv"]
         assert sgp.active_protocol_domain == "airplay"
 
     def test_member_from_another_provider_keeps_the_protocol(self) -> None:
@@ -758,6 +758,40 @@ class TestDynamicLeaderSwitch:
         # picking the native-only spare would have cost a dissolve + reform
         assert sgp.sync_leader == kitchen
         ap_old.set_members.assert_any_await(player_ids_to_remove=["ap_old"])
+
+    @pytest.mark.asyncio
+    async def test_reform_hint_keeps_the_protocol_a_member_depends_on(self) -> None:
+        """The re-form hint names a protocol the remaining member can actually play on."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        old_leader = _make_mock_player(
+            "old_leader",
+            provider_domain="sonos",
+            protocol_domains=["airplay"],
+            active_output_protocol="ap_old",
+        )
+        # reachable over AirPlay and its Sendspin bridge, but never over sonos
+        apple_tv = _make_mock_player(
+            "apple_tv", provider_domain="airplay", protocol_domains=["sendspin"]
+        )
+        ap_old = _make_mock_player("ap_old", provider_domain="airplay")
+        ap_old.group_members = []
+        # the remaining member never joined the session, so no seamless handoff
+        ap_old.live_session_members = ["ap_old"]
+
+        mass.players.get_player = _player_lookup(
+            {"old_leader": old_leader, "apple_tv": apple_tv, "ap_old": ap_old}
+        )
+        sgp.sync_leader = old_leader
+        sgp._attr_group_members = ["old_leader", "apple_tv"]
+
+        with patch.object(sgp, "_dissolve_and_reform", new=AsyncMock()) as reform:
+            await sgp._dynamic_leader_switch("old_leader")
+
+        reform.assert_awaited_once()
+        assert reform.await_args is not None
+        assert reform.await_args.kwargs.get("preferred_protocol_domain") == "airplay"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -266,6 +266,89 @@ class TestActiveProtocolDomain:
         sgp._attr_group_members = ["leader"]
         assert sgp.active_protocol_domain == "sonos"
 
+    def test_bridged_airplay_member_keeps_the_protocol(self) -> None:
+        """An AirPlay speaker holds the group on AirPlay despite its Sendspin bridge."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player(
+            "leader", provider_domain="sonos", active_output_protocol="ap_leader"
+        )
+        ap_protocol = _make_mock_player("ap_leader", provider_domain="airplay")
+        # every AirPlay player gets a Sendspin bridge, so its playback paths are
+        # airplay + sendspin - neither of which can reach the leader's native domain
+        ap_speaker = _make_mock_player(
+            "ap_speaker", provider_domain="airplay", protocol_domains=["sendspin"]
+        )
+        mass.players.get_player = _player_lookup(
+            {"leader": leader, "ap_leader": ap_protocol, "ap_speaker": ap_speaker}
+        )
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader", "ap_speaker"]
+        assert sgp.active_protocol_domain == "airplay"
+
+    def test_member_from_another_provider_keeps_the_protocol(self) -> None:
+        """A member of a different provider keeps the shared protocol active."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player(
+            "leader",
+            provider_domain="sonos",
+            protocol_domains=["sendspin"],
+            active_output_protocol="sp_leader",
+        )
+        sp_protocol = _make_mock_player("sp_leader", provider_domain="sendspin")
+        # a Chromecast can only meet the Sonos leader on the shared sendspin bridge
+        chromecast = _make_mock_player(
+            "chromecast", provider_domain="chromecast", protocol_domains=["sendspin"]
+        )
+        mass.players.get_player = _player_lookup(
+            {"leader": leader, "sp_leader": sp_protocol, "chromecast": chromecast}
+        )
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader", "chromecast"]
+        assert sgp.active_protocol_domain == "sendspin"
+
+    def test_universal_leader_never_downshifts_to_its_wrapper_domain(self) -> None:
+        """A wrapped leader has no native path, so the live protocol stays active."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        # universal players play exclusively through their linked protocols
+        leader = _make_mock_player(
+            "leader",
+            provider_domain="universal_player",
+            protocol_domains=["airplay", "sendspin"],
+            active_output_protocol="ap_leader",
+        )
+        leader.is_native_player = False
+        ap_protocol = _make_mock_player("ap_leader", provider_domain="airplay")
+        mass.players.get_player = _player_lookup({"leader": leader, "ap_leader": ap_protocol})
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader"]
+        assert sgp.active_protocol_domain == "airplay"
+
+    def test_unreachable_members_do_not_block_the_downshift(self) -> None:
+        """Members that are offline or have no playback path are ignored."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player(
+            "leader", provider_domain="sonos", active_output_protocol="ap_leader"
+        )
+        ap_protocol = _make_mock_player("ap_leader", provider_domain="airplay")
+        offline = _make_mock_player("offline", provider_domain="airplay", available=False)
+        no_paths = _make_mock_player("no_paths", provider_domain="airplay")
+        no_paths.is_native_player = False
+        mass.players.get_player = _player_lookup(
+            {
+                "leader": leader,
+                "ap_leader": ap_protocol,
+                "offline": offline,
+                "no_paths": no_paths,
+            }
+        )
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader", "offline", "no_paths", "gone"]
+        assert sgp.active_protocol_domain == "sonos"
+
     def test_dissolve_clears_sync_leader(self) -> None:
         """Verify _dissolve_syncgroup clears the sync leader."""
         mass = _make_mock_mass()
@@ -635,36 +718,45 @@ class TestDynamicLeaderSwitch:
             protocol_domains=["airplay"],
             active_output_protocol="ap_old",
         )
-        # AirPlay device that is also reachable over its Sendspin bridge, so it
-        # does not count as requiring AirPlay and the group is due to downshift
-        apple_tv = _make_mock_player(
-            "apple_tv", provider_domain="airplay", protocol_domains=["sendspin"]
+        # streams over AirPlay but can also play natively, so it does not hold
+        # the group on AirPlay and the group is due to downshift
+        kitchen = _make_mock_player(
+            "kitchen",
+            provider_domain="sonos",
+            protocol_domains=["airplay"],
+            active_output_protocol="ap_kitchen",
         )
+        kitchen.linked_output_protocols[0].output_protocol_id = "ap_kitchen"
         # native-only member that never joined the live session
         spare = _make_mock_player("spare", provider_domain="sonos")
 
         ap_old = _make_mock_player("ap_old", provider_domain="airplay")
-        ap_old.group_members = ["ap_old", "apple_tv"]
-        ap_old.live_session_members = ["ap_old", "apple_tv"]
+        ap_kitchen = _make_mock_player("ap_kitchen", provider_domain="airplay")
+        ap_kitchen.protocol_parent_id = "kitchen"
+        # the session reports who takes part but no order, so our tracked order stands
+        ap_old.group_members = []
+        ap_old.live_session_members = ["ap_old", "ap_kitchen"]
 
         mass.players.get_player = _player_lookup(
             {
                 "old_leader": old_leader,
-                "apple_tv": apple_tv,
+                "kitchen": kitchen,
                 "spare": spare,
                 "ap_old": ap_old,
+                "ap_kitchen": ap_kitchen,
             }
         )
 
         sgp.sync_leader = old_leader
-        sgp._attr_group_members = ["old_leader", "apple_tv", "spare"]
+        # spare comes first, so selecting on the downshifted domain would pick it
+        sgp._attr_group_members = ["old_leader", "spare", "kitchen"]
         assert sgp.active_protocol_domain == "sonos"
 
         with patch.object(sgp, "update_state"):
             await sgp._dynamic_leader_switch("old_leader")
 
         # picking the native-only spare would have cost a dissolve + reform
-        assert sgp.sync_leader == apple_tv
+        assert sgp.sync_leader == kitchen
         ap_old.set_members.assert_any_await(player_ids_to_remove=["ap_old"])
 
     @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

When a sync group streams over a shared protocol (AirPlay, Sendspin), it decides whether it can drop back to the leader's own protocol. That check asked the wrong question: it only treated a speaker as needing the shared protocol if that protocol was its *one and only* way to play. Since every AirPlay speaker also gets a Sendspin bridge, no AirPlay speaker ever qualified, so the group would favour a leader on a protocol those speakers cannot actually play on. The same went for players added through a Universal Player, which have no protocol of their own at all.

It now asks whether every remaining speaker can play on the leader's own protocol, and only drops back when they all can.

This only steers which speaker the group prefers as leader; the protocol itself is re-negotiated when the group re-forms, so a wrong preference corrected itself. No playback breakage was reported — hence `maintenance`.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
