### PR TITLE
Move private Sendspin player methods to the bottom of the class

### DIFF
--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -1151,59 +1151,6 @@ class SendspinPlayer(SendspinBasePlayer):
         self._attr_expose_to_ha_by_default = True
         self._attr_type = PlayerType.PROTOCOL
 
-    def _subscribe_client_callbacks(self) -> None:
-        """Subscribe to client and group events for the currently bound client."""
-        super()._subscribe_client_callbacks()
-        self.api.disconnect_behaviour = DisconnectBehaviour.STOP
-        if controller_role := self._controller_role:
-            controller_role.set_supported_commands(SUPPORTED_GROUP_COMMANDS)
-
-    def _refresh_client_info(
-        self,
-        sendspin_client: SendspinClient,
-        hello_payload: ClientHelloPayload | None = None,
-    ) -> None:
-        """Refresh player attributes from a Sendspin client hello/info payload."""
-        super()._refresh_client_info(sendspin_client, hello_payload=hello_payload)
-        client_info = hello_payload or sendspin_client.info
-        if device_info := client_info.device_info:
-            # determine if this is a web/app player based on product name or manufacturer
-            # TODO: make this part of the spec and let clients explicitly report if they
-            # are a web/app player instead of relying on heuristics
-            self.is_web_player = (
-                device_info.product_name
-                in (
-                    "Web Browser",
-                    "Web Player",
-                    "Mobile Application",
-                    "PWA",
-                )
-                or device_info.manufacturer == "Music Assistant"
-            )
-        else:
-            self.is_web_player = False
-        if client_info.player_support:
-            for role in sendspin_client.roles_by_family("player"):
-                volume = role.get_player_volume()
-                muted = role.get_player_muted()
-                if volume is not None:
-                    self._attr_volume_level = volume
-                if muted is not None:
-                    self._attr_volume_muted = muted
-                if volume is not None or muted is not None:
-                    break
-        # virtual players are server-owned anchors that follow the same
-        # hidden/standalone semantics as web players, without relying on the
-        # device-info heuristics above
-        is_standalone = self.is_web_player or cast(
-            "SendspinProvider", self.provider
-        ).is_virtual_player(self.player_id)
-        self._attr_expose_to_ha_by_default = not is_standalone
-        self._attr_hidden_by_default = is_standalone
-        # register web/app player as native player type because it doesn't need to be linked
-        # every web/app player is just a standalone player.
-        self._attr_type = PlayerType.PLAYER if is_standalone else PlayerType.PROTOCOL
-
     def event_cb(self, client: SendspinClient, event: ClientEvent) -> None:
         """Event callback registered to the sendspin client."""
         match event:
@@ -1222,32 +1169,6 @@ class SendspinPlayer(SendspinBasePlayer):
                     )
             case _:
                 super().event_cb(client, event)
-
-    def _on_group_changed(self, new_group: SendspinGroup) -> None:
-        """Handle group change with controller commands and playback session cancellation."""
-        if controller_role := self._controller_role:
-            controller_role.set_supported_commands(SUPPORTED_GROUP_COMMANDS)
-        # Cancel active playback - push stream belongs to the old group
-        self.mass.create_task(self.playback_session.cancel("group changed"))
-        super()._on_group_changed(new_group)
-
-    def _on_group_stopped(self) -> None:
-        """Cancel playback session when group stops and we are the leader."""
-        if self.synced_to is not None:
-            return
-        # Bind the cancel to the session task that is live right now: by the time
-        # the deferred task below runs, play_media may already have started a fresh
-        # session, which must not be torn down by this stale group-stopped event.
-        stale_task = self.playback_session.playback_task
-        if stale_task is None or stale_task.done():
-            return
-        self.mass.create_task(self._cancel_stale_playback_session(stale_task))
-
-    async def _cancel_stale_playback_session(self, task: asyncio.Task[None]) -> None:
-        """Cancel the playback session only if the given task is still the active one."""
-        if self.playback_session.playback_task is not task:
-            return
-        await self.playback_session.cancel("group stopped")
 
     def group_event_cb(self, group: SendspinGroup, event: GroupEvent) -> None:
         """Event callback registered to the sendspin group this player belongs to."""
@@ -1293,68 +1214,6 @@ class SendspinPlayer(SendspinBasePlayer):
                 if self.synced_to is None:
                     self.mass.create_task(self._handle_controller_event(controller_event))
 
