### PR TITLE
Sendspin-driven AirPlay speakers keep the volume they are playing at across a track change

### DIFF
--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -653,7 +653,12 @@ class SendspinAirPlayBridge:
         # Drain stale audio data from the previous stream
         while not self._write_queue.empty():
             self._write_queue.get_nowait()
-        self.airplay_player.sync_volume_state()
+        if not keep_stream:
+            # Only a fresh process re-sends VOLUME= (on connect), and only a stream
+            # that stopped can have left our volume and mute state behind. A kept
+            # process kept streaming, so that state is still the one the device
+            # plays at and syncing it from the parent here would only desync it.
+            self.airplay_player.sync_volume_state()
         self._writer_task = self.mass.create_task(self._cli_writer())
         self.logger.info(
             "Bridge writer started for %s, awaiting first chunk",

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -653,12 +653,6 @@ class SendspinAirPlayBridge:
         # Drain stale audio data from the previous stream
         while not self._write_queue.empty():
             self._write_queue.get_nowait()
-        if not keep_stream:
-            # Only a fresh process re-sends VOLUME= (on connect), and only a stream
-            # that stopped can have left our volume and mute state behind. A kept
-            # process kept streaming, so that state is still the one the device
-            # plays at and syncing it from the parent here would only desync it.
-            self.airplay_player.sync_volume_state()
         self._writer_task = self.mass.create_task(self._cli_writer())
         self.logger.info(
             "Bridge writer started for %s, awaiting first chunk",
@@ -736,6 +730,10 @@ class SendspinAirPlayBridge:
             # Resolving and recording the decision never awaits, so two bridges
             # starting together cannot both find their group still undecided.
             self._use_shared_ptp = self._resolve_shared_ptp()
+            # Connecting is what re-sends VOLUME= to the device, so this is the one
+            # place the sync belongs: a kept process never reaches here and would
+            # otherwise be left playing at a volume nobody told it about.
+            self.airplay_player.sync_volume_state()
             await stream.connect(self._use_shared_ptp)
             await stream.wait_for_connection()
             if asyncio.current_task() is not self._airplay_stream_start_task:

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -1844,6 +1844,31 @@ def test_a_grace_timer_that_already_fired_spares_the_restarted_stream() -> None:
     assert not bridge._write_queue.empty()
 
 
+def test_a_kept_process_keeps_the_volume_and_mute_it_plays_at() -> None:
+    """
+    A warm restart does not re-sync volume and mute from the parent player.
+
+    Only a fresh cli process re-sends VOLUME= to the device, so a sync over a
+    kept process would move our state away from what the speaker is playing at
+    -- most visibly by clearing a mute the device is still holding, leaving it
+    silent with nothing in the UI to say so.
+    """
+    bridge, _ = _make_anchored_bridge(running=True)
+
+    bridge._restart_transport()
+
+    cast("MagicMock", bridge.airplay_player).sync_volume_state.assert_not_called()
+
+
+def test_a_fresh_process_syncs_the_volume_and_mute_from_the_parent() -> None:
+    """A cold restart still adopts the parent's volume and releases a foreign mute."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+
+    bridge._restart_transport()
+
+    cast("MagicMock", bridge.airplay_player).sync_volume_state.assert_called_once_with()
+
+
 async def test_the_cleanup_a_start_waits_on_cannot_cancel_it() -> None:
     """
     A start waiting for the pending teardown is not among the handles it cancels.

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -531,6 +531,99 @@ async def test_cold_start_connects_then_anchors_first_start() -> None:
     assert bridge._airplay_stream_ready.is_set()
 
 
+async def test_a_fresh_process_is_told_the_synced_volume_and_mute() -> None:
+    """
+    A cold start syncs volume and mute from the parent before it connects.
+
+    Connecting is what carries that state to the device, so a sync after it
+    would not be heard until the next command.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    stream = _make_anchor_stream()
+    order: list[str] = []
+    cast("MagicMock", bridge.airplay_player).sync_volume_state = MagicMock(
+        side_effect=lambda: order.append("sync")
+    )
+    stream.connect = AsyncMock(side_effect=lambda *_a, **_kw: order.append("connect"))
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=stream,
+        ),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.time",
+            return_value=UNIX_NOW_S,
+        ),
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    assert order == ["sync", "connect"]
+
+
+async def test_a_kept_process_keeps_the_volume_and_mute_it_plays_at() -> None:
+    """
+    A warm handover does not re-sync volume and mute from the parent player.
+
+    Only a connect re-sends VOLUME=, so a sync over a kept process would move our
+    state away from what the speaker is playing at -- most visibly by clearing a
+    mute the device is still holding, leaving it silent with nothing to say so.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    kept_stream = _make_anchor_stream()
+    bridge._airplay_stream = kept_stream
+    bridge.airplay_player.stream = kept_stream
+    bridge._started = True
+
+    # the whole warm restart, from the Sendspin stream-start callback to the handover
+    bridge._on_bridge_stream_start()
+    assert bridge._airplay_stream is kept_stream
+    bridge._drop_until_us = SENDSPIN_EPOCH_US
+    bridge._airplay_stream_start_task = asyncio.current_task()
+
+    with patch(
+        "music_assistant.providers.airplay.sendspin_bridge.time.time",
+        return_value=UNIX_NOW_S,
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    kept_stream.flush.assert_awaited_once_with()
+    cast("MagicMock", bridge.airplay_player).sync_volume_state.assert_not_called()
+
+
+async def test_a_failed_warm_handover_syncs_before_its_cold_retry() -> None:
+    """
+    The cold retry after a failed warm handover is not left with un-synced state.
+
+    That retry spawns a fresh process, which is sent whatever volume and mute it
+    finds on connect, so a mute the parent no longer owns would start it silent.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    kept_stream = _make_anchor_stream()
+    kept_stream.flush = AsyncMock(return_value=False)
+    bridge._airplay_stream = kept_stream
+    cold_stream = _make_anchor_stream()
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=cold_stream,
+        ),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.time",
+            return_value=UNIX_NOW_S,
+        ),
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    cold_stream.connect.assert_awaited_once_with(False)
+    cast("MagicMock", bridge.airplay_player).sync_volume_state.assert_called_once_with()
+
+
 async def test_a_superseded_cold_start_never_reaches_the_receiver() -> None:
     """
     A cold start that already lost the race bails out before it spawns anything.
@@ -1842,31 +1935,6 @@ def test_a_grace_timer_that_already_fired_spares_the_restarted_stream() -> None:
     assert bridge._airplay_stream is stream
     assert bridge._writer_task is new_writer_task
     assert not bridge._write_queue.empty()
-
-
-def test_a_kept_process_keeps_the_volume_and_mute_it_plays_at() -> None:
-    """
-    A warm restart does not re-sync volume and mute from the parent player.
-
-    Only a fresh cli process re-sends VOLUME= to the device, so a sync over a
-    kept process would move our state away from what the speaker is playing at
-    -- most visibly by clearing a mute the device is still holding, leaving it
-    silent with nothing in the UI to say so.
-    """
-    bridge, _ = _make_anchored_bridge(running=True)
-
-    bridge._restart_transport()
-
-    cast("MagicMock", bridge.airplay_player).sync_volume_state.assert_not_called()
-
-
-def test_a_fresh_process_syncs_the_volume_and_mute_from_the_parent() -> None:
-    """A cold restart still adopts the parent's volume and releases a foreign mute."""
-    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
-
-    bridge._restart_transport()
-
-    cast("MagicMock", bridge.airplay_player).sync_volume_state.assert_called_once_with()
 
 
 async def test_the_cleanup_a_start_waits_on_cannot_cancel_it() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5674. When Sendspin drives an AirPlay speaker, a track change reuses the running cliairplay process instead of reconnecting. Only a reconnect re-sends the volume to the speaker, but we re-synced volume and mute from the parent player on every restart — so on a reused process our state could drift away from what the speaker is actually playing at. The most visible case: the speaker stays silent while Music Assistant shows it unmuted.

The sync now happens in the one place a fresh process is spawned, right before it connects, instead of on every transport restart. A reused process keeps the volume and mute it is already playing at, and a fresh one — including the cold retry after a failed warm handover — is always told the state it is about to be sent. This matches the regular (non-Sendspin) AirPlay path, which already only syncs when it spawns a process.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Move the parent volume/mute sync to where a fresh AirPlay process is spawned, so a reused process is no longer left playing at a volume nobody told it about.
- Tests for the reused process, a fresh process, and the cold retry after a failed warm handover.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [x] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
