### PR TITLE
Split up the Chromecast media status handler

### DIFF
--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -655,7 +655,8 @@ class ChromecastPlayer(Player):
         Log a media error reported by the receiver, at most once per incident.
 
         Such an error (e.g. after a failed LOAD) otherwise only shows as a silent
-        return to idle.
+        return to idle. Any other status ends the incident, so a later error is
+        reported again.
 
         :param status: Media status as reported by the receiver.
         :param group_player: Cast group player whose status is being followed, if any.
@@ -665,9 +666,9 @@ class ChromecastPlayer(Player):
             return
         # a group forwards its status to every member, so only the group
         # player itself reports the error
-        if group_player is not None or self._media_error_reported:
+        if group_player is not None:
             return
-        if self._flow_stream_underrun():
+        if self._media_error_reported or self._flow_stream_underrun():
             return
         self._media_error_reported = True
         self.logger.warning(
@@ -689,6 +690,8 @@ class ChromecastPlayer(Player):
             self.set_current_media(uri=status.content_id or "", clear_all=True)
         elif status.player_is_paused:
             self._attr_playback_state = PlaybackState.PAUSED
+            # dropped so the metadata update below builds a fresh PlayerMedia instead of
+            # merging the new track into the previous one, which only truthy fields replace
             self._attr_current_media = None
             self._attr_active_source = None
         else:

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -599,7 +599,7 @@ class ChromecastPlayer(Player):
             except Exception:
                 self.logger.exception("Error in app status callback for %s", self.display_name)
 
-    def _handle_media_status(self, status: MediaStatus) -> None:  # noqa: PLR0915
+    def _handle_media_status(self, status: MediaStatus) -> None:
         """Process MediaStatus on the event loop thread."""
         self.logger.log(
             VERBOSE_LOG_LEVEL,
@@ -611,9 +611,6 @@ class ChromecastPlayer(Player):
         group_player: ChromecastPlayer | None = None
         if self.active_cast_group is not None:
             player_obj = self.mass.players.get_player(self.active_cast_group)
-            if not player_obj:
-                return
-            # Now assert/check the type to satisfy MyPy
             if not isinstance(player_obj, ChromecastPlayer):
                 return
             group_player = player_obj
@@ -621,34 +618,11 @@ class ChromecastPlayer(Player):
 
         # never surface the receiver's dashboard keepalive as actual playback
         if status.content_id and status.content_id.endswith(DASHBOARD_KEEPALIVE_SUFFIXES):
-            self._attr_playback_state = PlaybackState.IDLE
-            self._attr_current_media = None
-            self._attr_active_source = None
-            self._attr_elapsed_time = 0
-            self._attr_elapsed_time_last_updated = time.time()
-            self.update_state()
+            self._reset_to_idle()
             return
 
-        # surface a media error reported by the receiver (e.g. after a failed LOAD),
-        # which otherwise only shows as a silent return to idle
-        if status.player_is_idle and status.idle_reason == "ERROR":
-            # a group forwards its status to every member, so only the group
-            # player itself reports the error
-            if (
-                group_player is None
-                and not self._media_error_reported
-                and not self._flow_stream_underrun()
-            ):
-                self._media_error_reported = True
-                self.logger.warning(
-                    "%s reported a media playback error for %s",
-                    self.display_name,
-                    status.content_id or "the loaded media",
-                )
-        else:
-            self._media_error_reported = False
+        self._report_media_error(status, group_player)
 
-        # player state
         # pychromecast reports BUFFERING as 'playing', so a Cast group that underruns the
         # LIVE flow stream at EOF never goes idle. Treat that case as idle so the queue
         # can resume/restart.
@@ -657,8 +631,59 @@ class ChromecastPlayer(Player):
         )
         is_playing = status.player_is_playing and not flow_underrun
         is_idle = status.player_is_idle or flow_underrun
-        prev_state = self._attr_playback_state
+
+        self._update_playback_state(status, is_playing)
+        self._update_elapsed_time(status, is_playing)
+        self._update_active_source(group_player)
+        self._update_current_media(status, is_idle)
+        self._update_multichannel_group_members()
+        self.update_state()
+
+    def _reset_to_idle(self) -> None:
+        """Drop all playback state and publish the player as idle."""
+        self._attr_playback_state = PlaybackState.IDLE
+        self._attr_current_media = None
+        self._attr_active_source = None
+        self._attr_elapsed_time = 0
         self._attr_elapsed_time_last_updated = time.time()
+        self.update_state()
+
+    def _report_media_error(
+        self, status: MediaStatus, group_player: ChromecastPlayer | None
+    ) -> None:
+        """
+        Log a media error reported by the receiver, at most once per incident.
+
+        Such an error (e.g. after a failed LOAD) otherwise only shows as a silent
+        return to idle.
+
+        :param status: Media status as reported by the receiver.
+        :param group_player: Cast group player whose status is being followed, if any.
+        """
+        if not (status.player_is_idle and status.idle_reason == "ERROR"):
+            self._media_error_reported = False
+            return
+        # a group forwards its status to every member, so only the group
+        # player itself reports the error
+        if group_player is not None or self._media_error_reported:
+            return
+        if self._flow_stream_underrun():
+            return
+        self._media_error_reported = True
+        self.logger.warning(
+            "%s reported a media playback error for %s",
+            self.display_name,
+            status.content_id or "the loaded media",
+        )
+
+    def _update_playback_state(self, status: MediaStatus, is_playing: bool) -> None:
+        """
+        Apply the reported playback state, releasing the device once playback ended.
+
+        :param status: Media status as reported by the receiver.
+        :param is_playing: Whether the receiver is really playing audio.
+        """
+        prev_state = self._attr_playback_state
         if is_playing:
             self._attr_playback_state = PlaybackState.PLAYING
             self.set_current_media(uri=status.content_id or "", clear_all=True)
@@ -681,15 +706,24 @@ class ChromecastPlayer(Player):
                 # power control does, and a group member follows the group's session.
                 self._schedule_app_release()
 
-        # elapsed time
-        self._attr_elapsed_time_last_updated = time.time()
-        self._attr_elapsed_time = status.adjusted_current_time
-        if is_playing:
-            self._attr_elapsed_time = status.adjusted_current_time
-        else:
-            self._attr_elapsed_time = status.current_time
+    def _update_elapsed_time(self, status: MediaStatus, is_playing: bool) -> None:
+        """
+        Apply the playback position reported by the receiver.
 
-        # active source
+        :param status: Media status as reported by the receiver.
+        :param is_playing: Whether the receiver is really playing audio.
+        """
+        self._attr_elapsed_time_last_updated = time.time()
+        self._attr_elapsed_time = (
+            status.adjusted_current_time if is_playing else status.current_time
+        )
+
+    def _update_active_source(self, group_player: ChromecastPlayer | None) -> None:
+        """
+        Apply the active source, exposing a foreign Cast app as a selectable source.
+
+        :param group_player: Cast group player whose status is being followed, if any.
+        """
         if group_player:
             self._attr_active_source = group_player.active_source or group_player.player_id
         elif self.cc.app_id in (MASS_APP_ID, APP_MEDIA_RECEIVER, SENDSPIN_CAST_APP_ID):
@@ -715,6 +749,13 @@ class ChromecastPlayer(Player):
                     )
                 )
 
