### PR TITLE
Report an expired YouTube Music cookie instead of a raw parse error

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -274,6 +274,17 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
         parsed_results.podcasts = podcasts
         return parsed_results
 
+    async def sync_library(self, media_type: MediaType) -> None:
+        """Run library sync for this provider."""
+        try:
+            await super().sync_library(media_type)
+        except LoginFailed as err:
+            # Every following sync fails the same way until the cookie is replaced,
+            # so hand the provider back to the user for re-authentication.
+            if self.available:
+                self.unload_with_error(err)
+            raise
+
     async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve all library artists from Youtube Music."""
         artists_obj = await get_library_artists(

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -35,11 +35,13 @@ async def get_artist(
             artist = ytm.get_artist(channelId=prov_artist_id)
             # ChannelId can sometimes be different and original ID is not part of the response
             artist["channelId"] = prov_artist_id
-        except KeyError:
+        except KeyError as err:
+            _raise_if_signed_out(err)
             try:
                 user = ytm.get_user(channelId=prov_artist_id)
                 artist = {"channelId": prov_artist_id, "name": user["name"]}
-            except KeyError:
+            except KeyError as err:
+                _raise_if_signed_out(err)
                 artist = {"channelId": prov_artist_id, "name": "Unknown"}
         return artist
 
@@ -424,11 +426,17 @@ async def _run_ytmusic[T](func: Callable[[], T]) -> T:
     try:
         return await asyncio.to_thread(func)
     except (KeyError, IndexError) as err:
-        # An invalid cookie makes YouTube answer with its signed-out page instead of an auth
-        # error, so nav() fails on the unexpected payload and embeds it in the message.
-        if "signInEndpoint" not in str(err):
-            raise
-        raise LoginFailed(
-            "Your YouTube Music session is no longer valid. "
-            "Please reconfigure this provider with a fresh cookie."
-        ) from err
+        _raise_if_signed_out(err)
+        raise
+
+
+def _raise_if_signed_out(err: Exception) -> None:
+    """Raise LoginFailed if the error carries YouTube's signed-out page."""
+    # An invalid cookie makes YouTube answer with its signed-out page instead of an auth
+    # error, so nav() fails on the unexpected payload and embeds it in the message.
+    if "signInEndpoint" not in str(err):
+        return
+    raise LoginFailed(
+        "Your YouTube Music session is no longer valid. "
+        "Please reconfigure this provider with a fresh cookie."
+    ) from err

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -8,11 +8,13 @@ This also nicely separates the parsing logic from the Youtube Music provider log
 """
 
 import asyncio
+from collections.abc import Callable
 from http.cookies import SimpleCookie
 from time import time
 from typing import Any, Literal
 
 import ytmusicapi
+from music_assistant_models.errors import LoginFailed
 from ytmusicapi import LikeStatus
 from ytmusicapi.exceptions import YTMusicError
 
@@ -41,7 +43,7 @@ async def get_artist(
                 artist = {"channelId": prov_artist_id, "name": "Unknown"}
         return artist
 
-    return await asyncio.to_thread(_get_artist)
+    return await _run_ytmusic(_get_artist)
 
 
 async def get_album(
@@ -77,7 +79,7 @@ async def get_album(
                     album_track["likeStatus"] = playlist_track.get("likeStatus", "INDIFFERENT")
         return album
 
-    return await asyncio.to_thread(_get_album)
+    return await _run_ytmusic(_get_album)
 
 
 async def get_playlist(
@@ -97,7 +99,7 @@ async def get_playlist(
         playlist["id"] = prov_playlist_id if not playlist.get("id") else playlist["id"]
         return playlist
 
-    return await asyncio.to_thread(_get_playlist)
+    return await _run_ytmusic(_get_playlist)
 
 
 async def get_track(
@@ -129,7 +131,7 @@ async def get_track(
         track["isAvailable"] = track_obj["playabilityStatus"]["status"] == "OK"
         return track
 
-    return await asyncio.to_thread(_get_song)
+    return await _run_ytmusic(_get_song)
 
 
 async def get_podcast(
@@ -144,7 +146,7 @@ async def get_podcast(
             podcast_obj["podcastId"] = prov_podcast_id
         return podcast_obj
 
-    return await asyncio.to_thread(_get_podcast)
+    return await _run_ytmusic(_get_podcast)
 
 
 async def get_podcast_episode(
@@ -159,7 +161,7 @@ async def get_podcast_episode(
             episode["videoId"] = prov_episode_id
         return episode
 
-    return await asyncio.to_thread(_get_podcast_episode)
+    return await _run_ytmusic(_get_podcast_episode)
 
 
 async def get_library_artists(
@@ -178,7 +180,7 @@ async def get_library_artists(
             del artist["artist"]
         return artists
 
-    return await asyncio.to_thread(_get_library_artists)
+    return await _run_ytmusic(_get_library_artists)
 
 
 async def get_library_albums(
@@ -190,7 +192,7 @@ async def get_library_albums(
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
         return ytm.get_library_albums(limit=9999)
 
-    return await asyncio.to_thread(_get_library_albums)
+    return await _run_ytmusic(_get_library_albums)
 
 
 async def get_library_playlists(
@@ -208,7 +210,7 @@ async def get_library_playlists(
             playlist["checksum"] = get_playlist_checksum(playlist)
         return playlists
 
-    return await asyncio.to_thread(_get_library_playlists)
+    return await _run_ytmusic(_get_library_playlists)
 
 
 async def get_library_tracks(
@@ -220,7 +222,7 @@ async def get_library_tracks(
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
         return ytm.get_library_songs(limit=9999)
 
-    return await asyncio.to_thread(_get_library_tracks)
+    return await _run_ytmusic(_get_library_tracks)
 
 
 async def get_library_podcasts(
@@ -232,7 +234,7 @@ async def get_library_podcasts(
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
         return ytm.get_library_podcasts(limit=9999)
 
-    return await asyncio.to_thread(_get_library_podcasts)
+    return await _run_ytmusic(_get_library_podcasts)
 
 
 async def library_add_remove_artist(
@@ -246,7 +248,7 @@ async def library_add_remove_artist(
             return "actions" in ytm.subscribe_artists(channelIds=[prov_artist_id])
         return "actions" in ytm.unsubscribe_artists(channelIds=[prov_artist_id])
 
-    return await asyncio.to_thread(_library_add_remove_artist)
+    return await _run_ytmusic(_library_add_remove_artist)
 
 
 async def library_add_remove_album(
@@ -262,7 +264,7 @@ async def library_add_remove_album(
             return ytm.rate_playlist(playlist_id, LikeStatus.LIKE)
         return ytm.rate_playlist(playlist_id, LikeStatus.INDIFFERENT)
 
-    return await asyncio.to_thread(_library_add_remove_album)
+    return await _run_ytmusic(_library_add_remove_album)
 
 
 async def library_add_remove_playlist(
@@ -276,7 +278,7 @@ async def library_add_remove_playlist(
             return "actions" in ytm.rate_playlist(prov_item_id, LikeStatus.LIKE)
         return "actions" in ytm.rate_playlist(prov_item_id, LikeStatus.INDIFFERENT)
 
-    return await asyncio.to_thread(_library_add_remove_playlist)
+    return await _run_ytmusic(_library_add_remove_playlist)
 
 
 async def add_remove_playlist_tracks(
@@ -294,7 +296,7 @@ async def add_remove_playlist_tracks(
             return ytm.add_playlist_items(playlistId=prov_playlist_id, videoIds=prov_track_ids)
         return ytm.remove_playlist_items(playlistId=prov_playlist_id, videos=prov_track_ids)
 
-    return await asyncio.to_thread(_add_playlist_tracks)
+    return await _run_ytmusic(_add_playlist_tracks)
 
 
 async def get_song_radio_tracks(
@@ -319,7 +321,7 @@ async def get_song_radio_tracks(
                     track["duration"] = get_sec(track["length"])
         return result
 
-    return await asyncio.to_thread(_get_song_radio_tracks)
+    return await _run_ytmusic(_get_song_radio_tracks)
 
 
 async def search(
@@ -351,7 +353,7 @@ async def search(
                     del result["browseId"]
         return results[:limit]
 
-    return await asyncio.to_thread(_search)
+    return await _run_ytmusic(_search)
 
 
 def get_playlist_checksum(playlist_obj: dict[str, Any]) -> str:
@@ -397,7 +399,7 @@ async def get_home(
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
         return ytm.get_home(limit=limit)
 
-    return await asyncio.to_thread(_get_home)
+    return await _run_ytmusic(_get_home)
 
 
 def determine_recommendation_icon(name: str) -> str:
@@ -415,3 +417,18 @@ def determine_recommendation_icon(name: str) -> str:
     if "recommended" in query:
         return YTMRecommendationIcons.RECOMMENDED
     return YTMRecommendationIcons.DEFAULT
+
+
+async def _run_ytmusic[T](func: Callable[[], T]) -> T:
+    """Run a blocking ytmusicapi call in a thread, translating a signed-out session."""
+    try:
+        return await asyncio.to_thread(func)
+    except (KeyError, IndexError) as err:
+        # An invalid cookie makes YouTube answer with its signed-out page instead of an auth
+        # error, so nav() fails on the unexpected payload and embeds it in the message.
+        if "signInEndpoint" not in str(err):
+            raise
+        raise LoginFailed(
+            "Your YouTube Music session is no longer valid. "
+            "Please reconfigure this provider with a fresh cookie."
+        ) from err

--- a/tests/providers/ytmusic/test_helpers.py
+++ b/tests/providers/ytmusic/test_helpers.py
@@ -1,0 +1,42 @@
+"""Test the ytmusicapi call wrapper's handling of a signed-out session."""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import ytmusicapi
+from music_assistant_models.errors import LoginFailed
+
+from music_assistant.providers.ytmusic import helpers
+
+# A trimmed but realistic nav() KeyError: YouTube answered with its signed-out
+# page instead of an auth error, so the renderer lookup fails deep in that payload.
+SIGNED_OUT_PAYLOAD_ERROR = KeyError(
+    "Unable to find 'twoColumnBrowseResultsRenderer' using path "
+    "['contents', 'twoColumnBrowseResultsRenderer', 'tabs', 0] on "
+    "{'singleColumnBrowseResultsRenderer': {'tabs': [{'tabRenderer': {'content': "
+    "{'sectionListRenderer': {'contents': [{'itemSectionRenderer': {'contents': "
+    "[{'buttonRenderer': {'text': {'runs': [{'text': 'Sign in'}]}, "
+    "'navigationEndpoint': {'clickTrackingParams': '...', "
+    "'signInEndpoint': {'hack': True}}}}]}}]}}}}]}}, "
+    "exception: 'twoColumnBrowseResultsRenderer'"
+)
+
+
+def _patch_get_home(error: Exception) -> Any:
+    """Patch ytmusicapi.YTMusic so get_home() raises the given error."""
+    mock_ytm = MagicMock()
+    mock_ytm.get_home.side_effect = error
+    return patch.object(ytmusicapi, "YTMusic", return_value=mock_ytm)
+
+
+async def test_signed_out_payload_is_translated_to_login_failed() -> None:
+    """A KeyError carrying the signed-out page must surface as LoginFailed."""
+    with _patch_get_home(SIGNED_OUT_PAYLOAD_ERROR), pytest.raises(LoginFailed):
+        await helpers.get_home(headers={})
+
+
+async def test_unrelated_key_error_still_propagates() -> None:
+    """A KeyError unrelated to a signed-out session must propagate as-is."""
+    with _patch_get_home(KeyError("some_other_key")), pytest.raises(KeyError):
+        await helpers.get_home(headers={})

