### PR TITLE
Fix smart playlist removal from recommendations and add auto-refresh

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -319,7 +319,15 @@ class SmartPlaylistProvider(PluginProvider):
         if item_id != "smart_playlists":
             return items
         for pid, rules in self._rules_store.items():
-            items.append(await self._build_playlist(pid, rules))
+            playlist = await self._build_playlist(pid, rules)
+            # For recommendations, return ItemMapping with library DB item_id so removal works
+            library_item = await self.mass.music.playlists.get_library_item_by_prov_id(
+                pid, self.instance_id
+            )
+            if library_item:
+                items.append(ItemMapping.from_item(library_item))
+            else:
+                items.append(playlist)
         return items
 
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -21,6 +21,7 @@ from contextlib import suppress
 from dataclasses import replace as dc_replace
 from itertools import zip_longest
 from pathlib import Path
+from types import EllipsisType
 from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.auth import Scope
@@ -319,14 +320,13 @@ class SmartPlaylistProvider(PluginProvider):
         if item_id != "smart_playlists":
             return items
         for pid, rules in self._rules_store.items():
-            playlist = await self._build_playlist(pid, rules)
-            # For recommendations, return ItemMapping with library DB item_id so removal works
             library_item = await self.mass.music.playlists.get_library_item_by_prov_id(
                 pid, self.instance_id
             )
             if library_item:
                 items.append(ItemMapping.from_item(library_item))
             else:
+                playlist = await self._build_playlist(pid, rules, library_item)
                 items.append(playlist)
         return items
 
@@ -449,6 +449,7 @@ class SmartPlaylistProvider(PluginProvider):
                 self._descriptions_store.pop(prov_id, None)
                 await self._invalidate_dynamic_sample_cache(prov_id)
                 await self._flush_rules_to_disk()
+                self.signal_provider_event({"event": "recommendations_updated"})
                 break
 
     async def _on_media_item_updated(self, event: MassEvent) -> None:
@@ -501,6 +502,7 @@ class SmartPlaylistProvider(PluginProvider):
         library_playlist = await self.mass.music.playlists.add_item_to_library(playlist)
         self.mass.metadata.schedule_update_metadata(library_playlist)
         self._schedule_ai_description_refresh(playlist_id)
