### PR TITLE
Speak an announcement with your microphone

### DIFF
--- a/music_assistant/controllers/streams/README.md
+++ b/music_assistant/controllers/streams/README.md
@@ -44,7 +44,9 @@ Live announcements (`live_announcements.py`) are the one path where audio travel
 This splits across both webservers, because neither can do the job alone:
 
 - The **inbound** half is a WebSocket on the main webserver. Audio from a client is a privileged action, so it needs the authentication and the SSL support that the stream server deliberately does not have. Browsers additionally require a secure context to reach a microphone at all, which only the main webserver can offer.
-- The **outbound** half is an ordinary stream server route serving an open-ended WAV. The announcement renderer only ever pulls its audio from a URL, so exposing the buffered speech as one keeps live announcements on exactly the same path as every other announcement, and playback can start while the user is still talking.
+- The **outbound** half is an ordinary stream server route serving the buffered speech as a WAV. The announcement renderer only ever pulls its audio from a URL, so exposing the clip as one keeps live announcements on exactly the same path as every other announcement.
+
+The announcement is dispatched only once the clip is complete, not while it is still being spoken. Players that announce natively need the whole clip up front: AirPlay renders it to a file and schedules a single synchronized instant across every group member from its exact duration, and Sonos needs the duration to know how long the clip runs. Handing them a clip that is still growing gives one player type a head start and truncates another, so every player gets the same finished clip instead.
 
 A session is identified by an unguessable id that appears only in the stream URL, and it is dropped as soon as the announcement has been played.
 

