### PR TITLE
Restore saved speaker connections through the normal update path

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1446,6 +1446,7 @@ class ProtocolLinkingMixin:
             return
 
         # Add link entries for any cached protocols that aren't currently linked
+        updated_protocols = list(native_player.linked_output_protocols)
         for protocol_id in cached_protocol_ids:
             if protocol_id in linked_protocol_ids:
                 continue  # Already linked
@@ -1464,9 +1465,7 @@ class ProtocolLinkingMixin:
             protocol_domain = protocol_provider.split("--", maxsplit=1)[0]
 
             # Skip if parent already has a link from this domain
-            existing_domains = {
-                link.protocol_domain for link in native_player.linked_output_protocols
-            }
+            existing_domains = {link.protocol_domain for link in updated_protocols}
             if protocol_domain in existing_domains:
                 continue
 
@@ -1484,11 +1483,7 @@ class ProtocolLinkingMixin:
             if derived_from == native_player.player_id:
                 derived_from = "native"
 
-            # Appended in place rather than through set_linked_output_protocols():
-            # the player is still registering, so nothing is listening yet, and the
-            # update-all pass that closes registration marks it dirty and
-            # recalculates its state.
-            native_player.linked_output_protocols.append(
+            updated_protocols.append(
                 LinkedOutputProtocol(
                     output_protocol_id=protocol_id,
                     protocol_domain=protocol_domain,
@@ -1501,6 +1496,9 @@ class ProtocolLinkingMixin:
                 native_player.player_id,
                 protocol_id,
             )
+
+        if len(updated_protocols) != len(native_player.linked_output_protocols):
+            native_player.set_linked_output_protocols(updated_protocols)
 
     def _cleanup_protocol_links(self, player: Player) -> None:
         """Clean up protocol links when a player is permanently removed."""

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -7565,8 +7565,8 @@ class TestNativePlayerSiblingLinking:
 class TestCachedProtocolLinkRecovery:
     """Tests for recovering protocol links from config."""
 
-    def test_only_one_link_per_domain_is_recovered(self, mock_mass: MagicMock) -> None:
-        """Two cached protocols from the same domain recover a single link."""
+    def test_recovered_links_are_applied_through_the_setter(self, mock_mass: MagicMock) -> None:
+        """Recovery applies a single link per protocol domain through the setter."""
         controller = PlayerController(mock_mass)
 
         protocol_configs = {
@@ -7601,9 +7601,13 @@ class TestCachedProtocolLinkRecovery:
 
         controller._recover_cached_protocol_links(heos_player)
 
-        assert [link.output_protocol_id for link in heos_player.linked_output_protocols] == [
-            "ap_first"
-        ]
+        recovered = [link.output_protocol_id for link in heos_player.linked_output_protocols]
+        assert recovered == ["ap_first"]
+        mock_mass.players.trigger_player_update.assert_called_once_with("heos_player")
+
+        # a repeat pass has nothing left to recover, so no update is triggered
+        controller._recover_cached_protocol_links(heos_player)
+        mock_mass.players.trigger_player_update.assert_called_once_with("heos_player")
 
 
 class TestMultiMACMatching:

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -7562,6 +7562,50 @@ class TestNativePlayerSiblingLinking:
         assert sendspin_linked, "Sendspin should be linked via sibling protocol matching"
 
 
+class TestCachedProtocolLinkRecovery:
+    """Tests for recovering protocol links from config."""
+
+    def test_only_one_link_per_domain_is_recovered(self, mock_mass: MagicMock) -> None:
+        """Two cached protocols from the same domain recover a single link."""
+        controller = PlayerController(mock_mass)
+
+        protocol_configs = {
+            "ap_first": {
+                "provider": "airplay--first",
+                "player_type": "protocol",
+                "values": {"protocol_parent_id": "heos_player"},
+            },
+            "ap_second": {
+                "provider": "airplay--second",
+                "player_type": "protocol",
+                "values": {"protocol_parent_id": "heos_player"},
+            },
+        }
+
+        def config_get_side_effect(key: str, default: object = None) -> object:
+            if key == "players/heos_player/values/linked_protocol_ids":
+                return ["ap_first", "ap_second"]
+            if key == "players":
+                return protocol_configs
+            if key.startswith("players/"):
+                return protocol_configs.get(key.split("/", maxsplit=1)[1])
+            return default
+
+        mock_mass.config.get = MagicMock(side_effect=config_get_side_effect)
+
+        heos_player = MockPlayer(
+            MockProvider("heos", mass=mock_mass),
+            "heos_player",
+            "Denon AVR-X2700H",
+        )
+
+        controller._recover_cached_protocol_links(heos_player)
+
+        assert [link.output_protocol_id for link in heos_player.linked_output_protocols] == [
+            "ap_first"
+        ]
+
+
 class TestMultiMACMatching:
     """Tests for multi-MAC matching (reported MAC vs ARP MAC)."""
 


### PR DESCRIPTION
# What does this implement/fix?

When a speaker registers, we restore the output connections (AirPlay, Sendspin, ...) we saved for it earlier. That restore path added the entries straight into the player's internal list instead of going through the setter, so it was the only add/remove path in the file that skipped the normal "player changed" notification. It relied on the player still being mid-registration, even though the pass a few lines above it already goes through the setter in that exact same window.

Now it collects the restored entries and hands them to the setter in one go, so the code no longer depends on where it is called from.

**Related issue (if applicable):**

- follow-up on #5660

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Restored connections are collected and applied in a single call through the same setter every other add/remove path uses.
- The duplicate check reads the collected entries, so it keeps working unchanged now that they are no longer added one by one.
- Added a test for the restore path.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
