### PR TITLE
Apple Music: resolve library IDs in get_track and get_artist

### DIFF
--- a/music_assistant/providers/apple_music/media.py
+++ b/music_assistant/providers/apple_music/media.py
@@ -109,8 +109,12 @@ class AppleMusicMediaManager:
     @use_cache(cache_checksum=PARSED_ITEM_CACHE_CHECKSUM)
     async def get_artist(self, prov_artist_id: str) -> Artist:
         """Get full artist details by id."""
-        endpoint = f"catalog/{self.provider._storefront}/artists/{prov_artist_id}"
-        response = await self.api.get_data(endpoint, extend="editorialNotes")
+        if is_library_id(prov_artist_id):
+            endpoint = f"me/library/artists/{prov_artist_id}"
+            response = await self.api.get_data(endpoint, include="catalog", extend="editorialNotes")
+        else:
+            endpoint = f"catalog/{self.provider._storefront}/artists/{prov_artist_id}"
+            response = await self.api.get_data(endpoint, extend="editorialNotes")
         return cast("Artist", parse_artist(self.provider, response["data"][0]))
 
     @use_cache(cache_checksum=PARSED_ITEM_CACHE_CHECKSUM)
@@ -129,8 +133,12 @@ class AppleMusicMediaManager:
     @use_cache(cache_checksum=PARSED_ITEM_CACHE_CHECKSUM)
     async def get_track(self, prov_track_id: str) -> Track:
         """Get full track details by id."""
-        endpoint = f"catalog/{self.provider._storefront}/songs/{prov_track_id}"
-        response = await self.api.get_data(endpoint, include="artists,albums")
+        if is_library_id(prov_track_id):
+            endpoint = f"me/library/songs/{prov_track_id}"
+            response = await self.api.get_data(endpoint, include="catalog,artists,albums")
+        else:
+            endpoint = f"catalog/{self.provider._storefront}/songs/{prov_track_id}"
+            response = await self.api.get_data(endpoint, include="artists,albums")
         rating_response = await self.api.get_ratings([prov_track_id], MediaType.TRACK)
         is_favourite = rating_response.get(prov_track_id)
         return parse_track(self.provider, response["data"][0], is_favourite)