+        self.signal_provider_event({"event": "recommendations_updated"})
         return library_playlist
 
     async def generate_playlist(
@@ -698,7 +700,12 @@ class SmartPlaylistProvider(PluginProvider):
             self.logger.debug("Could not resolve playlist id %s: %s", playlist_id, err)
         return None
 
-    async def _build_playlist(self, playlist_id: str, rules: SmartPlaylistRules) -> Playlist:
+    async def _build_playlist(
+        self,
+        playlist_id: str,
+        rules: SmartPlaylistRules,
+        library_item: Playlist | None | EllipsisType = ...,
+    ) -> Playlist:
         """Build a Playlist object from stored rules."""
         name = self._names_store.get(playlist_id, playlist_id)
         playlist = Playlist(
@@ -720,15 +727,18 @@ class SmartPlaylistProvider(PluginProvider):
         playlist.is_dynamic = rules.is_dynamic
         playlist.metadata = MediaItemMetadata(
             description=self._description_for(playlist_id, rules),
-            images=await self._images_for(playlist_id),
+            images=await self._images_for(playlist_id, library_item),
         )
         return playlist
 
-    async def _images_for(self, playlist_id: str) -> UniqueList[MediaItemImage]:
+    async def _images_for(
+        self, playlist_id: str, library_item: Playlist | None | EllipsisType = ...
+    ) -> UniqueList[MediaItemImage]:
         """Return images for the playlist from the library, or empty list if none available."""
-        library_item = await self.mass.music.playlists.get_library_item_by_prov_id(
-            playlist_id, self.instance_id
-        )
+        if library_item is ...:
+            library_item = await self.mass.music.playlists.get_library_item_by_prov_id(
+                playlist_id, self.instance_id
+            )
         if library_item and library_item.metadata and library_item.metadata.images:
             return library_item.metadata.images
         return UniqueList([])

--- a/tests/providers/smart_playlist/test_recommendations.py
+++ b/tests/providers/smart_playlist/test_recommendations.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-from music_assistant_models.media_items import ItemMapping, Playlist
+from music_assistant_models.enums import EventType
+from music_assistant_models.event import MassEvent
+from music_assistant_models.media_items import ItemMapping, Playlist, ProviderMapping
 
 from music_assistant.providers.smart_playlist import SmartPlaylistProvider
 from music_assistant.providers.smart_playlist.helpers import SmartPlaylistRules
@@ -101,3 +103,98 @@ async def test_get_recommendation_items_returns_item_mapping_for_library_playlis
     assert item.item_id == "42"
     assert item.provider == "library"
     assert item.name == "Playlist A (Library)"
+
+
+async def test_delete_smart_playlist_signals_recommendations_updated() -> None:
+    """Deleting a smart playlist emits a recommendations_updated event."""
+    plugin, _mass = _make_plugin()
+    plugin._rules_store["abc123"] = SmartPlaylistRules(limit=10)
+    plugin._names_store["abc123"] = "Test Playlist"
+    plugin._flush_rules_to_disk = AsyncMock()  # type: ignore[method-assign]
+    plugin._invalidate_dynamic_sample_cache = AsyncMock()  # type: ignore[method-assign]
+    plugin.signal_provider_event = MagicMock()  # type: ignore[method-assign, misc]
+
+    library_playlist = Playlist(
+        item_id="999",
+        provider="library",
+        name="Test Playlist",
+        owner="Smart Playlist",
+        provider_mappings={
+            ProviderMapping(
+                item_id="abc123",
+                provider_domain="smart_playlist",
+                provider_instance=plugin.instance_id,
+            )
+        },
+    )
+    event = MassEvent(
+        event=EventType.MEDIA_ITEM_DELETED,
+        object_id="999",
+        data=library_playlist,
+    )
+
+    await plugin._on_media_item_deleted(event)
+
+    assert "abc123" not in plugin._rules_store
+    assert "abc123" not in plugin._names_store
+    payload = plugin.signal_provider_event.call_args.args[0]
+    assert payload["event"] == "recommendations_updated"
+
+
+async def test_delete_unrelated_playlist_does_not_signal() -> None:
+    """Deleting a playlist from a different provider does not emit an event."""
+    plugin, _mass = _make_plugin()
+    plugin._rules_store["abc123"] = SmartPlaylistRules(limit=10)
+    plugin.signal_provider_event = MagicMock()  # type: ignore[method-assign, misc]
+
+    unrelated_playlist = Playlist(
+        item_id="999",
+        provider="library",
+        name="Unrelated Playlist",
+        owner="Other",
+        provider_mappings={
+            ProviderMapping(
+                item_id="other_id",
+                provider_domain="other_provider",
+                provider_instance="other_instance",
+            )
+        },
+    )
+    event = MassEvent(
+        event=EventType.MEDIA_ITEM_DELETED,
+        object_id="999",
+        data=unrelated_playlist,
+    )
+
+    await plugin._on_media_item_deleted(event)
+
+    assert "abc123" in plugin._rules_store
+    plugin.signal_provider_event.assert_not_called()
+
+
+async def test_create_smart_playlist_signals_recommendations_updated() -> None:
+    """Creating a smart playlist emits a recommendations_updated event."""
+    plugin, mass = _make_plugin()
+    plugin._validate_rules = MagicMock()  # type: ignore[method-assign]
+    plugin._save_rules = AsyncMock()  # type: ignore[method-assign]
+    plugin._schedule_ai_description_refresh = MagicMock()  # type: ignore[method-assign]
+    plugin.signal_provider_event = MagicMock()  # type: ignore[method-assign, misc]
+
+    library_playlist = Playlist(
+        item_id="42",
+        provider="library",
+        name="New Playlist",
+        owner="Smart Playlist",
+        provider_mappings=set(),
+    )
+    mass.music.playlists.add_item_to_library = AsyncMock(return_value=library_playlist)
+    mass.metadata.schedule_update_metadata = MagicMock()
+
+    await plugin.create_smart_playlist(
+        name="New Playlist",
+        rules={"limit": 10},
+        is_dynamic=False,
+    )
+
+    payload = plugin.signal_provider_event.call_args.args[0]
+    assert payload["event"] == "recommendations_updated"

--- a/tests/providers/smart_playlist/test_recommendations.py
+++ b/tests/providers/smart_playlist/test_recommendations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-from music_assistant_models.media_items import Playlist
+from music_assistant_models.media_items import ItemMapping, Playlist
 
 from music_assistant.providers.smart_playlist import SmartPlaylistProvider
 from music_assistant.providers.smart_playlist.helpers import SmartPlaylistRules
@@ -64,7 +64,6 @@ async def test_get_recommendation_items_builds_playlists() -> None:
     assert [item.item_id for item in result] == ["abc", "def"]
     assert all(isinstance(item, Playlist) for item in result)
     assert [item.name for item in result] == ["Playlist A", "Playlist B"]
-    # the per-playlist artwork lookup ran for each built playlist
     assert mass.music.playlists.get_library_item_by_prov_id.await_count == 2
 
 
@@ -77,3 +76,28 @@ async def test_get_recommendation_items_unknown_id_returns_empty() -> None:
 
     assert list(result) == []
     mass.music.playlists.get_library_item_by_prov_id.assert_not_awaited()
+
+
+async def test_get_recommendation_items_returns_item_mapping_for_library_playlists() -> None:
+    """Library-backed playlists are returned as ItemMapping with library DB ID."""
+    plugin, mass = _make_plugin()
+    plugin._rules_store["abc"] = SmartPlaylistRules(limit=10)
+    plugin._names_store["abc"] = "Playlist A"
+
+    library_playlist = Playlist(
+        item_id="42",
+        provider="library",
+        name="Playlist A (Library)",
+        owner="Smart Playlist",
+        provider_mappings=set(),
+    )
+    mass.music.playlists.get_library_item_by_prov_id = AsyncMock(return_value=library_playlist)
+
+    result = await plugin.get_recommendation_items("smart_playlists")
+
+    assert len(result) == 1
+    item = result[0]
+    assert isinstance(item, ItemMapping)
+    assert item.item_id == "42"
+    assert item.provider == "library"
+    assert item.name == "Playlist A (Library)"


### PR DESCRIPTION
# What does this implement/fix?

Fixes ValueError when removing smart playlists from recommendation rows and adds automatic UI refresh when playlists are created or deleted.

### Bug Fix
Smart playlists in recommendation rows now return `ItemMapping` with library DB IDs instead of provider UUIDs, allowing `remove_item_from_library()` to work correctly. Respects architecture rule: never manually set `provider='library'`, use `ItemMapping.from_item()` pattern.

### Feature: Automatic Refresh
Emit `PROVIDER_EVENT` with `recommendations_updated` event when smart playlists are created or deleted, allowing frontend to subscribe and refresh the Smart Playlists row automatically.

### Performance Optimization
Reduce duplicate API calls by passing `library_item` from `get_recommendation_items()` to `_build_playlist()` to avoid calling `get_library_item_by_prov_id()` twice per playlist. Uses Ellipsis (`...`) sentinel pattern (already established in codebase).

**Related issue (if applicable):**

- N/A (bug discovered during development)

**Related frontend PR:**

- music-assistant/frontend#2506

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.