### PR TITLE
Fix Cast players ignoring media errors and the receiver app setting

### DIFF
--- a/music_assistant/providers/chromecast/helpers.py
+++ b/music_assistant/providers/chromecast/helpers.py
@@ -391,9 +391,12 @@ class CastStatusListener:
 
     def load_media_failed(self, queue_item_id: int, error_code: int) -> None:
         """Call when media failed to load."""
-        self.castplayer.logger.warning(
-            "Load media failed: %s - error code: %s", queue_item_id, error_code
-        )
+        if not self._valid:
+            return
+        # NOTE: pychromecast only calls this when the receiver includes a detailed
+        # error code in its LOAD_FAILED message; receivers that omit it are caught
+        # by the idleReason ERROR handling in the media status instead.
+        self.castplayer.on_load_media_failed(queue_item_id, error_code)
 
     def invalidate(self) -> None:
         """

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -434,13 +434,15 @@ class ChromecastPlayer(Player):
     async def _launch_app(self) -> None:
         """Launch the configured Media Receiver App on a Chromecast."""
         self.cancel_pending_app_quit()
-        if self.cc.app_id in (MASS_APP_ID, APP_MEDIA_RECEIVER):
-            return  # already active with a compatible media receiver app
-
         if self.config.get_value(CONF_USE_MASS_APP, True):
             app_id = MASS_APP_ID
         else:
             app_id = APP_MEDIA_RECEIVER
+
+        # compare against the configured app, not any compatible one: otherwise the
+        # use_mass_app setting is ignored for as long as the other app is running
+        if self.cc.app_id == app_id:
+            return  # the configured receiver app is already active
 
         event = asyncio.Event()
         launched = False

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -21,7 +21,11 @@ from music_assistant_models.enums import (
 from music_assistant_models.errors import PlayerUnavailableError
 from music_assistant_models.player import PlayerSource
 from pychromecast import IDLE_APP_ID
-from pychromecast.controllers.media import MEDIA_PLAYER_STATE_BUFFERING, STREAM_TYPE_LIVE
+from pychromecast.controllers.media import (
+    MEDIA_PLAYER_ERROR_CODES,
+    MEDIA_PLAYER_STATE_BUFFERING,
+    STREAM_TYPE_LIVE,
+)
 from pychromecast.controllers.multizone import MultizoneController
 from pychromecast.socket_client import CONNECTION_STATUS_CONNECTED, CONNECTION_STATUS_DISCONNECTED
 
@@ -86,6 +90,7 @@ class ChromecastPlayer(Player):
         self.last_multichannel_check = 0.0
         self.flow_meta_checksum: str | None = None
         self._app_quit_task_id: str = f"cast_quit_app_{player_id}"
+        self._media_error_reported = False
         # set static variables
         self._attr_supported_features = {
             PlayerFeature.PLAY_MEDIA,
@@ -310,6 +315,14 @@ class ChromecastPlayer(Player):
             return
         # Dispatch to event loop for thread-safe attribute mutation
         self.mass.loop.call_soon_threadsafe(self._handle_media_status, status)
+
+    def on_load_media_failed(self, queue_item_id: int, error_code: int) -> None:
+        """Handle a failed media load (called from pychromecast socket thread)."""
+        if self.mass.closing:
+            return
+        self.mass.loop.call_soon_threadsafe(
+            self._handle_load_media_failed, queue_item_id, error_code
+        )
 
     def on_new_connection_status(self, status: ConnectionStatus) -> None:
         """Handle updated ConnectionStatus (called from pychromecast socket thread)."""
@@ -588,6 +601,19 @@ class ChromecastPlayer(Player):
             self.update_state()
             return
 
+        # surface a media error reported by the receiver (e.g. after a failed LOAD),
+        # which otherwise only shows as a silent return to idle
+        if status.player_is_idle and status.idle_reason == "ERROR":
+            if not self._media_error_reported and not self._flow_stream_underrun():
+                self._media_error_reported = True
+                self.logger.warning(
+                    "%s reported a media playback error for %s",
+                    self.display_name,
+                    status.content_id or "the loaded media",
+                )
+        else:
+            self._media_error_reported = False
+
         # player state
         # pychromecast reports BUFFERING as 'playing', so a Cast group that underruns the
         # LIVE flow stream at EOF never goes idle. Treat that case as idle so the queue
@@ -670,6 +696,17 @@ class ChromecastPlayer(Player):
                     child._attr_active_source = self.active_source
                     child.update_state()
         self.update_state()
+
+    def _handle_load_media_failed(self, queue_item_id: int, error_code: int) -> None:
+        """Process a failed media load on the event loop thread."""
+        self._media_error_reported = True
+        self.logger.warning(
+            "%s failed to load media (queue item %s): error %s (%s)",
+            self.display_name,
+            queue_item_id,
+            error_code,
+            MEDIA_PLAYER_ERROR_CODES.get(error_code, "unknown code"),
+        )
 
     def _handle_connection_status(self, status: ConnectionStatus) -> None:
         """Process ConnectionStatus on the event loop thread."""

--- a/tests/providers/chromecast/test_launch_app.py
+++ b/tests/providers/chromecast/test_launch_app.py
@@ -130,13 +130,40 @@ async def test_default_receiver_used_when_mass_app_disabled() -> None:
     assert fake.launch_attempts == [APP_MEDIA_RECEIVER]
 
 
-async def test_compatible_app_already_running_is_left_alone() -> None:
-    """No LAUNCH is sent when a compatible receiver app is already active."""
-    fake = _fake_cast(running_app_id=APP_MEDIA_RECEIVER, launch_results={MASS_APP_ID: True})
+async def test_configured_app_already_running_is_left_alone() -> None:
+    """No LAUNCH is sent when the configured receiver app is already active."""
+    fake = _fake_cast(running_app_id=MASS_APP_ID, launch_results={MASS_APP_ID: True})
 
     await _launch_app(fake)
 
     assert fake.launch_attempts == []
+
+
+async def test_other_receiver_app_is_replaced_by_the_configured_one() -> None:
+    """
+    The other compatible receiver app is not accepted as-is.
+
+    Treating both receiver apps as interchangeable made the use_mass_app setting a
+    no-op for as long as the other app was running on the device.
+    """
+    fake = _fake_cast(running_app_id=APP_MEDIA_RECEIVER, launch_results={MASS_APP_ID: True})
+
+    await _launch_app(fake)
+
+    assert fake.launch_attempts == [MASS_APP_ID]
+
+
+async def test_disabled_mass_app_is_replaced_by_the_default_receiver() -> None:
+    """With the option disabled, a running MA app is replaced by the default receiver."""
+    fake = _fake_cast(
+        running_app_id=MASS_APP_ID,
+        use_mass_app=False,
+        launch_results={APP_MEDIA_RECEIVER: True},
+    )
+
+    await _launch_app(fake)
+
+    assert fake.launch_attempts == [APP_MEDIA_RECEIVER]
 
 
 async def test_refusal_reason_is_logged() -> None:

--- a/tests/providers/chromecast/test_media_status_error.py
+++ b/tests/providers/chromecast/test_media_status_error.py
@@ -1,0 +1,105 @@
+"""
+Tests for surfacing receiver media errors from ChromecastPlayer.
+
+Regression tests for https://github.com/music-assistant/support/issues/5981, where a
+receiver answered every LOAD with LOAD_FAILED and a media status carrying
+``idleReason: ERROR``, and Music Assistant logged nothing: the player silently
+returned to idle. A media error reported by the receiver must be visible in the log.
+
+The LOAD_FAILED message itself only reaches the ``load_media_failed`` listener when
+the receiver includes a detailed error code, so the media status path is the one
+that must catch the general case.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import MagicMock
+
+from music_assistant.providers.chromecast.player import ChromecastPlayer
+
+
+def _handle_media_status(fake: MagicMock, status: MagicMock) -> None:
+    ChromecastPlayer._handle_media_status(cast("ChromecastPlayer", fake), status)
+
+
+def _fake_player() -> MagicMock:
+    """Build a MagicMock standing in for an idle, ungrouped ChromecastPlayer."""
+    fake = MagicMock()
+    fake.active_cast_group = None
+    fake._media_error_reported = False
+    fake._flow_stream_underrun = MagicMock(return_value=False)
+    return fake
+
+
+def _error_status() -> MagicMock:
+    status = MagicMock()
+    status.content_id = "http://192.168.1.58:8097/flow/abc/track.flac"
+    status.player_is_playing = False
+    status.player_is_paused = False
+    status.player_is_idle = True
+    status.idle_reason = "ERROR"
+    return status
+
+
+def _playing_status() -> MagicMock:
+    status = MagicMock()
+    status.content_id = "http://192.168.1.58:8097/flow/abc/track.flac"
+    status.player_is_playing = True
+    status.player_is_paused = False
+    status.player_is_idle = False
+    status.idle_reason = None
+    return status
+
+
+def test_idle_error_is_logged() -> None:
+    """A media status with idleReason ERROR produces a warning naming the media."""
+    fake = _fake_player()
+
+    _handle_media_status(fake, _error_status())
+
+    fake.logger.warning.assert_called_once()
+    assert "track.flac" in str(fake.logger.warning.call_args)
+
+
+def test_repeated_error_status_is_logged_once() -> None:
+    """The receiver echoes the error status several times; only the first is logged."""
+    fake = _fake_player()
+
+    _handle_media_status(fake, _error_status())
+    _handle_media_status(fake, _error_status())
+    _handle_media_status(fake, _error_status())
+
+    fake.logger.warning.assert_called_once()
+
+
+def test_error_logged_again_after_recovery() -> None:
+    """A new error after successful playback is a new incident and is logged again."""
+    fake = _fake_player()
+
+    _handle_media_status(fake, _error_status())
+    _handle_media_status(fake, _playing_status())
+    _handle_media_status(fake, _error_status())
+
+    assert fake.logger.warning.call_count == 2
+
+
+def test_flow_stream_underrun_is_not_an_error() -> None:
+    """An idle ERROR at the end of a fully consumed flow stream is expected, not logged."""
+    fake = _fake_player()
+    fake._flow_stream_underrun = MagicMock(return_value=True)
+
+    _handle_media_status(fake, _error_status())
+
+    fake.logger.warning.assert_not_called()
+
+
+def test_load_media_failed_logs_the_error_code() -> None:
+    """A LOAD_FAILED with a detailed error code is logged with its meaning."""
+    fake = _fake_player()
+
+    ChromecastPlayer._handle_load_media_failed(cast("ChromecastPlayer", fake), 1, 104)
+
+    fake.logger.warning.assert_called_once()
+    assert "104" in str(fake.logger.warning.call_args)
+    assert fake._media_error_reported is True


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Two small fixes for Cast players, found while investigating a separate issue.

1. When a Cast device fails to play what it was given, it tells us, but Music
Assistant ignored the message. The player just went quiet and nothing was
logged. Now a warning is written saying which player failed and what it was
trying to play. This would have cut the investigation on the linked issue from
two weeks to one log file.

2. The "Use Music Assistant Cast App" setting was ignored whenever the device
was already running the other receiver app. Changing the setting appeared to
do nothing, which sent the investigation down the wrong path. Now the app the
user picked is always the one used.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
