### PR TITLE
AI Radio: send per-host TTS options to Home Assistant

### DIFF
--- a/music_assistant/helpers/tts.py
+++ b/music_assistant/helpers/tts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import StreamType
 from music_assistant_models.errors import InvalidDataError, MusicAssistantError
@@ -33,6 +33,7 @@ async def query_tts_engine(
     message: str,
     language: str | None = None,
     timeout: float | None = None,
+    options: dict[str, Any] | None = None,
 ) -> StreamDetails:
     """
     Render a message through a TTS engine.
@@ -42,13 +43,15 @@ async def query_tts_engine(
     :param language: Optional language code, omit to use the engine's own default voice.
     :param timeout: Seconds to wait for the engine, defaults to TTS_QUERY_TIMEOUT_SECONDS.
         Lower it for a caller that is holding something up while it waits.
+    :param options: Optional integration-specific TTS options, passed through to the
+        engine as-is. Ignored by engines that have none.
     """
     if timeout is None:
         timeout = TTS_QUERY_TIMEOUT_SECONDS
     try:
         async with asyncio.timeout(timeout) as query_timeout:
             return await engine.provider.get_tts_message(
-                message, language=language, engine_id=engine.id
+                message, language=language, engine_id=engine.id, options=options
             )
     except TimeoutError as err:
         # expired() tells our own cap apart from a timeout raised inside the engine
@@ -65,6 +68,7 @@ async def query_tts_engine_with_language_fallback(
     language: str | None = None,
     timeout: float | None = None,
     logger: logging.Logger | None = None,
+    options: dict[str, Any] | None = None,
 ) -> StreamDetails:
     """
     Render a message through a TTS engine, retrying without the language if it is rejected.
@@ -75,9 +79,11 @@ async def query_tts_engine_with_language_fallback(
     :param timeout: Seconds to wait for the engine, defaults to TTS_QUERY_TIMEOUT_SECONDS.
         Lower it for a caller that is holding something up while it waits.
     :param logger: Optional logger to report a rejected language on.
+    :param options: Optional integration-specific TTS options, passed through to the
+        engine as-is. Ignored by engines that have none.
     """
     try:
-        return await query_tts_engine(engine, message, language, timeout)
+        return await query_tts_engine(engine, message, language, timeout, options)
     except TimeoutError, MusicAssistantError:
         # a timeout or our own structured failure is not a language rejection, so a
         # language-less retry would not help and would only double the wait
@@ -93,7 +99,7 @@ async def query_tts_engine_with_language_fallback(
             language,
             err,
         )
-        return await query_tts_engine(engine, message, None, timeout)
+        return await query_tts_engine(engine, message, None, timeout, options)
 
 
 def resolve_tts_language(mass: MusicAssistant) -> str | None:

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import ProviderFeature
 from music_assistant_models.media_items import SearchResults, UniqueList