+    def _update_current_media(self, status: MediaStatus, is_idle: bool) -> None:
+        """
+        Apply the media metadata reported by the receiver.
+
+        :param status: Media status as reported by the receiver.
+        :param is_idle: Whether the receiver has nothing playing.
+        """
         if status.content_id and not is_idle:
             self.set_current_media(
                 uri=status.content_id,
@@ -728,23 +769,26 @@ class ChromecastPlayer(Player):
         else:
             self._attr_current_media = None
 
-        # weird workaround which is needed for multichannel group childs
-        # (e.g. a stereo pair within a cast group)
-        # where it does not receive updates from the group,
-        # so we need to update the group child(s) manually
-        if self.type == PlayerType.GROUP and self.powered:
-            for child_id in self.group_members:
-                if child := self.mass.players.get_player(child_id):
-                    assert isinstance(child, ChromecastPlayer)  # for type checking
-                    if not child.cast_info.is_multichannel_group:
-                        continue
-                    child._attr_playback_state = self._attr_playback_state
-                    child._attr_current_media = self._attr_current_media
-                    child._attr_elapsed_time = self._attr_elapsed_time
-                    child._attr_elapsed_time_last_updated = self._attr_elapsed_time_last_updated
-                    child._attr_active_source = self.active_source
-                    child.update_state()
-        self.update_state()
+    def _update_multichannel_group_members(self) -> None:
+        """
+        Mirror this group's playback state onto its multichannel members.
+
+        A stereo pair within a cast group receives no updates from the group itself,
+        so its state has to be pushed out manually.
+        """
+        if self.type != PlayerType.GROUP or not self.powered:
+            return
+        for child_id in self.group_members:
+            if child := self.mass.players.get_player(child_id):
+                assert isinstance(child, ChromecastPlayer)  # for type checking
+                if not child.cast_info.is_multichannel_group:
+                    continue
+                child._attr_playback_state = self._attr_playback_state
+                child._attr_current_media = self._attr_current_media
+                child._attr_elapsed_time = self._attr_elapsed_time
+                child._attr_elapsed_time_last_updated = self._attr_elapsed_time_last_updated
+                child._attr_active_source = self.active_source
+                child.update_state()
 
     def _handle_load_media_failed(self, queue_item_id: int, error_code: int) -> None:
         """Process a failed media load on the event loop thread."""

--- a/tests/providers/chromecast/helpers.py
+++ b/tests/providers/chromecast/helpers.py
@@ -1,0 +1,36 @@
+"""Shared helpers for the Chromecast player tests."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import cast
+from unittest.mock import MagicMock
+
+from music_assistant.providers.chromecast.player import ChromecastPlayer
+
+# Private helpers that _handle_media_status delegates its work to. The handler is
+# driven with a MagicMock as 'self', which would answer these calls itself instead of
+# updating the player state, so they are bound to the real implementation.
+# Extend this when the handler gains a helper, or its part is silently skipped.
+MEDIA_STATUS_HELPERS = (
+    "_reset_to_idle",
+    "_report_media_error",
+    "_update_playback_state",
+    "_update_elapsed_time",
+    "_update_active_source",
+    "_update_current_media",
+    "_update_multichannel_group_members",
+)
+
+
+def bind_media_status_helpers(fake: MagicMock) -> MagicMock:
+    """
+    Let a fake Cast player run the real media-status helpers, and return it.
+
+    :param fake: MagicMock standing in for a ChromecastPlayer.
+    """
+    for name in MEDIA_STATUS_HELPERS:
+        setattr(
+            fake, name, partial(getattr(ChromecastPlayer, name), cast("ChromecastPlayer", fake))
+        )
+    return fake

--- a/tests/providers/chromecast/test_idle_release.py
+++ b/tests/providers/chromecast/test_idle_release.py
@@ -21,6 +21,7 @@ from music_assistant.providers.chromecast.constants import (
     MASS_APP_ID,
 )
 from music_assistant.providers.chromecast.player import ChromecastPlayer
+from tests.providers.chromecast.helpers import bind_media_status_helpers
 
 
 def _handle_media_status(fake: MagicMock, status: MagicMock) -> None:
@@ -52,7 +53,7 @@ def _fake_player(
     fake._schedule_app_release = partial(
         ChromecastPlayer._schedule_app_release, cast("ChromecastPlayer", fake)
     )
-    return fake
+    return bind_media_status_helpers(fake)
 
 
 def _media_status(

--- a/tests/providers/chromecast/test_media_status_error.py
+++ b/tests/providers/chromecast/test_media_status_error.py
@@ -17,6 +17,7 @@ from typing import cast
 from unittest.mock import MagicMock
 
 from music_assistant.providers.chromecast.player import ChromecastPlayer
+from tests.providers.chromecast.helpers import bind_media_status_helpers
 
 
 def _handle_media_status(fake: MagicMock, status: MagicMock) -> None:
@@ -29,7 +30,7 @@ def _fake_player() -> MagicMock:
     fake.active_cast_group = None
     fake._media_error_reported = False
     fake._flow_stream_underrun = MagicMock(return_value=False)
-    return fake
+    return bind_media_status_helpers(fake)
 
 
 def _error_status() -> MagicMock:

--- a/tests/providers/chromecast/test_media_status_helper_binding.py
+++ b/tests/providers/chromecast/test_media_status_helper_binding.py
@@ -1,0 +1,39 @@
+"""
+Test that guards the media-status test setup itself.
+
+The media-status tests drive the handler with a MagicMock as ``self``, so a helper
+that is not bound to its real implementation answers as a mock and its part of the
+handler is skipped without any test failing.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+from music_assistant.providers.chromecast.player import ChromecastPlayer
+from tests.providers.chromecast.helpers import MEDIA_STATUS_HELPERS
+
+# helpers the tests deliberately keep mocked, to drive the handler down a chosen path
+MOCKED_SEAMS = {"_flow_stream_underrun"}
+
+
+def _private_methods_called_by_handler() -> set[str]:
+    """Return the names of the private ChromecastPlayer methods _handle_media_status calls."""
+    source = textwrap.dedent(inspect.getsource(ChromecastPlayer._handle_media_status))
+    return {
+        node.func.attr
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "self"
+        and node.func.attr.startswith("_")
+        and callable(getattr(ChromecastPlayer, node.func.attr, None))
+    }
+
+
+def test_every_media_status_helper_is_bound() -> None:
+    """Every helper the handler delegates to is bound, so no part of it is skipped."""
+    assert _private_methods_called_by_handler() - MOCKED_SEAMS == set(MEDIA_STATUS_HELPERS)

--- a/tests/providers/chromecast/test_media_status_keepalive.py
+++ b/tests/providers/chromecast/test_media_status_keepalive.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 from music_assistant_models.enums import PlaybackState
 
 from music_assistant.providers.chromecast.player import ChromecastPlayer
+from tests.providers.chromecast.helpers import bind_media_status_helpers
 
 
 def _handle_media_status(fake: MagicMock, status: MagicMock) -> None:
@@ -26,7 +27,7 @@ def _fake_player() -> MagicMock:
     """Build a MagicMock standing in for a ChromecastPlayer with no active cast group."""
     fake = MagicMock()
     fake.active_cast_group = None
-    return fake
+    return bind_media_status_helpers(fake)
 
 
 def _media_status(content_id: str, *, player_is_playing: bool, player_is_paused: bool) -> MagicMock:


### PR DESCRIPTION
# What does this implement/fix?

The method that handles status updates from a Cast device had grown to around 90 lines
doing nine unrelated things at once, and carried a lint exemption that hid any further
growth. Four recent PRs each added another branch to it.

It is now split into one helper per concern, with no behaviour change.

- split the handler into focused helpers and drop the lint exemption
- keep the dashboard keepalive check and the cast group redirection in the handler itself,
  since both decide whether the rest runs at all
- drop two assignments that were overwritten a few lines later
- let the Cast player tests run the real helpers, so their assertions keep covering the
  same behaviour, and add a test that catches a helper being left out of that setup

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
