### PR TITLE
Only hand a sync group over to a speaker that can still be reached

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3308,10 +3308,10 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         """
         Pick the new leader for an ad-hoc sync group leadership transfer.
 
-        Prefers a remaining member that supports the protocol the group is currently
-        playing on, so the other members can be regrouped under it; falls back to the
-        first remaining member. The members' own ``can_group_with`` is unusable here
-        because it is empty while they are still synced to the old leader.
+        Prefers a remaining member that can currently be reached on the protocol the
+        group is playing on, so the other members can be regrouped under it; falls back
+        to the first remaining member. The members' own ``can_group_with`` is unusable
+        here because it is empty while they are still synced to the old leader.
 
         :param leader: The current sync leader being removed.
         :param remaining_members: Candidate member player_ids, already filtered for
@@ -3326,10 +3326,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                 member = self.get_player(member_id)
                 if member is None:
                     continue
-                if member.provider.domain == active_domain or any(
-                    protocol.protocol_domain == active_domain and protocol.available
-                    for protocol in member.linked_output_protocols
-                ):
+                if active_domain in member.playback_domains:
                     return member_id
         return remaining_members[0]
 

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1699,6 +1699,18 @@ class Player(ABC):
         result.sort(key=lambda o: o.priority)
         return result
 
+    @cached_property
+    @final
+    def playback_domains(self) -> set[str]:
+        """
+        Return the protocol domains this player can be reached on right now.
+
+        Only outputs that are available at this moment are included, so a protocol
+        whose player went offline is left out. A wrapper player (UniversalPlayer)
+        contributes its linked protocols but never its own domain.
+        """
+        return {output.protocol_domain for output in self.output_protocols if output.available}
+
     @property
     @final
     def linked_output_protocols(self) -> list[OutputProtocol]:

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -896,26 +896,14 @@ class SyncGroupPlayer(Player):
                 result.append(pid)
         return result
 
-    def _member_playback_domains(self, player: Player) -> set[str]:
-        """
-        Return the protocol domains a player can be reached on right now.
-
-        Only outputs that are available at this moment count, so a protocol whose
-        player went offline is left out. A wrapper player (UniversalPlayer)
-        contributes its linked protocols but never its own domain.
-
-        :param player: The player to inspect.
-        """
-        return {output.protocol_domain for output in player.output_protocols if output.available}
-
     def _member_supports_protocol_domain(self, player: Player, domain: str) -> bool:
         """
-        Check if a player supports the given protocol domain.
+        Check if a player can be reached on the given protocol domain right now.
 
         :param player: The player to check.
         :param domain: The protocol domain string (e.g. "airplay", "sonos").
         """
-        return domain in self._member_playback_domains(player)
+        return domain in player.playback_domains
 
     def _all_members_can_play_on_domain(self, domain: str) -> bool:
         """
@@ -930,7 +918,7 @@ class SyncGroupPlayer(Player):
             member = self.mass.players.get_player(member_id)
             if member is None or not member.state.available:
                 continue
-            paths = self._member_playback_domains(member)
+            paths = member.playback_domains
             if paths and domain not in paths:
                 return False
         return True

--- a/scripts/lint_baselines/private_methods_not_last.txt
+++ b/scripts/lint_baselines/private_methods_not_last.txt
@@ -2,7 +2,7 @@
 # Private methods must live at the bottom of the class (see AGENTS.md).
 # Regenerate with: uv run -m scripts.check_method_order --update-baseline
 music_assistant/models/music_provider.py	5
-music_assistant/models/player.py	58
+music_assistant/models/player.py	59
 music_assistant/providers/_demo_audio_analysis_provider/__init__.py	3
 music_assistant/providers/alexa/__init__.py	1
 music_assistant/providers/apple_music/api_client.py	8

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
+from music_assistant_models.player import OutputProtocol
 
 from music_assistant.controllers.players import PlayerController
 from tests.common import MockPlayer, MockProvider