--- a/tests/providers/apple_music/test_media.py
+++ b/tests/providers/apple_music/test_media.py
@@ -1,0 +1,226 @@
+"""Unit tests for Apple Music catalog/library endpoint selection in the media manager."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import Artist, Track
+
+from music_assistant.providers.apple_music.media import AppleMusicMediaManager
+from tests.common import use_real_create_task
+
+
+def _catalog_song(catalog_id: str) -> dict[str, Any]:
+    """Build a minimal catalog/songs response item."""
+    return {
+        "id": catalog_id,
+        "type": "songs",
+        "attributes": {
+            "name": f"Catalog {catalog_id}",
+            "artistName": "Artist",
+            "albumName": "Album",
+            "durationInMillis": 180000,
+            "playParams": {"id": catalog_id},
+        },
+        "relationships": {},
+    }
+
+
+def _library_song(library_id: str, *, catalog_id: str | None = None) -> dict[str, Any]:
+    """Build a me/library/songs response item, optionally carrying its catalog twin."""
+    relationships: dict[str, Any] = {}
+    if catalog_id is not None:
+        relationships["catalog"] = {"data": [_catalog_song(catalog_id)]}
+    return {
+        "id": library_id,
+        "type": "library-songs",
+        "attributes": {
+            "name": f"Library {library_id}",
+            "artistName": "Artist",
+            "albumName": "Album",
+            "durationInMillis": 180000,
+            "playParams": {"id": library_id},
+        },
+        "relationships": relationships,
+    }
+
+
+def _catalog_artist(catalog_id: str) -> dict[str, Any]:
+    """Build a minimal catalog/artists response item."""
+    return {
+        "id": catalog_id,
+        "type": "artists",
+        "attributes": {
+            "name": f"Catalog Artist {catalog_id}",
+            "url": f"https://music.apple.com/artist/{catalog_id}",
+        },
+        "relationships": {},
+    }
+
+
+def _library_artist(library_id: str, *, catalog_id: str | None = None) -> dict[str, Any]:
+    """Build a me/library/artists response item, optionally carrying its catalog twin."""
+    relationships: dict[str, Any] = {}
+    if catalog_id is not None:
+        relationships["catalog"] = {"data": [_catalog_artist(catalog_id)]}
+    return {
+        "id": library_id,
+        "type": "library-artists",
+        "attributes": {"name": f"Library Artist {library_id}"},
+        "relationships": relationships,
+    }
+
+
+@pytest.fixture
+def mock_api() -> MagicMock:
+    """Return a MagicMock representing the Apple Music API client."""
+    api_client = MagicMock()
+    api_client.get_data = AsyncMock()
+    api_client.get_ratings = AsyncMock(return_value={})
+    return api_client
+
+
+@pytest.fixture
+def manager(mock_api: MagicMock) -> AppleMusicMediaManager:
+    """Return an AppleMusicMediaManager wired to a mock API client and a always-miss cache."""
+    provider = MagicMock()
+    provider.instance_id = "apple_music_test"
+    provider.domain = "apple_music"
+    provider._storefront = "us"
+    provider.logger = MagicMock()
+    provider.mass.cache.get = AsyncMock(return_value=None)
+    provider.mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
+    provider.mass.cache.set = AsyncMock()
+    use_real_create_task(provider.mass)
+    provider.api_client = mock_api
+
+    return AppleMusicMediaManager(provider)
+
+
+@pytest.mark.asyncio
+async def test_get_track_uses_catalog_endpoint_for_catalog_id(
+    manager: AppleMusicMediaManager,
+    mock_api: MagicMock,
+) -> None:
+    """get_track queries the catalog endpoint for a numeric adam id."""
+    mock_api.get_data.return_value = {"data": [_catalog_song("1234567890")]}
+
+    result = await manager.get_track("1234567890")
+
+    mock_api.get_data.assert_called_once_with(
+        "catalog/us/songs/1234567890",
+        include="artists,albums",
+    )
+    assert isinstance(result, Track)
+    assert result.item_id == "1234567890"
+
+
+@pytest.mark.asyncio
+async def test_get_track_uses_library_endpoint_for_library_id(
+    manager: AppleMusicMediaManager,
+    mock_api: MagicMock,
+) -> None:
+    """get_track queries me/library/songs for an 'i.' library id instead of 404ing."""
+    mock_api.get_data.return_value = {"data": [_library_song("i.AWPNG58CL3m51X")]}
+
+    result = await manager.get_track("i.AWPNG58CL3m51X")
+
+    mock_api.get_data.assert_called_once_with(
+        "me/library/songs/i.AWPNG58CL3m51X",
+        include="catalog,artists,albums",
+    )
+    assert isinstance(result, Track)
+    assert result.item_id == "i.AWPNG58CL3m51X"
+
+
+@pytest.mark.asyncio
+async def test_get_track_library_id_prefers_catalog_twin(
+    manager: AppleMusicMediaManager,
+    mock_api: MagicMock,
+) -> None:
+    """The included catalog relationship collapses a library id onto the catalog adam id."""
+
+    async def _get_data(_endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        # Apple only embeds the catalog twin when it was actually requested, so a
+        # dropped include= would silently leave the library id in place
+        catalog_id = "1234567890" if "catalog" in kwargs.get("include", "") else None
+        return {"data": [_library_song("i.AWPNG58CL3m51X", catalog_id=catalog_id)]}
+
+    mock_api.get_data.side_effect = _get_data
+
+    result = await manager.get_track("i.AWPNG58CL3m51X")
+
+    assert result.item_id == "1234567890"
+    assert result.name == "Catalog 1234567890"
+
+
+@pytest.mark.asyncio
+async def test_get_track_passes_library_id_to_get_ratings(
+    manager: AppleMusicMediaManager,
+    mock_api: MagicMock,
+) -> None:
+    """Ratings are requested with the id as given; get_ratings branches on the id form itself."""
+    mock_api.get_data.return_value = {"data": [_library_song("i.AWPNG58CL3m51X")]}
+    mock_api.get_ratings.return_value = {"i.AWPNG58CL3m51X": True}
+
+    result = await manager.get_track("i.AWPNG58CL3m51X")
+
+    mock_api.get_ratings.assert_awaited_once_with(["i.AWPNG58CL3m51X"], MediaType.TRACK)
+    assert result.favorite is True
+
+
+@pytest.mark.asyncio
+async def test_get_artist_uses_catalog_endpoint_for_catalog_id(
+    manager: AppleMusicMediaManager,
+    mock_api: MagicMock,
+) -> None:
+    """get_artist queries the catalog endpoint for a numeric artist id."""
+    mock_api.get_data.return_value = {"data": [_catalog_artist("987654321")]}
+
+    result = await manager.get_artist("987654321")
+
+    mock_api.get_data.assert_called_once_with(
+        "catalog/us/artists/987654321",
+        extend="editorialNotes",
+    )
+    assert isinstance(result, Artist)
+    assert result.item_id == "987654321"
+
+
+@pytest.mark.asyncio
+async def test_get_artist_uses_library_endpoint_for_library_id(
+    manager: AppleMusicMediaManager,
+    mock_api: MagicMock,
+) -> None:
+    """get_artist queries me/library/artists for a library id instead of 404ing."""
+    mock_api.get_data.return_value = {"data": [_library_artist("a.SomeLibraryArtist")]}
+
+    result = await manager.get_artist("a.SomeLibraryArtist")
+
+    mock_api.get_data.assert_called_once_with(
+        "me/library/artists/a.SomeLibraryArtist",
+        include="catalog",
+        extend="editorialNotes",
+    )
+    assert isinstance(result, Artist)
+    assert result.item_id == "a.SomeLibraryArtist"
+
+
+@pytest.mark.asyncio
+async def test_get_artist_library_id_prefers_catalog_twin(
+    manager: AppleMusicMediaManager,
+    mock_api: MagicMock,
+) -> None:
+    """The included catalog relationship collapses a library artist onto the catalog id."""
+
+    async def _get_data(_endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        catalog_id = "987654321" if "catalog" in kwargs.get("include", "") else None
+        return {"data": [_library_artist("a.SomeLibraryArtist", catalog_id=catalog_id)]}
+
+    mock_api.get_data.side_effect = _get_data
+
+    result = await manager.get_artist("a.SomeLibraryArtist")
+
+    assert result.item_id == "987654321"
+    assert result.name == "Catalog Artist 987654321"


### PR DESCRIPTION
## Problem

`get_album()` in `providers/apple_music/media.py` branches on `is_library_id()` and queries `me/library/albums/{id}` for library IDs. `get_track()` and `get_artist()` did not — they always built a catalog URL, so a library ID produced `catalog/{storefront}/songs/i.xxxxx`, which Apple answers with a 404. That surfaces as `MediaNotFoundError`.

## Why this is usually invisible

Every library fetch already asks for the catalog twin in the same request (`me/library/songs` is fetched with `include=catalog,albums,artists`), so `parse_track()` / `parse_artist()` take the embedded catalog object's ID and attributes and discard the `i.xxxxx` ID. The stored `item_id` is therefore the numeric catalog adam ID almost always, and the catalog endpoint is correct for it.

What survives as a library ID is the item with **no catalog counterpart** — iTunes Match, uploads, purchases, region-unavailable tracks. Those are precisely the items that then 404 on a single-item lookup.

## Change

Mirror `get_album()`'s existing branch in both methods:

- `get_track()` → `me/library/songs/{id}` with `include=catalog,artists,albums`
- `get_artist()` → `me/library/artists/{id}` with `include=catalog&extend=editorialNotes`

The artist call deliberately matches `get_library_artists()` in `library.py`, which already requests `me/library/artists` with exactly those parameters, rather than inventing a new parameter set.

`get_ratings()` already branches on `is_library_id()` internally, so it needed no change. `parse_track()` and `parse_artist()` already handle `library-songs` / `library-artists` objects and their `catalog` relationship — that code exists but nothing was reaching it through these two methods.

## Scope

This fixes **resolving** a library-only item — opening it, reading its metadata. It does **not** make such items playable, and it is not a fix for availability reporting on them. Those are separate concerns and are not addressed here.

## Tests

New `tests/providers/apple_music/test_media.py`, 7 tests, following the fixture style already used in `test_similar_artists.py` (mocked API client, always-miss cache so the `@use_cache` methods run):

- catalog ID still uses the catalog endpoint with unchanged parameters, for both methods (regression guard)
- library ID uses the library endpoint, for both methods
- a library ID collapses onto the catalog twin's ID when the catalog relationship is present. The fake API only embeds the twin when `include=` actually asked for it, so dropping `include=catalog` fails the test rather than passing silently
- ratings are requested with the ID as given, and the favourite flag reaches the parsed track

Full provider suite: **102 passed**. As a negative control, reverting only the `media.py` change fails 4 of the 7 new tests and leaves the 3 catalog-path tests passing.

`ruff check`, `ruff format --check` and `mypy` are clean on both changed files.
