### PR TITLE
AI Radio: add host presets and a per-host language

### DIFF
--- a/music_assistant/providers/ai_radio/hosts.py
+++ b/music_assistant/providers/ai_radio/hosts.py
@@ -333,6 +333,7 @@ class AIRadioHostsMixin:
 
         instructions = str(host.get("instructions") or "").strip() or DEFAULT_LLM_INSTRUCTIONS
         tts_engine = str(host.get("tts_engine") or "").strip()
+        language = str(host.get("language") or "").strip()
 
         section_ids: list[str] = []
         seen: set[str] = set()
@@ -370,6 +371,7 @@ class AIRadioHostsMixin:
             "name": name,
             "instructions": instructions,
             "tts_engine": tts_engine,
+            "language": language,
             "section_ids": section_ids,
             "section_order": deepcopy(raw_section_order),
             "merge_section_id": merge_section_id,
@@ -384,6 +386,7 @@ class AIRadioHostsMixin:
             "name": "Default Host",
             "instructions": DEFAULT_LLM_INSTRUCTIONS,
             "tts_engine": "",
+            "language": "",
             "section_ids": default_section_ids,
             "section_order": [
                 {"when": "start_of_playlist", "flow": [{"MUST": "Song_Introduction_Start"}]},
@@ -552,6 +555,7 @@ def _compile_preset_host(preset: _PresetHost) -> tuple[dict[str, Any], list[dict
         "name": preset.name,
         "instructions": preset.instructions,
         "tts_engine": "",
+        "language": "",
         "section_ids": [section["id"] for section in sections],
         "section_order": section_order,
         "merge_section_id": merge_section_id,

--- a/music_assistant/providers/ai_radio/provider.py
+++ b/music_assistant/providers/ai_radio/provider.py
@@ -134,6 +134,7 @@ class AIRadioProvider(
             ("ai_radio/hosts/save", self.save_host),
             ("ai_radio/hosts/delete", self.delete_host),
             ("ai_radio/hosts/template", self.host_template),
+            ("ai_radio/hosts/presets/list", self.list_host_presets),
             ("ai_radio/engines/tts/list", self.list_tts_engines),
             ("ai_radio/start", self.start_run),
             ("ai_radio/stop", self.stop_run),
@@ -340,6 +341,13 @@ class AIRadioProvider(
     async def host_template(self) -> dict[str, Any]:
         """Return a default host template."""
         return self._default_host_template()
+
+    async def list_host_presets(self) -> list[dict[str, Any]]:
+        """Return the bundled preset hosts as templates a client can add from."""
+        return [
+            {"host": deepcopy(host), "sections": deepcopy(sections)}
+            for host, sections in self._default_preset_hosts()
+        ]
 
     async def list_tts_engines(self) -> list[dict[str, str]]:
         """Return the available TTS engines for host voice selection."""

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -128,7 +128,7 @@ class AIRadioRenderMixin:
         # the caller holds the per-clip render lock, so of the several uncoordinated paths
         # that resolve the same clip only the first one mints; the rest hit the cache above
         path, stream_type, audio_format, duration = await self._mint_clip_media(
-            queue_item, text, clip_id, self._tts_language()
+            queue_item, text, clip_id
         )
         media = _CachedClipMedia(path, stream_type, audio_format, duration, now)
         # clips are minted per queue item, so without pruning the cache grows for as long as
@@ -147,9 +147,13 @@ class AIRadioRenderMixin:
         elapsed = asyncio.get_running_loop().time() - media.minted_at
         return max(MIN_CLIP_MEDIA_LIFETIME, round(CLIP_STREAMDETAILS_EXPIRATION - elapsed))
 
-    def _tts_language(self) -> str | None:
-        """Return the configured locale as a hyphenated language code, or None when unset."""
-        locale = self.mass.metadata.locale
+    def _tts_language(self, host_language: str | None = None) -> str | None:
+        """
+        Return the host's language, or the server locale, as a hyphenated language code.
+
+        :param host_language: The host's configured language override, if any.
+        """
+        locale = (host_language or "").strip() or self.mass.metadata.locale
         return locale.replace("_", "-") if locale else None
 
     def _find_clip_item(self, clip_id: str) -> QueueItem | None:
@@ -198,13 +202,17 @@ class AIRadioRenderMixin:
             resolved = resolved.replace(key, value)
         host = self._hosts.get(str(attributes.get(ATTR_HOST_ID) or "")) or {}
         instructions = str(host.get("instructions") or "")
+        language = str(host.get("language") or "")
         max_chars = int(attributes.get(ATTR_MAX_CHARS) or 0)
         web_mode = str(attributes.get(ATTR_WEB_SEARCH_MODE) or "disabled")
         try:
             text = cast(
                 "str",
                 await self._generate_text(
-                    instructions=instructions, prompt=resolved, web_mode=web_mode
+                    instructions=instructions,
+                    prompt=resolved,
+                    web_mode=web_mode,
+                    language=language,
                 ),
             )
         except Exception as err:
@@ -232,11 +240,12 @@ class AIRadioRenderMixin:
         return values
 
     async def _mint_clip_media(
-        self, queue_item: QueueItem, text: str, clip_id: str, language: str | None = None
+        self, queue_item: QueueItem, text: str, clip_id: str
     ) -> tuple[str, StreamType, AudioFormat, int | None]:
         """Convert the script to playable audio via the configured TTS engine."""
         host = self._hosts.get(str(queue_item.extra_attributes.get(ATTR_HOST_ID) or "")) or {}
         engine_uid = str(host.get("tts_engine") or "") or None
+        language = self._tts_language(str(host.get("language") or ""))
         try:
             path, stream_type, audio_format = await self._render_tts_media(
                 text, engine_uid, language

--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -137,6 +137,7 @@ class AIRadioRuntimeMixin:
             "host_id": str(host.get("id", "")),
             "instructions": str(host.get("instructions", "")),
             "tts_engine": str(host.get("tts_engine", "")),
+            "language": str(host.get("language", "")),
             "sections": sections,
             "section_order": deepcopy(host.get("section_order", [])),
             "merge_section_id": str(host.get("merge_section_id", "")),
@@ -1205,7 +1206,9 @@ class AIRadioRuntimeMixin:
             )
         return mode
 
-    async def _generate_text(self, instructions: str, prompt: str, web_mode: str) -> str:
+    async def _generate_text(
+        self, instructions: str, prompt: str, web_mode: str, language: str | None = None
+    ) -> str:
         """Generate one section text using the configured AI engine."""
         instructions = instructions.strip() or DEFAULT_LLM_INSTRUCTIONS
         query_parts: list[str] = []
@@ -1215,7 +1218,7 @@ class AIRadioRuntimeMixin:
         # stated as a default so a station can still ask for another language in its instructions
         query_parts.append(
             "Unless the program instructions ask for another language, write the output "
-            f"in the language matching the locale '{self.mass.metadata.locale}'."
+            f"in the language matching the locale '{language or self.mass.metadata.locale}'."
         )
         if web_mode == "force":
             query_parts.append(

--- a/tests/providers/ai_radio/test_hosts.py
+++ b/tests/providers/ai_radio/test_hosts.py
@@ -76,6 +76,36 @@ def test_normalize_host_requires_name() -> None:
         dummy._normalize_host(payload)
 
 
+def test_normalize_host_persists_language() -> None:
+    """Persist a host's language override through normalization."""
+    dummy = DummyHosts()
+    dummy._sections = {"Song_Transition": _section("Song_Transition")}
+    payload = _host(["Song_Transition"])
+    payload["language"] = "nl_NL"
+    normalized = dummy._normalize_host(payload)
+    assert normalized["language"] == "nl_NL"
+
+
+def test_normalize_host_defaults_missing_language_to_empty() -> None:
+    """Normalize a host with no 'language' key at all, for backwards compatibility."""
+    dummy = DummyHosts()
+    dummy._sections = {"Song_Transition": _section("Song_Transition")}
+    payload = _host(["Song_Transition"])
+    assert "language" not in payload
+    normalized = dummy._normalize_host(payload)
+    assert normalized["language"] == ""
+
+
+def test_normalize_host_strips_whitespace_only_language_to_empty() -> None:
+    """Treat a whitespace-only language as 'follow the server locale'."""
+    dummy = DummyHosts()
+    dummy._sections = {"Song_Transition": _section("Song_Transition")}
+    payload = _host(["Song_Transition"])
+    payload["language"] = "   "
+    normalized = dummy._normalize_host(payload)
+    assert normalized["language"] == ""
+
+
 def test_normalize_host_rejects_unknown_section_reference() -> None:
     """Reject hosts that reference shared sections that do not exist."""
     dummy = DummyHosts()

--- a/tests/providers/ai_radio/test_provider.py
+++ b/tests/providers/ai_radio/test_provider.py
@@ -349,6 +349,34 @@ async def test_host_crud_roundtrip(provider: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_host_presets_returns_every_preset_with_sections(provider: Any) -> None:
+    """The presets command returns each bundled preset paired with its sections."""
+    expected = provider._default_preset_hosts()
+
+    presets = await provider.list_host_presets()
+
+    assert len(presets) == len(expected)
+    assert {entry["host"]["id"] for entry in presets} == {host["id"] for host, _ in expected}
+    for entry in presets:
+        assert set(entry) == {"host", "sections"}
+        assert entry["sections"]
+
+
+@pytest.mark.asyncio
+async def test_list_host_presets_does_not_mutate_stored_state(provider: Any) -> None:
+    """Presets are templates: fetching them must not touch stored hosts or sections."""
+    presets = await provider.list_host_presets()
+
+    presets[0]["host"]["name"] = "mutated"
+    presets[0]["sections"][0]["name"] = "mutated"
+
+    assert provider._hosts == {}
+    fresh = await provider.list_host_presets()
+    assert fresh[0]["host"]["name"] != "mutated"
+    assert fresh[0]["sections"][0]["name"] != "mutated"
+
+
+@pytest.mark.asyncio
 async def test_save_section_leaves_the_stations_file_alone(provider: Any, tmp_path: Path) -> None:
     """Sections no longer live inside stations, so saving one must not rewrite them."""
     provider._sections_file = tmp_path / "sections.json"

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -55,7 +55,9 @@ class DummyRenderer(AIRadioRenderMixin):
     def _configured_now(self) -> Any:
         return __import__("datetime").datetime(2026, 7, 30, 18, 30)
 
-    async def _generate_text(self, instructions: str, prompt: str, web_mode: str) -> str:
+    async def _generate_text(
+        self, instructions: str, prompt: str, web_mode: str, language: str | None = None
+    ) -> str:
         # a real suspension point so concurrent callers actually interleave under
         # asyncio.gather, otherwise the lock in get_stream_details is never exercised
         await asyncio.sleep(0)
@@ -502,6 +504,7 @@ async def test_generate_script_uses_host_instructions() -> None:
         instructions: str,
         prompt: str,  # noqa: ARG001
         web_mode: str,  # noqa: ARG001
+        language: str | None = None,  # noqa: ARG001
     ) -> str:
         captured["instructions"] = instructions
         return "script"
@@ -525,6 +528,7 @@ async def test_generate_script_falls_back_to_default_instructions() -> None:
         instructions: str,
         prompt: str,  # noqa: ARG001
         web_mode: str,  # noqa: ARG001
+        language: str | None = None,  # noqa: ARG001
     ) -> str:
         # mirrors the empty-to-default fallback the real _generate_text applies (runtime.py)
         captured["instructions"] = instructions.strip() or DEFAULT_LLM_INSTRUCTIONS
@@ -536,6 +540,87 @@ async def test_generate_script_falls_back_to_default_instructions() -> None:
     await renderer._generate_script(item, "p", "clip_1")
 
     assert captured["instructions"] == DEFAULT_LLM_INSTRUCTIONS
+
+
+async def test_generate_script_forwards_the_hosts_language() -> None:
+    """The host's configured language reaches _generate_text, ready to override the locale."""
+    renderer = DummyRenderer()
+    renderer._hosts = {
+        "rick": {
+            "id": "rick",
+            "instructions": "Persona text.",
+            "tts_engine": "",
+            "language": "fr_FR",
+        }
+    }
+    captured: dict[str, str | None] = {}
+
+    async def fake_generate_text(
+        instructions: str,  # noqa: ARG001
+        prompt: str,  # noqa: ARG001
+        web_mode: str,  # noqa: ARG001
+        language: str | None = None,
+    ) -> str:
+        captured["language"] = language
+        return "script"
+
+    cast("Any", renderer)._generate_text = fake_generate_text
+    item = _clip_item("sess_001", **{ATTR_HOST_ID: "rick", ATTR_PROMPT: "p"})
+
+    await renderer._generate_script(item, "p", "clip_1")
+
+    assert captured["language"] == "fr_FR"
+
+
+async def test_generate_script_forwards_empty_language_when_host_has_none() -> None:
+    """A host with no configured language forwards an empty string, not None."""
+    renderer = DummyRenderer()
+    renderer._hosts = {"rick": {"id": "rick", "instructions": "Persona text.", "tts_engine": ""}}
+    captured: dict[str, str | None] = {}
+
+    async def fake_generate_text(
+        instructions: str,  # noqa: ARG001
+        prompt: str,  # noqa: ARG001
+        web_mode: str,  # noqa: ARG001
+        language: str | None = None,
+    ) -> str:
+        captured["language"] = language
+        return "script"
+
+    cast("Any", renderer)._generate_text = fake_generate_text
+    item = _clip_item("sess_001", **{ATTR_HOST_ID: "rick", ATTR_PROMPT: "p"})
+
+    await renderer._generate_script(item, "p", "clip_1")
+
+    assert captured["language"] == ""
+
+
+async def test_render_tts_media_prefers_the_hosts_language_over_the_locale() -> None:
+    """A host's configured language reaches the TTS engine, overriding the server locale."""
+    renderer = _tts_renderer("http://example.test/api/tts_proxy/abc123.mp3")
+    renderer._hosts = {"rick": {"id": "rick", "tts_engine": "", "language": "fr_FR"}}
+    _attach_queue(renderer, [_clip_item("sess_001", **{ATTR_HOST_ID: "rick"})])
+
+    await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    engine = cast("Any", renderer)._get_tts_engine.return_value
+    engine.provider.get_tts_message.assert_awaited_once_with(
+        "Good evening, it is warm out.", language="fr-FR", engine_id="tts.cloud"
+    )
+
+
+async def test_render_tts_media_falls_back_to_locale_when_host_language_is_empty() -> None:
+    """A host with no configured language falls back to the server locale for the TTS call."""
+    renderer = _tts_renderer("http://example.test/api/tts_proxy/abc123.mp3")
+    renderer._hosts = {"rick": {"id": "rick", "tts_engine": ""}}
+    _attach_queue(renderer, [_clip_item("sess_001", **{ATTR_HOST_ID: "rick"})])
+
+    await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    engine = cast("Any", renderer)._get_tts_engine.return_value
+    engine.provider.get_tts_message.assert_awaited_once_with(
+        "Good evening, it is warm out.", language="en-US", engine_id="tts.cloud"
+    )
 
 
 async def test_resolve_deferred_placeholders_skips_weather_without_token() -> None:
@@ -553,6 +638,7 @@ async def test_mint_clip_media_resolves_host_tts_engine() -> None:
     """A clip whose host declares a tts_engine reaches _get_tts_engine with that override."""
     renderer = _tts_renderer("http://example.test/api/tts_proxy/abc123.mp3")
     renderer._hosts = {"rick": {"id": "rick", "tts_engine": "tts.rick_voice"}}
+    cast("Any", renderer).mass = SimpleNamespace(metadata=SimpleNamespace(locale="en_US"))
     item = _clip_item("sess_001", **{ATTR_HOST_ID: "rick"})
 
     await renderer._mint_clip_media(item, "hello world", "clip_1")

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -587,6 +587,51 @@ async def test_generate_text_asks_for_the_system_locale_language() -> None:
     assert plugin.ai_query.await_args.kwargs == {"engine_id": "ai_task.default"}
 
 
+async def test_generate_text_prefers_the_hosts_language_over_the_system_locale() -> None:
+    """An explicit host language wins over the server locale in the AI query."""
+    plugin = _create_ai_plugin("hass_1", "ai_task.default")
+    plugin.ai_query = AsyncMock(return_value="section text")
+    runtime = DummyRuntime({CONF_AI_ENGINE: "hass_1/ai_task.default"})
+    _set_runtime_mass(
+        runtime,
+        _create_engine_mass(
+            ProviderFeature.AI_QUERY, plugin, metadata=SimpleNamespace(locale="nl_NL")
+        ),
+    )
+
+    await runtime._generate_text(
+        instructions="test",
+        prompt="test prompt",
+        web_mode="disabled",
+        language="fr_FR",
+    )
+
+    assert "fr_FR" in plugin.ai_query.await_args.args[0]
+    assert "nl_NL" not in plugin.ai_query.await_args.args[0]
+
+
+async def test_generate_text_falls_back_to_the_system_locale_when_language_is_empty() -> None:
+    """An unset host language keeps asking for the server locale, exactly as before."""
+    plugin = _create_ai_plugin("hass_1", "ai_task.default")
+    plugin.ai_query = AsyncMock(return_value="section text")
+    runtime = DummyRuntime({CONF_AI_ENGINE: "hass_1/ai_task.default"})
+    _set_runtime_mass(
+        runtime,
+        _create_engine_mass(
+            ProviderFeature.AI_QUERY, plugin, metadata=SimpleNamespace(locale="nl_NL")
+        ),
+    )
+
+    await runtime._generate_text(
+        instructions="test",
+        prompt="test prompt",
+        web_mode="disabled",
+        language="",
+    )
+
+    assert "nl_NL" in plugin.ai_query.await_args.args[0]
+
+
 @pytest.mark.parametrize("general", [{"instructions": "Host personality: minimal DJ."}, {}])
 async def test_generate_text_always_states_the_pronunciation_rules(
     general: dict[str, Any],
@@ -852,6 +897,7 @@ def test_build_program_merges_host_into_station() -> None:
         "name": "Rick",
         "instructions": "Persona.",
         "tts_engine": "engine-1",
+        "language": "fr_FR",
         "section_ids": ["Song_Transition"],
         "section_order": [{"when": "between_songs", "flow": [{"MUST": "Song_Transition"}]}],
         "merge_section_id": "",
@@ -871,6 +917,7 @@ def test_build_program_merges_host_into_station() -> None:
 
     assert program["instructions"] == "Persona."
     assert program["tts_engine"] == "engine-1"
+    assert program["language"] == "fr_FR"
     assert [s["id"] for s in program["sections"]] == ["Song_Transition"]
     assert program["section_order"] == host["section_order"]
     assert program["source_playlist_id"] == "p1"


### PR DESCRIPTION
# What does this implement/fix?

The four bundled AI Radio host personas were only ever written to disk on a fresh install, so anyone who upgraded never got them and anyone who deleted one could not get it back. This exposes them over the API as templates the frontend can offer when adding a host.

Hosts also gain an optional language. Until now both the written script and the spoken clip followed the server-wide locale, so a Dutch server could not have an English host.

- Add `ai_radio/hosts/presets/list`, returning each bundled preset as `{host, sections}` built from the existing preset compiler. Templates only: it never writes to stored hosts, sections or disk.
- Add an optional per-host `language`; empty means "follow the server locale", so hosts already on disk keep working unchanged.
- Apply that language to the AI query's locale instruction and to the TTS engine, both resolved from the host the clip belongs to.
- Leave the existing "engine rejected the language, retry with its default voice" fallback in place, so it now also covers a host-chosen language.

**Related issue (if applicable):**

- n/a

**Companion frontend PR:** https://github.com/music-assistant/frontend/pull/2474

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