@@ -465,28 +466,81 @@ class TestPlayerBaseIsActiveSession:
         assert player.is_active_session is False
 
 
+def _make_ad_hoc_group(
+    controller: PlayerController, mock_mass: MagicMock, airplay_available: bool
+) -> None:
+    """
+    Register an ad-hoc group playing over AirPlay, with only member "b" on that domain.
+
+    Member "a" is a plain native player, member "b" is a native player with a linked
+    AirPlay protocol player whose availability is driven by ``airplay_available``.
+    """
+    sonos = MockProvider("sonos", instance_id="sonos", mass=mock_mass)
+    airplay = MockProvider("airplay", instance_id="airplay", mass=mock_mass)
+
+    leader = MockPlayer(sonos, "leader", "Leader")
+    leader_protocol = MockPlayer(
+        airplay, "leader_airplay", "Leader AirPlay", player_type=PlayerType.PROTOCOL
+    )
+    leader.set_linked_output_protocols([_airplay_link(leader_protocol.player_id)])
+    leader.set_active_output_protocol(leader_protocol.player_id)
+
+    member_a = MockPlayer(sonos, "a", "Member A")
+    member_b = MockPlayer(sonos, "b", "Member B")
+    member_b_protocol = MockPlayer(
+        airplay, "b_airplay", "B AirPlay", player_type=PlayerType.PROTOCOL
+    )
+    member_b_protocol._attr_available = airplay_available
+    member_b.set_linked_output_protocols([_airplay_link(member_b_protocol.player_id)])
+
+    for player in (leader, member_a, member_b):
+        player._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+        player._cache.clear()
+
+    controller._players = {
+        p.player_id: p for p in (leader, leader_protocol, member_a, member_b, member_b_protocol)
+    }
+    mock_mass.players = controller
+
+
+def _airplay_link(protocol_id: str) -> OutputProtocol:
+    """Build an AirPlay link the way production does: without an `available` argument."""
+    return OutputProtocol(
+        output_protocol_id=protocol_id,
+        name="AirPlay",
+        protocol_domain="airplay",
+        priority=10,
+    )
+
+
 class TestAdHocLeadershipTransfer:
     """Unjoining an ad-hoc sync leader transfers leadership instead of dissolving."""
 
     def test_select_ad_hoc_leader_prefers_active_protocol(
-        self, controller: PlayerController
+        self, controller: PlayerController, mock_mass: MagicMock
     ) -> None:
         """The new leader should be a member that supports the group's active protocol."""
-        # leader is playing via an airplay protocol player
-        leader = MagicMock()
-        leader.active_output_protocol = "leader_airplay"
-        protocol_player = MagicMock()
-        protocol_player.provider.domain = "airplay"
-        # member_a can't do airplay, member_b can
-        member_a = MagicMock()
-        member_a.provider.domain = "sonos"
-        member_a.linked_output_protocols = []
-        member_b = MagicMock()
-        member_b.provider.domain = "airplay"
-        member_b.linked_output_protocols = []
-        controller._players = {"leader_airplay": protocol_player, "a": member_a, "b": member_b}
+        # member_a can't do airplay, member_b has an airplay protocol player that is up
+        _make_ad_hoc_group(controller, mock_mass, airplay_available=True)
 
+        leader = controller.get_player("leader")
+        assert leader is not None
         assert controller._select_ad_hoc_leader(leader, ["a", "b"]) == "b"
+
+    def test_select_ad_hoc_leader_skips_offline_protocol(
+        self, controller: PlayerController, mock_mass: MagicMock
+    ) -> None:
+        """A member whose protocol player went offline must not inherit the session."""
+        # member_b still claims an airplay link, but its protocol player is gone
+        _make_ad_hoc_group(controller, mock_mass, airplay_available=False)
+
+        leader = controller.get_player("leader")
+        assert leader is not None
+        member_b = controller.get_player("b")
+        assert member_b is not None
+        assert member_b.linked_output_protocols[0].available is True
+
+        assert controller._select_ad_hoc_leader(leader, ["a", "b"]) == "a"
 
     def test_select_ad_hoc_leader_falls_back_to_first(self, controller: PlayerController) -> None:
         """Without an active protocol to match, fall back to the first remaining member."""

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -542,6 +542,43 @@ class TestAdHocLeadershipTransfer:
 
         assert controller._select_ad_hoc_leader(leader, ["a", "b"]) == "a"
 