--- a/music_assistant/controllers/streams/README.md
+++ b/music_assistant/controllers/streams/README.md
@@ -6,6 +6,7 @@ This document provides an overview of the Music Assistant Streams Controller arc
 
 - [Overview](#overview)
 - [Network Architecture](#network-architecture)
+- [Inbound Audio](#inbound-audio)
 - [Core Components](#core-components)
 - [AudioBuffer](#audiobuffer)
 - [StreamsAudio](#streamsaudio)
@@ -35,6 +36,17 @@ The streams controller runs its own dedicated HTTP-only webserver on a separate 
 - **No SSL/TLS**: Many audio players (especially embedded devices) have limited resources and struggle with SSL handshakes. Since the stream server only runs on the internal network, encryption is unnecessary.
 - **No authentication**: Players need to access streams without credentials. Instead, stream URLs include a **session ID** that is validated on each request to prevent stale or invalid stream attempts.
 - **Separate port**: Keeps audio streaming isolated from the API, allowing independent scaling and configuration.
+
+## Inbound Audio
+
+Live announcements (`live_announcements.py`) are the one path where audio travels *into* the stream server rather than out of it: a client pushes raw PCM while a user speaks, and it is played on a player as an ordinary announcement.
+
+This splits across both webservers, because neither can do the job alone:
+
+- The **inbound** half is a WebSocket on the main webserver. Audio from a client is a privileged action, so it needs the authentication and the SSL support that the stream server deliberately does not have. Browsers additionally require a secure context to reach a microphone at all, which only the main webserver can offer.
+- The **outbound** half is an ordinary stream server route serving an open-ended WAV. The announcement renderer only ever pulls its audio from a URL, so exposing the buffered speech as one keeps live announcements on exactly the same path as every other announcement, and playback can start while the user is still talking.
+
+A session is identified by an unguessable id that appears only in the stream URL, and it is dropped as soon as the announcement has been played.
 
 ## Core Components
 

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import struct
 import time
 from collections.abc import AsyncGenerator
 from contextlib import aclosing
@@ -89,8 +88,13 @@ from music_assistant.controllers.streams.constants import (
     BufferSize,
     get_available_buffer_sizes,
 )
+from music_assistant.controllers.streams.live_announcements import (
+    LIVE_ANNOUNCEMENT_STREAM_PATH,
+    LiveAnnouncementManager,
+)
 from music_assistant.helpers.audio import (
     calculate_content_length,
+    create_streaming_wave_header,
     get_content_length,
     get_mime_type,
     store_content_length_in_cache,
@@ -131,33 +135,11 @@ if TYPE_CHECKING:
 isfile = wrap(os.path.isfile)
 
 
-def _streaming_wav_header(output_format: AudioFormat) -> bytes:
-    """Build a WAV header with open-ended (0xFFFFFFFF) RIFF/data sizes for live streams."""
-    channels = output_format.channels
-    sample_rate = output_format.sample_rate
-    bits_per_sample = output_format.bit_depth
-    byte_rate = sample_rate * channels * (bits_per_sample // 8)
-    block_align = channels * (bits_per_sample // 8)
-    # RIFF size & data size both set to 0xFFFFFFFF so clients honoring the WAV
-    # length fields don't cut the stream off (default header hardcodes ~6.7h).
-    return (
-        b"RIFF"
-        + struct.pack("<L", 0xFFFFFFFF)
-        + b"WAVE"
-        + b"fmt "
-        + struct.pack(
-            "<LHHLLHH", 16, 1, channels, sample_rate, byte_rate, block_align, bits_per_sample
-        )
-        + b"data"
-        + struct.pack("<L", 0xFFFFFFFF)
-    )
-
-
 async def _wav_passthrough_stream(
     audio_input: AsyncGenerator[bytes], output_format: AudioFormat
 ) -> AsyncGenerator[bytes]:
     """Yield a WAV header followed by raw PCM bytes from ``audio_input``."""
-    yield _streaming_wav_header(output_format)
+    yield create_streaming_wave_header(output_format)
     async for chunk in audio_input:
         yield chunk
 
@@ -201,6 +183,7 @@ class StreamsController(CoreController):
         )
         self.manifest.icon = "cast-audio"
         self.announcement_renderer = AnnouncementRenderer()
+        self.live_announcements = LiveAnnouncementManager(mass, self.logger)
         self._bind_ip: str = "0.0.0.0"
         self._base_url: str = ""
         self._configured_publish_ip: str | None = None
@@ -234,6 +217,7 @@ class StreamsController(CoreController):
             "active_output_streams": self._active_output_streams,
             "active_announcements": self.announcement_renderer.active_announcements,
             "active_announcement_renders": self.announcement_renderer.active_renders,
+            "active_live_announcements": self.live_announcements.active_sessions,
             "publish_ip_configured": self._configured_publish_ip is not None,
         }
 
@@ -471,6 +455,11 @@ class StreamsController(CoreController):
                 ),
                 ("*", "/command/{queue_id}/{command}.mp3", self.serve_command_request),
                 ("*", "/announcement/{player_id}.{fmt}", self.serve_announcement_stream),
+                (
+                    "GET",
+                    LIVE_ANNOUNCEMENT_STREAM_PATH,
+                    self.live_announcements.serve_stream,
+                ),
             ],
         )
         # adopt what the server actually bound to: a configured port of 0 is only resolved
@@ -493,9 +482,16 @@ class StreamsController(CoreController):
         )
         await self._reload_network_dependent_providers()
 
+    async def post_setup(self) -> None:
+        """Handle logic after all core controllers have been set up."""
+        # the inbound half of a live announcement rides on the webserver: it is the only
+        # one of the two servers that authenticates (and that browsers reach over https)
+        self.live_announcements.setup()
+
     async def close(self) -> None:
         """Cleanup on exit."""
         await self._audio_analysis.close()
+        await self.live_announcements.close()
         await self._server.close()
 
     async def resolve_stream_url(self, player_id: str, media: PlayerMedia) -> str:

--- a/music_assistant/controllers/streams/live_announcements.py
+++ b/music_assistant/controllers/streams/live_announcements.py
@@ -1,0 +1,403 @@
+"""
+Live announcements: speech captured by a client and played on a player as it is spoken.
+
+A client holds an authenticated WebSocket on the MA webserver and pushes raw PCM frames
+for as long as the user speaks. Those frames land in a LiveAnnouncementSession, which
+serves them as a WAV url on the stream server. From there on this is an ordinary
+announcement: the announcement renderer pulls that url like any other source, so
+playback starts while the user is still talking instead of after they finish.
+
+Wire format on the inbound WebSocket:
+- text {"type":"auth","token":...} - first message, omitted for Ingress connections
+- text {"type":"start","player_id":...,"sample_rate":...,"channels":...,
+        "pre_announce":...,"volume_level":...}
+- text {"type":"started"} back, after which audio is accepted
+- binary frames of raw little-endian signed 16-bit PCM in the announced format
+- text (any) to end the clip, or simply close the connection
+- text {"type":"finished"} or {"type":"error","message":...} back once it has played
+
+A rejected client is closed with code 4001 and the reason in the close frame.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from contextlib import suppress
+from typing import TYPE_CHECKING, NamedTuple
+
+from aiohttp import WSMsgType, web
+from music_assistant_models.auth import Scope
+from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
+from orjson import dumps
+
+from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    get_authenticated_user,
+    has_scope,
+    is_request_from_ingress,
+)
+from music_assistant.helpers.audio import create_streaming_wave_header
+from music_assistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
+
+from .announcements import MAX_ANNOUNCEMENT_SECONDS
+
+if TYPE_CHECKING:
+    import logging
+    from collections.abc import AsyncGenerator, Callable
+
+    from music_assistant.mass import MusicAssistant
+
+# The client connects here to push its audio; the announcement itself is served from
+# the stream server, whose route only ever carries the session id.
+LIVE_ANNOUNCEMENT_ROUTE = "/live_announcement"
+LIVE_ANNOUNCEMENT_STREAM_PATH = "/live_announcement/{session_id}.wav"
+
+# Live audio is always uncompressed 16-bit PCM; only the rate and channel count vary,
+# and the client reports both in its start message. The clip is held in memory while it
+# is spoken, so the accepted range stops at what a capture device plausibly delivers -
+# anything beyond it is only a bigger buffer, since announcements render to 44.1kHz.
+LIVE_ANNOUNCEMENT_BIT_DEPTH = 16
+MIN_SAMPLE_RATE = 8000
+MAX_SAMPLE_RATE = 96000
+MAX_CHANNELS = 2
+
+# A client that stops sending without saying so holds the player's playback lock for as
+# long as it stays connected, so silence ends the clip on its own.
+IDLE_TIMEOUT = 10
+# Maximum time to wait for the handshake messages that precede the audio.
+HANDSHAKE_TIMEOUT = 10
+
+
+class LiveAnnouncementStart(NamedTuple):
+    """The validated contents of a client's start message."""
+
+    player_id: str
+    audio_format: AudioFormat
+    pre_announce: bool | None
+    volume_level: int | None
+
+
+class LiveAnnouncementSession:
+    """
+    The audio of a single live announcement, buffered while it is being spoken.
+
+    The whole clip is kept until the session is dropped: the consumer attaches slightly
+    after the first frames arrive (the announcement render has to spawn ffmpeg first),
+    so it must still be able to read the clip from the start.
+    """
+
+    def __init__(self, session_id: str, url: str, audio_format: AudioFormat) -> None:
+        """
+        Initialize the session.
+
+        :param session_id: The id that identifies this session in its stream url.
+        :param url: The url the announcement audio is served on.
+        :param audio_format: The format of the PCM frames the client sends.
+        """
+        self.session_id = session_id
+        self.url = url
+        self.audio_format = audio_format
+        self._chunks: list[bytes] = []
+        self._total_bytes = 0
+        self._finished = False
+        self._audio_added = asyncio.Condition()
+
+    @property
+    def duration(self) -> float:
+        """Return the duration (in seconds) of the audio received so far."""
+        return self._total_bytes / self.audio_format.pcm_sample_size
+
+    async def write(self, chunk: bytes) -> None:
+        """
+        Add a chunk of PCM audio to the clip.
+
+        :param chunk: Raw PCM audio in this session's format.
+        """
+        async with self._audio_added:
+            if self._finished:
+                return
+            self._chunks.append(chunk)
+            self._total_bytes += len(chunk)
+            self._audio_added.notify_all()
+
+    async def finish(self) -> None:
+        """End the clip, releasing any reader waiting for more audio."""
+        async with self._audio_added:
+            self._finished = True
+            self._audio_added.notify_all()
+
+    async def read(self) -> AsyncGenerator[bytes]:
+        """Yield the clip from the start, waiting for audio that is still being spoken."""
+        index = 0
+        while True:
+            async with self._audio_added:
+                while index >= len(self._chunks):
+                    if self._finished:
+                        return
+                    await self._audio_added.wait()
+                chunk = self._chunks[index]
+            index += 1
+            # yielded outside the lock, so a slow reader never blocks the client
+            yield chunk
+
+
+class LiveAnnouncementManager:
+    """Owner of the live announcements that are currently being spoken."""
+
+    def __init__(self, mass: MusicAssistant, logger: logging.Logger) -> None:
+        """
+        Initialize the manager.
+
+        :param mass: The MusicAssistant instance.
+        :param logger: Logger of the streams controller this manager belongs to.
+        """
+        self.mass = mass
+        self.logger = logger.getChild("live_announcements")
+        self._sessions: dict[str, LiveAnnouncementSession] = {}
+        self._connections: set[web.WebSocketResponse] = set()
+        self._unregister: Callable[[], None] | None = None
+
+    @property
+    def active_sessions(self) -> int:
+        """Return the number of live announcements currently in progress."""
+        return len(self._sessions)
+
+    def setup(self) -> None:
+        """Register the inbound audio route on the MA webserver."""
+        # this route rides on the webserver instead of the stream server because it is
+        # the only one of the two that is authenticated (and reachable over https).
+        self._unregister = self.mass.webserver.register_dynamic_route(
+            LIVE_ANNOUNCEMENT_ROUTE, self.handle_ws, "GET"
+        )
+
+    async def close(self) -> None:
+        """Unregister the route and disconnect any client that is still speaking."""
+        if self._unregister is not None:
+            self._unregister()
+            self._unregister = None
+        for ws in list(self._connections):
+            with suppress(Exception):
+                await ws.close()
+
+    async def serve_stream(self, request: web.Request) -> web.StreamResponse:
+        """Serve the audio of a live announcement to the announcement renderer."""
+        session_id = request.match_info["session_id"]
+        if (session := self._sessions.get(session_id)) is None:
+            raise web.HTTPNotFound(reason=f"Unknown live announcement: {session_id}")
+        resp = web.StreamResponse(status=200, reason="OK")
+        resp.content_type = "audio/wav"
+        resp.enable_chunked_encoding()
+        await resp.prepare(request)
+        # the header declares an open-ended length: how long the user will speak is
+        # not known when the first bytes go out
+        await resp.write(create_streaming_wave_header(session.audio_format))
+        async for chunk in session.read():
+            try:
+                await resp.write(chunk)
+            except ConnectionResetError, BrokenPipeError:
+                break
+        return resp
+
+    async def handle_ws(self, request: web.Request) -> web.WebSocketResponse:
+        """Serve one client connection: receive the spoken audio and announce it."""
+        ws = web.WebSocketResponse(heartbeat=25)
+        await ws.prepare(request)
+        self._connections.add(ws)
+        try:
+            if not await self._authenticate(request, ws):
+                return ws
+            if (start := await self._read_start_message(request, ws)) is None:
+                return ws
+            await self._run_session(ws, start)
+        finally:
+            self._connections.discard(ws)
+            if not ws.closed:
+                await ws.close()
+        return ws
+
+    async def _run_session(self, ws: web.WebSocketResponse, start: LiveAnnouncementStart) -> None:
+        """Announce what the client speaks, from the start message up to the stop."""
+        session = self._create_session(start.audio_format)
+        # the announcement runs detached: it outlives the connection (a client that
+        # drops mid-sentence still gets what it spoke played out and its player restored)
+        # and it owns the session, dropping it once the audio has been consumed.
+        announcement = self.mass.create_task(
+            self._play_live_announcement(
+                session,
+                start.player_id,
+                pre_announce=start.pre_announce,
+                volume_level=start.volume_level,
+            )
+        )
+        try:
+            await self._send(ws, {"type": "started"})
+            await self._receive_audio(ws, session)
+        finally:
+            await session.finish()
+        if ws.closed:
+            # there is no longer anyone to report the outcome to, so release the
+            # connection handler and let the announcement play itself out
+            return
+        try:
+            await announcement
+        except Exception as err:
+            self.logger.warning("Live announcement to player %s failed: %s", start.player_id, err)
+            await self._send(ws, {"type": "error", "message": str(err)})
+            return
+        await self._send(ws, {"type": "finished"})
+
+    async def _receive_audio(
+        self, ws: web.WebSocketResponse, session: LiveAnnouncementSession
+    ) -> None:
+        """Buffer the audio frames the client sends until it stops speaking."""
+        while True:
+            try:
+                async with asyncio.timeout(IDLE_TIMEOUT):
+                    msg = await ws.receive()
+            except TimeoutError:
+                self.logger.warning(
+                    "Live announcement %s ended: no audio for %s seconds",
+                    session.session_id,
+                    IDLE_TIMEOUT,
+                )
+                return
+            if msg.type != WSMsgType.BINARY:
+                # any text frame is the client saying it is done; anything else is the
+                # connection going away, which means the same thing
+                return
+            await session.write(msg.data)
+            if session.duration >= MAX_ANNOUNCEMENT_SECONDS:
+                self.logger.warning(
+                    "Live announcement %s reached the maximum length of %s seconds",
+                    session.session_id,
+                    MAX_ANNOUNCEMENT_SECONDS,
+                )
+                return
+
+    async def _play_live_announcement(
+        self,
+        session: LiveAnnouncementSession,
+        player_id: str,
+        pre_announce: bool | None,
+        volume_level: int | None,
+    ) -> None:
+        """Play the session audio as an announcement and drop the session afterwards."""
+        try:
+            await self.mass.players.play_announcement(
+                player_id,
+                url=session.url,
+                pre_announce=pre_announce,
+                volume_level=volume_level,
+            )
+        finally:
+            self._sessions.pop(session.session_id, None)
+
+    def _create_session(self, audio_format: AudioFormat) -> LiveAnnouncementSession:
+        """Register a new session and return it."""
+        session_id = secrets.token_urlsafe(16)
+        path = LIVE_ANNOUNCEMENT_STREAM_PATH.format(session_id=session_id)
+        session = LiveAnnouncementSession(
+            session_id, f"{self.mass.streams.base_url}{path}", audio_format
+        )
+        self._sessions[session_id] = session
+        return session
+
+    async def _authenticate(self, request: web.Request, ws: web.WebSocketResponse) -> bool:
+        """
+        Authenticate a client connection, mirroring the visualizer relay handshake.
+
+        Ingress requests are authenticated by Home Assistant via headers; everything
+        else must send `{"type": "auth", "token": ...}` first.
+
+        :param request: The incoming HTTP request.
+        :param ws: The prepared WebSocket response.
+        :return: True when the client may announce.
+        """
+        if is_request_from_ingress(request):
+            user = await get_authenticated_user(request)
+        elif (message := await self._read_message(request, ws, "auth")) is None:
+            return False
+        elif not (token := message.get("token")):
+            return await self._reject(request, ws, "Auth message without a token")
+        else:
+            user = await self.mass.webserver.auth.authenticate_with_token(str(token))
+        if user is None:
+            return await self._reject(request, ws, "Authentication failed")
+        if not has_scope(user, Scope.PLAYERS_CONTROL):
+            return await self._reject(request, ws, "Not allowed to control players")
+        return True
+
+    async def _read_start_message(
+        self, request: web.Request, ws: web.WebSocketResponse
+    ) -> LiveAnnouncementStart | None:
+        """Read and validate the start message, returning None when it is unusable."""
+        if (message := await self._read_message(request, ws, "start")) is None:
+            return None
+        player_id = message.get("player_id")
+        if not isinstance(player_id, str) or self.mass.players.get_player(player_id) is None:
+            await self._reject(request, ws, f"Unknown player: {player_id}")
+            return None
+        sample_rate = message.get("sample_rate")
+        if (
+            not isinstance(sample_rate, int)
+            or not MIN_SAMPLE_RATE <= sample_rate <= MAX_SAMPLE_RATE
+        ):
+            await self._reject(request, ws, f"Unsupported sample rate: {sample_rate}")
+            return None
+        channels = message.get("channels", 1)
+        if not isinstance(channels, int) or not 1 <= channels <= MAX_CHANNELS:
+            await self._reject(request, ws, f"Unsupported channel count: {channels}")
+            return None
+        pre_announce = message.get("pre_announce")
+        volume_level = message.get("volume_level")
+        return LiveAnnouncementStart(
+            player_id=player_id,
+            audio_format=AudioFormat(
+                content_type=ContentType.PCM_S16LE,
+                sample_rate=sample_rate,
+                bit_depth=LIVE_ANNOUNCEMENT_BIT_DEPTH,
+                channels=channels,
+            ),
+            pre_announce=pre_announce if isinstance(pre_announce, bool) else None,
+            volume_level=volume_level if isinstance(volume_level, int) else None,
+        )
+
+    async def _read_message(
+        self, request: web.Request, ws: web.WebSocketResponse, expected_type: str
+    ) -> dict[str, object] | None:
+        """Read one json message of the expected type, returning None when it is not."""
+        try:
+            async with asyncio.timeout(HANDSHAKE_TIMEOUT):
+                msg = await ws.receive()
+        except TimeoutError:
+            await self._reject(request, ws, f"Timeout waiting for the {expected_type} message")
+            return None
+        if msg.type != WSMsgType.TEXT:
+            await self._reject(request, ws, f"Expected a {expected_type} message")
+            return None
+        try:
+            data = json_loads(msg.data)
+        except JSON_DECODE_EXCEPTIONS:
+            await self._reject(request, ws, f"Invalid JSON in the {expected_type} message")
+            return None
+        if not isinstance(data, dict) or data.get("type") != expected_type:
+            await self._reject(request, ws, f"Expected a {expected_type} message")
+            return None
+        return data
+
+    async def _reject(self, request: web.Request, ws: web.WebSocketResponse, reason: str) -> bool:
+        """
+        Close a connection that may not (or cannot) announce, and log why.
+
+        The reason travels in the close frame, where the client reads it to tell the
+        user what went wrong instead of showing a bare disconnect.
+        """
+        self.logger.warning("Rejected live announcement from %s: %s", request.remote, reason)
+        await ws.close(code=4001, message=reason.encode())
+        return False
+
+    async def _send(self, ws: web.WebSocketResponse, message: dict[str, object]) -> None:
+        """Send one json message, ignoring a client that already went away."""
+        with suppress(ConnectionError, RuntimeError):
+            await ws.send_str(dumps(message).decode())

--- a/music_assistant/controllers/streams/live_announcements.py
+++ b/music_assistant/controllers/streams/live_announcements.py
@@ -180,6 +180,9 @@ class LiveAnnouncementManager:
 
     def setup(self) -> None:
         """Register the inbound audio route on the MA webserver."""
+        # a reload closes and sets this manager up again, so the shutdown flag is
+        # cleared here - it would otherwise silence every clip until a restart
+        self._closing = False
         # this route rides on the webserver instead of the stream server because it is
         # the only one of the two that is authenticated (and reachable over https).
         self._unregister = self.mass.webserver.register_dynamic_route(

--- a/music_assistant/controllers/streams/live_announcements.py
+++ b/music_assistant/controllers/streams/live_announcements.py
@@ -3,9 +3,9 @@ Live announcements: speech captured by a client and played on a player as it is 
 
 A client holds an authenticated WebSocket on the MA webserver and pushes raw PCM frames
 for as long as the user speaks. Those frames land in a LiveAnnouncementSession, which
-serves them as a WAV url on the stream server. From there on this is an ordinary
-announcement: the announcement renderer pulls that url like any other source, so
-playback starts while the user is still talking instead of after they finish.
+serves them as a WAV url on the stream server. Once the clip is complete it is announced
+like any other: the announcement renderer pulls that url the same way it pulls a TTS
+clip, so every player plays it exactly as it plays the announcements it already knows.
 
 Wire format on the inbound WebSocket:
 - text {"type":"auth","token":...} - first message, omitted for Ingress connections
@@ -23,12 +23,13 @@ from __future__ import annotations
 
 import asyncio
 import secrets
-from contextlib import suppress
+from contextlib import aclosing, suppress
 from typing import TYPE_CHECKING, NamedTuple
 
 from aiohttp import WSMsgType, web
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import ContentType
+from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import AudioFormat
 from orjson import dumps
 
@@ -42,7 +43,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
 from music_assistant.helpers.audio import create_streaming_wave_header
 from music_assistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
 
-from .announcements import MAX_ANNOUNCEMENT_SECONDS
+from .announcements import MAX_ANNOUNCEMENT_SECONDS, MAX_CLIP_SECONDS
 
 if TYPE_CHECKING:
     import logging
@@ -75,6 +76,11 @@ HANDSHAKE_TIMEOUT = 10
 # Live announcements are spoken one at a time by a person, so a handful of sessions is
 # already generous; the cap bounds the audio that can be buffered at once.
 MAX_CONCURRENT_SESSIONS = 4
+# Room for the whole clip to play out and the player to be restored. A player provider
+# that never returns would otherwise hold one of the session slots until a restart.
+ANNOUNCEMENT_TIMEOUT = MAX_CLIP_SECONDS + 60
+# A close frame carries 125 bytes, two of which are taken by the status code.
+MAX_CLOSE_REASON_BYTES = 123
 
 
 class LiveAnnouncementStart(NamedTuple):
@@ -90,9 +96,9 @@ class LiveAnnouncementSession:
     """
     The audio of a single live announcement, buffered while it is being spoken.
 
-    The whole clip is kept until the session is dropped: the consumer attaches slightly
-    after the first frames arrive (the announcement render has to spawn ffmpeg first),
-    so it must still be able to read the clip from the start.
+    The whole clip is kept until the session is dropped, so the renderer - which only
+    starts pulling once the clip is complete - can read it from the start, and can do so
+    again if it is served more than once.
     """
 
     def __init__(self, session_id: str, url: str, audio_format: AudioFormat) -> None:
@@ -200,11 +206,15 @@ class LiveAnnouncementManager:
         # the header declares an open-ended length: how long the user will speak is
         # not known when the first bytes go out
         await resp.write(create_streaming_wave_header(session.audio_format))
-        async for chunk in session.read():
-            try:
-                await resp.write(chunk)
-            except ConnectionResetError, BrokenPipeError:
-                break
+        # aclosing releases the reader immediately when the renderer goes away, instead
+        # of leaving it parked on the session until garbage collection finalizes it
+        audio = session.read()
+        async with aclosing(audio):
+            async for chunk in audio:
+                try:
+                    await resp.write(chunk)
+                except ConnectionResetError, BrokenPipeError:
+                    break
         return resp
 
     async def handle_ws(self, request: web.Request) -> web.WebSocketResponse:
@@ -230,9 +240,22 @@ class LiveAnnouncementManager:
     async def _run_session(self, ws: web.WebSocketResponse, start: LiveAnnouncementStart) -> None:
         """Announce what the client speaks, from the start message up to the stop."""
         session = self._create_session(start.audio_format)
-        # the announcement runs detached: it outlives the connection (a client that
-        # drops mid-sentence still gets what it spoke played out and its player restored)
-        # and it owns the session, dropping it once the audio has been consumed.
+        try:
+            await self._send(ws, {"type": "started"})
+            await self._receive_audio(ws, session)
+        finally:
+            await session.finish()
+        if not session.duration:
+            # nothing was spoken (a mis-tap, or a client that never sent audio): announcing
+            # it would interrupt whatever the player is doing to play silence
+            self._sessions.pop(session.session_id, None)
+            await self._send(ws, {"type": "finished"})
+            return
+        # only now the clip is complete: players that announce natively need it whole up
+        # front - AirPlay renders it to a file and schedules one synchronized instant for
+        # every group member from its exact duration, which a growing clip cannot give.
+        # Its own task, so a client that drops still gets what it spoke played out, and
+        # it owns the session, dropping it once the audio has been consumed.
         announcement = self.mass.create_task(
             self._play_live_announcement(
                 session,
@@ -241,11 +264,6 @@ class LiveAnnouncementManager:
                 volume_level=start.volume_level,
             )
         )
-        try:
-            await self._send(ws, {"type": "started"})
-            await self._receive_audio(ws, session)
-        finally:
-            await session.finish()
         if ws.closed:
             # there is no longer anyone to report the outcome to, so release the
             # connection handler and let the announcement play itself out
@@ -312,12 +330,20 @@ class LiveAnnouncementManager:
     ) -> None:
         """Play the session audio as an announcement and drop the session afterwards."""
         try:
-            await self.mass.players.play_announcement(
-                player_id,
-                url=session.url,
-                pre_announce=pre_announce,
-                volume_level=volume_level,
-            )
+            # a player that plays announcements natively hands off to its provider, which
+            # has no deadline of its own - one that never returns would otherwise keep
+            # this session (and its slot) alive for as long as the server runs
+            async with asyncio.timeout(ANNOUNCEMENT_TIMEOUT):
+                await self.mass.players.play_announcement(
+                    player_id,
+                    url=session.url,
+                    pre_announce=pre_announce,
+                    volume_level=volume_level,
+                )
+        except TimeoutError as err:
+            # reported to the client rather than swallowed: a timeout means the player
+            # never confirmed it played, so "finished" would be a guess
+            raise PlayerCommandFailed("The announcement did not finish playing.") from err
         finally:
             self._sessions.pop(session.session_id, None)
 
@@ -435,7 +461,12 @@ class LiveAnnouncementManager:
         user what went wrong instead of showing a bare disconnect.
         """
         self.logger.warning("Rejected live announcement from %s: %s", request.remote, reason)
-        await ws.close(code=4001, message=reason.encode())
+        # a close frame carries at most 125 bytes, 2 of which are the status code, and a
+        # reason quoting client input can exceed that - which the browser drops entirely.
+        # the decode/encode round trip drops a character the cut landed in the middle of,
+        # since an invalid utf-8 reason would be rejected just the same.
+        message = reason.encode()[:MAX_CLOSE_REASON_BYTES].decode(errors="ignore").encode()
+        await ws.close(code=4001, message=message)
         return False
 
     async def _send(self, ws: web.WebSocketResponse, message: dict[str, object]) -> None:

--- a/music_assistant/controllers/streams/live_announcements.py
+++ b/music_assistant/controllers/streams/live_announcements.py
@@ -1,5 +1,5 @@
 """
-Live announcements: speech captured by a client and played on a player as it is spoken.
+Live announcements: speech captured by a client and played on a player once it is spoken.
 
 A client holds an authenticated WebSocket on the MA webserver and pushes raw PCM frames
 for as long as the user speaks. Those frames land in a LiveAnnouncementSession, which
@@ -330,6 +330,12 @@ class LiveAnnouncementManager:
     ) -> None:
         """Play the session audio as an announcement and drop the session afterwards."""
         try:
+            # the player was available when the handshake accepted it, but a whole clip
+            # has been spoken since; an unavailable player drops the command downstream
+            # without a word, which would be reported back as a clip that played
+            player = self.mass.players.get_player(player_id)
+            if player is None or not player.available:
+                raise PlayerCommandFailed(f"Player {player_id} is no longer available.")
             # a player that plays announcements natively hands off to its provider, which
             # has no deadline of its own - one that never returns would otherwise keep
             # this session (and its slot) alive for as long as the server runs

--- a/music_assistant/controllers/streams/live_announcements.py
+++ b/music_assistant/controllers/streams/live_announcements.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, NamedTuple
 from aiohttp import WSMsgType, web
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import ContentType
-from music_assistant_models.errors import PlayerCommandFailed
+from music_assistant_models.errors import MusicAssistantError, PlayerCommandFailed
 from music_assistant_models.media_items import AudioFormat
 from orjson import dumps
 
@@ -171,6 +171,7 @@ class LiveAnnouncementManager:
         self._sessions: dict[str, LiveAnnouncementSession] = {}
         self._connections: set[web.WebSocketResponse] = set()
         self._unregister: Callable[[], None] | None = None
+        self._closing = False
 
     @property
     def active_sessions(self) -> int:
@@ -187,6 +188,9 @@ class LiveAnnouncementManager:
 
     async def close(self) -> None:
         """Unregister the route and disconnect any client that is still speaking."""
+        # closing a connection reads as a client that stopped speaking, so without this
+        # a recording in progress would announce itself on a server that is going down
+        self._closing = True
         if self._unregister is not None:
             self._unregister()
             self._unregister = None
@@ -245,9 +249,10 @@ class LiveAnnouncementManager:
             await self._receive_audio(ws, session)
         finally:
             await session.finish()
-        if not session.duration:
+        if not session.duration or self._closing:
             # nothing was spoken (a mis-tap, or a client that never sent audio): announcing
-            # it would interrupt whatever the player is doing to play silence
+            # it would interrupt whatever the player is doing to play silence. the same
+            # applies while shutting down, where the clip was cut short by us.
             self._sessions.pop(session.session_id, None)
             await self._send(ws, {"type": "finished"})
             return
@@ -270,9 +275,16 @@ class LiveAnnouncementManager:
             return
         try:
             await announcement
-        except Exception as err:
+        except MusicAssistantError as err:
+            # a typed error carries a message meant for the person who spoke
             self.logger.warning("Live announcement to player %s failed: %s", start.player_id, err)
             await self._send(ws, {"type": "error", "message": str(err)})
+            return
+        except Exception:
+            # anything else is a defect rather than a failed announcement, so it is logged
+            # with its traceback and reported without leaking its internals
+            self.logger.exception("Live announcement to player %s failed", start.player_id)
+            await self._send(ws, {"type": "error", "message": "The announcement failed."})
             return
         await self._send(ws, {"type": "finished"})
 

--- a/music_assistant/controllers/streams/live_announcements.py
+++ b/music_assistant/controllers/streams/live_announcements.py
@@ -32,10 +32,12 @@ from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 from orjson import dumps
 
+from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_authenticated_user,
     has_scope,
     is_request_from_ingress,
+    set_current_user,
 )
 from music_assistant.helpers.audio import create_streaming_wave_header
 from music_assistant.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
@@ -63,10 +65,16 @@ MAX_SAMPLE_RATE = 96000
 MAX_CHANNELS = 2
 
 # A client that stops sending without saying so holds the player's playback lock for as
-# long as it stays connected, so silence ends the clip on its own.
+# long as it stays connected, so silence ends the clip on its own. The idle timeout only
+# measures the gap between frames, so a clip is bounded in wall clock time as well -
+# otherwise a trickle of frames could hold the player forever.
 IDLE_TIMEOUT = 10
+MAX_SESSION_SECONDS = MAX_ANNOUNCEMENT_SECONDS
 # Maximum time to wait for the handshake messages that precede the audio.
 HANDSHAKE_TIMEOUT = 10
+# Live announcements are spoken one at a time by a person, so a handful of sessions is
+# already generous; the cap bounds the audio that can be buffered at once.
+MAX_CONCURRENT_SESSIONS = 4
 
 
 class LiveAnnouncementStart(NamedTuple):
@@ -209,6 +217,9 @@ class LiveAnnouncementManager:
                 return ws
             if (start := await self._read_start_message(request, ws)) is None:
                 return ws
+            if len(self._sessions) >= MAX_CONCURRENT_SESSIONS:
+                await self._reject(request, ws, "Too many live announcements in progress")
+                return ws
             await self._run_session(ws, start)
         finally:
             self._connections.discard(ws)
@@ -251,6 +262,20 @@ class LiveAnnouncementManager:
         self, ws: web.WebSocketResponse, session: LiveAnnouncementSession
     ) -> None:
         """Buffer the audio frames the client sends until it stops speaking."""
