### PR TITLE
AI Radio hosts no longer sound quieter than the music

### DIFF
--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -10,6 +10,7 @@ import urllib.parse
 from collections.abc import AsyncGenerator, Iterable, Iterator
 from contextlib import aclosing
 from io import BytesIO
+from math import isfinite
 from typing import TYPE_CHECKING, Final
 
 from music_assistant_models.enums import (
@@ -790,19 +791,23 @@ def parse_loudnorm(raw_stderr: bytes | str) -> float | None:
     """Parse Loudness measurement from ffmpeg stderr output."""
     stderr_data = raw_stderr.decode() if isinstance(raw_stderr, bytes) else raw_stderr
     # the report is the last thing the filter logs, and ffmpeg prints it as a block of its
-    # own below the marker line, so the object is delimited rather than on a known line
-    marker = stderr_data.rfind("[Parsed_loudnorm_0 @")
+    # own below the marker line, so the object is delimited rather than on a known line.
+    # the marker carries the filter's position in the chain, which is only zero when
+    # loudnorm runs on its own
+    marker = stderr_data.rfind("[Parsed_loudnorm_")
     if marker < 0:
         return None
     start = stderr_data.find("{", marker)
-    end = stderr_data.find("}", start)
-    if start < 0 or end < 0:
+    if start < 0 or (end := stderr_data.find("}", start)) < 0:
         return None
     try:
         loudness_data = json_loads(stderr_data[start : end + 1])
-        return float(loudness_data["input_i"])
+        measurement = float(loudness_data["input_i"])
     except (*JSON_DECODE_EXCEPTIONS, KeyError, ValueError):
         return None
+    # digital silence reads as -inf, which is a report that the clip has no level rather
+    # than a level to correct against
+    return measurement if isfinite(measurement) else None
 
 
 def get_normalization_mode(

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -789,16 +789,20 @@ def is_grouping_preventing_dsp(player: Player) -> bool:
 def parse_loudnorm(raw_stderr: bytes | str) -> float | None:
     """Parse Loudness measurement from ffmpeg stderr output."""
     stderr_data = raw_stderr.decode() if isinstance(raw_stderr, bytes) else raw_stderr
-    if "[Parsed_loudnorm_0 @" not in stderr_data:
+    # the report is the last thing the filter logs, and ffmpeg prints it as a block of its
+    # own below the marker line, so the object is delimited rather than on a known line
+    marker = stderr_data.rfind("[Parsed_loudnorm_0 @")
+    if marker < 0:
         return None
-    for jsun_chunk in stderr_data.split(" { "):
-        try:
-            stderr_data = "{" + jsun_chunk.rsplit("}")[0].strip() + "}"
-            loudness_data = json_loads(stderr_data)
-            return float(loudness_data["input_i"])
-        except (*JSON_DECODE_EXCEPTIONS, KeyError, ValueError, IndexError):
-            continue
-    return None
+    start = stderr_data.find("{", marker)
+    end = stderr_data.find("}", start)
+    if start < 0 or end < 0:
+        return None
+    try:
+        loudness_data = json_loads(stderr_data[start : end + 1])
+        return float(loudness_data["input_i"])
+    except (*JSON_DECODE_EXCEPTIONS, KeyError, ValueError):
+        return None
 
 
 def get_normalization_mode(

--- a/music_assistant/providers/ai_radio/config.py
+++ b/music_assistant/providers/ai_radio/config.py
@@ -14,10 +14,12 @@ from music_assistant.helpers.datetime import host_timezone_name
 
 from .constants import (
     CONF_TIMEZONE,
+    CONF_TTS_LOUDNESS_BOOST,
     CONF_WEATHER_CITY,
     CONF_WEATHER_COUNTRY,
     CONF_WEATHER_PROVIDER,
     CONF_WEATHER_TIMEOUT,
+    DEFAULT_TTS_LOUDNESS_BOOST,
     DEFAULT_WEATHER_PROVIDER,
     DEFAULT_WEATHER_TIMEOUT_SECONDS,
 )
@@ -57,6 +59,13 @@ async def get_config_entries(
             key=CONF_WEATHER_TIMEOUT,
             type=ConfigEntryType.INTEGER,
             default_value=DEFAULT_WEATHER_TIMEOUT_SECONDS,
+            advanced=True,
+        ),
+        ConfigEntry(
+            key=CONF_TTS_LOUDNESS_BOOST,
+            type=ConfigEntryType.INTEGER,
+            default_value=DEFAULT_TTS_LOUDNESS_BOOST,
+            range=(0, 6),
             advanced=True,
         ),
     )

--- a/music_assistant/providers/ai_radio/constants.py
+++ b/music_assistant/providers/ai_radio/constants.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
+
 CONF_AI_ENGINE = "ai_engine"
 CONF_TTS_ENGINE = "tts_engine"
+CONF_TTS_LOUDNESS_BOOST = "tts_loudness_boost"
 CONF_TIMEZONE = "timezone"
 CONF_WEATHER_CITY = "weather_city"
 CONF_WEATHER_COUNTRY = "weather_country"
@@ -43,7 +47,11 @@ TTS_PRONUNCIATION_INSTRUCTIONS = (
     "notation, or both versions. Output only the spoken version. Examples: INXS → In Excess; "
     "Mi-Sex → My Sex; P!nk → Pink; blink-182 → Blink One Eighty-Two. If a name could be "
     "mispronounced by the TTS engine, rewrite it into the clearest natural spoken form "
-    "without explaining the change."
+    "without explaining the change. "
+    "Names and titles often stay in their original language while the voice reads everything "
+    "with the pronunciation rules of the script's language. When a name would be mangled that "
+    "way, respell it phonetically for the script's language so it still sounds like the "
+    "original; leave names that already read correctly untouched."
 )
 MERGE_SECTION_PROMPT = (
     "Merge the drafts below into one coherent radio break. "
@@ -66,6 +74,30 @@ AI_QUERY_TIMEOUT_SECONDS = 180
 
 # ffprobe reports no status code, so its message is all we have to spot a failed render
 TTS_SERVER_ERROR_MARKERS = ("Server returned 5XX", "HTTP error 5")
+
+DEFAULT_TTS_LOUDNESS_BOOST = 3
+
+# speech carries ~16 dB between its average level and its peaks, so the gain that would
+# lift it to the target on paper clips instead: speechnorm evens the clip out first and
+# the limiter, not the gain, is what guarantees the ceiling
+TTS_SPEECHNORM_FILTER = "speechnorm=e=12.5:r=0.0005:l=1"
+TTS_PEAK_CEILING_DB = -3.0
+
+# one measurement stands in for every clip an engine voices, but a fragment of a few
+# words is not representative enough of its level to become that reference
+MIN_LOUDNESS_REFERENCE_SECONDS = 2
+
+# a clip is seconds of audio, so a measurement that takes this long is a wedged fetch
+LOUDNESS_MEASURE_TIMEOUT = 60
+
+# spoken clips are handed to MA already decoded, so the filter chain runs once here
+# instead of once per output
+TTS_CLIP_PCM_FORMAT = AudioFormat(
+    content_type=ContentType.PCM_S16LE,
+    sample_rate=48000,
+    bit_depth=16,
+    channels=2,
+)
 
 SUPPORTED_FEATURES: set[Any] = set()
 EMPTY_SECTION_ID = "EMPTY_SECTION"

--- a/music_assistant/providers/ai_radio/constants.py
+++ b/music_assistant/providers/ai_radio/constants.py
@@ -77,11 +77,11 @@ TTS_SERVER_ERROR_MARKERS = ("Server returned 5XX", "HTTP error 5")
 
 DEFAULT_TTS_LOUDNESS_BOOST = 3
 
-# speech carries ~16 dB between its average level and its peaks, so the gain that would
-# lift it to the target on paper clips instead: speechnorm evens the clip out first and
-# the limiter, not the gain, is what guarantees the ceiling
+# speech carries ~16 dB between its average level and its peaks, so a plain gain that
+# reaches the target clips instead. speechnorm evens the clip out so the level is carried
+# by the whole clip, the trim then places it, and the limiter backstops the peaks
 TTS_SPEECHNORM_FILTER = "speechnorm=e=12.5:r=0.0005:l=1"
-TTS_PEAK_CEILING_DB = -3.0
+TTS_PEAK_CEILING_DB = -1.5
 
 # one measurement stands in for every clip an engine voices, but a fragment of a few
 # words is not representative enough of its level to become that reference

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.enums import ContentType, StreamType
@@ -17,6 +18,15 @@ from music_assistant_models.errors import (
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
+from music_assistant.constants import (
+    CONF_VALUE_DISABLED,
+    CONF_VALUE_ENABLED,
+    CONF_VOLUME_NORMALIZATION,
+    CONF_VOLUME_NORMALIZATION_TARGET,
+)
+from music_assistant.helpers.audio import parse_loudnorm
+from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
+from music_assistant.helpers.process import check_output
 from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.helpers.tts import (
     query_tts_engine_with_language_fallback,
@@ -32,13 +42,23 @@ from .constants import (
     ATTR_SESSION_ID,
     ATTR_WEB_SEARCH_MODE,
     CLIP_STREAMDETAILS_EXPIRATION,
+    CONF_TTS_LOUDNESS_BOOST,
+    DEFAULT_TTS_LOUDNESS_BOOST,
     DEFERRED_PLACEHOLDERS,
+    LOUDNESS_MEASURE_TIMEOUT,
     MIN_CLIP_MEDIA_LIFETIME,
+    MIN_LOUDNESS_REFERENCE_SECONDS,
+    TTS_CLIP_PCM_FORMAT,
+    TTS_PEAK_CEILING_DB,
     TTS_SERVER_ERROR_MARKERS,
+    TTS_SPEECHNORM_FILTER,
 )
-from .helpers import soft_limit_text
+from .helpers import coerce_int, soft_limit_text
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from music_assistant_models.config_entries import ProviderConfig
     from music_assistant_models.enums import MediaType
     from music_assistant_models.queue_item import QueueItem
 
@@ -56,6 +76,16 @@ class _CachedClipMedia:
     audio_format: AudioFormat
     duration: int | None
     minted_at: float
+    loudness: float | None
+
+
+@dataclass(slots=True)
+class _ClipAudio:
+    """What get_audio_stream needs to serve a levelled clip, carried on StreamDetails.data."""
+
+    path: str
+    input_format: AudioFormat
+    gain_db: float
 
 
 class AIRadioRenderMixin:
@@ -63,12 +93,14 @@ class AIRadioRenderMixin:
 
     if TYPE_CHECKING:
         mass: MusicAssistant
+        config: ProviderConfig
         logger: logging.Logger
         _hosts: dict[str, dict[str, Any]]
         _sessions: dict[str, SessionState]
 
     _render_locks: dict[str, asyncio.Lock]
     _media_cache: dict[str, _CachedClipMedia]
+    _engine_loudness: dict[tuple[str, str, str], float]
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """
@@ -94,7 +126,7 @@ class AIRadioRenderMixin:
                 self.mass.player_queues.signal_update(queue_item.queue_id, items_changed=True)
             media = await self._cached_clip_media(queue_item, text, item_id)
 
-        return StreamDetails(
+        streamdetails = StreamDetails(
             provider=self.instance_id,
             item_id=item_id,
             audio_format=media.audio_format,
@@ -110,6 +142,38 @@ class AIRadioRenderMixin:
             # that url has left or the stream outlives the token behind it
             expiration=self._remaining_media_lifetime(media),
         )
+        gain_db = self._loudness_gain(queue_item.queue_id, media.loudness)
+        if gain_db is not None:
+            # core never normalizes a sound effect, so the clip is levelled here or it
+            # airs noticeably quieter than the music around it
+            streamdetails.stream_type = StreamType.CUSTOM
+            # core mirrors what ffmpeg reports onto this object, so it gets a copy of the
+            # constant rather than a handle on the one every clip shares
+            streamdetails.decoded_audio_format = replace(TTS_CLIP_PCM_FORMAT)
+            streamdetails.data = _ClipAudio(media.path, media.audio_format, gain_db)
+        return streamdetails
+
+    async def get_audio_stream(
+        self, streamdetails: StreamDetails, seek_position: int = 0
+    ) -> AsyncGenerator[bytes]:
+        """
+        Return the levelled audio of a spoken clip as PCM.
+
+        :param streamdetails: The StreamDetails previously returned by get_stream_details.
+        :param seek_position: Ignored, a spoken clip cannot be seeked.
+        """
+        clip = cast("_ClipAudio", streamdetails.data)
+        async for chunk in get_ffmpeg_stream(
+            audio_input=clip.path,
+            input_format=clip.input_format,
+            output_format=TTS_CLIP_PCM_FORMAT,
+            filter_params=[
+                TTS_SPEECHNORM_FILTER,
+                f"volume={round(clip.gain_db, 2)}dB",
+                f"alimiter=limit={TTS_PEAK_CEILING_DB}dB:level=false",
+            ],
+        ):
+            yield chunk
 
     def _lock_for(self, clip_id: str) -> asyncio.Lock:
         """Return the per-clip render lock, creating it on first use."""
@@ -131,10 +195,10 @@ class AIRadioRenderMixin:
             return cached
         # the caller holds the per-clip render lock, so of the several uncoordinated paths
         # that resolve the same clip only the first one mints; the rest hit the cache above
-        path, stream_type, audio_format, duration = await self._mint_clip_media(
+        path, stream_type, audio_format, duration, loudness = await self._mint_clip_media(
             queue_item, text, clip_id
         )
-        media = _CachedClipMedia(path, stream_type, audio_format, duration, now)
+        media = _CachedClipMedia(path, stream_type, audio_format, duration, now, loudness)
         # clips are minted per queue item, so without pruning the cache grows for as long as
         # the server runs. an entry past its window can never be served again anyway
         for expired_id in [
@@ -150,6 +214,25 @@ class AIRadioRenderMixin:
         """Return the seconds the given minted media is still usable for."""
         elapsed = asyncio.get_running_loop().time() - media.minted_at
         return max(MIN_CLIP_MEDIA_LIFETIME, round(CLIP_STREAMDETAILS_EXPIRATION - elapsed))
+
+    def _loudness_gain(self, queue_id: str, loudness: float | None) -> float | None:
+        """Return the dB to lift the clip by, or None when it should air untouched."""
+        if loudness is None:
+            return None
+        normalization = self.mass.config.get_effective_player_queue_config_value(
+            queue_id, CONF_VOLUME_NORMALIZATION, CONF_VALUE_ENABLED
+        )
+        if normalization == CONF_VALUE_DISABLED:
+            # the music is not levelled either, so there is nothing to match
+            return None
+        target = self.mass.streams.get_config_value(
+            CONF_VOLUME_NORMALIZATION_TARGET, return_type=int
+        )
+        boost = coerce_int(
+            self.config.get_value(CONF_TTS_LOUDNESS_BOOST), DEFAULT_TTS_LOUDNESS_BOOST
+        )
+        gain_db = (target + boost) - loudness
+        return gain_db if gain_db > 0 else None
 
     def _tts_language(self, host_language: str | None = None) -> str | None:
         """
@@ -246,7 +329,7 @@ class AIRadioRenderMixin:
 
     async def _mint_clip_media(
         self, queue_item: QueueItem, text: str, clip_id: str
-    ) -> tuple[str, StreamType, AudioFormat, int | None]:
+    ) -> tuple[str, StreamType, AudioFormat, int | None, float | None]:
         """Convert the script to playable audio via the configured TTS engine."""
         host = self._hosts.get(str(queue_item.extra_attributes.get(ATTR_HOST_ID) or "")) or {}
         engine_uid = str(host.get("tts_engine") or "") or None
@@ -258,11 +341,58 @@ class AIRadioRenderMixin:
             )
             # the probe is the first fetch, so a failed render surfaces here and not in playback
             duration = await self._probe_duration(path)
-            return path, stream_type, audio_format, duration
         except Exception as err:
             self.logger.warning("AI Radio clip %s failed TTS: %s", clip_id, err)
             self._record_skip(queue_item, f"TTS failed: {err}")
             raise MediaNotFoundError(f"AI Radio clip {clip_id} failed TTS") from err
+        loudness = await self._reference_loudness(engine_uid, language, options, path, duration)
+        return path, stream_type, audio_format, duration, loudness
+
+    async def _reference_loudness(
+        self,
+        engine_uid: str | None,
+        language: str | None,
+        options: dict[str, Any],
+        path: str,
+        duration: int | None,
+    ) -> float | None:
+        """Return the loudness in LUFS to level this clip against, or None when unknown."""
+        if not hasattr(self, "_engine_loudness"):
+            self._engine_loudness = {}
+        # engine, language and options together decide which voice speaks, and clips from one
+        # voice land within a dB of each other, so measuring one of them is enough
+        key = (engine_uid or "", language or "", json.dumps(options, sort_keys=True, default=str))
+        if (cached := self._engine_loudness.get(key)) is not None:
+            return cached
+        if (loudness := await self._measure_loudness(path)) is None:
+            return None
+        if (duration or 0) >= MIN_LOUDNESS_REFERENCE_SECONDS:
+            self._engine_loudness[key] = loudness
+        return loudness
+
+    async def _measure_loudness(self, path: str) -> float | None:
+        """Return the integrated loudness of the given audio in LUFS, or None when it fails."""
+        try:
+            returncode, output = await check_output(
+                "ffmpeg",
+                "-hide_banner",
+                "-nostats",
+                "-i",
+                path,
+                "-af",
+                "loudnorm=print_format=json",
+                "-f",
+                "null",
+                "-",
+                timeout=LOUDNESS_MEASURE_TIMEOUT,
+            )
+        except (OSError, TimeoutError) as err:
+            self.logger.debug("Could not measure AI Radio clip loudness: %s", err)
+            return None
+        if returncode != 0:
+            self.logger.debug("Could not measure AI Radio clip loudness: ffmpeg failed")
+            return None
+        return parse_loudnorm(output)
 
     async def _render_tts_media(
         self,

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -231,8 +231,9 @@ class AIRadioRenderMixin:
         boost = coerce_int(
             self.config.get_value(CONF_TTS_LOUDNESS_BOOST), DEFAULT_TTS_LOUDNESS_BOOST
         )
-        gain_db = (target + boost) - loudness
-        return gain_db if gain_db > 0 else None
+        # the reference is taken behind speechnorm, which lands close to the target on its
+        # own, so this trim is small and runs in either direction
+        return (target + boost) - loudness
 
     def _tts_language(self, host_language: str | None = None) -> str | None:
         """
@@ -379,8 +380,11 @@ class AIRadioRenderMixin:
                 "-nostats",
                 "-i",
                 path,
+                # measure behind speechnorm: it is what the gain is applied on top of, and it
+                # levels the clip itself, so the reading has to come from its output or the
+                # gain corrects for a level that no longer reaches it
                 "-af",
-                "loudnorm=print_format=json",
+                f"{TTS_SPEECHNORM_FILTER},loudnorm=print_format=json",
                 "-f",
                 "null",
                 "-",

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -9,7 +9,7 @@ import logging
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, cast
 
-from music_assistant_models.enums import ContentType, StreamType
+from music_assistant_models.enums import ContentType, StreamType, VolumeNormalizationMode
 from music_assistant_models.errors import (
     InvalidDataError,
     MediaNotFoundError,
@@ -23,6 +23,7 @@ from music_assistant.constants import (
     CONF_VALUE_ENABLED,
     CONF_VOLUME_NORMALIZATION,
     CONF_VOLUME_NORMALIZATION_TARGET,
+    CONF_VOLUME_NORMALIZATION_TRACKS,
 )
 from music_assistant.helpers.audio import parse_loudnorm
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
@@ -215,15 +216,17 @@ class AIRadioRenderMixin:
         elapsed = asyncio.get_running_loop().time() - media.minted_at
         return max(MIN_CLIP_MEDIA_LIFETIME, round(CLIP_STREAMDETAILS_EXPIRATION - elapsed))
 
-    def _loudness_gain(self, queue_id: str, loudness: float | None) -> float | None:
-        """Return the dB to lift the clip by, or None when it should air untouched."""
-        if loudness is None:
-            return None
+    def _wanted_loudness(self, queue_id: str) -> float | None:
+        """Return the level in LUFS a clip should air at, or None when it should air as is."""
         normalization = self.mass.config.get_effective_player_queue_config_value(
             queue_id, CONF_VOLUME_NORMALIZATION, CONF_VALUE_ENABLED
         )
         if normalization == CONF_VALUE_DISABLED:
-            # the music is not levelled either, so there is nothing to match
+            return None
+        # the queue switch only says normalization may run; the tracks around the clip are
+        # the ones it has to match, and their own preference can still turn it off
+        tracks_mode = self.mass.streams.get_config_value(CONF_VOLUME_NORMALIZATION_TRACKS)
+        if tracks_mode == VolumeNormalizationMode.DISABLED.value:
             return None
         target = self.mass.streams.get_config_value(
             CONF_VOLUME_NORMALIZATION_TARGET, return_type=int
@@ -231,9 +234,15 @@ class AIRadioRenderMixin:
         boost = coerce_int(
             self.config.get_value(CONF_TTS_LOUDNESS_BOOST), DEFAULT_TTS_LOUDNESS_BOOST
         )
+        return target + boost
+
+    def _loudness_gain(self, queue_id: str, loudness: float | None) -> float | None:
+        """Return the dB to lift the clip by, or None when it should air untouched."""
+        if loudness is None or (wanted := self._wanted_loudness(queue_id)) is None:
+            return None
         # the reference is taken behind speechnorm, which lands close to the target on its
         # own, so this trim is small and runs in either direction
-        return (target + boost) - loudness
+        return wanted - loudness
 
     def _tts_language(self, host_language: str | None = None) -> str | None:
         """
@@ -346,7 +355,13 @@ class AIRadioRenderMixin:
             self.logger.warning("AI Radio clip %s failed TTS: %s", clip_id, err)
             self._record_skip(queue_item, f"TTS failed: {err}")
             raise MediaNotFoundError(f"AI Radio clip {clip_id} failed TTS") from err
-        loudness = await self._reference_loudness(engine_uid, language, options, path, duration)
+        # measuring costs a fetch and a decode on the just-in-time render path, so it only
+        # runs where the reading has somewhere to go
+        loudness = (
+            await self._reference_loudness(engine_uid, language, options, path, duration)
+            if self._wanted_loudness(queue_item.queue_id) is not None
+            else None
+        )
         return path, stream_type, audio_format, duration, loudness
 
     async def _reference_loudness(

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -170,7 +170,7 @@ class AIRadioRenderMixin:
             filter_params=[
                 TTS_SPEECHNORM_FILTER,
                 f"volume={round(clip.gain_db, 2)}dB",
-                f"alimiter=limit={TTS_PEAK_CEILING_DB}dB:level=false",
+                f"alimiter=limit={TTS_PEAK_CEILING_DB}dB:level=false:latency=true",
             ],
         ):
             yield chunk

--- a/music_assistant/providers/ai_radio/strings.json
+++ b/music_assistant/providers/ai_radio/strings.json
@@ -23,6 +23,10 @@
     "weather_timeout_seconds": {
       "label": "Weather Request Timeout",
       "description": "How long to wait for the weather provider to respond, in seconds, before giving up."
+    },
+    "tts_loudness_boost": {
+      "label": "Spoken Clip Loudness Boost",
+      "description": "How many decibels above the music the spoken sections should sit. Peaks are always limited so the audio can never clip, which means high values mainly add compression rather than loudness. Set to 0 to keep spoken clips at the same level as the music."
     }
   },
   "setup_flow": {

--- a/music_assistant/providers/ai_radio/strings.json
+++ b/music_assistant/providers/ai_radio/strings.json
@@ -26,7 +26,7 @@
     },
     "tts_loudness_boost": {
       "label": "Spoken Clip Loudness Boost",
-      "description": "How many decibels above the music the spoken sections should sit. Peaks are always limited so the audio can never clip, which means high values mainly add compression rather than loudness. Set to 0 to keep spoken clips at the same level as the music."
+      "description": "How many decibels above the music the spoken sections should sit. Peaks are always limited so the audio can never clip, so the last few decibels arrive mostly as compression rather than loudness. Set to 0 to keep spoken clips at the same level as the music."
     }
   },
   "setup_flow": {

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -844,6 +844,8 @@
   "provider.acoustid_lookup.manifest.description": "Identifies local audio files using AcoustID/Chromaprint fingerprinting and fills in their MusicBrainz recording ID for subsequent metadata enrichment.",
   "provider.ai_radio.config_entries.timezone.description": "IANA timezone (e.g. Europe/Amsterdam) used to resolve the current time for stations.",
   "provider.ai_radio.config_entries.timezone.label": "Timezone",
+  "provider.ai_radio.config_entries.tts_loudness_boost.description": "How many decibels above the music the spoken sections should sit. Peaks are always limited so the audio can never clip, which means high values mainly add compression rather than loudness. Set to 0 to keep spoken clips at the same level as the music.",
+  "provider.ai_radio.config_entries.tts_loudness_boost.label": "Spoken Clip Loudness Boost",
   "provider.ai_radio.config_entries.weather_city.description": "City used to look up the weather forecast for stations that reference it.",
   "provider.ai_radio.config_entries.weather_city.label": "Weather City",
   "provider.ai_radio.config_entries.weather_country.description": "Country used to look up the weather forecast for stations that reference it.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -844,7 +844,7 @@
   "provider.acoustid_lookup.manifest.description": "Identifies local audio files using AcoustID/Chromaprint fingerprinting and fills in their MusicBrainz recording ID for subsequent metadata enrichment.",
   "provider.ai_radio.config_entries.timezone.description": "IANA timezone (e.g. Europe/Amsterdam) used to resolve the current time for stations.",
   "provider.ai_radio.config_entries.timezone.label": "Timezone",
-  "provider.ai_radio.config_entries.tts_loudness_boost.description": "How many decibels above the music the spoken sections should sit. Peaks are always limited so the audio can never clip, which means high values mainly add compression rather than loudness. Set to 0 to keep spoken clips at the same level as the music.",
+  "provider.ai_radio.config_entries.tts_loudness_boost.description": "How many decibels above the music the spoken sections should sit. Peaks are always limited so the audio can never clip, so the last few decibels arrive mostly as compression rather than loudness. Set to 0 to keep spoken clips at the same level as the music.",
   "provider.ai_radio.config_entries.tts_loudness_boost.label": "Spoken Clip Loudness Boost",
   "provider.ai_radio.config_entries.weather_city.description": "City used to look up the weather forecast for stations that reference it.",
   "provider.ai_radio.config_entries.weather_city.label": "Weather City",

--- a/tests/helpers/test_audio.py
+++ b/tests/helpers/test_audio.py
@@ -11,6 +11,7 @@ from music_assistant_models.media_items import AudioFormat
 from music_assistant.helpers.audio import (
     build_concat_filelist,
     calculate_content_length,
+    parse_loudnorm,
     resolve_output_player_ids,
 )
 from music_assistant.helpers.ffmpeg import DEFAULT_MP3_BIT_RATE
@@ -70,3 +71,38 @@ def test_build_concat_filelist_escapes_multiple_apostrophes() -> None:
     """Every apostrophe in a path is escaped, not just the first."""
     result = build_concat_filelist(["/x/it's a, b's & c's.mp3"])
     assert result == "file '/x/it'\\''s a, b'\\''s & c'\\''s.mp3'\n"
+
+
+# verbatim ffmpeg 7.1 output: the report is a block below the marker line, not inline
+FFMPEG_LOUDNORM_OUTPUT = b"""[out#0/null @ 0x93b] Output stream
+[Parsed_loudnorm_0 @ 0x93b41d440] \n{
+\t"input_i" : "-17.86",
+\t"input_tp" : "-1.89",
+\t"input_lra" : "0.40",
+\t"input_thresh" : "-27.86",
+\t"output_i" : "-23.92",
+\t"normalization_type" : "dynamic",
+\t"target_offset" : "-0.08"
+}
+size=N/A time=00:00:03.20 bitrate=N/A speed=  86x
+"""
+
+
+def test_parse_loudnorm_reads_the_measurement_ffmpeg_actually_prints() -> None:
+    """The integrated loudness is read from loudnorm's own JSON report block."""
+    assert parse_loudnorm(FFMPEG_LOUDNORM_OUTPUT) == -17.86
+
+
+def test_parse_loudnorm_accepts_a_decoded_string() -> None:
+    """Callers that already decoded the output get the same measurement."""
+    assert parse_loudnorm(FFMPEG_LOUDNORM_OUTPUT.decode()) == -17.86
+
+
+def test_parse_loudnorm_without_a_report_returns_none() -> None:
+    """Output from a run that never reached the filter carries no measurement."""
+    assert parse_loudnorm(b"ffmpeg: Invalid data found when processing input") is None
+
+
+def test_parse_loudnorm_with_a_truncated_report_returns_none() -> None:
+    """A report cut off mid-object is not mistaken for a measurement."""
+    assert parse_loudnorm(b'[Parsed_loudnorm_0 @ 0x1] \n{\n\t"input_i" : "-17.8') is None

--- a/tests/helpers/test_audio.py
+++ b/tests/helpers/test_audio.py
@@ -106,3 +106,15 @@ def test_parse_loudnorm_without_a_report_returns_none() -> None:
 def test_parse_loudnorm_with_a_truncated_report_returns_none() -> None:
     """A report cut off mid-object is not mistaken for a measurement."""
     assert parse_loudnorm(b'[Parsed_loudnorm_0 @ 0x1] \n{\n\t"input_i" : "-17.8') is None
+
+
+def test_parse_loudnorm_treats_digital_silence_as_no_measurement() -> None:
+    """A silent clip reports -inf, which is the absence of a level, not a level."""
+    silent = FFMPEG_LOUDNORM_OUTPUT.replace(b'"-17.86"', b'"-inf"')
+    assert parse_loudnorm(silent) is None
+
+
+def test_parse_loudnorm_reads_a_report_from_further_down_the_filter_chain() -> None:
+    """The marker carries the filter's position, which is not zero behind another filter."""
+    chained = FFMPEG_LOUDNORM_OUTPUT.replace(b"[Parsed_loudnorm_0 @", b"[Parsed_loudnorm_1 @")
+    assert parse_loudnorm(chained) == -17.86

--- a/tests/providers/ai_radio/test_config.py
+++ b/tests/providers/ai_radio/test_config.py
@@ -47,7 +47,12 @@ def test_optional_entries_use_the_advanced_flag_not_the_advanced_category() -> N
     for entry in entries:
         assert entry.category != "advanced", f"{entry.key} uses the deprecated advanced category"
     advanced = {entry.key for entry in entries if entry.advanced}
-    assert advanced == {"timezone", "weather_provider", "weather_timeout_seconds"}
+    assert advanced == {
+        "timezone",
+        "weather_provider",
+        "weather_timeout_seconds",
+        "tts_loudness_boost",
+    }
 
 
 def test_weather_country_is_a_dropdown_defaulting_to_the_server_region() -> None:

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -889,7 +889,7 @@ async def test_the_clip_is_evened_out_and_lifted_before_it_is_limited(
     assert captured["filter_params"] == [
         TTS_SPEECHNORM_FILTER,
         "volume=7.0dB",
-        f"alimiter=limit={TTS_PEAK_CEILING_DB}dB:level=false",
+        f"alimiter=limit={TTS_PEAK_CEILING_DB}dB:level=false:latency=true",
     ]
 
 

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -19,6 +20,7 @@ from music_assistant_models.errors import (
 from music_assistant_models.media_items import AudioFormat, ProviderMapping, SoundEffect
 from music_assistant_models.queue_item import QueueItem
 
+from music_assistant.constants import CONF_VALUE_DISABLED, CONF_VALUE_ENABLED
 from music_assistant.helpers.tags import AudioTags
 from music_assistant.models.plugin import PluginProvider, TTSEngine
 from music_assistant.providers.ai_radio.constants import (
@@ -31,6 +33,9 @@ from music_assistant.providers.ai_radio.constants import (
     ATTR_WEB_SEARCH_MODE,
     CLIP_STREAMDETAILS_EXPIRATION,
     DEFAULT_LLM_INSTRUCTIONS,
+    MIN_LOUDNESS_REFERENCE_SECONDS,
+    TTS_CLIP_PCM_FORMAT,
+    TTS_SPEECHNORM_FILTER,
 )
 from music_assistant.providers.ai_radio.models import SessionState
 from music_assistant.providers.ai_radio.rendering import AIRadioRenderMixin
@@ -52,6 +57,8 @@ class DummyRenderer(AIRadioRenderMixin):
         self.tts_options: list[dict[str, Any] | None] = []
         self.weather_calls = 0
         self.fail_generation = False
+        self.measure_calls: list[str] = []
+        self.measured_loudness: float | None = None
 
     def _configured_now(self) -> Any:
         return __import__("datetime").datetime(2026, 7, 30, 18, 30)
@@ -88,6 +95,10 @@ class DummyRenderer(AIRadioRenderMixin):
 
     async def _probe_duration(self, path: str) -> int | None:
         return 9
+
+    async def _measure_loudness(self, path: str) -> float | None:
+        self.measure_calls.append(path)
+        return self.measured_loudness
 
 
 class RealTtsRenderer(DummyRenderer):
@@ -162,6 +173,20 @@ def _attach_queues(renderer: DummyRenderer, queues: dict[str, list[QueueItem]]) 
 def _attach_queue(renderer: DummyRenderer, items: list[QueueItem]) -> list[bool]:
     """Wire a single-queue player_queues stub and return the signal_update call log."""
     return _attach_queues(renderer, {"player_a": items})
+
+
+def _attach_normalization(
+    renderer: DummyRenderer, *, enabled: bool = True, target: int = -14, boost: int = 3
+) -> None:
+    """Wire the queue, streams and provider config that decide the clip's loudness gain."""
+    mass = cast("Any", renderer).mass
+    mass.config = SimpleNamespace(
+        get_effective_player_queue_config_value=lambda *_args: (
+            CONF_VALUE_ENABLED if enabled else CONF_VALUE_DISABLED
+        )
+    )
+    mass.streams = SimpleNamespace(get_config_value=lambda *_args, **_kwargs: target)
+    cast("Any", renderer).config = SimpleNamespace(get_value=lambda *_args: boost)
 
 
 async def test_render_resolves_deferred_placeholders_at_render_time() -> None:
@@ -801,3 +826,175 @@ async def test_local_file_clip_yields_local_file_streamdetails(tmp_path: Path) -
 
     assert streamdetails.stream_type == StreamType.LOCAL_FILE
     assert streamdetails.path == str(clip)
+
+
+async def test_a_measured_clip_is_lifted_to_the_target_plus_the_boost() -> None:
+    """A clip quieter than the levelled music is served through the provider's own chain."""
+    renderer = DummyRenderer()
+    renderer.measured_loudness = -18.0
+    _attach_queue(renderer, [_clip_item("sess_001")])
+    _attach_normalization(renderer, target=-14, boost=3)
+
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert streamdetails.stream_type == StreamType.CUSTOM
+    assert streamdetails.decoded_audio_format == TTS_CLIP_PCM_FORMAT
+    assert streamdetails.audio_format.content_type == ContentType.MP3
+    assert streamdetails.data.gain_db == pytest.approx(7.0)
+
+
+async def test_the_clip_is_evened_out_and_lifted_before_it_is_limited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The filter chain reaches ffmpeg as speechnorm, then gain, then the peak limiter."""
+    captured: dict[str, Any] = {}
+
+    async def fake_ffmpeg_stream(**kwargs: Any) -> AsyncGenerator[bytes]:
+        captured.update(kwargs)
+        yield b"pcm"
+
+    monkeypatch.setattr(
+        "music_assistant.providers.ai_radio.rendering.get_ffmpeg_stream", fake_ffmpeg_stream
+    )
+    renderer = DummyRenderer()
+    renderer.measured_loudness = -18.0
+    _attach_queue(renderer, [_clip_item("sess_001")])
+    _attach_normalization(renderer, target=-14, boost=3)
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    chunks = [chunk async for chunk in renderer.get_audio_stream(streamdetails)]
+
+    assert chunks == [b"pcm"]
+    assert captured["audio_input"] == streamdetails.path
+    assert captured["input_format"].content_type == ContentType.MP3
+    assert captured["output_format"] == TTS_CLIP_PCM_FORMAT
+    assert captured["filter_params"] == [
+        TTS_SPEECHNORM_FILTER,
+        "volume=7.0dB",
+        "alimiter=limit=-3.0dB:level=false",
+    ]
+
+
+async def test_the_engine_reference_is_measured_once_and_reused() -> None:
+    """A second clip from the same voice levels itself against the stored measurement."""
+    renderer = DummyRenderer()
+    renderer.measured_loudness = -18.0
+    _attach_queue(renderer, [_clip_item("sess_001"), _clip_item("sess_002")])
+    _attach_normalization(renderer)
+
+    first = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+    second = await renderer.get_stream_details("sess_002", MediaType.SOUND_EFFECT)
+
+    assert len(renderer.measure_calls) == 1
+    assert first.data.gain_db == second.data.gain_db
+
+
+async def test_a_short_clip_levels_itself_but_never_becomes_the_reference() -> None:
+    """A clip of a few words is too thin a sample to speak for the rest of the engine."""
+
+    class BriefRenderer(DummyRenderer):
+        async def _probe_duration(self, path: str) -> int | None:
+            return MIN_LOUDNESS_REFERENCE_SECONDS - 1
+
+    renderer = BriefRenderer()
+    renderer.measured_loudness = -18.0
+    _attach_queue(renderer, [_clip_item("sess_001"), _clip_item("sess_002")])
+    _attach_normalization(renderer)
+
+    first = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+    await renderer.get_stream_details("sess_002", MediaType.SOUND_EFFECT)
+
+    assert first.stream_type == StreamType.CUSTOM
+    assert len(renderer.measure_calls) == 2
+    assert cast("Any", renderer)._engine_loudness == {}
+
+
+async def test_clip_plays_untouched_when_the_queue_does_not_normalize() -> None:
+    """With the music unlevelled there is nothing to match, so the clip airs as rendered."""
+    renderer = DummyRenderer()
+    renderer.measured_loudness = -18.0
+    _attach_queue(renderer, [_clip_item("sess_001")])
+    _attach_normalization(renderer, enabled=False)
+
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert streamdetails.stream_type == StreamType.HTTP
+    assert streamdetails.decoded_audio_format is None
+    assert streamdetails.data is None
+
+
+async def test_clip_plays_untouched_when_it_could_not_be_measured() -> None:
+    """A failed measurement leaves the clip playable at its own level."""
+    renderer = DummyRenderer()
+    _attach_queue(renderer, [_clip_item("sess_001")])
+    _attach_normalization(renderer)
+
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert renderer.measure_calls
+    assert streamdetails.stream_type == StreamType.HTTP
+    assert streamdetails.data is None
+
+
+async def test_clip_plays_untouched_when_it_is_already_loud_enough() -> None:
+    """A clip at or above the wanted level is not put through the chain for nothing."""
+    renderer = DummyRenderer()
+    renderer.measured_loudness = -8.0
+    _attach_queue(renderer, [_clip_item("sess_001")])
+    _attach_normalization(renderer, target=-14, boost=3)
+
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert streamdetails.stream_type == StreamType.HTTP
+    assert streamdetails.data is None
+
+
+# verbatim ffmpeg 7.1 output, so the parsing this depends on is covered for real
+FFMPEG_LOUDNORM_OUTPUT = b"""[Parsed_loudnorm_0 @ 0x93b41d440] \n{
+\t"input_i" : "-18.37",
+\t"input_tp" : "-1.89",
+\t"input_lra" : "0.40",
+\t"input_thresh" : "-27.86",
+\t"normalization_type" : "dynamic"
+}
+"""
+
+
+async def test_the_measurement_reads_the_level_out_of_ffmpegs_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The engine reference comes from loudnorm's report on the rendered clip."""
+    captured: dict[str, Any] = {}
+
+    async def fake_check_output(*args: str, **_kwargs: Any) -> tuple[int, bytes]:
+        captured["args"] = args
+        return 0, FFMPEG_LOUDNORM_OUTPUT
+
+    monkeypatch.setattr(
+        "music_assistant.providers.ai_radio.rendering.check_output", fake_check_output
+    )
+    renderer = DummyRenderer()
+
+    loudness = await AIRadioRenderMixin._measure_loudness(renderer, "http://ha.invalid/clip.mp3")
+
+    assert loudness == -18.37
+    assert "http://ha.invalid/clip.mp3" in captured["args"]
+    assert "loudnorm=print_format=json" in captured["args"]
+
+
+async def test_a_failed_measurement_leaves_the_level_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ffmpeg run that did not succeed yields no reference rather than a wrong one."""
+
+    async def fake_check_output(*_args: str, **_kwargs: Any) -> tuple[int, bytes]:
+        return 1, b"ffmpeg: Invalid data found when processing input"
+
+    monkeypatch.setattr(
+        "music_assistant.providers.ai_radio.rendering.check_output", fake_check_output
+    )
+    renderer = DummyRenderer()
+
+    assert (
+        await AIRadioRenderMixin._measure_loudness(renderer, "http://ha.invalid/clip.mp3") is None
+    )

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -20,7 +20,12 @@ from music_assistant_models.errors import (
 from music_assistant_models.media_items import AudioFormat, ProviderMapping, SoundEffect
 from music_assistant_models.queue_item import QueueItem
 
-from music_assistant.constants import CONF_VALUE_DISABLED, CONF_VALUE_ENABLED
+from music_assistant.constants import (
+    CONF_VALUE_DISABLED,
+    CONF_VALUE_ENABLED,
+    CONF_VOLUME_NORMALIZATION,
+    CONF_VOLUME_NORMALIZATION_TARGET,
+)
 from music_assistant.helpers.tags import AudioTags
 from music_assistant.models.plugin import PluginProvider, TTSEngine
 from music_assistant.providers.ai_radio.constants import (
@@ -32,9 +37,11 @@ from music_assistant.providers.ai_radio.constants import (
     ATTR_STATION_ID,
     ATTR_WEB_SEARCH_MODE,
     CLIP_STREAMDETAILS_EXPIRATION,
+    CONF_TTS_LOUDNESS_BOOST,
     DEFAULT_LLM_INSTRUCTIONS,
     MIN_LOUDNESS_REFERENCE_SECONDS,
     TTS_CLIP_PCM_FORMAT,
+    TTS_PEAK_CEILING_DB,
     TTS_SPEECHNORM_FILTER,
 )
 from music_assistant.providers.ai_radio.models import SessionState
@@ -179,14 +186,25 @@ def _attach_normalization(
     renderer: DummyRenderer, *, enabled: bool = True, target: int = -14, boost: int = 3
 ) -> None:
     """Wire the queue, streams and provider config that decide the clip's loudness gain."""
+
+    def queue_setting(queue_id: str, key: str, default: str) -> str:
+        assert queue_id == "player_a"
+        assert key == CONF_VOLUME_NORMALIZATION
+        assert default == CONF_VALUE_ENABLED
+        return CONF_VALUE_ENABLED if enabled else CONF_VALUE_DISABLED
+
+    def streams_setting(key: str, **_kwargs: Any) -> int:
+        assert key == CONF_VOLUME_NORMALIZATION_TARGET
+        return target
+
+    def provider_setting(key: str) -> int:
+        assert key == CONF_TTS_LOUDNESS_BOOST
+        return boost
+
     mass = cast("Any", renderer).mass
-    mass.config = SimpleNamespace(
-        get_effective_player_queue_config_value=lambda *_args: (
-            CONF_VALUE_ENABLED if enabled else CONF_VALUE_DISABLED
-        )
-    )
-    mass.streams = SimpleNamespace(get_config_value=lambda *_args, **_kwargs: target)
-    cast("Any", renderer).config = SimpleNamespace(get_value=lambda *_args: boost)
+    mass.config = SimpleNamespace(get_effective_player_queue_config_value=queue_setting)
+    mass.streams = SimpleNamespace(get_config_value=streams_setting)
+    cast("Any", renderer).config = SimpleNamespace(get_value=provider_setting)
 
 
 async def test_render_resolves_deferred_placeholders_at_render_time() -> None:
@@ -871,7 +889,7 @@ async def test_the_clip_is_evened_out_and_lifted_before_it_is_limited(
     assert captured["filter_params"] == [
         TTS_SPEECHNORM_FILTER,
         "volume=7.0dB",
-        "alimiter=limit=-3.0dB:level=false",
+        f"alimiter=limit={TTS_PEAK_CEILING_DB}dB:level=false",
     ]
 
 
@@ -936,8 +954,8 @@ async def test_clip_plays_untouched_when_it_could_not_be_measured() -> None:
     assert streamdetails.data is None
 
 
-async def test_clip_plays_untouched_when_it_is_already_loud_enough() -> None:
-    """A clip at or above the wanted level is not put through the chain for nothing."""
+async def test_a_clip_above_the_wanted_level_is_trimmed_back_down() -> None:
+    """The trim runs in either direction, so a loud voice is brought down to the target."""
     renderer = DummyRenderer()
     renderer.measured_loudness = -8.0
     _attach_queue(renderer, [_clip_item("sess_001")])
@@ -945,8 +963,21 @@ async def test_clip_plays_untouched_when_it_is_already_loud_enough() -> None:
 
     streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
 
-    assert streamdetails.stream_type == StreamType.HTTP
-    assert streamdetails.data is None
+    assert streamdetails.stream_type == StreamType.CUSTOM
+    assert streamdetails.data.gain_db == pytest.approx(-3.0)
+
+
+async def test_the_levelled_clip_does_not_hand_out_the_shared_pcm_format() -> None:
+    """Core writes what ffmpeg reports onto this format, so it may not be the shared one."""
+    renderer = DummyRenderer()
+    renderer.measured_loudness = -18.0
+    _attach_queue(renderer, [_clip_item("sess_001")])
+    _attach_normalization(renderer)
+
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert streamdetails.decoded_audio_format == TTS_CLIP_PCM_FORMAT
+    assert streamdetails.decoded_audio_format is not TTS_CLIP_PCM_FORMAT
 
 
 # verbatim ffmpeg 7.1 output, so the parsing this depends on is covered for real
@@ -979,7 +1010,9 @@ async def test_the_measurement_reads_the_level_out_of_ffmpegs_report(
 
     assert loudness == -18.37
     assert "http://ha.invalid/clip.mp3" in captured["args"]
-    assert "loudnorm=print_format=json" in captured["args"]
+    # the reading has to come from behind speechnorm, or the gain corrects for a level
+    # that never reaches it
+    assert f"{TTS_SPEECHNORM_FILTER},loudnorm=print_format=json" in captured["args"]
 
 
 async def test_a_failed_measurement_leaves_the_level_unknown(

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -11,7 +11,12 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.enums import (
+    ContentType,
+    MediaType,
+    StreamType,
+    VolumeNormalizationMode,
+)
 from music_assistant_models.errors import (
     InvalidDataError,
     MediaNotFoundError,
@@ -25,6 +30,7 @@ from music_assistant.constants import (
     CONF_VALUE_ENABLED,
     CONF_VOLUME_NORMALIZATION,
     CONF_VOLUME_NORMALIZATION_TARGET,
+    CONF_VOLUME_NORMALIZATION_TRACKS,
 )
 from music_assistant.helpers.tags import AudioTags
 from music_assistant.models.plugin import PluginProvider, TTSEngine
@@ -174,6 +180,7 @@ def _attach_queues(renderer: DummyRenderer, queues: dict[str, list[QueueItem]]) 
         ),
         metadata=SimpleNamespace(locale="en_US"),
     )
+    _attach_normalization(renderer, queue_ids=tuple(queues))
     return signals
 
 
@@ -183,17 +190,25 @@ def _attach_queue(renderer: DummyRenderer, items: list[QueueItem]) -> list[bool]
 
 
 def _attach_normalization(
-    renderer: DummyRenderer, *, enabled: bool = True, target: int = -14, boost: int = 3
+    renderer: DummyRenderer,
+    *,
+    enabled: bool = True,
+    target: int = -14,
+    boost: int = 3,
+    tracks_mode: str = VolumeNormalizationMode.FALLBACK_DYNAMIC.value,
+    queue_ids: tuple[str, ...] = ("player_a",),
 ) -> None:
     """Wire the queue, streams and provider config that decide the clip's loudness gain."""
 
     def queue_setting(queue_id: str, key: str, default: str) -> str:
-        assert queue_id == "player_a"
+        assert queue_id in queue_ids
         assert key == CONF_VOLUME_NORMALIZATION
         assert default == CONF_VALUE_ENABLED
         return CONF_VALUE_ENABLED if enabled else CONF_VALUE_DISABLED
 
-    def streams_setting(key: str, **_kwargs: Any) -> int:
+    def streams_setting(key: str, **_kwargs: Any) -> str | int:
+        if key == CONF_VOLUME_NORMALIZATION_TRACKS:
+            return tracks_mode
         assert key == CONF_VOLUME_NORMALIZATION_TARGET
         return target
 
@@ -692,6 +707,7 @@ async def test_mint_clip_media_resolves_host_tts_engine() -> None:
     renderer = _tts_renderer("http://example.test/api/tts_proxy/abc123.mp3")
     renderer._hosts = {"rick": {"id": "rick", "tts_engine": "tts.rick_voice"}}
     cast("Any", renderer).mass = SimpleNamespace(metadata=SimpleNamespace(locale="en_US"))
+    _attach_normalization(renderer)
     item = _clip_item("sess_001", **{ATTR_HOST_ID: "rick"})
 
     await renderer._mint_clip_media(item, "hello world", "clip_1")
@@ -710,6 +726,7 @@ async def test_mint_clip_media_forwards_the_hosts_options() -> None:
         }
     }
     cast("Any", renderer).mass = SimpleNamespace(metadata=SimpleNamespace(locale="en_US"))
+    _attach_normalization(renderer)
     item = _clip_item("sess_001", **{ATTR_HOST_ID: "rick"})
 
     await renderer._mint_clip_media(item, "hello world", "clip_1")
@@ -722,6 +739,7 @@ async def test_mint_clip_media_sends_no_options_for_a_host_without_any() -> None
     renderer = DummyRenderer()
     renderer._hosts = {"rick": {"id": "rick", "tts_engine": ""}}
     cast("Any", renderer).mass = SimpleNamespace(metadata=SimpleNamespace(locale="en_US"))
+    _attach_normalization(renderer)
     item = _clip_item("sess_001", **{ATTR_HOST_ID: "rick"})
 
     await renderer._mint_clip_media(item, "hello world", "clip_1")
@@ -1031,3 +1049,28 @@ async def test_a_failed_measurement_leaves_the_level_unknown(
     assert (
         await AIRadioRenderMixin._measure_loudness(renderer, "http://ha.invalid/clip.mp3") is None
     )
+
+
+async def test_clip_plays_untouched_when_tracks_are_not_normalized() -> None:
+    """The queue switch alone does not mean the music around the clip is levelled."""
+    renderer = DummyRenderer()
+    renderer.measured_loudness = -18.0
+    _attach_queue(renderer, [_clip_item("sess_001")])
+    _attach_normalization(renderer, tracks_mode=VolumeNormalizationMode.DISABLED.value)
+
+    streamdetails = await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert streamdetails.stream_type == StreamType.HTTP
+    assert streamdetails.data is None
+
+
+async def test_no_measurement_is_taken_when_the_reading_has_nowhere_to_go() -> None:
+    """Measuring costs a fetch and a decode, so a queue that will not use it is not charged."""
+    renderer = DummyRenderer()
+    renderer.measured_loudness = -18.0
+    _attach_queue(renderer, [_clip_item("sess_001")])
+    _attach_normalization(renderer, enabled=False)
+
+    await renderer.get_stream_details("sess_001", MediaType.SOUND_EFFECT)
+
+    assert renderer.measure_calls == []


### PR DESCRIPTION
# What does this implement/fix?

The spoken AI Radio sections played noticeably quieter than the music around them. Clips are sound effects, and the streams controller never applies volume normalization to those, so the music was pulled to the normalization target while the host's voice aired at whatever level the TTS engine happened to produce — several dB below it.

Speech also can't simply be turned up: it has roughly 16 dB between its average level and its peaks, so a plain gain that reaches the wanted level clips hard. The clip is now evened out and peak-limited instead, so it can sit above the music without ever clipping.

While in there: a Dutch host reading English song titles sounded awkward, because the AI was never told what to do with names that stay in another language than the script.

## Changes

- Measure the level a text-to-speech engine speaks at, once per voice, and reuse it for every clip that voice renders (clips from one voice land within a dB of each other).
- Level each clip against the queue's normalization target plus a new **Spoken Clip Loudness Boost** setting (advanced, default 3 dB), with a limiter holding the peaks so a louder target can never clip.
- Leave the clip untouched when the queue does not normalize or when the level could not be measured; otherwise the clip is placed on the target, which also brings an unusually loud voice back down.
- Tell the AI to respell foreign names phonetically for the language it is writing in, so a Dutch voice reading an English title stays recognisable.
- Fix `parse_loudnorm`, which never matched the report modern ffmpeg prints and so always came back empty.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
