### PR TITLE
Document the data channels used by remote access

### DIFF
--- a/music_assistant/controllers/webserver/README.md
+++ b/music_assistant/controllers/webserver/README.md
@@ -265,6 +265,37 @@ Remote access enables users to connect to their Music Assistant instance from an
    - Responses and events sent back through data channel
    - Authentication and authorization work identically to local WebSocket
 
+### Data Channels
+
+A single remote session multiplexes several WebRTC data channels over one peer connection.
+The gateway routes each incoming channel by its label through a label -> handler table, with
+two kinds of handlers:
+
+- **Bridged**: the channel is pumped both ways to a local WebSocket
+  - `sendspin`: the built-in Sendspin server (web player)
+  - `live_announcement`: the live announcement route on the local webserver
+- **Served in-process**: handled by the gateway itself, without a local WebSocket
+  - `http_proxy`: proxied HTTP requests (album art and other assets)
+
+When a bridged channel or its local WebSocket closes, only that bridge is torn down and the
+session stays up.
+
+The client's own API channel has no fixed label: the **first** channel with a label the server
+does not recognise becomes the API channel (the frontend labels it `ma-api`) and is bridged to
+`/ws`. Any **later** unrecognised label is refused, since taking it for a second API channel
+would replace the live bridge and break the session.
+
+Proxied HTTP requests are answered on the channel they arrived on. That is what keeps older
+clients working: they send `http-proxy-request` over `ma-api` and get the response back there,
+so the gateway needs no version negotiation of its own.
+
+**Adding a new label** is not backwards compatible by itself: servers from before the routing
+table mistake an unknown label for the API channel, which breaks the entire remote session
+instead of just the new feature. Clients therefore feature-detect on `schema_version` from
+`server_info` before opening one, so `http_proxy` requires `API_SCHEMA_VERSION >= 49`. Bump
+`API_SCHEMA_VERSION` ([constants.py](../../constants.py)) when adding a label and gate the
+client on the new value.
+
 ### ICE Servers (STUN/TURN)
 
 NAT traversal is critical for WebRTC connections. Music Assistant uses:

--- a/music_assistant/controllers/webserver/README.md
+++ b/music_assistant/controllers/webserver/README.md
@@ -277,13 +277,14 @@ two kinds of handlers:
 - **Served in-process**: handled by the gateway itself, without a local WebSocket
   - `http_proxy`: proxied HTTP requests (album art and other assets)
 
-When a bridged channel or its local WebSocket closes, only that bridge is torn down and the
-session stays up.
+When one of these channels or its local WebSocket closes, only that channel is torn down and
+the session stays up.
 
 The client's own API channel has no fixed label: the **first** channel with a label the server
 does not recognise becomes the API channel (the frontend labels it `ma-api`) and is bridged to
 `/ws`. Any **later** unrecognised label is refused, since taking it for a second API channel
-would replace the live bridge and break the session.
+would replace the live bridge and break the session. The API channel shares its lifetime with
+the session: when it or its local WebSocket closes, the whole session is torn down.
 
 Proxied HTTP requests are answered on the channel they arrived on. That is what keeps older
 clients working: they send `http-proxy-request` over `ma-api` and get the response back there,
@@ -291,8 +292,8 @@ so the gateway needs no version negotiation of its own.
 
 **Adding a new label** is not backwards compatible by itself: servers from before the routing
 table mistake an unknown label for the API channel, which breaks the entire remote session
-instead of just the new feature. Clients therefore feature-detect on `schema_version` from
-`server_info` before opening one, so `http_proxy` requires `API_SCHEMA_VERSION >= 49`. Bump
+instead of just the new feature. A client must therefore feature-detect on `schema_version`
+from `server_info` before opening one: `http_proxy` requires `API_SCHEMA_VERSION >= 49`. Bump
 `API_SCHEMA_VERSION` ([constants.py](../../constants.py)) when adding a label and gate the
 client on the new value.
 


### PR DESCRIPTION
# What does this implement/fix?

A remote connection now uses several WebRTC data channels next to the API channel: the web
player, live announcements and (since #5635) album art and other HTTP requests. How those
channels are routed, and the rules a client has to follow to add one, were nowhere written
down. This adds a short section to the webserver README so the next channel does not have
to rediscover them.

- Document the channel label -> handler table and the two handler kinds (bridged to a local
  WebSocket vs served by the gateway itself)
- Document that the first channel with an unknown label becomes the client's API channel and
  any later unknown one is refused
- Document that proxied HTTP requests are answered on the channel they arrived on, which is
  what keeps older clients working
- Document why a new channel label needs a `schema_version` check on the client side

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
