### PR TITLE
Hand a sync group over to a speaker that's still playing

### DIFF
--- a/music_assistant/providers/sync_group/README.md
+++ b/music_assistant/providers/sync_group/README.md
@@ -76,9 +76,10 @@ The sync group doesn't directly play audio. Instead, it delegates to a **sync le
 The sync leader is selected when the group is powered on (which forms the group). Selection is also re-evaluated when the current leader is removed from the group or becomes unavailable.
 
 1. **Keep current leader**: If a leader exists and is still available, keep it
-2. **Prefer protocol continuity**: When re-selecting after a leader change while playing, prefer a member that supports the currently active output protocol so the live session can continue without a teardown
-3. **Prioritize static members**: For static groups, prefer members from the configured list
-4. **First available**: Otherwise pick the first available member as leader
+2. **Prefer session continuity**: When re-selecting after a leader change while playing, prefer a member that the live session already feeds, since only such a member can inherit the session without a teardown
+3. **Prefer protocol continuity**: Otherwise prefer a member that supports the currently active output protocol, so the group at least stays on that protocol
+4. **Prioritize static members**: For static groups, prefer members from the configured list
+5. **First available**: Otherwise pick the first available member as leader
 
 ### Leader Responsibilities
 
@@ -261,7 +262,7 @@ When `SET_MEMBERS` is called on a dynamic group:
 1. Remove from the internal member list (static members cannot be removed)
 2. If removing the **sync leader** while playing:
    - If the active protocol supports dynamic leader switching (provider domain is in `PROVIDERS_WITH_DYNAMIC_LEADER_SWITCH` — currently AirPlay, Snapcast, Sendspin), perform a **seamless handoff** at the protocol level: pick a new leader from the live session, then call `set_members(player_ids_to_remove=[old_leader_protocol])` on the old session player and `set_members(player_ids_to_add=[remaining_protocol_ids])` on the new leader's protocol player. Remaining members keep playing.
-   - If the chosen new leader is not part of the live session (e.g. a freshly-added player), or the protocol doesn't support handoff: fall back to **dissolve + re-form** (brief audio gap)
+   - If no remaining member is part of the live session (e.g. only freshly-added players are left), or the protocol doesn't support handoff: fall back to **dissolve + re-form** (brief audio gap)
 3. If removing a non-leader member: forward to `cmd_set_members` on the leader
 
 ### Removing Last Member

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -33,7 +33,7 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Collection
 
     from music_assistant_models.player import PlayerSource
 
@@ -547,8 +547,8 @@ class SyncGroupPlayer(Player):
                 # protocol supports dynamic leader switching: try to remove
                 # only the departing leader and keep remaining members playing.
                 # _dynamic_leader_switch will fall back to dissolve+reform
-                # automatically if the chosen new leader isn't already part of
-                # the live session (e.g. a freshly-added player).
+                # automatically if no remaining member is part of the live
+                # session (e.g. only freshly-added players are left).
                 await self._dynamic_leader_switch(old_leader_id)
             else:
                 # protocol doesn't support dynamic leader switching or not playing
@@ -799,51 +799,60 @@ class SyncGroupPlayer(Player):
         self,
         new_members: list[str] | None = None,
         preferred_protocol_domain: str | None = None,
+        preferred_member_ids: Collection[str] | None = None,
     ) -> Player | None:
         """
-        Select a (new) sync leader, preferring protocol continuity.
+        Select a (new) sync leader, preferring session and protocol continuity.
 
         :param new_members: Optional list of newly added member ids to consider
             when no current/static members are available.
         :param preferred_protocol_domain: If provided, prefer members that
             support this protocol domain so playback keeps using the same
             protocol.
+        :param preferred_member_ids: If provided, prefer members from this
+            collection (e.g. the ones a live session already feeds). Outranks
+            ``preferred_protocol_domain``.
         """
         if self.group_members and self.sync_leader and self.sync_leader.state.available:
             # current leader is still available, no need to select a new one
             return self.sync_leader
         # with selecting a new leader, we prioritize the static group members
         group_members = self.static_group_members or self.group_members or new_members or []
