### PR TITLE
Log the right size when a remote connection drops a message

### DIFF
--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -1008,7 +1008,8 @@ class WebRTCGateway:
             pass
         except RTCError as err:
             # a single failed send (e.g. an over-limit message) must not tear down the pump
-            self.logger.warning("Dropping %d-byte data channel message: %s", len(data), err)
+            size = len(data.encode()) if isinstance(data, str) else len(data)
+            self.logger.warning("Dropping %d-byte data channel message: %s", size, err)
 
     def _try_extract_sendspin_client_id(self, session: WebRTCSession, message: str) -> None:
         """Try to extract client_id from sendspin auth message and set on websocket client."""

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -13,7 +13,14 @@ from urllib.parse import urlparse
 
 import aiohttp
 import pytest
-from aiolibdatachannel import DataChannel, IceServer, LogLevel, PeerConnection, RTCConfiguration
+from aiolibdatachannel import (
+    DataChannel,
+    IceServer,
+    LogLevel,
+    PeerConnection,
+    RTCConfiguration,
+    RTCError,
+)
 from cryptography.hazmat.primitives import serialization
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
@@ -1775,6 +1782,24 @@ async def test_send_chunked_stops_framing_once_the_channel_closes(
     # the guard and the send of the first piece, then the guard again: the other ten pieces
     # are never framed
     assert channel.open_checks == 3
+
+
+async def test_dropped_message_is_logged_with_its_size_on_the_wire(
+    cert_pems: tuple[str, str], caplog: pytest.LogCaptureFixture
+) -> None:
+    """The size in the drop warning counts bytes, so it can be read against the channel limit."""
+    gateway = _proxy_gateway(cert_pems)
+    gateway.logger = logging.getLogger("test_webrtc_dropped_message_size")
+    channel = Mock()
+    channel.is_open = True
+    channel.send = AsyncMock(side_effect=RTCError("message too large"))
+    # 100 characters, 300 bytes once encoded
+    text = "音" * 100
+
+    with caplog.at_level(logging.WARNING, logger="test_webrtc_dropped_message_size"):
+        await gateway._send_on_channel(cast("DataChannel", channel), text)
+
+    assert "Dropping 300-byte data channel message" in caplog.text
 
 
 async def test_ma_api_channel_chunks_within_the_negotiated_limit(


### PR DESCRIPTION
# What does this implement/fix?

When a remote connection has to drop a message it could not send, the log line reports how big that message was. For text messages it was counting characters instead of bytes, so the reported size was too small — up to three times too small for non-Latin text. Since the usual reason for a drop is the message being over the connection's size limit, that made the one log line you go to when diagnosing it point the wrong way.

- Report the actual byte size of dropped text messages
- Added a test covering it

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
