### PR TITLE
Album art uses far less data over a remote connection

### DIFF
--- a/music_assistant/controllers/webserver/README.md
+++ b/music_assistant/controllers/webserver/README.md
@@ -290,6 +290,17 @@ Proxied HTTP requests are answered on the channel they arrived on. That is what 
 clients working: they send `http-proxy-request` over `ma-api` and get the response back there,
 so the gateway needs no version negotiation of its own.
 
+The reply is framed to suit that channel. On `ma-api` it is one JSON message with the body
+hex-encoded, which costs about 2.7x the image once the oversized-message chunking below is
+applied on top. `http_proxy` carries nothing else, so there the reply is a JSON header
+(`type`, `id`, `status`, `headers`, `size`) followed by the body as raw binary messages — the
+image costs its own size and no more. Those binary messages carry no request id, so the
+gateway holds the channel for a whole reply: replies go out one at a time rather than
+interleaving, which a channel that sends one message at a time would do anyway.
+Frames are capped at the channel's
+`max_message_size`, which is the lower of our own 256 KiB ceiling and what the peer
+advertises in its SDP — and libdatachannel assumes only 64 KiB when it advertises nothing.
+
 **Adding a new label** is not backwards compatible by itself: servers from before the routing
 table mistake an unknown label for the API channel, which breaks the entire remote session
 instead of just the new feature. A client must therefore feature-detect on `schema_version`

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -47,6 +47,10 @@ HTTP_PROXY_CONCURRENCY = 6
 # Chunk messages larger than this; libdatachannel caps data-channel messages at 256 KiB.
 DATA_CHANNEL_CHUNK_SIZE = 64 * 1024
 
+# Preferred body chunk size on the dedicated http proxy channel. Raw binary needs no escaping,
+# so this sits close to libdatachannel's 256 KiB cap; the channel's negotiated limit still wins.
+HTTP_PROXY_BODY_CHUNK_SIZE = 192 * 1024
+
 DEFAULT_SENDSPIN_URL = f"ws://localhost:{SENDSPIN_SERVER_PORT}/sendspin"
 
 # Labels of the data channels the gateway routes, next to the client's own API channel
@@ -524,13 +528,19 @@ class WebRTCGateway:
             self.logger.exception("Failed to add ICE candidate for session %s", session_id)
 
     async def _handle_http_proxy_request(
-        self, channel: DataChannel | None, request_data: dict[str, Any]
+        self,
+        channel: DataChannel | None,
+        request_data: dict[str, Any],
+        send_lock: asyncio.Lock | None = None,
     ) -> None:
         """
         Handle an HTTP proxy request from a remote client.
 
         :param channel: Data channel the request arrived on, and the response is sent back on.
         :param request_data: The decoded ``http-proxy-request`` message.
+        :param send_lock: Send lock of the dedicated http proxy channel, which answers with a
+            JSON header plus a raw binary body. Omitted for clients that proxy over the API
+            channel, which get the whole response hex-encoded in one JSON message instead.
         """
         request_id = request_data.get("id")
         method = request_data.get("method", "GET")
@@ -556,12 +566,22 @@ class WebRTCGateway:
                 ) as response:
                     body = await response.read()
                     await self._send_http_proxy_response(
-                        channel, request_id, response.status, dict(response.headers), body
+                        channel,
+                        request_id,
+                        response.status,
+                        dict(response.headers),
+                        body,
+                        send_lock,
                     )
             except Exception as err:
                 self.logger.exception("Error handling HTTP proxy request")
                 await self._send_http_proxy_response(
-                    channel, request_id, 500, {"Content-Type": "text/plain"}, str(err).encode()
+                    channel,
+                    request_id,
+                    500,
+                    {"Content-Type": "text/plain"},
+                    str(err).encode(),
+                    send_lock,
                 )
 
     async def _send_http_proxy_response(
@@ -571,20 +591,50 @@ class WebRTCGateway:
         status: int,
         headers: dict[str, str],
         body: bytes,
+        send_lock: asyncio.Lock | None = None,
     ) -> None:
