### PR TITLE
Announcements no longer restart the Cast session

### DIFF
--- a/music_assistant/providers/chromecast/constants.py
+++ b/music_assistant/providers/chromecast/constants.py
@@ -23,6 +23,10 @@ DASHBOARD_NAMESPACE = "urn:x-cast:io.music-assistant.cast"
 # Seconds to wait for a Cast receiver to acknowledge an app launch.
 APP_LAUNCH_TIMEOUT = 30.0
 
+# Seconds the receiver app is kept running after playback stopped, so a
+# follow-up command can reuse the Cast session instead of starting a new one.
+APP_QUIT_DELAY = 10.0
+
 # keepalive media the cast receiver plays while showing a dashboard
 DASHBOARD_KEEPALIVE_SUFFIXES = ("/dashboard-keepalive.mp4", "/keepalive.png")
 

--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -144,6 +144,11 @@ class ChromecastDashboards:
         """
         url = await self.mass.dashboard.resolve_dashboard_url(dashboard, player_id)
         chromecast = await self._get_or_create_chromecast(device_id)
+        castplayer = self.mass.players.get_player(device_id)
+        if isinstance(castplayer, ChromecastPlayer):
+            # an earlier stop on the player may still have a release of the receiver
+            # app pending, which would close the dashboard we are about to show
+            castplayer.cancel_pending_app_quit()
         try:
             await self.mass.loop.run_in_executor(None, send_show_dashboard, chromecast, url)
         except TimeoutError as err:

--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -142,12 +142,12 @@ class ChromecastDashboards:
         :param dashboard: Dashboard to show.
         :param player_id: Player to show, when dashboard is NOW_PLAYING.
         """
-        url = await self.mass.dashboard.resolve_dashboard_url(dashboard, player_id)
         castplayer = self.mass.players.get_player(device_id)
         if isinstance(castplayer, ChromecastPlayer):
             # an earlier stop on the player may still have a release of the receiver
             # app pending, which would close the dashboard we are about to show
             castplayer.cancel_pending_app_quit()
+        url = await self.mass.dashboard.resolve_dashboard_url(dashboard, player_id)
         chromecast = await self._get_or_create_chromecast(device_id)
         try:
             await self.mass.loop.run_in_executor(None, send_show_dashboard, chromecast, url)

