### PR TITLE
Keep Cast playback working when a device release is already on its way

### DIFF
--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -142,15 +142,22 @@ class ChromecastDashboards:
         :param dashboard: Dashboard to show.
         :param player_id: Player to show, when dashboard is NOW_PLAYING.
         """
+        force_launch = False
         castplayer = self.mass.players.get_player(device_id)
         if isinstance(castplayer, ChromecastPlayer):
             # an earlier stop on the player may still have a release of the receiver
             # app pending, which would close the dashboard we are about to show
             castplayer.cancel_pending_app_quit()
+            # a release that is already on the wire will close the app anyway, so the
+            # receiver's 'already running' short-circuit has to be bypassed
+            force_launch = castplayer.app_quit_sent
         url = await self.mass.dashboard.resolve_dashboard_url(dashboard, player_id)
         chromecast = await self._get_or_create_chromecast(device_id)
         try:
-            await self.mass.loop.run_in_executor(None, send_show_dashboard, chromecast, url)
+            await self.mass.loop.run_in_executor(
+                None,
+                functools.partial(send_show_dashboard, chromecast, url, force_launch=force_launch),
+            )
         except TimeoutError as err:
             # the helper's message already carries device name + failure reason
             raise PlayerUnavailableError(

--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -142,9 +142,10 @@ class ChromecastDashboards:
         :param dashboard: Dashboard to show.
         :param player_id: Player to show, when dashboard is NOW_PLAYING.
         """
+        player = self.mass.players.get_player(device_id)
+        castplayer = player if isinstance(player, ChromecastPlayer) else None
         force_launch = False
-        castplayer = self.mass.players.get_player(device_id)
-        if isinstance(castplayer, ChromecastPlayer):
+        if castplayer is not None:
             # an earlier stop on the player may still have a release of the receiver
             # app pending, which would close the dashboard we are about to show
             castplayer.cancel_pending_app_quit()
@@ -166,6 +167,10 @@ class ChromecastDashboards:
                 translation_owner=self.provider.translation_owner,
                 translation_args=[chromecast.name],
             ) from err
+
+        if castplayer is not None:
+            # this launch established a session the player can trust again
+            castplayer.app_quit_sent = False
 
         self._drop_active_cast(device_id)
         session_id = chromecast.status.session_id if chromecast.status else None

--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -168,8 +168,8 @@ class ChromecastDashboards:
                 translation_args=[chromecast.name],
             ) from err
 
-        if castplayer is not None:
-            # this launch established a session the player can trust again
+        if force_launch and castplayer is not None:
+            # this launch replaced the session the recorded release was closing
             castplayer.app_quit_sent = False
 
         self._drop_active_cast(device_id)

--- a/music_assistant/providers/chromecast/helpers.py
+++ b/music_assistant/providers/chromecast/helpers.py
@@ -38,6 +38,7 @@ def send_show_dashboard(
     chromecast: Chromecast,
     url: str,
     timeout: float = 30.0,
+    force_launch: bool = False,
 ) -> None:
     """
     Launch the MA cast receiver app and send it a show_dashboard message.
@@ -47,6 +48,8 @@ def send_show_dashboard(
     :param chromecast: Connected Chromecast to show the dashboard on.
     :param url: Fully-qualified dashboard URL for the receiver to load.
     :param timeout: Seconds to wait for the app launch and the dashboard namespace.
+    :param force_launch: Start a new session even when the receiver already reports
+        the app as running.
     :raises TimeoutError: If the receiver app did not launch (in time), or the
         dashboard namespace never became available.
     """