-
-        # if a preferred protocol is given, prefer members that support it
-        if preferred_protocol_domain:
-            for member_id in group_members:
-                member_player = self.mass.players.get_player(member_id)
-                if (
-                    member_player
-                    and member_player.state.available
-                    and self._member_supports_protocol_domain(
-                        member_player, preferred_protocol_domain
-                    )
-                ):
-                    self.logger.debug(
-                        "Auto-selected %s as sync leader for group %s "
-                        "(supports active protocol %s)",
-                        member_player.display_name,
-                        self.display_name,
-                        preferred_protocol_domain,
-                    )
-                    return member_player
-
-        # fallback: pick any available member
-        for member_id in group_members:
-            member_player = self.mass.players.get_player(member_id)
-            if member_player and member_player.state.available:
-                self.logger.debug(
-                    f"Auto-selected {member_player.display_name} as sync leader for "
-                    f"group {self.display_name}"
-                )
-                return member_player
+        candidates = [
+            member_player
+            for member_id in group_members
+            if (member_player := self.mass.players.get_player(member_id))
+            and member_player.state.available
+        ]
+        preferred_ids = set(preferred_member_ids or ())
+        # preference tiers, most specific first: a member that is already fed by the
+        # live session can take it over without restarting playback, and one that
+        # supports the active protocol at least keeps the session on that protocol
+        for reason, matches in (
+            (
+                "takes part in the live session",
+                [x for x in candidates if x.player_id in preferred_ids],
+            ),
+            (
+                f"supports active protocol {preferred_protocol_domain}",
+                [
+                    x
+                    for x in candidates
+                    if preferred_protocol_domain
+                    and self._member_supports_protocol_domain(x, preferred_protocol_domain)
+                ],
+            ),
+            ("first available member", candidates),
+        ):
+            if not matches:
+                continue
+            self.logger.debug(
+                "Auto-selected %s as sync leader for group %s (%s)",
+                matches[0].display_name,
+                self.display_name,
+                reason,
+            )
+            return matches[0]
         return None
 
     # -----------------------------------------------------------------------
@@ -1054,24 +1063,6 @@ class SyncGroupPlayer(Player):
             # leader resumed playing, cancel any pending grace
             self._cancel_idle_grace_timer()
 
-    def _is_player_in_session(self, player: Player, session_player: Player | None) -> bool:
-        """
-        Return True if ``player`` already takes part in the live session.
-
-        A seamless leader handoff only works when the candidate is already a member
-        of the session. If not (e.g. a freshly-added player that has never played
-        anything), we must fall back to dissolve + reform.
-
-        :param player: The candidate new leader.
-        :param session_player: The player that owns the live session (snapshot taken
-            before the old leader was cleared via ``_active_session_player()``).
-        """
-        if session_player is None:
-            return False
-        return player.player_id in self._translate_to_parent_ids(
-            session_player.live_session_members
-        )
-
     async def _dissolve_and_reform(
         self,
         old_leader_id: str,
@@ -1192,9 +1183,9 @@ class SyncGroupPlayer(Player):
         Snapcast). The old leader is removed from the live session and the
         remaining members keep playing uninterrupted on a newly selected leader.
 
