### PR TITLE
Keep AirPlay speakers from starting at full volume or silent when a device has several interfaces

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -2078,6 +2078,8 @@ class Player(ABC):
         not depend on whether that output has been marked active yet.
 
         :param output_protocol_id: Player id of the output protocol rendering the audio.
+        :return: A control id, or NATIVE/FAKE/NONE. NONE means nothing in the signal path
+            of that output owns the volume; no sibling interface is offered as a fallback.
         """
         return self.__control_for_output(
             PlayerFeature.VOLUME_SET, CONF_VOLUME_CONTROL, output_protocol_id
@@ -2092,9 +2094,17 @@ class Player(ABC):
 
         :param output_protocol_id: Player id of the output protocol rendering the audio.
         """
-        return self.__control_for_output(
+        control = self.__control_for_output(
             PlayerFeature.VOLUME_MUTE, CONF_MUTE_CONTROL, output_protocol_id
         )
+        if (
+            control == PLAYER_CONTROL_FAKE
+            and self.volume_control_for_output(output_protocol_id) == PLAYER_CONTROL_NONE
+        ):
+            # fake mute is simulated by setting the volume to zero, so without a volume
+            # control on this output there is no way to mute it at all
+            return PLAYER_CONTROL_NONE
+        return control
 
     def _update_setup_data(self, key: str, value: ConfigValueType, immediate: bool = True) -> None:
         """

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -2067,6 +2067,35 @@ class Player(ABC):
                 f"Player {self.display_name} does not support feature {feature.name}"
             )
 
+    @final
+    def volume_control_for_output(self, output_protocol_id: str) -> str:
+        """
+        Return the volume control that owns audio rendered over the given output.
+
+        Unlike :attr:`volume_control`, which answers where a volume command should go
+        right now, this answers who owns the volume of one specific output. Callers that
+        know which interface is about to carry the audio must use this, so the answer does
+        not depend on whether that output has been marked active yet.
+
+        :param output_protocol_id: Player id of the output protocol rendering the audio.
+        """
+        return self.__control_for_output(
+            PlayerFeature.VOLUME_SET, CONF_VOLUME_CONTROL, output_protocol_id
+        )
+
+    @final
+    def mute_control_for_output(self, output_protocol_id: str) -> str:
+        """
+        Return the mute control that owns audio rendered over the given output.
+
+        The mute counterpart of :meth:`volume_control_for_output`.
+
+        :param output_protocol_id: Player id of the output protocol rendering the audio.
+        """
+        return self.__control_for_output(
+            PlayerFeature.VOLUME_MUTE, CONF_MUTE_CONTROL, output_protocol_id
+        )
+
     def _update_setup_data(self, key: str, value: ConfigValueType, immediate: bool = True) -> None:
         """
         Update a single setup_data value for this player (e.g. a rotated pairing credential).
@@ -2168,6 +2197,32 @@ class Player(ABC):
                 return protocol_player
 
         return None
+
+    @final
+    def __control_for_output(
+        self, feature: PlayerFeature, conf_key: str, output_protocol_id: str
+    ) -> str:
+        """Resolve the control owning the given feature for one specific output."""
+        conf = self.mass.config.get_raw_player_config_value(self.player_id, conf_key)
+        if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
+            return str(conf)
+        if conf and conf not in (PLAYER_CONTROL_PROTOCOL, "auto"):
+            # An explicitly configured control is a statement about the device as a whole,
+            # so it stays in charge no matter which of its interfaces renders the audio.
+            if (_player := self.mass.players.get_player(str(conf))) and _player.available:
+                return _player.player_id
+            if _control := self.mass.players.get_player_control(str(conf)):
+                return _control.id
+        if feature in self.supported_features:
+            return PLAYER_CONTROL_NATIVE
+        # Deliberately no fallback to a sibling interface: the caller named the output that
+        # carries the audio, so anything else is by definition not in that signal path.
+        # Availability is not checked either - the named output is the one about to render.
+        if (
+            protocol_player := self.mass.players.get_player(output_protocol_id)
+        ) and feature in protocol_player.supported_features:
+            return protocol_player.player_id
+        return PLAYER_CONTROL_NONE
 
     @final
     def __collect_input_snapshot(self) -> dict[str, Any]:

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -823,8 +823,8 @@ class AirPlayPlayer(Player):
         so we try to sync from that parent player if possible. If another control owns
         the parent's volume, we play at unity gain instead.
 
-        Both controls are resolved against this player as the rendering output, so the
-        outcome does not depend on the parent already pointing at us.
+        Both controls are resolved against this player as the rendering output, so which
+        control is deemed to own them does not depend on the parent already pointing at us.
         """
         if not self.protocol_parent_id:
             return
@@ -927,31 +927,27 @@ class AirPlayPlayer(Player):
         return True
 
     def _sync_mute_state(self, parent_player: Player) -> bool:
-        """Adopt the parent's mute state if it owns this output, return True if changed."""
-        mute_control = parent_player.mute_control_for_output(self.player_id)
-        if self._control_routes_to_self(mute_control):
-            if (parent_muted := parent_player.state.volume_muted) is None:
-                return False
-            muted = bool(parent_muted)
-        elif self._attr_volume_muted:
-            # The mute belongs to a control that does not own this output (a sibling
-            # interface, the receiver itself, or nothing at all). Our mute is a latch that
-            # is only ever cleared by an explicit unmute, so leaving it set here would
-            # start the stream silent and swallow every volume command that follows.
-            muted = False
-        else:
-            # never latched, so there is nothing to clear and no state to invent
+        """Release a mute owned by another control, return True if changed."""
+        if not self._attr_volume_muted:
+            # nothing latched, so nothing that could silence this stream
             return False
-        if self._attr_volume_muted == muted:
+        if self._control_routes_to_self(parent_player.mute_control_for_output(self.player_id)):
+            # our own mute, applied through the parent
             return False
-        self._attr_volume_muted = muted
+        # The mute belongs to a control that does not own this output (a sibling interface,
+        # the receiver itself, or nothing at all). Our mute is a latch that only an explicit
+        # unmute clears, so leaving it set would start the stream silent and swallow every
+        # volume command after it. The parent's mute state is deliberately not adopted here:
+        # it is resolved through the ambient control, which is the very thing that may be
+        # pointing at another interface.
+        self._attr_volume_muted = False
         return True
 
     def _control_routes_to_self(self, control: str) -> bool:
         """Return True if the given (resolved) control routes to this player."""
         if control == self.player_id:
             return True
-        # bridge players riding on this player (e.g. Sendspin-over-AirPlay) forward volume here
+        # bridge players riding on this player (e.g. Sendspin-over-AirPlay) forward to us
         if control_player := self.mass.players.get_player(control):
             return control_player.underlying_player_id == self.player_id
         return False

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -813,50 +813,28 @@ class AirPlayPlayer(Player):
             bit_depth=24,
         )
 