@@ -273,7 +273,11 @@ class PluginProvider(Provider):
         return []
 
     async def get_tts_message(
-        self, message: str, language: str | None = None, engine_id: str | None = None
+        self,
+        message: str,
+        language: str | None = None,
+        engine_id: str | None = None,
+        options: dict[str, Any] | None = None,
     ) -> StreamDetails:
         """
         Convert text to speech audio.
@@ -284,6 +288,9 @@ class PluginProvider(Provider):
         :param language: Optional language code.
         :param engine_id: The provider-scoped id of the engine to use (``TTSEngine.id``,
             not its ``uid``). Omit or pass None to use the plugin's own default engine.
+        :param options: Optional integration-specific options (for example a voice
+            tuning parameter), passed through to the engine as-is. Ignored by plugins
+            that have none.
         :return: StreamDetails for the generated audio. ``path`` must be either a
             fetchable http(s)/rtsp/rtmp URL or the absolute path of an existing local
             file, and must stay resolvable for as long as consumers may play the clip.

--- a/music_assistant/providers/ai_radio/hosts.py
+++ b/music_assistant/providers/ai_radio/hosts.py
@@ -334,6 +334,12 @@ class AIRadioHostsMixin:
         instructions = str(host.get("instructions") or "").strip() or DEFAULT_LLM_INSTRUCTIONS
         tts_engine = str(host.get("tts_engine") or "").strip()
         language = str(host.get("language") or "").strip()
+        options_raw = host.get("options")
+        options = (
+            {str(key): value for key, value in options_raw.items()}
+            if isinstance(options_raw, dict)
+            else {}
+        )
 
         section_ids: list[str] = []
         seen: set[str] = set()
@@ -372,6 +378,7 @@ class AIRadioHostsMixin:
             "instructions": instructions,
             "tts_engine": tts_engine,
             "language": language,
+            "options": options,
             "section_ids": section_ids,
             "section_order": deepcopy(raw_section_order),
             "merge_section_id": merge_section_id,
@@ -387,6 +394,7 @@ class AIRadioHostsMixin:
             "instructions": DEFAULT_LLM_INSTRUCTIONS,
             "tts_engine": "",
             "language": "",
+            "options": {},
             "section_ids": default_section_ids,
             "section_order": [
                 {"when": "start_of_playlist", "flow": [{"MUST": "Song_Introduction_Start"}]},
@@ -556,6 +564,7 @@ def _compile_preset_host(preset: _PresetHost) -> tuple[dict[str, Any], list[dict
         "instructions": preset.instructions,
         "tts_engine": "",
         "language": "",
+        "options": {},
         "section_ids": [section["id"] for section in sections],
         "section_order": section_order,
         "merge_section_id": merge_section_id,

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -251,9 +251,10 @@ class AIRadioRenderMixin:
         host = self._hosts.get(str(queue_item.extra_attributes.get(ATTR_HOST_ID) or "")) or {}
         engine_uid = str(host.get("tts_engine") or "") or None
         language = self._tts_language(str(host.get("language") or ""))
+        options = host.get("options") or {}
         try:
             path, stream_type, audio_format = await self._render_tts_media(
-                text, engine_uid, language
+                text, engine_uid, language, options
             )
             # the probe is the first fetch, so a failed render surfaces here and not in playback
             duration = await self._probe_duration(path)
@@ -264,12 +265,16 @@ class AIRadioRenderMixin:
             raise MediaNotFoundError(f"AI Radio clip {clip_id} failed TTS") from err
 
     async def _render_tts_media(
-        self, text: str, engine_uid: str | None = None, language: str | None = None
+        self,
+        text: str,
+        engine_uid: str | None = None,
+        language: str | None = None,
+        options: dict[str, Any] | None = None,
     ) -> tuple[str, StreamType, AudioFormat]:
         """Ask the TTS engine for audio and return the path, stream type and format to play it."""
         engine = await self._get_tts_engine(engine_uid)
         stream_details = await query_tts_engine_with_language_fallback(
-            engine, text, language, logger=self.logger
+            engine, text, language, logger=self.logger, options=options
         )
         path, stream_type = await resolve_tts_stream_path(engine, stream_details)
         audio_format = stream_details.audio_format

--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -138,6 +138,7 @@ class AIRadioRuntimeMixin:
             "instructions": str(host.get("instructions", "")),
             "tts_engine": str(host.get("tts_engine", "")),
             "language": str(host.get("language", "")),
+            "options": deepcopy(host.get("options", {})),
             "sections": sections,
             "section_order": deepcopy(host.get("section_order", [])),
             "merge_section_id": str(host.get("merge_section_id", "")),

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from contextlib import suppress
 from functools import partial
 from itertools import batched
 from sys import intern
@@ -960,13 +959,14 @@ class HomeAssistantProvider(PluginProvider):
         """Raise for a failed tts_get_url response without masking a language rejection."""
         if response.ok:
             return
-        error_message: str | None = None
-        with suppress(Exception):
-            body = await response.json()
-            if isinstance(body, dict) and isinstance(body.get("error"), str):
-                error_message = body["error"]
+        try:
+            # content_type=None so an error body served as text/plain still parses
+            body = await response.json(content_type=None)
+        except ValueError:
+            body = None
+        error_message = body.get("error") if isinstance(body, dict) else None
         # HA returns the same 400 for a rejected option and an unsupported language
-        if error_message and "Invalid options found" in error_message:
+        if isinstance(error_message, str) and "Invalid options found" in error_message:
             raise MusicAssistantError(error_message)
         response.raise_for_status()
 

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from contextlib import suppress
 from functools import partial
 from itertools import batched
 from sys import intern
@@ -65,7 +66,7 @@ from .helpers import ControlCapabilities, get_control_name, is_entity_id
 if TYPE_CHECKING:
     from collections.abc import Callable, Collection, Mapping
 
-    from aiohttp import ClientSession
+    from aiohttp import ClientResponse, ClientSession
     from hass_client.models import (
         Area,
         CompressedState,
@@ -666,7 +667,11 @@ class HomeAssistantProvider(PluginProvider):
         await asyncio.sleep(duration or 5)
 
     async def get_tts_message(
-        self, message: str, language: str | None = None, engine_id: str | None = None
+        self,
+        message: str,
+        language: str | None = None,
+        engine_id: str | None = None,
+        options: dict[str, Any] | None = None,
     ) -> StreamDetails:
         """Handle text-to-speech via Home Assistant's REST API."""
         entity_id = engine_id or next((engine.id for engine in self._tts_engines), None)
