### PR TITLE
Report a Cast group playback error once instead of once per speaker

### DIFF
--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -606,7 +606,13 @@ class ChromecastPlayer(Player):
         # surface a media error reported by the receiver (e.g. after a failed LOAD),
         # which otherwise only shows as a silent return to idle
         if status.player_is_idle and status.idle_reason == "ERROR":
-            if not self._media_error_reported and not self._flow_stream_underrun():
+            # a group forwards its status to every member, so only the group
+            # player itself reports the error
+            if (
+                group_player is None
+                and not self._media_error_reported
+                and not self._flow_stream_underrun()
+            ):
                 self._media_error_reported = True
                 self.logger.warning(
                     "%s reported a media playback error for %s",

--- a/tests/providers/chromecast/test_media_status_error.py
+++ b/tests/providers/chromecast/test_media_status_error.py
@@ -84,6 +84,25 @@ def test_error_logged_again_after_recovery() -> None:
     assert fake.logger.warning.call_count == 2
 
 
+def test_group_error_is_not_logged_by_every_member() -> None:
+    """A group's error reaches all its members, but only the group itself reports it."""
+    group = MagicMock()
+    # a plain spec= mock has no 'cc', which is set in __init__
+    group.__class__ = ChromecastPlayer  # type: ignore[assignment]
+    group.cc.media_controller.status = _error_status()
+    member = _fake_player()
+    member.active_cast_group = "group-uuid"
+    member.mass.players.get_player = MagicMock(return_value=group)
+
+    _handle_media_status(member, _error_status())
+
+    member.logger.warning.assert_not_called()
+    # assert the group status was really processed, so the check above cannot pass
+    # just because the member bailed out before reaching the error handling
+    member.mass.players.get_player.assert_called_once_with("group-uuid")
+    member.update_state.assert_called_once()
+
+
 def test_flow_stream_underrun_is_not_an_error() -> None:
     """An idle ERROR at the end of a fully consumed flow stream is expected, not logged."""
     fake = _fake_player()


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Follow-up to #5622. A Cast group sends its media status to every speaker in the
group, so a single failed track produced one warning per speaker, each naming a
speaker that was never asked to play anything. A group of three logged four lines
for one problem and pointed at the wrong devices.

The group itself now reports the error, once.

- Skip the media error warning on group members, so only the group logs it
- Added a test covering a group error reaching its members

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
