### PR TITLE
Update playlist names when they are renamed on the streaming service

### DIFF
--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -439,8 +439,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
         self._verify_update_allowed(cur_item, update)
         metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
         cur_item.external_ids.update(update.external_ids)
-        name = update.name if overwrite else cur_item.name
-        sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name
+        # a non-editable playlist can't be renamed locally, so the provider owns its name
+        adopt_name = overwrite or not cur_item.is_editable
+        name = update.name if adopt_name else cur_item.name
+        sort_name = update.sort_name if adopt_name else cur_item.sort_name or update.sort_name
         # adopt the synced item's translation_key + params (as a unit) when it supplies a key, so
         # the localized name follows the provider, existing rows backfill, and a stale param (e.g.
         # a renamed Spotify account) self-heals; otherwise keep what we have (unless overwriting).
@@ -454,7 +456,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
             self.db_table,
             {"item_id": db_id},
             {
-                # always prefer name/owner from updated item here
+                # always prefer owner from the updated item here
                 "name": name,
                 "sort_name": sort_name,
                 "translation_key": translation_key,

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -1248,6 +1248,13 @@ class MusicProvider(Provider):
                         library_item = await self.mass.music.playlists.update_item_in_library(
                             library_item.item_id, prov_item, overwrite=True
                         )
+                    elif not library_item.is_editable and prov_item.name != library_item.name:
+                        # a non-editable playlist can't be renamed locally, so the provider
+                        # is the sole source of truth for its name. The normal update path
+                        # leaves its locally-enriched metadata and images alone.
+                        library_item = await self.mass.music.playlists.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
                     if not library_item.favorite and prov_item.favorite:
                         # existing library item not favorite but should be
                         await self.mass.music.playlists.set_favorite(library_item.item_id, True)

--- a/tests/controllers/music/test_playlists.py
+++ b/tests/controllers/music/test_playlists.py
@@ -9,8 +9,10 @@ playlist's ``translation_key`` survives the library round-trip.
 from __future__ import annotations
 
 import pytest
+from music_assistant_models.helpers import create_safe_string
 from music_assistant_models.media_items import Playlist, ProviderMapping
 
+from music_assistant.constants import DB_TABLE_PLAYLISTS
 from music_assistant.controllers.music.media.playlists import PlaylistController
 from music_assistant.mass import MusicAssistant
 
@@ -33,6 +35,7 @@ def _make_playlist(
     *,
     translation_key: str | None = None,
     translation_params: list[str] | None = None,
+    is_editable: bool = False,
 ) -> Playlist:
     """Create a provider-mapped Playlist for adding to the library."""
     return Playlist(
@@ -45,7 +48,7 @@ def _make_playlist(
             ProviderMapping(item_id=item_id, provider_domain="builtin", provider_instance="builtin")
         },
         owner="Music Assistant",
-        is_editable=False,
+        is_editable=is_editable,
     )
 
 
@@ -92,3 +95,42 @@ class TestPlaylistTranslationKey:
         )
         fetched = await playlist_ctrl.get_library_item(int(created.item_id))
         assert fetched.translation_key == "recently_played"
+
+
+class TestPlaylistNameUpdate:
+    """A non-editable playlist has no local source of truth for its name."""
+
+    async def test_noneditable_playlist_adopts_provider_rename(
+        self, mass: MusicAssistant, playlist_ctrl: PlaylistController
+    ) -> None:
+        """Renaming a followed (non-editable) playlist upstream updates the library row."""
+        created = await playlist_ctrl.add_item_to_library(
+            _make_playlist("detop40", "Top 40 week 31 2026")
+        )
+        renamed = _make_playlist("detop40", "Top 40 week 32 2026")
+        await playlist_ctrl.update_item_in_library(created.item_id, renamed)
+
+        fetched = await playlist_ctrl.get_library_item(int(created.item_id))
+        assert fetched.name == "Top 40 week 32 2026"
+        assert fetched.sort_name == renamed.sort_name
+
+        # search_name/search_sort_name are derived columns and must follow suit
+        db_row = await mass.music.database.get_row(
+            DB_TABLE_PLAYLISTS, {"item_id": int(created.item_id)}
+        )
+        assert db_row is not None
+        assert db_row["search_name"] == create_safe_string(fetched.name, True, True)
+        assert db_row["search_sort_name"] == create_safe_string(fetched.sort_name or "", True, True)
+
+    async def test_editable_playlist_keeps_local_name_on_provider_rename(
+        self, playlist_ctrl: PlaylistController
+    ) -> None:
+        """A user-editable playlist's local name is never overwritten by the provider."""
+        created = await playlist_ctrl.add_item_to_library(
+            _make_playlist("my_playlist", "My Playlist", is_editable=True)
+        )
+        renamed = _make_playlist("my_playlist", "Provider Renamed", is_editable=True)
+        await playlist_ctrl.update_item_in_library(created.item_id, renamed)
+
+        fetched = await playlist_ctrl.get_library_item(int(created.item_id))
+        assert fetched.name == "My Playlist"