-        """Send an HTTP-proxy response back on the channel its request arrived on."""
-        await self._send_chunked(
-            channel,
-            json.dumps(
-                {
-                    "type": "http-proxy-response",
-                    "id": request_id,
-                    "status": status,
-                    "headers": headers,
-                    "body": body.hex(),
-                }
-            ),
+        """
+        Send an HTTP-proxy response back on the channel its request arrived on.
+
+        :param send_lock: Send lock of the dedicated http proxy channel, whose responses are a
+            JSON header followed by the body as raw binary frames. Without it the response goes
+            out hex-encoded inside one JSON message, as clients on the API channel expect.
+        """
+        if send_lock is None:
+            await self._send_chunked(
+                channel,
+                json.dumps(
+                    {
+                        "type": "http-proxy-response",
+                        "id": request_id,
+                        "status": status,
+                        "headers": headers,
+                        "body": body.hex(),
+                    }
+                ),
+            )
+            return
+
+        header = json.dumps(
+            {
+                "type": "http-proxy-response",
+                "id": request_id,
+                "status": status,
+                "headers": headers,
+                "size": len(body),
+            }
         )
+        # The body frames carry no request id, so an interleaved response would be
+        # indistinguishable from this one's body: hold the channel for header plus body.
+        # Concurrent fetches are unaffected, and the channel sends one message at a time anyway.
+        async with send_lock:
+            await self._send_on_channel(channel, header)
+            if channel is None or not channel.is_open:
+                return
+            # a peer that advertises no limit in its SDP is assumed to accept only 64 KiB
+            chunk_size = min(HTTP_PROXY_BODY_CHUNK_SIZE, channel.max_message_size)
+            for offset in range(0, len(body), chunk_size):
+                await self._send_on_channel(channel, body[offset : offset + chunk_size])
 
     async def _send_chunked(self, channel: DataChannel | None, text: str) -> None:
         """Send a text message on a data channel, chunking it if it exceeds the size limit."""
@@ -861,6 +911,7 @@ class WebRTCGateway:
         self, session: WebRTCSession, served: _ServedChannel, channel: DataChannel
     ) -> None:
         """Serve proxied HTTP requests arriving on their own data channel."""
+        send_lock = asyncio.Lock()
         try:
             async for message in channel:
                 if not isinstance(message, str):
@@ -872,7 +923,9 @@ class WebRTCGateway:
                 if isinstance(request, dict) and request.get("type") == "http-proxy-request":
                     # handle off the receive loop so a slow fetch never holds up the next
                     # request (bounded by the gateway-wide semaphore; see #4889)
-                    session.pc.spawn_task(self._handle_http_proxy_request(channel, request))
+                    session.pc.spawn_task(
+                        self._handle_http_proxy_request(channel, request, send_lock)
+                    )
         except ConnectionClosedError:
             self.logger.debug("%s channel closed for session %s", served.label, session.session_id)
         except asyncio.CancelledError:

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -44,7 +44,7 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.remote_access")
 # instead of piling up local requests and the response bodies they buffer (see #4889).
 HTTP_PROXY_CONCURRENCY = 6
 
-# Chunk messages larger than this; libdatachannel caps data-channel messages at 256 KiB.
+# Chunk messages larger than this; each piece becomes a base64 frame roughly a third larger.
 DATA_CHANNEL_CHUNK_SIZE = 64 * 1024
 
 # Preferred body chunk size on the dedicated http proxy channel. Raw binary needs no escaping,
@@ -626,7 +626,8 @@ class WebRTCGateway:
         )
         # The body frames carry no request id, so an interleaved response would be
         # indistinguishable from this one's body: hold the channel for header plus body.
-        # Concurrent fetches are unaffected, and the channel sends one message at a time anyway.
+        # Responses therefore queue whole rather than frame by frame, which costs nothing on
+        # a channel that already sends one message at a time.
         async with send_lock:
             await self._send_on_channel(channel, header)
             if channel is None or not channel.is_open:
@@ -643,9 +644,8 @@ class WebRTCGateway:
             await self._send_on_channel(channel, text)
             return
 
