### PR TITLE
Allow radio stations to play as dynamic stations

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 47
+API_SCHEMA_VERSION: Final[int] = 48
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -9,7 +9,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 
-DB_SCHEMA_VERSION: Final[int] = 57
+DB_SCHEMA_VERSION: Final[int] = 58
 
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60

--- a/music_assistant/controllers/music/database.py
+++ b/music_assistant/controllers/music/database.py
@@ -359,7 +359,8 @@ class MusicDatabaseSetupMixin:
             [timestamp_added] INTEGER DEFAULT (cast(strftime('%s','now') as int)),
             [timestamp_modified] INTEGER NOT NULL DEFAULT 0,
             [search_name] TEXT NOT NULL,
-            [search_sort_name] TEXT NOT NULL
+            [search_sort_name] TEXT NOT NULL,
+            [is_dynamic] BOOLEAN NOT NULL DEFAULT 0
             );"""
         )
         await self.database.execute(

--- a/music_assistant/controllers/music/media/radio.py
+++ b/music_assistant/controllers/music/media/radio.py
@@ -171,6 +171,9 @@ class RadioController(MediaControllerBase[Radio]):
     ) -> list[Radio]:
         """Return all versions of a radio station we can find on all providers."""
         radio = await self.get(item_id, provider_instance_id_or_domain)
+        if radio.is_dynamic:
+            # a dynamic station is its provider's own, so a same-named station is a different one
+            return []
         # perform a search on all provider(types) to collect all versions/variants
         all_versions = {
             prov_item.item_id: prov_item

--- a/music_assistant/controllers/music/media/radio.py
+++ b/music_assistant/controllers/music/media/radio.py
@@ -237,8 +237,7 @@ class RadioController(MediaControllerBase[Radio]):
         if db_radio.provider != "library":
             return  # Matching only supported for database items
         if db_radio.is_dynamic:
-            # a dynamic station (e.g. Pandora) has no equivalent on other providers; matching by
-            # name would cross-link it to an unrelated internet radio stream with a similar name
+            # matching a dynamic station by name would link an unrelated radio stream to it
             return
 
         # try to find match on all providers

--- a/music_assistant/controllers/music/media/radio.py
+++ b/music_assistant/controllers/music/media/radio.py
@@ -13,9 +13,10 @@ from music_assistant_models.errors import (
     InvalidDataError,
     MusicAssistantError,
     ProviderUnavailableError,
+    UnsupportedFeaturedException,
 )
 from music_assistant_models.helpers import create_safe_string
-from music_assistant_models.media_items import ProviderMapping, Radio, RadioSummary
+from music_assistant_models.media_items import ProviderMapping, Radio, RadioSummary, Track
 
 from music_assistant.constants import DB_TABLE_RADIOS
 from music_assistant.controllers.tasks.context import (
@@ -68,6 +69,11 @@ class RadioController(MediaControllerBase[Radio]):
             f"music/{api_base}/radio_versions", self.versions, required_scope=Scope.LIBRARY_READ
         )
         self.mass.register_api_command(
+            f"music/{api_base}/radio_tracks",
+            self.radio_tracks,
+            required_scope=Scope.LIBRARY_READ,
+        )
+        self.mass.register_api_command(
             f"music/{api_base}/export_radios", self.export_radios, required_scope=Scope.LIBRARY_READ
         )
         self.mass.register_api_command(
@@ -82,10 +88,28 @@ class RadioController(MediaControllerBase[Radio]):
         query = f"""
         SELECT
             {self._summary_base_columns()},
+            {self.db_table}.is_dynamic,
             json_extract({self.db_table}.metadata, '$.description') AS description,
             {self._provider_mappings_query()} AS provider_mappings
             FROM {self.db_table}"""
         return query, {}
+
+    async def radio_tracks(self, item_id: str, provider_instance_id_or_domain: str) -> list[Track]:
+        """
+        Return a fresh batch of tracks for a dynamic radio station.
+
+        :param item_id: The provider (or library) item id of the station.
+        :param provider_instance_id_or_domain: The provider instance id or domain the
+            item id belongs to ("library" for a library item).
+        """
+        radio = await self.get_provider_item(item_id, provider_instance_id_or_domain)
+        if not radio.is_dynamic:
+            raise UnsupportedFeaturedException(f"{radio.name} is not a dynamic radio station")
+        if provider_instance_id_or_domain == "library":
+            provider_instance_id_or_domain, item_id = self._select_provider_id(radio)
+        if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
+            raise ProviderUnavailableError(f"{provider_instance_id_or_domain} is not available")
+        return await cast("MusicProvider", provider).get_dynamic_radio_tracks(item_id)
 
     async def export_radios(self) -> str:
         """Export all library radio stations to M3U8 format."""
@@ -201,6 +225,10 @@ class RadioController(MediaControllerBase[Radio]):
         """
         if db_radio.provider != "library":
             return  # Matching only supported for database items
+        if db_radio.is_dynamic:
+            # a dynamic station (e.g. Pandora) has no equivalent on other providers; matching by
+            # name would cross-link it to an unrelated internet radio stream with a similar name
+            return
 
         # try to find match on all providers
         cur_provider_domains = {x.provider_domain for x in db_radio.provider_mappings}
@@ -234,6 +262,7 @@ class RadioController(MediaControllerBase[Radio]):
                     item.sort_name if item.sort_name is not None else "", True, True
                 ),
                 "timestamp_added": int(item.date_added.timestamp()) if item.date_added else UNSET,
+                "is_dynamic": item.is_dynamic,
             },
         )
         # update/set external id lookup table
@@ -268,6 +297,7 @@ class RadioController(MediaControllerBase[Radio]):
                 "timestamp_added": int(update.date_added.timestamp())
                 if update.date_added
                 else UNSET,
+                "is_dynamic": update.is_dynamic,
             },
         )
         # update/set external id lookup table
@@ -286,6 +316,7 @@ class RadioController(MediaControllerBase[Radio]):
     def _parse_summary_row(self, db_row: Mapping[str, Any]) -> RadioSummary:
         """Parse a raw summary db row into a RadioSummary object."""
         item = cast("RadioSummary", super()._parse_summary_row(db_row))
+        item.is_dynamic = bool(db_row["is_dynamic"])
         item.metadata.description = db_row["description"]
         return item
 

--- a/music_assistant/controllers/music/media/radio.py
+++ b/music_assistant/controllers/music/media/radio.py
@@ -103,10 +103,21 @@ class RadioController(MediaControllerBase[Radio]):
             item id belongs to ("library" for a library item).
         """
         radio = await self.get_provider_item(item_id, provider_instance_id_or_domain)
+        return await self.dynamic_tracks(radio)
+
+    async def dynamic_tracks(self, radio: Radio) -> list[Track]:
+        """
+        Return a fresh batch of tracks for an already resolved dynamic radio station.
+
+        :param radio: The dynamic station to fetch the next batch for.
+        """
         if not radio.is_dynamic:
             raise UnsupportedFeaturedException(f"{radio.name} is not a dynamic radio station")
-        if provider_instance_id_or_domain == "library":
-            provider_instance_id_or_domain, item_id = self._select_provider_id(radio)
+        provider_instance_id_or_domain, item_id = (
+            self._select_provider_id(radio)
+            if radio.provider == "library"
+            else (radio.provider, radio.item_id)
+        )
         if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
             raise ProviderUnavailableError(f"{provider_instance_id_or_domain} is not available")
         return await cast("MusicProvider", provider).get_dynamic_radio_tracks(item_id)

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -992,6 +992,16 @@ async def migrate_database(  # noqa: PLR0915
                 if "duplicate column" not in str(err):
                     raise
 
+    if prev_version <= 57:
+        # add is_dynamic column to radio table
+        try:
+            await database.execute(
+                f"ALTER TABLE {DB_TABLE_RADIOS} ADD COLUMN is_dynamic BOOLEAN NOT NULL DEFAULT 0"
+            )
+        except Exception as err:
+            if "duplicate column" not in str(err):
+                raise
+
     # NOTE: this genre restore runs after the <= 50 step on purpose: it inserts genres
     # with the current code/schema, so the external_ids column must be gone first.
     if prev_version <= 47:

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -44,6 +44,7 @@ from music_assistant_models.media_items import (
     PlayableMediaItemType,
     Playlist,
     PodcastEpisode,
+    Radio,
     SoundEffect,
     Track,
 )
@@ -1596,6 +1597,19 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         :param sort_by: Optional sort key for the returned tracks.
         """
         return await self._media_resolver.get_playlist_tracks(playlist, start_item, sort_by)
