### PR TITLE
Speak an announcement in your own language

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 46
+API_SCHEMA_VERSION: Final[int] = 47
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -48,7 +48,11 @@ from music_assistant.helpers.plugin_engines import (
     resolve_tts_engine,
     select_core_tts_engine,
 )
-from music_assistant.helpers.tts import query_tts_engine, resolve_tts_stream_path
+from music_assistant.helpers.tts import (
+    query_tts_engine_with_language_fallback,
+    resolve_tts_language,
+    resolve_tts_stream_path,
+)
 from music_assistant.helpers.util import TaskManager, validate_announcement_chime_url
 from music_assistant.models.player import Player
 
@@ -162,6 +166,7 @@ class AnnouncementsMixin:
         pre_announce_url: str | None = None,
         message: str | None = None,
         tts_engine: str | None = None,
+        language: str | None = None,
     ) -> None:
         """
         Handle playback of an announcement on given player.
@@ -176,6 +181,8 @@ class AnnouncementsMixin:
         :param message: Text to speak as the announcement, rendered by a TTS engine.
         :param tts_engine: Optional uid of the TTS engine to speak the message,
             defaults to the engine configured on the player controller.
+        :param language: Optional language code to speak the message in (e.g. 'nl-NL'),
+            defaults to the language configured for Music Assistant.
         """
         player = self.get_player(player_id, True)
         assert player is not None  # for type checking
@@ -185,6 +192,8 @@ class AnnouncementsMixin:
             raise PlayerCommandFailed("Provide either a url or a message, not both.")
         if tts_engine and not message:
             raise PlayerCommandFailed("A tts_engine can only be used to speak a message.")
+        if language and not message:
+            raise PlayerCommandFailed("A language can only be used to speak a message.")
         if url and not url.startswith("http"):
             raise PlayerCommandFailed("Only URLs are supported for announcements")
         if (
@@ -197,7 +206,7 @@ class AnnouncementsMixin:
         # a group - plays the resulting audio instead of speaking the text again
         is_speech = bool(message)
         if message:
-            url = await self._render_announcement_message(message, tts_engine)
+            url = await self._render_announcement_message(message, tts_engine, language)
         assert url is not None  # for type checking
         # determine pre-announce from (group)player config
         if pre_announce is None and (is_speech or "tts" in url):
@@ -393,12 +402,16 @@ class AnnouncementsMixin:
             )
         return None
 
-    async def _render_announcement_message(self, message: str, tts_engine: str | None) -> str:
+    async def _render_announcement_message(
+        self, message: str, tts_engine: str | None, language: str | None
+    ) -> str:
         """
         Speak a message through a TTS engine and return the url of the resulting audio.
 
         :param message: The text to speak.
         :param tts_engine: Optional uid of the engine to use, defaults to the configured one.
+        :param language: Optional language to speak the message in, defaults to the
+            language configured for Music Assistant.
         """
         if tts_engine:
             engine = await resolve_tts_engine(self.mass, tts_engine)
@@ -408,7 +421,13 @@ class AnnouncementsMixin:
             engine = await select_core_tts_engine(self.mass, self.domain, CONF_ANNOUNCE_TTS_ENGINE)
             if engine is None:
                 raise PlayerCommandFailed("No text-to-speech engine is available.")
-        stream_details = await query_tts_engine(engine, message, timeout=ANNOUNCEMENT_TTS_TIMEOUT)
+        stream_details = await query_tts_engine_with_language_fallback(
+            engine,
+            message,
+            language or resolve_tts_language(self.mass),
+            timeout=ANNOUNCEMENT_TTS_TIMEOUT,
+            logger=self.logger,
+        )
         path, _ = await resolve_tts_stream_path(engine, stream_details)
         if not path.startswith("http"):
             # a group announcement is forwarded to each member through this same command,

--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -50,7 +50,6 @@ from music_assistant.helpers.plugin_engines import (
 )
 from music_assistant.helpers.tts import (
     query_tts_engine_with_language_fallback,
-    resolve_tts_language,
     resolve_tts_stream_path,
 )
 from music_assistant.helpers.util import TaskManager, validate_announcement_chime_url
