### PR TITLE
Fix outdated AirPlay comments about how warm playback boundaries work

### DIFF
--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -567,13 +567,14 @@ keeps their exposed player id stable and their Universal Player merging intact.
    the imageproxy (e.g. filesystem-provider images with no public URL) does not
    currently render on the Apple TV's now-playing screen, while externally-hosted
    art does
-5. **Warm boundaries wait for the queued audio**: Pause, seek and track changes
-   leave the audio the receiver already holds in place, so it renders that
-   first and `buffer_depth` is also the delay before the boundary is heard.
-   Dropping the queue instead produced audible noise bursts on Apple receivers,
-   so keeping it is an accepted trade-off. It is most noticeable on pause, where
-   playback is expected to stop at once. On a receiver that needs a deep queue
-   to render at all, the delay cannot be tuned away without silencing it
+5. **Warm boundaries wait for the queued audio** (native AirPlay 2): Pause, seek
+   and track changes leave the audio the receiver already holds in place, so it
+   renders that first and `buffer_depth` is also the delay before the boundary
+   is heard. Dropping the queue instead produced audible noise bursts (measured
+   on Apple receivers), so keeping it is an accepted trade-off. It is most
+   noticeable on pause, where playback is expected to stop at once. On a
+   receiver that needs a deep queue to render at all, the delay cannot be tuned
+   away without silencing it
 
 ## Development Notes
 

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -173,9 +173,10 @@ AIRPLAY_GROUP_START_LEAD_MS: Final[int] = 500
 # short leads above; solo cold starts have no sync partner to miss.
 AIRPLAY_COLD_GROUP_START_LEAD_MS: Final[int] = 2500
 # Margin added on top of a member's reported warm lead (the splice-timeline
-# queue depth on Apple receivers) when anchoring a warm re-start: covers the
-# command round-trips between the flush acks and the shared START so every
-# member's skip target lands beyond its queued audio.
+# queue depth; that timeline is the default for every native AirPlay 2 session)
+# when anchoring a warm re-start: covers the command round-trips between the
+# flush acks and the shared START so every member's skip target lands beyond
+# its queued audio.
 AIRPLAY_SPLICE_LEAD_MARGIN_MS: Final[int] = 150
 
 # Floor for the late-join PCM ring, which has to hold every sample between the
@@ -219,12 +220,12 @@ AIRPLAY_REJOIN_ATTEMPT_DELAYS: Final[tuple[int, ...]] = (5,)
 
 # Shared audible instant for a native announcement over a live stream: now +
 # the largest member span + this margin. A member can only mix the clip into
-# audio it has not delivered yet, and its span (warm_lead_ms on the Apple
-# splice timeline, the reported lead_ms otherwise) is how far its delivery
-# head runs ahead of the audible position - so the earliest instant EVERY
-# member can honor lies one max-span out. The margin covers fanning the
-# command out over the pipes and the per-member arm processing, so one shared
-# instant stays feasible for all members.
+# audio it has not delivered yet, and its span (warm_lead_ms on the splice
+# timeline, the reported lead_ms otherwise) is how far its delivery head runs
+# ahead of the audible position - so the earliest instant EVERY member can
+# honor lies one max-span out. The margin covers fanning the command out over
+# the pipes and the per-member arm processing, so one shared instant stays
+# feasible for all members.
 AIRPLAY_ANNOUNCE_AT_MARGIN_MS: Final[int] = 300
 # Span assumed for a member whose binary reported neither a warm lead nor a
 # device lead (both read 0 = unreported): the binary's own default playback

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -760,10 +760,11 @@ class SendspinAirPlayBridge:
         """
         Flush a kept, still-connected stream and resume it on the new track.
 
-        The stream is flushed in place (receiver + ring + stdin drained) while
-        its connection stays alive, then the new PCM is fed into the SAME cli
-        stdin and re-anchored with a single START. Returns True once resumed; any
-        failure returns False so the caller falls back to a cold restart.
+        The stream is flushed in place (the binary's input ring and stdin
+        drained) while its connection stays alive, then the new PCM is fed into
+        the SAME cli stdin and re-anchored with a single START. Returns True once
+        resumed; any failure returns False so the caller falls back to a cold
+        restart.
 
         :param stream: The kept AirPlayStream to flush and resume.
         """

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -226,9 +226,10 @@ class AirPlayStream:
         self.device_min_frames: int = 0
         self.device_max_frames: int = 0
         # Minimum lead (ms) a warm commanded START needs for exact placement.
-        # Nonzero on the Apple splice timeline, where the receiver's queued
-        # audio plays out before the new content can begin; a warm group
-        # anchor must sit beyond the largest member value. 0 = no constraint.
+        # Nonzero on the splice timeline, the default for every native AirPlay 2
+        # session, where the receiver's queued audio plays out before the new
+        # content can begin; a warm group anchor must sit beyond the largest
+        # member value. 0 = no constraint.
         self.warm_lead_ms: int = 0
         # Audible instant (unix ms) of the delivery head frozen by the latest
         # warm flush, from the flushed ack (0 = none/no constraint). The warm
@@ -422,9 +423,12 @@ class AirPlayStream:
         """
         Flush the live stream in place and wait for the binary's acknowledgement.
 
-        Sends ``ACTION=FLUSH`` — the binary stops sending audio, flushes the
-        receiver, discards its input ring and drains stdin, then reports
-        ``[STATUS] flushed`` while keeping the connection and stdin reader alive.
+        Sends ``ACTION=FLUSH`` — the binary stops sending content, discards its
+        input ring and drains stdin, then reports ``[STATUS] flushed`` while
+        keeping the connection and stdin reader alive. The receiver is not asked
+        to discard on the splice timeline: its queued audio plays out and the
+        next START splices onto the same line, so a warm anchor has to clear
+        :attr:`warm_lead_ms` and :attr:`flushed_head_unix_ms`.
         The caller must have stopped feeding old audio before calling this; what
         it already wrote is seen through to the binary here, and stdin is held
         quiet until the flush is acknowledged, so the drain removes exactly the

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -1019,7 +1019,7 @@ class AirPlayStreamSession:
         Return the shared audible-start instant for a readiness-confirmed start.
 
         :param warm: True for a warm re-start over live connections (seek/next/
-            resume-from-park). Members on the Apple splice timeline report a
+            resume-from-park). Members on the splice timeline report a
             minimum warm lead — their queued audio plays out before the new
             content can begin — and the shared anchor must sit beyond the
             largest member value so every member splices at the same instant.


### PR DESCRIPTION
# What does this implement/fix?

Several comments in the AirPlay provider described the cliairplay "splice timeline" as something only Apple receivers use, and described a warm flush as making the receiver throw away the audio it still had queued. Both were true at some point, but neither is true of the binary today — and during a recent review they were quoted as if they were, leading to a wrong conclusion that only got caught by reading the binary's source.

Verified against `music-assistant/airplay-cli` @ `origin/main`:

- The splice timeline is the default for **every** native AirPlay 2 session — its deny-list is empty. It is off only for the RAOP-compat flow (used by Sonos) and legacy RAOP, so the real distinction is native AirPlay 2 vs RAOP, not Apple vs everything else. A non-Apple receiver like the Edifier MS50A rides it, which is the only reason its buffer depth setting does anything.
- On that timeline the binary deliberately does **not** ask the receiver to discard: the queued audio plays out and the next start splices onto the same line.

Comment-only, no behaviour change.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