@@ -674,13 +679,15 @@ class HomeAssistantProvider(PluginProvider):
             raise UnsupportedFeaturedException("TTS entity is not available")
         ha_url, headers, http_session = self._get_ha_http()
         # the tts_get_url payload field is called engine_id but takes a tts entity_id
-        payload: dict[str, str] = {"engine_id": entity_id, "message": message}
+        payload: dict[str, Any] = {"engine_id": entity_id, "message": message}
         if language:
             payload["language"] = language
+        if options:
+            payload["options"] = options
         async with http_session.post(
             f"{ha_url}/api/tts_get_url", headers=headers, json=payload
         ) as response:
-            response.raise_for_status()
+            await self._raise_for_tts_error(response)
             data = await response.json()
         url = str(data["url"])
         return StreamDetails(
@@ -948,6 +955,20 @@ class HomeAssistantProvider(PluginProvider):
         ssl = bool(self.get_setup_value(CONF_VERIFY_SSL, True))
         http_session = self.mass.http_session if ssl else self.mass.http_session_no_ssl
         return ha_url, headers, http_session
+
+    async def _raise_for_tts_error(self, response: ClientResponse) -> None:
+        """Raise for a failed tts_get_url response without masking a language rejection."""
+        if response.ok:
+            return
+        error_message: str | None = None
+        with suppress(Exception):
+            body = await response.json()
+            if isinstance(body, dict) and isinstance(body.get("error"), str):
+                error_message = body["error"]
+        # HA returns the same 400 for a rejected option and an unsupported language
+        if error_message and "Invalid options found" in error_message:
+            raise MusicAssistantError(error_message)
+        response.raise_for_status()
 
     async def _disconnect_hass(self) -> None:
         """Stop listening for Home Assistant events and disconnect the client."""

--- a/music_assistant/providers/openai_tts/__init__.py
+++ b/music_assistant/providers/openai_tts/__init__.py
@@ -16,7 +16,7 @@ import shutil
 import time
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aiofiles
 from aiofiles.os import makedirs, remove, replace
@@ -180,7 +180,11 @@ class OpenAITTSProvider(PluginProvider):
         return [TTSEngine(id=voice, name=voice, provider=self) for voice in self._voices]
 
     async def get_tts_message(
-        self, message: str, language: str | None = None, engine_id: str | None = None
+        self,
+        message: str,
+        language: str | None = None,
+        engine_id: str | None = None,
+        options: dict[str, Any] | None = None,
     ) -> StreamDetails:
         """
         Render the given message as speech.
@@ -189,6 +193,7 @@ class OpenAITTSProvider(PluginProvider):
         :param language: Ignored: the speech endpoint has no language parameter, the
             backend infers the language from the message itself.
         :param engine_id: The voice to render with; defaults to the first available voice.
+        :param options: Ignored: this provider has no configurable TTS options.
         :return: StreamDetails for the (cached) audio clip.
         """
         voice = engine_id or self._voices[0]

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -3157,7 +3157,7 @@ class TestPlayAnnouncementMessage:
 
         # no language is sent, so the engine speaks in the language it is configured for
         engine.provider.get_tts_message.assert_awaited_once_with(
-            "dinner is ready", language=None, engine_id="voice"
+            "dinner is ready", language=None, engine_id="voice", options=None
         )
         registered = mock_mass.streams.announcement_renderer.register.call_args.args[1]
         assert registered["announcement_url"] == "http://speech/spoken.mp3"
@@ -3177,7 +3177,7 @@ class TestPlayAnnouncementMessage:
             )
 
         engine.provider.get_tts_message.assert_awaited_once_with(
-            "het eten is klaar", language="nl-NL", engine_id="voice"
+            "het eten is klaar", language="nl-NL", engine_id="voice", options=None
         )
 
     async def test_a_rejected_language_is_retried_without_it(self, mock_mass: MagicMock) -> None:

--- a/tests/providers/ai_radio/test_hosts.py
+++ b/tests/providers/ai_radio/test_hosts.py
@@ -106,6 +106,49 @@ def test_normalize_host_strips_whitespace_only_language_to_empty() -> None:
     assert normalized["language"] == ""
 
 
+def test_normalize_host_persists_options() -> None:
+    """Persist a host's TTS options through normalization."""
+    dummy = DummyHosts()
+    dummy._sections = {"Song_Transition": _section("Song_Transition")}
+    payload = _host(["Song_Transition"])
+    payload["options"] = {"voice": "en_US-lessac-medium", "length_scale": 1.2}
+    normalized = dummy._normalize_host(payload)
+    assert normalized["options"] == {"voice": "en_US-lessac-medium", "length_scale": 1.2}
+
+
+def test_normalize_host_defaults_missing_options_to_empty_dict() -> None:
+    """Normalize a host with no 'options' key at all, for backwards compatibility."""
+    dummy = DummyHosts()
+    dummy._sections = {"Song_Transition": _section("Song_Transition")}
+    payload = _host(["Song_Transition"])
+    assert "options" not in payload
+    normalized = dummy._normalize_host(payload)
+    assert normalized["options"] == {}
+
+
+def test_normalize_host_ignores_non_dict_options() -> None:
+    """Fall back to an empty dict when 'options' is not a mapping."""
+    dummy = DummyHosts()
+    dummy._sections = {"Song_Transition": _section("Song_Transition")}
+    payload = _host(["Song_Transition"])
+    payload["options"] = "not-a-dict"
+    normalized = dummy._normalize_host(payload)
+    assert normalized["options"] == {}
+
+
+def test_normalize_host_keeps_option_value_types() -> None:
+    """Keep option values as they came in, e.g. a float stays a float."""
+    dummy = DummyHosts()
+    dummy._sections = {"Song_Transition": _section("Song_Transition")}
+    payload = _host(["Song_Transition"])
+    payload["options"] = {"length_scale": 1.2, "speed": 3}
+    normalized = dummy._normalize_host(payload)
+    assert normalized["options"]["length_scale"] == 1.2
+    assert isinstance(normalized["options"]["length_scale"], float)
+    assert normalized["options"]["speed"] == 3
+    assert isinstance(normalized["options"]["speed"], int)
+
+
 def test_normalize_host_rejects_unknown_section_reference() -> None:
     """Reject hosts that reference shared sections that do not exist."""
     dummy = DummyHosts()

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -49,6 +49,7 @@ class DummyRenderer(AIRadioRenderMixin):
         self._hosts: dict[str, dict[str, Any]] = {}
         self.llm_prompts: list[str] = []
         self.tts_texts: list[str] = []
