### PR TITLE
Rename the player media-updated callback for consistency

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -114,7 +114,7 @@ def _resolve_position(
 # position change (seek/buffer correction) instead of regular playback progression
 POSITION_JUMP_THRESHOLD = 1.0
 
-# Changes to any of these state keys fire the (debounced) _on_player_media_updated
+# Changes to any of these state keys fire the (debounced) on_player_media_updated
 # callback. The palette is included because it resolves asynchronously (shortly
 # after a track change) and players push it to their device from the callback.
 MEDIA_IDENTITY_KEYS = frozenset(
@@ -1231,7 +1231,7 @@ class Player(ABC):
             self.device_info.model,
         )
 
-    def _on_player_media_updated(self) -> None:  # noqa: B027
+    def on_player_media_updated(self) -> None:  # noqa: B027
         """Handle callback when the current media of the player is updated."""
         # optional callback for players that want to be informed when the final
         # current media is updated (after applying group/sync membership logic).
@@ -1923,7 +1923,7 @@ class Player(ABC):
             # debounce the callback to avoid multiple calls when multiple
             # state updates happen in a short time
             self.mass.call_later(
-                1, self._on_player_media_updated, task_id=f"player_media_updated_{self.player_id}"
+                1, self.on_player_media_updated, task_id=f"player_media_updated_{self.player_id}"
             )
         # persist the default name if it changed
         if self.name and self.config.default_name != self.name:

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -512,7 +512,7 @@ class AirPlayPlayer(Player):
                     for member in self.stream.session.sync_clients:
                         self.mass.call_later(
                             1,
-                            member._on_player_media_updated,
+                            member.on_player_media_updated,
                             task_id=f"player_media_updated_{member.player_id}",
                         )
                     return
@@ -893,6 +893,16 @@ class AirPlayPlayer(Player):
         if rejoin_task and not rejoin_task.done() and rejoin_task is not asyncio.current_task():
             rejoin_task.cancel()
 
+    def on_player_media_updated(self) -> None:
+        """Handle callback when the current media of the player is updated."""
+        if not self.stream or not self.stream.running:
+            return
+        metadata = self.state.current_media
+        if not metadata:
+            return
+        progress = int(metadata.corrected_elapsed_time or 0)
+        self.mass.create_task(self.stream.send_metadata(progress, metadata))
+
     def _volume_control_routes_to_self(self, volume_control: str) -> bool:
         """Return True if the given (resolved) volume control routes volume to this player."""
         if volume_control == self.player_id:
@@ -1198,16 +1208,6 @@ class AirPlayPlayer(Player):
             port=port,
             device_id=device_id,
         )
-
-    def _on_player_media_updated(self) -> None:
-        """Handle callback when the current media of the player is updated."""
-        if not self.stream or not self.stream.running:
-            return
-        metadata = self.state.current_media
-        if not metadata:
-            return
-        progress = int(metadata.corrected_elapsed_time or 0)
-        self.mass.create_task(self.stream.send_metadata(progress, metadata))
 
     async def _get_session_pcm_format(
         self, sync_clients: list[AirPlayPlayer], media: PlayerMedia

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -346,7 +346,7 @@ class AirPlayStream:
         await self._send_current_volume()
         self.mass.call_later(2, self._send_current_volume)
         # settle artwork and the position on top of the identity push above
-        self.player._on_player_media_updated()
+        self.player.on_player_media_updated()
 
     async def stop(self, force: bool = False) -> None:
         """

--- a/music_assistant/providers/alexa/__init__.py
+++ b/music_assistant/providers/alexa/__init__.py
@@ -333,7 +333,7 @@ class AlexaPlayer(Player):
         self._attr_current_media = media
         self.update_state()
 
-    def _on_player_media_updated(self) -> None:
+    def on_player_media_updated(self) -> None:
         """
         Handle callback when the current media of the player is updated.
 

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -331,22 +331,7 @@ class ChromecastPlayer(Player):
         # Dispatch to event loop for thread-safe attribute mutation
         self.mass.loop.call_soon_threadsafe(self._handle_connection_status, status)
 
-    @staticmethod
-    def _is_google_device(cast_info: ChromecastInfo) -> bool:
-        """
-        Check if a device is a Google device with native Cast support.
-
-        Google devices (Chromecast, Nest, Google Home) have native Cast support
-        and should be exposed as PlayerType.PLAYER. Non-Google devices with Cast
-        support should be exposed as PlayerType.PROTOCOL.
-        """
-        if not cast_info.manufacturer:
-            # If no manufacturer, check model name for Google devices
-            model = cast_info.model_name.lower() if cast_info.model_name else ""
-            return any(google in model for google in ("chromecast", "google", "nest", "home"))
-        return cast_info.manufacturer.lower() in ("google", "google inc.")
-
-    def _on_player_media_updated(self) -> None:
+    def on_player_media_updated(self) -> None:
         """Handle callback when the current media of the player is updated."""
         if self.powered is False:
             return
@@ -430,6 +415,21 @@ class ChromecastPlayer(Player):
                 )
 
         self.mass.create_task(update_flow_metadata())