-    async def _handle_controller_event(self, event: ControllerEvent) -> None:
-        """Handle a controller event from the ControllerGroupRole."""
-        queue = self.mass.player_queues.get_active_queue(self.player_id)
-        match event:
-            case ControllerPlayEvent():
-                await self.mass.players.cmd_play(self.player_id)
-            case ControllerPauseEvent():
-                await self.mass.players.cmd_pause(self.player_id)
-            case ControllerStopEvent():
-                await self.mass.players.cmd_stop(self.player_id)
-            case ControllerNextEvent():
-                await self.mass.players.cmd_next_track(self.player_id)
-            case ControllerPreviousEvent():
-                await self.mass.players.cmd_previous_track(self.player_id)
-            case ControllerRepeatEvent(mode=mode) if queue:
-                match mode:
-                    case SendspinRepeatMode.OFF:
-                        self.mass.player_queues.set_repeat(queue.queue_id, RepeatMode.OFF)
-                    case SendspinRepeatMode.ONE:
-                        self.mass.player_queues.set_repeat(queue.queue_id, RepeatMode.ONE)
-                    case SendspinRepeatMode.ALL:
-                        self.mass.player_queues.set_repeat(queue.queue_id, RepeatMode.ALL)
-            case ControllerShuffleEvent(shuffle=shuffle) if queue:
-                await self.mass.player_queues.set_shuffle(queue.queue_id, shuffle_enabled=shuffle)
-            case ControllerSeekEvent(position_ms=position_ms) if (
-                queue and queue.current_item and queue.current_item.duration
-            ):
-                # Clamp in case track duration changed after we advertised the seek range.
-                duration_ms = int(queue.current_item.duration * 1000)
-                await self.mass.player_queues.seek(
-                    queue.queue_id, max(0, min(position_ms, duration_ms)) // 1000
-                )
-            case ControllerSeekRelativeEvent(offset_ms=offset_ms) if (
-                queue and queue.current_item and queue.current_item.duration
-            ):
-                # Clamp current position + offset to the 0..duration range.
-                target_ms = int(queue.corrected_elapsed_time * 1000) + offset_ms
-                duration_ms = int(queue.current_item.duration * 1000)
-                await self.mass.player_queues.seek(
-                    queue.queue_id, max(0, min(target_ms, duration_ms)) // 1000
-                )
-
-    async def _sync_membership_from_group(self, group: SendspinGroup) -> None:
-        """Sync MA/player + playback session membership from authoritative group state."""
-        # Ignore stale events from a group we no longer belong to.
-        if group is not self.api.group:
-            return
-        group_client_ids = [client.client_id for client in group.clients]
-        is_leader = bool(group_client_ids) and group_client_ids[0] == self.player_id
-        desired_group_members = group_client_ids if is_leader else []
-        desired_session_members = group_client_ids[1:] if is_leader else []
-        if self._attr_group_members != desired_group_members:
-            self._attr_group_members = desired_group_members
-            self.update_state()
-        # Only use STOP when we actually lead other members.
-        self.api.disconnect_behaviour = (
-            DisconnectBehaviour.STOP
-            if is_leader and len(desired_session_members) > 0
-            else DisconnectBehaviour.UNGROUP
-        )
-        await self.playback_session.sync_members(set(desired_session_members))
-
     async def volume_set(self, volume_level: int) -> None:
         """Handle VOLUME_SET command on the player."""
         roles = self.api.roles_by_family("player")
@@ -1389,16 +1248,6 @@ class SendspinPlayer(SendspinBasePlayer):
             await self.api.group.stop()
         finally:
             await self.playback_session.cancel("stop command")
-
-    def _get_cast_bridge_manager(self) -> SendspinBridgeManager | None:
-        """Return the Chromecast provider's Sendspin bridge manager, if loaded."""
-        chromecast_provider = self.mass.get_provider("chromecast")
-        if chromecast_provider is None:
-            return None
-        manager = getattr(chromecast_provider, "bridge_manager", None)
-        if manager is None:
-            return None
-        return cast("SendspinBridgeManager", manager)
 
     async def play_media(self, media: PlayerMedia) -> None:
         """Play media command."""
@@ -1448,51 +1297,6 @@ class SendspinPlayer(SendspinBasePlayer):
         """Handle logic when the PlayerConfig is first loaded or updated."""
         await self._apply_preferred_format()
         await self._apply_static_delay()