--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -143,12 +143,12 @@ class ChromecastDashboards:
         :param player_id: Player to show, when dashboard is NOW_PLAYING.
         """
         url = await self.mass.dashboard.resolve_dashboard_url(dashboard, player_id)
-        chromecast = await self._get_or_create_chromecast(device_id)
         castplayer = self.mass.players.get_player(device_id)
         if isinstance(castplayer, ChromecastPlayer):
             # an earlier stop on the player may still have a release of the receiver
             # app pending, which would close the dashboard we are about to show
             castplayer.cancel_pending_app_quit()
+        chromecast = await self._get_or_create_chromecast(device_id)
         try:
             await self.mass.loop.run_in_executor(None, send_show_dashboard, chromecast, url)
         except TimeoutError as err:

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -32,6 +32,7 @@ from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 from .constants import (
     APP_LAUNCH_TIMEOUT,
     APP_MEDIA_RECEIVER,
+    APP_QUIT_DELAY,
     CAST_PLAYER_CONFIG_ENTRIES,
     CONF_ENTRY_SAMPLE_RATES_CAST,
     CONF_ENTRY_SAMPLE_RATES_CAST_GROUP,
@@ -84,6 +85,7 @@ class ChromecastPlayer(Player):
         self.last_poll = 0.0
         self.last_multichannel_check = 0.0
         self.flow_meta_checksum: str | None = None
+        self._app_quit_task_id: str = f"cast_quit_app_{player_id}"
         # set static variables
         self._attr_supported_features = {
             PlayerFeature.PLAY_MEDIA,
@@ -150,8 +152,24 @@ class ChromecastPlayer(Player):
         """Send STOP command to given player."""
         if self.type == PlayerType.GROUP:
             await asyncio.to_thread(self.cc.media_controller.stop)
-        else:
+            return
+        if self.cc.app_id not in (MASS_APP_ID, APP_MEDIA_RECEIVER):
+            # another app is casting to the device, release it right away
             await asyncio.to_thread(self.cc.quit_app)
+            return
+        if self.cc.media_controller.status.media_session_id is not None:
+            # a stop is refused by the cast library when nothing was ever loaded
+            await asyncio.to_thread(self.cc.media_controller.stop)
+        # The device is released a bit later so a follow-up command (such as an
+        # announcement, which stops playback first) can reuse the Cast session.
+        # Starting a new session makes the device play its 'cast connected' chime.
+        self.mass.call_later(
+            APP_QUIT_DELAY, self._quit_app_when_unused, task_id=self._app_quit_task_id
+        )
+
+    def cancel_pending_app_quit(self) -> None:
+        """Cancel a pending release of the receiver app, to keep the device claimed."""
+        self.mass.cancel_timer(self._app_quit_task_id)
 
     async def play(self) -> None:
         """Send PLAY command to given player."""
@@ -260,6 +278,10 @@ class ChromecastPlayer(Player):
     async def on_unload(self) -> None:
         """Handle logic when the player is unloaded from the Player controller."""
         await super().on_unload()
+        # a quit that already fired runs as a task under the same id,
+        # which only cancel_task reaches
+        self.cancel_pending_app_quit()
+        self.mass.cancel_task(self._app_quit_task_id)
         self.mz_controller = None
         if self.status_listener is not None:
             self.status_listener.invalidate()
@@ -398,6 +420,7 @@ class ChromecastPlayer(Player):
 
     async def _launch_app(self) -> None:
         """Launch the configured Media Receiver App on a Chromecast."""
+        self.cancel_pending_app_quit()
         if self.cc.app_id in (MASS_APP_ID, APP_MEDIA_RECEIVER):
             return  # already active with a compatible media receiver app
 
@@ -478,6 +501,16 @@ class ChromecastPlayer(Player):
             reason,
             suggestion,
         )
+
+    async def _quit_app_when_unused(self) -> None:
+        """Release the Cast device, unless the receiver app got used again."""
+        if self.cc.app_id not in (MASS_APP_ID, APP_MEDIA_RECEIVER):
+            return  # another app took over the device
+        status = self.cc.media_controller.status
+        if status.player_is_playing or status.player_is_paused:
+            # something is loaded again, e.g. the keepalive media of a dashboard
+            return
+        await asyncio.to_thread(self.cc.quit_app)
 
     def _handle_cast_status(self, status: CastStatus) -> None:
         """Process CastStatus on the event loop thread."""

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -504,6 +504,8 @@ class ChromecastPlayer(Player):
 
     async def _quit_app_when_unused(self) -> None:
         """Release the Cast device, unless the receiver app got used again."""
+        if not self.available:
+            return  # the device dropped off in the meantime
         if self.cc.app_id not in (MASS_APP_ID, APP_MEDIA_RECEIVER):
             return  # another app took over the device
         status = self.cc.media_controller.status

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -533,6 +533,7 @@ class SendspinChromecastBridge:
 
     async def _launch_sendspin_app(self) -> None:
         """Launch the Sendspin Cast Receiver app and send the server config."""
+        self.cast_player.cancel_pending_app_quit()
         try:
             # Launch the Sendspin Cast App on the Chromecast.
             # force_launch=True ensures the Cast device kills any running app

--- a/tests/providers/chromecast/test_dashboard_commands.py
+++ b/tests/providers/chromecast/test_dashboard_commands.py
@@ -145,6 +145,23 @@ async def test_on_show_reuses_connected_player_cc() -> None:
     mock_send_show_dashboard.assert_called_once_with(connected_chromecast, url)
 
 
+async def test_on_show_keeps_the_player_from_releasing_the_device() -> None:
+    """A release still pending from a stop on the player would close the dashboard."""
+    dashboards = _make_dashboards()
+    device_uuid = uuid4()
+    connected_chromecast = MagicMock()
+    connected_chromecast.socket_client.is_connected = True
+    castplayer = MagicMock(spec=ChromecastPlayer)
+    castplayer.cc = connected_chromecast
+    dashboards.mass.players.get_player.return_value = castplayer  # type: ignore[attr-defined]
+    dashboards.mass.dashboard.resolve_dashboard_url = AsyncMock(return_value="https://mass.test")  # type: ignore[method-assign]
+
+    with patch("music_assistant.providers.chromecast.dashboard.send_show_dashboard"):
+        await dashboards._on_show(str(device_uuid), DashboardType.PARTY, None)
+
+    castplayer.cancel_pending_app_quit.assert_called_once()
+
+
 async def test_on_show_reuses_cached_on_demand_connection() -> None:
     """A cached on-demand connection (no MA player) is reused instead of reconnecting."""
     dashboards = _make_dashboards()

--- a/tests/providers/chromecast/test_stop.py
+++ b/tests/providers/chromecast/test_stop.py
@@ -50,6 +50,7 @@ def _fake_cast(
     """
     fake = MagicMock()
     fake.type = player_type