+        try:
+            async with asyncio.timeout(MAX_SESSION_SECONDS):
+                await self._read_frames(ws, session)
+        except TimeoutError:
+            self.logger.warning(
+                "Live announcement %s ended: it ran for the maximum of %s seconds",
+                session.session_id,
+                MAX_SESSION_SECONDS,
+            )
+
+    async def _read_frames(
+        self, ws: web.WebSocketResponse, session: LiveAnnouncementSession
+    ) -> None:
+        """Read audio frames until the client stops speaking or falls silent."""
         while True:
             try:
                 async with asyncio.timeout(IDLE_TIMEOUT):
@@ -266,6 +291,9 @@ class LiveAnnouncementManager:
                 # any text frame is the client saying it is done; anything else is the
                 # connection going away, which means the same thing
                 return
+            if not msg.data:
+                # carries no audio, so it must not grow the clip that is held in memory
+                continue
             await session.write(msg.data)
             if session.duration >= MAX_ANNOUNCEMENT_SECONDS:
                 self.logger.warning(
@@ -314,7 +342,8 @@ class LiveAnnouncementManager:
         :param ws: The prepared WebSocket response.
         :return: True when the client may announce.
         """
-        if is_request_from_ingress(request):
+        is_ingress = is_request_from_ingress(request)
+        if is_ingress:
             user = await get_authenticated_user(request)
         elif (message := await self._read_message(request, ws, "auth")) is None:
             return False
@@ -324,8 +353,17 @@ class LiveAnnouncementManager:
             user = await self.mass.webserver.auth.authenticate_with_token(str(token))
         if user is None:
             return await self._reject(request, ws, "Authentication failed")
+        if not is_ingress and user.username == HOMEASSISTANT_SYSTEM_USER:
+            # the token of the Home Assistant system user is only meant to travel over
+            # the ingress connection, mirroring the policy of the websocket api
+            return await self._reject(
+                request, ws, "Home Assistant system user not allowed on regular webserver"
+            )
         if not has_scope(user, Scope.PLAYERS_CONTROL):
             return await self._reject(request, ws, "Not allowed to control players")
+        # the announcement is dispatched as a task, which inherits this context, so the
+        # player command it runs sees the user and applies their player restrictions
+        set_current_user(user)
         return True
 
     async def _read_start_message(
@@ -335,8 +373,11 @@ class LiveAnnouncementManager:
         if (message := await self._read_message(request, ws, "start")) is None:
             return None
         player_id = message.get("player_id")
-        if not isinstance(player_id, str) or self.mass.players.get_player(player_id) is None:
-            await self._reject(request, ws, f"Unknown player: {player_id}")
+        player = self.mass.players.get_player(player_id) if isinstance(player_id, str) else None
+        # an unavailable player silently drops the command downstream, which would
+        # otherwise be reported to the client as an announcement that played
+        if not isinstance(player_id, str) or player is None or not player.available:
+            await self._reject(request, ws, f"Unknown or unavailable player: {player_id}")
             return None
         sample_rate = message.get("sample_rate")
         if (

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -649,6 +649,16 @@ class WebRTCGateway:
         """Accept incoming data channels and start their bridges."""
         async for channel in session.pc.incoming_data_channels():
             if (target := self._bridge_targets.get(channel.label)) is not None:
+                if channel.label in session.ws_bridges:
+                    # replacing the entry would leave the running bridge untracked, and
+                    # tearing either one down would then orphan the other's websocket
+                    self.logger.warning(
+                        "Refusing a second '%s' data channel for session %s",
+                        channel.label,
+                        session.session_id,
+                    )
+                    channel.close()
+                    continue
                 bridge = _ChannelBridge(label=channel.label, target=target, channel=channel)
                 session.ws_bridges[channel.label] = bridge
                 session.pc.spawn_task(self._bridge_websocket(session, bridge, channel))
@@ -764,7 +774,7 @@ class WebRTCGateway:
                 bridge.target.url,
                 session.session_id,
             )
-            channel.close()
+            await self._close_ws_bridge(session, bridge)
             return
 
         # from_local runs as its own PC-owned pump; this task drives channel -> local
@@ -820,7 +830,10 @@ class WebRTCGateway:
 
     async def _close_ws_bridge(self, session: WebRTCSession, bridge: _ChannelBridge) -> None:
         """Close one bridged data channel and its local WebSocket."""
-        session.ws_bridges.pop(bridge.label, None)
+        # only drop the entry while it still points at this bridge, so a teardown can
+        # never untrack a bridge that replaced it
+        if session.ws_bridges.get(bridge.label) is bridge:
+            del session.ws_bridges[bridge.label]
         local_ws = bridge.local_ws
         bridge.local_ws = None
         if local_ws is not None and not local_ws.closed:

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -14,8 +14,8 @@ import contextlib
 import json
 import logging
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 from urllib.parse import urlparse
 
 import aiohttp
@@ -32,6 +32,7 @@ from aiolibdatachannel import (
 )
 
 from music_assistant.constants import MASS_LOGGER_NAME, SENDSPIN_SERVER_PORT, VERBOSE_LOG_LEVEL
+from music_assistant.controllers.streams.live_announcements import LIVE_ANNOUNCEMENT_ROUTE
 
 if TYPE_CHECKING:
     from aiolibdatachannel import DataChannel
@@ -47,6 +48,27 @@ MA_API_CHUNK_SIZE = 64 * 1024
 
 DEFAULT_SENDSPIN_URL = f"ws://localhost:{SENDSPIN_SERVER_PORT}/sendspin"
 
+# Labels of the data channels that are bridged to a local WebSocket
+CHANNEL_SENDSPIN = "sendspin"
+CHANNEL_LIVE_ANNOUNCEMENT = "live_announcement"
+
+
+class _BridgeTarget(NamedTuple):
+    """The local WebSocket a data channel label is bridged to."""
+
+    url: str
+    on_first_message: Callable[[WebRTCSession, str], None] | None = None
+
+
+@dataclass
+class _ChannelBridge:
+    """A bridged data channel together with the local WebSocket it is connected to."""
+
+    label: str
+    target: _BridgeTarget
+    channel: DataChannel | None
+    local_ws: aiohttp.ClientWebSocketResponse | None = None
+
 
 @dataclass
 class WebRTCSession:
@@ -57,9 +79,8 @@ class WebRTCSession:
     # Main API channel (ma-api) - bridges to local MA WebSocket API
     data_channel: DataChannel | None = None
     local_ws: aiohttp.ClientWebSocketResponse | None = None
-    # Sendspin channel - bridges to internal sendspin server
-    sendspin_channel: DataChannel | None = None
-    sendspin_ws: aiohttp.ClientWebSocketResponse | None = None
+    # Bridged WebSocket channels (sendspin, live announcements) by data channel label
+    ws_bridges: dict[str, _ChannelBridge] = field(default_factory=dict)
     sendspin_player_id: str | None = None  # Extracted from first sendspin auth message
 
 
@@ -123,6 +144,17 @@ class WebRTCGateway:
         self.logger = LOGGER
         self._ice_servers_callback = ice_servers_callback
         self._set_sendspin_player_callback = set_sendspin_player_callback
+
+        # Data channel label -> the local WebSocket that channel is bridged to. The live
+        # announcement route sits on the same webserver as the ma-api WebSocket.
+        self._bridge_targets: dict[str, _BridgeTarget] = {
+            CHANNEL_SENDSPIN: _BridgeTarget(
+                self.sendspin_url, self._try_extract_sendspin_client_id
+            ),
+            CHANNEL_LIVE_ANNOUNCEMENT: _BridgeTarget(
+                _ws_url_for_path(self.local_ws_url, LIVE_ANNOUNCEMENT_ROUTE)
+            ),
+        }
 
         # Static ICE servers used at registration time (relayed to clients via signaling server)
         self.ice_servers = ice_servers or self.DEFAULT_ICE_SERVERS
@@ -575,12 +607,13 @@ class WebRTCGateway:
             return
 
         # Close the local bridges first so no more data is fed through the channels
-        for local_ws in (session.local_ws, session.sendspin_ws):
+        bridged = [bridge.local_ws for bridge in session.ws_bridges.values()]
+        for local_ws in (session.local_ws, *bridged):
             if local_ws is not None and not local_ws.closed:
                 with contextlib.suppress(Exception):
                     await local_ws.close()
         session.local_ws = None
-        session.sendspin_ws = None
+        session.ws_bridges.clear()
 
         # aclose tears down all PC-owned pumps and every data channel; safe here because
         # _close_session is never invoked from within a PC-owned task
@@ -615,13 +648,23 @@ class WebRTCGateway:
     async def _accept_channels(self, session: WebRTCSession) -> None:
         """Accept incoming data channels and start their bridges."""
         async for channel in session.pc.incoming_data_channels():
-            # The browser opens "ma-api" (default) and "sendspin" (by label); route each
-            if channel.label == "sendspin":
-                session.sendspin_channel = channel
-                session.pc.spawn_task(self._bridge_sendspin(session, channel))
-            else:
+            if (target := self._bridge_targets.get(channel.label)) is not None:
+                bridge = _ChannelBridge(label=channel.label, target=target, channel=channel)
+                session.ws_bridges[channel.label] = bridge
+                session.pc.spawn_task(self._bridge_websocket(session, bridge, channel))
+            elif session.data_channel is None:
+                # the browser opens its API channel first, whatever label it gives it
                 session.data_channel = channel
                 session.pc.spawn_task(self._bridge_ma_api(session, channel))
+            else:
+                # a label this server does not know must not be taken for a second API
+                # channel: that would replace the live bridge and break the session
+                self.logger.warning(
+                    "Refusing data channel with unknown label '%s' for session %s",
+                    channel.label,
+                    session.session_id,
+                )
+                channel.close()
 
     async def _bridge_ma_api(self, session: WebRTCSession, channel: DataChannel) -> None:
         """Bridge the ma-api data channel to the local WebSocket API."""
@@ -703,55 +746,67 @@ class WebRTCGateway:
         # leaving the client an open channel that silently drops messages
         self._schedule_close(session.session_id)
 
-    async def _bridge_sendspin(self, session: WebRTCSession, channel: DataChannel) -> None:
-        """Bridge the sendspin data channel to the internal sendspin server."""
+    async def _bridge_websocket(
+        self, session: WebRTCSession, bridge: _ChannelBridge, channel: DataChannel
+    ) -> None:
+        """Bridge a data channel to the local WebSocket its label is routed to."""
         try:
-            session.sendspin_ws = await self.http_session.ws_connect(self.sendspin_url)
-            self.logger.debug("Sendspin channel connected for session %s", session.session_id)
+            # TLS verification would fail on the bind address and adds nothing to a dial
+            # that never leaves this host (a no-op for the plain ws:// targets)
+            bridge.local_ws = await self.http_session.ws_connect(bridge.target.url, ssl=False)
+            self.logger.debug(
+                "%s channel connected for session %s", bridge.label, session.session_id
+            )
         except Exception:
             self.logger.exception(
-                "Failed to connect sendspin channel to internal server for session %s",
+                "Failed to connect %s channel to %s for session %s",
+                bridge.label,
+                bridge.target.url,
                 session.session_id,
             )
             channel.close()
             return
 
-        # from_local runs as its own PC-owned pump; this task drives channel -> internal
-        session.pc.spawn_task(self._sendspin_from_local(session, channel))
-        await self._sendspin_to_local(session, channel)
-        # channel -> internal loop ended (remote channel closed): tear down only this bridge
-        await self._close_sendspin_bridge(session)
+        # from_local runs as its own PC-owned pump; this task drives channel -> local
+        session.pc.spawn_task(self._ws_bridge_from_local(session, bridge, channel))
+        await self._ws_bridge_to_local(session, bridge, channel)
+        # channel -> local loop ended (remote channel closed): tear down only this bridge
+        await self._close_ws_bridge(session, bridge)
 
-    async def _sendspin_to_local(self, session: WebRTCSession, channel: DataChannel) -> None:
-        """Forward messages from the sendspin data channel to the internal sendspin server."""
+    async def _ws_bridge_to_local(
+        self, session: WebRTCSession, bridge: _ChannelBridge, channel: DataChannel
+    ) -> None:
+        """Forward messages from a bridged data channel to its local WebSocket."""
         first_message = True
         try:
             async for message in channel:
-                # Check only the first message for client_id extraction
                 if first_message:
                     first_message = False
-                    if isinstance(message, str):
-                        self._try_extract_sendspin_client_id(session, message)
+                    if bridge.target.on_first_message and isinstance(message, str):
+                        bridge.target.on_first_message(session, message)
 
-                if session.sendspin_ws and not session.sendspin_ws.closed:
+                local_ws = bridge.local_ws
+                if local_ws and not local_ws.closed:
                     if isinstance(message, bytes):
-                        await session.sendspin_ws.send_bytes(message)
+                        await local_ws.send_bytes(message)
                     else:
-                        await session.sendspin_ws.send_str(message)
+                        await local_ws.send_str(message)
         except ConnectionClosedError:
-            self.logger.debug("Sendspin channel closed for session %s", session.session_id)
+            self.logger.debug("%s channel closed for session %s", bridge.label, session.session_id)
         except asyncio.CancelledError:
             raise
         except Exception:
-            self.logger.exception("Error forwarding sendspin to local")
+            self.logger.exception("Error forwarding %s to local", bridge.label)
 
-    async def _sendspin_from_local(self, session: WebRTCSession, channel: DataChannel) -> None:
-        """Forward messages from the internal sendspin server to the sendspin data channel."""
-        sendspin_ws = session.sendspin_ws
-        if sendspin_ws is None:
+    async def _ws_bridge_from_local(
+        self, session: WebRTCSession, bridge: _ChannelBridge, channel: DataChannel
+    ) -> None:
+        """Forward messages from a bridged local WebSocket to its data channel."""
+        local_ws = bridge.local_ws
+        if local_ws is None:
             return
         try:
-            async for msg in sendspin_ws:
+            async for msg in local_ws:
                 if msg.type in {aiohttp.WSMsgType.TEXT, aiohttp.WSMsgType.BINARY}:
                     await self._send_on_channel(channel, msg.data)
                 elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSED):
@@ -759,19 +814,20 @@ class WebRTCGateway:
         except asyncio.CancelledError:
             raise
         except Exception:
-            self.logger.exception("Error forwarding sendspin from local")
-        # the internal sendspin WS closed: close only this bridge, leaving the ma-api session up
-        await self._close_sendspin_bridge(session)
+            self.logger.exception("Error forwarding %s from local", bridge.label)
+        # the local WS closed: close only this bridge, leaving the ma-api session up
+        await self._close_ws_bridge(session, bridge)
 
-    async def _close_sendspin_bridge(self, session: WebRTCSession) -> None:
-        """Close the internal Sendspin bridge for a WebRTC session."""
-        sendspin_ws = session.sendspin_ws
-        session.sendspin_ws = None
-        if sendspin_ws is not None and not sendspin_ws.closed:
+    async def _close_ws_bridge(self, session: WebRTCSession, bridge: _ChannelBridge) -> None:
+        """Close one bridged data channel and its local WebSocket."""
+        session.ws_bridges.pop(bridge.label, None)
+        local_ws = bridge.local_ws
+        bridge.local_ws = None
+        if local_ws is not None and not local_ws.closed:
             with contextlib.suppress(Exception):
-                await sendspin_ws.close()
-        channel = session.sendspin_channel
-        session.sendspin_channel = None
+                await local_ws.close()
+        channel = bridge.channel
+        bridge.channel = None
         if channel is not None and not channel.closed:
             with contextlib.suppress(Exception):
                 await channel.aclose()
@@ -850,6 +906,17 @@ class _BenignNativeNoiseFilter(logging.Filter):
 
 
 _BENIGN_NATIVE_NOISE_FILTER = _BenignNativeNoiseFilter()
+
+
+def _ws_url_for_path(ws_url: str, path: str) -> str:
+    """
+    Return the url of another WebSocket route on the same host.
+
+    :param ws_url: WebSocket url to take the scheme and host from.
+    :param path: Route to reach on that same host.
+    """
+    parsed = urlparse(ws_url)
+    return f"{parsed.scheme}://{parsed.netloc}{path}"
 
 
 def _is_usable_ice_url(url: str) -> bool:

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -255,6 +255,32 @@ def create_wave_header(
     return file.getvalue()
 
 
+def create_streaming_wave_header(audio_format: AudioFormat) -> bytes:
+    """
+    Generate a wave header for a stream whose length is not known up front.
+
+    :param audio_format: The PCM format the audio behind the header is in.
+    """
+    channels = audio_format.channels
+    sample_rate = audio_format.sample_rate
+    bits_per_sample = audio_format.bit_depth
+    byte_rate = sample_rate * channels * (bits_per_sample // 8)
+    block_align = channels * (bits_per_sample // 8)
+    # RIFF size & data size both set to 0xFFFFFFFF so clients honoring the WAV
+    # length fields don't cut the stream off (create_wave_header hardcodes ~6.7h).
+    return (
+        b"RIFF"
+        + struct.pack("<L", 0xFFFFFFFF)
+        + b"WAVE"
+        + b"fmt "
+        + struct.pack(
+            "<LHHLLHH", 16, 1, channels, sample_rate, byte_rate, block_align, bits_per_sample
+        )
+        + b"data"
+        + struct.pack("<L", 0xFFFFFFFF)
+    )
+
+
 def parse_extinf_metadata(extinf_line: str) -> dict[str, str]:
     """
     Parse metadata from HLS EXTINF line.

--- a/tests/controllers/streams/test_live_announcements.py
+++ b/tests/controllers/streams/test_live_announcements.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import re
 from contextlib import aclosing
+from types import MethodType
 from typing import TYPE_CHECKING, Any, NamedTuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -16,12 +17,16 @@ from music_assistant_models.auth import User, UserRole
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
+from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER
+from music_assistant.controllers.players.controller import PlayerController
+from music_assistant.controllers.players.helpers import handle_player_command
 from music_assistant.controllers.streams import live_announcements
 from music_assistant.controllers.streams.live_announcements import (
     LIVE_ANNOUNCEMENT_ROUTE,
     LiveAnnouncementManager,
     LiveAnnouncementSession,
 )
+from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.audio import create_streaming_wave_header
 from tests.common import use_real_create_task
 
@@ -52,6 +57,7 @@ class Harness(NamedTuple):
     manager: LiveAnnouncementManager
     mass: MagicMock
     client: TestClient[web.Request, web.Application]
+    player: MagicMock
 
 
 @pytest.fixture(name="harness")
@@ -62,8 +68,9 @@ async def harness_fixture() -> AsyncGenerator[Harness]:
     mass.webserver.auth.authenticate_with_token = AsyncMock(
         return_value=User(user_id="user_1", username="listener", role=UserRole.USER)
     )
+    player = _player()
     mass.players.get_player = MagicMock(
-        side_effect=lambda player_id: MagicMock() if player_id == PLAYER_ID else None
+        side_effect=lambda player_id: player if player_id == PLAYER_ID else None
     )
     mass.players.play_announcement = AsyncMock()
     # the announcement is dispatched as a task, which must actually run
@@ -74,7 +81,7 @@ async def harness_fixture() -> AsyncGenerator[Harness]:
     client: TestClient[web.Request, web.Application] = TestClient(TestServer(app))
     await client.start_server()
     try:
-        yield Harness(manager, mass, client)
+        yield Harness(manager, mass, client, player)
     finally:
         await client.close()
 
@@ -231,6 +238,51 @@ async def test_the_announcement_outlives_a_client_that_drops(harness: Harness) -
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("player_filter", [[], [PLAYER_ID]], ids=["no filter", "player allowed"])
+async def test_the_announcement_runs_as_the_user_that_spoke_it(
+    harness: Harness, player_filter: list[str]
+) -> None:
+    """
+    The user of the connection reaches the task the announcement is dispatched on.
+
+    Player commands apply the user's restrictions from that context, so without it
+    every live announcement would run unrestricted.
+    """
+    user = User(
+        user_id="user_4", username="speaker", role=UserRole.USER, player_filter=player_filter
+    )
+    harness.mass.webserver.auth.authenticate_with_token = AsyncMock(return_value=user)
+    announced = _announce_through_player_commands(harness)
+
+    ws = await _start_speaking(harness.client)
+    assert await _reply(ws) == "started"
+    await ws.send_bytes(b"\x01\x02")
+    await ws.send_str('{"type": "stop"}')
+    assert await _reply(ws) == "finished"
+
+    assert announced == [(PLAYER_ID, user)]
+
+
+@pytest.mark.asyncio
+async def test_a_user_without_access_to_the_player_is_refused(harness: Harness) -> None:
+    """A player outside the user's filter is refused, as it is for any other command."""
+    harness.mass.webserver.auth.authenticate_with_token = AsyncMock(
+        return_value=User(
+            user_id="user_5", username="guest", role=UserRole.USER, player_filter=["other_player"]
+        )
+    )
+    announced = _announce_through_player_commands(harness)
+
+    ws = await _start_speaking(harness.client)
+    assert await _reply(ws) == "started"
+    await ws.send_bytes(b"\x01\x02")
+    await ws.send_str('{"type": "stop"}')
+    assert await _reply(ws) == "error"
+
+    assert announced == []
+
+
+@pytest.mark.asyncio
 async def test_a_client_that_goes_silent_ends_its_own_clip(
     harness: Harness, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -241,6 +293,72 @@ async def test_a_client_that_goes_silent_ends_its_own_clip(
     assert await _reply(ws) == "started"
     await ws.send_bytes(b"\x01\x02")
 
+    assert await _reply(ws) == "finished"
+
+
+@pytest.mark.asyncio
+async def test_a_clip_that_keeps_going_is_cut_off(
+    harness: Harness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A client that keeps sending cannot hold on to the player indefinitely."""
+    # with the idle timeout out of reach, only the wall clock bound can end this clip
+    monkeypatch.setattr(live_announcements, "MAX_SESSION_SECONDS", 0.1)
+    monkeypatch.setattr(live_announcements, "IDLE_TIMEOUT", 30)
+
+    ws = await _start_speaking(harness.client)
+    assert await _reply(ws) == "started"
+    await ws.send_bytes(b"\x01\x02")
+
+    assert await _reply(ws) == "finished"
+
+
+@pytest.mark.asyncio
+async def test_only_so_many_clips_can_be_in_progress_at_once(
+    harness: Harness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The audio buffered at the same time is bounded by a cap on the sessions."""
+    monkeypatch.setattr(live_announcements, "MAX_CONCURRENT_SESSIONS", 1)
+    playing = asyncio.Event()
+
+    async def _play(*_args: Any, **_kwargs: Any) -> None:
+        await playing.wait()
+
+    harness.mass.players.play_announcement = AsyncMock(side_effect=_play)
+
+    speaking = await _start_speaking(harness.client)
+    assert await _reply(speaking) == "started"
+    rejected = await _start_speaking(harness.client)
+    assert await _close_code(rejected) == REJECTED
+
+    playing.set()
+    await speaking.send_str('{"type": "stop"}')
+    assert await _reply(speaking) == "finished"
+    assert harness.mass.players.play_announcement.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_frames_are_not_part_of_the_clip(harness: Harness) -> None:
+    """A frame without audio must not grow the clip that is held in memory."""
+    playing = asyncio.Event()
+
+    async def _play(*_args: Any, **_kwargs: Any) -> None:
+        await playing.wait()
+
+    harness.mass.players.play_announcement = AsyncMock(side_effect=_play)
+
+    ws = await _start_speaking(harness.client)
+    assert await _reply(ws) == "started"
+    await ws.send_bytes(b"")
+    await ws.send_bytes(b"\x01\x02")
+    await ws.send_bytes(b"")
+    await ws.send_str('{"type": "stop"}')
+
+    session_id = _session_id(harness.mass.players.play_announcement.call_args.kwargs["url"])
+    request, writer = _stream_request(session_id)
+    await harness.manager.serve_stream(request)
+    assert _frames_written(writer) == [b"\x01\x02"]
+
+    playing.set()
     assert await _reply(ws) == "finished"
 
 
@@ -260,6 +378,38 @@ async def test_an_ingress_client_announces_without_an_auth_message(harness: Harn
 
     harness.mass.webserver.auth.authenticate_with_token.assert_not_called()
     harness.mass.players.play_announcement.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_the_home_assistant_system_user_announces_over_ingress(harness: Harness) -> None:
+    """Home Assistant announces as its own system user, which ingress is the home of."""
+    user = User(user_id="user_6", username=HOMEASSISTANT_SYSTEM_USER, role=UserRole.SERVICE)
+    with (
+        patch.object(live_announcements, "is_request_from_ingress", return_value=True),
+        patch.object(live_announcements, "get_authenticated_user", AsyncMock(return_value=user)),
+    ):
+        ws = await harness.client.ws_connect(LIVE_ANNOUNCEMENT_ROUTE)
+        await ws.send_json({"type": "start", "player_id": PLAYER_ID, "sample_rate": SAMPLE_RATE})
+        assert await _reply(ws) == "started"
+        await ws.send_str('{"type": "stop"}')
+        assert await _reply(ws) == "finished"
+
+    harness.mass.players.play_announcement.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_the_home_assistant_system_user_is_rejected_off_ingress(harness: Harness) -> None:
+    """The Home Assistant system token is not accepted on the regular webserver."""
+    harness.mass.webserver.auth.authenticate_with_token = AsyncMock(
+        return_value=User(
+            user_id="user_7", username=HOMEASSISTANT_SYSTEM_USER, role=UserRole.SERVICE
+        )
+    )
+    ws = await harness.client.ws_connect(LIVE_ANNOUNCEMENT_ROUTE)
+    await ws.send_json({"type": "auth", "token": VALID_TOKEN})
+
+    assert await _close_code(ws) == REJECTED
+    harness.mass.players.play_announcement.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -298,6 +448,22 @@ async def test_a_user_that_may_not_control_players_is_rejected(harness: Harness)
 
 
 @pytest.mark.asyncio
+async def test_an_unavailable_player_is_rejected(harness: Harness) -> None:
+    """
+    A player that is offline is refused up front.
+
+    The command for such a player is silently dropped downstream, which would leave
+    the client believing its announcement played.
+    """
+    harness.player.available = False
+
+    ws = await _start_speaking(harness.client)
+
+    assert await _close_code(ws) == REJECTED
+    harness.mass.players.play_announcement.assert_not_called()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "start_message",
     [
@@ -324,6 +490,35 @@ def _session(session_id: str = "session1") -> LiveAnnouncementSession:
     return LiveAnnouncementSession(
         session_id, f"{BASE_URL}/live_announcement/{session_id}.wav", LIVE_FORMAT
     )
+
+
+def _player() -> MagicMock:
+    """Return the player the tests announce on."""
+    player = MagicMock()
+    player.player_id = PLAYER_ID
+    player.display_name = "Kitchen"
+    player.available = True
+    player.protocol_parent_id = None
+    return player
+
+
+def _announce_through_player_commands(harness: Harness) -> list[tuple[str, User | None]]:
+    """
+    Announce through the guards every player command passes, instead of a bare mock.
+
+    :param harness: The harness whose announcements should run through the guards.
+    :return: The player and the user of every announcement that got through.
+    """
+    controller = PlayerController.__new__(PlayerController)
+    controller._players = {PLAYER_ID: harness.player}
+    controller.logger = logging.getLogger("test.streams.live_announcements.players")
+    announced: list[tuple[str, User | None]] = []
+
+    async def _play(_self: PlayerController, player_id: str, **_kwargs: Any) -> None:
+        announced.append((player_id, get_current_user()))
+
+    harness.mass.players.play_announcement = MethodType(handle_player_command(_play), controller)
+    return announced
 
 
 async def _start_speaking(
@@ -375,6 +570,11 @@ def _stream_request(session_id: str) -> tuple[web.Request, MagicMock]:
 def _written(writer: MagicMock) -> bytes:
     """Return the body that was written to a served stream."""
     return b"".join(call.args[0] for call in writer.write.call_args_list)
+
+
+def _frames_written(writer: MagicMock) -> list[bytes]:
+    """Return the audio chunks written to a served stream, without the wave header."""
+    return [call.args[0] for call in writer.write.call_args_list[1:]]
 
 
 def _session_id(url: str) -> str:

--- a/tests/controllers/streams/test_live_announcements.py
+++ b/tests/controllers/streams/test_live_announcements.py
@@ -23,6 +23,7 @@ from music_assistant.controllers.players.helpers import handle_player_command
 from music_assistant.controllers.streams import live_announcements
 from music_assistant.controllers.streams.live_announcements import (
     LIVE_ANNOUNCEMENT_ROUTE,
+    MAX_CLOSE_REASON_BYTES,
     LiveAnnouncementManager,
     LiveAnnouncementSession,
 )
@@ -60,6 +61,14 @@ class Harness(NamedTuple):
     player: MagicMock
 
 
+class BlockedAnnouncement(NamedTuple):
+    """An announcement that reports its progress and plays for as long as the test wants."""
+
+    started: asyncio.Event
+    release: asyncio.Event
+    done: asyncio.Event
+
+
 @pytest.fixture(name="harness")
 async def harness_fixture() -> AsyncGenerator[Harness]:
     """Yield a live announcement manager served on a real websocket route."""
@@ -87,12 +96,12 @@ async def harness_fixture() -> AsyncGenerator[Harness]:
 
 
 @pytest.mark.asyncio
-async def test_read_replays_the_clip_and_waits_for_the_rest() -> None:
+async def test_read_replays_the_clip_from_the_start() -> None:
     """
-    A reader attaching mid-sentence gets the clip from the start and then follows along.
+    A reader gets the whole clip from the start and follows the audio still coming in.
 
-    The renderer only starts pulling once its ffmpeg is up, by which time the client is
-    already speaking, so the session is a buffer and not a queue.
+    The clip is replayed rather than consumed, so it can be served again whenever the
+    renderer comes back for it.
     """
     session = _session()
     await session.write(b"first")
@@ -114,7 +123,7 @@ async def test_read_replays_the_clip_and_waits_for_the_rest() -> None:
         with pytest.raises(StopAsyncIteration):
             await asyncio.wait_for(end, timeout=REPLY_TIMEOUT)
 
-    # audio that arrives after the clip ended is not part of it
+    # the whole clip is served again, without the audio that arrived after it ended
     await session.write(b"late")
     assert [chunk async for chunk in session.read()] == [b"first", b"second"]
 
@@ -144,7 +153,7 @@ async def test_an_unknown_session_is_not_served() -> None:
 
 @pytest.mark.asyncio
 async def test_a_spoken_clip_is_announced_on_the_player(harness: Harness) -> None:
-    """The start message starts the announcement and a text frame ends the clip."""
+    """A text frame completes the clip, which is then announced on the chosen player."""
     ws = await _start_speaking(harness.client, pre_announce=True, volume_level=42)
     assert await _reply(ws) == "started"
 
@@ -161,16 +170,9 @@ async def test_a_spoken_clip_is_announced_on_the_player(harness: Harness) -> Non
 
 
 @pytest.mark.asyncio
-async def test_the_renderer_is_served_what_is_being_spoken(harness: Harness) -> None:
-    """The announcement url delivers an open-ended wave header and then the frames."""
-    served: list[bytes] = []
-
-    async def _pull(_player_id: str, url: str, **_kwargs: Any) -> None:
-        request, writer = _stream_request(_session_id(url))
-        await harness.manager.serve_stream(request)
-        served.append(_written(writer))
-
-    harness.mass.players.play_announcement = AsyncMock(side_effect=_pull)
+async def test_the_renderer_is_served_the_finished_clip(harness: Harness) -> None:
+    """The announcement url delivers a wave header followed by the clip that was spoken."""
+    served = _serve_the_clip_when_announced(harness)
 
     ws = await _start_speaking(harness.client)
     assert await _reply(ws) == "started"
@@ -179,32 +181,28 @@ async def test_the_renderer_is_served_what_is_being_spoken(harness: Harness) -> 
     await ws.send_str('{"type": "stop"}')
     assert await _reply(ws) == "finished"
 
-    assert served == [create_streaming_wave_header(LIVE_FORMAT) + b"\x01\x02\x03\x04"]
+    assert served == [[create_streaming_wave_header(LIVE_FORMAT), b"\x01\x02", b"\x03\x04"]]
 
 
 @pytest.mark.asyncio
 async def test_the_session_lives_as_long_as_the_announcement(harness: Harness) -> None:
     """The audio stays available for as long as the player is playing it."""
-    playing = asyncio.Event()
-
-    async def _play(*_args: Any, **_kwargs: Any) -> None:
-        await playing.wait()
-
-    harness.mass.players.play_announcement = AsyncMock(side_effect=_play)
+    blocked = _block_announcement(harness)
 
     ws = await _start_speaking(harness.client)
     assert await _reply(ws) == "started"
     await ws.send_bytes(b"\x01\x02")
     await ws.send_str('{"type": "stop"}')
+    await _wait(blocked.started)
 
-    # the player is still on the clip, so a renderer starting late is still served
+    # the player is on the clip, so it must stay available to be (re)fetched
     session_id = _session_id(harness.mass.players.play_announcement.call_args.kwargs["url"])
     assert harness.manager.active_sessions == 1
     request, writer = _stream_request(session_id)
     await harness.manager.serve_stream(request)
-    assert _written(writer).endswith(b"\x01\x02")
+    assert _written(writer) == [create_streaming_wave_header(LIVE_FORMAT), b"\x01\x02"]
 
-    playing.set()
+    blocked.release.set()
     assert await _reply(ws) == "finished"
 
     assert harness.manager.active_sessions == 0
@@ -216,25 +214,36 @@ async def test_the_session_lives_as_long_as_the_announcement(harness: Harness) -
 @pytest.mark.asyncio
 async def test_the_announcement_outlives_a_client_that_drops(harness: Harness) -> None:
     """A client that disconnects mid-sentence still gets what it spoke played out."""
-    playing = asyncio.Event()
-    played = asyncio.Event()
-
-    async def _play(*_args: Any, **_kwargs: Any) -> None:
-        await playing.wait()
-        played.set()
-
-    harness.mass.players.play_announcement = AsyncMock(side_effect=_play)
+    blocked = _block_announcement(harness)
 
     ws = await _start_speaking(harness.client)
     assert await _reply(ws) == "started"
     await ws.send_bytes(b"\x01\x02")
     await ws.close()
 
-    assert not played.is_set()
+    # the clip is announced although there is no longer anyone to report back to
+    await _wait(blocked.started)
     assert harness.manager.active_sessions == 1
+    blocked.release.set()
+    await _wait(blocked.done)
 
-    playing.set()
-    await asyncio.wait_for(played.wait(), timeout=REPLY_TIMEOUT)
+
+@pytest.mark.asyncio
+async def test_a_player_that_never_finishes_is_not_waited_on_forever(
+    harness: Harness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A player that never reports back ends as an error instead of holding the session."""
+    monkeypatch.setattr(live_announcements, "ANNOUNCEMENT_TIMEOUT", 0.1)
+    # never released: this stands in for a provider that hands off and never returns
+    _block_announcement(harness)
+
+    ws = await _start_speaking(harness.client)
+    assert await _reply(ws) == "started"
+    await ws.send_bytes(b"\x01\x02")
+    await ws.send_str('{"type": "stop"}')
+
+    assert await _reply(ws) == "error"
+    assert harness.manager.active_sessions == 0
 
 
 @pytest.mark.asyncio
@@ -286,7 +295,7 @@ async def test_a_user_without_access_to_the_player_is_refused(harness: Harness) 
 async def test_a_client_that_goes_silent_ends_its_own_clip(
     harness: Harness, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Silence ends the clip instead of holding the player until the client disconnects."""
+    """Silence ends the clip on its own, so a client that stops sending is not left open."""
     monkeypatch.setattr(live_announcements, "IDLE_TIMEOUT", 0.05)
 
     ws = await _start_speaking(harness.client)
@@ -294,13 +303,14 @@ async def test_a_client_that_goes_silent_ends_its_own_clip(
     await ws.send_bytes(b"\x01\x02")
 
     assert await _reply(ws) == "finished"
+    harness.mass.players.play_announcement.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_a_clip_that_keeps_going_is_cut_off(
     harness: Harness, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A client that keeps sending cannot hold on to the player indefinitely."""
+    """A client that keeps sending cannot keep its session open indefinitely."""
     # with the idle timeout out of reach, only the wall clock bound can end this clip
     monkeypatch.setattr(live_announcements, "MAX_SESSION_SECONDS", 0.1)
     monkeypatch.setattr(live_announcements, "IDLE_TIMEOUT", 30)
@@ -310,6 +320,7 @@ async def test_a_clip_that_keeps_going_is_cut_off(
     await ws.send_bytes(b"\x01\x02")
 
     assert await _reply(ws) == "finished"
+    harness.mass.players.play_announcement.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -318,19 +329,14 @@ async def test_only_so_many_clips_can_be_in_progress_at_once(
 ) -> None:
     """The audio buffered at the same time is bounded by a cap on the sessions."""
     monkeypatch.setattr(live_announcements, "MAX_CONCURRENT_SESSIONS", 1)
-    playing = asyncio.Event()
-
-    async def _play(*_args: Any, **_kwargs: Any) -> None:
-        await playing.wait()
-
-    harness.mass.players.play_announcement = AsyncMock(side_effect=_play)
 
     speaking = await _start_speaking(harness.client)
     assert await _reply(speaking) == "started"
+    await speaking.send_bytes(b"\x01\x02")
+
     rejected = await _start_speaking(harness.client)
     assert await _close_code(rejected) == REJECTED
 
-    playing.set()
     await speaking.send_str('{"type": "stop"}')
     assert await _reply(speaking) == "finished"
     assert harness.mass.players.play_announcement.await_count == 1
@@ -339,12 +345,7 @@ async def test_only_so_many_clips_can_be_in_progress_at_once(
 @pytest.mark.asyncio
 async def test_empty_frames_are_not_part_of_the_clip(harness: Harness) -> None:
     """A frame without audio must not grow the clip that is held in memory."""
-    playing = asyncio.Event()
-
-    async def _play(*_args: Any, **_kwargs: Any) -> None:
-        await playing.wait()
-
-    harness.mass.players.play_announcement = AsyncMock(side_effect=_play)
+    served = _serve_the_clip_when_announced(harness)
 
     ws = await _start_speaking(harness.client)
     assert await _reply(ws) == "started"
@@ -352,14 +353,28 @@ async def test_empty_frames_are_not_part_of_the_clip(harness: Harness) -> None:
     await ws.send_bytes(b"\x01\x02")
     await ws.send_bytes(b"")
     await ws.send_str('{"type": "stop"}')
-
-    session_id = _session_id(harness.mass.players.play_announcement.call_args.kwargs["url"])
-    request, writer = _stream_request(session_id)
-    await harness.manager.serve_stream(request)
-    assert _frames_written(writer) == [b"\x01\x02"]
-
-    playing.set()
     assert await _reply(ws) == "finished"
+
+    assert served == [[create_streaming_wave_header(LIVE_FORMAT), b"\x01\x02"]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("frames", [[], [b"", b""]], ids=["no audio at all", "only empty frames"])
+async def test_a_clip_without_audio_is_not_announced(harness: Harness, frames: list[bytes]) -> None:
+    """
+    A clip nobody spoke into is dropped instead of played.
+
+    Announcing silence would interrupt whatever the player is doing for nothing.
+    """
+    ws = await _start_speaking(harness.client)
+    assert await _reply(ws) == "started"
+    for frame in frames:
+        await ws.send_bytes(frame)
+    await ws.send_str('{"type": "stop"}')
+
+    assert await _reply(ws) == "finished"
+    harness.mass.players.play_announcement.assert_not_called()
+    assert harness.manager.active_sessions == 0
 
 
 @pytest.mark.asyncio
@@ -373,6 +388,7 @@ async def test_an_ingress_client_announces_without_an_auth_message(harness: Harn
         ws = await harness.client.ws_connect(LIVE_ANNOUNCEMENT_ROUTE)
         await ws.send_json({"type": "start", "player_id": PLAYER_ID, "sample_rate": SAMPLE_RATE})
         assert await _reply(ws) == "started"
+        await ws.send_bytes(b"\x01\x02")
         await ws.send_str('{"type": "stop"}')
         assert await _reply(ws) == "finished"
 
@@ -391,6 +407,7 @@ async def test_the_home_assistant_system_user_announces_over_ingress(harness: Ha
         ws = await harness.client.ws_connect(LIVE_ANNOUNCEMENT_ROUTE)
         await ws.send_json({"type": "start", "player_id": PLAYER_ID, "sample_rate": SAMPLE_RATE})
         assert await _reply(ws) == "started"
+        await ws.send_bytes(b"\x01\x02")
         await ws.send_str('{"type": "stop"}')
         assert await _reply(ws) == "finished"
 
@@ -464,6 +481,21 @@ async def test_an_unavailable_player_is_rejected(harness: Harness) -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_long_rejection_reason_still_reaches_the_client(harness: Harness) -> None:
+    """The reason quotes what the client sent, which must still fit in a close frame."""
+    ws = await harness.client.ws_connect(LIVE_ANNOUNCEMENT_ROUTE)
+    await ws.send_json({"type": "auth", "token": VALID_TOKEN})
+    await ws.send_json({"type": "start", "player_id": "x" * 500, "sample_rate": SAMPLE_RATE})
+
+    msg = await asyncio.wait_for(ws.receive(), timeout=REPLY_TIMEOUT)
+    assert msg.type is WSMsgType.CLOSE
+    assert msg.data == REJECTED
+    assert msg.extra is not None
+    assert msg.extra.startswith("Unknown or unavailable player")
+    assert len(msg.extra.encode()) <= MAX_CLOSE_REASON_BYTES
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "start_message",
     [
@@ -521,6 +553,47 @@ def _announce_through_player_commands(harness: Harness) -> list[tuple[str, User 
     return announced
 
 
+def _block_announcement(harness: Harness) -> BlockedAnnouncement:
+    """
+    Keep an announcement playing until the test releases it.
+
+    :param harness: The harness whose announcements should block.
+    :return: The events reporting the announcement and releasing it again.
+    """
+    blocked = BlockedAnnouncement(asyncio.Event(), asyncio.Event(), asyncio.Event())
+
+    async def _play(*_args: Any, **_kwargs: Any) -> None:
+        blocked.started.set()
+        await blocked.release.wait()
+        blocked.done.set()
+
+    harness.mass.players.play_announcement = AsyncMock(side_effect=_play)
+    return blocked
+
+
+def _serve_the_clip_when_announced(harness: Harness) -> list[list[bytes]]:
+    """
+    Fetch the announcement url the way the renderer does, whenever one is announced.
+
+    :param harness: The harness whose announcements should be fetched.
+    :return: What was written to the stream for each of them.
+    """
+    served: list[list[bytes]] = []
+
+    async def _pull(_player_id: str, url: str, **_kwargs: Any) -> None:
+        request, writer = _stream_request(_session_id(url))
+        await harness.manager.serve_stream(request)
+        served.append(_written(writer))
+
+    harness.mass.players.play_announcement = AsyncMock(side_effect=_pull)
+    return served
+
+
+async def _wait(event: asyncio.Event) -> None:
+    """Wait for something the server is expected to do right away."""
+    await asyncio.wait_for(event.wait(), timeout=REPLY_TIMEOUT)
+
+
 async def _start_speaking(
     client: TestClient[web.Request, web.Application], **start: object
 ) -> ClientWebSocketResponse:
@@ -567,14 +640,9 @@ def _stream_request(session_id: str) -> tuple[web.Request, MagicMock]:
     return request, writer
 
 
-def _written(writer: MagicMock) -> bytes:
-    """Return the body that was written to a served stream."""
-    return b"".join(call.args[0] for call in writer.write.call_args_list)
-
-
-def _frames_written(writer: MagicMock) -> list[bytes]:
-    """Return the audio chunks written to a served stream, without the wave header."""
-    return [call.args[0] for call in writer.write.call_args_list[1:]]
+def _written(writer: MagicMock) -> list[bytes]:
+    """Return the chunks that were written to a served stream, header first."""
+    return [call.args[0] for call in writer.write.call_args_list]
 
 
 def _session_id(url: str) -> str:

--- a/tests/controllers/streams/test_live_announcements.py
+++ b/tests/controllers/streams/test_live_announcements.py
@@ -1,0 +1,382 @@
+"""Tests for the live announcements a client speaks into the webserver."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from contextlib import aclosing
+from typing import TYPE_CHECKING, Any, NamedTuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import WSMsgType, web
+from aiohttp.test_utils import TestClient, TestServer, make_mocked_request
+from music_assistant_models.auth import User, UserRole
+from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
+
+from music_assistant.controllers.streams import live_announcements
+from music_assistant.controllers.streams.live_announcements import (
+    LIVE_ANNOUNCEMENT_ROUTE,
+    LiveAnnouncementManager,
+    LiveAnnouncementSession,
+)
+from music_assistant.helpers.audio import create_streaming_wave_header
+from tests.common import use_real_create_task
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from aiohttp import ClientWebSocketResponse
+
+PLAYER_ID = "player1"
+BASE_URL = "http://ma.local:8097"
+VALID_TOKEN = "valid-token"
+SAMPLE_RATE = 16000
+LIVE_FORMAT = AudioFormat(
+    content_type=ContentType.PCM_S16LE,
+    sample_rate=SAMPLE_RATE,
+    bit_depth=16,
+    channels=1,
+)
+# the close code a client that may not (or cannot) announce is disconnected with
+REJECTED = 4001
+# upper bound on anything the server is expected to answer right away
+REPLY_TIMEOUT = 5
+
+
+class Harness(NamedTuple):
+    """A live announcement manager, its MusicAssistant stub and a client for its route."""
+
+    manager: LiveAnnouncementManager
+    mass: MagicMock
+    client: TestClient[web.Request, web.Application]
+
+
+@pytest.fixture(name="harness")
+async def harness_fixture() -> AsyncGenerator[Harness]:
+    """Yield a live announcement manager served on a real websocket route."""
+    mass = MagicMock()
+    mass.streams.base_url = BASE_URL
+    mass.webserver.auth.authenticate_with_token = AsyncMock(
+        return_value=User(user_id="user_1", username="listener", role=UserRole.USER)
+    )
+    mass.players.get_player = MagicMock(
+        side_effect=lambda player_id: MagicMock() if player_id == PLAYER_ID else None
+    )
+    mass.players.play_announcement = AsyncMock()
+    # the announcement is dispatched as a task, which must actually run
+    use_real_create_task(mass)
+    manager = LiveAnnouncementManager(mass, logging.getLogger("test.streams.live_announcements"))
+    app = web.Application()
+    app.router.add_get(LIVE_ANNOUNCEMENT_ROUTE, manager.handle_ws)
+    client: TestClient[web.Request, web.Application] = TestClient(TestServer(app))
+    await client.start_server()
+    try:
+        yield Harness(manager, mass, client)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_read_replays_the_clip_and_waits_for_the_rest() -> None:
+    """
+    A reader attaching mid-sentence gets the clip from the start and then follows along.
+
+    The renderer only starts pulling once its ffmpeg is up, by which time the client is
+    already speaking, so the session is a buffer and not a queue.
+    """
+    session = _session()
+    await session.write(b"first")
+
+    stream = session.read()
+    async with aclosing(stream):
+        assert await anext(stream) == b"first"
+        reader = asyncio.ensure_future(anext(stream))
+        await asyncio.sleep(0)
+        assert not reader.done()
+        await session.write(b"second")
+        assert await asyncio.wait_for(reader, timeout=REPLY_TIMEOUT) == b"second"
+
+        # the clip only ends when the client says it is done
+        end = asyncio.ensure_future(anext(stream))
+        await asyncio.sleep(0)
+        assert not end.done()
+        await session.finish()
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.wait_for(end, timeout=REPLY_TIMEOUT)
+
+    # audio that arrives after the clip ended is not part of it
+    await session.write(b"late")
+    assert [chunk async for chunk in session.read()] == [b"first", b"second"]
+
+
+@pytest.mark.asyncio
+async def test_duration_follows_the_audio_that_arrived() -> None:
+    """The duration is what has been spoken so far, in seconds of PCM."""
+    session = _session()
+    assert session.duration == 0
+
+    await session.write(b"\x00" * LIVE_FORMAT.pcm_sample_size)
+    assert session.duration == 1.0
+
+    await session.write(b"\x00" * (LIVE_FORMAT.pcm_sample_size // 2))
+    assert session.duration == 1.5
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_session_is_not_served() -> None:
+    """A session id that is not (or no longer) live has nothing to serve."""
+    manager = LiveAnnouncementManager(MagicMock(), logging.getLogger("test.streams.live"))
+    request, _ = _stream_request("ghost")
+
+    with pytest.raises(web.HTTPNotFound):
+        await manager.serve_stream(request)
+
+
+@pytest.mark.asyncio
+async def test_a_spoken_clip_is_announced_on_the_player(harness: Harness) -> None:
+    """The start message starts the announcement and a text frame ends the clip."""
+    ws = await _start_speaking(harness.client, pre_announce=True, volume_level=42)
+    assert await _reply(ws) == "started"
+
+    await ws.send_bytes(b"\x01\x02")
+    await ws.send_str('{"type": "stop"}')
+    assert await _reply(ws) == "finished"
+
+    harness.mass.players.play_announcement.assert_awaited_once()
+    call = harness.mass.players.play_announcement.call_args
+    assert call.args == (PLAYER_ID,)
+    assert call.kwargs["pre_announce"] is True
+    assert call.kwargs["volume_level"] == 42
+    assert re.fullmatch(rf"{re.escape(BASE_URL)}/live_announcement/[\w-]+\.wav", call.kwargs["url"])
+
+
+@pytest.mark.asyncio
+async def test_the_renderer_is_served_what_is_being_spoken(harness: Harness) -> None:
+    """The announcement url delivers an open-ended wave header and then the frames."""
+    served: list[bytes] = []
+
+    async def _pull(_player_id: str, url: str, **_kwargs: Any) -> None:
+        request, writer = _stream_request(_session_id(url))
+        await harness.manager.serve_stream(request)
+        served.append(_written(writer))
+
+    harness.mass.players.play_announcement = AsyncMock(side_effect=_pull)
+
+    ws = await _start_speaking(harness.client)
+    assert await _reply(ws) == "started"
+    await ws.send_bytes(b"\x01\x02")
+    await ws.send_bytes(b"\x03\x04")
+    await ws.send_str('{"type": "stop"}')
+    assert await _reply(ws) == "finished"
+
+    assert served == [create_streaming_wave_header(LIVE_FORMAT) + b"\x01\x02\x03\x04"]
+
+
+@pytest.mark.asyncio
+async def test_the_session_lives_as_long_as_the_announcement(harness: Harness) -> None:
+    """The audio stays available for as long as the player is playing it."""
+    playing = asyncio.Event()
+
+    async def _play(*_args: Any, **_kwargs: Any) -> None:
+        await playing.wait()
+
+    harness.mass.players.play_announcement = AsyncMock(side_effect=_play)
+
+    ws = await _start_speaking(harness.client)
+    assert await _reply(ws) == "started"
+    await ws.send_bytes(b"\x01\x02")
+    await ws.send_str('{"type": "stop"}')
+
+    # the player is still on the clip, so a renderer starting late is still served
+    session_id = _session_id(harness.mass.players.play_announcement.call_args.kwargs["url"])
+    assert harness.manager.active_sessions == 1
+    request, writer = _stream_request(session_id)
+    await harness.manager.serve_stream(request)
+    assert _written(writer).endswith(b"\x01\x02")
+
+    playing.set()
+    assert await _reply(ws) == "finished"
+
+    assert harness.manager.active_sessions == 0
+    late_request, _ = _stream_request(session_id)
+    with pytest.raises(web.HTTPNotFound):
+        await harness.manager.serve_stream(late_request)
+
+
+@pytest.mark.asyncio
+async def test_the_announcement_outlives_a_client_that_drops(harness: Harness) -> None:
+    """A client that disconnects mid-sentence still gets what it spoke played out."""
+    playing = asyncio.Event()
+    played = asyncio.Event()
+
+    async def _play(*_args: Any, **_kwargs: Any) -> None:
+        await playing.wait()
+        played.set()
+
+    harness.mass.players.play_announcement = AsyncMock(side_effect=_play)
+
+    ws = await _start_speaking(harness.client)
+    assert await _reply(ws) == "started"
+    await ws.send_bytes(b"\x01\x02")
+    await ws.close()
+
+    assert not played.is_set()
+    assert harness.manager.active_sessions == 1
+
+    playing.set()
+    await asyncio.wait_for(played.wait(), timeout=REPLY_TIMEOUT)
+
+
+@pytest.mark.asyncio
+async def test_a_client_that_goes_silent_ends_its_own_clip(
+    harness: Harness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Silence ends the clip instead of holding the player until the client disconnects."""
+    monkeypatch.setattr(live_announcements, "IDLE_TIMEOUT", 0.05)
+
+    ws = await _start_speaking(harness.client)
+    assert await _reply(ws) == "started"
+    await ws.send_bytes(b"\x01\x02")
+
+    assert await _reply(ws) == "finished"
+
+
+@pytest.mark.asyncio
+async def test_an_ingress_client_announces_without_an_auth_message(harness: Harness) -> None:
+    """Home Assistant authenticates its own users, so ingress skips the auth message."""
+    user = User(user_id="user_2", username="ha_user", role=UserRole.USER)
+    with (
+        patch.object(live_announcements, "is_request_from_ingress", return_value=True),
+        patch.object(live_announcements, "get_authenticated_user", AsyncMock(return_value=user)),
+    ):
+        ws = await harness.client.ws_connect(LIVE_ANNOUNCEMENT_ROUTE)
+        await ws.send_json({"type": "start", "player_id": PLAYER_ID, "sample_rate": SAMPLE_RATE})
+        assert await _reply(ws) == "started"
+        await ws.send_str('{"type": "stop"}')
+        assert await _reply(ws) == "finished"
+
+    harness.mass.webserver.auth.authenticate_with_token.assert_not_called()
+    harness.mass.players.play_announcement.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_an_auth_message_without_a_token_is_rejected(harness: Harness) -> None:
+    """A client that presents no token never gets to announce."""
+    ws = await harness.client.ws_connect(LIVE_ANNOUNCEMENT_ROUTE)
+    await ws.send_json({"type": "auth"})
+
+    assert await _close_code(ws) == REJECTED
+    harness.mass.players.play_announcement.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_token_is_rejected(harness: Harness) -> None:
+    """A token that does not resolve to a user never gets to announce."""
+    harness.mass.webserver.auth.authenticate_with_token = AsyncMock(return_value=None)
+    ws = await harness.client.ws_connect(LIVE_ANNOUNCEMENT_ROUTE)
+    await ws.send_json({"type": "auth", "token": "nope"})
+
+    assert await _close_code(ws) == REJECTED
+    harness.mass.players.play_announcement.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_user_that_may_not_control_players_is_rejected(harness: Harness) -> None:
+    """Announcing takes the players control scope, whatever else the token is valid for."""
+    # a role id outside ROLE_SCOPES grants no scopes at all
+    harness.mass.webserver.auth.authenticate_with_token = AsyncMock(
+        return_value=User(user_id="user_3", username="kiosk", role="kiosk")
+    )
+    ws = await harness.client.ws_connect(LIVE_ANNOUNCEMENT_ROUTE)
+    await ws.send_json({"type": "auth", "token": VALID_TOKEN})
+
+    assert await _close_code(ws) == REJECTED
+    harness.mass.players.play_announcement.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "start_message",
+    [
+        {"type": "start", "player_id": "ghost", "sample_rate": SAMPLE_RATE},
+        {"type": "start", "player_id": PLAYER_ID, "sample_rate": 1000},
+        {"type": "start", "player_id": PLAYER_ID, "sample_rate": SAMPLE_RATE, "channels": 3},
+    ],
+    ids=["unknown player", "sample rate out of range", "channel count out of range"],
+)
+async def test_an_unusable_start_message_is_rejected(
+    harness: Harness, start_message: dict[str, object]
+) -> None:
+    """Nothing is announced when the client cannot say what to send where."""
+    ws = await harness.client.ws_connect(LIVE_ANNOUNCEMENT_ROUTE)
+    await ws.send_json({"type": "auth", "token": VALID_TOKEN})
+    await ws.send_json(start_message)
+
+    assert await _close_code(ws) == REJECTED
+    harness.mass.players.play_announcement.assert_not_called()
+
+
+def _session(session_id: str = "session1") -> LiveAnnouncementSession:
+    """Return a session for the format the tests speak in."""
+    return LiveAnnouncementSession(
+        session_id, f"{BASE_URL}/live_announcement/{session_id}.wav", LIVE_FORMAT
+    )
+
+
+async def _start_speaking(
+    client: TestClient[web.Request, web.Application], **start: object
+) -> ClientWebSocketResponse:
+    """
+    Connect, authenticate and send the start message.
+
+    :param client: Test client for the manager's websocket route.
+    :param start: Extra fields to put in the start message.
+    """
+    ws = await client.ws_connect(LIVE_ANNOUNCEMENT_ROUTE)
+    await ws.send_json({"type": "auth", "token": VALID_TOKEN})
+    await ws.send_json(
+        {"type": "start", "player_id": PLAYER_ID, "sample_rate": SAMPLE_RATE, **start}
+    )
+    return ws
+
+
+async def _reply(ws: ClientWebSocketResponse) -> str:
+    """Return the type of the next message the server sends."""
+    message = await asyncio.wait_for(ws.receive_json(), timeout=REPLY_TIMEOUT)
+    return str(message["type"])
+
+
+async def _close_code(ws: ClientWebSocketResponse) -> int:
+    """Return the code the server closed the connection with."""
+    msg = await asyncio.wait_for(ws.receive(), timeout=REPLY_TIMEOUT)
+    assert msg.type is WSMsgType.CLOSE
+    return int(msg.data)
+
+
+def _stream_request(session_id: str) -> tuple[web.Request, MagicMock]:
+    """Return a request for the audio of the given session, plus the writer serving it."""
+    writer = MagicMock()
+    writer.write = AsyncMock()
+    writer.write_headers = AsyncMock()
+    writer.write_eof = AsyncMock()
+    writer.drain = AsyncMock()
+    request = make_mocked_request(
+        "GET",
+        f"/live_announcement/{session_id}.wav",
+        match_info={"session_id": session_id},
+        writer=writer,
+    )
+    return request, writer
+
+
+def _written(writer: MagicMock) -> bytes:
+    """Return the body that was written to a served stream."""
+    return b"".join(call.args[0] for call in writer.write.call_args_list)
+
+
+def _session_id(url: str) -> str:
+    """Return the session id in a live announcement url."""
+    return url.rsplit("/", maxsplit=1)[-1].removesuffix(".wav")

--- a/tests/controllers/streams/test_live_announcements.py
+++ b/tests/controllers/streams/test_live_announcements.py
@@ -378,6 +378,26 @@ async def test_a_clip_without_audio_is_not_announced(harness: Harness, frames: l
 
 
 @pytest.mark.asyncio
+async def test_a_reloaded_manager_still_announces(harness: Harness) -> None:
+    """
+    A reload leaves the manager able to announce again.
+
+    A core controller reload closes and sets the manager up again, so a shutdown
+    that is never undone would silence every clip until the server restarts.
+    """
+    await harness.manager.close()
+    harness.manager.setup()
+
+    ws = await _start_speaking(harness.client)
+    assert await _reply(ws) == "started"
+    await ws.send_bytes(b"\x01\x02")
+    await ws.send_str('{"type": "stop"}')
+
+    assert await _reply(ws) == "finished"
+    harness.mass.players.play_announcement.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_an_ingress_client_announces_without_an_auth_message(harness: Harness) -> None:
     """Home Assistant authenticates its own users, so ingress skips the auth message."""
     user = User(user_id="user_2", username="ha_user", role=UserRole.USER)

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -844,6 +844,10 @@ class _FakeLocalWS:
         """Queue a text message as if the local server sent it."""
         self._incoming.put_nowait(SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data=data))
 
+    def feed_bytes(self, data: bytes) -> None:
+        """Queue a binary message as if the local server sent it."""
+        self._incoming.put_nowait(SimpleNamespace(type=aiohttp.WSMsgType.BINARY, data=data))
+
     def __aiter__(self) -> AsyncIterator[SimpleNamespace]:
         return self
 
@@ -898,14 +902,39 @@ class _FakeBidiChannel:
         return message
 
 
+class _FakeHttpSession:
+    """ClientSession stand-in handing out one fake WebSocket per dialed url."""
+
+    def __init__(self) -> None:
+        self.dialed: list[str] = []
+        self.dial_kwargs: list[dict[str, Any]] = []
+        self.websockets: dict[str, _FakeLocalWS] = {}
+
+    async def ws_connect(self, url: str, **kwargs: Any) -> _FakeLocalWS:
+        self.dialed.append(url)
+        self.dial_kwargs.append(kwargs)
+        local_ws = _FakeLocalWS()
+        self.websockets[url] = local_ws
+        return local_ws
+
+
 class _FakePeerConnection:
     """PeerConnection stand-in that runs gateway-spawned pumps as asyncio tasks."""
 
     def __init__(self) -> None:
         self._tasks: list[asyncio.Task[None]] = []
+        self._incoming: asyncio.Queue[_FakeBidiChannel] = asyncio.Queue()
 
     def spawn_task(self, coro: Coroutine[Any, Any, None]) -> None:
         self._tasks.append(asyncio.ensure_future(coro))
+
+    def offer_channel(self, channel: _FakeBidiChannel) -> None:
+        """Offer a data channel as if the browser had opened it."""
+        self._incoming.put_nowait(channel)
+
+    async def incoming_data_channels(self) -> AsyncIterator[DataChannel]:
+        while True:
+            yield cast("DataChannel", await self._incoming.get())
 
     async def aclose(self) -> None:
         for task in self._tasks:
@@ -925,6 +954,17 @@ def _register_bridge_session(
     )
     gateway.sessions[session_id] = session
     return session
+
+
+def _register_routed_session(
+    gateway: WebRTCGateway, session_id: str
+) -> tuple[WebRTCSession, _FakePeerConnection]:
+    """Register a session that routes the data channels offered to its PeerConnection."""
+    pc = _FakePeerConnection()
+    session = WebRTCSession(session_id=session_id, pc=cast("PeerConnection", pc))
+    gateway.sessions[session_id] = session
+    pc.spawn_task(gateway._accept_channels(session))
+    return session, pc
 
 
 async def _wait_for(predicate: Callable[[], bool], timeout: float = 15.0) -> None:
@@ -1066,6 +1106,183 @@ async def test_session_closes_when_ma_api_channel_closes(cert_pems: tuple[str, s
     await _wait_for(lambda: "channel-close-session" not in gateway.sessions)
     assert "channel-close-session" not in gateway.sessions
     await asyncio.wait_for(bridge, timeout=5)
+
+
+# ---- channel routing -------------------------------------------------------
+
+LOCAL_WS_URL = "ws://127.0.0.1:8095/ws"
+SENDSPIN_URL = "ws://127.0.0.1:8927/sendspin"
+
+
+def _routing_gateway(
+    cert_pems: tuple[str, str],
+    http_session: _FakeHttpSession,
+    local_ws_url: str = LOCAL_WS_URL,
+    set_sendspin_player_callback: Callable[[str, str], None] | None = None,
+) -> WebRTCGateway:
+    """Create a gateway whose local WebSockets are all served by the fake HTTP session."""
+    cert_pem, key_pem = cert_pems
+    return WebRTCGateway(
+        http_session=cast("aiohttp.ClientSession", http_session),
+        remote_id="TEST-REMOTE-ID",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+        local_ws_url=local_ws_url,
+        sendspin_url=SENDSPIN_URL,
+        set_sendspin_player_callback=set_sendspin_player_callback,
+    )
+
+
+async def test_sendspin_channel_bridges_to_the_sendspin_server(cert_pems: tuple[str, str]) -> None:
+    """A sendspin channel reaches the internal sendspin server, web player id and all."""
+    http_session = _FakeHttpSession()
+    announced_players: list[tuple[str, str]] = []
+    gateway = _routing_gateway(
+        cert_pems,
+        http_session,
+        set_sendspin_player_callback=lambda session_id, player_id: announced_players.append(
+            (session_id, player_id)
+        ),
+    )
+    session, pc = _register_routed_session(gateway, "sendspin-session")
+    channel = _FakeBidiChannel(label="sendspin")
+    pc.offer_channel(channel)
+    try:
+        await _wait_for(lambda: SENDSPIN_URL in http_session.websockets)
+        local_ws = http_session.websockets[SENDSPIN_URL]
+
+        # the first message announces the web player, and is forwarded verbatim
+        auth = json.dumps({"type": "auth", "token": "t", "client_id": "web-player-1"})
+        channel.feed(auth)
+        await _wait_for(lambda: local_ws.sent == [auth])
+        assert announced_players == [("sendspin-session", "web-player-1")]
+        assert session.sendspin_player_id == "web-player-1"
+
+        # audio keeps flowing in both directions, text and binary alike
+        channel.feed(b"\x01\x02")
+        await _wait_for(lambda: local_ws.sent == [auth, b"\x01\x02"])
+        local_ws.feed_text('{"type":"hello"}')
+        local_ws.feed_bytes(b"\x03\x04")
+        await _wait_for(lambda: channel.sent == ['{"type":"hello"}', b"\x03\x04"])
+    finally:
+        await gateway._close_session("sendspin-session")
+
+
+@pytest.mark.parametrize(
+    ("local_ws_url", "expected_url"),
+    [
+        ("ws://127.0.0.1:8095/ws", "ws://127.0.0.1:8095/live_announcement"),
+        # an https webserver is still dialed on its bind address, which no cert covers
+        ("wss://127.0.0.1:8095/ws", "wss://127.0.0.1:8095/live_announcement"),
+    ],
+)
+async def test_live_announcement_channel_bridges_to_the_webserver(
+    cert_pems: tuple[str, str], local_ws_url: str, expected_url: str
+) -> None:
+    """A live announcement channel reaches the webserver route that takes the audio."""
+    http_session = _FakeHttpSession()
+    gateway = _routing_gateway(cert_pems, http_session, local_ws_url=local_ws_url)
+    session, pc = _register_routed_session(gateway, "announce-session")
+    channel = _FakeBidiChannel(label="live_announcement")
+    pc.offer_channel(channel)
+    try:
+        await _wait_for(lambda: expected_url in http_session.websockets)
+        local_ws = http_session.websockets[expected_url]
+        assert http_session.dial_kwargs == [{"ssl": False}]
+
+        # the client authenticates on the route itself, so its handshake passes through
+        handshake = [
+            json.dumps({"type": "auth", "token": "t"}),
+            json.dumps({"type": "start", "player_id": "player1", "sample_rate": 16000}),
+        ]
+        for message in handshake:
+            channel.feed(message)
+        await _wait_for(lambda: local_ws.sent == handshake)
+        # the sendspin snoop belongs to the sendspin bridge only
+        assert session.sendspin_player_id is None
+
+        # spoken audio goes up, the route's replies come back
+        channel.feed(b"\x00\x01")
+        await _wait_for(lambda: local_ws.sent == [*handshake, b"\x00\x01"])
+        local_ws.feed_text('{"type":"started"}')
+        await _wait_for(lambda: channel.sent == ['{"type":"started"}'])
+    finally:
+        await gateway._close_session("announce-session")
+
+
+@pytest.mark.parametrize("closed_by", ["browser", "local"])
+async def test_closing_a_bridged_channel_leaves_the_api_session_up(
+    cert_pems: tuple[str, str], closed_by: str
+) -> None:
+    """Losing a bridged WebSocket tears down that bridge only, never the API session."""
+    http_session = _FakeHttpSession()
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "mixed-session")
+    api_channel = _FakeBidiChannel()
+    sendspin_channel = _FakeBidiChannel(label="sendspin")
+    pc.offer_channel(api_channel)
+    pc.offer_channel(sendspin_channel)
+    try:
+        await _wait_for(
+            lambda: session.local_ws is not None and SENDSPIN_URL in http_session.dialed
+        )
+        sendspin_ws = http_session.websockets[SENDSPIN_URL]
+
+        if closed_by == "browser":
+            sendspin_channel.close()
+        else:
+            await sendspin_ws.close()
+        await _wait_for(lambda: not session.ws_bridges)
+
+        assert sendspin_ws.closed is True
+        assert sendspin_channel.closed is True
+        # the API session is untouched: still registered, still bridged, channel still open
+        assert "mixed-session" in gateway.sessions
+        assert session.local_ws is not None
+        assert cast("_FakeLocalWS", session.local_ws).closed is False
+        assert api_channel.closed is False
+    finally:
+        await gateway._close_session("mixed-session")
+
+
+async def test_the_first_channel_is_the_api_channel_whatever_its_label(
+    cert_pems: tuple[str, str],
+) -> None:
+    """Clients may label their API channel freely, so the first channel bridges to the API."""
+    http_session = _FakeHttpSession()
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "labelled-session")
+    channel = _FakeBidiChannel(label="ma-api-v2")
+    pc.offer_channel(channel)
+    try:
+        await _wait_for(lambda: session.local_ws is not None)
+        assert session.data_channel is cast("DataChannel", channel)
+        assert http_session.dialed == [f"{LOCAL_WS_URL}?webrtc_session_id=labelled-session"]
+    finally:
+        await gateway._close_session("labelled-session")
+
+
+async def test_unknown_channel_label_cannot_replace_the_api_channel(
+    cert_pems: tuple[str, str],
+) -> None:
+    """A channel this server has no route for is refused instead of hijacking the session."""
+    http_session = _FakeHttpSession()
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "unknown-session")
+    api_channel = _FakeBidiChannel()
+    unknown_channel = _FakeBidiChannel(label="channel-from-the-future")
+    pc.offer_channel(api_channel)
+    try:
+        await _wait_for(lambda: session.local_ws is not None)
+        pc.offer_channel(unknown_channel)
+        await _wait_for(lambda: unknown_channel.closed)
+
+        assert session.data_channel is cast("DataChannel", api_channel)
+        assert "unknown-session" in gateway.sessions
+        # only the API channel was ever bridged
+        assert http_session.dialed == [f"{LOCAL_WS_URL}?webrtc_session_id=unknown-session"]
+    finally:
+        await gateway._close_session("unknown-session")
 
 
 class _FakeDataChannel:


### PR DESCRIPTION
# What does this implement/fix?

Announcements can be typed as a message today. This adds the other half: you hold a button in the web UI and talk, and your voice comes out of the chosen speaker.

The audio arrives over an authenticated WebSocket on the webserver and is served back out as a WAV url on the stream server, which the existing announcement renderer pulls like any other source. Nothing in the announcement or player path changes.

The microphone needs a secure connection, so the UI only offers this where the browser allows it: the hosted app, Home Assistant ingress (with HA on https), Music Assistant with SSL enabled, or localhost.

**Related issue (if applicable):**

- n/a

**Companion frontend PR:**

- https://github.com/music-assistant/frontend/pull/2471

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- new `live_announcements` module: the session buffer, the inbound WebSocket route and the outbound WAV route
- the clip is announced once it is complete, so every player gets it whole — AirPlay needs that to schedule one synchronized instant across a group, and Sonos to know how long it runs
- a clip ends on the stop message, on disconnect, after 10s of silence, or at the existing 300s announcement cap; a press that captures nothing is not announced at all
- the announcement runs as the user who spoke it, so their player restrictions apply
- data channels in the remote-access gateway are now routed by label, so this works over a remote connection as well as Sendspin does
- the streaming WAV header helper moved to `helpers/audio` so both callers share it

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