-        # libdatachannel enforces the 256 KiB message limit, so oversized messages are split
-        # into base64 frames the client reassembles by group id (base64 keeps each frame's size
-        # predictable regardless of JSON escaping / unicode).
+        # Oversized messages are split into base64 frames the client reassembles by group id
+        # (base64 keeps each frame's size predictable regardless of JSON escaping / unicode).
         self._chunk_group_seq += 1
         group_id = self._chunk_group_seq
         count = (len(data) + DATA_CHANNEL_CHUNK_SIZE - 1) // DATA_CHANNEL_CHUNK_SIZE

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -865,10 +865,11 @@ class _FakeBidiChannel:
     what the gateway sent back on ``sent``.
     """
 
-    def __init__(self, label: str = "ma-api") -> None:
+    def __init__(self, label: str = "ma-api", max_message_size: int = 256 * 1024) -> None:
         self.label = label
         self.is_open = True
         self.closed = False
+        self.max_message_size = max_message_size
         self.sent: list[str | bytes] = []
         self._inbound: asyncio.Queue[str | bytes | None] = asyncio.Queue()
 
@@ -876,6 +877,8 @@ class _FakeBidiChannel:
         return
 
     async def send(self, data: str | bytes) -> None:
+        # a real send always suspends, which is what lets concurrent senders interleave
+        await asyncio.sleep(0)
         self.sent.append(data)
 
     def feed(self, message: str | bytes) -> None:
@@ -909,6 +912,7 @@ class _FakeHttpSession:
         self.websockets: dict[str, _FakeLocalWS] = {}
         self.requested: list[str] = []
         self.response_body = b""
+        self.bodies: dict[str, bytes] = {}
 
     async def ws_connect(self, url: str, **kwargs: Any) -> _FakeLocalWS:
         self.dialed.append(url)
@@ -918,12 +922,12 @@ class _FakeHttpSession:
         return local_ws
 
     def request(self, _method: str, url: str, **_kwargs: Any) -> AsyncMock:
-        """Serve ``response_body`` for a proxied HTTP request."""
+        """Serve this url's entry in ``bodies``, falling back to ``response_body``."""
         self.requested.append(url)
         response = AsyncMock()
         response.status = 200
         response.headers = {"Content-Type": "image/jpeg"}
-        response.read = AsyncMock(return_value=self.response_body)
+        response.read = AsyncMock(return_value=self.bodies.get(url, self.response_body))
         ctx = AsyncMock()
         ctx.__aenter__ = AsyncMock(return_value=response)
         ctx.__aexit__ = AsyncMock(return_value=False)
@@ -1304,6 +1308,23 @@ def _proxy_request(request_id: str, path: str) -> str:
     )
 
 
+def _read_proxy_response(sent: list[str | bytes]) -> tuple[dict[str, Any], bytes]:
+    """
+    Read the binary-framed response a client would reassemble from the proxy channel.
+
+    :param sent: Messages the gateway sent, starting at the response's JSON header.
+    """
+    header = json.loads(cast("str", sent[0]))
+    body = b""
+    for message in sent[1:]:
+        assert isinstance(message, bytes), f"expected a binary body frame, got {message!r}"
+        body += message
+        if len(body) >= header["size"]:
+            break
+    assert len(body) == header["size"]
+    return header, body
+
+
 async def test_http_proxy_channel_answers_on_its_own_channel(cert_pems: tuple[str, str]) -> None:
     """A proxied request on the http proxy channel is answered there, not on the API channel."""
     http_session = _FakeHttpSession()