+    def test_select_ad_hoc_leader_accepts_native_member_on_active_domain(
+        self, controller: PlayerController, mock_mass: MagicMock
+    ) -> None:
+        """A member that plays the active protocol natively is still a valid leader."""
+        # a Chromecast speaker has no linked protocol player: it *is* the chromecast output
+        chromecast = MockProvider("chromecast", instance_id="chromecast", mass=mock_mass)
+        sonos = MockProvider("sonos", instance_id="sonos", mass=mock_mass)
+
+        leader = MockPlayer(sonos, "leader", "Leader")
+        leader_protocol = MockPlayer(
+            chromecast, "leader_cast", "Leader Cast", player_type=PlayerType.PROTOCOL
+        )
+        leader.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id=leader_protocol.player_id,
+                    name="Chromecast",
+                    protocol_domain="chromecast",
+                    priority=30,
+                )
+            ]
+        )
+        leader.set_active_output_protocol(leader_protocol.player_id)
+
+        member_a = MockPlayer(sonos, "a", "Member A")
+        member_c = MockPlayer(chromecast, "c", "Member C")
+        for player in (leader, member_a, member_c):
+            player._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+            player._cache.clear()
+
+        controller._players = {
+            p.player_id: p for p in (leader, leader_protocol, member_a, member_c)
+        }
+        mock_mass.players = controller
+
+        assert controller._select_ad_hoc_leader(leader, ["a", "c"]) == "c"
+
     def test_select_ad_hoc_leader_falls_back_to_first(self, controller: PlayerController) -> None:
         """Without an active protocol to match, fall back to the first remaining member."""
         leader = MagicMock()

--- a/tests/models/test_player_playback_domains.py
+++ b/tests/models/test_player_playback_domains.py
@@ -44,11 +44,13 @@ def _link_protocol(
     protocol_id: str,
     domain: str,
     available: bool,
+    needs_setup: bool = False,
 ) -> MockPlayer:
     """Link a protocol player of the given domain to the parent and register it."""
     provider = MockProvider(domain, instance_id=domain, mass=mock_mass)
     protocol_player = MockPlayer(provider, protocol_id, domain, player_type=PlayerType.PROTOCOL)
     protocol_player._attr_available = available
