### PR TITLE
Rebuild the dev add-on when a new nightly is released

### DIFF
--- a/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
+++ b/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
@@ -51,8 +51,9 @@ Only one release workflow runs at a time, and queued runs are never cancelled.
    - Nightly: `nightly`
    Each alias's current amd64 and arm64 image labels are checked independently. An alias
    that already points to a newer release is never moved backward.
-10. Deterministically update the matching Home Assistant add-on and dispatch the
-    frontend version from `source_sha` to `app.music-assistant.io`.
+10. Deterministically update the matching Home Assistant add-on, and on nightly the
+    `music_assistant_dev` add-on as well, then dispatch the frontend version from
+    `source_sha` to `app.music-assistant.io`.
 
 The exact image tag is already the full version (`X.Y.Z`, `X.Y.ZbN`, `X.Y.ZrcN`, or
 `X.Y.Z.devN`). Rolling aliases are never pushed before the immutable release verifies.
@@ -137,6 +138,13 @@ The add-on changelog update removes duplicate entries for the same version, prep
 canonical entry using the GitHub publication date, and retains three distinct releases.
 The add-on repository's default branch is resolved through GitHub, and non-fast-forward
 updates retry a bounded pull/rebase/push sequence.
+
+A nightly release also sets the `music_assistant_dev` add-on to the same version, in the
+same commit. That add-on has no prebuilt image: the Supervisor builds it locally from
+`ghcr.io/music-assistant/server:nightly`, so moving its version is what offers installed
+add-ons the rebuild that picks up the new base image and the current wrapper files. It
+gets no changelog entry, because it runs whichever source branch the user configured
+rather than the published release.
 
 Frontend recovery reads the target repository's `channels.json` first. Equal or newer
 frontend state suppresses the dispatch; an older state receives a payload containing a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1432,6 +1432,7 @@ jobs:
         env:
           CHANNEL: ${{ inputs.channel }}
         run: |
+          dev_folder=""
           case "$CHANNEL" in
             stable)
               folder="music_assistant"
@@ -1441,9 +1442,12 @@ jobs:
               ;;
             nightly)
               folder="music_assistant_nightly"
+              # the dev add-on is built from the nightly image, so it follows this release
+              dev_folder="music_assistant_dev"
               ;;
           esac
           echo "folder=$folder" >> "$GITHUB_OUTPUT"
+          echo "dev_folder=$dev_folder" >> "$GITHUB_OUTPUT"
 
       - name: Update add-on release
         env:
@@ -1465,9 +1469,20 @@ jobs:
             --notes "$RUNNER_TEMP/release-notes.md" \
             --retain 3
 
