### PR TITLE
Fix silent AirPlay playback after breaking up a paused group

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -429,7 +429,7 @@ class AirPlayPlayer(Player):
             self.update_state()
 
     async def play(self) -> None:
-        """Send PLAY (unpause) command to player."""
+        """Handle PLAY (unpause) command on the player."""
         session = self.stream.session if self.stream and self.stream.running else None
         if self.group_members or self.synced_to or (session and session.parked):
             # Grouped pause parks the whole session (standby); unpausing one

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -430,16 +430,21 @@ class AirPlayPlayer(Player):
 
     async def play(self) -> None:
         """Send PLAY (unpause) command to player."""
-        if self.group_members or self.synced_to:
+        session = self.stream.session if self.stream and self.stream.running else None
+        if self.group_members or self.synced_to or (session and session.parked):
             # Grouped pause parks the whole session (standby); unpausing one
-            # member cannot restart the group in sync. Resume via the queue
+            # member cannot restart the group in sync, and a parked member is
+            # held with nothing being fed until a re-anchor - which ACTION=PLAY
+            # does not carry, so it would report playback over silence. The park
+            # outlives the group, so a player left alone by an ungroup is keyed
+            # on the park itself, not on its membership. Resume via the queue
             # instead: play_media flushes and re-anchors every parked member at
             # one shared instant. The queue can belong to a linked native parent
             # (for example Sonos), so resolve it instead of using the AirPlay ID.
             active_queue = self.mass.players.get_active_queue(self)
             if active_queue is None:
                 raise PlayerCommandFailed(
-                    f"Cannot resume grouped AirPlay player {self.display_name} without an active queue"
+                    f"Cannot resume AirPlay player {self.display_name} without an active queue"
                 )
             await self.mass.player_queues.resume(active_queue.queue_id, fade_in=False)
             return

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -84,6 +84,11 @@ class AirPlayStreamSession:
         self.start_unix_ms: int = 0
         self.start_time: float = 0.0
         self.seconds_streamed: float = 0
+        # Parked in standby: the members stay connected but nothing is fed and
+        # their binaries hold until a START, so only a re-anchor (play_media)
+        # revives them. It outlives the group that parked it, which is why the
+        # session - not the group membership - owns this.
+        self.parked: bool = False
         # Timing source for the whole session, decided once in start() and applied
         # identically to every native AirPlay 2 member (and any late joiner) so a
         # sync group can never mix shared-PTP and NTP members.
@@ -344,6 +349,7 @@ class AirPlayStreamSession:
         self._pcm_buffer.clear()
         self._client_skip_bytes.clear()
         self._reset_member_shifts()
+        self.parked = True
         return True
 
     async def stop(self) -> None:
@@ -1210,6 +1216,8 @@ class AirPlayStreamSession:
             )
         self.start_unix_ms = target_ms
         self.start_time = target_ms / 1000
+        # the only place a session (re)gains a live timeline, so any park ends here
+        self.parked = False
 
     async def _flush_member(self, player: AirPlayPlayer) -> bool:
         """Flush one member's live stream in place and report the binary's ack."""

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -36,6 +36,7 @@ from music_assistant.providers.airplay.constants import (
 )
 from music_assistant.providers.airplay.player import AirPlayPlayer
 from music_assistant.providers.airplay.provider import AirPlayProvider
+from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
 
 # _airplay._tcp features bitmask with the AirPlay 2 feature bits set (bit 38/48).
 AP2_FEATURES = "0x4A7FDFD5,0x3C177FDE"
@@ -629,6 +630,8 @@ def _setup_running_stream(player: AirPlayPlayer) -> AsyncMock:
     """Attach a mock running stream to the player and return the send_cli_command mock."""
     stream = MagicMock()
     stream.running = True
+    # every streaming player has a session; this one is playing, not parked
+    stream.session = MagicMock(parked=False)
     send_cmd = AsyncMock()
     stream.send_cli_command = send_cmd
     player.stream = stream
