### PR TITLE
Cast devices are freed up again when playback ends

### DIFF
--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -531,7 +531,12 @@ class ChromecastPlayer(Player):
         if self.cc.app_id not in (MASS_APP_ID, APP_MEDIA_RECEIVER):
             return  # another app took over the device
         status = self.cc.media_controller.status
-        if status.player_is_playing or status.player_is_paused:
+        # a device that ran dry at the end of the flow stream keeps reporting buffering,
+        # which counts as playing. no audio is coming for it, so it is not really in use.
+        ran_dry = (
+            status.player_state == MEDIA_PLAYER_STATE_BUFFERING and self._flow_stream_underrun()
+        )
+        if (status.player_is_playing or status.player_is_paused) and not ran_dry:
             # something is loaded again, e.g. the keepalive media of a dashboard
             return
         await asyncio.to_thread(self.cc.quit_app)

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -680,6 +680,10 @@ class ChromecastPlayer(Player):
             self._attr_active_source = group_player.active_source or group_player.player_id
         elif self.cc.app_id in (MASS_APP_ID, APP_MEDIA_RECEIVER, SENDSPIN_CAST_APP_ID):
             self._attr_active_source = None
+        elif self.cc.app_id in (None, IDLE_APP_ID):
+            # a released device sits on its backdrop with no app running, which is
+            # not something the user can select as a source
+            self._attr_active_source = None
         else:
             app_name = self.cc.app_display_name or "Unknown App"
             app_id = app_name.lower().replace(" ", "_")

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -165,12 +165,7 @@ class ChromecastPlayer(Player):
         if self.cc.media_controller.status.media_session_id is not None:
             # a stop is refused by the cast library when nothing was ever loaded
             await asyncio.to_thread(self.cc.media_controller.stop)
-        # The device is released a bit later so a follow-up command (such as an
-        # announcement, which stops playback first) can reuse the Cast session.
-        # Starting a new session makes the device play its 'cast connected' chime.
-        self.mass.call_later(
-            APP_QUIT_DELAY, self._quit_app_when_unused, task_id=self._app_quit_task_id
-        )
+        self._schedule_app_release()
 
     def cancel_pending_app_quit(self) -> None:
         """Cancel a pending release of the receiver app, to keep the device claimed."""
@@ -517,6 +512,18 @@ class ChromecastPlayer(Player):
             suggestion,
         )
 
+    def _schedule_app_release(self) -> None:
+        """
+        Arm the delayed release of the Cast device.
+
+        The device is released a bit later so a follow-up command (such as an
+        announcement, which stops playback first) can reuse the Cast session.
+        Starting a new session makes the device play its 'cast connected' chime.
+        """
+        self.mass.call_later(
+            APP_QUIT_DELAY, self._quit_app_when_unused, task_id=self._app_quit_task_id
+        )
+
     async def _quit_app_when_unused(self) -> None:
         """Release the Cast device, unless the receiver app got used again."""
         if not self.available:
@@ -631,6 +638,7 @@ class ChromecastPlayer(Player):
         )
         is_playing = status.player_is_playing and not flow_underrun
         is_idle = status.player_is_idle or flow_underrun
+        prev_state = self._attr_playback_state
         self._attr_elapsed_time_last_updated = time.time()
         if is_playing:
             self._attr_playback_state = PlaybackState.PLAYING
@@ -643,6 +651,16 @@ class ChromecastPlayer(Player):
             self._attr_playback_state = PlaybackState.IDLE
             self._attr_current_media = None
             self._attr_active_source = None
+            if (
+                prev_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
+                and self.type != PlayerType.GROUP
+                and self.active_cast_group is None
+            ):
+                # Playback that ends on its own never gets a stop command (the queue ran
+                # out, or an announcement finished), so without this the device would stay
+                # claimed forever. A cast group is left alone: quitting its app is what its
+                # power control does, and a group member follows the group's session.
+                self._schedule_app_release()
 
         # elapsed time
         self._attr_elapsed_time_last_updated = time.time()

