### PR TITLE
Remote connections keep large messages within what the client accepts

### DIFF
--- a/music_assistant/controllers/webserver/README.md
+++ b/music_assistant/controllers/webserver/README.md
@@ -298,7 +298,7 @@ image costs its own size and no more. Those binary messages carry no request id,
 gateway holds the channel for a whole reply: replies go out one at a time rather than
 interleaving, which a channel that sends one message at a time would do anyway.
 
-Both channels size their bulk frames to the channel's `max_message_size`, which is the lower of
+`ma-api` and `http_proxy` size their bulk frames to the channel's `max_message_size`, the lower of
 our own 256 KiB ceiling and what the peer advertises in its SDP — and libdatachannel assumes
 only 64 KiB when it advertises nothing. On `http_proxy` that bounds the binary body frames. On
 `ma-api` a message that does not fit is split into `__chunk__` frames (`id`, `seq`, `count`,

--- a/music_assistant/controllers/webserver/README.md
+++ b/music_assistant/controllers/webserver/README.md
@@ -297,9 +297,13 @@ applied on top. `http_proxy` carries nothing else, so there the reply is a JSON 
 image costs its own size and no more. Those binary messages carry no request id, so the
 gateway holds the channel for a whole reply: replies go out one at a time rather than
 interleaving, which a channel that sends one message at a time would do anyway.
-Frames are capped at the channel's
-`max_message_size`, which is the lower of our own 256 KiB ceiling and what the peer
-advertises in its SDP — and libdatachannel assumes only 64 KiB when it advertises nothing.
+
+Frames on both channels are capped at the channel's `max_message_size`, which is the lower of
+our own 256 KiB ceiling and what the peer advertises in its SDP — and libdatachannel assumes
+only 64 KiB when it advertises nothing. An `ma-api` message that does not fit is split into
+`__chunk__` frames (`id`, `seq`, `count`, `b64`) the client reassembles by group id, each piece
+at most 64 KiB and sized down further so its base64 payload and JSON envelope stay under the
+cap.
 
 **Adding a new label** is not backwards compatible by itself: servers from before the routing
 table mistake an unknown label for the API channel, which breaks the entire remote session

--- a/music_assistant/controllers/webserver/README.md
+++ b/music_assistant/controllers/webserver/README.md
@@ -301,9 +301,10 @@ interleaving, which a channel that sends one message at a time would do anyway.
 `ma-api` and `http_proxy` size their bulk frames to the channel's `max_message_size`, the lower of
 our own 256 KiB ceiling and what the peer advertises in its SDP — and libdatachannel assumes
 only 64 KiB when it advertises nothing. On `http_proxy` that bounds the binary body frames. On
-`ma-api` a message that does not fit is split into `__chunk__` frames (`id`, `seq`, `count`,
-`b64`) the client reassembles by group id, each piece at most 64 KiB and sized down further so
-its base64 payload and JSON envelope stay under the cap.
+`ma-api` any message over 64 KiB — or over the cap, whichever is lower — is split into
+`__chunk__` frames (`id`, `seq`, `count`, `b64`) the client reassembles by group id. A client
+therefore has to expect chunking well before the cap: pieces are 64 KiB by preference, sized
+down only when the cap cannot fit that much base64 plus the frame's JSON envelope.
 
 **Adding a new label** is not backwards compatible by itself: servers from before the routing
 table mistake an unknown label for the API channel, which breaks the entire remote session

--- a/music_assistant/controllers/webserver/README.md
+++ b/music_assistant/controllers/webserver/README.md
@@ -298,12 +298,12 @@ image costs its own size and no more. Those binary messages carry no request id,
 gateway holds the channel for a whole reply: replies go out one at a time rather than
 interleaving, which a channel that sends one message at a time would do anyway.
 
-Frames on both channels are capped at the channel's `max_message_size`, which is the lower of
+Both channels size their bulk frames to the channel's `max_message_size`, which is the lower of
 our own 256 KiB ceiling and what the peer advertises in its SDP — and libdatachannel assumes
-only 64 KiB when it advertises nothing. An `ma-api` message that does not fit is split into
-`__chunk__` frames (`id`, `seq`, `count`, `b64`) the client reassembles by group id, each piece
-at most 64 KiB and sized down further so its base64 payload and JSON envelope stay under the
-cap.
+only 64 KiB when it advertises nothing. On `http_proxy` that bounds the binary body frames. On
+`ma-api` a message that does not fit is split into `__chunk__` frames (`id`, `seq`, `count`,
+`b64`) the client reassembles by group id, each piece at most 64 KiB and sized down further so
+its base64 payload and JSON envelope stay under the cap.
 
 **Adding a new label** is not backwards compatible by itself: servers from before the routing
 table mistake an unknown label for the API channel, which breaks the entire remote session

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -44,8 +44,13 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.remote_access")
 # instead of piling up local requests and the response bodies they buffer (see #4889).
 HTTP_PROXY_CONCURRENCY = 6
 
-# Chunk messages larger than this; each piece becomes a base64 frame roughly a third larger.
+# Preferred piece size when chunking an oversized message; each piece becomes a base64 frame
+# roughly a third larger, so the channel's negotiated limit can size it down further.
 DATA_CHANNEL_CHUNK_SIZE = 64 * 1024
+
+# Room a chunk frame's JSON envelope takes around its base64 payload: the fixed keys plus the
+# group, sequence and count numbers.
+DATA_CHANNEL_CHUNK_OVERHEAD = 128
 
 # Preferred body chunk size on the dedicated http proxy channel. Raw binary needs no escaping,
 # so this sits close to libdatachannel's 256 KiB cap; the channel's negotiated limit still wins.
@@ -639,20 +644,25 @@ class WebRTCGateway:
 
     async def _send_chunked(self, channel: DataChannel | None, text: str) -> None:
         """Send a text message on a data channel, chunking it if it exceeds the size limit."""
+        if channel is None or not channel.is_open:
+            return
+        # a peer that advertises no limit in its SDP is assumed to accept only 64 KiB
+        limit = channel.max_message_size
         data = text.encode()
-        if len(data) <= DATA_CHANNEL_CHUNK_SIZE:
+        if len(data) <= min(DATA_CHANNEL_CHUNK_SIZE, limit):
             await self._send_on_channel(channel, text)
             return
 
         # Oversized messages are split into base64 frames the client reassembles by group id
         # (base64 keeps each frame's size predictable regardless of JSON escaping / unicode).
+        # A piece is sized so its frame still fits the limit: base64 turns every 3 bytes into 4,
+        # on top of the JSON envelope.
+        piece_size = min(DATA_CHANNEL_CHUNK_SIZE, (limit - DATA_CHANNEL_CHUNK_OVERHEAD) // 4 * 3)
         self._chunk_group_seq += 1
         group_id = self._chunk_group_seq
-        count = (len(data) + DATA_CHANNEL_CHUNK_SIZE - 1) // DATA_CHANNEL_CHUNK_SIZE
+        count = (len(data) + piece_size - 1) // piece_size
         for seq in range(count):
-            if channel is None or not channel.is_open:
-                return
-            piece = data[seq * DATA_CHANNEL_CHUNK_SIZE : (seq + 1) * DATA_CHANNEL_CHUNK_SIZE]
+            piece = data[seq * piece_size : (seq + 1) * piece_size]
             await self._send_on_channel(
                 channel,
                 json.dumps(

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -662,6 +662,10 @@ class WebRTCGateway:
         group_id = self._chunk_group_seq
         count = (len(data) + piece_size - 1) // piece_size
         for seq in range(count):
+            # a send onto a closed channel returns without suspending, so without this the
+            # loop would encode and discard every remaining piece without yielding
+            if channel.is_closed:
+                return
             piece = data[seq * piece_size : (seq + 1) * piece_size]
             await self._send_on_channel(
                 channel,

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -644,7 +644,8 @@ class WebRTCGateway:
 
     async def _send_chunked(self, channel: DataChannel | None, text: str) -> None:
         """Send a text message on a data channel, chunking it if it exceeds the size limit."""
-        if channel is None or not channel.is_open:
+        # reading the limit off a closed channel raises, and it has nothing left to receive
+        if channel is None or channel.is_closed:
             return
         # a peer that advertises no limit in its SDP is assumed to accept only 64 KiB
         limit = channel.max_message_size
@@ -662,9 +663,10 @@ class WebRTCGateway:
         group_id = self._chunk_group_seq
         count = (len(data) + piece_size - 1) // piece_size
         for seq in range(count):
-            # a send onto a closed channel returns without suspending, so without this the
-            # loop would encode and discard every remaining piece without yielding
-            if channel.is_closed:
+            # a send onto a channel that is no longer open returns without suspending, so
+            # without this the loop would frame and discard every remaining piece without
+            # ever yielding
+            if not channel.is_open:
                 return
             piece = data[seq * piece_size : (seq + 1) * piece_size]
             await self._send_on_channel(

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -48,8 +48,8 @@ HTTP_PROXY_CONCURRENCY = 6
 # roughly a third larger, so the channel's negotiated limit can size it down further.
 DATA_CHANNEL_CHUNK_SIZE = 64 * 1024
 
-# Room a chunk frame's JSON envelope takes around its base64 payload: the fixed keys plus the
-# group, sequence and count numbers.
+# Room a chunk frame's JSON envelope takes around its base64 payload: 60 bytes of fixed keys
+# plus the group, sequence and count numbers.
 DATA_CHANNEL_CHUNK_OVERHEAD = 128
 
 # Preferred body chunk size on the dedicated http proxy channel. Raw binary needs no escaping,

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -1584,8 +1584,9 @@ async def test_a_second_http_proxy_channel_is_refused(cert_pems: tuple[str, str]
 class _FakeDataChannel:
     """Data channel stand-in that captures outbound messages for proxy tests."""
 
-    def __init__(self) -> None:
+    def __init__(self, max_message_size: int = 256 * 1024) -> None:
         self.is_open = True
+        self.max_message_size = max_message_size
         self.sent: list[str] = []
 
     async def send(self, data: str) -> None:
@@ -1676,3 +1677,104 @@ async def test_send_chunked_large_message_chunked(cert_pems: tuple[str, str]) ->
     assert len(channel.sent) > 1
     assert all(len(m.encode()) < 256 * 1024 for m in channel.sent)
     assert _reassemble_chunks(channel.sent) == text
+
+
+async def test_send_chunked_keeps_the_framing_released_clients_expect(
+    cert_pems: tuple[str, str],
+) -> None:
+    """Against the 256 KiB limit every browser advertises, the frames must not move."""
+    gateway = _proxy_gateway(cert_pems)
+    channel = _FakeDataChannel()
+    text = '{"event":"' + "x" * (DATA_CHANNEL_CHUNK_SIZE * 2 + 5000) + '"}'
+    data = text.encode()
+
+    await gateway._send_chunked(cast("DataChannel", channel), text)
+
+    # the exact wire format the bundled frontend and the mobile app reassemble: 64 KiB pieces,
+    # numbered from zero within a group id that counts up per message
+    assert channel.sent == [
+        json.dumps(
+            {
+                "type": "__chunk__",
+                "id": 1,
+                "seq": seq,
+                "count": 3,
+                "b64": base64.b64encode(
+                    data[seq * DATA_CHANNEL_CHUNK_SIZE : (seq + 1) * DATA_CHANNEL_CHUNK_SIZE]
+                ).decode(),
+            }
+        )
+        for seq in range(3)
+    ]
+    # a full piece has always serialised well past 64 KiB, which only a peer advertising no
+    # limit of its own would reject
+    assert len(channel.sent[0]) == 87447
+
+
+async def test_send_chunked_honours_the_negotiated_message_limit(
+    cert_pems: tuple[str, str],
+) -> None:
+    """A peer that advertises no limit in its SDP gets frames it can actually accept."""
+    gateway = _proxy_gateway(cert_pems)
+    # what libdatachannel assumes when the peer advertises no a=max-message-size
+    channel = _FakeDataChannel(max_message_size=64 * 1024)
+    text = '{"data":"' + "音楽" * DATA_CHANNEL_CHUNK_SIZE + '"}'
+
+    await gateway._send_chunked(cast("DataChannel", channel), text)
+
+    assert len(channel.sent) > 1
+    assert all(len(m.encode()) <= channel.max_message_size for m in channel.sent)
+    assert _reassemble_chunks(channel.sent) == text
+
+
+async def test_send_chunked_passthrough_stops_at_the_negotiated_limit(
+    cert_pems: tuple[str, str],
+) -> None:
+    """A message past a small peer's limit is chunked rather than sent whole."""
+    gateway = _proxy_gateway(cert_pems)
+    channel = _FakeDataChannel(max_message_size=16 * 1024)
+    text = '{"data":"' + "x" * (32 * 1024) + '"}'
+
+    await gateway._send_chunked(cast("DataChannel", channel), text)
+
+    assert len(channel.sent) > 1
+    assert all(len(m.encode()) <= channel.max_message_size for m in channel.sent)
+    assert _reassemble_chunks(channel.sent) == text
+
+
+async def test_ma_api_channel_chunks_within_the_negotiated_limit(
+    cert_pems: tuple[str, str],
+) -> None:
+    """A large API event reaches a peer that advertises no limit instead of being dropped."""
+    cert_pem, key_pem = cert_pems
+    fake_ws = _FakeLocalWS()
+    http_session = Mock()
+    http_session.ws_connect = AsyncMock(
+        return_value=cast("aiohttp.ClientWebSocketResponse", fake_ws)
+    )
+    gateway = WebRTCGateway(
+        http_session=http_session,
+        remote_id="TEST-REMOTE-ID",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+    )
+    # what libdatachannel assumes when the peer advertises no a=max-message-size
+    channel = _FakeBidiChannel(max_message_size=64 * 1024)
+    session = _register_bridge_session(gateway, "small-limit-session", channel)
+    bridge = asyncio.ensure_future(gateway._bridge_ma_api(session, cast("DataChannel", channel)))
+    try:
+        await _wait_for(lambda: session.local_ws is not None)
+
+        event = json.dumps({"event": "queue_updated", "data": "x" * (200 * 1024)})
+        fake_ws.feed_text(event)
+        await _wait_for(
+            lambda: bool(channel.sent) and len(channel.sent) == json.loads(channel.sent[0])["count"]
+        )
+
+        frames = cast("list[str]", channel.sent)
+        assert all(len(frame.encode()) <= channel.max_message_size for frame in frames)
+        assert _reassemble_chunks(frames) == event
+    finally:
+        channel.close()
+        await asyncio.wait_for(bridge, timeout=5)
+        await _wait_for(lambda: "small-limit-session" not in gateway.sessions)

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -868,6 +868,7 @@ class _FakeBidiChannel:
     def __init__(self, label: str = "ma-api", max_message_size: int = 256 * 1024) -> None:
         self.label = label
         self.is_open = True
+        self.is_closed = False
         self.closed = False
         self.max_message_size = max_message_size
         self.sent: list[str | bytes] = []
@@ -887,6 +888,7 @@ class _FakeBidiChannel:
 
     def close(self) -> None:
         self.closed = True
+        self.is_closed = True
         self.is_open = False
         self._inbound.put_nowait(None)
 
@@ -1582,15 +1584,32 @@ async def test_a_second_http_proxy_channel_is_refused(cert_pems: tuple[str, str]
 
 
 class _FakeDataChannel:
-    """Data channel stand-in that captures outbound messages for proxy tests."""
+    """
+    Data channel stand-in that captures outbound messages for proxy tests.
 
-    def __init__(self, max_message_size: int = 256 * 1024) -> None:
-        self.is_open = True
+    :param close_after: Close the channel once this many messages have been sent.
+    """
+
+    def __init__(self, max_message_size: int = 256 * 1024, close_after: int | None = None) -> None:
+        self.is_closed = False
         self.max_message_size = max_message_size
         self.sent: list[str] = []
+        # the gateway consults the channel once per outbound message, so this counts how far
+        # a send loop got even when the messages themselves are discarded
+        self.open_checks = 0
+        self._is_open = True
+        self._close_after = close_after
+
+    @property
+    def is_open(self) -> bool:
+        self.open_checks += 1
+        return self._is_open
 
     async def send(self, data: str) -> None:
         self.sent.append(data)
+        if self._close_after is not None and len(self.sent) >= self._close_after:
+            self._is_open = False
+            self.is_closed = True
 
 
 def _proxy_gateway(cert_pems: tuple[str, str]) -> WebRTCGateway:
@@ -1740,6 +1759,21 @@ async def test_send_chunked_passthrough_stops_at_the_negotiated_limit(
     assert len(channel.sent) > 1
     assert all(len(m.encode()) <= channel.max_message_size for m in channel.sent)
     assert _reassemble_chunks(channel.sent) == text
+
+
+async def test_send_chunked_stops_framing_once_the_channel_closes(
+    cert_pems: tuple[str, str],
+) -> None:
+    """A channel that goes away mid-message stops the loop instead of encoding the rest."""
+    gateway = _proxy_gateway(cert_pems)
+    channel = _FakeDataChannel(close_after=1)
+    text = '{"data":"' + "x" * (DATA_CHANNEL_CHUNK_SIZE * 3) + '"}'
+
+    await gateway._send_chunked(cast("DataChannel", channel), text)
+
+    assert len(channel.sent) == 1
+    # the opening guard plus the one delivered piece: the other three are never framed
+    assert channel.open_checks == 2
 
 
 async def test_ma_api_channel_chunks_within_the_negotiated_limit(

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -1708,7 +1708,7 @@ async def test_send_chunked_keeps_the_framing_released_clients_expect(
     ]
     # a full piece has always serialised well past 64 KiB, which only a peer advertising no
     # limit of its own would reject
-    assert len(channel.sent[0]) == 87447
+    assert len(channel.sent[0].encode()) == 87447
 
 
 async def test_send_chunked_honours_the_negotiated_message_limit(

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -1767,13 +1767,14 @@ async def test_send_chunked_stops_framing_once_the_channel_closes(
     """A channel that goes away mid-message stops the loop instead of encoding the rest."""
     gateway = _proxy_gateway(cert_pems)
     channel = _FakeDataChannel(close_after=1)
-    text = '{"data":"' + "x" * (DATA_CHANNEL_CHUNK_SIZE * 3) + '"}'
+    text = '{"data":"' + "x" * (DATA_CHANNEL_CHUNK_SIZE * 10) + '"}'
 
     await gateway._send_chunked(cast("DataChannel", channel), text)
 
     assert len(channel.sent) == 1
-    # the opening guard plus the one delivered piece: the other three are never framed
-    assert channel.open_checks == 2
+    # the guard and the send of the first piece, then the guard again: the other ten pieces
+    # are never framed
+    assert channel.open_checks == 3
 
 
 async def test_ma_api_channel_chunks_within_the_negotiated_limit(


### PR DESCRIPTION
# What does this implement/fix?

Large messages sent over a remote connection are split into smaller pieces before they go out.
Those pieces were cut to a fixed size, but the encoding applied afterwards makes each piece
about a third bigger — so the finished piece could end up larger than the client said it can
accept. Clients that don't state a size get assumed to accept only a small one, and anything
over that is thrown away without a trace: not just album art, but any large update.

Every client we ship today states a size that is comfortably large, so nobody is hitting this.
The pieces are now cut to fit whatever the client actually accepts, and the sizing for today's
clients is unchanged. Found while reviewing #5643, which fixed the same thing on the separate
image channel.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Chunk pieces are sized from the channel's negotiated message limit instead of a fixed 64 KiB,
  leaving room for the encoding growth and the wrapper around it.
- Messages that fit are still sent whole, now also checked against that same limit.
- Tests pin the frame layout released clients parse today, and cover a client that states no
  size of its own.
- Documented the framing in the webserver README.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