-
-    async def _apply_preferred_format(self) -> None:
-        """Read config and set/clear the players preferred format."""
-        player_role = self._player_role
-        if player_role is None:
-            return
-
-        config_value = cast(
-            "str",
-            self.config.get_value(CONF_PREFERRED_SENDSPIN_FORMAT, SENDSPIN_FORMAT_AUTOMATIC),
-        )
-        if config_value == SENDSPIN_FORMAT_AUTOMATIC:
-            # Automatic mode: clear override and let client decide.
-            player_role.set_preferred_format(None, None)
-            return
-
-        parsed = option_value_to_format(config_value)
-        if parsed is None:
-            self.logger.warning(
-                "Invalid audio format config value '%s' for player %s",
-                config_value,
-                self.display_name,
-            )
-            return
-
-        codec, audio_format = parsed
-        if not player_role.set_preferred_format(audio_format, codec):
-            self.logger.warning(
-                "Failed to set preferred audio format %s %s for player %s",
-                codec.name,
-                audio_format,
-                self.display_name,
-            )
-
-    async def _apply_static_delay(self) -> None:
-        """Read config and send set_static_delay command if supported."""
-        player_role = self._player_role
-        if player_role is None:
-            return
-
-        config_value = cast(
-            "int",
-            self.config.get_value(CONF_SENDSPIN_STATIC_DELAY, self.static_delay_default_ms),
-        )
-        player_role.set_static_delay(config_value)
 
     async def set_members(
         self,
@@ -1576,6 +1380,366 @@ class SendspinPlayer(SendspinBasePlayer):
                 if not f.done():
                     f.cancel()
         # self.group_members will be updated by the group event callback
+
+    def on_player_media_updated(self) -> None:
+        """Handle callback when the current media of the player is updated."""
+        if self.synced_to is not None:
+            # Only leader sends metadata
+            return
+        self.mass.create_task(
+            self.send_current_media_metadata(),
+            task_id=f"sendspin_metadata_{self.player_id}",
+            abort_existing=True,
+        )
+
+    async def send_current_media_metadata(self) -> None:
+        """Send the current media metadata to the sendspin group."""
+        if not self.available:
+            return
+        current_media = self.state.current_media
+        if current_media is None:
+            await self._clear_current_media_metadata()
+            return
+        # check if we are playing a MA queue item
+        queue_item: QueueItem | None = None
+        queue: PlayerQueue | None = None
+        if current_media.source_id and current_media.queue_item_id:
+            queue = self.mass.player_queues.get(current_media.source_id)
+            queue_item = self.mass.player_queues.get_item(
+                current_media.source_id, current_media.queue_item_id
+            )
+
+        # Runs even without a queue item so radio / Spotify Connect streams still get art.
+        await self._send_album_artwork(current_media)
+        if queue_item:
+            await self._send_artist_artwork(queue_item)
+
+        track_number: int | None = None
+        year: int | None = None
+        album_artist: str | None = None
+        if queue_item and queue_item.media_item and is_track(queue_item.media_item):
+            track = queue_item.media_item
+            track_number = track.track_number or None
+            album_mapping = track.album
+            if album_mapping is not None:
+                year = album_mapping.year
+                if not isinstance(album_mapping, Album):
+                    # Cheap DB-only lookup, no external API call; None if not in library
+                    result = await self.mass.music.get_library_item_by_prov_id(
+                        MediaType.ALBUM, album_mapping.item_id, album_mapping.provider
+                    )
+                    full_album: Album | None = result if isinstance(result, Album) else None
+                else:
+                    full_album = album_mapping
+                if full_album and full_album.artists:
+                    album_artist = full_album.artist_str
+
+        track_duration = current_media.duration or 0
+        if controller_role := self._controller_role:
+            controller_role.set_seek_max_ms(int(track_duration * 1000) if track_duration else None)
+        repeat = SendspinRepeatMode.OFF
+        if queue and queue.repeat_mode == RepeatMode.ALL:
+            repeat = SendspinRepeatMode.ALL
+        elif queue and queue.repeat_mode == RepeatMode.ONE:
+            repeat = SendspinRepeatMode.ONE
+
+        shuffle = queue.shuffle_enabled if queue else False
+        is_playing = self.state.playback_state == PlaybackState.PLAYING
+        track_progress = self._compute_track_progress_ms(current_media, is_playing=is_playing)
+
+        metadata = Metadata(
+            title=current_media.title,
+            artist=current_media.artist,
+            album_artist=album_artist,
+            album=current_media.album,
+            artwork_url=current_media.image_url,
+            year=year,
+            track=track_number,
+            track_duration=track_duration * 1000 if track_duration is not None else None,
+            track_progress=track_progress,
+            playback_speed=1000 if is_playing else 0,
+            repeat=repeat,
+            shuffle=shuffle,
+        )
+
+        # Send metadata to the group
+        if (metadata_role := self._metadata_role) is not None:
+            metadata_role.set_metadata(metadata)
+
+        self._publish_repeat_shuffle(repeat, shuffle=shuffle)
+
+        # Send color palette derived from the cover art (already computed by
+        # the players controller with the Sendspin defined minimum contrast values).
+        if (color_role := self._color_role) is not None:
+            self._send_color_palette(color_role, current_media.palette)
+
+        await self._send_beat_schedule(queue, queue_item, track_progress, is_playing)
+
+    async def get_config_entries(self) -> list[ConfigEntry]:
+        """Return all (provider/player specific) Config Entries for the player."""
+        entries: list[ConfigEntry] = []
+        # Show alert if this Cast device is known to lack AudioContext support
+        if self.mass.config.get_raw_player_config_value(
+            self.player_id, CONF_CAST_AUDIO_UNSUPPORTED
+        ):
+            entries.append(
+                ConfigEntry(
+                    key="cast_audio_unsupported",
+                    type=ConfigEntryType.ALERT,
+                    required=False,
+                )
+            )
+        entries.extend(await super().get_config_entries())
+        # Build dynamic format options from player's supported formats
+        player_role = self._player_role
+        if player_role is not None:
+            supported_formats = player_role.get_supported_formats()
+            if supported_formats:
+                format_options = [
+                    ConfigValueOption(SENDSPIN_FORMAT_AUTOMATIC),
+                ]
+                for fmt in supported_formats:
+                    format_options.append(
+                        ConfigValueOption(
+                            format_to_option_value(fmt), title=format_to_display_string(fmt)
+                        )
+                    )
+                entries.append(
+                    ConfigEntry(
+                        key=CONF_PREFERRED_SENDSPIN_FORMAT,
+                        type=ConfigEntryType.STRING,
+                        category="protocol_generic",
+                        default_value=SENDSPIN_FORMAT_AUTOMATIC,
+                        options=format_options,
+                        advanced=True,
+                    )
+                )
+
+        if (
+            player_role is not None
+            and PlayerCommand.SET_STATIC_DELAY in player_role.state_supported_commands
+        ):
+            entries.append(
+                ConfigEntry(
+                    key=CONF_SENDSPIN_STATIC_DELAY,
+                    type=ConfigEntryType.INTEGER,
+                    required=False,
+                    default_value=self.static_delay_default_ms,
+                    range=(0, 5000),
+                    immediate_apply=True,
+                    # Not a advanced option since this will only show up for players where it is likely
+                    # necessary to adjust the delay.
+                    advanced=False,
+                )
+            )
+
+        if self._hass_announce_entity_id is not None:
+            # announcements are relayed to the device via Home Assistant,
+            # which has no volume control for announcements
+            entries.extend(HIDDEN_ANNOUNCE_VOLUME_CONFIG_ENTRIES)
+
+        return entries
+
+    async def on_unload(self) -> None:
+        """Handle logic when the player is unloaded from the Player controller."""
+        await self.playback_session.close()
+        await super().on_unload()
+
+    def _subscribe_client_callbacks(self) -> None:
+        """Subscribe to client and group events for the currently bound client."""
+        super()._subscribe_client_callbacks()
+        self.api.disconnect_behaviour = DisconnectBehaviour.STOP
+        if controller_role := self._controller_role:
+            controller_role.set_supported_commands(SUPPORTED_GROUP_COMMANDS)
+
+    def _refresh_client_info(
+        self,
+        sendspin_client: SendspinClient,
+        hello_payload: ClientHelloPayload | None = None,
+    ) -> None:
+        """Refresh player attributes from a Sendspin client hello/info payload."""
+        super()._refresh_client_info(sendspin_client, hello_payload=hello_payload)
+        client_info = hello_payload or sendspin_client.info
+        if device_info := client_info.device_info:
+            # determine if this is a web/app player based on product name or manufacturer
+            # TODO: make this part of the spec and let clients explicitly report if they
+            # are a web/app player instead of relying on heuristics
+            self.is_web_player = (
+                device_info.product_name
+                in (
+                    "Web Browser",
+                    "Web Player",
+                    "Mobile Application",
+                    "PWA",
+                )
+                or device_info.manufacturer == "Music Assistant"
+            )
+        else:
+            self.is_web_player = False
+        if client_info.player_support:
+            for role in sendspin_client.roles_by_family("player"):
+                volume = role.get_player_volume()
+                muted = role.get_player_muted()
+                if volume is not None:
+                    self._attr_volume_level = volume
+                if muted is not None:
+                    self._attr_volume_muted = muted
+                if volume is not None or muted is not None:
+                    break
+        # virtual players are server-owned anchors that follow the same
+        # hidden/standalone semantics as web players, without relying on the
+        # device-info heuristics above
+        is_standalone = self.is_web_player or cast(
+            "SendspinProvider", self.provider
+        ).is_virtual_player(self.player_id)
+        self._attr_expose_to_ha_by_default = not is_standalone
+        self._attr_hidden_by_default = is_standalone
+        # register web/app player as native player type because it doesn't need to be linked
+        # every web/app player is just a standalone player.
+        self._attr_type = PlayerType.PLAYER if is_standalone else PlayerType.PROTOCOL
+
+    def _on_group_changed(self, new_group: SendspinGroup) -> None:
+        """Handle group change with controller commands and playback session cancellation."""
+        if controller_role := self._controller_role:
+            controller_role.set_supported_commands(SUPPORTED_GROUP_COMMANDS)
+        # Cancel active playback - push stream belongs to the old group
+        self.mass.create_task(self.playback_session.cancel("group changed"))
+        super()._on_group_changed(new_group)
+
+    def _on_group_stopped(self) -> None:
+        """Cancel playback session when group stops and we are the leader."""
+        if self.synced_to is not None:
+            return
+        # Bind the cancel to the session task that is live right now: by the time
+        # the deferred task below runs, play_media may already have started a fresh
+        # session, which must not be torn down by this stale group-stopped event.
+        stale_task = self.playback_session.playback_task
+        if stale_task is None or stale_task.done():
+            return
+        self.mass.create_task(self._cancel_stale_playback_session(stale_task))
+
+    async def _cancel_stale_playback_session(self, task: asyncio.Task[None]) -> None:
+        """Cancel the playback session only if the given task is still the active one."""
+        if self.playback_session.playback_task is not task:
+            return
+        await self.playback_session.cancel("group stopped")
+
+    async def _handle_controller_event(self, event: ControllerEvent) -> None:
+        """Handle a controller event from the ControllerGroupRole."""
+        queue = self.mass.player_queues.get_active_queue(self.player_id)
+        match event:
+            case ControllerPlayEvent():
+                await self.mass.players.cmd_play(self.player_id)
+            case ControllerPauseEvent():
+                await self.mass.players.cmd_pause(self.player_id)
+            case ControllerStopEvent():
+                await self.mass.players.cmd_stop(self.player_id)
+            case ControllerNextEvent():
+                await self.mass.players.cmd_next_track(self.player_id)
+            case ControllerPreviousEvent():
+                await self.mass.players.cmd_previous_track(self.player_id)
+            case ControllerRepeatEvent(mode=mode) if queue:
+                match mode:
+                    case SendspinRepeatMode.OFF:
+                        self.mass.player_queues.set_repeat(queue.queue_id, RepeatMode.OFF)
+                    case SendspinRepeatMode.ONE:
+                        self.mass.player_queues.set_repeat(queue.queue_id, RepeatMode.ONE)
+                    case SendspinRepeatMode.ALL:
+                        self.mass.player_queues.set_repeat(queue.queue_id, RepeatMode.ALL)
+            case ControllerShuffleEvent(shuffle=shuffle) if queue:
+                await self.mass.player_queues.set_shuffle(queue.queue_id, shuffle_enabled=shuffle)
+            case ControllerSeekEvent(position_ms=position_ms) if (
+                queue and queue.current_item and queue.current_item.duration
+            ):
+                # Clamp in case track duration changed after we advertised the seek range.
+                duration_ms = int(queue.current_item.duration * 1000)
+                await self.mass.player_queues.seek(
+                    queue.queue_id, max(0, min(position_ms, duration_ms)) // 1000
+                )
+            case ControllerSeekRelativeEvent(offset_ms=offset_ms) if (
+                queue and queue.current_item and queue.current_item.duration
+            ):
+                # Clamp current position + offset to the 0..duration range.
+                target_ms = int(queue.corrected_elapsed_time * 1000) + offset_ms
+                duration_ms = int(queue.current_item.duration * 1000)
+                await self.mass.player_queues.seek(
+                    queue.queue_id, max(0, min(target_ms, duration_ms)) // 1000
+                )
+
+    async def _sync_membership_from_group(self, group: SendspinGroup) -> None:
+        """Sync MA/player + playback session membership from authoritative group state."""
+        # Ignore stale events from a group we no longer belong to.
+        if group is not self.api.group:
+            return
+        group_client_ids = [client.client_id for client in group.clients]
+        is_leader = bool(group_client_ids) and group_client_ids[0] == self.player_id
+        desired_group_members = group_client_ids if is_leader else []
+        desired_session_members = group_client_ids[1:] if is_leader else []
+        if self._attr_group_members != desired_group_members:
+            self._attr_group_members = desired_group_members
+            self.update_state()
+        # Only use STOP when we actually lead other members.
+        self.api.disconnect_behaviour = (
+            DisconnectBehaviour.STOP
+            if is_leader and len(desired_session_members) > 0
+            else DisconnectBehaviour.UNGROUP
+        )
+        await self.playback_session.sync_members(set(desired_session_members))
+
+    def _get_cast_bridge_manager(self) -> SendspinBridgeManager | None:
+        """Return the Chromecast provider's Sendspin bridge manager, if loaded."""
+        chromecast_provider = self.mass.get_provider("chromecast")
+        if chromecast_provider is None:
+            return None
+        manager = getattr(chromecast_provider, "bridge_manager", None)
+        if manager is None:
+            return None
+        return cast("SendspinBridgeManager", manager)
+
+    async def _apply_preferred_format(self) -> None:
+        """Read config and set/clear the players preferred format."""
+        player_role = self._player_role
+        if player_role is None:
+            return
+
+        config_value = cast(
+            "str",
+            self.config.get_value(CONF_PREFERRED_SENDSPIN_FORMAT, SENDSPIN_FORMAT_AUTOMATIC),
+        )
+        if config_value == SENDSPIN_FORMAT_AUTOMATIC:
+            # Automatic mode: clear override and let client decide.
+            player_role.set_preferred_format(None, None)
+            return
+
+        parsed = option_value_to_format(config_value)
+        if parsed is None:
+            self.logger.warning(
+                "Invalid audio format config value '%s' for player %s",
+                config_value,
+                self.display_name,
+            )
+            return
+
+        codec, audio_format = parsed
+        if not player_role.set_preferred_format(audio_format, codec):
+            self.logger.warning(
+                "Failed to set preferred audio format %s %s for player %s",
+                codec.name,
+                audio_format,
+                self.display_name,
+            )
+
+    async def _apply_static_delay(self) -> None:
+        """Read config and send set_static_delay command if supported."""
+        player_role = self._player_role
+        if player_role is None:
+            return
+
+        config_value = cast(
+            "int",
+            self.config.get_value(CONF_SENDSPIN_STATIC_DELAY, self.static_delay_default_ms),
+        )
+        player_role.set_static_delay(config_value)
 
     async def _send_album_artwork(self, current_media: PlayerMedia) -> str | None:
         """
@@ -1666,17 +1830,6 @@ class SendspinPlayer(SendspinBasePlayer):
             self.logger.debug("Skipping undecodable artwork: %s", err)
             return None
 
-    def on_player_media_updated(self) -> None:
-        """Handle callback when the current media of the player is updated."""
-        if self.synced_to is not None:
-            # Only leader sends metadata
-            return
-        self.mass.create_task(
-            self.send_current_media_metadata(),
-            task_id=f"sendspin_metadata_{self.player_id}",
-            abort_existing=True,
-        )
-
     async def _clear_current_media_metadata(self) -> None:
         """Clear all metadata and artwork from the sendspin group."""
         # Stop any in-flight beat-analysis polling task
@@ -1709,6 +1862,24 @@ class SendspinPlayer(SendspinBasePlayer):
         if (controller_role := self._controller_role) is not None:
             controller_role.set_repeat(repeat)
             controller_role.set_shuffle(shuffle=shuffle)
+
+    def _send_color_palette(
+        self, color_role: ColorGroupRole, palette: MediaItemPalette | None
+    ) -> None:
+        """Push the palette already attached to current_media to the sendspin group."""
+        if palette is None:
+            color_role.clear()
+            return
+        color_role.set_color(
+            Color(
+                background_dark=palette.background_dark,
+                background_light=palette.background_light,
+                primary=palette.primary,
+                accent=palette.accent,
+                on_dark=palette.on_dark,
+                on_light=palette.on_light,
+            )
+        )
 
     def _compute_track_progress_ms(self, current_media: PlayerMedia, *, is_playing: bool) -> int:
         """
@@ -1746,107 +1917,6 @@ class SendspinPlayer(SendspinBasePlayer):
         is_playing = self.state.playback_state == PlaybackState.PLAYING
         track_progress = self._compute_track_progress_ms(current_media, is_playing=is_playing)
         await self._send_beat_schedule(queue, queue_item, track_progress, is_playing)
-
-    async def send_current_media_metadata(self) -> None:
-        """Send the current media metadata to the sendspin group."""
-        if not self.available:
-            return
-        current_media = self.state.current_media
-        if current_media is None:
-            await self._clear_current_media_metadata()
-            return
-        # check if we are playing a MA queue item
-        queue_item: QueueItem | None = None
-        queue: PlayerQueue | None = None
-        if current_media.source_id and current_media.queue_item_id:
-            queue = self.mass.player_queues.get(current_media.source_id)
-            queue_item = self.mass.player_queues.get_item(
-                current_media.source_id, current_media.queue_item_id
-            )
-
-        # Runs even without a queue item so radio / Spotify Connect streams still get art.
-        await self._send_album_artwork(current_media)
-        if queue_item:
-            await self._send_artist_artwork(queue_item)
-
-        track_number: int | None = None
-        year: int | None = None
-        album_artist: str | None = None
-        if queue_item and queue_item.media_item and is_track(queue_item.media_item):
-            track = queue_item.media_item
-            track_number = track.track_number or None
-            album_mapping = track.album
-            if album_mapping is not None:
-                year = album_mapping.year
-                if not isinstance(album_mapping, Album):
-                    # Cheap DB-only lookup, no external API call; None if not in library
-                    result = await self.mass.music.get_library_item_by_prov_id(
-                        MediaType.ALBUM, album_mapping.item_id, album_mapping.provider
-                    )
-                    full_album: Album | None = result if isinstance(result, Album) else None
-                else:
-                    full_album = album_mapping
-                if full_album and full_album.artists:
-                    album_artist = full_album.artist_str
-
-        track_duration = current_media.duration or 0
-        if controller_role := self._controller_role:
-            controller_role.set_seek_max_ms(int(track_duration * 1000) if track_duration else None)
-        repeat = SendspinRepeatMode.OFF
-        if queue and queue.repeat_mode == RepeatMode.ALL:
-            repeat = SendspinRepeatMode.ALL
-        elif queue and queue.repeat_mode == RepeatMode.ONE:
-            repeat = SendspinRepeatMode.ONE
-
-        shuffle = queue.shuffle_enabled if queue else False
-        is_playing = self.state.playback_state == PlaybackState.PLAYING
-        track_progress = self._compute_track_progress_ms(current_media, is_playing=is_playing)
-
-        metadata = Metadata(
-            title=current_media.title,
-            artist=current_media.artist,
-            album_artist=album_artist,
-            album=current_media.album,
-            artwork_url=current_media.image_url,
-            year=year,
-            track=track_number,
-            track_duration=track_duration * 1000 if track_duration is not None else None,
-            track_progress=track_progress,
-            playback_speed=1000 if is_playing else 0,
-            repeat=repeat,
-            shuffle=shuffle,
-        )
-
-        # Send metadata to the group
-        if (metadata_role := self._metadata_role) is not None:
-            metadata_role.set_metadata(metadata)
-
-        self._publish_repeat_shuffle(repeat, shuffle=shuffle)
-
-        # Send color palette derived from the cover art (already computed by
-        # the players controller with the Sendspin defined minimum contrast values).
-        if (color_role := self._color_role) is not None:
-            self._send_color_palette(color_role, current_media.palette)
-
-        await self._send_beat_schedule(queue, queue_item, track_progress, is_playing)
-
-    def _send_color_palette(
-        self, color_role: ColorGroupRole, palette: MediaItemPalette | None
-    ) -> None:
-        """Push the palette already attached to current_media to the sendspin group."""
-        if palette is None:
-            color_role.clear()
-            return
-        color_role.set_color(
-            Color(
-                background_dark=palette.background_dark,
-                background_light=palette.background_light,
-                primary=palette.primary,
-                accent=palette.accent,
-                on_dark=palette.on_dark,
-                on_light=palette.on_light,
-            )
-        )
 
     @staticmethod
     def _flow_track_offset_us(pq_data: PlayerQueueData | None, queue_item: QueueItem) -> int | None:
@@ -2019,76 +2089,6 @@ class SendspinPlayer(SendspinBasePlayer):
         finally:
             if self._beat_retry_queue_item_id == queue_item_id:
                 self._beat_retry_queue_item_id = None
-
-    async def get_config_entries(self) -> list[ConfigEntry]:
-        """Return all (provider/player specific) Config Entries for the player."""
-        entries: list[ConfigEntry] = []
-        # Show alert if this Cast device is known to lack AudioContext support
-        if self.mass.config.get_raw_player_config_value(
-            self.player_id, CONF_CAST_AUDIO_UNSUPPORTED
-        ):
-            entries.append(
-                ConfigEntry(
-                    key="cast_audio_unsupported",
-                    type=ConfigEntryType.ALERT,
-                    required=False,
-                )
-            )
-        entries.extend(await super().get_config_entries())
-        # Build dynamic format options from player's supported formats
-        player_role = self._player_role
-        if player_role is not None:
-            supported_formats = player_role.get_supported_formats()
-            if supported_formats:
-                format_options = [
-                    ConfigValueOption(SENDSPIN_FORMAT_AUTOMATIC),
-                ]
-                for fmt in supported_formats:
-                    format_options.append(
-                        ConfigValueOption(
-                            format_to_option_value(fmt), title=format_to_display_string(fmt)
-                        )
-                    )
-                entries.append(
-                    ConfigEntry(
-                        key=CONF_PREFERRED_SENDSPIN_FORMAT,
-                        type=ConfigEntryType.STRING,
-                        category="protocol_generic",
-                        default_value=SENDSPIN_FORMAT_AUTOMATIC,
-                        options=format_options,
-                        advanced=True,
-                    )
-                )
-
-        if (
-            player_role is not None
-            and PlayerCommand.SET_STATIC_DELAY in player_role.state_supported_commands
-        ):
-            entries.append(
-                ConfigEntry(
-                    key=CONF_SENDSPIN_STATIC_DELAY,
-                    type=ConfigEntryType.INTEGER,
-                    required=False,
-                    default_value=self.static_delay_default_ms,
-                    range=(0, 5000),
-                    immediate_apply=True,
-                    # Not a advanced option since this will only show up for players where it is likely
-                    # necessary to adjust the delay.
-                    advanced=False,
-                )
-            )
-
-        if self._hass_announce_entity_id is not None:
-            # announcements are relayed to the device via Home Assistant,
-            # which has no volume control for announcements
-            entries.extend(HIDDEN_ANNOUNCE_VOLUME_CONFIG_ENTRIES)
-
-        return entries
-
-    async def on_unload(self) -> None:
-        """Handle logic when the player is unloaded from the Player controller."""
-        await self.playback_session.close()
-        await super().on_unload()
 
 
 class SendspinVisualizerPlayer(SendspinBasePlayer):

--- a/scripts/lint_baselines/private_methods_not_last.txt
+++ b/scripts/lint_baselines/private_methods_not_last.txt
@@ -58,7 +58,6 @@ music_assistant/providers/plex_connect/server.py	8
 music_assistant/providers/qqmusic/__init__.py	21
 music_assistant/providers/samsung_wam/features/grouping/coordinator.py	1
 music_assistant/providers/samsung_wam/features/state_sync/handler.py	8
-music_assistant/providers/sendspin/player.py	12
 music_assistant/providers/smart_playlist/__init__.py	8
 music_assistant/providers/snapcast/control.py	1
 music_assistant/providers/snapcast/player.py	5


### PR DESCRIPTION
# What does this implement/fix?

The `SendspinPlayer` class had public and private methods interleaved, which the repo rule in AGENTS.md ("private methods at the bottom, public at the top") disallows. It was grandfathered in `scripts/lint_baselines/private_methods_not_last.txt` at 12 violations.

This reorders the class so all public methods come first, and drops the file from the lint baseline. No behaviour change — every method body, signature, decorator and docstring is untouched, and nothing was added or removed.

The diff is large but is a pure move; `git diff --color-moved` makes it readable.

- Moved all private methods of `SendspinPlayer` below the public ones
- Kept related helpers grouped: the artwork helpers together, and the beat-schedule helpers (including the `_BEAT_RETRY_*` constants) together
- Removed `music_assistant/providers/sendspin/player.py` from the method-order lint baseline (12 → 0)

`SendspinBasePlayer` and `SendspinVisualizerPlayer` in the same file already complied and were left alone.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
