### PR TITLE
Explain why recovered protocol links are added in place

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1484,7 +1484,10 @@ class ProtocolLinkingMixin:
             if derived_from == native_player.player_id:
                 derived_from = "native"
 
-            # Add the link entry
+            # Appended in place rather than through set_linked_output_protocols():
+            # the player is still registering, so nothing is listening yet, and the
+            # update-all pass that closes registration marks it dirty and
+            # recalculates its state.
             native_player.linked_output_protocols.append(
                 LinkedOutputProtocol(
                     output_protocol_id=protocol_id,


### PR DESCRIPTION
# What does this implement/fix?

The pass that recovers cached protocol links on startup adds them by mutating the
player's link list directly, instead of going through `set_linked_output_protocols()`
like every other add/remove path in that file. That reads as an inconsistency and
invites a "fix" that isn't needed.

It turns out to be safe, so this documents why rather than changing it: the pass runs
while the player is still registering, so nothing is listening to that player yet, and
the update-all pass that closes registration marks it dirty and recalculates its state,
which publishes the recovered entries.

Comment only — no behaviour change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes. No test changes: this is a comment-only change.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
