### PR TITLE
Bump auntie-sounds to 2.0.4

### DIFF
--- a/music_assistant/providers/bbc_sounds/manifest.json
+++ b/music_assistant/providers/bbc_sounds/manifest.json
@@ -11,7 +11,7 @@
     "[auntie-sounds](https://github.com/kieranhogg/auntie-sounds)"
   ],
   "requirements": [
-    "auntie-sounds==2.0.3",
+    "auntie-sounds==2.0.4",
     "pytz==2026.2"
   ],
   "multi_instance": false

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -21,7 +21,7 @@ aiovban==1.1.0
 alexapy==1.30.0
 async-upnp-client==0.48.0
 audible==0.10.0
-auntie-sounds==2.0.3
+auntie-sounds==2.0.4
 av==16.1.0
 awesomeversion>=24.6.0
 bandcamp-async-api==0.2.2


### PR DESCRIPTION
# What does this implement/fix?

Bumps the BBC Sounds provider's `auntie-sounds` pin from 2.0.3 to 2.0.4.

Upstream 2.0.4 contains no library code changes. It only relaxes its own dependency pins from `==` to `>=` (`appdirs`, `beautifulsoup4`, `colorlog`, `pytz`, `typing-extensions`), which reduces the chance of a version clash when the provider's requirements are installed alongside the rest of MA.

- Bump `auntie-sounds` to 2.0.4 in the `bbc_sounds` manifest
- Regenerate `requirements_all.txt`

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