@@ -60,7 +63,7 @@ def send_show_dashboard(
 
     deadline = time.monotonic() + timeout
     chromecast.socket_client.receiver_controller.launch_app(
-        MASS_APP_ID, callback_function=_on_launched
+        MASS_APP_ID, force_launch=force_launch, callback_function=_on_launched
     )
     if not launched.wait(timeout):
         msg = f"Timed out launching app on {chromecast.name}"

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -163,7 +163,7 @@ class ChromecastPlayer(Player):
             return
         if self.cc.app_id not in (MASS_APP_ID, APP_MEDIA_RECEIVER):
             # another app is casting to the device, release it right away
-            await asyncio.to_thread(self.cc.quit_app)
+            await self._quit_app()
             return
         if self.cc.media_controller.status.media_session_id is not None:
             # a stop is refused by the cast library when nothing was ever loaded
@@ -204,7 +204,7 @@ class ChromecastPlayer(Player):
             self._attr_active_source = None
         else:
             self._attr_active_source = None
-            await asyncio.to_thread(self.cc.quit_app)
+            await self._quit_app()
         # optimistically update the state
         self.update_state()
 
@@ -546,6 +546,12 @@ class ChromecastPlayer(Player):
         if (status.player_is_playing or status.player_is_paused) and not ran_dry:
             # something is loaded again, e.g. the keepalive media of a dashboard
             return
+        await self._quit_app()
+
+    async def _quit_app(self) -> None:
+        """Release the Cast device, so a follow-up launch is not skipped as unnecessary."""
+        # a receiver reports our app as running until it answers the quit, and an
+        # unanswered one leaves it reported for the full request timeout
         self.app_quit_sent = True
         await asyncio.to_thread(self.cc.quit_app)
 

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -60,6 +60,9 @@ class ChromecastPlayer(Player):
     """Chromecast Player."""
 
     active_cast_group: str | None = None
+    # a quit that is already on the wire cannot be recalled, so a receiver that
+    # still reports our app is no longer proof that the session is usable
+    app_quit_sent: bool = False
 
     def __init__(
         self,
@@ -170,6 +173,9 @@ class ChromecastPlayer(Player):
     def cancel_pending_app_quit(self) -> None:
         """Cancel a pending release of the receiver app, to keep the device claimed."""
         self.mass.cancel_timer(self._app_quit_task_id)
+        # a quit that already fired runs as a task under the same id,
+        # which only cancel_task reaches
+        self.mass.cancel_task(self._app_quit_task_id)
 
     async def play(self) -> None:
         """Send PLAY command to given player."""
@@ -278,10 +284,7 @@ class ChromecastPlayer(Player):
     async def on_unload(self) -> None:
         """Handle logic when the player is unloaded from the Player controller."""
         await super().on_unload()
-        # a quit that already fired runs as a task under the same id,
-        # which only cancel_task reaches
         self.cancel_pending_app_quit()
-        self.mass.cancel_task(self._app_quit_task_id)
         self.mz_controller = None
         if self.status_listener is not None:
             self.status_listener.invalidate()
@@ -435,8 +438,10 @@ class ChromecastPlayer(Player):
             app_id = APP_MEDIA_RECEIVER
 
         # compare against the configured app, not any compatible one: otherwise the
-        # use_mass_app setting is ignored for as long as the other app is running
-        if self.cc.app_id == app_id:
+        # use_mass_app setting is ignored for as long as the other app is running.
+        # a sent quit clears the reported app id only once the receiver answers, so
+        # skipping the launch then would load into a session that is being torn down
+        if self.cc.app_id == app_id and not self.app_quit_sent:
             return  # the configured receiver app is already active
 
         event = asyncio.Event()
@@ -493,6 +498,8 @@ class ChromecastPlayer(Player):
                 translation_args=[self.display_name],
             )
 
+        self.app_quit_sent = False
+
     def _log_launch_failure(self, app_id: str, reason: str) -> None:
         """
         Log a failed receiver app launch and which config option to try instead.
@@ -539,6 +546,7 @@ class ChromecastPlayer(Player):
         if (status.player_is_playing or status.player_is_paused) and not ran_dry:
             # something is loaded again, e.g. the keepalive media of a dashboard
             return
+        self.app_quit_sent = True
         await asyncio.to_thread(self.cc.quit_app)
 
     def _handle_cast_status(self, status: CastStatus) -> None:

--- a/tests/providers/chromecast/test_dashboard_commands.py
+++ b/tests/providers/chromecast/test_dashboard_commands.py
@@ -188,6 +188,8 @@ async def test_on_show_forces_a_launch_when_a_release_is_on_the_wire(
     mock_send_show_dashboard.assert_called_once_with(
         connected_chromecast, url, force_launch=app_quit_sent
     )
+    # the dashboard just established a session, so the player can trust it again
+    assert castplayer.app_quit_sent is False
 
 
 async def test_on_show_reuses_cached_on_demand_connection() -> None:

--- a/tests/providers/chromecast/test_dashboard_commands.py
+++ b/tests/providers/chromecast/test_dashboard_commands.py
@@ -192,6 +192,30 @@ async def test_on_show_forces_a_launch_when_a_release_is_on_the_wire(
     assert castplayer.app_quit_sent is False
 
 
+async def test_on_show_leaves_a_release_sent_while_it_was_launching() -> None:
+    """Only the release this launch replaced is resolved, not one that arrived meanwhile."""
+    dashboards = _make_dashboards()
+    device_uuid = uuid4()
+    connected_chromecast = MagicMock()
+    connected_chromecast.socket_client.is_connected = True
+    castplayer = MagicMock(spec=ChromecastPlayer)
+    castplayer.cc = connected_chromecast
+    castplayer.app_quit_sent = False
+    dashboards.mass.players.get_player.return_value = castplayer  # type: ignore[attr-defined]
+    dashboards.mass.dashboard.resolve_dashboard_url = AsyncMock(return_value="https://mass.test")  # type: ignore[method-assign]
+
+    def _release_the_device(*_args: object, **_kwargs: object) -> None:
+        castplayer.app_quit_sent = True
+
+    with patch(
+        "music_assistant.providers.chromecast.dashboard.send_show_dashboard",
+        side_effect=_release_the_device,
+    ):
+        await dashboards._on_show(str(device_uuid), DashboardType.PARTY, None)
+
+    assert castplayer.app_quit_sent is True
+
+
 async def test_on_show_reuses_cached_on_demand_connection() -> None:
     """A cached on-demand connection (no MA player) is reused instead of reconnecting."""
     dashboards = _make_dashboards()

--- a/tests/providers/chromecast/test_dashboard_commands.py
+++ b/tests/providers/chromecast/test_dashboard_commands.py
@@ -133,6 +133,7 @@ async def test_on_show_reuses_connected_player_cc() -> None:
     connected_chromecast.socket_client.is_connected = True
     castplayer = MagicMock(spec=ChromecastPlayer)
     castplayer.cc = connected_chromecast
+    castplayer.app_quit_sent = False
     dashboards.mass.players.get_player.return_value = castplayer  # type: ignore[attr-defined]
     url = "https://mass.example.com?path=%2Fparty"
     dashboards.mass.dashboard.resolve_dashboard_url = AsyncMock(return_value=url)  # type: ignore[method-assign]
@@ -142,7 +143,7 @@ async def test_on_show_reuses_connected_player_cc() -> None:
     ) as mock_send_show_dashboard:
         await dashboards._on_show(str(device_uuid), DashboardType.PARTY, None)
 
-    mock_send_show_dashboard.assert_called_once_with(connected_chromecast, url)
+    mock_send_show_dashboard.assert_called_once_with(connected_chromecast, url, force_launch=False)
 
 
 async def test_on_show_keeps_the_player_from_releasing_the_device() -> None:
@@ -153,6 +154,7 @@ async def test_on_show_keeps_the_player_from_releasing_the_device() -> None:
     connected_chromecast.socket_client.is_connected = True
     castplayer = MagicMock(spec=ChromecastPlayer)
     castplayer.cc = connected_chromecast
+    castplayer.app_quit_sent = False
     dashboards.mass.players.get_player.return_value = castplayer  # type: ignore[attr-defined]
     dashboards.mass.dashboard.resolve_dashboard_url = AsyncMock(return_value="https://mass.test")  # type: ignore[method-assign]
 
@@ -160,6 +162,32 @@ async def test_on_show_keeps_the_player_from_releasing_the_device() -> None:
         await dashboards._on_show(str(device_uuid), DashboardType.PARTY, None)
 
     castplayer.cancel_pending_app_quit.assert_called_once()
+
+
+@pytest.mark.parametrize("app_quit_sent", [True, False])
+async def test_on_show_forces_a_launch_when_a_release_is_on_the_wire(
+    app_quit_sent: bool,
+) -> None:
+    """A release that can no longer be cancelled closes the app, so a new session is needed."""
+    dashboards = _make_dashboards()
+    device_uuid = uuid4()
+    connected_chromecast = MagicMock()
+    connected_chromecast.socket_client.is_connected = True
+    castplayer = MagicMock(spec=ChromecastPlayer)
+    castplayer.cc = connected_chromecast
+    castplayer.app_quit_sent = app_quit_sent
+    dashboards.mass.players.get_player.return_value = castplayer  # type: ignore[attr-defined]
+    url = "https://mass.example.com?path=%2Fparty"
+    dashboards.mass.dashboard.resolve_dashboard_url = AsyncMock(return_value=url)  # type: ignore[method-assign]
+
+    with patch(
+        "music_assistant.providers.chromecast.dashboard.send_show_dashboard"
+    ) as mock_send_show_dashboard:
+        await dashboards._on_show(str(device_uuid), DashboardType.PARTY, None)
+
+    mock_send_show_dashboard.assert_called_once_with(
+        connected_chromecast, url, force_launch=app_quit_sent
+    )
 
 
 async def test_on_show_reuses_cached_on_demand_connection() -> None:
@@ -177,7 +205,7 @@ async def test_on_show_reuses_cached_on_demand_connection() -> None:
     ) as mock_send_show_dashboard:
         await dashboards._on_show(str(device_uuid), DashboardType.PARTY, None)
 
-    mock_send_show_dashboard.assert_called_once_with(connected_chromecast, url)
+    mock_send_show_dashboard.assert_called_once_with(connected_chromecast, url, force_launch=False)
 
 
 async def test_on_show_raises_for_unknown_device() -> None:

--- a/tests/providers/chromecast/test_helpers_dashboard.py
+++ b/tests/providers/chromecast/test_helpers_dashboard.py
@@ -32,6 +32,28 @@ def test_send_show_dashboard_happy_path() -> None:
         DASHBOARD_NAMESPACE,
         {"type": "show_dashboard", "url": "https://mass.example.com?path=%2Fparty"},
     )
+    # a running session is reused by default, so the device does not chime again
+    launch_app = chromecast.socket_client.receiver_controller.launch_app
+    assert launch_app.call_args.kwargs["force_launch"] is False
+
+
+def test_send_show_dashboard_forwards_force_launch() -> None:
+    """A forced launch starts a new session even when the receiver reports the app running."""
+    chromecast = MagicMock()
+    chromecast.name = "Living Room TV"
+    chromecast.socket_client.app_namespaces = {DASHBOARD_NAMESPACE}
+
+    def _launch_app(
+        _app_id: str, *, callback_function: Callable[[bool, Any], None], **_kwargs: Any
+    ) -> None:
+        callback_function(True, None)
+
+    chromecast.socket_client.receiver_controller.launch_app.side_effect = _launch_app
+
+    send_show_dashboard(chromecast, "https://mass.example.com?path=%2Fparty", force_launch=True)
+
+    launch_app = chromecast.socket_client.receiver_controller.launch_app
+    assert launch_app.call_args.kwargs["force_launch"] is True
 
 
 def test_send_show_dashboard_launch_failure_raises() -> None:

--- a/tests/providers/chromecast/test_launch_app.py
+++ b/tests/providers/chromecast/test_launch_app.py
@@ -7,6 +7,9 @@ to an app that was not running. Playback never started and nothing was logged.
 
 A failed launch must be reported, and the configured receiver app must not be swapped
 for the other one.
+
+A launch is also needed when the receiver still reports our app while a release of it
+is already on the wire, since the LOAD would otherwise land in a dying session.
 """
 
 from __future__ import annotations
@@ -34,6 +37,7 @@ def _fake_cast(
     launch_results: dict[str, bool | None],
     refusal_reason: str | None = None,
     app_id_after_launch: str | None = "same",
+    app_quit_sent: bool = False,
 ) -> MagicMock:
     """
     Build a MagicMock Cast whose receiver answers launches per app id.
@@ -45,6 +49,7 @@ def _fake_cast(
     :param refusal_reason: LAUNCH_ERROR reason reported by the receiver.
     :param app_id_after_launch: App the receiver reports running after accepting a
         launch. "same" means the app that was asked for.
+    :param app_quit_sent: Whether a release of the receiver app is already on the wire.
     """
     fake = MagicMock()
     # the launch runs in an executor and is acknowledged from that thread, so the real
@@ -52,6 +57,7 @@ def _fake_cast(
     fake.mass.loop = asyncio.get_running_loop()
     fake.display_name = "Fake Cast"
     fake.cc.app_id = running_app_id
+    fake.app_quit_sent = app_quit_sent
     fake.config.get_value = MagicMock(return_value=use_mass_app)
     fake.launch_attempts = []
     fake.cc.socket_client.receiver_controller.launch_failure.reason = refusal_reason
@@ -137,6 +143,58 @@ async def test_configured_app_already_running_is_left_alone() -> None:
     await _launch_app(fake)
 
     assert fake.launch_attempts == []
+
+
+async def test_app_that_is_being_quit_is_relaunched() -> None:
+    """A receiver still reporting our app is no proof of a usable session after a quit."""
+    fake = _fake_cast(
+        running_app_id=MASS_APP_ID,
+        launch_results={MASS_APP_ID: True},
+        app_quit_sent=True,
+    )
+
+    await _launch_app(fake)
+
+    assert fake.launch_attempts == [MASS_APP_ID]
+
+
+async def test_confirmed_launch_clears_the_pending_quit() -> None:
+    """The new session is not the one that was quit, so it is usable again."""
+    fake = _fake_cast(
+        running_app_id=MASS_APP_ID,
+        launch_results={MASS_APP_ID: True},
+        app_quit_sent=True,
+    )
+
+    await _launch_app(fake)
+
+    assert fake.app_quit_sent is False
+
+
+@pytest.mark.parametrize(
+    ("launch_results", "app_id_after_launch"),
+    [
+        ({MASS_APP_ID: False}, "same"),
+        ({MASS_APP_ID: None}, "same"),
+        ({MASS_APP_ID: True}, None),
+    ],
+    ids=["refused", "unanswered", "not_started"],
+)
+async def test_failed_launch_keeps_the_pending_quit(
+    launch_results: dict[str, bool | None], app_id_after_launch: str | None
+) -> None:
+    """No new session came up, so the one that was quit is still the doomed one."""
+    fake = _fake_cast(
+        running_app_id=MASS_APP_ID,
+        launch_results=launch_results,
+        app_id_after_launch=app_id_after_launch,
+        app_quit_sent=True,
+    )
+
+    with pytest.raises(PlayerUnavailableError):
+        await _launch_app(fake)
+
+    assert fake.app_quit_sent is True
 
 
 async def test_other_receiver_app_is_replaced_by_the_configured_one() -> None:

--- a/tests/providers/chromecast/test_stop.py
+++ b/tests/providers/chromecast/test_stop.py
@@ -52,6 +52,7 @@ def _fake_cast(
     fake.type = player_type
     fake.available = True
     fake.cc.app_id = running_app_id
+    fake.app_quit_sent = False
     fake._app_quit_task_id = "cast_quit_app_test"
     fake.cancel_pending_app_quit = partial(
         ChromecastPlayer.cancel_pending_app_quit, cast("ChromecastPlayer", fake)
@@ -128,7 +129,10 @@ async def test_launching_an_app_cancels_a_pending_release() -> None:
 
     await ChromecastPlayer._launch_app(cast("ChromecastPlayer", fake))
 
+    # a timer that already fired is re-created as a task under the same id, so both
+    # have to be cancelled to reliably catch the release
     fake.mass.cancel_timer.assert_called_once_with(fake._app_quit_task_id)
+    fake.mass.cancel_task.assert_called_once_with(fake._app_quit_task_id)
 
 
 @pytest.mark.parametrize("app_id", [MASS_APP_ID, APP_MEDIA_RECEIVER])
@@ -178,3 +182,34 @@ async def test_a_device_that_ran_dry_at_the_end_of_the_flow_stream_is_quit() -> 
     await _quit_app_when_unused(fake)
 
     fake.cc.quit_app.assert_called_once()
+
+
+async def test_a_sent_quit_is_recorded() -> None:
+    """A quit that is on the wire cannot be recalled, so the player has to remember it."""
+    fake = _fake_cast(player_state="IDLE")
+
+    await _quit_app_when_unused(fake)
+
+    assert fake.app_quit_sent is True
+
+
+@pytest.mark.parametrize(
+    ("available", "running_app_id", "player_state"),
+    [
+        (False, MASS_APP_ID, "IDLE"),
+        (True, SENDSPIN_CAST_APP_ID, "IDLE"),
+        (True, MASS_APP_ID, "PLAYING"),
+        (True, MASS_APP_ID, "PAUSED"),
+    ],
+    ids=["unavailable", "foreign_app", "playing", "paused"],
+)
+async def test_a_skipped_quit_is_not_recorded(
+    available: bool, running_app_id: str, player_state: str
+) -> None:
+    """Nothing was sent, so the Cast session is still fine to load into."""
+    fake = _fake_cast(running_app_id=running_app_id, player_state=player_state)
+    fake.available = available
+
+    await _quit_app_when_unused(fake)
+
+    assert fake.app_quit_sent is False

--- a/tests/providers/chromecast/test_stop.py
+++ b/tests/providers/chromecast/test_stop.py
@@ -60,6 +60,7 @@ def _fake_cast(
     fake._schedule_app_release = partial(
         ChromecastPlayer._schedule_app_release, cast("ChromecastPlayer", fake)
     )
+    fake._quit_app = partial(ChromecastPlayer._quit_app, cast("ChromecastPlayer", fake))
     status = fake.cc.media_controller.status
     status.player_state = player_state
     status.player_is_playing = player_state in ("PLAYING", "BUFFERING")
@@ -99,6 +100,7 @@ async def test_stop_ends_a_foreign_cast_session_right_away(app_id: str | None) -
 
     fake.cc.quit_app.assert_called_once()
     fake.mass.call_later.assert_not_called()
+    assert fake.app_quit_sent is True
 
 
 async def test_stop_on_a_group_leaves_the_app_alone() -> None:
@@ -213,3 +215,13 @@ async def test_a_skipped_quit_is_not_recorded(
     await _quit_app_when_unused(fake)
 
     assert fake.app_quit_sent is False
+
+
+async def test_powering_off_a_group_records_the_release() -> None:
+    """A receiver that never answers the quit keeps reporting the app for the full timeout."""
+    fake = _fake_cast(player_type=PlayerType.GROUP)
+
+    await ChromecastPlayer.power(cast("ChromecastPlayer", fake), False)
+
+    fake.cc.quit_app.assert_called_once()
+    assert fake.app_quit_sent is True


### PR DESCRIPTION
# What does this implement/fix?

A Cast device is released a short while after playback ends, freeing it up for
other apps. Once that release has actually been sent to the device it can no
longer be recalled — but the device keeps reporting the Music Assistant app as
running until it answers back. A playback request arriving in that gap saw the
app as already running, skipped the launch, and sent the track into a session
that was about to be closed. Playback then silently never started.

The same gap could also drop a dashboard that was being shown on a Cast display.

The player now remembers that a release went out and starts a fresh session
instead of trusting the reported state.

- A new track starting right as the device is being released now plays
- Showing a dashboard in that same moment no longer lands on a closing session
- Cancelling a pending release now also reaches one that has just gone off

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