@@ -182,7 +181,7 @@ class AnnouncementsMixin:
         :param tts_engine: Optional uid of the TTS engine to speak the message,
             defaults to the engine configured on the player controller.
         :param language: Optional language code to speak the message in (e.g. 'nl-NL'),
-            defaults to the language configured for Music Assistant.
+            omit to let the engine speak in the language it is configured for.
         """
         player = self.get_player(player_id, True)
         assert player is not None  # for type checking
@@ -410,8 +409,8 @@ class AnnouncementsMixin:
 
         :param message: The text to speak.
         :param tts_engine: Optional uid of the engine to use, defaults to the configured one.
-        :param language: Optional language to speak the message in, defaults to the
-            language configured for Music Assistant.
+        :param language: Optional language to speak the message in, omit to let the
+            engine speak in the language it is configured for.
         """
         if tts_engine:
             engine = await resolve_tts_engine(self.mass, tts_engine)
@@ -424,7 +423,7 @@ class AnnouncementsMixin:
         stream_details = await query_tts_engine_with_language_fallback(
             engine,
             message,
-            language or resolve_tts_language(self.mass),
+            language,
             timeout=ANNOUNCEMENT_TTS_TIMEOUT,
             logger=self.logger,
         )

--- a/music_assistant/helpers/tts.py
+++ b/music_assistant/helpers/tts.py
@@ -3,16 +3,22 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import StreamType
 from music_assistant_models.errors import InvalidDataError, MusicAssistantError
 
+from music_assistant.constants import MASS_LOGGER_NAME
+
 if TYPE_CHECKING:
     from music_assistant_models.streamdetails import StreamDetails
 
+    from music_assistant.mass import MusicAssistant
     from music_assistant.models.plugin import TTSEngine
+
+LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.helpers.tts")
 
 # last-resort guard so a wedged engine fails the call instead of hanging its caller.
 # Kept above the deadlines the engines apply themselves (120s in the OpenAI-compatible