--- a/tests/providers/chromecast/test_idle_release.py
+++ b/tests/providers/chromecast/test_idle_release.py
@@ -1,0 +1,172 @@
+"""
+Tests for how ChromecastPlayer releases a Cast device once playback ends by itself.
+
+Playback that finishes on its own never gets a stop command: the queue simply runs
+out, or an announcement ends. Without a release the receiver app stays loaded, which
+on a TV or Nest Hub means Music Assistant stays on screen instead of the backdrop.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import PlaybackState, PlayerType
+
+from music_assistant.providers.chromecast.constants import (
+    APP_QUIT_DELAY,
+    MASS_APP_ID,
+)
+from music_assistant.providers.chromecast.player import ChromecastPlayer
+
+
+def _handle_media_status(fake: MagicMock, status: MagicMock) -> None:
+    ChromecastPlayer._handle_media_status(cast("ChromecastPlayer", fake), status)
+
+
+def _fake_player(
+    *,
+    prev_state: PlaybackState = PlaybackState.PLAYING,
+    player_type: PlayerType = PlayerType.PLAYER,
+    active_cast_group: str | None = None,
+) -> MagicMock:
+    """
+    Build a MagicMock Cast player that handles media status like the real one.
+
+    :param prev_state: Playback state the player was in before the status arrives.
+    :param player_type: Type of the player.
+    :param active_cast_group: Player id of the cast group the player plays through, if any.
+    """
+    fake = MagicMock()
+    fake.type = player_type
+    fake.active_cast_group = active_cast_group
+    fake.powered = False
+    fake.group_members = []
+    fake.cc.app_id = MASS_APP_ID
+    fake._app_quit_task_id = "cast_quit_app_test"
+    fake._attr_playback_state = prev_state
+    fake._flow_stream_underrun.return_value = False
+    fake._schedule_app_release = partial(
+        ChromecastPlayer._schedule_app_release, cast("ChromecastPlayer", fake)
+    )
+    return fake
+
+
+def _media_status(
+    *,
+    playing: bool = False,
+    paused: bool = False,
+    content_id: str = "",
+) -> MagicMock:
+    """
+    Build a MediaStatus as the receiver reports it.
+
+    :param playing: Whether the receiver reports playback.
+    :param paused: Whether the receiver reports paused playback.
+    :param content_id: Content id the receiver has loaded, if any.
+    """
+    status = MagicMock()
+    status.content_id = content_id
+    status.player_state = "PLAYING" if playing else "PAUSED" if paused else "IDLE"
+    status.player_is_playing = playing
+    status.player_is_paused = paused
+    status.player_is_idle = not playing and not paused
+    return status
+
+
+def _assert_release_scheduled(fake: MagicMock) -> None:
+    fake.mass.call_later.assert_called_once_with(
+        APP_QUIT_DELAY, fake._quit_app_when_unused, task_id=fake._app_quit_task_id
+    )
+
+
+@pytest.mark.parametrize("prev_state", [PlaybackState.PLAYING, PlaybackState.PAUSED])
+def test_playback_ending_releases_the_device(prev_state: PlaybackState) -> None:
+    """Nothing follows up on playback that ended on its own, so the device is released."""
+    fake = _fake_player(prev_state=prev_state)
+
+    _handle_media_status(fake, _media_status())
+
+    assert fake._attr_playback_state == PlaybackState.IDLE
+    _assert_release_scheduled(fake)
+
+
+def test_an_announcement_on_an_idle_player_releases_the_device() -> None:
+    """
+    An announcement claims an idle device, so it must hand it back afterwards.
+
+    The player is never stopped in this flow (there was nothing to stop), which is
+    what used to leave the receiver app loaded for good.
+    """
+    fake = _fake_player(prev_state=PlaybackState.IDLE)
+
+    _handle_media_status(fake, _media_status(playing=True, content_id="http://mass/announce.mp3"))
+    assert fake._attr_playback_state == PlaybackState.PLAYING
+    fake.mass.call_later.assert_not_called()
+
+    _handle_media_status(fake, _media_status())
+
+    _assert_release_scheduled(fake)
+
+
+def test_pausing_keeps_the_device_claimed() -> None:
+    """A paused player is meant to be resumed, so it keeps its Cast session."""
+    fake = _fake_player()
+
+    _handle_media_status(fake, _media_status(paused=True, content_id="http://mass/track.flac"))
+
+    assert fake._attr_playback_state == PlaybackState.PAUSED
+    fake.mass.call_later.assert_not_called()
+
+
+def test_an_idle_player_is_not_released_again() -> None:
+    """A player that was already idle has no session of its own to release."""
+    fake = _fake_player(prev_state=PlaybackState.IDLE)
+
+    _handle_media_status(fake, _media_status())
+
+    fake.mass.call_later.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "content_id",
+    [
+        "https://cast.music-assistant.io/dashboard-keepalive.mp4",
+        "https://cast.music-assistant.io/keepalive.png",
+    ],
+)
+def test_a_dashboard_keepalive_does_not_release_the_device(content_id: str) -> None:
+    """The receiver is showing a dashboard, so the device is deliberately kept claimed."""
+    fake = _fake_player()
+
+    _handle_media_status(fake, _media_status(content_id=content_id))
+
+    assert fake._attr_playback_state == PlaybackState.IDLE
+    fake.mass.call_later.assert_not_called()
+
+
+def test_a_cast_group_is_not_released_when_playback_ends() -> None:
+    """A cast group is released by its power control, not by playback ending."""
+    fake = _fake_player(player_type=PlayerType.GROUP)
+
+    _handle_media_status(fake, _media_status())
+
+    assert fake._attr_playback_state == PlaybackState.IDLE
+    fake.mass.call_later.assert_not_called()
+
+
+def test_a_group_member_is_not_released_when_the_group_stops() -> None:
+    """A member follows the group's Cast session, so it has none of its own to release."""
+    fake = _fake_player(active_cast_group="group_player_1")
+    # the handler reads the group's status instead of its own, but only for a real cast player
+    group = MagicMock(spec=ChromecastPlayer)
+    group.cc = MagicMock()
+    group.cc.media_controller.status = _media_status()
+    fake.mass.players.get_player.return_value = group
+
+    _handle_media_status(fake, _media_status())
+
+    assert fake._attr_playback_state == PlaybackState.IDLE
+    fake.mass.call_later.assert_not_called()