-    def sync_volume_level(self) -> None:
+    def sync_volume_state(self) -> None:
         """
-        Sync volume from parent player if needed.
+        Sync volume and mute from the parent player if needed.
 
         AirPlay players only report their volume level when we are actually streaming to them
         and we remember the last used/reported volume level in the player config by default
         but if we have a parent player, that may know better about the current volume level,
         so we try to sync from that parent player if possible. If another control owns
         the parent's volume, we play at unity gain instead.
+
+        Both controls are resolved against this player as the rendering output, so the
+        outcome does not depend on the parent already pointing at us.
         """
         if not self.protocol_parent_id:
             return
         parent_player = self.mass.players.get_player(self.protocol_parent_id)
         if not parent_player:
             return
-        volume_control = parent_player.volume_control
-        if volume_control == PLAYER_CONTROL_NATIVE:
-            # Native parent volume is on the receiver/amplifier scale.
-            # Keep the AirPlay child volume learned from DACP feedback instead.
-            return
-        if not self._volume_control_routes_to_self(volume_control):
-            # Another control (e.g. DLNA/Chromecast hardware volume) owns the parent's
-            # volume; play at unity gain so we don't attenuate on top of it.
-            # Not persisted, so the last software volume survives a switch back.
-            if self._attr_volume_level != 100:
-                self._attr_volume_level = 100
-                self.update_state()
-            return
-        if parent_player.state.volume_level is None:
-            return
-        if parent_player.state.volume_level == 0:
-            # A parent volume of 0 usually means the (idle) sibling interface
-            # feeding the parent doesn't know the real device volume, e.g. the
-            # cast side of the same device reports 0 while in standby. Adopting
-            # it would start the stream hard muted, so keep our own last known
-            # volume instead.
-            return
-        if self._attr_volume_level == parent_player.state.volume_level:
-            return
-        self._attr_volume_level = parent_player.state.volume_level
-        self.mass.config.set_raw_player_config_value(
-            self.player_id, CONF_STORED_VOLUME, self._attr_volume_level
-        )
-        self.update_state()
+        volume_changed = self._sync_volume_level(parent_player)
+        mute_changed = self._sync_mute_state(parent_player)
+        if volume_changed or mute_changed:
+            self.update_state()
 
     async def on_config_updated(self) -> None:
         """Handle logic when the player config is updated."""