@@ -51,6 +57,55 @@ async def query_tts_engine(
         raise MusicAssistantError(
             f"TTS engine '{engine.uid}' did not respond within {timeout}s"
         ) from err
+
+
+async def query_tts_engine_with_language_fallback(
+    engine: TTSEngine,
+    message: str,
+    language: str | None = None,
+    timeout: float | None = None,
+    logger: logging.Logger | None = None,
+) -> StreamDetails:
+    """
+    Render a message through a TTS engine, retrying without the language if it is rejected.
+
+    :param engine: The TTS engine to speak the message.
+    :param message: The text to speak.
+    :param language: Optional language code, omit to use the engine's own default voice.
+    :param timeout: Seconds to wait for the engine, defaults to TTS_QUERY_TIMEOUT_SECONDS.
+        Lower it for a caller that is holding something up while it waits.
+    :param logger: Optional logger to report a rejected language on.
+    """
+    try:
+        return await query_tts_engine(engine, message, language, timeout)
+    except TimeoutError, MusicAssistantError:
+        # a timeout or our own structured failure is not a language rejection, so a
+        # language-less retry would not help and would only double the wait
+        raise
+    except Exception as err:
+        if language is None:
+            raise
+        # some engines reject a language they don't support; fall back to the engine's
+        # own default voice rather than losing the audio entirely
+        (logger or LOGGER).warning(
+            "TTS engine '%s' rejected language '%s' (%s), retrying with its default voice",
+            engine.uid,
+            language,
+            err,
+        )
+        return await query_tts_engine(engine, message, None, timeout)
+
+
+def resolve_tts_language(mass: MusicAssistant) -> str | None:
+    """
+    Return the language a TTS engine should speak in, as a hyphenated code like 'en-US'.
+
+    Returns None when no language is configured, leaving the engine on its own default voice.
+
+    :param mass: The Music Assistant instance holding the configured locale.
+    """
+    locale = mass.metadata.locale
+    return locale.replace("_", "-") if locale else None
 
 
 async def resolve_tts_stream_path(

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -18,7 +18,11 @@ from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.helpers.tags import async_parse_tags
-from music_assistant.helpers.tts import query_tts_engine, resolve_tts_stream_path
+from music_assistant.helpers.tts import (
+    query_tts_engine_with_language_fallback,
+    resolve_tts_language,
+    resolve_tts_stream_path,
+)
 
 from .constants import (
     ATTR_HOST_ID,
@@ -153,8 +157,9 @@ class AIRadioRenderMixin:
 
         :param host_language: The host's configured language override, if any.
         """
-        locale = (host_language or "").strip() or self.mass.metadata.locale
-        return locale.replace("_", "-") if locale else None
+        if override := (host_language or "").strip():
+            return override.replace("_", "-")
+        return resolve_tts_language(self.mass)
 
     def _find_clip_item(self, clip_id: str) -> QueueItem | None:
         """Return the queue item holding the given clip, or None when no queue holds it."""
@@ -263,25 +268,9 @@ class AIRadioRenderMixin:
     ) -> tuple[str, StreamType, AudioFormat]:
         """Ask the TTS engine for audio and return the path, stream type and format to play it."""
         engine = await self._get_tts_engine(engine_uid)
-        try:
-            stream_details = await query_tts_engine(engine, text, language)
-        except TimeoutError, MusicAssistantError:
-            # a timeout or our own structured failure is not a language rejection, so a
-            # language-less retry would not help and would only double the wait
-            raise
-        except Exception as err:
-            if language is None:
-                raise
-            # some engines reject a language they don't support; fall back to the engine's
-            # own default voice rather than losing the clip entirely
-            self.logger.warning(
-                "AI Radio TTS engine '%s' rejected language '%s' (%s), retrying with its "
-                "default voice",
-                engine.uid,
-                language,
-                err,
-            )
-            stream_details = await query_tts_engine(engine, text, None)
+        stream_details = await query_tts_engine_with_language_fallback(
+            engine, text, language, logger=self.logger
+        )
         path, stream_type = await resolve_tts_stream_path(engine, stream_details)
         audio_format = stream_details.audio_format
         if audio_format.content_type == ContentType.UNKNOWN:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -36,6 +36,7 @@ from music_assistant_models.enums import (
 )
 from music_assistant_models.errors import (
     InvalidDataError,
+    MusicAssistantError,
     PlayerCommandFailed,
     UnsupportedFeaturedException,
 )
@@ -3133,12 +3134,13 @@ class TestPlayAnnouncementMessage:
         return engine
 
     def _make_player(
-        self, mock_mass: MagicMock, announcements: dict[str, object]
+        self, mock_mass: MagicMock, announcements: dict[str, object], locale: str = "en_US"
     ) -> tuple[PlayerController, AsyncMock]:
-        """Create a controller and a player with native announcement support."""
+        """Create a controller and a player with native announcement support, at given locale."""
         controller, player, _render = TestPlayAnnouncementCleanup()._make_player(
             mock_mass, announcements
         )
+        mock_mass.metadata.locale = locale
         announce = AsyncMock()
         player.play_announcement = announce  # type: ignore[method-assign]
         return controller, announce
@@ -3155,11 +3157,90 @@ class TestPlayAnnouncementMessage:
             await controller.play_announcement("player_1", message="dinner is ready")
 
         engine.provider.get_tts_message.assert_awaited_once_with(
-            "dinner is ready", language=None, engine_id="voice"
+            "dinner is ready", language="en-US", engine_id="voice"
         )
         registered = mock_mass.streams.announcement_renderer.register.call_args.args[1]
         assert registered["announcement_url"] == "http://speech/spoken.mp3"
         announce.assert_awaited_once()
+
+    async def test_an_explicit_language_reaches_the_engine(self, mock_mass: MagicMock) -> None:
+        """A message names the language to speak it in, overriding the configured locale."""
+        announcements: dict[str, object] = {}
+        controller, _announce = self._make_player(mock_mass, announcements)
+        engine = self._make_engine()
+
+        with patch(
+            f"{self.ANNOUNCE_MODULE}.select_core_tts_engine", AsyncMock(return_value=engine)
+        ):
+            await controller.play_announcement(
+                "player_1", message="het eten is klaar", language="nl-NL"
+            )
+
+        engine.provider.get_tts_message.assert_awaited_once_with(
+            "het eten is klaar", language="nl-NL", engine_id="voice"
+        )
+
+    async def test_no_configured_locale_leaves_the_engine_on_its_own_voice(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Without a configured language the engine picks its own default voice."""
+        announcements: dict[str, object] = {}
+        controller, _announce = self._make_player(mock_mass, announcements, locale="")
+        engine = self._make_engine()
+
+        with patch(
+            f"{self.ANNOUNCE_MODULE}.select_core_tts_engine", AsyncMock(return_value=engine)
+        ):
+            await controller.play_announcement("player_1", message="dinner is ready")
+
+        engine.provider.get_tts_message.assert_awaited_once_with(
+            "dinner is ready", language=None, engine_id="voice"
+        )
+
+    async def test_a_rejected_language_is_retried_without_it(self, mock_mass: MagicMock) -> None:
+        """An engine that rejects the language speaks the message in its default voice."""
+        announcements: dict[str, object] = {}
+        controller, announce = self._make_player(mock_mass, announcements)
+        engine = self._make_engine()
+        engine.provider.get_tts_message = AsyncMock(
+            side_effect=[
+                RuntimeError("unsupported language"),
+                SimpleNamespace(path="http://speech/spoken.mp3"),
+            ]
+        )
+
+        with patch(
+            f"{self.ANNOUNCE_MODULE}.select_core_tts_engine", AsyncMock(return_value=engine)
+        ):
+            await controller.play_announcement("player_1", message="dinner is ready")
+
+        first_call, second_call = engine.provider.get_tts_message.await_args_list
+        assert first_call.kwargs["language"] == "en-US"
+        assert second_call.kwargs["language"] is None
+        registered = mock_mass.streams.announcement_renderer.register.call_args.args[1]
+        assert registered["announcement_url"] == "http://speech/spoken.mp3"
+        announce.assert_awaited_once()
+
+    @pytest.mark.parametrize(
+        "error", [TimeoutError(), MusicAssistantError("engine did not respond within 30s")]
+    )
+    async def test_a_failure_that_is_not_a_language_rejection_is_not_retried(
+        self, mock_mass: MagicMock, error: Exception
+    ) -> None:
+        """A timeout or a structured failure is no language rejection, so it is not retried."""
+        announcements: dict[str, object] = {}
+        controller, announce = self._make_player(mock_mass, announcements)
+        engine = self._make_engine()
+        engine.provider.get_tts_message = AsyncMock(side_effect=error)
+
+        with (
+            patch(f"{self.ANNOUNCE_MODULE}.select_core_tts_engine", AsyncMock(return_value=engine)),
+            pytest.raises(MusicAssistantError),
+        ):
+            await controller.play_announcement("player_1", message="dinner is ready")
+
+        engine.provider.get_tts_message.assert_awaited_once()
+        announce.assert_not_awaited()
 
     async def test_an_explicit_engine_is_used(self, mock_mass: MagicMock) -> None:
         """A message names the engine to speak it, overriding the configured default."""
@@ -3210,7 +3291,7 @@ class TestPlayAnnouncementMessage:
 
         with (
             patch(f"{self.ANNOUNCE_MODULE}.select_core_tts_engine", AsyncMock(return_value=engine)),
-            patch(f"{self.ANNOUNCE_MODULE}.query_tts_engine", query),
+            patch(f"{self.ANNOUNCE_MODULE}.query_tts_engine_with_language_fallback", query),
         ):
             await controller.play_announcement("player_1", message="hello")
 
@@ -3225,6 +3306,16 @@ class TestPlayAnnouncementMessage:
         with pytest.raises(PlayerCommandFailed, match="only be used to speak a message"):
             await controller.play_announcement(
                 "player_1", url="http://test/clip.mp3", tts_engine="tts_plugin/voice"
+            )
+
+    async def test_a_language_without_a_message_is_rejected(self, mock_mass: MagicMock) -> None:
+        """Naming a language for a url announcement is rejected instead of silently ignored."""
+        announcements: dict[str, object] = {}
+        controller, _announce = self._make_player(mock_mass, announcements)
+
+        with pytest.raises(PlayerCommandFailed, match="A language can only be used"):
+            await controller.play_announcement(
+                "player_1", url="http://test/clip.mp3", language="nl-NL"
             )
 
     async def test_a_failing_engine_surfaces_its_error(self, mock_mass: MagicMock) -> None:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -3134,13 +3134,12 @@ class TestPlayAnnouncementMessage:
         return engine
 
     def _make_player(
-        self, mock_mass: MagicMock, announcements: dict[str, object], locale: str = "en_US"
+        self, mock_mass: MagicMock, announcements: dict[str, object]
     ) -> tuple[PlayerController, AsyncMock]:
-        """Create a controller and a player with native announcement support, at given locale."""
+        """Create a controller and a player with native announcement support."""
         controller, player, _render = TestPlayAnnouncementCleanup()._make_player(
             mock_mass, announcements
         )
-        mock_mass.metadata.locale = locale
         announce = AsyncMock()
         player.play_announcement = announce  # type: ignore[method-assign]
         return controller, announce
@@ -3156,15 +3155,16 @@ class TestPlayAnnouncementMessage:
         ):
             await controller.play_announcement("player_1", message="dinner is ready")
 
+        # no language is sent, so the engine speaks in the language it is configured for
         engine.provider.get_tts_message.assert_awaited_once_with(
-            "dinner is ready", language="en-US", engine_id="voice"
+            "dinner is ready", language=None, engine_id="voice"
         )
         registered = mock_mass.streams.announcement_renderer.register.call_args.args[1]
         assert registered["announcement_url"] == "http://speech/spoken.mp3"
         announce.assert_awaited_once()
 
     async def test_an_explicit_language_reaches_the_engine(self, mock_mass: MagicMock) -> None:
-        """A message names the language to speak it in, overriding the configured locale."""
+        """A message can name the language to speak it in."""
         announcements: dict[str, object] = {}
         controller, _announce = self._make_player(mock_mass, announcements)
         engine = self._make_engine()
@@ -3178,23 +3178,6 @@ class TestPlayAnnouncementMessage:
 
         engine.provider.get_tts_message.assert_awaited_once_with(
             "het eten is klaar", language="nl-NL", engine_id="voice"
-        )
-
-    async def test_no_configured_locale_leaves_the_engine_on_its_own_voice(
-        self, mock_mass: MagicMock
-    ) -> None:
-        """Without a configured language the engine picks its own default voice."""
-        announcements: dict[str, object] = {}
-        controller, _announce = self._make_player(mock_mass, announcements, locale="")
-        engine = self._make_engine()
-
-        with patch(
-            f"{self.ANNOUNCE_MODULE}.select_core_tts_engine", AsyncMock(return_value=engine)
-        ):
-            await controller.play_announcement("player_1", message="dinner is ready")
-
-        engine.provider.get_tts_message.assert_awaited_once_with(
-            "dinner is ready", language=None, engine_id="voice"
         )
 
     async def test_a_rejected_language_is_retried_without_it(self, mock_mass: MagicMock) -> None:
@@ -3212,7 +3195,9 @@ class TestPlayAnnouncementMessage:
         with patch(
             f"{self.ANNOUNCE_MODULE}.select_core_tts_engine", AsyncMock(return_value=engine)
         ):
-            await controller.play_announcement("player_1", message="dinner is ready")
+            await controller.play_announcement(
+                "player_1", message="dinner is ready", language="en-US"
+            )
 
         first_call, second_call = engine.provider.get_tts_message.await_args_list
         assert first_call.kwargs["language"] == "en-US"


### PR DESCRIPTION
# What does this implement/fix?

An announcement always spoke in the language the text-to-speech engine is configured for, with no way to ask for a different one. That is the right default, but it left no room for an automation that wants a single announcement in another language on an engine that can speak several.

`play_announcement` now takes an optional language. Nothing changes unless it is given: leave it out and the engine speaks in its own configured language exactly as before.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- `play_announcement` takes an optional `language`; without it the engine keeps speaking in the language it is configured for
- an engine that rejects a language it does not support falls back to its own default voice, so the announcement still plays
- that fallback moved to `helpers/tts`, so AI Radio and announcements share one implementation instead of two

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
