### PR TITLE
Album art no longer holds up the app over a remote connection

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 48
+API_SCHEMA_VERSION: Final[int] = 49
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -13,8 +13,9 @@ import base64
 import contextlib
 import json
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, field
+from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 from urllib.parse import urlparse
 
@@ -39,18 +40,19 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.remote_access")
 
-# Max concurrent proxied (image) fetches, so a burst of album-art requests over the
-# data channel stays bounded and never blocks the API message pump (see #4889).
+# Max concurrent proxied (image) fetches, so a burst of album-art requests stays bounded
+# instead of piling up local requests and the response bodies they buffer (see #4889).
 HTTP_PROXY_CONCURRENCY = 6
 
-# Chunk ma-api messages larger than this; libdatachannel caps data-channel messages at 256 KiB.
-MA_API_CHUNK_SIZE = 64 * 1024
+# Chunk messages larger than this; libdatachannel caps data-channel messages at 256 KiB.
+DATA_CHANNEL_CHUNK_SIZE = 64 * 1024
 
 DEFAULT_SENDSPIN_URL = f"ws://localhost:{SENDSPIN_SERVER_PORT}/sendspin"
 
-# Labels of the data channels that are bridged to a local WebSocket
+# Labels of the data channels the gateway routes, next to the client's own API channel
 CHANNEL_SENDSPIN = "sendspin"
 CHANNEL_LIVE_ANNOUNCEMENT = "live_announcement"
+CHANNEL_HTTP_PROXY = "http_proxy"
 
 
 class _BridgeTarget(NamedTuple):
@@ -61,11 +63,10 @@ class _BridgeTarget(NamedTuple):
 
 
 @dataclass
-class _ChannelBridge:
-    """A bridged data channel together with the local WebSocket it is connected to."""
+class _ServedChannel:
+    """A data channel the gateway serves, plus the local WebSocket it is bridged to (if any)."""
 
     label: str
-    target: _BridgeTarget
     channel: DataChannel | None
     local_ws: aiohttp.ClientWebSocketResponse | None = None
 
@@ -79,9 +80,15 @@ class WebRTCSession:
     # Main API channel (ma-api) - bridges to local MA WebSocket API
     data_channel: DataChannel | None = None
     local_ws: aiohttp.ClientWebSocketResponse | None = None
-    # Bridged WebSocket channels (sendspin, live announcements) by data channel label
-    ws_bridges: dict[str, _ChannelBridge] = field(default_factory=dict)
+    # Channels served by label (sendspin, live announcements, http proxy)
+    channels: dict[str, _ServedChannel] = field(default_factory=dict)
     sendspin_player_id: str | None = None  # Extracted from first sendspin auth message
+
+
+# Serves one incoming data channel for a session until that channel goes away.
+_ChannelHandler = Callable[
+    [WebRTCSession, _ServedChannel, "DataChannel"], Coroutine[Any, Any, None]
+]
 
 
 class WebRTCGateway:
@@ -145,15 +152,19 @@ class WebRTCGateway:
         self._ice_servers_callback = ice_servers_callback
         self._set_sendspin_player_callback = set_sendspin_player_callback
 