@@ -916,12 +894,65 @@ class AirPlayPlayer(Player):
         progress = int(metadata.corrected_elapsed_time or 0)
         self.mass.create_task(self.stream.send_metadata(progress, metadata))
 
-    def _volume_control_routes_to_self(self, volume_control: str) -> bool:
-        """Return True if the given (resolved) volume control routes volume to this player."""
-        if volume_control == self.player_id:
+    def _sync_volume_level(self, parent_player: Player) -> bool:
+        """Adopt the parent's volume level if it owns this output, return True if changed."""
+        volume_control = parent_player.volume_control_for_output(self.player_id)
+        if volume_control == PLAYER_CONTROL_NATIVE:
+            # Native parent volume is on the receiver/amplifier scale.
+            # Keep the AirPlay child volume learned from DACP feedback instead.
+            return False
+        if not self._control_routes_to_self(volume_control):
+            # Another control (e.g. DLNA/Chromecast hardware volume) owns the parent's
+            # volume; play at unity gain so we don't attenuate on top of it.
+            # Not persisted, so the last software volume survives a switch back.
+            if self._attr_volume_level == 100:
+                return False
+            self._attr_volume_level = 100
+            return True
+        if parent_player.state.volume_level is None:
+            return False
+        if parent_player.state.volume_level == 0:
+            # A parent volume of 0 usually means the (idle) sibling interface
+            # feeding the parent doesn't know the real device volume, e.g. the
+            # cast side of the same device reports 0 while in standby. Adopting
+            # it would start the stream hard muted, so keep our own last known
+            # volume instead.
+            return False
+        if self._attr_volume_level == parent_player.state.volume_level:
+            return False
+        self._attr_volume_level = parent_player.state.volume_level
+        self.mass.config.set_raw_player_config_value(
+            self.player_id, CONF_STORED_VOLUME, self._attr_volume_level
+        )
+        return True
+
+    def _sync_mute_state(self, parent_player: Player) -> bool:
+        """Adopt the parent's mute state if it owns this output, return True if changed."""
+        mute_control = parent_player.mute_control_for_output(self.player_id)
+        if self._control_routes_to_self(mute_control):
+            if (parent_muted := parent_player.state.volume_muted) is None:
+                return False
+            muted = bool(parent_muted)
+        elif self._attr_volume_muted:
+            # The mute belongs to a control that does not own this output (a sibling
+            # interface, the receiver itself, or nothing at all). Our mute is a latch that
+            # is only ever cleared by an explicit unmute, so leaving it set here would
+            # start the stream silent and swallow every volume command that follows.
+            muted = False
+        else:
+            # never latched, so there is nothing to clear and no state to invent
+            return False
+        if self._attr_volume_muted == muted:
+            return False
+        self._attr_volume_muted = muted
+        return True
+
+    def _control_routes_to_self(self, control: str) -> bool:
+        """Return True if the given (resolved) control routes to this player."""
+        if control == self.player_id:
             return True
         # bridge players riding on this player (e.g. Sendspin-over-AirPlay) forward volume here
-        if control_player := self.mass.players.get_player(volume_control):
+        if control_player := self.mass.players.get_player(control):
             return control_player.underlying_player_id == self.player_id
         return False
 

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -653,7 +653,7 @@ class SendspinAirPlayBridge:
         # Drain stale audio data from the previous stream
         while not self._write_queue.empty():
             self._write_queue.get_nowait()