--- a/tests/providers/ytmusic/test_helpers.py
+++ b/tests/providers/ytmusic/test_helpers.py
@@ -40,3 +40,25 @@ async def test_unrelated_key_error_still_propagates() -> None:
     """A KeyError unrelated to a signed-out session must propagate as-is."""
     with _patch_get_home(KeyError("some_other_key")), pytest.raises(KeyError):
         await helpers.get_home(headers={})
+
+
+async def test_get_artist_does_not_hide_signed_out_behind_its_fallback() -> None:
+    """get_artist's channel fallback must not turn a signed-out session into an artist."""
+    mock_ytm = MagicMock()
+    mock_ytm.get_artist.side_effect = SIGNED_OUT_PAYLOAD_ERROR
+    mock_ytm.get_user.side_effect = SIGNED_OUT_PAYLOAD_ERROR
+    with (
+        patch.object(ytmusicapi, "YTMusic", return_value=mock_ytm),
+        pytest.raises(LoginFailed),
+    ):
+        await helpers.get_artist(prov_artist_id="UC123", headers={})
+
+
+async def test_get_artist_fallback_still_returns_unknown() -> None:
+    """An artist that is neither a channel nor a user still falls back to Unknown."""
+    mock_ytm = MagicMock()
+    mock_ytm.get_artist.side_effect = KeyError("header")
+    mock_ytm.get_user.side_effect = KeyError("name")
+    with patch.object(ytmusicapi, "YTMusic", return_value=mock_ytm):
+        artist = await helpers.get_artist(prov_artist_id="UC123", headers={})
+    assert artist == {"channelId": "UC123", "name": "Unknown"}

