### PR TITLE
Album art keeps showing when its provider has a hiccup

### DIFF
--- a/music_assistant/controllers/metadata/images.py
+++ b/music_assistant/controllers/metadata/images.py
@@ -20,7 +20,7 @@ import aiofiles
 from aiohttp import web
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import ImageType
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import MediaNotFoundError, ProviderUnavailableError
 from music_assistant_models.media_items import (
     Album,
     BrowseFolder,
@@ -313,9 +313,11 @@ class ImageProxyMixin:
             thumbnail_bytes, content_format = await self._resolve_thumbnail(
                 path, provider, size, image_format, flatten_transparency
             )
-        except (MediaNotFoundError, OSError) as err:
+        except (MediaNotFoundError, ProviderUnavailableError, OSError) as err:
             # normalize a missing/unreadable image into one typed error so callers
-            # (and not just the HTTP imageproxy handler) can handle it uniformly
+            # (and not just the HTTP imageproxy handler) can handle it uniformly.
+            # an unavailable provider is included: to a caller it is equally unreadable,
+            # and leaking it would abort sends that only meant to skip the artwork
             raise MediaNotFoundError(f"Image not found or unreadable: {path}") from err
         if base64:
             enc_image = b64encode(thumbnail_bytes).decode()

--- a/music_assistant/controllers/metadata/images.py
+++ b/music_assistant/controllers/metadata/images.py
@@ -20,7 +20,7 @@ import aiofiles
 from aiohttp import web
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import ImageType
-from music_assistant_models.errors import MediaNotFoundError, ProviderUnavailableError
+from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import (
     Album,
     BrowseFolder,
@@ -419,8 +419,6 @@ class ImageProxyMixin:
         :param image_format: Requested output format (jpg/jpeg/png/svg).
         :param flatten_transparency: Composite alpha onto white and keep JPEG when True.
         """
-        if not self.mass.get_provider(provider) and not path.startswith("http"):
-            raise ProviderUnavailableError
         if provider == "builtin" and path.startswith("/collage/"):
             # special case for collage images
             collage_rel = path.rsplit("/collage/", maxsplit=1)[-1]

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -24,7 +24,11 @@ import aiofiles
 import aiofiles.os
 from aiohttp.client_exceptions import ClientError
 from music_assistant_models.enums import ProviderIconVariant
-from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
+from music_assistant_models.errors import (
+    MediaNotFoundError,
+    MusicAssistantError,
+    ProviderUnavailableError,
+)
 from PIL import Image, UnidentifiedImageError
 
 from music_assistant.constants import APPLICATION_NAME
@@ -325,6 +329,9 @@ async def get_image_data(
         _depth,
         task_id=f"imgsrc.{cache_key}",
         abort_existing=False,
+        # the failure reaches every waiter below, and whoever serves the image reports it
+        # once with the path it was asked for
+        log_exceptions=False,
     )
     return await join_task(task)
 
@@ -480,6 +487,12 @@ async def _fetch_source_image(
     # use ffmpeg for embedded images
     if is_safe_path(path_or_url) and (img_data := await get_embedded_image(path_or_url)):
         return img_data, True
+    if prov is None:
+        # every provider-independent route is exhausted, so an absent provider means the
+        # path was never resolved rather than that the image is gone. Reporting it as
+        # missing would cache that verdict and keep serving it after the provider returns.
+        msg = f"{provider} is not available to resolve image {path_or_url}"
+        raise ProviderUnavailableError(msg)
     msg = f"Image not found: {path_or_url}"
     raise FileNotFoundError(msg)
 
@@ -634,6 +647,8 @@ async def _get_image_thumb(
         flatten_transparency,
         task_id=f"thumb.{cache_filename}",
         abort_existing=False,
+        # as above: reported once by the caller that serves the image
+        log_exceptions=False,
     )
     thumb_data = await join_task(task)
     _put_in_memory_cache(cache_filename, thumb_data)

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -329,8 +329,8 @@ async def get_image_data(
         _depth,
         task_id=f"imgsrc.{cache_key}",
         abort_existing=False,
-        # the failure reaches every waiter below, and whoever serves the image reports it
-        # once with the path it was asked for
+        # the failure reaches every waiter below; a fetch failure is reported here anyway,
+        # so a warning naming the task on top of that says nothing new
         log_exceptions=False,
     )
     return await join_task(task)
@@ -458,6 +458,16 @@ async def _fetch_source_image(
                 return resolved_image, True
             if isinstance(resolved_image, str):
                 path_or_url = resolved_image
+    elif not path_or_url.startswith(("http", "data:image")) and mass.get_provider(
+        provider, return_unavailable=True
+    ):
+        # a registered provider that is momentarily down is the only thing that can turn
+        # its own path into something readable, so stop here: the routes below would probe
+        # a path relative to nothing (spawning ffmpeg per request for the whole outage),
+        # and reporting it as missing would cache that verdict. An unknown provider does
+        # fall through - it is gone for good, so a missing image is the honest verdict.
+        msg = f"{provider} is not available to resolve image {path_or_url}"
+        raise ProviderUnavailableError(msg)
     # handle HTTP location
     if path_or_url.startswith("http"):
         # handle imageproxy URLs pointing to our own server
@@ -487,12 +497,6 @@ async def _fetch_source_image(
     # use ffmpeg for embedded images
     if is_safe_path(path_or_url) and (img_data := await get_embedded_image(path_or_url)):
         return img_data, True
-    if prov is None:
-        # every provider-independent route is exhausted, so an absent provider means the
-        # path was never resolved rather than that the image is gone. Reporting it as
-        # missing would cache that verdict and keep serving it after the provider returns.
-        msg = f"{provider} is not available to resolve image {path_or_url}"
-        raise ProviderUnavailableError(msg)
     msg = f"Image not found: {path_or_url}"
     raise FileNotFoundError(msg)
 
@@ -647,7 +651,8 @@ async def _get_image_thumb(
         flatten_transparency,
         task_id=f"thumb.{cache_filename}",
         abort_existing=False,
-        # as above: reported once by the caller that serves the image
+        # the failure reaches every waiter, which is where it belongs; a task that lost
+        # every waiter still leaves a debug line behind
         log_exceptions=False,
     )
     thumb_data = await join_task(task)

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -458,14 +458,16 @@ async def _fetch_source_image(
                 return resolved_image, True
             if isinstance(resolved_image, str):
                 path_or_url = resolved_image
-    elif not path_or_url.startswith(("http", "data:image")) and mass.get_provider(
-        provider, return_unavailable=True
+    elif (
+        not path_or_url.startswith(("http", "data:image"))
+        and not Path(path_or_url).is_absolute()
+        and mass.get_provider(provider, return_unavailable=True)
     ):
-        # a registered provider that is momentarily down is the only thing that can turn
-        # its own path into something readable, so stop here: the routes below would probe
-        # a path relative to nothing (spawning ffmpeg per request for the whole outage),
-        # and reporting it as missing would cache that verdict. An unknown provider does
-        # fall through - it is gone for good, so a missing image is the honest verdict.
+        # a relative path means only the provider can say what it is relative to, so a
+        # registered provider that is momentarily down leaves nothing to try: the routes
+        # below would probe a path relative to nothing (spawning ffmpeg per request for
+        # the whole outage) and reporting it as missing would cache that verdict. An
+        # unknown provider does fall through - it is gone for good, so missing is honest.
         msg = f"{provider} is not available to resolve image {path_or_url}"
         raise ProviderUnavailableError(msg)
     # handle HTTP location

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -2127,6 +2127,9 @@ def guard_single_request[SelfT: _SupportsMass, **P, R](
             task_id=task_id,
             abort_existing=False,
             eager_start=True,
+            # every caller awaits the flight below and so sees the failure itself; the
+            # task's own exception log would report a handled error as an unhandled one
+            log_exceptions=False,
             **kwargs,
         )
         return await join_task(task)

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -720,7 +720,8 @@ class MusicAssistant:
                            for next event loop iteration. This ensures proper ordering
                            when creating multiple tasks in sequence.
         :param log_exceptions: Set to False when the caller awaits the task and reports
-                               its failures itself, so a handled error is not also logged.
+                               its failures itself; the task then logs at debug level
+                               instead of warning.
         :param kwargs: Keyword arguments to pass to the coroutine function.
         """
         if task_id and (existing := self._tracked_tasks.get(task_id)) and not existing.done():
@@ -761,9 +762,13 @@ class MusicAssistant:
                 return
             # always retrieve the exception, otherwise asyncio logs a noisy
             # "Task exception was never retrieved" error at garbage collection time
-            if (err := _task.exception()) and log_exceptions:
+            if err := _task.exception():
                 task_name = _task.get_name() if hasattr(_task, "get_name") else str(_task)
-                LOGGER.warning(
+                # a failure the waiters report themselves is demoted rather than dropped:
+                # work that outlives every waiter (join_task keeps it running) would
+                # otherwise fail without a trace anywhere
+                LOGGER.log(
+                    logging.WARNING if log_exceptions else logging.DEBUG,
                     "Exception in task %s - target: %s: %s",
                     task_name,
                     str(target),

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -704,6 +704,7 @@ class MusicAssistant:
         task_id: str | None = None,
         abort_existing: bool = False,
         eager_start: bool = True,
+        log_exceptions: bool = True,
         **kwargs: Any,
     ) -> asyncio.Task[_R]:
         """
@@ -718,6 +719,8 @@ class MusicAssistant:
         :param eager_start: If True (default), start task immediately without waiting
                            for next event loop iteration. This ensures proper ordering
                            when creating multiple tasks in sequence.
+        :param log_exceptions: Set to False when the caller awaits the task and reports
+                               its failures itself, so a handled error is not also logged.
         :param kwargs: Keyword arguments to pass to the coroutine function.
         """
         if task_id and (existing := self._tracked_tasks.get(task_id)) and not existing.done():
@@ -758,7 +761,7 @@ class MusicAssistant:
                 return
             # always retrieve the exception, otherwise asyncio logs a noisy
             # "Task exception was never retrieved" error at garbage collection time
-            if err := _task.exception():
+            if (err := _task.exception()) and log_exceptions:
                 task_name = _task.get_name() if hasattr(_task, "get_name") else str(_task)
                 LOGGER.warning(
                     "Exception in task %s - target: %s: %s",

--- a/tests/controllers/metadata/test_image_proxy.py
+++ b/tests/controllers/metadata/test_image_proxy.py
@@ -4,11 +4,12 @@ import asyncio
 import hashlib
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
 from music_assistant_models.enums import ImageType
+from music_assistant_models.errors import ProviderUnavailableError
 from music_assistant_models.media_items import (
     MediaItemImage,
     MediaItemMetadata,
@@ -42,6 +43,7 @@ from music_assistant.helpers.images import (
     is_svg_data,
     player_image_url,
 )
+from music_assistant.providers.filesystem_local import LocalFileSystemProvider
 
 
 @pytest.fixture
@@ -56,6 +58,26 @@ async def metadata_controller(
     pure helper tests here, which need neither a controller nor a cache database.
     """
     return metadata_controller
+
+
+def _fake_image_provider(instance_id: str, resolved_path: str) -> LocalFileSystemProvider:
+    """
+    Build a bare filesystem provider that resolves any image path to `resolved_path`.
+
+    A real provider instance is used rather than a mock because the image helpers narrow
+    on the concrete provider types before calling `resolve_image`.
+
+    :param instance_id: Instance id to register the provider under.
+    :param resolved_path: Absolute path every image path resolves to.
+    """
+    with patch.object(LocalFileSystemProvider, "__init__", lambda *_a, **_kw: None):
+        provider = LocalFileSystemProvider.__new__(LocalFileSystemProvider)
+    provider.config = MagicMock(instance_id=instance_id)
+    provider.manifest = MagicMock(domain="filesystem_local")
+    provider.logger = MagicMock()
+    provider.available = True
+    provider.resolve_image = AsyncMock(return_value=resolved_path)  # type: ignore[method-assign]
+    return provider
 
 
 async def _wait_for_persisted_image_id(
@@ -613,6 +635,63 @@ async def test_invalidate_image_cache_end_to_end(
     new_palette = await get_palette(mass, image_path, "builtin")
     assert new_palette is not None
     assert new_palette.primary != palette.primary
+
+
+async def test_cached_thumb_survives_an_unavailable_provider(
+    metadata_controller: MetaDataController, tmp_path: Any
+) -> None:
+    """
+    An already-rendered thumbnail is served while its owning provider is unavailable.
+
+    A filesystem provider marks itself unavailable after a single failed scan and only
+    recovers on a later full sync, so art that is already cached must keep being served
+    for the whole of that window.
+    """
+    mass = metadata_controller.mass
+    source_path = tmp_path / "cover.png"
+    Image.new("RGB", (300, 300), (200, 30, 30)).save(str(source_path), "PNG")
+    provider = _fake_image_provider("filesystem_local--abcd1234", str(source_path))
+    mass._providers[provider.instance_id] = provider
+
+    # the relative path is only resolvable through the provider
+    image_id = metadata_controller.compute_image_id(provider.instance_id, "Artist/Album/cover.jpg")
+    request = MagicMock()
+    request.path = f"/imageproxy/{image_id}"
+    request.query = {"size": "256"}
+
+    warm = await metadata_controller.handle_imageproxy(request)
+    assert warm.status == 200
+    assert warm.body
+
+    provider.available = False
+    assert mass.get_provider(provider.instance_id) is None
+
+    cold = await metadata_controller.handle_imageproxy(request)
+    assert cold.status == 200
+    assert cold.body == warm.body
+
+
+async def test_unavailable_provider_is_not_cached_as_a_missing_image(
+    metadata_controller: MetaDataController, tmp_path: Any
+) -> None:
+    """An unavailable provider is not remembered as a failed source, so recovery is instant."""
+    mass = metadata_controller.mass
+    source_path = tmp_path / "cover.png"
+    Image.new("RGB", (300, 300), (30, 30, 200)).save(str(source_path), "PNG")
+    provider = _fake_image_provider("filesystem_local--efgh5678", str(source_path))
+    provider.available = False
+    mass._providers[provider.instance_id] = provider
+
+    image_path = "Artist/Album/never-fetched.jpg"
+    with pytest.raises(ProviderUnavailableError):
+        await get_image_thumb(mass, image_path, 256, provider.instance_id)
+
+    cache_key = create_thumb_hash(provider.instance_id, image_path)
+    assert cache_key not in images_helper._failed_sources
+
+    # the provider coming back is enough; nothing has to expire first
+    provider.available = True
+    assert await get_image_thumb(mass, image_path, 256, provider.instance_id)
 
 
 def test_player_image_url_forces_jpeg_on_imageproxy_urls() -> None:

--- a/tests/controllers/metadata/test_image_proxy.py
+++ b/tests/controllers/metadata/test_image_proxy.py
@@ -2,14 +2,15 @@
 
 import asyncio
 import hashlib
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import web
 from music_assistant_models.enums import ImageType
-from music_assistant_models.errors import ProviderUnavailableError
+from music_assistant_models.errors import MediaNotFoundError, ProviderUnavailableError
 from music_assistant_models.media_items import (
     MediaItemImage,
     MediaItemMetadata,
@@ -60,6 +61,18 @@ async def metadata_controller(
     return metadata_controller
 
 
+@pytest.fixture(autouse=True)
+def _reset_image_caches() -> Iterator[None]:
+    """Isolate the module-level image caches between tests."""
+    images_helper._thumb_memory_cache.clear()
+    images_helper._source_memory_cache.clear()
+    images_helper._failed_sources.clear()
+    yield
+    images_helper._thumb_memory_cache.clear()
+    images_helper._source_memory_cache.clear()
+    images_helper._failed_sources.clear()
+
+
 def _fake_image_provider(instance_id: str, resolved_path: str) -> LocalFileSystemProvider:
     """
     Build a bare filesystem provider that resolves any image path to `resolved_path`.
@@ -70,8 +83,7 @@ def _fake_image_provider(instance_id: str, resolved_path: str) -> LocalFileSyste
     :param instance_id: Instance id to register the provider under.
     :param resolved_path: Absolute path every image path resolves to.
     """
-    with patch.object(LocalFileSystemProvider, "__init__", lambda *_a, **_kw: None):
-        provider = LocalFileSystemProvider.__new__(LocalFileSystemProvider)
+    provider = LocalFileSystemProvider.__new__(LocalFileSystemProvider)
     provider.config = MagicMock(instance_id=instance_id)
     provider.manifest = MagicMock(domain="filesystem_local")
     provider.logger = MagicMock()
@@ -665,6 +677,9 @@ async def test_cached_thumb_survives_an_unavailable_provider(
 
     provider.available = False
     assert mass.get_provider(provider.instance_id) is None
+    # drop the memory tier so the on-disk thumbnail is what has to answer: that is the
+    # reported scenario, where the art was rendered long before the provider went down
+    images_helper._thumb_memory_cache.clear()
 
     cold = await metadata_controller.handle_imageproxy(request)
     assert cold.status == 200
@@ -672,7 +687,7 @@ async def test_cached_thumb_survives_an_unavailable_provider(
 
 
 async def test_unavailable_provider_is_not_cached_as_a_missing_image(
-    metadata_controller: MetaDataController, tmp_path: Any
+    metadata_controller: MetaDataController, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """An unavailable provider is not remembered as a failed source, so recovery is instant."""
     mass = metadata_controller.mass
@@ -681,6 +696,13 @@ async def test_unavailable_provider_is_not_cached_as_a_missing_image(
     provider = _fake_image_provider("filesystem_local--efgh5678", str(source_path))
     provider.available = False
     mass._providers[provider.instance_id] = provider
+
+    # a provider-relative path is unresolvable without its provider, so none of the
+    # fallback routes may be tried - probing one costs an ffmpeg spawn per request
+    async def _no_embedded_probe(*_args: Any, **_kwargs: Any) -> bytes | None:
+        raise AssertionError("embedded-image probe attempted without a provider")
+
+    monkeypatch.setattr(images_helper, "get_embedded_image", _no_embedded_probe)
 
     image_path = "Artist/Album/never-fetched.jpg"
     with pytest.raises(ProviderUnavailableError):
@@ -692,6 +714,28 @@ async def test_unavailable_provider_is_not_cached_as_a_missing_image(
     # the provider coming back is enough; nothing has to expire first
     provider.available = True
     assert await get_image_thumb(mass, image_path, 256, provider.instance_id)
+
+
+async def test_get_thumbnail_reports_unavailable_as_media_not_found(
+    metadata_controller: MetaDataController, tmp_path: Any
+) -> None:
+    """
+    `get_thumbnail` keeps normalizing to one typed error when a provider is unavailable.
+
+    Callers that only mean to skip the artwork catch `MediaNotFoundError`; leaking a
+    different type aborts the whole send they were part of.
+    """
+    mass = metadata_controller.mass
+    source_path = tmp_path / "cover.png"
+    Image.new("RGB", (300, 300), (10, 200, 10)).save(str(source_path), "PNG")
+    provider = _fake_image_provider("filesystem_local--ijkl9012", str(source_path))
+    provider.available = False
+    mass._providers[provider.instance_id] = provider
+
+    with pytest.raises(MediaNotFoundError):
+        await metadata_controller.get_thumbnail(
+            "Artist/Album/cover.jpg", provider.instance_id, size=256
+        )
 
 
 def test_player_image_url_forces_jpeg_on_imageproxy_urls() -> None:

--- a/tests/controllers/metadata/test_image_proxy.py
+++ b/tests/controllers/metadata/test_image_proxy.py
@@ -716,6 +716,25 @@ async def test_unavailable_provider_is_not_cached_as_a_missing_image(
     assert await get_image_thumb(mass, image_path, 256, provider.instance_id)
 
 
+async def test_absolute_path_is_read_without_its_provider(
+    metadata_controller: MetaDataController, tmp_path: Any
+) -> None:
+    """
+    An absolute image path stays readable while its provider is unavailable.
+
+    Providers that write their own image files (playlist artwork, collages) pair an
+    absolute path with their instance id, and such a file needs no provider to be read.
+    """
+    mass = metadata_controller.mass
+    source_path = tmp_path / "playlist-art.png"
+    Image.new("RGB", (300, 300), (200, 200, 10)).save(str(source_path), "PNG")
+    provider = _fake_image_provider("playlist_metadata--mnop3456", str(source_path))
+    provider.available = False
+    mass._providers[provider.instance_id] = provider
+
+    assert await get_image_thumb(mass, str(source_path), 256, provider.instance_id)
+
+
 async def test_get_thumbnail_reports_unavailable_as_media_not_found(
     metadata_controller: MetaDataController, tmp_path: Any
 ) -> None:

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import gc
+import logging
 import socket
 import threading
 import time
@@ -601,7 +602,7 @@ class TestGuardSingleRequest:
     async def test_failure_reaches_the_caller_without_being_logged(
         self, mass_minimal: MusicAssistant, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A failure raised at the caller is not also logged as an unhandled task exception."""
+        """A failure raised at the caller is not also warned about as an unhandled one."""
         caller = _GuardedCaller(mass_minimal)
         caller.error = ProviderUnavailableError("some_provider is not available")
         caller.release.set()
@@ -612,7 +613,11 @@ class TestGuardSingleRequest:
         # the task's done callback runs an iteration after the task itself finished
         await asyncio.sleep(0)
         await asyncio.sleep(0)
-        assert "Exception in task" not in caplog.text
+        assert not [
+            record
+            for record in caplog.records
+            if record.levelno >= logging.WARNING and "Exception in task" in record.getMessage()
+        ]
 
     @pytest.mark.asyncio
     async def test_instances_get_their_own_request(self, mass_minimal: MusicAssistant) -> None:

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import ifaddr
 import pytest
 from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import ProviderUnavailableError
 from music_assistant_models.media_items import Album, ItemMapping, ProviderMapping, Track
 
 from music_assistant.helpers import util
@@ -597,6 +598,23 @@ class TestGuardSingleRequest:
         assert caller.calls == 1
 
     @pytest.mark.asyncio
+    async def test_failure_reaches_the_caller_without_being_logged(
+        self, mass_minimal: MusicAssistant, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A failure raised at the caller is not also logged as an unhandled task exception."""
+        caller = _GuardedCaller(mass_minimal)
+        caller.error = ProviderUnavailableError("some_provider is not available")
+        caller.release.set()
+
+        with pytest.raises(ProviderUnavailableError):
+            await caller.fetch("123")
+
+        # the task's done callback runs an iteration after the task itself finished
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert "Exception in task" not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_instances_get_their_own_request(self, mass_minimal: MusicAssistant) -> None:
         """Two objects of the same class each issue their own request."""
         first = _GuardedCaller(mass_minimal)
@@ -771,12 +789,15 @@ class _GuardedCaller:
         self.mass = mass
         self.calls = 0
         self.release = asyncio.Event()
+        self.error: Exception | None = None
 
     @guard_single_request
     async def fetch(self, item_id: str) -> str:
         """Return the result for the given item id, once released."""
         self.calls += 1
         await self.release.wait()
+        if self.error is not None:
+            raise self.error
         return f"result-{item_id}"
 
     @guard_single_request


### PR DESCRIPTION
# What does this implement/fix?

Album art could stop showing up while everything else kept working — most visibly on a cast dashboard, which sits on one screen for hours and so never re-requests an image it already failed to load.

A local-file provider marks itself unavailable after a single failed library scan and only recovers when a later full sync completes. During that window the image proxy rejected *every* image belonging to that provider before it even looked in its caches, so art that was already rendered and sitting on disk was answered with a "not found". It also remembered the failure as a missing image for 5 minutes, delaying recovery further.

Album art stored as a `cover.jpg` next to the music files is hit hardest, because that image belongs to the album rather than the track and needs one extra provider lookup that embedded artwork does not.

Changes:

- Cached artwork is now served even while its provider is briefly unavailable; availability is only checked once there is no other way left to read the image.
- An unavailable provider is reported as such instead of as a missing image, so nothing is remembered and art returns the moment the provider does.
- Failures on this path now say *why* they failed — the log line previously ended in a colon with no reason.
- Shared work that every caller waits for no longer logs failures its callers already report. This is what produced the stream of `Exception in task ... is not available` warnings.

**Related issue (if applicable):**

- reported on Discord

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
