### PR TITLE
Fix AirPlay speaker joining a group at full volume

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -2511,18 +2511,11 @@ class ProtocolLinkingMixin:
             else []
         )
 
-        self.logger.debug(
-            "Calling set_members on protocol player %s with add=%s, remove=%s",
-            parent_protocol_player.state.name,
-            filtered_protocol_add,
-            filtered_protocol_remove,
-        )
-        await parent_protocol_player.set_members(
-            player_ids_to_add=filtered_protocol_add or None,
-            player_ids_to_remove=filtered_protocol_remove or None,
-        )
-
-        # Set active output protocol on added child players
+        # Set active output protocol on added child players. This runs before set_members
+        # because a member's own stream starts inside that call and the provider resolves the
+        # member's volume control as it starts: unless its parent already points at this
+        # protocol, that resolution picks a sibling interface of the same device (e.g. its
+        # cast side) over the one carrying the audio.
         if filtered_protocol_add:
             for child_protocol_id in filtered_protocol_add:
                 if child_protocol := self.get_player(child_protocol_id):
@@ -2535,6 +2528,17 @@ class ProtocolLinkingMixin:
                                     child_protocol_id,
                                 )
                                 child_player.set_active_output_protocol(child_protocol_id)
+
+        self.logger.debug(
+            "Calling set_members on protocol player %s with add=%s, remove=%s",
+            parent_protocol_player.state.name,
+            filtered_protocol_add,
+            filtered_protocol_remove,
+        )
+        await parent_protocol_player.set_members(
+            player_ids_to_add=filtered_protocol_add or None,
+            player_ids_to_remove=filtered_protocol_remove or None,
+        )
 
         # If we added members via this protocol, set it as the active output protocol
         # and restart playback if currently playing AND we're switching protocols

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -3090,6 +3090,109 @@ class TestProtocolSwitchingDuringPlayback:
             controller.cmd_resume.assert_not_awaited()
         controller._handle_set_members.assert_not_awaited()
 
+    async def test_joining_member_protocol_is_active_before_its_stream_starts(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A joining member's parent knows which protocol carries its audio before its stream starts.
+
+        The member's stream is started from inside set_members, and providers resolve the
+        member's volume control while starting it. A device that also exposes a higher
+        priority sibling interface (e.g. a soundbar that is both Chromecast and AirPlay)
+        would otherwise resolve volume to that sibling and apply its volume semantics to
+        a stream it does not attenuate.
+        """
+        controller = PlayerController(mock_mass)
+
+        airplay_provider = MockProvider("airplay", instance_id="airplay", mass=mock_mass)
+        cast_provider = MockProvider("chromecast", instance_id="chromecast", mass=mock_mass)
+
+        leader = MockPlayer(airplay_provider, "leader", "Kitchen")
+        leader_airplay = MockPlayer(
+            airplay_provider,
+            "leader_airplay",
+            "Kitchen (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        leader_airplay._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader_airplay.set_protocol_parent_id("leader")
+
+        # the joining device exposes both a Chromecast and an AirPlay interface, and has no
+        # native volume of its own, so its volume control is one of the two protocol players
+        joiner = MockPlayer(cast_provider, "joiner", "Living Room")
+        joiner._attr_supported_features = set()
+        joiner_cast = MockPlayer(
+            cast_provider,
+            "joiner_cast",
+            "Living Room (Cast)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        joiner_cast.set_protocol_parent_id("joiner")
+        joiner_airplay = MockPlayer(
+            airplay_provider,
+            "joiner_airplay",
+            "Living Room (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        joiner_airplay._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        joiner_airplay.set_protocol_parent_id("joiner")
+
+        leader.set_linked_output_protocols(
+            [
+                LinkedOutputProtocol(
+                    output_protocol_id="leader_airplay",
+                    protocol_domain="airplay",
+                    priority=10,
+                )
+            ]
+        )
+        joiner.set_linked_output_protocols(
+            [
+                LinkedOutputProtocol(
+                    output_protocol_id="joiner_cast",
+                    protocol_domain="chromecast",
+                    priority=10,
+                ),
+                LinkedOutputProtocol(
+                    output_protocol_id="joiner_airplay",
+                    protocol_domain="airplay",
+                    priority=20,
+                ),
+            ]
+        )
+
+        mock_mass.players = controller
+        controller._players = {
+            player.player_id: player
+            for player in (leader, leader_airplay, joiner, joiner_cast, joiner_airplay)
+        }
+        for player in controller._players.values():
+            player.update_state(signal_event=False)
+
+        # While the device sits idle its Chromecast interface owns the volume: the winner is
+        # decided by the hardcoded per-domain control priority, not by the link priorities.
+        assert joiner.volume_control == "joiner_cast"
+
+        observed_volume_controls: list[str] = []
+
+        async def record_set_members(
+            player_ids_to_add: list[str] | None = None,  # noqa: ARG001
+            player_ids_to_remove: list[str] | None = None,  # noqa: ARG001
+        ) -> None:
+            observed_volume_controls.append(joiner.volume_control)
+
+        leader_airplay.set_members = record_set_members  # type: ignore[method-assign]
+        controller._handle_set_members = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._forward_protocol_set_members(
+            parent_player=leader,
+            parent_protocol_player=leader_airplay,
+            protocol_members_to_add=["joiner_airplay"],
+            protocol_members_to_remove=[],
+        )
+
+        assert observed_volume_controls == ["joiner_airplay"]
+
 
 class TestNativeProtocolPlayerGrouping:
     """Tests for grouping with native protocol players (e.g., native AirPlay like Apple TV)."""


### PR DESCRIPTION
# What does this implement/fix?

Adding an AirPlay speaker to a group that was already playing could make it start at full volume. Reported for a speaker joining late, and confirmed in a user log: the joining speaker was driven to 100% (0.00 dB) while the speaker already playing correctly stayed at its own level.

It happens on devices that expose more than one interface — a soundbar that is both Chromecast and AirPlay, for example. The joining speaker's stream was started before its player knew that AirPlay was carrying the audio, so its volume was resolved against the other interface of the same device instead. That interface doesn't attenuate the AirPlay stream, so the speaker played at full output.

Speakers that start playback normally were never affected, because there the output is picked before playback starts.

- Tell a joining member which protocol carries its audio before its stream is started, so its volume is resolved against the interface actually playing
- Add a regression test covering a joining member whose device also has a Chromecast interface

**Related issue (if applicable):**

- n/a (reported by beta testers, with log)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