+    fake.available = True
     fake.cc.app_id = running_app_id
     fake._app_quit_task_id = "cast_quit_app_test"
     fake.cancel_pending_app_quit = partial(
@@ -125,15 +126,6 @@ async def test_launching_an_app_cancels_a_pending_release() -> None:
     fake.mass.cancel_timer.assert_called_once_with(fake._app_quit_task_id)
 
 
-async def test_claiming_the_device_cancels_a_pending_release() -> None:
-    """Anything launching an app on the device keeps it from being released."""
-    fake = _fake_cast()
-
-    fake.cancel_pending_app_quit()
-
-    fake.mass.cancel_timer.assert_called_once_with(fake._app_quit_task_id)
-
-
 @pytest.mark.parametrize("app_id", [MASS_APP_ID, APP_MEDIA_RECEIVER])
 async def test_unused_receiver_app_is_quit(app_id: str) -> None:
     """Nothing came along within the grace period, so the device is released."""
@@ -142,6 +134,16 @@ async def test_unused_receiver_app_is_quit(app_id: str) -> None:
     await _quit_app_when_unused(fake)
 
     fake.cc.quit_app.assert_called_once()
+
+
+async def test_unreachable_device_is_not_quit() -> None:
+    """The device dropped off within the grace period, so there is nothing to send to."""
+    fake = _fake_cast(player_state="IDLE")
+    fake.available = False
+
+    await _quit_app_when_unused(fake)
+
+    fake.cc.quit_app.assert_not_called()
 
 
 async def test_app_of_another_sender_is_not_quit() -> None:

--- a/tests/providers/chromecast/test_stop.py
+++ b/tests/providers/chromecast/test_stop.py
@@ -1,0 +1,163 @@
+"""
+Tests for how ChromecastPlayer releases a Cast device on stop.
+
+Quitting the receiver app ends the Cast session, and the device plays its 'cast
+connected' chime whenever a new one is started. Stopping must therefore leave the
+session in place for a while, so a follow-up command (an announcement stops playback
+before it plays) does not have to start a new one.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import PlayerType
+
+from music_assistant.providers.chromecast.constants import (
+    APP_MEDIA_RECEIVER,
+    APP_QUIT_DELAY,
+    MASS_APP_ID,
+    SENDSPIN_CAST_APP_ID,
+)
+from music_assistant.providers.chromecast.player import ChromecastPlayer
+
+
+async def _stop(fake: MagicMock) -> None:
+    await ChromecastPlayer.stop(cast("ChromecastPlayer", fake))
+
+
+async def _quit_app_when_unused(fake: MagicMock) -> None:
+    await ChromecastPlayer._quit_app_when_unused(cast("ChromecastPlayer", fake))
+
+
+def _fake_cast(
+    *,
+    player_type: PlayerType = PlayerType.PLAYER,
+    running_app_id: str | None = MASS_APP_ID,
+    player_state: str = "PLAYING",
+    media_session_id: int | None = 1,
+) -> MagicMock:
+    """
+    Build a MagicMock Cast player.
+
+    :param player_type: Type of the player.
+    :param running_app_id: App id the receiver is running, if any.
+    :param player_state: Media player state the receiver reports.
+    :param media_session_id: Media session the receiver reports, if any.
+    """
+    fake = MagicMock()
+    fake.type = player_type
+    fake.cc.app_id = running_app_id
+    fake._app_quit_task_id = "cast_quit_app_test"
+    fake.cancel_pending_app_quit = partial(
+        ChromecastPlayer.cancel_pending_app_quit, cast("ChromecastPlayer", fake)
+    )
+    status = fake.cc.media_controller.status
+    status.player_is_playing = player_state in ("PLAYING", "BUFFERING")
+    status.player_is_paused = player_state == "PAUSED"
+    status.media_session_id = media_session_id
+    return fake
+
+
+async def test_stop_keeps_the_cast_session_alive() -> None:
+    """Stopping a player must not end the Cast session right away."""
+    fake = _fake_cast()
+
+    await _stop(fake)
+
+    fake.cc.media_controller.stop.assert_called_once()
+    fake.cc.quit_app.assert_not_called()
+
+
+async def test_stop_schedules_the_device_release() -> None:
+    """The device is released a little later, so a follow-up command can reuse it."""
+    fake = _fake_cast()
+
+    await _stop(fake)
+
+    fake.mass.call_later.assert_called_once_with(
+        APP_QUIT_DELAY, fake._quit_app_when_unused, task_id=fake._app_quit_task_id
+    )
+
+
+@pytest.mark.parametrize("app_id", [SENDSPIN_CAST_APP_ID, "CC32E753", None])
+async def test_stop_ends_a_foreign_cast_session_right_away(app_id: str | None) -> None:
+    """A session of another app is not ours to keep around."""
+    fake = _fake_cast(running_app_id=app_id)
+
+    await _stop(fake)
+
+    fake.cc.quit_app.assert_called_once()
+    fake.mass.call_later.assert_not_called()
+
+
+async def test_stop_on_a_group_leaves_the_app_alone() -> None:
+    """A cast group is released by its power command, not by stop."""
+    fake = _fake_cast(player_type=PlayerType.GROUP)
+
+    await _stop(fake)
+
+    fake.cc.media_controller.stop.assert_called_once()
+    fake.cc.quit_app.assert_not_called()
+    fake.mass.call_later.assert_not_called()
+
+
+async def test_stop_without_a_media_session_is_not_sent() -> None:
+    """Nothing was ever loaded, so there is no playback to stop."""
+    fake = _fake_cast(media_session_id=None)
+
+    await _stop(fake)
+
+    fake.cc.media_controller.stop.assert_not_called()
+    fake.cc.quit_app.assert_not_called()
+    fake.mass.call_later.assert_called_once()
+
+
+async def test_launching_an_app_cancels_a_pending_release() -> None:
+    """The device is claimed again within the grace period, so it must not be released."""
+    fake = _fake_cast(running_app_id=MASS_APP_ID)
+
+    await ChromecastPlayer._launch_app(cast("ChromecastPlayer", fake))
+
+    fake.mass.cancel_timer.assert_called_once_with(fake._app_quit_task_id)
+
+
+async def test_claiming_the_device_cancels_a_pending_release() -> None:
+    """Anything launching an app on the device keeps it from being released."""
+    fake = _fake_cast()
+
+    fake.cancel_pending_app_quit()
+
+    fake.mass.cancel_timer.assert_called_once_with(fake._app_quit_task_id)
+
+
+@pytest.mark.parametrize("app_id", [MASS_APP_ID, APP_MEDIA_RECEIVER])
+async def test_unused_receiver_app_is_quit(app_id: str) -> None:
+    """Nothing came along within the grace period, so the device is released."""
+    fake = _fake_cast(running_app_id=app_id, player_state="IDLE")
+
+    await _quit_app_when_unused(fake)
+
+    fake.cc.quit_app.assert_called_once()
+
+
+async def test_app_of_another_sender_is_not_quit() -> None:
+    """Another app took over the device, so it is no longer ours to release."""
+    fake = _fake_cast(running_app_id=SENDSPIN_CAST_APP_ID, player_state="IDLE")
+
+    await _quit_app_when_unused(fake)
+
+    fake.cc.quit_app.assert_not_called()
+
+
+@pytest.mark.parametrize("player_state", ["PLAYING", "BUFFERING", "PAUSED"])
+async def test_receiver_app_in_use_is_not_quit(player_state: str) -> None:
+    """The receiver app got used again (such as by a dashboard), so it is left running."""
+    fake = _fake_cast(player_state=player_state)
+
+    await _quit_app_when_unused(fake)
+
+    fake.cc.quit_app.assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

Playing an announcement on a Cast player that was playing music started a brand new Cast session, so the device played its "cast connected" chime instead of the announcement chime.

Stopping a Cast player closed the receiver app entirely, which ends the session. Since an announcement stops playback before it plays, every announcement (from Music Assistant and from Home Assistant) had to start a fresh session first.

Stopping now just stops playback and the device is released a little later, so anything that follows shortly after can reuse the session.

- Stop no longer closes the receiver app right away; the device is released 10 seconds later
- The release is cancelled when the device gets used again (playback, a dashboard or a Sendspin stream)
- The release is skipped when another app has taken over the device in the meantime
- Stopping a device that is running someone else's cast app still releases it immediately

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