-        self.airplay_player.sync_volume_level()
+        self.airplay_player.sync_volume_state()
         self._writer_task = self.mass.create_task(self._cli_writer())
         self.logger.info(
             "Bridge writer started for %s, awaiting first chunk",

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -1018,8 +1018,8 @@ class AirPlayStreamSession:
         """
         # joining a session supersedes any pending automatic group re-join
         airplay_player.cancel_group_rejoin()
-        # sync volume from parent player if needed
-        airplay_player.sync_volume_level()
+        # sync volume/mute from parent player if needed
+        airplay_player.sync_volume_state()
         if airplay_player.stream and airplay_player.stream.running:
             await airplay_player.stream.stop()
         stream_pcm_format = airplay_player.get_stream_pcm_format(self.pcm_format)

--- a/tests/models/test_player_controls.py
+++ b/tests/models/test_player_controls.py
@@ -657,3 +657,64 @@ class TestControlForOutput:
         player = _create_player(mock_mass)
         _link_protocols(player, [_make_protocol_link("proto_a")])
         assert player.mute_control_for_output("proto_a") == PLAYER_CONTROL_NONE
+
+    def test_explicit_player_id_config_beats_named_output(self, mock_mass: MagicMock) -> None:
+        """An explicitly configured control outranks the output carrying the audio."""
+        proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_SET})
+        proto_b = _create_protocol_player(mock_mass, "proto_b", {PlayerFeature.VOLUME_SET})
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": proto_a, "proto_b": proto_b})
+        )
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect({CONF_VOLUME_CONTROL: "proto_a"})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(
+            player,
+            [
+                _make_protocol_link("proto_a", priority=0),
+                _make_protocol_link("proto_b", priority=1),
+            ],
+        )
+        assert player.volume_control_for_output("proto_b") == "proto_a"
+
+    def test_does_not_require_output_to_be_available(self, mock_mass: MagicMock) -> None:
+        """
+        An unavailable reading does not hand the volume to a different interface.
+
+        The caller names the output it is about to stream to, so a stale registry
+        reading is no reason to fall back to a sibling that isn't in the signal path.
+        """
+        proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_SET})
+        proto_b = _create_protocol_player(
+            mock_mass, "proto_b", {PlayerFeature.VOLUME_SET}, available=False
+        )
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": proto_a, "proto_b": proto_b})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(
+            player,
+            [
+                _make_protocol_link("proto_a", priority=0),
+                _make_protocol_link("proto_b", priority=1),
+            ],
+        )
+        assert player.volume_control == "proto_a"
+        assert player.volume_control_for_output("proto_b") == "proto_b"
+
+    def test_fake_mute_degrades_without_volume_control_on_output(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Fake mute drives the volume to zero, so it needs a volume control to drive."""
+        proto_a = _create_protocol_player(mock_mass, "proto_a", set())
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": proto_a})
+        )
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect({CONF_MUTE_CONTROL: PLAYER_CONTROL_FAKE})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(player, [_make_protocol_link("proto_a")])
+        assert player.volume_control_for_output("proto_a") == PLAYER_CONTROL_NONE
+        assert player.mute_control_for_output("proto_a") == PLAYER_CONTROL_NONE

--- a/tests/models/test_player_controls.py
+++ b/tests/models/test_player_controls.py
@@ -527,3 +527,133 @@ class TestActiveOutputProtocolClearCancellation:
         player.set_active_output_protocol("ap_1")
 
         mock_mass.cancel_task.assert_called_once_with("clear_active_protocol_main_player")