+
+    async def get_dynamic_source_tracks(self, item: MediaItemType) -> list[Track]:
+        """
+        Return a fresh batch of tracks for a dynamic source (a dynamic playlist or radio station).
+
+        :param item: The dynamic playlist or radio station to fetch the next batch for.
+        """
+        if isinstance(item, Radio):
+            return await self.mass.music.radio.radio_tracks(item.item_id, item.provider)
+        if isinstance(item, Playlist):
+            tracks = await self.get_playlist_tracks(item, start_item=None)
+            return [track for track in tracks if isinstance(track, Track)]
+        return []
 
     def recency_windows(self) -> RecencyWindows:
         """Return the configured recency windows (a global setting; used for recency-aware gating)."""

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -44,7 +44,6 @@ from music_assistant_models.media_items import (
     PlayableMediaItemType,
     Playlist,
     PodcastEpisode,
-    Radio,
     SoundEffect,
     Track,
 )
@@ -1604,12 +1603,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
 
         :param item: The dynamic playlist or radio station to fetch the next batch for.
         """
-        if isinstance(item, Radio):
-            return await self.mass.music.radio.radio_tracks(item.item_id, item.provider)
-        if isinstance(item, Playlist):
-            tracks = await self.get_playlist_tracks(item, start_item=None)
-            return [track for track in tracks if isinstance(track, Track)]
-        return []
+        return await self._media_resolver.get_dynamic_source_tracks(item)
 
     def recency_windows(self) -> RecencyWindows:
         """Return the configured recency windows (a global setting; used for recency-aware gating)."""

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -68,6 +68,7 @@ from music_assistant.controllers.player_queues.constants import (
 from music_assistant.controllers.player_queues.helpers import (
     get_current_playback_speed,
     handle_play_action,
+    is_dynamic_source,
 )
 from music_assistant.controllers.player_queues.managed_pool import ManagedPool
 from music_assistant.controllers.player_queues.media_resolver import MediaResolver
@@ -1692,13 +1693,13 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         self._queue_data[queue.queue_id].source_items = items
         # keep every occurrence server-side (a source added more than once weights it up in the
         # managed pool), but expose only the distinct container sources on the wire for clients to
-        # show. Individual items (tracks, radio streams, podcast episodes, ...) are omitted; see
+        # show. Individual items (tracks, live radio streams, podcast episodes, ...) are omitted; see
         # `_WIRE_SOURCE_MEDIA_TYPES`. Autoplay/pool refill reads the full `source_items` above, not
         # this projected list, so it is unaffected.
         seen: set[str] = set()
         sources: list[ItemMapping] = []
         for item in items:
-            if item.media_type not in _WIRE_SOURCE_MEDIA_TYPES:
+            if item.media_type not in _WIRE_SOURCE_MEDIA_TYPES and not is_dynamic_source(item):
                 continue
             mapping = ItemMapping.from_item(item)
             if mapping.uri and mapping.uri in seen:

--- a/music_assistant/controllers/player_queues/helpers.py
+++ b/music_assistant/controllers/player_queues/helpers.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import functools
 import random
 from collections.abc import Awaitable, Callable, Coroutine
-from typing import TYPE_CHECKING, Any, Concatenate, Protocol, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Any, Concatenate, Protocol, TypedDict, TypeGuard, TypeVar
 
-from music_assistant_models.media_items import MediaItemMetadata, Playlist, Track
+from music_assistant_models.media_items import MediaItemMetadata, Playlist, Radio, Track
 from music_assistant_models.queue_item import QueueItem
 
 from music_assistant.constants import ATTR_PLAY_ACTION_IN_PROGRESS, PlaylistPlayableItem
@@ -15,7 +15,11 @@ from music_assistant.controllers.players.constants import PlayerLockPurpose
 
 if TYPE_CHECKING:
     from music_assistant_models.enums import ContentType, PlaybackState
-    from music_assistant_models.media_items import MediaItemType, PlayableMediaItemType
+    from music_assistant_models.media_items import (
+        BrowseFolder,
+        MediaItemType,
+        PlayableMediaItemType,
+    )
     from music_assistant_models.player_queue import PlayerQueue
 
     from music_assistant import MusicAssistant
@@ -109,9 +113,14 @@ def handle_play_action[PlayActionHostT: _PlayActionHost, **P, R](
     return wrapper
 
 
+def is_dynamic_source(item: MediaItemType | BrowseFolder) -> TypeGuard[Playlist | Radio]:
+    """Return True if the item supplies its own on-demand track feed."""
+    return isinstance(item, Playlist | Radio) and item.is_dynamic
+
+
 def has_dynamic_source(source_items: list[MediaItemType]) -> bool:
-    """Return True if any source is a dynamic playlist (the queue is in dynamic mode)."""
-    return any(isinstance(item, Playlist) and item.is_dynamic for item in source_items)
+    """Return True if any source supplies its own on-demand track feed (the queue is dynamic)."""
+    return any(is_dynamic_source(item) for item in source_items)
 
 
 def build_queue_item(queue_id: str, media_item: PlayableMediaItemType) -> QueueItem:

--- a/music_assistant/controllers/player_queues/helpers.py
+++ b/music_assistant/controllers/player_queues/helpers.py
@@ -118,6 +118,21 @@ def is_dynamic_source(item: MediaItemType | BrowseFolder) -> TypeGuard[Playlist 
     return isinstance(item, Playlist | Radio) and item.is_dynamic
 
 
+def find_dynamic_source(queue_data: PlayerQueueData) -> MediaItemType | None:
+    """
+    Return the queue's most recently added dynamic source, if it has one.
+
+    Prefers the queue's sources and falls back to what was enqueued on it.
+
+    :param queue_data: The queue to inspect.
+    """
+    for items in (queue_data.source_items, queue_data.enqueued_media_items):
+        for item in reversed(items):
+            if is_dynamic_source(item):
+                return item
+    return None
+
+
 def has_dynamic_source(source_items: list[MediaItemType]) -> bool:
     """Return True if any source supplies its own on-demand track feed (the queue is dynamic)."""
     return any(is_dynamic_source(item) for item in source_items)

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -32,14 +32,18 @@ from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from music_assistant_models.errors import MusicAssistantError
-from music_assistant_models.media_items import Playlist, Track
+from music_assistant_models.media_items import Track
 
 from music_assistant.controllers.music.recency import song_keys
 from music_assistant.controllers.player_queues.constants import (
     MANAGED_POOL_SOURCE_CAP,
     MANAGED_POOL_TARGET,
 )
-from music_assistant.controllers.player_queues.helpers import interleave_groups, space_by_artist
+from music_assistant.controllers.player_queues.helpers import (
+    interleave_groups,
+    is_dynamic_source,
+    space_by_artist,
+)
 from music_assistant.helpers.track_filter import track_filter
 
 if TYPE_CHECKING:
@@ -200,14 +204,14 @@ class ManagedPool:
         Group the queue's source items into dynamic sources and fetch each one's candidates.
 
         :param queue_id: The queue being filled.
-        :param include_dynamic: Whether to include dynamic-playlist sources; skipped on the initial
-            fill, where each dynamic playlist seeds its own first batch directly.
+        :param include_dynamic: Whether to include dynamic sources; skipped on the initial
+            fill, where each dynamic source seeds its own first batch directly.
         """
         # multiplicity = how often a source was added (adding a source more than once weights it up)
         counts: dict[str, int] = {}
         items: dict[str, MediaItemType] = {}
         for item in self.queues.queue_data(queue_id).source_items:
-            if isinstance(item, Playlist) and item.is_dynamic and not include_dynamic:
+            if is_dynamic_source(item) and not include_dynamic:
                 continue
             if not (uri := _uri(item)):
                 continue
@@ -218,7 +222,7 @@ class ManagedPool:
         materialized = self._materialized.setdefault(queue_id, {})
         sources: list[DynamicSource] = []
         for uri, media_item in items.items():
-            if isinstance(media_item, Playlist) and media_item.is_dynamic:
+            if is_dynamic_source(media_item):
                 fill_mode = DynamicFillMode.DYNAMIC
                 candidates = await self._fetch_dynamic(media_item)
             else:
@@ -243,12 +247,10 @@ class ManagedPool:
         return sources
 
     async def _fetch_dynamic(self, media_item: MediaItemType) -> list[Track]:
-        """Fetch the next self-managed batch from a dynamic playlist (radio playlist, station)."""
-        if not isinstance(media_item, Playlist):
-            return []
+        """Fetch the next self-managed batch from a dynamic playlist or radio station."""
         with suppress(MusicAssistantError):
-            tracks = await self.queues.get_playlist_tracks(media_item, start_item=None)
-            return [track for track in tracks if isinstance(track, Track) and track.available]
+            tracks = await self.queues.get_dynamic_source_tracks(media_item)
+            return [track for track in tracks if track.available]
         return []
 
     async def _fetch_tracks(self, media_item: MediaItemType) -> list[Track]:

--- a/music_assistant/controllers/player_queues/media_resolver.py
+++ b/music_assistant/controllers/player_queues/media_resolver.py
@@ -28,6 +28,7 @@ from music_assistant_models.media_items import (
     Playlist,
     Podcast,
     PodcastEpisode,
+    Radio,
     Track,
     UniqueList,
 )
@@ -238,6 +239,19 @@ class MediaResolver:
             artist_tracks = await self.get_artist_tracks(artist)
             result.extend(artist_tracks[:5])
         return result
+
+    async def get_dynamic_source_tracks(self, item: MediaItemType) -> list[Track]:
+        """
+        Return a fresh batch of tracks for a dynamic playlist or radio station.
+
+        :param item: The dynamic source to fetch the next batch for.
+        """
+        if isinstance(item, Radio):
+            return await self.mass.music.radio.dynamic_tracks(item)
+        if isinstance(item, Playlist):
+            tracks = await self.get_playlist_tracks(item, start_item=None)
+            return [track for track in tracks if isinstance(track, Track)]
+        return []
 
     async def get_playlist_tracks(
         self,

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -29,7 +29,6 @@ from music_assistant_models.media_items import (
     Artist,
     ItemMapping,
     MediaItemType,
-    Playlist,
 )
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
 
@@ -41,6 +40,7 @@ from music_assistant.controllers.player_queues.base import _PlayerQueuesBase
 from music_assistant.controllers.player_queues.helpers import (
     CompareState,
     build_queue_item,
+    find_dynamic_source,
     get_current_playback_speed,
 )
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
@@ -466,27 +466,10 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
                         )
                         await self.play_index(queue.queue_id, next_index)
                     return
-            # If the queue was started from a dynamic playlist, fetch fresh tracks and continue.
+            # If the queue was started from a dynamic source, fetch fresh tracks and continue.
             qdata = self._queue_data.get(queue.queue_id)
-            source_items = qdata.source_items if qdata else []
-            dynamic_playlist = next(
-                (
-                    item
-                    for item in reversed(source_items)
-                    if isinstance(item, Playlist) and item.is_dynamic
-                ),
-                None,
-            )
-            if dynamic_playlist is None:
-                dynamic_playlist = next(
-                    (
-                        item
-                        for item in reversed(queue_data.enqueued_media_items)
-                        if isinstance(item, Playlist) and item.is_dynamic
-                    ),
-                    None,
-                )
-            if dynamic_playlist is not None:
+            dynamic_source = find_dynamic_source(qdata) if qdata else None
+            if dynamic_source is not None:
                 try:
                     # Restore the queue owner's user context so provider filters and
                     # per-user logic (e.g. smart playlist dedup) are respected during
@@ -497,8 +480,8 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
                         else None
                     )
                     set_current_user(playback_user)