--- a/tests/test_dynamic_playlist_framework.py
+++ b/tests/test_dynamic_playlist_framework.py
@@ -270,12 +270,12 @@ async def test_sync_does_not_overwrite_editable_playlist_on_name_change() -> Non
     playlists_ctrl.update_item_in_library.assert_not_called()
 
 
-async def test_sync_does_not_overwrite_noneditable_static_playlist_on_name_change() -> None:
+async def test_sync_updates_name_for_noneditable_static_playlist_on_name_change() -> None:
     """
-    Non-editable, non-dynamic playlists (e.g. a provider's "Favorites") are spared.
+    A non-editable, non-dynamic playlist (e.g. a followed YT Music playlist) adopts a rename.
 
-    Only non-editable *dynamic* playlists are treated as provider-owned; a static
-    non-editable playlist keeps its locally-enriched metadata/images.
+    Unlike the dynamic case, this goes through the normal (overwrite=False) update path,
+    which only lets the name follow the provider and leaves images/metadata untouched.
     """
     provider, playlists_ctrl, prov_item = _build_sync_fixture(
         library_is_editable=False,
@@ -288,7 +288,7 @@ async def test_sync_does_not_overwrite_noneditable_static_playlist_on_name_chang
 
     await _run_sync(provider, prov_item)
 
-    playlists_ctrl.update_item_in_library.assert_not_called()
+    playlists_ctrl.update_item_in_library.assert_called_once_with("1", prov_item)
 
 
 async def test_sync_skips_update_when_noneditable_playlist_unchanged() -> None:
@@ -299,6 +299,22 @@ async def test_sync_skips_update_when_noneditable_playlist_unchanged() -> None:
         prov_name="Same Name",
         library_images=["same.jpg"],
         prov_images=["same.jpg"],
+    )
+
+    await _run_sync(provider, prov_item)
+
+    playlists_ctrl.update_item_in_library.assert_not_called()
+
+
+async def test_sync_skips_update_for_noneditable_static_playlist_image_only_change() -> None:
+    """An image-only divergence is out of scope for static playlists; only a rename triggers."""
+    provider, playlists_ctrl, prov_item = _build_sync_fixture(
+        library_is_editable=False,
+        library_name="Same Name",
+        prov_name="Same Name",
+        library_images=["old.jpg"],
+        prov_images=["new.jpg"],
+        is_dynamic=False,
     )
 
     await _run_sync(provider, prov_item)


### PR DESCRIPTION
# What does this implement/fix?

A playlist you follow from a streaming service keeps its old name in your library when the owner renames it. For example a weekly "Top 40 week 31 2026" playlist on YouTube Music stays at week 31 forever, even though the tracks update correctly.

Library sync only refreshed a playlist when its provider mapping, date added or supported media types changed, so a plain rename was never noticed. On top of that, the update path kept the stored name.

Playlists you own yourself keep their local name, since you can rename those in Music Assistant.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

### Changes

- Library sync now updates a playlist you don't own when its name changed on the provider
- The provider's name and sort name are applied to those playlists; cover art and enriched metadata are left alone
- Playlists you own keep their local name
- Added tests for renamed followed playlists and for owned playlists keeping their name