+
+    @staticmethod
+    def _is_google_device(cast_info: ChromecastInfo) -> bool:
+        """
+        Check if a device is a Google device with native Cast support.
+
+        Google devices (Chromecast, Nest, Google Home) have native Cast support
+        and should be exposed as PlayerType.PLAYER. Non-Google devices with Cast
+        support should be exposed as PlayerType.PROTOCOL.
+        """
+        if not cast_info.manufacturer:
+            # If no manufacturer, check model name for Google devices
+            model = cast_info.model_name.lower() if cast_info.model_name else ""
+            return any(google in model for google in ("chromecast", "google", "nest", "home"))
+        return cast_info.manufacturer.lower() in ("google", "google inc.")
 
     async def _launch_app(self) -> None:
         """Launch the configured Media Receiver App on a Chromecast."""

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -1666,7 +1666,7 @@ class SendspinPlayer(SendspinBasePlayer):
             self.logger.debug("Skipping undecodable artwork: %s", err)
             return None
 
-    def _on_player_media_updated(self) -> None:
+    def on_player_media_updated(self) -> None:
         """Handle callback when the current media of the player is updated."""
         if self.synced_to is not None:
             # Only leader sends metadata

--- a/scripts/lint_baselines/private_methods_not_last.txt
+++ b/scripts/lint_baselines/private_methods_not_last.txt
@@ -2,7 +2,7 @@
 # Private methods must live at the bottom of the class (see AGENTS.md).
 # Regenerate with: uv run -m scripts.check_method_order --update-baseline
 music_assistant/models/music_provider.py	5
-music_assistant/models/player.py	59
+music_assistant/models/player.py	10
 music_assistant/providers/_demo_audio_analysis_provider/__init__.py	3
 music_assistant/providers/alexa/__init__.py	1
 music_assistant/providers/apple_music/api_client.py	8
@@ -58,7 +58,7 @@ music_assistant/providers/plex_connect/server.py	8
 music_assistant/providers/qqmusic/__init__.py	21
 music_assistant/providers/samsung_wam/features/grouping/coordinator.py	1
 music_assistant/providers/samsung_wam/features/state_sync/handler.py	8
-music_assistant/providers/sendspin/player.py	11
+music_assistant/providers/sendspin/player.py	12
 music_assistant/providers/smart_playlist/__init__.py	8
 music_assistant/providers/snapcast/control.py	1
 music_assistant/providers/snapcast/player.py	5

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2209,10 +2209,10 @@ async def test_wait_for_connection_pushes_metadata_immediately() -> None:
     # Nothing is written before the binary has a reader on the command pipe.
     assert operation_order == ["reader", "metadata"]
     # Metadata pushed synchronously on connect...
-    player._on_player_media_updated.assert_called_once_with()
+    player.on_player_media_updated.assert_called_once_with()
     # ...and never routed through the delayed call_later path.
     deferred_callables = [call.args[1] for call in player.provider.mass.call_later.call_args_list]
-    assert player._on_player_media_updated not in deferred_callables
+    assert player.on_player_media_updated not in deferred_callables
     # The volume resend is still deferred (existing behavior preserved).
     assert player.provider.mass.call_later.call_count == 1
     assert player.provider.mass.call_later.call_args_list[0].args[0] == 2


### PR DESCRIPTION
# What does this implement/fix?

`Player._on_player_media_updated` was the odd one out among the callbacks a player provider can
override — its siblings are `on_group_updated`, `on_sync_parent_updated` and
`on_group_member_updated`. Because its name looked private while it sits in the overridable part of
the class, our "private methods last" linter counted the entire public API of `Player` behind it as
misplaced, and the lint baseline had to grandfather 59 entries for that single file. Dropping the
underscore brings that down to 10.

No behaviour change, but note this is a public API rename for provider authors: a provider that
overrides `_on_player_media_updated` has to drop the underscore. Every provider in this repo is
updated here.

- rename `Player._on_player_media_updated` to `on_player_media_updated`, including every provider
  override and call site
- move the override into the public part of the AirPlay and Cast players, so both files stay off the
  lint baseline (Sendspin is already grandfathered and goes 11 → 12)
- regenerate the method-order baseline (`models/player.py` 59 → 10)

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