-                    dynamic_tracks = await self._media_resolver.get_playlist_tracks(
-                        dynamic_playlist, start_item=None
+                    dynamic_tracks = await self._media_resolver.get_dynamic_source_tracks(
+                        dynamic_source
                     )
                     if dynamic_tracks:
                         queue_items = [
@@ -527,8 +510,8 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
                                     return
                 except MusicAssistantError as err:
                     self.logger.warning(
-                        "Failed to refresh dynamic playlist %s for queue %s: %s",
-                        getattr(dynamic_playlist, "name", repr(dynamic_playlist)),
+                        "Failed to refresh dynamic source %s for queue %s: %s",
+                        getattr(dynamic_source, "name", repr(dynamic_source)),
                         queue.display_name,
                         err,
                     )

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -33,7 +33,6 @@ from music_assistant_models.media_items import (
     ItemMapping,
     MediaItemType,
     PlayableMediaItemType,
-    Playlist,
     PodcastEpisode,
     Track,
     UniqueList,
@@ -56,6 +55,7 @@ from music_assistant.controllers.player_queues.helpers import (
     build_queue_item,
     handle_play_action,
     has_dynamic_source,
+    is_dynamic_source,
 )
 from music_assistant.controllers.player_queues.managed_pool import gate_tracks
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
@@ -755,16 +755,15 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                 # their successor from the queue's last item instead).
                 # Use FIFO list to keep track of the last 10 played items
                 # Skip ItemMapping and BrowseFolder - only queue full MediaItemType objects
-                if not isinstance(media_item, BrowseFolder) and media_item.media_type in (
-                    MediaType.TRACK,
-                    MediaType.ALBUM,
-                    MediaType.PLAYLIST,
-                    MediaType.ARTIST,
+                if not isinstance(media_item, BrowseFolder) and (
+                    is_dynamic_source(media_item)
+                    or media_item.media_type
+                    in (MediaType.TRACK, MediaType.ALBUM, MediaType.PLAYLIST, MediaType.ARTIST)
                 ):
                     queue_data.enqueued_media_items.append(media_item)
                     if len(queue_data.enqueued_media_items) > 10:
                         queue_data.enqueued_media_items.pop(0)
-                    if isinstance(media_item, Playlist) and media_item.is_dynamic:
+                    if is_dynamic_source(media_item):
                         # a dynamic playlist/station is always a self-managing dynamic source
                         source_items.append(media_item)
 
@@ -783,7 +782,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                         self.clear(queue_id, skip_stop=True)
 
                 # collect media_items to play
-                if isinstance(media_item, Playlist) and media_item.is_dynamic:
+                if is_dynamic_source(media_item):
                     # a dynamic playlist/station supplies its own tracks on demand; just mark it
                     # played. The queue goes dynamic below and the bounded pool seeds its batch from
                     # all sources, so there is no need to fetch a batch here.

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -290,6 +290,9 @@ def compare_radio(
     # return early on exact item_id match
     if compare_item_ids(base_item, compare_item):
         return True
+    # a dynamic station is its provider's own, so a same-named station is a different one
+    if _is_dynamic_radio(base_item) or _is_dynamic_radio(compare_item):
+        return False
     # compare version
     if not compare_version(base_item.version, compare_item.version):
         return False
@@ -621,3 +624,8 @@ def compare_explicit(base: MediaItemMetadata, compare: MediaItemMetadata) -> boo
         # only strict compare them if both have the info set
         return base.explicit == compare.explicit
     return None
+
+
+def _is_dynamic_radio(item: Radio | ItemMapping) -> bool:
+    """Return True if the item is a dynamic radio station."""
+    return isinstance(item, Radio) and item.is_dynamic

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -265,6 +265,17 @@ class MusicProvider(Provider):
         """Get all playlist tracks for given playlist id."""
         raise NotImplementedError
 
+    async def get_dynamic_radio_tracks(self, prov_radio_id: str) -> list[Track]:
+        """
+        Return a fresh batch of tracks for a dynamic radio station.
+
+        Only called for a Radio with `is_dynamic` set. Every call returns a new batch;
+        there is no stable listing and no pagination.
+
+        :param prov_radio_id: The provider's ID of the radio station.
+        """
+        raise NotImplementedError
+
     async def get_podcast_episodes(
         self,
         prov_podcast_id: str,
@@ -1474,6 +1485,17 @@ class MusicProvider(Provider):
                     elif self._library_item_needs_update(library_item, prov_item):
                         library_item = await self.mass.music.radio.update_item_in_library(
                             library_item.item_id, prov_item
+                        )
+                    elif prov_item.is_dynamic and (
+                        prov_item.name != library_item.name
+                        or prov_item.metadata.images != library_item.metadata.images
+                    ):
+                        # the provider is the sole source of truth for a dynamic station's name
+                        # and artwork (e.g. a renamed/re-arted Pandora station): overwrite=True
+                        # replaces the full stored record, which is fine here since there's no
+                        # local customization on a station to lose.
+                        library_item = await self.mass.music.radio.update_item_in_library(
+                            library_item.item_id, prov_item, overwrite=True
                         )
                     if not library_item.favorite and prov_item.favorite:
                         # existing library item not favorite but should be

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -1482,13 +1482,10 @@ class MusicProvider(Provider):
                         for prov_map in prov_item.provider_mappings:
                             prov_map.in_library = True
                         library_item = await self.mass.music.radio.add_item_to_library(prov_item)
-                    elif self._library_item_needs_update(library_item, prov_item):
-                        library_item = await self.mass.music.radio.update_item_in_library(
-                            library_item.item_id, prov_item
-                        )
-                    elif prov_item.is_dynamic != library_item.is_dynamic:
-                        # the station switched between a live stream and a dynamic feed, which
-                        # decides how the queue plays it
+                    elif (
+                        self._library_item_needs_update(library_item, prov_item)
+                        or prov_item.is_dynamic != library_item.is_dynamic
+                    ):
                         library_item = await self.mass.music.radio.update_item_in_library(
                             library_item.item_id, prov_item
                         )
@@ -1496,10 +1493,7 @@ class MusicProvider(Provider):
                         prov_item.name != library_item.name
                         or prov_item.metadata.images != library_item.metadata.images
                     ):
-                        # the provider is the sole source of truth for a dynamic station's name
-                        # and artwork (e.g. a renamed/re-arted Pandora station): overwrite=True
-                        # replaces the full stored record, which is fine here since there's no
-                        # local customization on a station to lose.
+                        # overwrite is safe: a station carries no local customization to lose
                         library_item = await self.mass.music.radio.update_item_in_library(
                             library_item.item_id, prov_item, overwrite=True
                         )

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -1486,6 +1486,12 @@ class MusicProvider(Provider):
                         library_item = await self.mass.music.radio.update_item_in_library(
                             library_item.item_id, prov_item
                         )
+                    elif prov_item.is_dynamic != library_item.is_dynamic:
+                        # the station switched between a live stream and a dynamic feed, which
+                        # decides how the queue plays it
+                        library_item = await self.mass.music.radio.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
                     elif prov_item.is_dynamic and (
                         prov_item.name != library_item.name
                         or prov_item.metadata.images != library_item.metadata.images

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -1482,18 +1482,21 @@ class MusicProvider(Provider):
                         for prov_map in prov_item.provider_mappings:
                             prov_map.in_library = True
                         library_item = await self.mass.music.radio.add_item_to_library(prov_item)
-                    elif prov_item.is_dynamic != library_item.is_dynamic or (
-                        prov_item.is_dynamic
-                        and (
-                            prov_item.name != library_item.name
-                            or prov_item.metadata.images != library_item.metadata.images
-                        )
+                    elif prov_item.is_dynamic and (
+                        not library_item.is_dynamic
+                        or prov_item.name != library_item.name
+                        or prov_item.metadata.images != library_item.metadata.images
                     ):
-                        # overwrite drops name-matched mappings that would serve the wrong tracks
+                        # must overwrite: merging keeps mappings that serve the wrong tracks
+                        for prov_map in prov_item.provider_mappings:
+                            prov_map.in_library = True  # overwrite re-inserts the rows
                         library_item = await self.mass.music.radio.update_item_in_library(
                             library_item.item_id, prov_item, overwrite=True
                         )
-                    elif self._library_item_needs_update(library_item, prov_item):
+                    elif self._library_item_needs_update(library_item, prov_item) or (
+                        library_item.is_dynamic and not prov_item.is_dynamic
+                    ):
+                        # a station leaving dynamic mode is no longer provider-owned, so merge
                         library_item = await self.mass.music.radio.update_item_in_library(
                             library_item.item_id, prov_item
                         )

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -1482,20 +1482,20 @@ class MusicProvider(Provider):
                         for prov_map in prov_item.provider_mappings:
                             prov_map.in_library = True
                         library_item = await self.mass.music.radio.add_item_to_library(prov_item)
-                    elif (
-                        self._library_item_needs_update(library_item, prov_item)
-                        or prov_item.is_dynamic != library_item.is_dynamic
-                    ):
-                        library_item = await self.mass.music.radio.update_item_in_library(
-                            library_item.item_id, prov_item
+                    elif prov_item.is_dynamic != library_item.is_dynamic or (
+                        prov_item.is_dynamic
+                        and (
+                            prov_item.name != library_item.name
+                            or prov_item.metadata.images != library_item.metadata.images
                         )
-                    elif prov_item.is_dynamic and (
-                        prov_item.name != library_item.name
-                        or prov_item.metadata.images != library_item.metadata.images
                     ):
-                        # overwrite is safe: a station carries no local customization to lose
+                        # overwrite drops name-matched mappings that would serve the wrong tracks
                         library_item = await self.mass.music.radio.update_item_in_library(
                             library_item.item_id, prov_item, overwrite=True
+                        )
+                    elif self._library_item_needs_update(library_item, prov_item):
+                        library_item = await self.mass.music.radio.update_item_in_library(
+                            library_item.item_id, prov_item
                         )
                     if not library_item.favorite and prov_item.favorite:
                         # existing library item not favorite but should be

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "ifaddr==0.2.0",
   "getmac==0.9.5",
   "mashumaro==3.20",
-  "music-assistant-models==1.1.187",
+  "music-assistant-models==1.1.188",
   "music-assistant-frontend==2.17.270",
   "mutagen==1.48.1",
   "orjson==3.11.6",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -51,7 +51,7 @@ markdownify==1.2.3
 mashumaro==3.20
 modern_colorthief==0.2.1
 music-assistant-frontend==2.17.270
-music-assistant-models==1.1.187
+music-assistant-models==1.1.188
 mutagen==1.48.1
 niconico.py-ma==2.1.0.post2
 nnAudio==0.3.4

--- a/tests/controllers/music/test_music_migrations.py
+++ b/tests/controllers/music/test_music_migrations.py
@@ -525,3 +525,20 @@ async def test_migration_adds_columns_leapfrogged_by_the_stable_schema_version(
 
     assert {"translation_key", "translation_params"} <= await _table_columns(database, "playlists")
     assert "playback_speed" in await _table_columns(database, DB_TABLE_PLAYLOG)
+
+
+async def test_migration_adds_is_dynamic_column_to_radios(database: DatabaseConnection) -> None:
+    """A pre-58 database gets the radios.is_dynamic column, mirroring the playlist one."""
+    assert "is_dynamic" not in await _table_columns(database, "radios")
+
+    mass = MagicMock()
+    mass.cache.clear = AsyncMock()
+    await migrate_database(
+        mass,
+        database,
+        MagicMock(),
+        prev_version=57,
+        create_tables=AsyncMock(),
+    )
+
+    assert "is_dynamic" in await _table_columns(database, "radios")

--- a/tests/controllers/music/test_radio_dynamic.py
+++ b/tests/controllers/music/test_radio_dynamic.py
@@ -321,6 +321,20 @@ class TestSyncLibraryRadiosDynamicFlag:
         assert library_item is not None
         assert library_item.is_dynamic is True
 
+    async def test_switching_to_dynamic_keeps_the_station_listed(
+        self, radio_mass: MusicAssistant, radio_ctrl: RadioController
+    ) -> None:
+        """A station that becomes dynamic stays in the library listing."""
+        provider = cast("FakeDynamicRadioProvider", radio_mass.get_provider(FAKE_INSTANCE))
+        provider.toggle_station_is_dynamic = False
+        await provider._sync_library_radios()
+        assert "Toggle Station" in [item.name for item in await radio_ctrl.library_items()]
+
+        provider.toggle_station_is_dynamic = True
+        await provider._sync_library_radios()
+
+        assert "Toggle Station" in [item.name for item in await radio_ctrl.library_items()]
+
     async def test_switching_to_dynamic_drops_name_matched_mappings(
         self, radio_mass: MusicAssistant, radio_ctrl: RadioController
     ) -> None:

--- a/tests/controllers/music/test_radio_dynamic.py
+++ b/tests/controllers/music/test_radio_dynamic.py
@@ -29,13 +29,33 @@ FAKE_DOMAIN = "fake_dynamic_radio"
 FAKE_INSTANCE = "fake_dynamic_radio--instance"
 DYNAMIC_STATION_ID = "dynamic-1"
 STATIC_STATION_ID = "static-1"
+TOGGLE_STATION_ID = "toggle-1"
 
 
 class FakeDynamicRadioProvider(MusicProvider):
     """Streaming-style provider owning one dynamic and one static radio station."""
 
+    # controls the is_dynamic value get_library_radios reports for TOGGLE_STATION_ID
+    toggle_station_is_dynamic: bool = False
+
     async def sync_library(self, media_type: MediaType) -> None:
         """No-op sync implementation for tests."""
+
+    async def get_library_radios(self) -> AsyncGenerator[Radio]:
+        """Yield the single toggle station, honoring the current is_dynamic flag."""
+        yield Radio(
+            item_id=TOGGLE_STATION_ID,
+            provider=self.instance_id,
+            name="Toggle Station",
+            is_dynamic=self.toggle_station_is_dynamic,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=TOGGLE_STATION_ID,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                )
+            },
+        )
 
     async def get_radio(self, prov_radio_id: str) -> Radio:
         """Return the requested fake station."""
@@ -203,3 +223,49 @@ class TestMatchProvidersDynamicGuard:
         monkeypatch.setattr(type(radio_mass.music), "providers", property(_track_access))
         await radio_ctrl.match_providers(static_radio)
         assert accessed is True
+
+
+class TestSyncLibraryRadiosDynamicFlag:
+    """Tests for the is_dynamic branch of MusicProvider._sync_library_radios."""
+
+    @staticmethod
+    def _toggle_mapping() -> ProviderMapping:
+        return ProviderMapping(
+            item_id=TOGGLE_STATION_ID,
+            provider_domain=FAKE_DOMAIN,
+            provider_instance=FAKE_INSTANCE,
+        )
+
+    async def test_switching_to_dynamic_updates_library_item(
+        self, radio_mass: MusicAssistant, radio_ctrl: RadioController
+    ) -> None:
+        """A provider reporting the same station as dynamic updates the stored flag."""
+        provider = cast("FakeDynamicRadioProvider", radio_mass.get_provider(FAKE_INSTANCE))
+        provider.toggle_station_is_dynamic = False
+        await provider._sync_library_radios()
+        library_item = await radio_ctrl.get_library_item_by_prov_mappings([self._toggle_mapping()])
+        assert library_item is not None
+        assert library_item.is_dynamic is False
+
+        provider.toggle_station_is_dynamic = True
+        await provider._sync_library_radios()
+        library_item = await radio_ctrl.get_library_item_by_prov_mappings([self._toggle_mapping()])
+        assert library_item is not None
+        assert library_item.is_dynamic is True
+
+    async def test_switching_to_non_dynamic_updates_library_item(
+        self, radio_mass: MusicAssistant, radio_ctrl: RadioController
+    ) -> None:
+        """A provider reporting the same station as no longer dynamic updates the stored flag."""
+        provider = cast("FakeDynamicRadioProvider", radio_mass.get_provider(FAKE_INSTANCE))
+        provider.toggle_station_is_dynamic = True
+        await provider._sync_library_radios()
+        library_item = await radio_ctrl.get_library_item_by_prov_mappings([self._toggle_mapping()])
+        assert library_item is not None
+        assert library_item.is_dynamic is True
+
+        provider.toggle_station_is_dynamic = False
+        await provider._sync_library_radios()
+        library_item = await radio_ctrl.get_library_item_by_prov_mappings([self._toggle_mapping()])
+        assert library_item is not None
+        assert library_item.is_dynamic is False

--- a/tests/controllers/music/test_radio_dynamic.py
+++ b/tests/controllers/music/test_radio_dynamic.py
@@ -98,8 +98,23 @@ class FakeDynamicRadioProvider(MusicProvider):
     async def search(
         self, search_query: str, media_types: list[MediaType], limit: int = 5
     ) -> SearchResults:
-        """Return no results; matching is not exercised through this provider."""
-        return SearchResults()
+        """Return a same-named station, so a name-only match would find something to report."""
+        return SearchResults(
+            radio=[
+                Radio(
+                    item_id="same-name-elsewhere",
+                    provider=self.instance_id,
+                    name=search_query,
+                    provider_mappings={
+                        ProviderMapping(
+                            item_id="same-name-elsewhere",
+                            provider_domain=self.domain,
+                            provider_instance=self.instance_id,
+                        )
+                    },
+                )
+            ]
+        )
 
 
 @pytest.fixture(name="radio_mass")
@@ -204,6 +219,14 @@ class TestAddToLibraryDynamicGuard:
         assert {mapping.provider_domain for mapping in dynamic_item.provider_mappings} == {
             FAKE_DOMAIN
         }
+
+
+class TestVersionsDynamicGuard:
+    """Tests for the dynamic-station guard on RadioController.versions."""
+
+    async def test_dynamic_station_has_no_other_versions(self, radio_ctrl: RadioController) -> None:
+        """A dynamic station reports no other versions, and searches nothing to find that out."""
+        assert await radio_ctrl.versions(DYNAMIC_STATION_ID, FAKE_INSTANCE) == []
 
 
 class TestMatchProvidersDynamicGuard:

--- a/tests/controllers/music/test_radio_dynamic.py
+++ b/tests/controllers/music/test_radio_dynamic.py
@@ -1,0 +1,205 @@
+"""
+Integration tests for dynamic radio stations on the RadioController.
+
+Uses a fully booted MusicAssistant instance (mirrors test_radio_export_import.py) with a
+small fake music provider that owns one dynamic and one non-dynamic radio station, to
+verify the guards and track-feed wiring introduced for dynamic radio stations (mirrors
+the existing dynamic-playlist wiring on PlaylistController/media_resolver).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from music_assistant_models.config_entries import ProviderConfig
+from music_assistant_models.enums import MediaType, ProviderFeature, ProviderType
+from music_assistant_models.errors import UnsupportedFeaturedException
+from music_assistant_models.media_items import ProviderMapping, Radio, SearchResults, Track
+from music_assistant_models.provider import ProviderManifest
+
+from music_assistant.controllers.music.media.radio import RadioController
+from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+FAKE_DOMAIN = "fake_dynamic_radio"
+FAKE_INSTANCE = "fake_dynamic_radio--instance"
+DYNAMIC_STATION_ID = "dynamic-1"
+STATIC_STATION_ID = "static-1"
+
+
+class FakeDynamicRadioProvider(MusicProvider):
+    """Streaming-style provider owning one dynamic and one static radio station."""
+
+    async def sync_library(self, media_type: MediaType) -> None:
+        """No-op sync implementation for tests."""
+
+    async def get_radio(self, prov_radio_id: str) -> Radio:
+        """Return the requested fake station."""
+        is_dynamic = prov_radio_id == DYNAMIC_STATION_ID
+        return Radio(
+            item_id=prov_radio_id,
+            provider=self.instance_id,
+            name="Dynamic Station" if is_dynamic else "Static Station",
+            is_dynamic=is_dynamic,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=prov_radio_id,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                )
+            },
+        )
+
+    async def get_dynamic_radio_tracks(self, prov_radio_id: str) -> list[Track]:
+        """Return a fixed batch of fake tracks for the dynamic station."""
+        return [
+            Track(
+                item_id=f"{prov_radio_id}-t{i}",
+                provider=self.instance_id,
+                name=f"Track {i}",
+                provider_mappings={
+                    ProviderMapping(
+                        item_id=f"{prov_radio_id}-t{i}",
+                        provider_domain=self.domain,
+                        provider_instance=self.instance_id,
+                    )
+                },
+            )
+            for i in range(3)
+        ]
+
+    async def search(
+        self, search_query: str, media_types: list[MediaType], limit: int = 5
+    ) -> SearchResults:
+        """Return no results; matching is not exercised through this provider."""
+        return SearchResults()
+
+
+@pytest.fixture(name="radio_mass")
+async def radio_mass_fixture(mass: MusicAssistant) -> AsyncGenerator[MusicAssistant]:
+    """Return a booted instance with the fake dynamic-radio provider registered."""
+    config = ProviderConfig(
+        values={},
+        type=ProviderType.MUSIC,
+        domain=FAKE_DOMAIN,
+        instance_id=FAKE_INSTANCE,
+        name="Fake Dynamic Radio",
+    )
+    provider = FakeDynamicRadioProvider(
+        mass,
+        manifest=ProviderManifest(
+            type=ProviderType.MUSIC,
+            domain=FAKE_DOMAIN,
+            name="Fake Dynamic Radio",
+            description="Fake dynamic radio provider",
+            codeowners=["@music-assistant"],
+        ),
+        config=config,
+        supported_features={ProviderFeature.LIBRARY_RADIOS, ProviderFeature.SEARCH},
+    )
+    provider.available = True
+    mass._providers[FAKE_INSTANCE] = provider
+    try:
+        yield mass
+    finally:
+        mass._providers.pop(FAKE_INSTANCE, None)
+
+
+@pytest.fixture(name="radio_ctrl")
+def radio_ctrl_fixture(radio_mass: MusicAssistant) -> RadioController:
+    """Get the radio controller from the booted Music Assistant instance."""
+    return radio_mass.music.radio
+
+
+class TestRadioTracks:
+    """Tests for RadioController.radio_tracks."""
+
+    async def test_raises_for_non_dynamic_station(self, radio_ctrl: RadioController) -> None:
+        """A non-dynamic (live-stream) station has no track feed."""
+        with pytest.raises(UnsupportedFeaturedException):
+            await radio_ctrl.radio_tracks(STATIC_STATION_ID, FAKE_INSTANCE)
+
+    async def test_returns_provider_tracks_for_provider_item(
+        self, radio_ctrl: RadioController
+    ) -> None:
+        """A dynamic station's tracks are fetched straight from its provider."""
+        tracks = await radio_ctrl.radio_tracks(DYNAMIC_STATION_ID, FAKE_INSTANCE)
+        assert [track.name for track in tracks] == ["Track 0", "Track 1", "Track 2"]
+
+    async def test_returns_provider_tracks_for_library_item(
+        self, radio_mass: MusicAssistant, radio_ctrl: RadioController
+    ) -> None:
+        """A library-resolved dynamic station still fetches its tracks from its own provider."""
+        provider = cast("MusicProvider", radio_mass.get_provider(FAKE_INSTANCE))
+        station = await provider.get_radio(DYNAMIC_STATION_ID)
+        library_item = await radio_ctrl.add_item_to_library(station)
+        tracks = await radio_ctrl.radio_tracks(str(library_item.item_id), "library")
+        assert len(tracks) == 3
+
+
+class TestMatchProvidersDynamicGuard:
+    """Tests for the dynamic-station guard on RadioController.match_providers."""
+
+    async def test_dynamic_station_returns_before_searching(
+        self,
+        radio_mass: MusicAssistant,
+        radio_ctrl: RadioController,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A dynamic station returns immediately, without inspecting any other provider."""
+        dynamic_radio = Radio(
+            item_id="1",
+            provider="library",
+            name="Dynamic",
+            is_dynamic=True,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=DYNAMIC_STATION_ID,
+                    provider_domain=FAKE_DOMAIN,
+                    provider_instance=FAKE_INSTANCE,
+                )
+            },
+        )
+
+        def _boom(_self: object) -> list[MusicProvider]:
+            raise AssertionError("must not access other providers for a dynamic station")
+
+        monkeypatch.setattr(type(radio_mass.music), "providers", property(_boom))
+        # must not raise: the guard returns before the (patched-to-explode) providers property
+        await radio_ctrl.match_providers(dynamic_radio)
+
+    async def test_non_dynamic_station_still_searches(
+        self,
+        radio_mass: MusicAssistant,
+        radio_ctrl: RadioController,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A non-dynamic station is unaffected by the guard and still triggers matching."""
+        static_radio = Radio(
+            item_id="2",
+            provider="library",
+            name="Static",
+            is_dynamic=False,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=STATIC_STATION_ID,
+                    provider_domain=FAKE_DOMAIN,
+                    provider_instance=FAKE_INSTANCE,
+                )
+            },
+        )
+        accessed = False
+        real_providers = list(radio_mass.music.providers)
+
+        def _track_access(_self: object) -> list[MusicProvider]:
+            nonlocal accessed
+            accessed = True
+            return real_providers
+
+        monkeypatch.setattr(type(radio_mass.music), "providers", property(_track_access))
+        await radio_ctrl.match_providers(static_radio)
+        assert accessed is True

--- a/tests/controllers/music/test_radio_dynamic.py
+++ b/tests/controllers/music/test_radio_dynamic.py
@@ -9,6 +9,7 @@ the existing dynamic-playlist wiring on PlaylistController/media_resolver).
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, cast
 
 import pytest
@@ -37,6 +38,7 @@ class FakeDynamicRadioProvider(MusicProvider):
 
     # controls the is_dynamic value get_library_radios reports for TOGGLE_STATION_ID
     toggle_station_is_dynamic: bool = False
+    toggle_station_date_added: datetime | None = None
 
     async def sync_library(self, media_type: MediaType) -> None:
         """No-op sync implementation for tests."""
@@ -48,6 +50,7 @@ class FakeDynamicRadioProvider(MusicProvider):
             provider=self.instance_id,
             name="Toggle Station",
             is_dynamic=self.toggle_station_is_dynamic,
+            date_added=self.toggle_station_date_added,
             provider_mappings={
                 ProviderMapping(
                     item_id=TOGGLE_STATION_ID,
@@ -252,6 +255,69 @@ class TestSyncLibraryRadiosDynamicFlag:
         library_item = await radio_ctrl.get_library_item_by_prov_mappings([self._toggle_mapping()])
         assert library_item is not None
         assert library_item.is_dynamic is True
+
+    async def test_switching_to_dynamic_drops_name_matched_mappings(
+        self, radio_mass: MusicAssistant, radio_ctrl: RadioController
+    ) -> None:
+        """Only the owning provider is left to serve a station's tracks once it becomes dynamic."""
+        provider = cast("FakeDynamicRadioProvider", radio_mass.get_provider(FAKE_INSTANCE))
+        provider.toggle_station_is_dynamic = False
+        await provider._sync_library_radios()
+        library_item = await radio_ctrl.get_library_item_by_prov_mappings([self._toggle_mapping()])
+        assert library_item is not None
+        # a same-named station on another provider, as cross-provider matching would have added
+        await radio_ctrl.add_provider_mappings(
+            library_item.item_id,
+            [
+                ProviderMapping(
+                    item_id="unrelated-stream",
+                    provider_domain="some_radio_directory",
+                    provider_instance="some_radio_directory--instance",
+                )
+            ],
+        )
+
+        provider.toggle_station_is_dynamic = True
+        await provider._sync_library_radios()
+
+        library_item = await radio_ctrl.get_library_item_by_prov_mappings([self._toggle_mapping()])
+        assert library_item is not None
+        assert {mapping.provider_domain for mapping in library_item.provider_mappings} == {
+            FAKE_DOMAIN
+        }
+
+    async def test_dynamic_switch_wins_over_a_coinciding_generic_update(
+        self, radio_mass: MusicAssistant, radio_ctrl: RadioController
+    ) -> None:
+        """A station going dynamic is overwritten even when the same sync has a generic update."""
+        provider = cast("FakeDynamicRadioProvider", radio_mass.get_provider(FAKE_INSTANCE))
+        provider.toggle_station_is_dynamic = False
+        provider.toggle_station_date_added = datetime(2026, 1, 1, tzinfo=UTC)
+        await provider._sync_library_radios()
+        library_item = await radio_ctrl.get_library_item_by_prov_mappings([self._toggle_mapping()])
+        assert library_item is not None
+        await radio_ctrl.add_provider_mappings(
+            library_item.item_id,
+            [
+                ProviderMapping(
+                    item_id="unrelated-stream",
+                    provider_domain="some_radio_directory",
+                    provider_instance="some_radio_directory--instance",
+                )
+            ],
+        )
+
+        # a changed date_added makes _library_item_needs_update true alongside the dynamic switch
+        provider.toggle_station_is_dynamic = True
+        provider.toggle_station_date_added = datetime(2026, 6, 1, tzinfo=UTC)
+        await provider._sync_library_radios()
+
+        library_item = await radio_ctrl.get_library_item_by_prov_mappings([self._toggle_mapping()])
+        assert library_item is not None
+        assert library_item.is_dynamic is True
+        assert {mapping.provider_domain for mapping in library_item.provider_mappings} == {
+            FAKE_DOMAIN
+        }
 
     async def test_switching_to_non_dynamic_updates_library_item(
         self, radio_mass: MusicAssistant, radio_ctrl: RadioController

--- a/tests/controllers/music/test_radio_dynamic.py
+++ b/tests/controllers/music/test_radio_dynamic.py
@@ -164,6 +164,48 @@ class TestRadioTracks:
         assert len(tracks) == 3
 
 
+class TestAddToLibraryDynamicGuard:
+    """Tests that adding a dynamic station never folds it into an existing station."""
+
+    async def test_same_named_live_station_is_left_alone(
+        self, radio_mass: MusicAssistant, radio_ctrl: RadioController
+    ) -> None:
+        """A dynamic station gets its own library item instead of joining a same-named stream."""
+        live_station = Radio(
+            item_id="live-1",
+            provider="some_radio_directory--instance",
+            name="Chill Vibes",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="live-1",
+                    provider_domain="some_radio_directory",
+                    provider_instance="some_radio_directory--instance",
+                )
+            },
+        )
+        live_item = await radio_ctrl.add_item_to_library(live_station)
+        station = Radio(
+            item_id=DYNAMIC_STATION_ID,
+            provider=FAKE_INSTANCE,
+            name="Chill Vibes",
+            is_dynamic=True,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=DYNAMIC_STATION_ID,
+                    provider_domain=FAKE_DOMAIN,
+                    provider_instance=FAKE_INSTANCE,
+                )
+            },
+        )
+
+        dynamic_item = await radio_ctrl.add_item_to_library(station)
+
+        assert dynamic_item.item_id != live_item.item_id
+        assert {mapping.provider_domain for mapping in dynamic_item.provider_mappings} == {
+            FAKE_DOMAIN
+        }
+
+
 class TestMatchProvidersDynamicGuard:
     """Tests for the dynamic-station guard on RadioController.match_providers."""
 

--- a/tests/controllers/player_queues/test_enqueue_options.py
+++ b/tests/controllers/player_queues/test_enqueue_options.py
@@ -83,12 +83,13 @@ def _podcast(item_id: str) -> Podcast:
     )
 
 
-def _radio(item_id: str) -> Radio:
+def _radio(item_id: str, *, is_dynamic: bool = False) -> Radio:
     """Build a Radio on the 'test' provider (an individual item, omitted from the wire `sources`)."""
     return Radio(
         item_id=item_id,
         provider="test",
         name=f"Radio {item_id}",
+        is_dynamic=is_dynamic,
         provider_mappings={
             ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
         },
@@ -430,6 +431,20 @@ def test_store_sources_keeps_only_container_types_on_wire() -> None:
     assert ctrl._queue_data["q1"].source_items == items
     # but only the container sources are shown to clients, in original order
     assert [mapping.uri for mapping in queue.sources] == [album.uri, podcast.uri]
+
+
+def test_store_sources_keeps_a_dynamic_station_on_wire() -> None:
+    """A dynamic station is a source the queue plays from, so clients get to show it."""
+    ctrl = _controller()
+    ctrl._managed_pool = Mock()
+    queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+    station = _radio("dyn", is_dynamic=True)
+    live_stream = _radio("live")
+
+    ctrl.store_sources(queue, [station, live_stream])
+
+    assert [mapping.uri for mapping in queue.sources] == [station.uri]
 
 
 def _shuffled_queue(ctrl: PlayerQueuesController) -> PlayerQueue:

--- a/tests/controllers/player_queues/test_player_queues_helpers.py
+++ b/tests/controllers/player_queues/test_player_queues_helpers.py
@@ -25,6 +25,7 @@ from music_assistant_models.unique_list import UniqueList
 from music_assistant.constants import ATTR_PLAY_ACTION_IN_PROGRESS
 from music_assistant.controllers.player_queues.helpers import (
     build_queue_item,
+    find_dynamic_source,
     get_current_playback_speed,
     handle_play_action,
     has_dynamic_source,
@@ -88,6 +89,17 @@ def _queue() -> PlayerQueue:
     return PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
 
 
+def _queue_data(
+    *,
+    source_items: list[MediaItemType] | None = None,
+    enqueued_media_items: list[MediaItemType] | None = None,
+) -> PlayerQueueData:
+    queue_data = PlayerQueueData(queue=_queue())
+    queue_data.source_items = source_items or []
+    queue_data.enqueued_media_items = enqueued_media_items or []
+    return queue_data
+
+
 class TestHasDynamicSource:
     """Tests for has_dynamic_source."""
 
@@ -143,6 +155,42 @@ class TestIsDynamicSource:
     def test_track(self) -> None:
         """A track is never a dynamic source."""
         assert is_dynamic_source(_track("Song")) is False
+
+
+class TestFindDynamicSource:
+    """Tests for find_dynamic_source."""
+
+    def test_dynamic_radio_source(self) -> None:
+        """A dynamic radio station is found, so an idle queue can refill from it."""
+        station = _radio(is_dynamic=True)
+        queue_data = _queue_data(source_items=[station])
+        assert find_dynamic_source(queue_data) is station
+
+    def test_dynamic_playlist_source(self) -> None:
+        """A dynamic playlist is found the same way."""
+        playlist = _playlist(is_dynamic=True)
+        queue_data = _queue_data(source_items=[playlist])
+        assert find_dynamic_source(queue_data) is playlist
+
+    def test_prefers_the_last_added_source(self) -> None:
+        """The most recently added dynamic source wins."""
+        first = _playlist(is_dynamic=True, name="A")
+        last = _radio(is_dynamic=True, name="B")
+        queue_data = _queue_data(source_items=[first, _track("Song"), last])
+        assert find_dynamic_source(queue_data) is last
+
+    def test_falls_back_to_enqueued_items(self) -> None:
+        """A queue without dynamic sources falls back to what was enqueued on it."""
+        station = _radio(is_dynamic=True)
+        queue_data = _queue_data(source_items=[_track("Song")], enqueued_media_items=[station])
+        assert find_dynamic_source(queue_data) is station
+
+    def test_no_dynamic_source(self) -> None:
+        """A queue of finite items has nothing to refill from."""
+        queue_data = _queue_data(
+            source_items=[_playlist(is_dynamic=False)], enqueued_media_items=[_track("Song")]
+        )
+        assert find_dynamic_source(queue_data) is None
 
 
 class TestGetCurrentPlaybackSpeed:

--- a/tests/controllers/player_queues/test_player_queues_helpers.py
+++ b/tests/controllers/player_queues/test_player_queues_helpers.py
@@ -28,6 +28,7 @@ from music_assistant.controllers.player_queues.helpers import (
     get_current_playback_speed,
     handle_play_action,
     has_dynamic_source,
+    is_dynamic_source,
     space_by_artist,
 )
 from music_assistant.controllers.player_queues.state import PlayerQueueData
@@ -44,6 +45,16 @@ _PROVIDER_MAPPINGS = {
 
 def _playlist(*, is_dynamic: bool, name: str = "PL") -> Playlist:
     return Playlist(
+        item_id=name.lower(),
+        provider="test",
+        name=name,
+        provider_mappings=_PROVIDER_MAPPINGS,
+        is_dynamic=is_dynamic,
+    )
+
+
+def _radio(*, is_dynamic: bool, name: str = "R") -> Radio:
+    return Radio(
         item_id=name.lower(),
         provider="test",
         name=name,
@@ -108,6 +119,30 @@ class TestHasDynamicSource:
     def test_non_playlist_item(self) -> None:
         """A non-playlist media item is not a dynamic source."""
         assert has_dynamic_source([_track("Song")]) is False
+
+
+class TestIsDynamicSource:
+    """Tests for is_dynamic_source."""
+
+    def test_dynamic_playlist(self) -> None:
+        """A dynamic playlist supplies its own on-demand feed."""
+        assert is_dynamic_source(_playlist(is_dynamic=True)) is True
+
+    def test_non_dynamic_playlist(self) -> None:
+        """A non-dynamic playlist is not a dynamic source."""
+        assert is_dynamic_source(_playlist(is_dynamic=False)) is False
+
+    def test_dynamic_radio(self) -> None:
+        """A dynamic radio station supplies its own on-demand feed."""
+        assert is_dynamic_source(_radio(is_dynamic=True)) is True
+
+    def test_non_dynamic_radio(self) -> None:
+        """A non-dynamic (live-stream) radio is not a dynamic source."""
+        assert is_dynamic_source(_radio(is_dynamic=False)) is False
+
+    def test_track(self) -> None:
+        """A track is never a dynamic source."""
+        assert is_dynamic_source(_track("Song")) is False
 
 
 class TestGetCurrentPlaybackSpeed:

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -398,7 +398,9 @@ def test_compare_strings_case_insensitive_fuzzy() -> None:
 def test_compare_radio() -> None:
     """Test the radio compare helper."""
 
-    def _radio(item_id: str, provider: str, name: str, *, is_dynamic: bool = False):
+    def _radio(
+        item_id: str, provider: str, name: str, *, is_dynamic: bool = False
+    ) -> media_items.Radio:
         return media_items.Radio(
             item_id=item_id,
             provider=provider,

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -393,3 +393,33 @@ def test_compare_strings_case_insensitive_fuzzy() -> None:
     # These differ slightly ("Feat." vs "FT.") so create_safe_string won't match,
     # falling through to SequenceMatcher which must compare both strings lowered.
     assert compare.compare_strings("Track Feat. John", "TRACK FT. JOHN", strict=False) is True
+
+
+def test_compare_radio() -> None:
+    """Test the radio compare helper."""
+
+    def _radio(item_id: str, provider: str, name: str, *, is_dynamic: bool = False):
+        return media_items.Radio(
+            item_id=item_id,
+            provider=provider,
+            name=name,
+            is_dynamic=is_dynamic,
+            provider_mappings={
+                media_items.ProviderMapping(
+                    item_id=item_id, provider_domain=provider, provider_instance=provider
+                )
+            },
+        )
+
+    live_a = _radio("a", "tunein", "Chill Vibes")
+    live_b = _radio("b", "radiobrowser", "Chill Vibes")
+    # a live station is matched across providers on its name
+    assert compare.compare_radio(live_a, live_b) is True
+
+    station = _radio("c", "pandora", "Chill Vibes", is_dynamic=True)
+    # a dynamic station only exists on its own provider, so the name is not enough
+    assert compare.compare_radio(station, live_a) is False
+    assert compare.compare_radio(live_a, station) is False
+    # ... but it is still recognised as itself
+    same = _radio("c", "pandora", "Chill Vibes", is_dynamic=True)
+    assert compare.compare_radio(station, same) is True

--- a/tests/integration/test_dynamic_radio_e2e.py
+++ b/tests/integration/test_dynamic_radio_e2e.py
@@ -1,0 +1,145 @@
+"""
+End-to-end test for enqueueing a dynamic radio station through the real queue controller.
+
+Boots the hermetic `e2e_mass` fixture (fake `test` provider + demo players) plus a small
+fake provider exposing one dynamic ("Pandora-style") station, and exercises the same
+dynamic-mode transition covered for dynamic playlists in test_dynamic_mode_e2e.py: enqueueing
+the station records it as a dynamic source, puts the queue into dynamic mode, and fills the
+managed pool from the provider's ``get_dynamic_radio_tracks``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from music_assistant_models.config_entries import ProviderConfig
+from music_assistant_models.enums import MediaType, ProviderType, QueueOption
+from music_assistant_models.media_items import ProviderMapping, Radio, Track
+from music_assistant_models.provider import ProviderManifest
+
+from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
+
+from .conftest import demo_players, wait_for
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+FAKE_RADIO_DOMAIN = "fake_dynamic_radio_e2e"
+FAKE_RADIO_INSTANCE = "fake_dynamic_radio_e2e--instance"
+DYNAMIC_STATION_ID = "station-1"
+STATION_BATCH_SIZE = 10
+
+
+class FakeDynamicRadioProvider(MusicProvider):
+    """Provider owning a single dynamic ("Pandora-style") radio station."""
+
+    async def sync_library(self, media_type: MediaType) -> None:
+        """No-op sync implementation for tests."""
+
+    async def get_radio(self, prov_radio_id: str) -> Radio:
+        """Return the fake dynamic station."""
+        return Radio(
+            item_id=prov_radio_id,
+            provider=self.instance_id,
+            name="Dynamic Station",
+            is_dynamic=True,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=prov_radio_id,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                )
+            },
+        )
+
+    async def get_dynamic_radio_tracks(self, prov_radio_id: str) -> list[Track]:
+        """Return a fixed batch of fake tracks for the dynamic station."""
+        return [
+            Track(
+                item_id=f"{prov_radio_id}-t{i}",
+                provider=self.instance_id,
+                name=f"Station Track {i}",
+                duration=60,
+                provider_mappings={
+                    ProviderMapping(
+                        item_id=f"{prov_radio_id}-t{i}",
+                        provider_domain=self.domain,
+                        provider_instance=self.instance_id,
+                    )
+                },
+            )
+            for i in range(STATION_BATCH_SIZE)
+        ]
+
+
+@pytest.fixture
+async def e2e_mass_with_dynamic_radio(
+    e2e_mass: MusicAssistant,
+) -> AsyncGenerator[MusicAssistant]:
+    """Register the fake dynamic-radio provider on top of the hermetic e2e instance."""
+    config = ProviderConfig(
+        values={},
+        type=ProviderType.MUSIC,
+        domain=FAKE_RADIO_DOMAIN,
+        instance_id=FAKE_RADIO_INSTANCE,
+        name="Fake Dynamic Radio",
+    )
+    provider = FakeDynamicRadioProvider(
+        e2e_mass,
+        manifest=ProviderManifest(
+            type=ProviderType.MUSIC,
+            domain=FAKE_RADIO_DOMAIN,
+            name="Fake Dynamic Radio",
+            description="Fake dynamic radio provider",
+            codeowners=["@music-assistant"],
+        ),
+        config=config,
+        supported_features=set(),
+    )
+    provider.available = True
+    e2e_mass._providers[FAKE_RADIO_INSTANCE] = provider
+    # the global "available providers" cache drives MediaItem.available; refresh it so the
+    # fake station's tracks are not filtered out of the managed pool as unavailable
+    await e2e_mass._update_available_providers_cache()
+    try:
+        yield e2e_mass
+    finally:
+        e2e_mass._providers.pop(FAKE_RADIO_INSTANCE, None)
+        await e2e_mass._update_available_providers_cache()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_dynamic_radio_enters_dynamic_mode(
+    e2e_mass_with_dynamic_radio: MusicAssistant,
+) -> None:
+    """Enqueueing a dynamic radio station puts the queue in dynamic mode and fills the pool."""
+    mass = e2e_mass_with_dynamic_radio
+    queue_id = demo_players(mass)[0].player_id
+    provider = cast("MusicProvider", mass.get_provider(FAKE_RADIO_INSTANCE))
+    assert provider is not None
+    station = await provider.get_radio(DYNAMIC_STATION_ID)
+
+    # ADD keeps this off the playback path (no streamdetails needed for the fake tracks),
+    # mirroring how test_dynamic_mode_e2e.py adds a dynamic playlist without starting playback.
+    await mass.player_queues.play_media(queue_id, station, option=QueueOption.ADD)
+
+    assert await wait_for(lambda: len(mass.player_queues.items(queue_id)) > 0), (
+        "dynamic radio pool never populated"
+    )
+    queue = mass.player_queues.get(queue_id)
+    assert queue is not None
+    assert queue.is_dynamic is True
+
+    data = mass.player_queues._queue_data[queue_id]
+    assert any(
+        isinstance(item, Radio) and item.is_dynamic and item.item_id == DYNAMIC_STATION_ID
+        for item in data.source_items
+    )
+
+    # the pool was filled straight from the provider's get_dynamic_radio_tracks batch
+    items = mass.player_queues.items(queue_id)
+    item_ids = {item.media_item.item_id for item in items if item.media_item}
+    assert item_ids <= {f"{DYNAMIC_STATION_ID}-t{i}" for i in range(STATION_BATCH_SIZE)}
+    assert item_ids


### PR DESCRIPTION
# What does this implement/fix?

Radio stations can now be "dynamic": instead of one live stream, the provider hands out a fresh
batch of tracks on demand and Music Assistant keeps the queue topped up. Playlists could already
do this, radio could not.

Services like Pandora and Apple Music call their content "stations", but the way it plays matches
a dynamic playlist, not radio. Until now the only way to ship such a provider was to list the
stations under Playlists, which is not where users look for them. With this, a provider can pick
the media type that matches what users expect and still get the dynamic playback behaviour.

Nothing changes for existing radio stations, and nothing changes for users until a provider starts
using the flag.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

## Changes

- A radio station can be flagged as dynamic; the queue then treats it exactly like a dynamic
  playlist, as a self-managing source that keeps refilling rather than a single queue item.
- New provider method `get_dynamic_radio_tracks` plus a `music/radios/radio_tracks` API command
  so the UI can show a sample of what a station would play.
- A single `is_dynamic_source()` check replaces the playlist-only checks that were spread across
  the queue loader and the managed pool.
- A dynamic station is no longer matched against other providers by name, which would otherwise
  link it to an unrelated internet radio stream.
- The provider now owns a dynamic station's name and artwork, so a renamed station no longer stays
  stale in the library.
- Database schema 57 -> 58 for the new `is_dynamic` column on radio stations.

## Companion PRs

- models: https://github.com/music-assistant/models/pull/360
- frontend: https://github.com/music-assistant/frontend/pull/2478

Depends on the models PR: CI stays red until `music-assistant-models` 1.1.188 is released.