+        self.tts_options: list[dict[str, Any] | None] = []
         self.weather_calls = 0
         self.fail_generation = False
 
@@ -71,9 +72,14 @@ class DummyRenderer(AIRadioRenderMixin):
         return {"<weather_hourly>": f"fresh weather {self.weather_calls}"}
 
     async def _render_tts_media(
-        self, text: str, engine_uid: str | None = None, language: str | None = None
+        self,
+        text: str,
+        engine_uid: str | None = None,
+        language: str | None = None,
+        options: dict[str, Any] | None = None,
     ) -> tuple[str, StreamType, AudioFormat]:
         self.tts_texts.append(text)
+        self.tts_options.append(options)
         return (
             f"http://ha.invalid/api/tts_proxy/{len(self.tts_texts)}.mp3",
             StreamType.HTTP,
@@ -291,7 +297,7 @@ async def test_render_tts_media_passes_the_locale_as_language() -> None:
 
     engine = cast("Any", renderer)._get_tts_engine.return_value
     engine.provider.get_tts_message.assert_awaited_once_with(
-        "Good evening, it is warm out.", language="en-US", engine_id="tts.cloud"
+        "Good evening, it is warm out.", language="en-US", engine_id="tts.cloud", options={}
     )
 
 
@@ -412,7 +418,11 @@ async def test_tts_failure_raises_media_not_found_and_records_skip() -> None:
 
     class UnspeakableRenderer(DummyRenderer):
         async def _render_tts_media(
-            self, text: str, engine_uid: str | None = None, language: str | None = None
+            self,
+            text: str,
+            engine_uid: str | None = None,
+            language: str | None = None,
+            options: dict[str, Any] | None = None,
         ) -> tuple[str, StreamType, AudioFormat]:
             raise RuntimeError("tts down")
 
@@ -605,7 +615,7 @@ async def test_render_tts_media_prefers_the_hosts_language_over_the_locale() -> 
 
     engine = cast("Any", renderer)._get_tts_engine.return_value
     engine.provider.get_tts_message.assert_awaited_once_with(
-        "Good evening, it is warm out.", language="fr-FR", engine_id="tts.cloud"
+        "Good evening, it is warm out.", language="fr-FR", engine_id="tts.cloud", options={}
     )
 
 
@@ -619,7 +629,7 @@ async def test_render_tts_media_falls_back_to_locale_when_host_language_is_empty
 
     engine = cast("Any", renderer)._get_tts_engine.return_value
     engine.provider.get_tts_message.assert_awaited_once_with(
-        "Good evening, it is warm out.", language="en-US", engine_id="tts.cloud"
+        "Good evening, it is warm out.", language="en-US", engine_id="tts.cloud", options={}
     )
 
 
@@ -646,6 +656,59 @@ async def test_mint_clip_media_resolves_host_tts_engine() -> None:
     cast("Any", renderer)._get_tts_engine.assert_awaited_once_with("tts.rick_voice")
 
 
+async def test_mint_clip_media_forwards_the_hosts_options() -> None:
+    """A host's configured TTS options are forwarded into the render call."""
+    renderer = DummyRenderer()
+    renderer._hosts = {
+        "rick": {
+            "id": "rick",
+            "tts_engine": "",
+            "options": {"voice": "en_US-lessac-medium", "length_scale": 1.2},
+        }
+    }
+    cast("Any", renderer).mass = SimpleNamespace(metadata=SimpleNamespace(locale="en_US"))
+    item = _clip_item("sess_001", **{ATTR_HOST_ID: "rick"})
+
+    await renderer._mint_clip_media(item, "hello world", "clip_1")
+
+    assert renderer.tts_options == [{"voice": "en_US-lessac-medium", "length_scale": 1.2}]
+
+
+async def test_mint_clip_media_sends_no_options_for_a_host_without_any() -> None:
+    """A host with no configured options forwards an empty dict, not None."""
+    renderer = DummyRenderer()
+    renderer._hosts = {"rick": {"id": "rick", "tts_engine": ""}}
+    cast("Any", renderer).mass = SimpleNamespace(metadata=SimpleNamespace(locale="en_US"))
+    item = _clip_item("sess_001", **{ATTR_HOST_ID: "rick"})
+
+    await renderer._mint_clip_media(item, "hello world", "clip_1")
+
+    assert renderer.tts_options == [{}]
+
+
+async def test_render_tts_media_forwards_the_hosts_tts_options() -> None:
+    """A host's configured TTS options reach the engine's get_tts_message call."""
+    renderer = _tts_renderer("http://example.test/api/tts_proxy/abc123.mp3")
+    renderer._hosts = {
+        "rick": {
+            "id": "rick",
+            "tts_engine": "",
+            "options": {"voice": "en_US-lessac-medium", "length_scale": 1.2},
+        }
+    }
+    _attach_queue(renderer, [_clip_item("sess_001", **{ATTR_HOST_ID: "rick"})])
+
+    await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    engine = cast("Any", renderer)._get_tts_engine.return_value
+    engine.provider.get_tts_message.assert_awaited_once_with(
+        "Good evening, it is warm out.",
+        language="en-US",
+        engine_id="tts.cloud",
+        options={"voice": "en_US-lessac-medium", "length_scale": 1.2},
+    )
+
+
 async def test_render_tts_media_streams_a_url_over_http() -> None:
     """A TTS engine returning a proxy URL yields an HTTP stream with the MP3 default format."""
     renderer = _tts_renderer("http://example.test/api/tts_proxy/abc123.mp3")
@@ -658,7 +721,7 @@ async def test_render_tts_media_streams_a_url_over_http() -> None:
     engine = cast("Any", renderer)._get_tts_engine.return_value
     # the provider-scoped engine.id, never engine.uid, and never omitted
     engine.provider.get_tts_message.assert_awaited_once_with(
-        "hello world", language=None, engine_id="tts.cloud"
+        "hello world", language=None, engine_id="tts.cloud", options=None
     )
 
 

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -755,6 +755,17 @@ async def test_tts_invalid_option_raises_music_assistant_error() -> None:
             await provider.get_tts_message("Hello", options={"speaking_cadance": 1})
 
 
+async def test_tts_error_body_that_is_not_json_still_raises_the_generic_way() -> None:
+    """An unparsable error body leaves the status error to speak for itself."""
+    async with _start_provider([_state("tts.first", "First")]) as (provider, _):
+        post = _mock_tts_error_response(provider, "Invalid options found: ['x']")
+        response = post.return_value.__aenter__.return_value
+        response.json.side_effect = ValueError("not json")
+
+        with pytest.raises(ClientResponseError):
+            await provider.get_tts_message("Hello", options={"x": 1})
+
+
 async def test_tts_unsupported_language_still_raises_the_generic_way() -> None:
     """An unsupported-language 400 keeps raising as before, so the caller's retry still fires."""
     async with _start_provider([_state("tts.first", "First")]) as (provider, _):

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -11,9 +11,14 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aiohttp import ClientResponseError
 from hass_client.exceptions import BaseHassClientError
 from music_assistant_models.enums import EventType, ProviderFeature
-from music_assistant_models.errors import SetupFailedError, UnsupportedFeaturedException
+from music_assistant_models.errors import (
+    MusicAssistantError,
+    SetupFailedError,
+    UnsupportedFeaturedException,
+)
 
 from music_assistant.constants import CONF_LOG_LEVEL
 from music_assistant.providers.hass import (
@@ -656,8 +661,22 @@ async def test_ai_query_not_advertised_without_entity() -> None:
 def _mock_tts_response(provider: HomeAssistantProvider) -> MagicMock:
     """Let the Home Assistant tts_get_url endpoint return a URL and return the post mock."""
     response = AsyncMock()
+    response.ok = True
     response.raise_for_status = MagicMock()
     response.json.return_value = {"url": "http://homeassistant.local/tts.mp3"}
+    post = cast("MagicMock", provider.mass.http_session.post)
+    post.return_value.__aenter__.return_value = response
+    return post
+
+
+def _mock_tts_error_response(provider: HomeAssistantProvider, error_message: str) -> MagicMock:
+    """Let the tts_get_url endpoint fail with a 400 carrying the given HA error body."""
+    response = AsyncMock()
+    response.ok = False
+    response.json.return_value = {"error": error_message}
+    response.raise_for_status = MagicMock(
+        side_effect=ClientResponseError(MagicMock(), (), status=400, message=error_message)
+    )
     post = cast("MagicMock", provider.mass.http_session.post)
     post.return_value.__aenter__.return_value = response
     return post
@@ -699,6 +718,50 @@ async def test_tts_not_advertised_without_entity() -> None:
 
         with pytest.raises(UnsupportedFeaturedException):
             await provider.get_tts_message("Hello")
+
+
+async def test_tts_sends_options_in_the_payload() -> None:
+    """A host's TTS options are forwarded in the tts_get_url payload."""
+    async with _start_provider([_state("tts.first", "First")]) as (provider, _):
+        post = _mock_tts_response(provider)
+
+        await provider.get_tts_message(
+            "Hello", options={"voice": "en_US-lessac-medium", "length_scale": 1.2}
+        )
+
+        assert post.call_args.kwargs["json"] == {
+            "engine_id": "tts.first",
+            "message": "Hello",
+            "options": {"voice": "en_US-lessac-medium", "length_scale": 1.2},
+        }
+
+
+async def test_tts_omits_options_from_the_payload_when_empty() -> None:
+    """An empty options dict is not sent to Home Assistant."""
+    async with _start_provider([_state("tts.first", "First")]) as (provider, _):
+        post = _mock_tts_response(provider)
+
+        await provider.get_tts_message("Hello", options={})
+
+        assert post.call_args.kwargs["json"] == {"engine_id": "tts.first", "message": "Hello"}
+
+
+async def test_tts_invalid_option_raises_music_assistant_error() -> None:
+    """HA rejecting an unknown TTS option surfaces as MusicAssistantError with HA's message."""
+    async with _start_provider([_state("tts.first", "First")]) as (provider, _):
+        _mock_tts_error_response(provider, "Invalid options found: ['speaking_cadance']")
+
+        with pytest.raises(MusicAssistantError, match=r"Invalid options found"):
+            await provider.get_tts_message("Hello", options={"speaking_cadance": 1})
+
+
+async def test_tts_unsupported_language_still_raises_the_generic_way() -> None:
+    """An unsupported-language 400 keeps raising as before, so the caller's retry still fires."""
+    async with _start_provider([_state("tts.first", "First")]) as (provider, _):
+        _mock_tts_error_response(provider, "Language 'xx' not supported")
+
+        with pytest.raises(ClientResponseError):
+            await provider.get_tts_message("Hello", language="xx")
 
 
 async def test_registry_update_refreshes_the_engines() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Home Assistant's TTS entities accept integration-specific options — a Piper voice, a `length_scale`, a speaking cadence — and its `tts_get_url` endpoint already takes them. Music Assistant never sent any, so an AI Radio host was stuck with whatever voice the entity defaults to.

A host now carries an optional `options` dict that is passed straight through to the engine.

- Add `options` to `PluginProvider.get_tts_message` and to both TTS helpers, defaulted so every existing caller is unaffected.
- The Home Assistant provider adds them to its `tts_get_url` payload when non-empty.
- Store them per host, defaulting to `{}`, so hosts already on disk normalize unchanged. Values keep their JSON type, since HA hands them to the integration as-is and `length_scale` has to arrive as a number.
- A rejected option now fails loudly. HA validates option names against the entity's `supported_options` and returns a 400, and it returns the same 400 for an unsupported language — which is the case the existing language retry exists for. So an options rejection is raised as a `MusicAssistantError` carrying HA's own "Invalid options found: [...]" text, which propagates instead of triggering a pointless retry; every other failure keeps its current behaviour.

**Related issue (if applicable):**

- n/a

**Companion frontend PR:** https://github.com/music-assistant/frontend/pull/2498

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