-        # Data channel label -> the local WebSocket that channel is bridged to. The live
-        # announcement route sits on the same webserver as the ma-api WebSocket.
-        self._bridge_targets: dict[str, _BridgeTarget] = {
-            CHANNEL_SENDSPIN: _BridgeTarget(
-                self.sendspin_url, self._try_extract_sendspin_client_id
+        # Data channel label -> the handler that serves it. The bridged labels each name a
+        # local WebSocket; the live announcement route sits on the same webserver as the
+        # ma-api WebSocket. The http proxy is served in-process instead of bridged.
+        self._channel_handlers: dict[str, _ChannelHandler] = {
+            CHANNEL_SENDSPIN: partial(
+                self._bridge_websocket,
+                target=_BridgeTarget(self.sendspin_url, self._try_extract_sendspin_client_id),
             ),
-            CHANNEL_LIVE_ANNOUNCEMENT: _BridgeTarget(
-                _ws_url_for_path(self.local_ws_url, LIVE_ANNOUNCEMENT_ROUTE)
+            CHANNEL_LIVE_ANNOUNCEMENT: partial(
+                self._bridge_websocket,
+                target=_BridgeTarget(_ws_url_for_path(self.local_ws_url, LIVE_ANNOUNCEMENT_ROUTE)),
             ),
+            CHANNEL_HTTP_PROXY: self._serve_http_proxy,
         }
 
         # Static ICE servers used at registration time (relayed to clients via signaling server)
@@ -513,9 +524,14 @@ class WebRTCGateway:
             self.logger.exception("Failed to add ICE candidate for session %s", session_id)
 
     async def _handle_http_proxy_request(
-        self, session: WebRTCSession, request_data: dict[str, Any]
+        self, channel: DataChannel | None, request_data: dict[str, Any]
     ) -> None:
-        """Handle HTTP proxy request from remote client."""
+        """
+        Handle an HTTP proxy request from a remote client.
+
+        :param channel: Data channel the request arrived on, and the response is sent back on.
+        :param request_data: The decoded ``http-proxy-request`` message.
+        """
         request_id = request_data.get("id")
         method = request_data.get("method", "GET")
         path = request_data.get("path", "/")
@@ -540,25 +556,25 @@ class WebRTCGateway:
                 ) as response:
                     body = await response.read()
                     await self._send_http_proxy_response(
-                        session, request_id, response.status, dict(response.headers), body
+                        channel, request_id, response.status, dict(response.headers), body
                     )
             except Exception as err:
                 self.logger.exception("Error handling HTTP proxy request")
                 await self._send_http_proxy_response(
-                    session, request_id, 500, {"Content-Type": "text/plain"}, str(err).encode()
+                    channel, request_id, 500, {"Content-Type": "text/plain"}, str(err).encode()
                 )
 
     async def _send_http_proxy_response(
         self,
-        session: WebRTCSession,
+        channel: DataChannel | None,
         request_id: str | None,
         status: int,
         headers: dict[str, str],
         body: bytes,
     ) -> None:
-        """Send an HTTP-proxy response over the ma-api channel."""
-        await self._send_ma_api(
-            session.data_channel,
+        """Send an HTTP-proxy response back on the channel its request arrived on."""
+        await self._send_chunked(
+            channel,
             json.dumps(
                 {
                     "type": "http-proxy-response",
@@ -570,10 +586,10 @@ class WebRTCGateway:
             ),
         )
 
-    async def _send_ma_api(self, channel: DataChannel | None, text: str) -> None:
-        """Send a text message on the ma-api channel, chunking it if it exceeds the size limit."""
+    async def _send_chunked(self, channel: DataChannel | None, text: str) -> None:
+        """Send a text message on a data channel, chunking it if it exceeds the size limit."""
         data = text.encode()
-        if len(data) <= MA_API_CHUNK_SIZE:
+        if len(data) <= DATA_CHANNEL_CHUNK_SIZE:
             await self._send_on_channel(channel, text)
             return
 
@@ -582,11 +598,11 @@ class WebRTCGateway:
         # predictable regardless of JSON escaping / unicode).
         self._chunk_group_seq += 1
         group_id = self._chunk_group_seq
-        count = (len(data) + MA_API_CHUNK_SIZE - 1) // MA_API_CHUNK_SIZE
+        count = (len(data) + DATA_CHANNEL_CHUNK_SIZE - 1) // DATA_CHANNEL_CHUNK_SIZE
         for seq in range(count):
             if channel is None or not channel.is_open:
                 return
-            piece = data[seq * MA_API_CHUNK_SIZE : (seq + 1) * MA_API_CHUNK_SIZE]
+            piece = data[seq * DATA_CHANNEL_CHUNK_SIZE : (seq + 1) * DATA_CHANNEL_CHUNK_SIZE]
             await self._send_on_channel(
                 channel,
                 json.dumps(
@@ -607,13 +623,13 @@ class WebRTCGateway:
             return
 
         # Close the local bridges first so no more data is fed through the channels
-        bridged = [bridge.local_ws for bridge in session.ws_bridges.values()]
+        bridged = [served.local_ws for served in session.channels.values()]
         for local_ws in (session.local_ws, *bridged):
             if local_ws is not None and not local_ws.closed:
                 with contextlib.suppress(Exception):
                     await local_ws.close()
         session.local_ws = None
-        session.ws_bridges.clear()
+        session.channels.clear()
 
         # aclose tears down all PC-owned pumps and every data channel; safe here because
         # _close_session is never invoked from within a PC-owned task
@@ -646,12 +662,12 @@ class WebRTCGateway:
             )
 
     async def _accept_channels(self, session: WebRTCSession) -> None:
-        """Accept incoming data channels and start their bridges."""
+        """Accept incoming data channels and start their handlers."""
         async for channel in session.pc.incoming_data_channels():
-            if (target := self._bridge_targets.get(channel.label)) is not None:
-                if channel.label in session.ws_bridges:
-                    # replacing the entry would leave the running bridge untracked, and
-                    # tearing either one down would then orphan the other's websocket
+            if (handler := self._channel_handlers.get(channel.label)) is not None:
+                if channel.label in session.channels:
+                    # replacing the entry would leave the running handler untracked, and
+                    # tearing either one down would then orphan the other's resources
                     self.logger.warning(
                         "Refusing a second '%s' data channel for session %s",
                         channel.label,
@@ -659,9 +675,9 @@ class WebRTCGateway:
                     )
                     channel.close()
                     continue
-                bridge = _ChannelBridge(label=channel.label, target=target, channel=channel)
-                session.ws_bridges[channel.label] = bridge
-                session.pc.spawn_task(self._bridge_websocket(session, bridge, channel))
+                served = _ServedChannel(label=channel.label, channel=channel)
+                session.channels[channel.label] = served
+                session.pc.spawn_task(handler(session, served, channel))
             elif session.data_channel is None:
                 # the browser opens its API channel first, whatever label it gives it
                 session.data_channel = channel
@@ -715,11 +731,11 @@ class WebRTCGateway:
                             isinstance(msg_data, dict)
                             and msg_data.get("type") == "http-proxy-request"
                         ):
-                            # Handle off the receive loop so a slow image fetch never
-                            # blocks API messages or the next image (bounded by the
-                            # gateway-wide semaphore; see #4889).
+                            # clients from before the http proxy channel existed still
+                            # proxy over this one; handle off the receive loop so a slow
+                            # fetch never blocks API messages or the next image (see #4889)
                             session.pc.spawn_task(
-                                self._handle_http_proxy_request(session, msg_data)
+                                self._handle_http_proxy_request(channel, msg_data)
                             )
                             continue
                     except json.JSONDecodeError, ValueError:
@@ -745,7 +761,7 @@ class WebRTCGateway:
         try:
             async for msg in local_ws:
                 if msg.type == aiohttp.WSMsgType.TEXT:
-                    await self._send_ma_api(channel, msg.data)
+                    await self._send_chunked(channel, msg.data)
                 elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSED):
                     break
         except asyncio.CancelledError:
@@ -757,34 +773,43 @@ class WebRTCGateway:
         self._schedule_close(session.session_id)
 
     async def _bridge_websocket(
-        self, session: WebRTCSession, bridge: _ChannelBridge, channel: DataChannel
+        self,
+        session: WebRTCSession,
+        served: _ServedChannel,
+        channel: DataChannel,
+        *,
+        target: _BridgeTarget,
     ) -> None:
         """Bridge a data channel to the local WebSocket its label is routed to."""
         try:
             # TLS verification would fail on the bind address and adds nothing to a dial
             # that never leaves this host (a no-op for the plain ws:// targets)
-            bridge.local_ws = await self.http_session.ws_connect(bridge.target.url, ssl=False)
+            served.local_ws = await self.http_session.ws_connect(target.url, ssl=False)
             self.logger.debug(
-                "%s channel connected for session %s", bridge.label, session.session_id
+                "%s channel connected for session %s", served.label, session.session_id
             )
         except Exception:
             self.logger.exception(
                 "Failed to connect %s channel to %s for session %s",
-                bridge.label,
-                bridge.target.url,
+                served.label,
+                target.url,
                 session.session_id,
             )
-            await self._close_ws_bridge(session, bridge)
+            await self._close_channel(session, served)
             return
 
         # from_local runs as its own PC-owned pump; this task drives channel -> local
-        session.pc.spawn_task(self._ws_bridge_from_local(session, bridge, channel))
-        await self._ws_bridge_to_local(session, bridge, channel)
+        session.pc.spawn_task(self._ws_bridge_from_local(session, served, channel))
+        await self._ws_bridge_to_local(session, served, channel, target)
         # channel -> local loop ended (remote channel closed): tear down only this bridge
-        await self._close_ws_bridge(session, bridge)
+        await self._close_channel(session, served)
 
     async def _ws_bridge_to_local(
-        self, session: WebRTCSession, bridge: _ChannelBridge, channel: DataChannel
+        self,
+        session: WebRTCSession,
+        served: _ServedChannel,
+        channel: DataChannel,
+        target: _BridgeTarget,
     ) -> None:
         """Forward messages from a bridged data channel to its local WebSocket."""
         first_message = True
@@ -792,27 +817,27 @@ class WebRTCGateway:
             async for message in channel:
                 if first_message:
                     first_message = False
-                    if bridge.target.on_first_message and isinstance(message, str):
-                        bridge.target.on_first_message(session, message)
+                    if target.on_first_message and isinstance(message, str):
+                        target.on_first_message(session, message)
 
-                local_ws = bridge.local_ws
+                local_ws = served.local_ws
                 if local_ws and not local_ws.closed:
                     if isinstance(message, bytes):
                         await local_ws.send_bytes(message)
                     else:
                         await local_ws.send_str(message)
         except ConnectionClosedError:
-            self.logger.debug("%s channel closed for session %s", bridge.label, session.session_id)
+            self.logger.debug("%s channel closed for session %s", served.label, session.session_id)
         except asyncio.CancelledError:
             raise
         except Exception:
-            self.logger.exception("Error forwarding %s to local", bridge.label)
+            self.logger.exception("Error forwarding %s to local", served.label)
 
     async def _ws_bridge_from_local(
-        self, session: WebRTCSession, bridge: _ChannelBridge, channel: DataChannel
+        self, session: WebRTCSession, served: _ServedChannel, channel: DataChannel
     ) -> None:
         """Forward messages from a bridged local WebSocket to its data channel."""
-        local_ws = bridge.local_ws
+        local_ws = served.local_ws
         if local_ws is None:
             return
         try:
@@ -824,23 +849,48 @@ class WebRTCGateway:
         except asyncio.CancelledError:
             raise
         except Exception:
-            self.logger.exception("Error forwarding %s from local", bridge.label)
+            self.logger.exception("Error forwarding %s from local", served.label)
         # the local WS closed: close only this bridge, leaving the ma-api session up
-        await self._close_ws_bridge(session, bridge)
+        await self._close_channel(session, served)
 
-    async def _close_ws_bridge(self, session: WebRTCSession, bridge: _ChannelBridge) -> None:
-        """Close one bridged data channel and its local WebSocket."""
-        # only drop the entry while it still points at this bridge, so a teardown can
-        # never untrack a bridge that replaced it
-        if session.ws_bridges.get(bridge.label) is bridge:
-            del session.ws_bridges[bridge.label]
-        local_ws = bridge.local_ws
-        bridge.local_ws = None
+    async def _serve_http_proxy(
+        self, session: WebRTCSession, served: _ServedChannel, channel: DataChannel
+    ) -> None:
+        """Serve proxied HTTP requests arriving on their own data channel."""
+        try:
+            async for message in channel:
+                if not isinstance(message, str):
+                    continue
+                try:
+                    request = json.loads(message)
+                except json.JSONDecodeError, ValueError:
+                    continue
+                if isinstance(request, dict) and request.get("type") == "http-proxy-request":
+                    # handle off the receive loop so a slow fetch never holds up the next
+                    # request (bounded by the gateway-wide semaphore; see #4889)
+                    session.pc.spawn_task(self._handle_http_proxy_request(channel, request))
+        except ConnectionClosedError:
+            self.logger.debug("%s channel closed for session %s", served.label, session.session_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger.exception("Error serving %s channel", served.label)
+        # the remote channel closed: tear down only this channel, leaving the session up
+        await self._close_channel(session, served)
+
+    async def _close_channel(self, session: WebRTCSession, served: _ServedChannel) -> None:
+        """Close one served data channel and the local WebSocket it is bridged to."""
+        # only drop the entry while it still points at this channel, so a teardown can
+        # never untrack a channel that replaced it
+        if session.channels.get(served.label) is served:
+            del session.channels[served.label]
+        local_ws = served.local_ws
+        served.local_ws = None
         if local_ws is not None and not local_ws.closed:
             with contextlib.suppress(Exception):
                 await local_ws.close()
-        channel = bridge.channel
-        bridge.channel = None
+        channel = served.channel
+        served.channel = None
         if channel is not None and not channel.closed:
             with contextlib.suppress(Exception):
                 await channel.aclose()

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -86,8 +86,8 @@ class WebRTCSession:
 
 
 # Serves one incoming data channel for a session until that channel goes away.
-_ChannelHandler = Callable[
-    [WebRTCSession, _ServedChannel, "DataChannel"], Coroutine[Any, Any, None]
+type _ChannelHandler = Callable[
+    [WebRTCSession, _ServedChannel, DataChannel], Coroutine[Any, Any, None]
 ]
 
 
@@ -731,9 +731,9 @@ class WebRTCGateway:
                             isinstance(msg_data, dict)
                             and msg_data.get("type") == "http-proxy-request"
                         ):
-                            # clients from before the http proxy channel existed still
-                            # proxy over this one; handle off the receive loop so a slow
-                            # fetch never blocks API messages or the next image (see #4889)
+                            # clients without a dedicated http proxy channel proxy over
+                            # this one; handle off the receive loop so a slow fetch never
+                            # blocks API messages or the next image (see #4889)
                             session.pc.spawn_task(
                                 self._handle_http_proxy_request(channel, msg_data)
                             )
@@ -780,7 +780,11 @@ class WebRTCGateway:
         *,
         target: _BridgeTarget,
     ) -> None:
-        """Bridge a data channel to the local WebSocket its label is routed to."""
+        """
+        Bridge a data channel to the local WebSocket its label is routed to.
+
+        :param target: The local WebSocket this channel's label is routed to.
+        """
         try:
             # TLS verification would fail on the bind address and adds nothing to a dial
             # that never leaves this host (a no-op for the plain ws:// targets)

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -24,7 +24,7 @@ from music_assistant.controllers.webserver.remote_access import (
     RemoteAccessManager,
 )
 from music_assistant.controllers.webserver.remote_access.gateway import (
-    MA_API_CHUNK_SIZE,
+    DATA_CHANNEL_CHUNK_SIZE,
     WebRTCGateway,
     WebRTCSession,
     _is_usable_ice_url,
@@ -699,10 +699,9 @@ async def test_http_proxy_request_cannot_change_host(
         key_pem=key_pem,
         local_ws_url="ws://localhost:8095/ws",
     )
-    session = WebRTCSession(session_id="s1", pc=Mock())
 
     await gateway._handle_http_proxy_request(
-        session, {"id": "1", "method": "GET", "path": malicious_path}
+        None, {"id": "1", "method": "GET", "path": malicious_path}
     )
 
     parsed = urlparse(captured_url["url"])
@@ -740,9 +739,8 @@ async def test_http_proxy_request_keeps_the_unverified_dial_on_this_host(
         key_pem=key_pem,
         local_ws_url="wss://127.0.0.1:8095/ws",
     )
-    session = WebRTCSession(session_id="s1", pc=Mock())
 
-    await gateway._handle_http_proxy_request(session, {"id": "1", "method": "GET", "path": "/info"})
+    await gateway._handle_http_proxy_request(None, {"id": "1", "method": "GET", "path": "/info"})
 
     assert captured_kwargs["ssl"] is False
     assert captured_kwargs["allow_redirects"] is False
@@ -909,6 +907,8 @@ class _FakeHttpSession:
         self.dialed: list[str] = []
         self.dial_kwargs: list[dict[str, Any]] = []
         self.websockets: dict[str, _FakeLocalWS] = {}
+        self.requested: list[str] = []
+        self.response_body = b""
 
     async def ws_connect(self, url: str, **kwargs: Any) -> _FakeLocalWS:
         self.dialed.append(url)
@@ -916,6 +916,18 @@ class _FakeHttpSession:
         local_ws = _FakeLocalWS()
         self.websockets[url] = local_ws
         return local_ws
+
+    def request(self, _method: str, url: str, **_kwargs: Any) -> AsyncMock:
+        """Serve ``response_body`` for a proxied HTTP request."""
+        self.requested.append(url)
+        response = AsyncMock()
+        response.status = 200
+        response.headers = {"Content-Type": "image/jpeg"}
+        response.read = AsyncMock(return_value=self.response_body)
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=response)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
 
 
 class _FakePeerConnection:
@@ -1232,7 +1244,7 @@ async def test_closing_a_bridged_channel_leaves_the_api_session_up(
             sendspin_channel.close()
         else:
             await sendspin_ws.close()
-        await _wait_for(lambda: not session.ws_bridges)
+        await _wait_for(lambda: not session.channels)
 
         assert sendspin_ws.closed is True
         assert sendspin_channel.closed is True
@@ -1285,6 +1297,112 @@ async def test_unknown_channel_label_cannot_replace_the_api_channel(
         await gateway._close_session("unknown-session")
 
 
+def _proxy_request(request_id: str, path: str) -> str:
+    """Build the http-proxy-request message a client sends for a proxied path."""
+    return json.dumps(
+        {"type": "http-proxy-request", "id": request_id, "method": "GET", "path": path}
+    )
+
+
+async def test_http_proxy_channel_answers_on_its_own_channel(cert_pems: tuple[str, str]) -> None:
+    """A proxied request on the http proxy channel is answered there, not on the API channel."""
+    http_session = _FakeHttpSession()
+    http_session.response_body = b"\xff\xd8jpeg-bytes"
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "proxy-session")
+    api_channel = _FakeBidiChannel()
+    proxy_channel = _FakeBidiChannel(label="http_proxy")
+    pc.offer_channel(api_channel)
+    pc.offer_channel(proxy_channel)
+    try:
+        await _wait_for(lambda: session.local_ws is not None)
+
+        proxy_channel.feed(_proxy_request("img-1", "/imageproxy/abc"))
+        await _wait_for(lambda: bool(proxy_channel.sent))
+
+        assert http_session.requested == ["http://127.0.0.1:8095/imageproxy/abc"]
+        response = json.loads(cast("str", proxy_channel.sent[0]))
+        assert response["type"] == "http-proxy-response"
+        assert response["id"] == "img-1"
+        assert response["status"] == 200
+        assert bytes.fromhex(response["body"]) == b"\xff\xd8jpeg-bytes"
+        # the image never touches the API channel, nor the local API WebSocket
+        assert api_channel.sent == []
+        assert cast("_FakeLocalWS", session.local_ws).sent == []
+    finally:
+        await gateway._close_session("proxy-session")
+
+
+async def test_http_proxy_request_on_the_api_channel_is_still_answered(
+    cert_pems: tuple[str, str],
+) -> None:
+    """Clients that predate the http proxy channel keep proxying over the API channel."""
+    http_session = _FakeHttpSession()
+    http_session.response_body = b"legacy-body"
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "legacy-session")
+    api_channel = _FakeBidiChannel()
+    pc.offer_channel(api_channel)
+    try:
+        await _wait_for(lambda: session.local_ws is not None)
+
+        api_channel.feed(_proxy_request("img-2", "/imageproxy/def"))
+        await _wait_for(lambda: bool(api_channel.sent))
+
+        assert http_session.requested == ["http://127.0.0.1:8095/imageproxy/def"]
+        response = json.loads(cast("str", api_channel.sent[0]))
+        assert response["type"] == "http-proxy-response"
+        assert response["id"] == "img-2"
+        assert bytes.fromhex(response["body"]) == b"legacy-body"
+        # the proxy request is served here, never forwarded to the local API WebSocket
+        assert cast("_FakeLocalWS", session.local_ws).sent == []
+    finally:
+        await gateway._close_session("legacy-session")
+
+
+async def test_closing_the_http_proxy_channel_leaves_the_api_session_up(
+    cert_pems: tuple[str, str],
+) -> None:
+    """Losing the http proxy channel tears down that channel only, never the API session."""
+    http_session = _FakeHttpSession()
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "proxy-close-session")
+    api_channel = _FakeBidiChannel()
+    proxy_channel = _FakeBidiChannel(label="http_proxy")
+    pc.offer_channel(api_channel)
+    pc.offer_channel(proxy_channel)
+    try:
+        await _wait_for(lambda: "http_proxy" in session.channels)
+
+        proxy_channel.close()
+        await _wait_for(lambda: not session.channels)
+
+        assert "proxy-close-session" in gateway.sessions
+        assert session.local_ws is not None
+        assert api_channel.closed is False
+    finally:
+        await gateway._close_session("proxy-close-session")
+
+
+async def test_a_second_http_proxy_channel_is_refused(cert_pems: tuple[str, str]) -> None:
+    """A duplicate label is refused so the running handler is never left untracked."""
+    http_session = _FakeHttpSession()
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "duplicate-session")
+    first = _FakeBidiChannel(label="http_proxy")
+    second = _FakeBidiChannel(label="http_proxy")
+    pc.offer_channel(first)
+    try:
+        await _wait_for(lambda: "http_proxy" in session.channels)
+        pc.offer_channel(second)
+        await _wait_for(lambda: second.closed)
+
+        assert first.closed is False
+        assert session.channels["http_proxy"].channel is cast("DataChannel", first)
+    finally:
+        await gateway._close_session("duplicate-session")
+
+
 class _FakeDataChannel:
     """Data channel stand-in that captures outbound messages for proxy tests."""
 
@@ -1321,13 +1439,14 @@ def _reassemble_chunks(frames: list[str]) -> str:
 async def test_http_proxy_response_small_body_single_message(
     cert_pems: tuple[str, str],
 ) -> None:
-    """A body within the chunk size is sent as one legacy http-proxy-response message."""
+    """A body within the chunk size is sent as one http-proxy-response message."""
     gateway = _proxy_gateway(cert_pems)
     channel = _FakeDataChannel()
-    session = cast("WebRTCSession", SimpleNamespace(data_channel=channel))
     body = b"\x00\x01\x02small-body"
 
-    await gateway._send_http_proxy_response(session, "req-small", 200, {"X-Test": "y"}, body)
+    await gateway._send_http_proxy_response(
+        cast("DataChannel", channel), "req-small", 200, {"X-Test": "y"}, body
+    )
 
     assert len(channel.sent) == 1
     msg = json.loads(channel.sent[0])
@@ -1342,10 +1461,10 @@ async def test_http_proxy_response_large_body_chunked(cert_pems: tuple[str, str]
     """A large HTTP-proxy response is split into base64 chunk frames the client reassembles."""
     gateway = _proxy_gateway(cert_pems)
     channel = _FakeDataChannel()
-    session = cast("WebRTCSession", SimpleNamespace(data_channel=channel))
-    body = bytes(range(256)) * ((MA_API_CHUNK_SIZE * 5) // 512)  # big body -> big JSON message
+    # big body -> big JSON message
+    body = bytes(range(256)) * ((DATA_CHANNEL_CHUNK_SIZE * 5) // 512)
 
-    await gateway._send_http_proxy_response(session, "req-big", 200, {}, body)
+    await gateway._send_http_proxy_response(cast("DataChannel", channel), "req-big", 200, {}, body)
 
     assert len(channel.sent) > 1
     assert all(json.loads(m)["type"] == "__chunk__" for m in channel.sent)
@@ -1359,22 +1478,22 @@ async def test_http_proxy_response_large_body_chunked(cert_pems: tuple[str, str]
     assert bytes.fromhex(reassembled["body"]) == body
 
 
-async def test_send_ma_api_small_message_passthrough(cert_pems: tuple[str, str]) -> None:
-    """A ma-api message within the limit is sent verbatim, not chunked."""
+async def test_send_chunked_small_message_passthrough(cert_pems: tuple[str, str]) -> None:
+    """A message within the limit is sent verbatim, not chunked."""
     gateway = _proxy_gateway(cert_pems)
     channel = _FakeDataChannel()
-    await gateway._send_ma_api(cast("DataChannel", channel), '{"event":"player_updated"}')
+    await gateway._send_chunked(cast("DataChannel", channel), '{"event":"player_updated"}')
     assert channel.sent == ['{"event":"player_updated"}']
 
 
-async def test_send_ma_api_large_message_chunked(cert_pems: tuple[str, str]) -> None:
-    """A large ma-api message is chunked and reassembles byte-identically (multibyte-safe)."""
+async def test_send_chunked_large_message_chunked(cert_pems: tuple[str, str]) -> None:
+    """A large message is chunked and reassembles byte-identically (multibyte-safe)."""
     gateway = _proxy_gateway(cert_pems)
     channel = _FakeDataChannel()
     # multibyte payload so chunk boundaries fall mid-character, exercising the byte-level split
-    text = '{"data":"' + "音楽" * MA_API_CHUNK_SIZE + '"}'
+    text = '{"data":"' + "音楽" * DATA_CHANNEL_CHUNK_SIZE + '"}'
 
-    await gateway._send_ma_api(cast("DataChannel", channel), text)
+    await gateway._send_chunked(cast("DataChannel", channel), text)
 
     assert len(channel.sent) > 1
     assert all(len(m.encode()) < 256 * 1024 for m in channel.sent)

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -1360,6 +1360,65 @@ async def test_http_proxy_request_on_the_api_channel_is_still_answered(
         await gateway._close_session("legacy-session")
 
 
+async def test_http_proxy_channel_reports_a_failed_fetch_on_its_own_channel(
+    cert_pems: tuple[str, str],
+) -> None:
+    """A fetch that raises still answers the client, on the channel it asked over."""
+    http_session = _FakeHttpSession()
+    http_session.request = Mock(side_effect=RuntimeError("boom"))  # type: ignore[method-assign]
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "proxy-error-session")
+    api_channel = _FakeBidiChannel()
+    proxy_channel = _FakeBidiChannel(label="http_proxy")
+    pc.offer_channel(api_channel)
+    pc.offer_channel(proxy_channel)
+    try:
+        await _wait_for(lambda: session.local_ws is not None)
+
+        proxy_channel.feed(_proxy_request("img-3", "/imageproxy/boom"))
+        await _wait_for(lambda: bool(proxy_channel.sent))
+
+        response = json.loads(cast("str", proxy_channel.sent[0]))
+        assert response["id"] == "img-3"
+        assert response["status"] == 500
+        assert api_channel.sent == []
+    finally:
+        await gateway._close_session("proxy-error-session")
+
+
+@pytest.mark.parametrize(
+    "junk",
+    [
+        "not json at all",
+        json.dumps(["not", "a", "dict"]),
+        json.dumps({"type": "something-else"}),
+        b"\x00\x01binary",
+    ],
+)
+async def test_http_proxy_channel_survives_junk(
+    cert_pems: tuple[str, str], junk: str | bytes
+) -> None:
+    """Anything that is not a proxy request is ignored without killing the channel."""
+    http_session = _FakeHttpSession()
+    http_session.response_body = b"still-here"
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "proxy-junk-session")
+    proxy_channel = _FakeBidiChannel(label="http_proxy")
+    pc.offer_channel(proxy_channel)
+    try:
+        await _wait_for(lambda: "http_proxy" in session.channels)
+
+        proxy_channel.feed(junk)
+        proxy_channel.feed(_proxy_request("img-4", "/imageproxy/ok"))
+        await _wait_for(lambda: bool(proxy_channel.sent))
+
+        response = json.loads(cast("str", proxy_channel.sent[0]))
+        assert response["id"] == "img-4"
+        assert bytes.fromhex(response["body"]) == b"still-here"
+    finally:
+        await gateway._close_session("proxy-junk-session")
+
+
 async def test_closing_the_http_proxy_channel_leaves_the_api_session_up(
     cert_pems: tuple[str, str],
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Over a remote connection, album art and preview images are fetched through the WebRTC
connection. Until now they travelled on the same data channel as the API messages, so a
screen full of album art would queue ahead of API traffic on that one ordered stream —
and every API message had to wait for the image backlog to drain before it could be sent.
The result is a UI that feels sluggish exactly when it is loading a big list.

Images now get their own data channel, so they no longer sit in front of API messages.

- Route data channels by label to a handler, so a label can be served in-process instead
  of only being bridged to a local WebSocket
- Serve proxied HTTP requests (album art, previews) on a dedicated `http_proxy` channel
- Answer every proxy request on the channel it arrived on, so clients that still proxy
  over the API channel keep working unchanged
- Bump the API schema version so clients can tell whether the channel is available

**Related issue (if applicable):**

- follow-up to #4889

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: https://github.com/music-assistant/frontend/pull/2503
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.