### PR TITLE
Document the AirPlay audio buffer depth setting

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -538,7 +538,8 @@ keeps their exposed player id stable and their Universal Player merging intact.
 ### General
 - **`password`**: Device password, stored encrypted (hidden). It is entered through the player's setup flow, not the settings form: a device that announces password protection without one stored - or that rejects the stored one - is marked as needing setup, which offers the password step again
 - **`ignore_volume`**: Ignore device volume reports (default: false)
-- **`sync_adjust`**: Per-player audio synchronization delay correction in milliseconds (default: 0; negative = play earlier, e.g. to compensate for a TV/AV receiver that adds latency). The playback lead/buffer is handled automatically by the binary.
+- **`sync_adjust`**: Per-player audio synchronization delay correction in milliseconds (default: 0; negative = play earlier, e.g. to compensate for a TV/AV receiver that adds latency). The playback lead is handled automatically by the binary.
+- **`buffer_depth`**: Advanced per-player override of how much audio the receiver keeps queued ahead of playback, in milliseconds. Defaults to the depth the device's family needs, or Automatic when no family matches; Automatic resolves through that same table at stream time, so it never downgrades an affected device. Receivers whose internal pipeline starves at the shallow default render nothing behind an otherwise healthy session, and deepening their queue is what makes them play. Applies to the AirPlay 2 route only - a player forced to RAOP keeps the binary's own depth. The cost is the delay under Known Issues below
 
 ### Pairing
 - **`raop_credentials`**: Stored RAOP pairing credentials (hidden)
@@ -555,13 +556,22 @@ keeps their exposed player id stable and their Universal Player merging intact.
 
 1. **DACP remote control**: Only active while streaming; controlled devices use
    Companion/MRP for idle and external playback control
-2. **Pause while synced**: Not supported; uses stop instead
+2. **Pause while synced**: Parks the whole session instead of pausing members
+   individually, so they can resume sample-aligned; a member that has lost its
+   connection falls back to stop
 3. **HomePod power control**: Current HomePod firmware does not advertise
    Companion PIN pairing, so explicit power/wake control is unavailable
 4. **Apple TV artwork for non-public images**: Cover art only reachable through
    the imageproxy (e.g. filesystem-provider images with no public URL) does not
    currently render on the Apple TV's now-playing screen, while externally-hosted
    art does
+5. **Warm boundaries wait for the queued audio**: Pause, seek and track changes
+   leave the audio the receiver already holds in place, so it renders that
+   first and `buffer_depth` is also the delay before the boundary is heard.
+   Dropping the queue instead produced audible noise bursts on Apple receivers,
+   so keeping it is an accepted trade-off. It is most noticeable on pause, where
+   playback is expected to stop at once. On a receiver that needs a deep queue
+   to render at all, the delay cannot be tuned away without silencing it
 
 ## Development Notes
 

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -281,7 +281,7 @@ CONF_RAOP_CREDENTIALS: Final[str] = "raop_credentials"
 CONF_AIRPLAY_CREDENTIALS: Final[str] = "airplay_credentials"
 
 # AirPlay serves the shared sync-adjust control as a non-advanced (always visible)
-# setting: the binary handles lead/buffer automatically and does not apply
+# setting: the binary handles the playback lead automatically and does not apply
 # device-reported render latency, so sync_adjust is the primary way to compensate
 # a device wired to a TV / AV receiver / amplifier that adds its own audio delay.
 # The AirPlay-scoped strings spell out the sign; the shared entry stays advanced

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -999,8 +999,9 @@ class AirPlayStream:
             str(self.pcm_format.bit_depth),
         ]
 
-        # The binary owns the playback lead/buffer (2000 ms default, clamped to
-        # the device-reported window); there is no user override for it.
+        # The binary owns the playback lead (2000 ms default, clamped to the
+        # device-reported window) and there is no user override for it; the
+        # receiver queue depth is the one tunable, passed as --latency below.
 
         # The endpoint must follow the same capability decision as the binary:
         # legacy RAOP uses _raop, while native and RAOP-compatible AP2 use _airplay.


### PR DESCRIPTION
# What does this implement/fix?

The `Audio buffer depth` player setting was missing from the AirPlay README's configuration options, and the neighbouring `sync_adjust` entry still said the buffer was handled automatically by the binary.

Older LinkPlay speakers need a deep receiver queue to play at all, and that same depth is how long a pause, seek or track change takes to become audible. That is an accepted trade-off - discarding the queued audio instead is an audible noise burst on Apple receivers - so it is now written down rather than rediscovered.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Document `buffer_depth` under the AirPlay configuration options
- Note under Known Issues that warm boundaries wait for the audio already queued in the speaker, so the depth is also the pause/seek delay
- Correct the `sync_adjust` entry, which no longer covers the buffer
- Correct the "pause while synced" limitation, which said pause is unsupported when the session is actually parked
- Fix a code comment in `stream.py` that still said the queue depth had no user override

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