--- a/tests/providers/ytmusic/test_ytmusic.py
+++ b/tests/providers/ytmusic/test_ytmusic.py
@@ -1,10 +1,13 @@
 """Test YouTube Music Provider."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import ClientError, ServerDisconnectedError
+from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import LoginFailed
 
+from music_assistant.models.music_provider import MusicProvider
 from music_assistant.providers.ytmusic import YoutubeMusicProvider
 
 
@@ -64,3 +67,28 @@ async def test_verify_po_token_url_transient_failure(
         return_value=_ping_context_manager(exc=exc)
     )
     assert await provider._verify_po_token_url() is False
+
+
+async def test_sync_library_unloads_on_invalid_session(provider: YoutubeMusicProvider) -> None:
+    """A library sync that hits an invalid session unloads the provider for re-auth."""
+    provider.available = True
+    provider.unload_with_error = MagicMock()  # type: ignore[method-assign]
+    err = LoginFailed("Your YouTube Music session is no longer valid.")
+    with (
+        patch.object(MusicProvider, "sync_library", AsyncMock(side_effect=err)),
+        pytest.raises(LoginFailed),
+    ):
+        await provider.sync_library(MediaType.PLAYLIST)
+    provider.unload_with_error.assert_called_once_with(err)
+
+
+async def test_sync_library_keeps_other_errors_silent(provider: YoutubeMusicProvider) -> None:
+    """Any other sync failure must not unload the provider."""
+    provider.available = True
+    provider.unload_with_error = MagicMock()  # type: ignore[method-assign]
+    with (
+        patch.object(MusicProvider, "sync_library", AsyncMock(side_effect=KeyError("boom"))),
+        pytest.raises(KeyError),
+    ):
+        await provider.sync_library(MediaType.PLAYLIST)
+    provider.unload_with_error.assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

When a stored YouTube Music cookie is no longer a valid session, YouTube does not
answer with an auth error. It returns its normal signed-out page. `ytmusicapi`'s
`nav()` then fails on the unexpected payload and raises a `KeyError` with the whole
page embedded in the message, which ended up verbatim in the UI and the log:

```
Error handling message: music/refresh_item: "Unable to find 'twoColumnBrowseResultsRenderer' using path [...] on {'singleColumnBrowseResultsRenderer': ... 'Sign in to listen to your liked tracks' ...}"
```

Nothing told the user their cookie needs replacing, and every library sync kept
failing the same way.

- Route every `ytmusicapi` call through a wrapper that turns a signed-out response into `LoginFailed` with an actionable message
- Unload the provider on that error during a library sync, so the user is asked once for a fresh cookie instead of every sync failing silently
- Add regression tests for the translation, for unrelated `KeyError`s, and for the unload

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6031

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