+    protocol_player._attr_needs_setup = needs_setup
     protocol_player._cache.clear()
     parent.set_linked_output_protocols(
         [
@@ -105,6 +107,12 @@ class TestPlaybackDomains:
         assert player.linked_output_protocols[0].available is True
         assert player.playback_domains == {"sonos"}
 
+    def test_linked_protocol_needing_setup_is_left_out(self, mock_mass: MagicMock) -> None:
+        """Test that an unpaired protocol receiver cannot accept a stream."""
+        player = _make_native_player(mock_mass)
+        _link_protocol(mock_mass, player, "ap_1", "airplay", available=True, needs_setup=True)
+        assert player.playback_domains == {"sonos"}
+
     def test_unregistered_linked_protocol_is_left_out(self, mock_mass: MagicMock) -> None:
         """Test that a linked protocol without a live player is not reported."""
         player = _make_native_player(mock_mass)
@@ -121,6 +129,18 @@ class TestPlaybackDomains:
         player._cache.clear()
         _link_protocol(mock_mass, player, "ap_1", "airplay", available=True)
         assert player.playback_domains == {"airplay"}
+
+    def test_protocol_endpoint_reports_own_domain(self, mock_mass: MagicMock) -> None:
+        """Test that a player that is itself a protocol endpoint reports its domain."""
+        provider = MockProvider("airplay", instance_id="airplay", mass=mock_mass)
+        player = MockPlayer(provider, "ap_1", "AirPlay", player_type=PlayerType.PROTOCOL)
+        player._attr_supported_features = {PlayerFeature.SET_MEMBERS}
+        player._cache.clear()
+        assert player.playback_domains == {"airplay"}
+
+        player._attr_available = False
+        player._cache.clear()
+        assert player.playback_domains == set()
 
     def test_recomputed_after_state_update(self, mock_mass: MagicMock) -> None:
         """Test that the cached value follows the protocol player going offline."""

--- a/tests/models/test_player_playback_domains.py
+++ b/tests/models/test_player_playback_domains.py
@@ -1,0 +1,133 @@
+"""
+Tests for Player.playback_domains.
+
+Covers the live availability view: native playback, linked protocol players that
+are (un)available, and wrapper players that only contribute their linked protocols.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import PlayerFeature, PlayerType
+from music_assistant_models.player import OutputProtocol
+
+from tests.common import MockPlayer, MockProvider
+
+
+@pytest.fixture
+def mock_mass() -> MagicMock:
+    """Create a mock MusicAssistant instance."""
+    mass = MagicMock()
+    mass.closing = False
+    mass.config.get = MagicMock(return_value=[])
+    mass.config.get_raw_player_config_value = MagicMock(return_value=None)
+    mass.config.get_raw_core_config_value = MagicMock(return_value="GLOBAL")
+    mass.config.set = MagicMock()
+    mass.players.get_player = MagicMock(return_value=None)
+    return mass
+
+
+def _make_native_player(mock_mass: MagicMock, domain: str = "sonos") -> MockPlayer:
+    """Create a native player (own playback path) of the given provider domain."""
+    provider = MockProvider(domain, instance_id=domain, mass=mock_mass)
+    player = MockPlayer(provider, "parent", "Parent")
+    player._attr_supported_features = {PlayerFeature.PLAY_MEDIA}
+    player._cache.clear()
+    return player
+
+
+def _link_protocol(
+    mock_mass: MagicMock,
+    parent: MockPlayer,
+    protocol_id: str,
+    domain: str,
+    available: bool,
+) -> MockPlayer:
+    """Link a protocol player of the given domain to the parent and register it."""
+    provider = MockProvider(domain, instance_id=domain, mass=mock_mass)
+    protocol_player = MockPlayer(provider, protocol_id, domain, player_type=PlayerType.PROTOCOL)
+    protocol_player._attr_available = available
+    protocol_player._cache.clear()
+    parent.set_linked_output_protocols(
+        [
+            *parent.linked_output_protocols,
+            # no `available` argument: production links protocols without one, so the
+            # flag stays at its dataclass default of True forever
+            OutputProtocol(
+                output_protocol_id=protocol_id,
+                name=domain,
+                protocol_domain=domain,
+                priority=10,
+            ),
+        ]
+    )
+    registered = {protocol_player.player_id: protocol_player}
+    mock_mass.players.get_player = MagicMock(side_effect=lambda pid: registered.get(pid))
+    parent._cache.clear()
+    return protocol_player
+
+
+class TestPlaybackDomains:
+    """Tests for Player.playback_domains."""
+
+    def test_native_player_reports_own_domain(self, mock_mass: MagicMock) -> None:
+        """Test that a native player reports its own provider domain."""
+        player = _make_native_player(mock_mass)
+        assert player.playback_domains == {"sonos"}
+
+    def test_unavailable_native_player_reports_nothing(self, mock_mass: MagicMock) -> None:
+        """Test that an offline native player no longer offers its own domain."""
+        player = _make_native_player(mock_mass)
+        player._attr_available = False
+        player._cache.clear()
+        assert player.playback_domains == set()
+
+    def test_native_player_needing_setup_reports_nothing(self, mock_mass: MagicMock) -> None:
+        """Test that a player that still needs setup cannot accept a stream."""
+        player = _make_native_player(mock_mass)
+        player._attr_needs_setup = True
+        player._cache.clear()
+        assert player.playback_domains == set()
+
+    def test_linked_protocol_adds_its_domain(self, mock_mass: MagicMock) -> None:
+        """Test that an available linked protocol adds its domain."""
+        player = _make_native_player(mock_mass)
+        _link_protocol(mock_mass, player, "ap_1", "airplay", available=True)
+        assert player.playback_domains == {"sonos", "airplay"}
+
+    def test_offline_linked_protocol_is_left_out(self, mock_mass: MagicMock) -> None:
+        """Test that a linked protocol whose player went offline is not reported."""
+        player = _make_native_player(mock_mass)
+        _link_protocol(mock_mass, player, "ap_1", "airplay", available=False)
+        # the link itself still claims to be available; only the live player counts
+        assert player.linked_output_protocols[0].available is True
+        assert player.playback_domains == {"sonos"}
+
+    def test_unregistered_linked_protocol_is_left_out(self, mock_mass: MagicMock) -> None:
+        """Test that a linked protocol without a live player is not reported."""
+        player = _make_native_player(mock_mass)
+        _link_protocol(mock_mass, player, "ap_1", "airplay", available=True)
+        mock_mass.players.get_player = MagicMock(return_value=None)
+        player._cache.clear()
+        assert player.playback_domains == {"sonos"}
+
+    def test_wrapper_player_only_reports_linked_protocols(self, mock_mass: MagicMock) -> None:
+        """Test that a UniversalPlayer never contributes its own domain."""
+        provider = MockProvider("universal_player", instance_id="universal_player", mass=mock_mass)
+        player = MockPlayer(provider, "up_1", "Universal")
+        player._attr_supported_features = {PlayerFeature.PLAY_MEDIA}
+        player._cache.clear()
+        _link_protocol(mock_mass, player, "ap_1", "airplay", available=True)
+        assert player.playback_domains == {"airplay"}
+
+    def test_recomputed_after_state_update(self, mock_mass: MagicMock) -> None:
+        """Test that the cached value follows the protocol player going offline."""
+        player = _make_native_player(mock_mass)
+        protocol_player = _link_protocol(mock_mass, player, "ap_1", "airplay", available=True)
+        assert player.playback_domains == {"sonos", "airplay"}
+
+        protocol_player._attr_available = False
+        player.update_state(signal_event=False)
+        assert player.playback_domains == {"sonos"}

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -129,6 +129,10 @@ def _make_mock_player(
         outputs.append(live)
     player.output_protocols = outputs
 
+    # mirrors Player.playback_domains: derived from the live view, never the
+    # stale link-time flags
+    player.playback_domains = {output.protocol_domain for output in outputs if output.available}
+
     # State mock
     # real lists, so a test that needs members has to say so instead of silently
     # getting an empty auto-attribute


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5613. A speaker's list of linked protocols carries an "available" flag that is set once when the link is made and never refreshed, so it stays `True` even after that protocol player has gone offline. #5613 fixed the sync group's use of it; two other places still asked the same question by hand.

The one that mattered: when the leader of an ad-hoc group is removed while music is playing, the leader role is handed to a remaining member that can play on the same protocol. That check trusted the stale flag, so it could hand the group to a speaker whose AirPlay side was already gone. It now picks a speaker that is actually reachable, and otherwise falls back to the first remaining member (which switches the group to another protocol) instead of moving onto a dead one.

## Changes

- Added `Player.playback_domains` — a single, live answer to "which protocols can this speaker be reached on right now" — next to `Player.output_protocols`.
- Leader hand-over in the player controller now uses it instead of the stale flag.
- The sync group's private copy of the same logic is gone; it uses the shared property.
- Tests for the new property and for the leader hand-over skipping an offline speaker.

`_resolve_session_target` in the sync group was checked too and deliberately left alone: it looks up *which* player object of a member handles a given protocol, not whether that member is reachable. Filtering it on live availability would drop a member from the hand-over bookkeeping right after the old session's ownership has been torn down, leaving it playing with nobody owning it.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