-        If the selected new leader is not already part of the live session (e.g.
-        a freshly-added player), a seamless handoff isn't possible. In that case
-        we fall back to dissolve + reform, accepting a brief audio gap.
+        If no remaining member takes part in the live session (e.g. only
+        freshly-added players are left), a seamless handoff isn't possible. In
+        that case we fall back to dissolve + reform, accepting a brief audio gap.
 
         :param old_leader_id: The player_id of the leader being removed.
         """
@@ -1216,6 +1207,14 @@ class SyncGroupPlayer(Player):
         # `preferred_domain` once the group is due to downshift to native, and
         # a seamless handoff must stay on the protocol carrying the stream.
         session_domain = session_player.provider.domain if session_player else None
+        # The members the session feeds right now: only one of those can take it over
+        # without a restart. Tracked membership is not enough — a member can be dropped
+        # from the session (or never make it in) while still being listed as a member.
+        live_member_ids = (
+            self._translate_to_parent_ids(session_player.live_session_members)
+            if session_player
+            else []
+        )
 
         # Remove the old leader from our group members list
         if old_leader_id in self._attr_group_members:
@@ -1226,10 +1225,13 @@ class SyncGroupPlayer(Player):
         # end up tracking a different leader than the one that inherits the session.
         self._align_members_with_session(session_player)
 
-        # Pick a new leader preferring one that supports the currently active
-        # protocol so the session continuation is seamless.
+        # Pick a new leader, preferring one that is already fed by the live session
+        # so the session continuation is seamless.
         self.sync_leader = None
-        new_leader = self._select_sync_leader(preferred_protocol_domain=session_domain)
+        new_leader = self._select_sync_leader(
+            preferred_protocol_domain=session_domain,
+            preferred_member_ids=live_member_ids,
+        )
 
         if not new_leader:
             # No remaining members to take over — stop the old leader's
@@ -1246,10 +1248,10 @@ class SyncGroupPlayer(Player):
             await self._dissolve_syncgroup()
             return
 
-        # A seamless handoff requires the new leader to already be a
-        # sync_client of the live session. If it's a freshly-added player
-        # with no existing stream, fall back to dissolve + reform.
-        if not self._is_player_in_session(new_leader, session_player):
+        # A seamless handoff requires the new leader to already be a sync_client of
+        # the live session. Selection prefers such a member, so reaching this means
+        # no remaining member has a stream to inherit: fall back to dissolve + reform.
+        if new_leader.player_id not in live_member_ids:
             self.logger.info(
                 "New leader %s is not in the live session; dissolving and re-forming syncgroup %s",
                 new_leader.display_name,

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -1207,9 +1207,9 @@ class SyncGroupPlayer(Player):
         # `preferred_domain` once the group is due to downshift to native, and
         # a seamless handoff must stay on the protocol carrying the stream.
         session_domain = session_player.provider.domain if session_player else None
-        # The members the session feeds right now: only one of those can take it over
-        # without a restart. Tracked membership is not enough — a member can be dropped
-        # from the session (or never make it in) while still being listed as a member.
+        # The members the session feeds right now: only a member from this set can take
+        # it over without a restart. Tracked membership is not enough — a member can be
+        # dropped from the session (or never make it in) while still being listed.
         live_member_ids = (
             self._translate_to_parent_ids(session_player.live_session_members)
             if session_player

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -169,6 +169,27 @@ class TestProtocolAwareLeaderSelection:
         leader = sgp._select_sync_leader(preferred_protocol_domain="airplay")
         assert leader == player_a
 
+    def test_select_leader_prefers_live_session_member(self) -> None:
+        """A member the live session already feeds outranks a plain protocol match."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        # both speak AirPlay, but only player_b takes part in the live session
+        player_a = _make_mock_player(
+            "player_a", provider_domain="sonos", protocol_domains=["airplay"]
+        )
+        player_b = _make_mock_player(
+            "player_b", provider_domain="sonos", protocol_domains=["airplay"]
+        )
+        mass.players.get_player = _player_lookup({"player_a": player_a, "player_b": player_b})
+
+        sgp._attr_group_members = ["player_a", "player_b"]
+
+        leader = sgp._select_sync_leader(
+            preferred_protocol_domain="airplay", preferred_member_ids=["player_b"]
+        )
+        assert leader == player_b
+
     def test_select_leader_no_protocol_uses_first_available(self) -> None:
         """When no preferred protocol, pick first available."""
         mass = _make_mock_mass()