+
+
+class TestControlForOutput:
+    """Test the output-scoped volume/mute control resolution."""
+
+    def _get_player_lookup(self, players: dict[str, MockPlayer]) -> Any:
+        """Create a side_effect that looks up players by ID."""
+
+        def _lookup(pid: str) -> MockPlayer | None:
+            return players.get(pid)
+
+        return _lookup
+
+    def test_resolves_named_output_without_active_protocol(self, mock_mass: MagicMock) -> None:
+        """
+        The named output owns the volume even when no protocol is marked active.
+
+        This is the ordering trap the ambient volume_control falls into: with nothing
+        active it picks a sibling interface, which made a joining AirPlay speaker
+        decide another control owned the volume and play at unity gain.
+        """
+        proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_SET})
+        proto_b = _create_protocol_player(mock_mass, "proto_b", {PlayerFeature.VOLUME_SET})
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": proto_a, "proto_b": proto_b})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(
+            player,
+            [
+                _make_protocol_link("proto_a", priority=0),
+                _make_protocol_link("proto_b", priority=1),
+            ],
+        )
+        # the ambient answer picks the first linked protocol, the output-scoped one
+        # answers for the interface that is actually about to render
+        assert player.volume_control == "proto_a"
+        assert player.volume_control_for_output("proto_b") == "proto_b"
+
+    def test_ignores_active_protocol_pointing_elsewhere(self, mock_mass: MagicMock) -> None:
+        """A protocol marked active does not override the named output."""
+        proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_SET})
+        proto_b = _create_protocol_player(mock_mass, "proto_b", {PlayerFeature.VOLUME_SET})
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": proto_a, "proto_b": proto_b})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(
+            player,
+            [
+                _make_protocol_link("proto_a", priority=0),
+                _make_protocol_link("proto_b", priority=1),
+            ],
+            active_protocol_id="proto_a",
+        )
+        assert player.volume_control_for_output("proto_b") == "proto_b"
+
+    def test_returns_none_when_output_lacks_feature(self, mock_mass: MagicMock) -> None:
+        """No fallback to a sibling: an output without the feature does not own it."""
+        proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_SET})
+        proto_b = _create_protocol_player(mock_mass, "proto_b", set())
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": proto_a, "proto_b": proto_b})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(
+            player,
+            [
+                _make_protocol_link("proto_a", priority=0),
+                _make_protocol_link("proto_b", priority=1),
+            ],
+        )
+        assert player.volume_control == "proto_a"
+        assert player.volume_control_for_output("proto_b") == PLAYER_CONTROL_NONE
+
+    def test_prefers_native(self, mock_mass: MagicMock) -> None:
+        """A player with native volume owns it regardless of the output."""
+        proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_SET})
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": proto_a})
+        )
+        player = _create_player(mock_mass, features={PlayerFeature.VOLUME_SET})
+        _link_protocols(player, [_make_protocol_link("proto_a")])
+        assert player.volume_control_for_output("proto_a") == PLAYER_CONTROL_NATIVE
+
+    def test_explicit_config_wins(self, mock_mass: MagicMock) -> None:
+        """An explicitly configured control is a device-wide statement, so it still wins."""
+        proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_SET})
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": proto_a})
+        )
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect({CONF_VOLUME_CONTROL: PLAYER_CONTROL_FAKE})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(player, [_make_protocol_link("proto_a")])
+        assert player.volume_control_for_output("proto_a") == PLAYER_CONTROL_FAKE
+
+    def test_unknown_output_returns_none(self, mock_mass: MagicMock) -> None:
+        """An output that cannot be resolved owns nothing."""
+        player = _create_player(mock_mass)
+        assert player.volume_control_for_output("nope") == PLAYER_CONTROL_NONE
+
+    def test_mute_resolves_named_output(self, mock_mass: MagicMock) -> None:
+        """Mute resolves against the named output the same way volume does."""
+        proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_MUTE})
+        proto_b = _create_protocol_player(mock_mass, "proto_b", {PlayerFeature.VOLUME_MUTE})
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": proto_a, "proto_b": proto_b})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(
+            player,
+            [
+                _make_protocol_link("proto_a", priority=0),
+                _make_protocol_link("proto_b", priority=1),
+            ],
+        )
+        assert player.mute_control == "proto_a"
+        assert player.mute_control_for_output("proto_b") == "proto_b"
+
+    def test_mute_returns_none_when_output_lacks_feature(self, mock_mass: MagicMock) -> None:
+        """An output with volume but no mute does not own the mute."""
+        proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_SET})
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": proto_a})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(player, [_make_protocol_link("proto_a")])
+        assert player.mute_control_for_output("proto_a") == PLAYER_CONTROL_NONE

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -731,6 +731,7 @@ def test_sync_volume_state_keeps_stored_volume_for_native_parent(
     parent = MagicMock()
     parent.state.volume_level = 36
     parent.volume_control_for_output.return_value = PLAYER_CONTROL_NATIVE
+    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
     airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
     airplay_player.set_protocol_parent_id("parent")
     airplay_player._attr_volume_level = 48
@@ -773,6 +774,7 @@ def test_sync_volume_state_uses_parent_volume_when_control_is_self(
     parent = MagicMock()
     parent.state.volume_level = 42
     parent.volume_control_for_output.return_value = "test_player"
+    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
     airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
     airplay_player.set_protocol_parent_id("parent")
     airplay_player._attr_volume_level = 48
@@ -796,6 +798,7 @@ def test_sync_volume_state_uses_parent_volume_via_bridge_control(
     parent = MagicMock()
     parent.state.volume_level = 42
     parent.volume_control_for_output.return_value = "sendspin_bridge"
+    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
     bridge = MagicMock()
     bridge.underlying_player_id = "test_player"
     airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
@@ -824,6 +827,7 @@ def test_sync_volume_state_unity_gain_when_other_control_owns_volume(
     parent = MagicMock()
     parent.state.volume_level = 30
     parent.volume_control_for_output.return_value = "dlna_player"
+    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
     dlna_player = MagicMock()
     dlna_player.underlying_player_id = None
     airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
@@ -854,6 +858,7 @@ def test_sync_volume_state_ignores_parent_volume_zero(
     parent = MagicMock()
     parent.state.volume_level = 0
     parent.volume_control_for_output.return_value = "test_player"
+    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
     airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
     airplay_player.set_protocol_parent_id("parent")
     airplay_player._attr_volume_level = 48
@@ -897,10 +902,10 @@ def test_sync_volume_state_clears_mute_latch_owned_by_other_control(
     mock_update.assert_called_once()
 
 
-def test_sync_volume_state_adopts_parent_mute_when_control_is_self(
+def test_sync_volume_state_keeps_mute_owned_by_this_output(
     airplay_player: AirPlayPlayer,
 ) -> None:
-    """Adopt the parent mute state when this player owns the parent's mute."""
+    """Keep our own mute when this player owns the parent's mute."""
     parent = MagicMock()
     parent.state.volume_level = 40
     parent.state.volume_muted = True
@@ -908,13 +913,13 @@ def test_sync_volume_state_adopts_parent_mute_when_control_is_self(
     parent.mute_control_for_output.return_value = "test_player"
     airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
     airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_muted = False
+    airplay_player._attr_volume_muted = True
 
     with patch.object(AirPlayPlayer, "update_state") as mock_update:
         airplay_player.sync_volume_state()
 
     assert airplay_player._attr_volume_muted is True
-    mock_update.assert_called_once()
+    mock_update.assert_not_called()
 
 
 def test_sync_volume_state_leaves_unknown_mute_untouched(
@@ -953,6 +958,7 @@ def test_sync_volume_state_resolves_against_this_output(
     parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
     airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
     airplay_player.set_protocol_parent_id("parent")
+    airplay_player._attr_volume_muted = True
 
     airplay_player.sync_volume_state()
 

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -724,19 +724,19 @@ async def test_volume_mute_no_stream(airplay_player: AirPlayPlayer) -> None:
         mock_update.assert_called_once()
 
 
-def test_sync_volume_level_keeps_stored_volume_for_native_parent(
+def test_sync_volume_state_keeps_stored_volume_for_native_parent(
     airplay_player: AirPlayPlayer,
 ) -> None:
     """Keep the child AirPlay volume when the parent uses native volume control."""
     parent = MagicMock()
     parent.state.volume_level = 36
-    parent.volume_control = PLAYER_CONTROL_NATIVE
+    parent.volume_control_for_output.return_value = PLAYER_CONTROL_NATIVE
     airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
     airplay_player.set_protocol_parent_id("parent")
     airplay_player._attr_volume_level = 48
 
     with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_level()
+        airplay_player.sync_volume_state()
 
     assert airplay_player._attr_volume_level == 48
     airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
@@ -766,19 +766,19 @@ def test_update_volume_from_device_keeps_native_parent_feedback(
     mock_update.assert_called_once()
 
 
-def test_sync_volume_level_uses_parent_volume_when_control_is_self(
+def test_sync_volume_state_uses_parent_volume_when_control_is_self(
     airplay_player: AirPlayPlayer,
 ) -> None:
     """Pull the parent volume when the parent's volume control is this player."""
     parent = MagicMock()
     parent.state.volume_level = 42
-    parent.volume_control = "test_player"
+    parent.volume_control_for_output.return_value = "test_player"
     airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
     airplay_player.set_protocol_parent_id("parent")
     airplay_player._attr_volume_level = 48
 
     with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_level()
+        airplay_player.sync_volume_state()
 
     assert airplay_player._attr_volume_level == 42
     airplay_player.mass.config.set_raw_player_config_value.assert_called_once_with(  # type: ignore[attr-defined]
@@ -789,13 +789,13 @@ def test_sync_volume_level_uses_parent_volume_when_control_is_self(
     mock_update.assert_called_once()
 
 
-def test_sync_volume_level_uses_parent_volume_via_bridge_control(
+def test_sync_volume_state_uses_parent_volume_via_bridge_control(
     airplay_player: AirPlayPlayer,
 ) -> None:
     """Pull the parent volume when the volume control is a bridge riding on this player."""
     parent = MagicMock()
     parent.state.volume_level = 42
-    parent.volume_control = "sendspin_bridge"
+    parent.volume_control_for_output.return_value = "sendspin_bridge"
     bridge = MagicMock()
     bridge.underlying_player_id = "test_player"
     airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
@@ -806,7 +806,7 @@ def test_sync_volume_level_uses_parent_volume_via_bridge_control(
     airplay_player._attr_volume_level = 48
 
     with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_level()
+        airplay_player.sync_volume_state()
 
     assert airplay_player._attr_volume_level == 42
     airplay_player.mass.config.set_raw_player_config_value.assert_called_once_with(  # type: ignore[attr-defined]
@@ -817,13 +817,13 @@ def test_sync_volume_level_uses_parent_volume_via_bridge_control(
     mock_update.assert_called_once()
 
 
-def test_sync_volume_level_unity_gain_when_other_control_owns_volume(
+def test_sync_volume_state_unity_gain_when_other_control_owns_volume(
     airplay_player: AirPlayPlayer,
 ) -> None:
     """Play at unity gain when the parent volume is owned by another (hardware) control."""
     parent = MagicMock()
     parent.state.volume_level = 30
-    parent.volume_control = "dlna_player"
+    parent.volume_control_for_output.return_value = "dlna_player"
     dlna_player = MagicMock()
     dlna_player.underlying_player_id = None
     airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
@@ -834,14 +834,14 @@ def test_sync_volume_level_unity_gain_when_other_control_owns_volume(
     airplay_player._attr_volume_level = 48
 
     with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_level()
+        airplay_player.sync_volume_state()
 
     assert airplay_player._attr_volume_level == 100
     airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
     mock_update.assert_called_once()
 
 
-def test_sync_volume_level_ignores_parent_volume_zero(
+def test_sync_volume_state_ignores_parent_volume_zero(
     airplay_player: AirPlayPlayer,
 ) -> None:
     """
@@ -853,17 +853,111 @@ def test_sync_volume_level_ignores_parent_volume_zero(
     """
     parent = MagicMock()
     parent.state.volume_level = 0
-    parent.volume_control = "test_player"
+    parent.volume_control_for_output.return_value = "test_player"
     airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
     airplay_player.set_protocol_parent_id("parent")
     airplay_player._attr_volume_level = 48
 
     with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_level()
+        airplay_player.sync_volume_state()
 
     assert airplay_player._attr_volume_level == 48
     airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
     mock_update.assert_not_called()
+
+
+def test_sync_volume_state_clears_mute_latch_owned_by_other_control(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """
+    Clear our mute when it is owned by a control that doesn't render this stream.
+
+    The mute is a latch that only an explicit unmute clears, so a mute applied while
+    a sibling interface owned the parent would otherwise start this stream silent and
+    swallow every volume command after it.
+    """
+    parent = MagicMock()
+    parent.state.volume_level = 40
+    parent.state.volume_muted = False
+    parent.volume_control_for_output.return_value = PLAYER_CONTROL_NATIVE
+    parent.mute_control_for_output.return_value = "cast_player"
+    cast_player = MagicMock()
+    cast_player.underlying_player_id = None
+    airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
+        "parent": parent,
+        "cast_player": cast_player,
+    }.get
+    airplay_player.set_protocol_parent_id("parent")
+    airplay_player._attr_volume_muted = True
+
+    with patch.object(AirPlayPlayer, "update_state") as mock_update:
+        airplay_player.sync_volume_state()
+
+    assert airplay_player._attr_volume_muted is False
+    mock_update.assert_called_once()
+
+
+def test_sync_volume_state_adopts_parent_mute_when_control_is_self(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """Adopt the parent mute state when this player owns the parent's mute."""
+    parent = MagicMock()
+    parent.state.volume_level = 40
+    parent.state.volume_muted = True
+    parent.volume_control_for_output.return_value = PLAYER_CONTROL_NATIVE
+    parent.mute_control_for_output.return_value = "test_player"
+    airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
+    airplay_player.set_protocol_parent_id("parent")
+    airplay_player._attr_volume_muted = False
+
+    with patch.object(AirPlayPlayer, "update_state") as mock_update:
+        airplay_player.sync_volume_state()
+
+    assert airplay_player._attr_volume_muted is True
+    mock_update.assert_called_once()
+
+
+def test_sync_volume_state_leaves_unknown_mute_untouched(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """Never having latched a mute is not the same as being unmuted."""
+    parent = MagicMock()
+    parent.state.volume_level = 48
+    parent.state.volume_muted = False
+    parent.volume_control_for_output.return_value = PLAYER_CONTROL_NATIVE
+    parent.mute_control_for_output.return_value = "cast_player"
+    cast_player = MagicMock()
+    cast_player.underlying_player_id = None
+    airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
+        "parent": parent,
+        "cast_player": cast_player,
+    }.get
+    airplay_player.set_protocol_parent_id("parent")
+    airplay_player._attr_volume_muted = None
+
+    with patch.object(AirPlayPlayer, "update_state") as mock_update:
+        airplay_player.sync_volume_state()
+
+    assert airplay_player._attr_volume_muted is None
+    mock_update.assert_not_called()
+
+
+def test_sync_volume_state_resolves_against_this_output(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """Both controls are resolved for this player as the rendering output."""
+    parent = MagicMock()
+    parent.state.volume_level = 40
+    parent.state.volume_muted = False
+    parent.volume_control_for_output.return_value = PLAYER_CONTROL_NATIVE
+    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
+    airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
+    airplay_player.set_protocol_parent_id("parent")
+
+    airplay_player.sync_volume_state()
+
+    parent.volume_control_for_output.assert_called_once_with("test_player")
+    parent.mute_control_for_output.assert_called_once_with("test_player")
 
 
 # --- Pause / stop dispatch tests ---


### PR DESCRIPTION
# What does this implement/fix?

`Player.volume_control` answers "where should a volume command go right now", but a few callers were using it to answer a different question: "which interface will actually carry the audio for the stream about to start". When nothing is streaming yet, the first question falls back to a fixed per-domain order (cast, then DLNA, then AirPlay, then Sendspin), so the second question got the wrong answer — and only got the right one if the caller happened to run after the output was marked active.

That ordering dependency is what made an AirPlay speaker join a group at full volume (#5668). That fix reordered the calls; this one separates the two questions so the order stops mattering.

It also closes the same gap on the mute side, which had no fix yet: an AirPlay speaker's mute is a latch that is only ever cleared by an explicit unmute. Mute the player while it streams over AirPlay, then stop playback, and the parent starts reporting the idle Cast side's (unmuted) state — the mute disappears from the UI with nothing left to unmute, while the speaker itself stays latched. The next stream then starts silent and ignores volume changes, and an announcement sent to it plays inaudibly. On Apple devices the device-feedback path that would normally clear it is disabled, so it never recovers.

**Related issue (if applicable):**

- follow-up to #5668

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Added `Player.volume_control_for_output()` and `Player.mute_control_for_output()`, which resolve the control for one named output instead of the ambient one. No fallback to a sibling interface: if the output carrying the audio doesn't own the control, nothing does.
- AirPlay's stream-start sync now uses those, so its volume decision no longer depends on the parent already pointing at it.
- That sync now covers mute too, clearing a stale latch left behind by a control that doesn't own this output.
- `volume_control` / `mute_control` themselves are unchanged — every other caller genuinely wants the ambient answer.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