@@ -1318,14 +1339,16 @@ async def test_http_proxy_channel_answers_on_its_own_channel(cert_pems: tuple[st
         await _wait_for(lambda: session.local_ws is not None)
 
         proxy_channel.feed(_proxy_request("img-1", "/imageproxy/abc"))
-        await _wait_for(lambda: bool(proxy_channel.sent))
+        await _wait_for(lambda: len(proxy_channel.sent) >= 2)
 
         assert http_session.requested == ["http://127.0.0.1:8095/imageproxy/abc"]
-        response = json.loads(cast("str", proxy_channel.sent[0]))
+        response, body = _read_proxy_response(proxy_channel.sent)
         assert response["type"] == "http-proxy-response"
         assert response["id"] == "img-1"
         assert response["status"] == 200
-        assert bytes.fromhex(response["body"]) == b"\xff\xd8jpeg-bytes"
+        # the body rides as raw binary, so it costs its own size on the wire and no more
+        assert body == b"\xff\xd8jpeg-bytes"
+        assert "body" not in response
         # the image never touches the API channel, nor the local API WebSocket
         assert api_channel.sent == []
         assert cast("_FakeLocalWS", session.local_ws).sent == []
@@ -1376,14 +1399,101 @@ async def test_http_proxy_channel_reports_a_failed_fetch_on_its_own_channel(
         await _wait_for(lambda: session.local_ws is not None)
 
         proxy_channel.feed(_proxy_request("img-3", "/imageproxy/boom"))
-        await _wait_for(lambda: bool(proxy_channel.sent))
+        await _wait_for(lambda: len(proxy_channel.sent) >= 2)
 
-        response = json.loads(cast("str", proxy_channel.sent[0]))
+        response, body = _read_proxy_response(proxy_channel.sent)
         assert response["id"] == "img-3"
         assert response["status"] == 500
+        assert b"boom" in body
         assert api_channel.sent == []
     finally:
         await gateway._close_session("proxy-error-session")
+
+
+async def test_http_proxy_channel_splits_a_large_body_into_binary_frames(
+    cert_pems: tuple[str, str],
+) -> None:
+    """A body past the channel's message limit arrives as raw frames that concatenate back."""
+    http_session = _FakeHttpSession()
+    http_session.response_body = bytes(range(256)) * 2048  # 512 KiB
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "proxy-large-session")
+    proxy_channel = _FakeBidiChannel(label="http_proxy")
+    pc.offer_channel(proxy_channel)
+    try:
+        await _wait_for(lambda: "http_proxy" in session.channels)
+
+        proxy_channel.feed(_proxy_request("img-5", "/imageproxy/large"))
+        await _wait_for(lambda: len(proxy_channel.sent) >= 4)
+
+        response, body = _read_proxy_response(proxy_channel.sent)
+        assert response["size"] == len(http_session.response_body)
+        assert body == http_session.response_body
+        frames = proxy_channel.sent[1:]
+        assert all(len(frame) <= proxy_channel.max_message_size for frame in frames)
+        # the wire cost is the body itself, not the ~2.7x a hex-in-base64 response took
+        assert sum(len(frame) for frame in frames) == len(http_session.response_body)
+    finally:
+        await gateway._close_session("proxy-large-session")
+
+
+async def test_http_proxy_channel_honours_the_negotiated_message_limit(
+    cert_pems: tuple[str, str],
+) -> None:
+    """A peer that advertises a small limit gets frames it can actually accept."""
+    http_session = _FakeHttpSession()
+    http_session.response_body = b"x" * (200 * 1024)
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "proxy-small-frames-session")
+    # what a peer that advertises no a=max-message-size in its SDP is assumed to accept
+    proxy_channel = _FakeBidiChannel(label="http_proxy", max_message_size=64 * 1024)
+    pc.offer_channel(proxy_channel)
+    try:
+        await _wait_for(lambda: "http_proxy" in session.channels)
+
+        proxy_channel.feed(_proxy_request("img-6", "/imageproxy/small-frames"))
+        await _wait_for(lambda: len(proxy_channel.sent) >= 5)
+
+        _, body = _read_proxy_response(proxy_channel.sent)
+        assert body == http_session.response_body
+        assert all(len(frame) <= 64 * 1024 for frame in proxy_channel.sent[1:])
+    finally:
+        await gateway._close_session("proxy-small-frames-session")
+
+
+async def test_http_proxy_channel_never_interleaves_two_responses(
+    cert_pems: tuple[str, str],
+) -> None:
+    """Body frames carry no request id, so each response must reach the client in one run."""
+    http_session = _FakeHttpSession()
+    http_session.bodies = {
+        "http://127.0.0.1:8095/imageproxy/one": b"1" * (300 * 1024),
+        "http://127.0.0.1:8095/imageproxy/two": b"2" * (300 * 1024),
+    }
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "proxy-concurrent-session")
+    proxy_channel = _FakeBidiChannel(label="http_proxy")
+    pc.offer_channel(proxy_channel)
+    try:
+        await _wait_for(lambda: "http_proxy" in session.channels)
+
+        proxy_channel.feed(_proxy_request("img-one", "/imageproxy/one"))
+        proxy_channel.feed(_proxy_request("img-two", "/imageproxy/two"))
+        await _wait_for(lambda: sum(isinstance(m, str) for m in proxy_channel.sent) == 2)
+        await _wait_for(lambda: len(proxy_channel.sent) >= 6)
+
+        # split at the second header: each response owns an unbroken run of body frames
+        second = next(i for i, m in enumerate(proxy_channel.sent) if i and isinstance(m, str))
+        first_header, first_body = _read_proxy_response(proxy_channel.sent[:second])
+        second_header, second_body = _read_proxy_response(proxy_channel.sent[second:])
+        assert {first_header["id"], second_header["id"]} == {"img-one", "img-two"}
+        # each body is one repeated byte, so any interleaving shows up as a mixed run
+        filler = {"img-one": ord("1"), "img-two": ord("2")}
+        assert set(first_body) == {filler[first_header["id"]]}
+        assert set(second_body) == {filler[second_header["id"]]}
+        assert len(first_body) == len(second_body) == 300 * 1024
+    finally:
+        await gateway._close_session("proxy-concurrent-session")
 
 
 @pytest.mark.parametrize(
@@ -1410,11 +1520,11 @@ async def test_http_proxy_channel_survives_junk(
 
         proxy_channel.feed(junk)
         proxy_channel.feed(_proxy_request("img-4", "/imageproxy/ok"))
-        await _wait_for(lambda: bool(proxy_channel.sent))
+        await _wait_for(lambda: len(proxy_channel.sent) >= 2)
 
-        response = json.loads(cast("str", proxy_channel.sent[0]))
+        response, body = _read_proxy_response(proxy_channel.sent)
         assert response["id"] == "img-4"
-        assert bytes.fromhex(response["body"]) == b"still-here"
+        assert body == b"still-here"
     finally:
         await gateway._close_session("proxy-junk-session")
 

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -1308,6 +1308,11 @@ def _proxy_request(request_id: str, path: str) -> str:
     )
 
 
+def _body_delivered(sent: list[str | bytes], size: int) -> bool:
+    """Return whether the binary frames sent so far add up to a whole body of ``size``."""
+    return sum(len(m) for m in sent if isinstance(m, bytes)) >= size
+
+
 def _read_proxy_response(sent: list[str | bytes]) -> tuple[dict[str, Any], bytes]:
     """
     Read the binary-framed response a client would reassemble from the proxy channel.
@@ -1424,7 +1429,9 @@ async def test_http_proxy_channel_splits_a_large_body_into_binary_frames(
         await _wait_for(lambda: "http_proxy" in session.channels)
 
         proxy_channel.feed(_proxy_request("img-5", "/imageproxy/large"))
-        await _wait_for(lambda: len(proxy_channel.sent) >= 4)
+        await _wait_for(
+            lambda: _body_delivered(proxy_channel.sent, len(http_session.response_body))
+        )
 
         response, body = _read_proxy_response(proxy_channel.sent)
         assert response["size"] == len(http_session.response_body)
@@ -1452,7 +1459,9 @@ async def test_http_proxy_channel_honours_the_negotiated_message_limit(
         await _wait_for(lambda: "http_proxy" in session.channels)
 
         proxy_channel.feed(_proxy_request("img-6", "/imageproxy/small-frames"))
-        await _wait_for(lambda: len(proxy_channel.sent) >= 5)
+        await _wait_for(
+            lambda: _body_delivered(proxy_channel.sent, len(http_session.response_body))
+        )
 
         _, body = _read_proxy_response(proxy_channel.sent)
         assert body == http_session.response_body


### PR DESCRIPTION
# What does this implement/fix?

Over a remote connection album art travels through the WebRTC connection. On the dedicated
image channel added in #5635 each image was hex-encoded inside a JSON message and then
base64-chunked, so a 200 KB cover cost roughly 530 KB on the wire — about 2.7x the image,
over what is usually the user's home upstream.

That channel carries nothing but proxied responses, so its format is ours to pick: images
now travel as themselves, a small JSON header followed by the body as raw binary frames.

- Send responses on the image channel as a JSON header plus raw binary body frames
- Size those frames against the channel's negotiated message limit, so a peer that
  advertises a small limit still gets frames it can accept
- Hold the channel for a whole response, since binary frames carry no request id
- Leave the hex-in-JSON response untouched for clients that proxy over the API channel
  (the mobile app and every released frontend)

No schema bump: schema 49 and the image channel are both still unreleased, so no client
in the wild expects the old format on this channel.

Pacing was measured rather than assumed, and deliberately left alone: chunk size makes no
difference (every gap sits under the run-to-run spread), and raising the buffered-amount-low
threshold *deadlocks* the sender — libdatachannel only signals on a downward crossing, which
a stop-and-wait sender never makes.

**Related issue (if applicable):**

- follow-up to #5635

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: https://github.com/music-assistant/frontend/pull/2507
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