@@ -1426,6 +1429,58 @@ async def test_set_members_warns_when_the_leader_has_no_session(
 
     assert leader.group_members == ["leader", "child"]
     assert "no stream session to join" in caplog.text
+
+
+def _attach_live_stream(player: AirPlayPlayer, session: AirPlayStreamSession) -> MagicMock:
+    """Attach a mock stream that is connected and fed by the given session."""
+    stream = MagicMock()
+    stream.running = True
+    stream.connected = True
+    stream.session = session
+    stream.send_cli_command = AsyncMock(return_value=True)
+    stream.stop = AsyncMock()
+    player.stream = stream
+    return stream
+
+
+@pytest.mark.asyncio
+async def test_play_after_ungrouping_a_parked_group_resumes_via_the_queue() -> None:
+    """
+    Breaking a parked group up leaves the remaining player alone with the park.
+
+    Its binary is held at standby with nothing being fed, so the resume still has
+    to re-anchor through the queue: ACTION=PLAY carries no anchor and would
+    report playback over silence.
+    """
+    leader = _make_idle_player("leader")
+    child = _make_idle_player("child")
+    session = AirPlayStreamSession(
+        MagicMock(mass=leader.mass), [leader, child], AIRPLAY_PCM_FORMAT, MagicMock()
+    )
+    leader_stream = _attach_live_stream(leader, session)
+    child_stream = _attach_live_stream(child, session)
+    leader._attr_group_members = ["leader", "child"]
+    players = _players_mock(leader)
+    players.get_player.side_effect = lambda player_id: {"leader": leader, "child": child}.get(
+        player_id
+    )
+    players.get_active_queue.return_value = MagicMock(queue_id="leader")
+    resume_queue = AsyncMock()
+    cast("MagicMock", leader.mass).player_queues.resume = resume_queue
+
+    await leader.pause()
+    await leader.set_members(player_ids_to_remove=["child"])
+    leader_stream.send_cli_command.reset_mock()
+    await leader.play()
+
+    # the removal stops only the child; the leader keeps its parked session
+    child_stream.stop.assert_awaited_once()
+    leader_stream.stop.assert_not_awaited()
+    assert leader.group_members == []
+    assert session.sync_clients == [leader]
+    assert session.parked is True
+    resume_queue.assert_awaited_once_with("leader", fade_in=False)
+    leader_stream.send_cli_command.assert_not_awaited()
 
 
 # --- Device password ---

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1059,7 +1059,7 @@ def _make_playing_leader(player_id: str = "leader") -> AirPlayPlayer:
     leader._attr_playback_state = PlaybackState.PLAYING
     stream = MagicMock()
     stream.running = True
-    stream.session = MagicMock()
+    stream.session = MagicMock(parked=False)
     leader.stream = stream
     return leader
 
@@ -1073,7 +1073,7 @@ def _attach_running_session(player: AirPlayPlayer, sync_clients: list[AirPlayPla
     """Attach a mock running stream whose session carries the given members."""
     stream = MagicMock()
     stream.running = True
-    stream.session = MagicMock()
+    stream.session = MagicMock(parked=False)
     stream.session.sync_clients = sync_clients
     player.stream = stream
 

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -618,6 +618,8 @@ async def test_standby_supports_every_connected_streaming_protocol(
     session.sync_clients = players
 
     assert await session.standby()
+    # the park is carried by the session, so it survives the group shrinking
+    assert session.parked is True
     for player in players:
         player.stream.send_cli_command.assert_awaited_once_with("ACTION=STANDBY")
         player.set_state_from_stream.assert_called_once_with(
@@ -664,6 +666,8 @@ async def test_standby_resumes_warm_on_existing_streams(
     ):
         assert await session.replace(MagicMock(), media)
 
+    # the re-anchor ends the park, so the members are playing again
+    assert session.parked is False
     # start = now (100_000 ms) + solo/group start lead, position 10s
     expected_start = 100_000 + (
         AIRPLAY_START_LEAD_MS if len(protocols) == 1 else AIRPLAY_GROUP_START_LEAD_MS


### PR DESCRIPTION
# What does this implement/fix?

Pausing a group of AirPlay speakers parks the whole session: every speaker keeps its connection but stops receiving audio until the queue re-anchors it. Removing speakers from that group while it is paused left the remaining player parked but no longer grouped, so pressing play just sent a plain unpause — which the speaker reports as playing while staying completely silent. Only stopping and starting playback got the sound back.

Found by code inspection rather than a user report, so labelling this as maintenance.

- The stream session now tracks its own parked state instead of it being inferred from group membership
- Play on a parked player resumes through the queue (which re-anchors playback) rather than sending a plain unpause
- The same branch also protects a member left behind when the leader removes itself, so it no longer reports playback it isn't producing
- Added test coverage for pausing a group and then breaking it up

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