+      - name: Update dev add-on version
+        if: steps.channel.outputs.dev_folder != ''
+        env:
+          DEV_FOLDER: ${{ steps.channel.outputs.dev_folder }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          python3 .release-workflow/scripts/release_workflow.py set-addon-version \
+            --config "addon-repo/$DEV_FOLDER/config.yaml" \
+            --version "$VERSION"
+
       - name: Commit add-on update
         env:
           ADDON_FOLDER: ${{ steps.channel.outputs.folder }}
+          DEV_FOLDER: ${{ steps.channel.outputs.dev_folder }}
           APP_SLUG: ${{ steps.app.outputs.slug }}
           APP_USER_ID: ${{ steps.app.outputs.user_id }}
           ADDON_BRANCH: ${{ steps.addon_repository.outputs.default_branch }}
@@ -1476,6 +1491,9 @@ jobs:
         run: |
           cd addon-repo
           git add "$ADDON_FOLDER/config.yaml" "$ADDON_FOLDER/CHANGELOG.md"
+          if [ -n "$DEV_FOLDER" ]; then
+            git add "$DEV_FOLDER/config.yaml"
+          fi
           if git diff --cached --quiet; then
             echo "Add-on $ADDON_FOLDER already references $VERSION"
             exit 0

--- a/scripts/release_workflow.py
+++ b/scripts/release_workflow.py
@@ -486,17 +486,7 @@ def update_addon_release(
     """
     if retain < 1:
         raise ReleaseWorkflowError("At least one changelog release must be retained")
-    config = config_path.read_text(encoding="utf-8")
-    config, replacements = re.subn(
-        r"^version: .+$",
-        f"version: {version}",
-        config,
-        count=1,
-        flags=re.MULTILINE,
-    )
-    if replacements != 1:
-        raise ReleaseWorkflowError(f"Expected one version field in {config_path}")
-    config_path.write_text(config, encoding="utf-8")
+    set_addon_version(config_path, version)
 
     existing = changelog_path.read_text(encoding="utf-8") if changelog_path.exists() else ""
     blocks = _changelog_blocks(existing)
@@ -510,6 +500,26 @@ def update_addon_release(
     new_block = f"# [{version}] - {release_date}\n\n{notes.strip()}"
     content = "\n\n\n".join([new_block, *previous_blocks[: retain - 1]]) + "\n"
     changelog_path.write_text(content, encoding="utf-8")
+
+
+def set_addon_version(config_path: Path, version: str) -> None:
+    """
+    Point an add-on at a release version, leaving the rest of its config untouched.
+
+    :param config_path: Add-on ``config.yaml`` path.
+    :param version: Server version and image tag.
+    """
+    config = config_path.read_text(encoding="utf-8")
+    config, replacements = re.subn(
+        r"^version: .+$",
+        f"version: {version}",
+        config,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if replacements != 1:
+        raise ReleaseWorkflowError(f"Expected one version field in {config_path}")
+    config_path.write_text(config, encoding="utf-8")
 
 
 def _next_stable(latest_stable: str | None) -> str:
@@ -688,6 +698,11 @@ def _configure_release_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--github-output", type=Path)
 
 
+def _configure_addon_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -744,12 +759,13 @@ def _build_parser() -> argparse.ArgumentParser:
     manifest_parser.add_argument("--github-output", type=Path)
 
     addon_parser = subparsers.add_parser("update-addon")
-    addon_parser.add_argument("--config", type=Path, required=True)
+    _configure_addon_parser(addon_parser)
     addon_parser.add_argument("--changelog", type=Path, required=True)
-    addon_parser.add_argument("--version", required=True)
     addon_parser.add_argument("--release-date", required=True)
     addon_parser.add_argument("--notes", type=Path, required=True)
     addon_parser.add_argument("--retain", type=int, default=3)
+
+    _configure_addon_parser(subparsers.add_parser("set-addon-version"))
     return parser
 
 
@@ -866,6 +882,8 @@ def main() -> int:
                 notes=args.notes.read_text(encoding="utf-8"),
                 retain=args.retain,
             )
+        elif args.command == "set-addon-version":
+            set_addon_version(args.config, args.version)
         return 0
     except (OSError, ReleaseWorkflowError, ValueError, json.JSONDecodeError) as err:
         print(f"ERROR: {err}", file=sys.stderr)

--- a/scripts/release_workflow.py
+++ b/scripts/release_workflow.py
@@ -510,11 +510,11 @@ def set_addon_version(config_path: Path, version: str) -> None:
     :param version: Server version and image tag.
     """
     config = config_path.read_text(encoding="utf-8")
+    # a duplicate key would leave the stale one in effect, so rewrite nothing unless it is unique
     config, replacements = re.subn(
         r"^version: .+$",
         f"version: {version}",
         config,
-        count=1,
         flags=re.MULTILINE,
     )
     if replacements != 1:

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -26,6 +26,7 @@ from scripts.release_workflow import (
     inspect_assets,
     is_current_release,
     select_release,
+    set_addon_version,
     update_addon_release,
     verify_oci_manifest,
 )
@@ -379,6 +380,57 @@ def test_addon_update_replaces_duplicate_version_and_retains_three(tmp_path: Pat
     assert first_result.count("# [older]") == 1
     assert "# [older]" in first_result
     assert "# [oldest]" in first_result
+
+
+def test_addon_version_update_leaves_the_rest_of_the_config_alone(tmp_path: Path) -> None:
+    """The dev add-on follows the nightly version without gaining a changelog."""
+    config = tmp_path / "config.yaml"
+    original = (
+        "name: Music Assistant DEV SERVER\n"
+        "# tracks the nightly base image; bumped by the server release workflow\n"
+        "version: 1.6.0\n"
+        "slug: music_assistant_dev\n"
+    )
+    config.write_text(original, encoding="utf-8")
+
+    set_addon_version(config, "2.10.0.dev2026081303")
+
+    assert config.read_text(encoding="utf-8") == original.replace(
+        "version: 1.6.0", "version: 2.10.0.dev2026081303"
+    )
+    assert list(tmp_path.iterdir()) == [config]
+
+
+def test_addon_version_update_requires_a_version_field(tmp_path: Path) -> None:
+    """A config without a version field fails instead of silently changing nothing."""
+    config = tmp_path / "config.yaml"
+    config.write_text("name: Music Assistant DEV SERVER\n", encoding="utf-8")
+
+    with pytest.raises(ReleaseWorkflowError):
+        set_addon_version(config, "2.10.0.dev2026081303")
+
+
+def test_release_workflow_bumps_the_dev_addon_on_nightly_only() -> None:
+    """Nightly carries the locally built dev add-on along with the nightly add-on."""
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    parsed_workflow = cast("dict[str, Any]", yaml.safe_load(workflow))
+    channel_run = str(
+        _workflow_step(parsed_workflow, "update_addon", "Resolve add-on channel")["run"]
+    )
+
+    assert channel_run.index('dev_folder=""') < channel_run.index('case "$CHANNEL" in')
+    assert channel_run.count('dev_folder="music_assistant_dev"') == 1
+    nightly_arm = channel_run.split("nightly)")[1].split(";;", maxsplit=1)[0]
+    assert 'dev_folder="music_assistant_dev"' in nightly_arm
+    assert 'echo "dev_folder=$dev_folder" >> "$GITHUB_OUTPUT"' in channel_run
+
+    dev_step = _workflow_step(parsed_workflow, "update_addon", "Update dev add-on version")
+    assert dev_step["if"] == "steps.channel.outputs.dev_folder != ''"
+    assert "release_workflow.py set-addon-version" in str(dev_step["run"])
+
+    commit_step = _workflow_step(parsed_workflow, "update_addon", "Commit add-on update")
+    assert commit_step["env"]["DEV_FOLDER"] == "${{ steps.channel.outputs.dev_folder }}"
+    assert 'git add "$DEV_FOLDER/config.yaml"' in str(commit_step["run"])
 
 
 def test_automation_drops_legacy_credentials() -> None:

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -401,13 +401,26 @@ def test_addon_version_update_leaves_the_rest_of_the_config_alone(tmp_path: Path
     assert list(tmp_path.iterdir()) == [config]
 
 
-def test_addon_version_update_requires_a_version_field(tmp_path: Path) -> None:
-    """A config without a version field fails instead of silently changing nothing."""
+@pytest.mark.parametrize(
+    "config_text",
+    [
+        "name: Music Assistant DEV SERVER\n",
+        "name: Music Assistant DEV SERVER\nversion: 1.6.0\nslug: dev\nversion: 1.5.2\n",
+    ],
+    ids=["missing", "duplicate"],
+)
+def test_addon_version_update_requires_exactly_one_version_field(
+    tmp_path: Path,
+    config_text: str,
+) -> None:
+    """A missing or duplicated version field fails instead of writing a stale config."""
     config = tmp_path / "config.yaml"
-    config.write_text("name: Music Assistant DEV SERVER\n", encoding="utf-8")
+    config.write_text(config_text, encoding="utf-8")
 
     with pytest.raises(ReleaseWorkflowError):
         set_addon_version(config, "2.10.0.dev2026081303")
+
+    assert config.read_text(encoding="utf-8") == config_text
 
 
 def test_release_workflow_bumps_the_dev_addon_on_nightly_only() -> None:
@@ -426,11 +439,17 @@ def test_release_workflow_bumps_the_dev_addon_on_nightly_only() -> None:
 
     dev_step = _workflow_step(parsed_workflow, "update_addon", "Update dev add-on version")
     assert dev_step["if"] == "steps.channel.outputs.dev_folder != ''"
-    assert "release_workflow.py set-addon-version" in str(dev_step["run"])
+    dev_run = str(dev_step["run"])
+    assert "release_workflow.py set-addon-version" in dev_run
+    assert '--config "addon-repo/$DEV_FOLDER/config.yaml"' in dev_run
 
     commit_step = _workflow_step(parsed_workflow, "update_addon", "Commit add-on update")
     assert commit_step["env"]["DEV_FOLDER"] == "${{ steps.channel.outputs.dev_folder }}"
     assert 'git add "$DEV_FOLDER/config.yaml"' in str(commit_step["run"])
+
+    # the bump is only committed if it happens first
+    step_names = [step.get("name") for step in parsed_workflow["jobs"]["update_addon"]["steps"]]
+    assert step_names.index("Update dev add-on version") < step_names.index("Commit add-on update")
 
 
 def test_automation_drops_legacy_credentials() -> None:


### PR DESCRIPTION
# What does this implement/fix?

The DEV add-on is the only add-on Home Assistant builds on the user's own machine, and its
base image is the nightly server image. Home Assistant only offers a rebuild when the
add-on's version number changes, and that number was bumped by hand — so it had been stuck
for months. Installed dev add-ons kept running an old base image, and fixes to the add-on's
own start-up script never reached anyone who already had it installed.

The nightly release already updates the nightly add-on in `home-assistant-addon`. This
carries the dev add-on along in the same commit, so a rebuild is offered after every
nightly.

- Nightly releases now also set `music_assistant_dev` to the released version, in the same
  commit as the nightly add-on
- Added a `set-addon-version` command to the release script for add-ons that have no
  changelog of their own
- The dev add-on gets no changelog entry: it runs whichever source branch the user
  configured, not the published release
- Other channels are untouched

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
