### PR TITLE
Protocol links no longer carry a stale availability flag

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3787,14 +3787,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             and (protocol_player := self.get_player(player.active_output_protocol))
         ):
             # Use the already-set protocol directly
-            output_protocol = next(
-                (
-                    p
-                    for p in player.linked_output_protocols
-                    if p.output_protocol_id == player.active_output_protocol
-                ),
-                None,
-            )
+            output_protocol = player.get_linked_protocol(player.active_output_protocol)
             if output_protocol is not None:
                 target_player = protocol_player
         if target_player is None:

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -25,7 +25,6 @@ from music_assistant_models.enums import (
     ProviderType,
 )
 from music_assistant_models.errors import PlayerCommandFailed, PlayerUnavailableError
-from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import (
     CONF_CACHED_ARP_MAC,
@@ -47,7 +46,7 @@ from music_assistant.helpers.util import (
     is_valid_mac_address,
     normalize_mac_for_matching,
 )
-from music_assistant.models.player import Player
+from music_assistant.models.player import LinkedOutputProtocol, Player
 from music_assistant.providers.sync_group.constants import CONF_ALLOWED_MEMBERS
 from music_assistant.providers.universal_player import UniversalPlayer, UniversalPlayerProvider
 from music_assistant.providers.universal_player.constants import (
@@ -58,6 +57,8 @@ from music_assistant.providers.universal_player.constants import (
 if TYPE_CHECKING:
     from collections.abc import Coroutine
     from typing import Any
+
+    from music_assistant_models.player import OutputProtocol
 
     from music_assistant import MusicAssistant
 
@@ -1273,9 +1274,8 @@ class ProtocolLinkingMixin:
 
         # Add the new link
         updated_protocols.append(
-            OutputProtocol(
+            LinkedOutputProtocol(
                 output_protocol_id=protocol_player.player_id,
-                name=protocol_player.provider.name,
                 protocol_domain=protocol_domain,
                 priority=priority,
                 derived_from=derived_from,
@@ -1445,12 +1445,12 @@ class ProtocolLinkingMixin:
         if not cached_protocol_ids:
             return
 
-        # Add OutputProtocol entries for any cached protocols that aren't currently linked
+        # Add link entries for any cached protocols that aren't currently linked
         for protocol_id in cached_protocol_ids:
             if protocol_id in linked_protocol_ids:
                 continue  # Already linked
 
-            # Get protocol player config to determine the protocol domain and availability
+            # Get protocol player config to determine the protocol domain
             protocol_config = self.mass.config.get(f"{CONF_PLAYERS}/{protocol_id}")
             if not protocol_config:
                 continue
@@ -1470,20 +1470,12 @@ class ProtocolLinkingMixin:
             if protocol_domain in existing_domains:
                 continue
 
-            # Get provider name for display
-            provider_name = protocol_domain.title()  # Default fallback
-            if provider := self.mass.get_provider(protocol_domain, return_unavailable=True):
-                provider_name = provider.name
-
             # Get priority for this protocol
             priority = PROTOCOL_PRIORITY.get(protocol_domain, 100)
 
-            # Check if protocol player is available (registered)
-            protocol_player = self.get_player(protocol_id)
-            is_available = protocol_player is not None and protocol_player.available
-
             # Resolve the derived-transport edge from the live player when
             # registered, else from the persisted edge in config
+            protocol_player = self.get_player(protocol_id)
             derived_from = (
                 protocol_player.underlying_player_id
                 if protocol_player
@@ -1492,23 +1484,19 @@ class ProtocolLinkingMixin:
             if derived_from == native_player.player_id:
                 derived_from = "native"
 
-            # Add the OutputProtocol entry
+            # Add the link entry
             native_player.linked_output_protocols.append(
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id=protocol_id,
-                    name=provider_name,
                     protocol_domain=protocol_domain,
                     priority=priority,
-                    is_native=False,
-                    available=is_available,
                     derived_from=derived_from,
                 )
             )
             self.logger.debug(
-                "Recovered cached protocol link %s -> %s (available: %s)",
+                "Recovered cached protocol link %s -> %s",
                 native_player.player_id,
                 protocol_id,
-                is_available,
             )
 
     def _cleanup_protocol_links(self, player: Player) -> None:
@@ -1763,7 +1751,7 @@ class ProtocolLinkingMixin:
                         player.state.name,
                         protocol_player.state.name,
                     )
-                    return protocol_player, linked
+                    return protocol_player, player.get_linked_protocol(linked.output_protocol_id)
 
         # 2. Check for user's preferred output protocol.
         # The value is only stored while it differs from the entry's default, which is computed
@@ -1792,7 +1780,9 @@ class ProtocolLinkingMixin:
                                     player.state.name,
                                     protocol_player.state.name,
                                 )
-                                return protocol_player, linked
+                                return protocol_player, player.get_linked_protocol(
+                                    linked.output_protocol_id
+                                )
                         break
 
         # 3. Use native playback if available
@@ -1812,7 +1802,7 @@ class ProtocolLinkingMixin:
                         player.state.name,
                         protocol_player.state.name,
                     )
-                    return protocol_player, linked
+                    return protocol_player, player.get_linked_protocol(linked.output_protocol_id)
 
         raise PlayerCommandFailed(f"Player {player.state.name} has no available output protocols")
 

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -17,6 +17,7 @@ import builtins
 import time
 from abc import ABC
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeVar, cast, final, overload
 
 from music_assistant_models.config_entries import MULTI_VALUE_SPLITTER, ConfigValueType
@@ -134,6 +135,29 @@ MEDIA_IDENTITY_KEYS = frozenset(
 # only invalidated by set_config, all other cached properties (including those
 # defined by player implementations) are invalidated on every update_state call
 _CONFIG_CACHED_PROPS = frozenset({"hide_in_ui", "expose_to_ha"})
+
+
+@dataclass(frozen=True, slots=True)
+class LinkedOutputProtocol:
+    """
+    A protocol player linked to a parent player.
+
+    Records the link itself (which protocol player, on which domain, how preferred)
+    and nothing about its current state: whether the protocol can actually be reached
+    right now is answered by Player.output_protocols / Player.playback_domains, which
+    resolve it from the live protocol player on every read.
+
+    :param output_protocol_id: player_id of the linked protocol player.
+    :param protocol_domain: Domain of the protocol, e.g. "airplay" or "dlna".
+    :param priority: Selection preference, lower is more preferred.
+    :param derived_from: output_protocol_id of the base output this transport runs on
+        top of ("native" when it rides on the parent player itself), if any.
+    """
+
+    output_protocol_id: str
+    protocol_domain: str
+    priority: int = 100
+    derived_from: str | None = None
 
 
 def _reconcile_position_anchor(
@@ -380,7 +404,7 @@ class Player(ABC):
         self._attr_options = []
         # do not override/overwrite these private attributes below!
         self._cache: dict[str, Any] = {}  # storage dict for cached properties
-        self.__attr_linked_protocols: list[OutputProtocol] = []
+        self.__attr_linked_protocols: list[LinkedOutputProtocol] = []
         self.__attr_protocol_parent_id: str | None = None
         self.__attr_active_output_protocol: str | None = None
         self._player_id = player_id
@@ -1713,7 +1737,7 @@ class Player(ABC):
 
     @property
     @final
-    def linked_output_protocols(self) -> list[OutputProtocol]:
+    def linked_output_protocols(self) -> list[LinkedOutputProtocol]:
         """Return the list of actively linked output protocol players."""
         return self.__attr_linked_protocols
 
@@ -1776,11 +1800,11 @@ class Player(ABC):
         self.update_state()
 
     @final
-    def set_linked_output_protocols(self, protocols: list[OutputProtocol]) -> None:
+    def set_linked_output_protocols(self, protocols: list[LinkedOutputProtocol]) -> None:
         """
         Set the actively linked output protocol players.
 
-        :param protocols: List of OutputProtocol objects representing active protocol players.
+        :param protocols: List of links to the active protocol players.
         """
         self.__attr_linked_protocols = protocols
         self.mass.players.trigger_player_update(self.player_id)
@@ -1796,14 +1820,15 @@ class Player(ABC):
         self.mass.players.trigger_player_update(self.player_id)
 
     @final
-    def get_linked_protocol(self, protocol_domain: str) -> OutputProtocol | None:
-        """Get a linked protocol by domain with current availability."""
+    def get_linked_protocol(self, output_protocol_id: str) -> OutputProtocol | None:
+        """
+        Get a linked output protocol by its id, with its name and availability resolved.
+
+        :param output_protocol_id: player_id of the linked protocol player.
+        """
         for linked in self.__attr_linked_protocols:
-            if linked.protocol_domain == protocol_domain:
-                protocol_player = self.mass.players.get_player(linked.output_protocol_id)
-                current_available = (
-                    protocol_player.available_for_playback if protocol_player else False
-                )
+            if linked.output_protocol_id == output_protocol_id:
+                protocol_player = self.mass.players.get_player(output_protocol_id)
                 return OutputProtocol(
                     output_protocol_id=linked.output_protocol_id,
                     name=protocol_player.provider.name
@@ -1811,8 +1836,7 @@ class Player(ABC):
                     else linked.protocol_domain.title(),
                     protocol_domain=linked.protocol_domain,
                     priority=linked.priority,
-                    available=current_available,
-                    is_native=False,
+                    available=protocol_player.available_for_playback if protocol_player else False,
                     derived_from=linked.derived_from,
                 )
         return None
@@ -1822,8 +1846,7 @@ class Player(ABC):
         """
         Get an output protocol by domain, including native protocol.
 
-        Unlike get_linked_protocol, this also checks if the player's native protocol
-        matches the requested domain.
+        Unlike get_linked_protocol, this also covers the player's own native output.
 
         :param protocol_domain: The protocol domain to search for (e.g., "airplay", "sonos").
         """
@@ -2219,10 +2242,7 @@ class Player(ABC):
                 self._extra_data.get(ATTR_FAKE_VOLUME),
                 self._extra_data.get(ATTR_FAKE_MUTE),
             ),
-            "linked_protocols": tuple(
-                (p.output_protocol_id, p.protocol_domain, p.priority, p.derived_from)
-                for p in self.__attr_linked_protocols
-            ),
+            "linked_protocols": tuple(self.__attr_linked_protocols),
             "protocol_parent_id": self.__attr_protocol_parent_id,
             "active_output_protocol": self.__attr_active_output_protocol,
             "active_mass_source": self.__active_mass_source,

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -1438,6 +1438,6 @@ class SyncGroupPlayer(Player):
         if player.provider.domain == domain:
             return player
         for linked in player.linked_output_protocols:
-            if linked.protocol_domain == domain and linked.available:
+            if linked.protocol_domain == domain:
                 return self.mass.players.get_player(linked.output_protocol_id)
         return None

--- a/tests/controllers/config/test_config_protocol_defaults.py
+++ b/tests/controllers/config/test_config_protocol_defaults.py
@@ -19,7 +19,6 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 from music_assistant_models.enums import PlayerFeature, PlayerType, ProviderType
-from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import (
     CONF_FLOW_MODE_SAMPLE_RATE,
@@ -29,7 +28,7 @@ from music_assistant.constants import (
     FLOW_MODE_SAMPLE_RATE_SMART,
 )
 from music_assistant.mass import MusicAssistant
-from music_assistant.models.player import DeviceInfo, Player
+from music_assistant.models.player import DeviceInfo, LinkedOutputProtocol, Player
 
 PARENT_ID = "sonos_123"
 CHILD_ID = "dlna_AABBCCDDEEFF"
@@ -106,9 +105,8 @@ async def _setup_parent_with_protocol_child(mass: MusicAssistant) -> _TestPlayer
     # link the DLNA protocol output to the parent so the virtual prefixed entry is emitted
     parent.set_linked_output_protocols(
         [
-            OutputProtocol(
+            LinkedOutputProtocol(
                 output_protocol_id=CHILD_ID,
-                name="DLNA",
                 protocol_domain="dlna",
                 priority=50,
             )

--- a/tests/controllers/config/test_control_only_player_config.py
+++ b/tests/controllers/config/test_control_only_player_config.py
@@ -13,14 +13,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import ConfigEntryType, PlayerFeature, PlayerType, ProviderType
-from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import (
     CONF_PREFERRED_OUTPUT_PROTOCOL,
     CONF_PROTOCOL_KEY_SPLITTER,
 )
 from music_assistant.mass import MusicAssistant
-from music_assistant.models.player import DeviceInfo, Player
+from music_assistant.models.player import DeviceInfo, LinkedOutputProtocol, Player
 
 PARENT_ID = "soundtouch_123"
 CHILD_ID = "dlna_AABBCCDDEEFF"
@@ -128,9 +127,8 @@ async def _setup_control_only_player(mass: MusicAssistant) -> _ControlOnlyPlayer
 
     parent.set_linked_output_protocols(
         [
-            OutputProtocol(
+            LinkedOutputProtocol(
                 output_protocol_id=CHILD_ID,
-                name="DLNA",
                 protocol_domain="dlna",
                 priority=50,
             )

--- a/tests/controllers/config/test_output_protocol_entries.py
+++ b/tests/controllers/config/test_output_protocol_entries.py
@@ -22,6 +22,7 @@ from music_assistant.constants import (
     CONF_PROTOCOL_KEY_SPLITTER,
 )
 from music_assistant.mass import MusicAssistant
+from music_assistant.models.player import LinkedOutputProtocol
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigValueOption
@@ -119,13 +120,14 @@ async def _control_only_player_entries(
     :param parent_entries: the config entries the control-only player itself reports.
     :param protocol_entries: the config entries its linked protocol player reports.
     """
-    protocols = [_make_output_protocol(_DLNA_ID, "dlna", 50, available=True)]
     player = MagicMock()
     player.player_id = _PARENT_ID
     player.needs_setup = False
     # no native protocol: this player only controls, playback goes through the linked protocol
-    player.output_protocols = protocols
-    player.linked_output_protocols = protocols
+    player.output_protocols = [_make_output_protocol(_DLNA_ID, "dlna", 50, available=True)]
+    player.linked_output_protocols = [
+        LinkedOutputProtocol(output_protocol_id=_DLNA_ID, protocol_domain="dlna", priority=50)
+    ]
     protocol_player = _make_protocol_player(available=True, needs_setup=False)
     protocol_player.player_id = _DLNA_ID
     protocol_player.translation_owner = "dlna"

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -36,7 +36,7 @@ from music_assistant.constants import CONF_PLAYERS, CONF_PROVIDERS, ENCRYPT_SUFF
 from music_assistant.controllers.music import MusicController
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.music_provider import MusicProvider
-from music_assistant.models.player import Player, _state_fingerprint
+from music_assistant.models.player import LinkedOutputProtocol, Player, _state_fingerprint
 from music_assistant.models.setup_flow import AbortFlow, SetupSession, StepExpiredError
 from music_assistant.providers.filesystem_local.setup_flow import (
     run_setup as filesystem_local_run_setup,
@@ -1468,7 +1468,15 @@ async def test_has_setup_flow_serialized_for_protocol_child() -> None:
     child._attr_needs_setup = False  # already set up, but its flow can be re-run
     players = {parent.player_id: parent, child.player_id: child}
     # link the child: set_linked_output_protocols survives the update_state cache flush
-    parent.set_linked_output_protocols([_child_output_protocol(child)])
+    parent.set_linked_output_protocols(
+        [
+            LinkedOutputProtocol(
+                output_protocol_id=child.player_id,
+                protocol_domain=child.provider.domain,
+                priority=10,
+            )
+        ]
+    )
     with patch.object(
         parent.mass.players, "get_player", side_effect=lambda pid, *_a, **_k: players.get(pid)
     ):

--- a/tests/controllers/players/test_active_protocol_lifecycle.py
+++ b/tests/controllers/players/test_active_protocol_lifecycle.py
@@ -17,9 +17,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
-from music_assistant_models.player import OutputProtocol, PlayerMedia
+from music_assistant_models.player import PlayerMedia
 
 from music_assistant.controllers.players import PlayerController
+from music_assistant.models.player import LinkedOutputProtocol
 from tests.common import MockPlayer, MockProvider
 
 
@@ -98,9 +99,8 @@ def _make_player_with_protocol(
     controller._players = {"player_1": player, "proto_1": protocol_player}
     player.set_linked_output_protocols(
         [
-            OutputProtocol(
+            LinkedOutputProtocol(
                 output_protocol_id="proto_1",
-                name="Sendspin",
                 protocol_domain="sendspin",
                 priority=40,
             )

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -40,7 +40,7 @@ from music_assistant_models.errors import (
     PlayerCommandFailed,
     UnsupportedFeaturedException,
 )
-from music_assistant_models.player import OutputProtocol, PlayerMedia, PlayerSource
+from music_assistant_models.player import PlayerMedia, PlayerSource
 from music_assistant_models.player_control import PlayerControl
 
 from music_assistant.constants import (
@@ -61,6 +61,7 @@ from music_assistant.controllers.players import PlayerController
 from music_assistant.controllers.players.announcements import ANNOUNCEMENT_TTS_TIMEOUT
 from music_assistant.controllers.webserver.helpers.auth_middleware import current_user
 from music_assistant.helpers.tts import TTS_QUERY_TIMEOUT_SECONDS
+from music_assistant.models.player import LinkedOutputProtocol
 from music_assistant.models.player_provider import PlayerProvider
 from tests.common import MockPlayer, MockProvider, create_mock_config, use_real_create_task
 
@@ -1584,9 +1585,8 @@ class TestProtocolOutputPlayPause:
         mock_mass.player_queues.get = MagicMock(return_value=queue)
         player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="proto_1",
-                    name="Sendspin",
                     protocol_domain="sendspin",
                     priority=40,
                 )
@@ -2901,9 +2901,8 @@ class TestMuteLockAfterUngroup:
         controller._players["proto_member"] = protocol_player
         member.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="proto_member",
-                    name="Sendspin",
                     protocol_domain="sendspin",
                     priority=40,
                 )
@@ -3427,9 +3426,8 @@ class TestNativeAnnouncementRouting:
         mock_mass.players = controller
         player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="proto_1",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=40,
                 )

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -15,9 +15,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
-from music_assistant_models.player import OutputProtocol
 
 from music_assistant.controllers.players import PlayerController
+from music_assistant.models.player import LinkedOutputProtocol
 from tests.common import MockPlayer, MockProvider
 
 
@@ -503,11 +503,10 @@ def _make_ad_hoc_group(
     mock_mass.players = controller
 
 
-def _airplay_link(protocol_id: str) -> OutputProtocol:
-    """Build an AirPlay link the way production does: without an `available` argument."""
-    return OutputProtocol(
+def _airplay_link(protocol_id: str) -> LinkedOutputProtocol:
+    """Build an AirPlay link to the given protocol player."""
+    return LinkedOutputProtocol(
         output_protocol_id=protocol_id,
-        name="AirPlay",
         protocol_domain="airplay",
         priority=10,
     )
@@ -538,7 +537,6 @@ class TestAdHocLeadershipTransfer:
         assert leader is not None
         member_b = controller.get_player("b")
         assert member_b is not None
-        assert member_b.linked_output_protocols[0].available is True
 
         assert controller._select_ad_hoc_leader(leader, ["a", "b"]) == "a"
 
@@ -556,9 +554,8 @@ class TestAdHocLeadershipTransfer:
         )
         leader.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id=leader_protocol.player_id,
-                    name="Chromecast",
                     protocol_domain="chromecast",
                     priority=30,
                 )

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -535,8 +535,6 @@ class TestAdHocLeadershipTransfer:
 
         leader = controller.get_player("leader")
         assert leader is not None
-        member_b = controller.get_player("b")
-        assert member_b is not None
 
         assert controller._select_ad_hoc_leader(leader, ["a", "b"]) == "a"
 

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -1599,7 +1599,7 @@ class TestPlayerGrouping:
         wiim_player.set_active_output_protocol("airplay_wiim")
         wiim_player.set_protocol_parent_id("airplay_wiim")
 
-        # Wire up mock_mass.players to controller so get_linked_protocol works
+        # Wire up mock_mass.players to controller so player lookups resolve
         mock_mass.players = controller
 
         controller._players = {
@@ -2318,7 +2318,7 @@ class TestCanGroupWith:
             ]
         )
 
-        # Wire up mock_mass.players to controller so get_linked_protocol works
+        # Wire up mock_mass.players to controller so player lookups resolve
         mock_mass.players = controller
 
         controller._players = {
@@ -2422,7 +2422,7 @@ class TestCanGroupWith:
         )
         sonos_player.set_active_output_protocol("airplay_sonos")
 
-        # Wire up mock_mass.players to controller so get_linked_protocol works
+        # Wire up mock_mass.players to controller so player lookups resolve
         mock_mass.players = controller
 
         controller._players = {
@@ -2558,7 +2558,7 @@ class TestCanGroupWith:
         sonos_player._cache.clear()
         wiim_player._cache.clear()
 
-        # Wire up mock_mass.players to controller so get_linked_protocol works
+        # Wire up mock_mass.players to controller so player lookups resolve
         mock_mass.players = controller
 
         controller._players = {

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -14,7 +14,7 @@ from music_assistant_models.enums import (
     PlayerFeature,
     PlayerType,
 )
-from music_assistant_models.player import OutputProtocol, PlayerMedia
+from music_assistant_models.player import PlayerMedia
 
 from music_assistant.constants import (
     ATTR_ENABLED,
@@ -27,7 +27,7 @@ from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.config.migrations import migrate
 from music_assistant.controllers.players import PlayerController
 from music_assistant.helpers.util import enrich_device_mac_address
-from music_assistant.models.player import DeviceInfo, Player
+from music_assistant.models.player import DeviceInfo, LinkedOutputProtocol, Player
 from music_assistant.models.player_provider import PlayerProvider
 from music_assistant.providers.universal_player.player import UniversalPlayer
 from music_assistant.providers.universal_player.provider import UniversalPlayerProvider
@@ -1171,9 +1171,8 @@ class TestSelectBestOutputProtocol:
         # Link DLNA protocol to native player
         native_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="dlna_AABBCCDDEEFF",
-                    name="DLNA",
                     protocol_domain="dlna",
                     priority=50,
                 )
@@ -1244,15 +1243,13 @@ class TestSelectBestOutputProtocol:
         # Link protocols to native player
         native_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_AABBCCDDEEFF",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
                 ),
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="dlna_AABBCCDDEEFF",
-                    name="DLNA",
                     protocol_domain="dlna",
                     priority=50,
                 ),
@@ -1349,15 +1346,13 @@ class TestSelectBestOutputProtocol:
         # Link both protocols, AirPlay with the better priority
         universal_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_AABBCCDDEEFF",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
                 ),
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="dlna_AABBCCDDEEFF",
-                    name="DLNA",
                     protocol_domain="dlna",
                     priority=50,
                 ),
@@ -1482,23 +1477,19 @@ class TestPlayerGrouping:
         # Link protocol players to native players
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
         wiim_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_wiim",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -1589,23 +1580,19 @@ class TestPlayerGrouping:
         # Link AirPlay to Sonos A
         sonos_a.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
         wiim_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_wiim",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -1712,37 +1699,29 @@ class TestPlayerGrouping:
         # Link protocols (DLNA has lower priority than AirPlay)
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="dlna_sonos",
-                    name="DLNA",
                     protocol_domain="dlna",
                     priority=50,  # Lower priority (higher number)
-                    available=True,
                 ),
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,  # Higher priority (lower number)
-                    available=True,
                 ),
             ]
         )
         wiim_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="dlna_wiim",
-                    name="DLNA",
                     protocol_domain="dlna",
                     priority=50,
-                    available=True,
                 ),
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_wiim",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 ),
             ]
         )
@@ -1802,12 +1781,10 @@ class TestJoinActiveNativeSession:
         """Link an AirPlay protocol player to a native player."""
         native_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id=airplay_id,
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -2135,12 +2112,10 @@ class TestSessionBoundNativeGrouping:
         """Link a bridge protocol player to a native player."""
         player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id=bridge_id,
-                    name="Bridge",
                     protocol_domain="sendspin",
                     priority=40,
-                    available=True,
                 )
             ]
         )
@@ -2335,12 +2310,10 @@ class TestCanGroupWith:
 
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -2430,24 +2403,20 @@ class TestCanGroupWith:
 
         wiim_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_other",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 ),
             ]
         )
 
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -2562,31 +2531,25 @@ class TestCanGroupWith:
 
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 ),
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="dlna_sonos",
-                    name="DLNA",
                     protocol_domain="dlna",
                     priority=50,
-                    available=True,
                 ),
             ]
         )
 
         wiim_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_other",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 ),
             ]
         )
@@ -2666,12 +2629,10 @@ class TestNativePlayerProtocolGrouping:
 
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos_1",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -2735,12 +2696,10 @@ class TestNativePlayerProtocolGrouping:
 
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos_1",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -2820,12 +2779,10 @@ class TestProtocolSwitchingDuringPlayback:
             players[bridge_id] = bridge
             players[parent_id].set_linked_output_protocols(
                 [
-                    OutputProtocol(
+                    LinkedOutputProtocol(
                         output_protocol_id=bridge_id,
-                        name="Bridge",
                         protocol_domain="sendspin",
                         priority=40,
-                        available=True,
                     )
                 ]
             )
@@ -2879,12 +2836,10 @@ class TestProtocolSwitchingDuringPlayback:
 
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -2942,12 +2897,10 @@ class TestProtocolSwitchingDuringPlayback:
 
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -3021,12 +2974,10 @@ class TestProtocolSwitchingDuringPlayback:
 
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -3184,12 +3135,10 @@ class TestNativeProtocolPlayerGrouping:
 
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -3399,12 +3348,10 @@ class TestFinalSyncedToWithNativeProtocolParent:
 
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -3467,12 +3414,10 @@ class TestUngroupTranslation:
 
         sonos_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_sonos",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
-                    available=True,
                 )
             ]
         )
@@ -3548,12 +3493,10 @@ class TestNativeProtocolDomainPlayerGrouping:
         # Link sendspin protocol to Kantoor
         kantoor.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="sendspin_kantoor",
-                    name="Sendspin",
                     protocol_domain="sendspin",
                     priority=40,
-                    available=True,
                 )
             ]
         )
@@ -3623,12 +3566,10 @@ class TestNativeProtocolDomainPlayerGrouping:
         # Link sendspin protocol to Kantoor
         kantoor.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="sendspin_kantoor",
-                    name="Sendspin",
                     protocol_domain="sendspin",
                     priority=40,
-                    available=True,
                 )
             ]
         )
@@ -3698,12 +3639,10 @@ class TestNativeProtocolDomainPlayerGrouping:
 
         kantoor.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="sendspin_kantoor",
-                    name="Sendspin",
                     protocol_domain="sendspin",
                     priority=40,
-                    available=True,
                 )
             ]
         )
@@ -3832,12 +3771,10 @@ class TestNativeProtocolDomainPlayerGrouping:
 
         mancave.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="spb_mancave",
-                    name="Sendspin",
                     protocol_domain="sendspin",
                     priority=40,
-                    available=True,
                 )
             ]
         )
@@ -7799,9 +7736,8 @@ class TestProtocolParentIdPersistence:
         # Set up linked protocols
         parent.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_test",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
                 )
@@ -7855,9 +7791,8 @@ class TestCleanupProtocolLinks:
 
         parent.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_test",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
                 )
@@ -7924,9 +7859,8 @@ class TestCleanupProtocolLinks:
 
         parent.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_live",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
                 )
@@ -7988,9 +7922,8 @@ class TestCleanupProtocolLinks:
 
         parent.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="airplay_live",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
                 )
@@ -8876,15 +8809,13 @@ class TestParentDisableCascade:
         native_player._attr_available = False
         native_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="ap_1",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
                 ),
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="dlna_1",
-                    name="DLNA",
                     protocol_domain="dlna",
                     priority=20,
                 ),
@@ -8934,9 +8865,8 @@ class TestParentDisableCascade:
         native_player._attr_available = False
         native_player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="ap_1",
-                    name="AirPlay",
                     protocol_domain="airplay",
                     priority=10,
                 ),

--- a/tests/models/test_player_controls.py
+++ b/tests/models/test_player_controls.py
@@ -21,7 +21,6 @@ from music_assistant_models.constants import (
     PLAYER_CONTROL_NONE,
 )
 from music_assistant_models.enums import PlayerFeature
-from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import (
     CONF_MUTE_CONTROL,
@@ -29,6 +28,7 @@ from music_assistant.constants import (
     CONF_PREFERRED_OUTPUT_PROTOCOL,
     CONF_VOLUME_CONTROL,
 )
+from music_assistant.models.player import LinkedOutputProtocol
 from tests.common import MockPlayer, MockProvider
 
 _PROTO_DOMAIN = "test_protocol"
@@ -89,15 +89,13 @@ def _create_protocol_player(
     return player
 
 
-def _make_output_protocol(
+def _make_protocol_link(
     protocol_id: str,
-    name: str,
     priority: int = 0,
-) -> OutputProtocol:
-    """Create an OutputProtocol for testing."""
-    return OutputProtocol(
+) -> LinkedOutputProtocol:
+    """Create a protocol link for testing."""
+    return LinkedOutputProtocol(
         output_protocol_id=protocol_id,
-        name=name,
         protocol_domain=_PROTO_DOMAIN,
         priority=priority,
     )
@@ -105,7 +103,7 @@ def _make_output_protocol(
 
 def _link_protocols(
     player: MockPlayer,
-    protocols: list[OutputProtocol],
+    protocols: list[LinkedOutputProtocol],
     active_protocol_id: str | None = None,
 ) -> None:
     """Link output protocols to a player and optionally set active protocol."""
@@ -210,7 +208,7 @@ class TestPowerControlAutoSelect:
         player = _create_player(mock_mass)
         _link_protocols(
             player,
-            [_make_output_protocol("proto_power", "Proto Power")],
+            [_make_protocol_link("proto_power")],
             active_protocol_id="proto_power",
         )
         assert player.power_control == PLAYER_CONTROL_NONE
@@ -220,7 +218,7 @@ class TestPowerControlAutoSelect:
         protocol = _create_protocol_player(mock_mass, "proto_power", {PlayerFeature.POWER})
         mock_mass.players.get_player = MagicMock(return_value=protocol)
         player = _create_player(mock_mass)
-        _link_protocols(player, [_make_output_protocol("proto_power", "Proto Power")])
+        _link_protocols(player, [_make_protocol_link("proto_power")])
         assert player.power_control == PLAYER_CONTROL_NONE
 
     def test_auto_returns_none_when_nothing_available(self, mock_mass: MagicMock) -> None:
@@ -282,7 +280,7 @@ class TestVolumeControlAutoSelect:
         protocol = _create_protocol_player(mock_mass, "proto_vol", {PlayerFeature.VOLUME_SET})
         mock_mass.players.get_player = MagicMock(return_value=protocol)
         player = _create_player(mock_mass)
-        _link_protocols(player, [_make_output_protocol("proto_vol", "Proto Vol")])
+        _link_protocols(player, [_make_protocol_link("proto_vol")])
         assert player.volume_control == "proto_vol"
 
     def test_auto_returns_none_when_nothing_available(self, mock_mass: MagicMock) -> None:
@@ -347,7 +345,7 @@ class TestMuteControlAutoSelect:
         protocol = _create_protocol_player(mock_mass, "proto_mute", {PlayerFeature.VOLUME_MUTE})
         mock_mass.players.get_player = MagicMock(return_value=protocol)
         player = _create_player(mock_mass)
-        _link_protocols(player, [_make_output_protocol("proto_mute", "Proto Mute")])
+        _link_protocols(player, [_make_protocol_link("proto_mute")])
         assert player.mute_control == "proto_mute"
 
     def test_auto_returns_none_when_nothing_available(self, mock_mass: MagicMock) -> None:
@@ -378,8 +376,8 @@ class TestProtocolPlayerPreferActive:
         _link_protocols(
             player,
             [
-                _make_output_protocol("proto_a", "Proto A", priority=0),
-                _make_output_protocol("proto_b", "Proto B", priority=1),
+                _make_protocol_link("proto_a", priority=0),
+                _make_protocol_link("proto_b", priority=1),
             ],
             active_protocol_id="proto_b",
         )
@@ -396,8 +394,8 @@ class TestProtocolPlayerPreferActive:
         _link_protocols(
             player,
             [
-                _make_output_protocol("proto_a", "Proto A", priority=0),
-                _make_output_protocol("proto_b", "Proto B", priority=1),
+                _make_protocol_link("proto_a", priority=0),
+                _make_protocol_link("proto_b", priority=1),
             ],
         )
         assert player.volume_control == "proto_a"
@@ -411,7 +409,7 @@ class TestProtocolPlayerPreferActive:
         player = _create_player(mock_mass)
         _link_protocols(
             player,
-            [_make_output_protocol("proto_a", "Proto A", priority=0)],
+            [_make_protocol_link("proto_a", priority=0)],
         )
         # no active protocol set -> power returns NONE
         assert player.power_control == PLAYER_CONTROL_NONE
@@ -425,7 +423,7 @@ class TestProtocolPlayerPreferActive:
         player = _create_player(mock_mass)
         _link_protocols(
             player,
-            [_make_output_protocol("proto_a", "Proto A", priority=0)],
+            [_make_protocol_link("proto_a", priority=0)],
             active_protocol_id="proto_a",
         )
         assert player.power_control == PLAYER_CONTROL_NONE
@@ -445,8 +443,8 @@ class TestProtocolPlayerPreferActive:
         _link_protocols(
             player,
             [
-                _make_output_protocol("proto_a", "Proto A", priority=0),
-                _make_output_protocol("proto_b", "Proto B", priority=1),
+                _make_protocol_link("proto_a", priority=0),
+                _make_protocol_link("proto_b", priority=1),
             ],
         )
         assert player.volume_control == "proto_b"
@@ -475,7 +473,7 @@ class TestPreferredOutputProtocolAutoValue:
         player = _create_player(mock_mass)
         _link_protocols(
             player,
-            [_make_output_protocol("proto_a", "Proto A")],
+            [_make_protocol_link("proto_a")],
             active_protocol_id="proto_a",
         )
         assert player.power_control == PLAYER_CONTROL_NONE
@@ -492,7 +490,7 @@ class TestPreferredOutputProtocolAutoValue:
         player = _create_player(mock_mass)
         _link_protocols(
             player,
-            [_make_output_protocol("proto_a", "Proto A")],
+            [_make_protocol_link("proto_a")],
         )
         # volume doesn't require active, so it falls back to linked protocol
         assert player.volume_control == "proto_a"
@@ -509,7 +507,7 @@ class TestPreferredOutputProtocolAutoValue:
         player = _create_player(mock_mass)
         _link_protocols(
             player,
-            [_make_output_protocol("proto_a", "Proto A")],
+            [_make_protocol_link("proto_a")],
         )
         assert player.power_control == PLAYER_CONTROL_NONE
 

--- a/tests/models/test_player_playback_domains.py
+++ b/tests/models/test_player_playback_domains.py
@@ -1,5 +1,5 @@
 """
-Tests for Player.playback_domains.
+Tests for Player.playback_domains and Player.get_linked_protocol.
 
 Covers the live availability view: native playback, linked protocol players that
 are (un)available, and wrapper players that only contribute their linked protocols.
@@ -146,3 +146,46 @@ class TestPlaybackDomains:
         protocol_player._attr_available = False
         player.update_state(signal_event=False)
         assert player.playback_domains == {"sonos"}
+
+
+class TestGetLinkedProtocol:
+    """Tests for Player.get_linked_protocol."""
+
+    def test_resolves_name_and_availability_from_live_player(self, mock_mass: MagicMock) -> None:
+        """Test that the returned entry describes the protocol player as it is right now."""
+        player = _make_native_player(mock_mass)
+        _link_protocol(mock_mass, player, "ap_1", "airplay", available=True)
+
+        output_protocol = player.get_linked_protocol("ap_1")
+        assert output_protocol is not None
+        assert output_protocol.name == "Mock Airplay"
+        assert output_protocol.available is True
+        assert output_protocol.protocol_domain == "airplay"
+        assert output_protocol.priority == 10
+
+    def test_reports_offline_protocol_player(self, mock_mass: MagicMock) -> None:
+        """Test that an unchanged link stops claiming availability once its player drops."""
+        player = _make_native_player(mock_mass)
+        protocol_player = _link_protocol(mock_mass, player, "ap_1", "airplay", available=True)
+
+        protocol_player._attr_available = False
+        output_protocol = player.get_linked_protocol("ap_1")
+        assert output_protocol is not None
+        assert output_protocol.available is False
+
+    def test_unregistered_protocol_player_falls_back_to_domain(self, mock_mass: MagicMock) -> None:
+        """Test that a link without a live player reports the domain and no availability."""
+        player = _make_native_player(mock_mass)
+        _link_protocol(mock_mass, player, "ap_1", "airplay", available=True)
+        mock_mass.players.get_player = MagicMock(return_value=None)
+
+        output_protocol = player.get_linked_protocol("ap_1")
+        assert output_protocol is not None
+        assert output_protocol.name == "Airplay"
+        assert output_protocol.available is False
+
+    def test_unknown_protocol_id_returns_none(self, mock_mass: MagicMock) -> None:
+        """Test that an id that is not linked resolves to nothing."""
+        player = _make_native_player(mock_mass)
+        _link_protocol(mock_mass, player, "ap_1", "airplay", available=True)
+        assert player.get_linked_protocol("cast_1") is None

--- a/tests/models/test_player_playback_domains.py
+++ b/tests/models/test_player_playback_domains.py
@@ -11,8 +11,8 @@ from unittest.mock import MagicMock
 
 import pytest
 from music_assistant_models.enums import PlayerFeature, PlayerType
-from music_assistant_models.player import OutputProtocol
 
+from music_assistant.models.player import LinkedOutputProtocol
 from tests.common import MockPlayer, MockProvider
 
 
@@ -55,11 +55,8 @@ def _link_protocol(
     parent.set_linked_output_protocols(
         [
             *parent.linked_output_protocols,
-            # no `available` argument: production links protocols without one, so the
-            # flag stays at its dataclass default of True forever
-            OutputProtocol(
+            LinkedOutputProtocol(
                 output_protocol_id=protocol_id,
-                name=domain,
                 protocol_domain=domain,
                 priority=10,
             ),
@@ -103,8 +100,6 @@ class TestPlaybackDomains:
         """Test that a linked protocol whose player went offline is not reported."""
         player = _make_native_player(mock_mass)
         _link_protocol(mock_mass, player, "ap_1", "airplay", available=False)
-        # the link itself still claims to be available; only the live player counts
-        assert player.linked_output_protocols[0].available is True
         assert player.playback_domains == {"sonos"}
 
     def test_linked_protocol_needing_setup_is_left_out(self, mock_mass: MagicMock) -> None:

--- a/tests/models/test_player_volume.py
+++ b/tests/models/test_player_volume.py
@@ -12,9 +12,9 @@ from unittest.mock import MagicMock
 
 import pytest
 from music_assistant_models.enums import PlayerFeature
-from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import CONF_MUTE_CONTROL, CONF_VOLUME_CONTROL
+from music_assistant.models.player import LinkedOutputProtocol
 from tests.common import MockPlayer, MockProvider
 
 
@@ -107,9 +107,8 @@ class TestFinalVolumeLevel:
         player._attr_volume_level = 55
         player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="cast_child",
-                    name="Chromecast",
                     protocol_domain="chromecast",
                 )
             ]
@@ -136,9 +135,8 @@ class TestFinalVolumeLevel:
         player._attr_volume_level = 55
         player.set_linked_output_protocols(
             [
-                OutputProtocol(
+                LinkedOutputProtocol(
                     output_protocol_id="cast_child",
-                    name="Chromecast",
                     protocol_domain="chromecast",
                 )
             ]

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -13,6 +13,7 @@ from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerTyp
 from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import CONF_GROUP_MEMBERS, CONF_PLAYERS, PROTOCOL_PRIORITY
+from music_assistant.models.player import LinkedOutputProtocol
 from music_assistant.providers.sync_group.player import SyncGroupPlayer
 
 
@@ -95,15 +96,13 @@ def _make_mock_player(
     )
     player.is_native_player = is_native
 
-    # Build linked_output_protocols. Their `available` flag is the one production
-    # sets at link time and never refreshes, so it stays True even for a protocol
-    # player that has since gone offline.
+    # Build linked_output_protocols: the links only record the topology, so they
+    # say nothing about whether the protocol player can be reached right now.
     offline = set(offline_protocol_domains or [])
     protocols = []
     for domain in protocol_domains or []:
-        proto = MagicMock(spec=OutputProtocol)
+        proto = MagicMock(spec=LinkedOutputProtocol)
         proto.protocol_domain = domain
-        proto.available = True
         # default to a synthetic protocol id; tests that need a specific id can override
         proto.output_protocol_id = f"{player_id}_{domain}_proto"
         protocols.append(proto)


### PR DESCRIPTION
# What does this implement/fix?

The list of protocol players linked to a speaker carried an "available" flag that
was set once when the link was made and never refreshed, so it kept claiming a
protocol was reachable long after that protocol player had gone offline. Three
earlier fixes (#5610, #5613, #5615) each patched one caller that trusted it.

Link entries now use their own type that records only the link itself — which
protocol player, on which domain, how preferred — so that flag can no longer be
read at all. Live availability keeps coming from `output_protocols` /
`playback_domains`, which resolve it from the protocol player on every read.

- Added `LinkedOutputProtocol` and switched `Player.linked_output_protocols` to it
- Protocol selection now hands callers a freshly resolved output protocol instead
  of the stored link, so the name and availability it carries are correct
- Dropped the last read of the stale flag in the sync group
- Nothing changes on the wire: `PlayerState.output_protocols` is untouched

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