@@ -792,6 +813,73 @@ class TestDynamicLeaderSwitch:
         reform.assert_awaited_once()
         assert reform.await_args is not None
         assert reform.await_args.kwargs.get("preferred_protocol_domain") == "airplay"
+
+    @pytest.mark.asyncio
+    async def test_leader_selection_skips_a_member_the_session_dropped(self) -> None:
+        """
+        A member the session dropped must not cost the group its seamless handoff.
+
+        AirPlay drops a member from its session on a write timeout without pruning it
+        from the group, so it stays an available candidate while no longer having a
+        stream to inherit.
+        """
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        old_leader = _make_mock_player("ap_old", provider_domain="airplay")
+        dropped = _make_mock_player("ap_dropped", provider_domain="airplay")
+        still_playing = _make_mock_player("ap_live", provider_domain="airplay")
+        # the session dropped ap_dropped, but the group bookkeeping still lists it
+        # (and lists it first, so it would be picked on member order alone)
+        old_leader.group_members = ["ap_old", "ap_dropped", "ap_live"]
+        old_leader.live_session_members = ["ap_old", "ap_live"]
+
+        mass.players.get_player = _player_lookup(
+            {"ap_old": old_leader, "ap_dropped": dropped, "ap_live": still_playing}
+        )
+
+        sgp.sync_leader = old_leader
+        sgp._attr_group_members = ["ap_old", "ap_dropped", "ap_live"]
+
+        with patch.object(sgp, "update_state"):
+            await sgp._dynamic_leader_switch("ap_old")
+
+        assert sgp.sync_leader == still_playing
+        # handed off at the protocol level, so playback was never stopped;
+        # the dropped member rejoins as a member of the new leader
+        old_leader.set_members.assert_any_await(player_ids_to_remove=["ap_old"])
+        still_playing.set_members.assert_any_await(player_ids_to_add=["ap_dropped"])
+        mass.players._handle_cmd_stop.assert_not_awaited()
+        assert sgp._reform_task is None
+
+    @pytest.mark.asyncio
+    async def test_dissolves_when_no_remaining_member_is_in_the_session(self) -> None:
+        """With every remaining member dropped from the session, the group must re-form."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        old_leader = _make_mock_player("ap_old", provider_domain="airplay")
+        dropped_a = _make_mock_player("ap_a", provider_domain="airplay")
+        dropped_b = _make_mock_player("ap_b", provider_domain="airplay")
+        old_leader.group_members = ["ap_old", "ap_a", "ap_b"]
+        old_leader.live_session_members = ["ap_old"]
+
+        mass.players.get_player = _player_lookup(
+            {"ap_old": old_leader, "ap_a": dropped_a, "ap_b": dropped_b}
+        )
+
+        sgp.sync_leader = old_leader
+        sgp._attr_group_members = ["ap_old", "ap_a", "ap_b"]
+
+        with patch.object(sgp, "update_state"):
+            await sgp._dynamic_leader_switch("ap_old")
+
+        # no member has a stream to inherit: stop and re-form with the remaining two
+        old_leader.set_members.assert_not_awaited()
+        mass.players._handle_cmd_stop.assert_awaited_with("ap_old")
+        assert sgp._attr_group_members == ["ap_a", "ap_b"]
+        assert sgp._reform_task is not None
+        assert sgp.sync_leader is None
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

When the lead speaker is removed from a sync group, the group tries to hand the stream over to one of the remaining speakers so the music keeps playing. It picked one blindly and only then checked whether that speaker was still part of the live stream. AirPlay drops a speaker from the stream on its own when it stops keeping up, and such a speaker still counts as a group member — so if it happened to be picked, the whole group stopped and restarted, even when another speaker was still playing and could have taken over silently.

Leader selection now prefers a speaker that the live stream is actually still feeding.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Leader selection prefers a member the live stream still feeds, over one that only matches the protocol.
- Stopping and re-forming the group stays the fallback for when no remaining speaker is part of the stream.
- Tests for both paths.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