--- a/tests/providers/chromecast/test_idle_release.py
+++ b/tests/providers/chromecast/test_idle_release.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from music_assistant_models.enums import PlaybackState, PlayerType
+from pychromecast import IDLE_APP_ID
 
 from music_assistant.providers.chromecast.constants import (
     APP_QUIT_DELAY,
@@ -124,6 +125,19 @@ def test_a_device_that_ran_dry_at_the_end_of_the_flow_stream_releases_it() -> No
 
     assert fake._attr_playback_state == PlaybackState.IDLE
     _assert_release_scheduled(fake)
+
+
+@pytest.mark.parametrize("app_id", [None, IDLE_APP_ID])
+def test_a_released_device_does_not_become_a_source(app_id: str | None) -> None:
+    """A released device sits on its backdrop, which is not something to select."""
+    fake = _fake_player()
+    fake.cc.app_id = app_id
+    fake._attr_source_list = []
+
+    _handle_media_status(fake, _media_status())
+
+    assert fake._attr_active_source is None
+    assert fake._attr_source_list == []
 
 
 def test_pausing_keeps_the_device_claimed() -> None:

--- a/tests/providers/chromecast/test_idle_release.py
+++ b/tests/providers/chromecast/test_idle_release.py
@@ -58,6 +58,7 @@ def _media_status(
     *,
     playing: bool = False,
     paused: bool = False,
+    buffering: bool = False,
     content_id: str = "",
 ) -> MagicMock:
     """
@@ -65,14 +66,17 @@ def _media_status(
 
     :param playing: Whether the receiver reports playback.
     :param paused: Whether the receiver reports paused playback.
+    :param buffering: Whether the receiver reports buffering, which it counts as playing.
     :param content_id: Content id the receiver has loaded, if any.
     """
     status = MagicMock()
     status.content_id = content_id
-    status.player_state = "PLAYING" if playing else "PAUSED" if paused else "IDLE"
-    status.player_is_playing = playing
+    status.player_state = (
+        "BUFFERING" if buffering else "PLAYING" if playing else "PAUSED" if paused else "IDLE"
+    )
+    status.player_is_playing = playing or buffering
     status.player_is_paused = paused
-    status.player_is_idle = not playing and not paused
+    status.player_is_idle = not playing and not paused and not buffering
     return status
 
 
@@ -111,6 +115,17 @@ def test_an_announcement_on_an_idle_player_releases_the_device() -> None:
     _assert_release_scheduled(fake)
 
 
+def test_a_device_that_ran_dry_at_the_end_of_the_flow_stream_releases_it() -> None:
+    """A device stuck buffering at flow EOF counts as finished, so it is released too."""
+    fake = _fake_player()
+    fake._flow_stream_underrun.return_value = True
+
+    _handle_media_status(fake, _media_status(buffering=True, content_id="http://mass/flow.flac"))
+
+    assert fake._attr_playback_state == PlaybackState.IDLE
+    _assert_release_scheduled(fake)
+
+
 def test_pausing_keeps_the_device_claimed() -> None:
     """A paused player is meant to be resumed, so it keeps its Cast session."""
     fake = _fake_player()
@@ -131,17 +146,19 @@ def test_an_idle_player_is_not_released_again() -> None:
 
 
 @pytest.mark.parametrize(
-    "content_id",
+    ("content_id", "playing", "paused"),
     [
-        "https://cast.music-assistant.io/dashboard-keepalive.mp4",
-        "https://cast.music-assistant.io/keepalive.png",
+        ("https://cast.music-assistant.io/dashboard-keepalive.mp4", True, False),
+        ("https://cast.music-assistant.io/keepalive.png", False, True),
     ],
 )
-def test_a_dashboard_keepalive_does_not_release_the_device(content_id: str) -> None:
+def test_a_dashboard_keepalive_does_not_release_the_device(
+    content_id: str, playing: bool, paused: bool
+) -> None:
     """The receiver is showing a dashboard, so the device is deliberately kept claimed."""
     fake = _fake_player()
 
-    _handle_media_status(fake, _media_status(content_id=content_id))
+    _handle_media_status(fake, _media_status(playing=playing, paused=paused, content_id=content_id))
 
     assert fake._attr_playback_state == PlaybackState.IDLE
     fake.mass.call_later.assert_not_called()

--- a/tests/providers/chromecast/test_stop.py
+++ b/tests/providers/chromecast/test_stop.py
@@ -56,6 +56,9 @@ def _fake_cast(
     fake.cancel_pending_app_quit = partial(
         ChromecastPlayer.cancel_pending_app_quit, cast("ChromecastPlayer", fake)
     )
+    fake._schedule_app_release = partial(
+        ChromecastPlayer._schedule_app_release, cast("ChromecastPlayer", fake)
+    )
     status = fake.cc.media_controller.status
     status.player_is_playing = player_state in ("PLAYING", "BUFFERING")
     status.player_is_paused = player_state == "PAUSED"

--- a/tests/providers/chromecast/test_stop.py
+++ b/tests/providers/chromecast/test_stop.py
@@ -60,9 +60,11 @@ def _fake_cast(
         ChromecastPlayer._schedule_app_release, cast("ChromecastPlayer", fake)
     )
     status = fake.cc.media_controller.status
+    status.player_state = player_state
     status.player_is_playing = player_state in ("PLAYING", "BUFFERING")
     status.player_is_paused = player_state == "PAUSED"
     status.media_session_id = media_session_id
+    fake._flow_stream_underrun.return_value = False
     return fake
 
 
@@ -166,3 +168,13 @@ async def test_receiver_app_in_use_is_not_quit(player_state: str) -> None:
     await _quit_app_when_unused(fake)
 
     fake.cc.quit_app.assert_not_called()
+
+
+async def test_a_device_that_ran_dry_at_the_end_of_the_flow_stream_is_quit() -> None:
+    """A device stuck buffering at flow EOF has no audio coming, so it is not in use."""
+    fake = _fake_cast(player_state="BUFFERING")
+    fake._flow_stream_underrun.return_value = True
+
+    await _quit_app_when_unused(fake)
+
+    fake.cc.quit_app.assert_called_once()


### PR DESCRIPTION
# What does this implement/fix?

Playing an announcement on an idle Cast player left the Music Assistant receiver app loaded on the device for good. On a TV or Nest Hub that means Music Assistant stays on screen instead of the backdrop, and the device keeps looking busy to other apps.

The same thing happened after ordinary playback: the device is only released when a stop command is sent, and nothing sends one when the queue simply runs out or an announcement finishes.

The device is now released once the player settles into idle, using the same short delay a stop already uses — so anything that follows shortly after (an announcement, the next queue, a dashboard) still reuses the Cast session.

- Cast devices are released when playback ends on its own, not just on an explicit stop
- Devices that keep reporting "buffering" at the end of a stream instead of going idle are now released too
- Cast groups are left alone: closing their app is what their power control does
- A paused player keeps its session, so resuming it does not restart the device

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.