### PR TITLE
Play announcements through the speaker's usual output

### DIFF
--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -394,6 +394,11 @@ class AnnouncementsMixin:
             # an idle linked protocol (e.g. the AirPlay child of a WiiM
             # playing natively) would seize the device from the active
             # output, with nothing restoring that playback afterwards.
+            # The pick is deliberately not published as the active output
+            # protocol: that would make the player mirror the protocol's
+            # playback state and group members, so an idle player would
+            # report PLAYING for the duration of the clip and the guard
+            # above would refuse the next announcement.
             return self._get_control_target(
                 player,
                 required_feature=PlayerFeature.PLAY_ANNOUNCEMENT,

--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -395,10 +395,9 @@ class AnnouncementsMixin:
             # playing natively) would seize the device from the active
             # output, with nothing restoring that playback afterwards.
             # The pick is deliberately not published as the active output
-            # protocol: that would make the player mirror the protocol's
-            # playback state and group members, so an idle player would
-            # report PLAYING for the duration of the clip and the guard
-            # above would refuse the next announcement.
+            # protocol: the player would then mirror that protocol's playback
+            # state, report PLAYING for the length of the clip and so fail
+            # the check above on the next announcement.
             return self._get_control_target(
                 player,
                 required_feature=PlayerFeature.PLAY_ANNOUNCEMENT,

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1846,13 +1846,15 @@ class ProtocolLinkingMixin:
         """
         Get the best player(protocol) to send audio-path commands to.
 
-        Prefers the active output protocol, otherwise the best available protocol
-        player that supports the needed feature.
-
-        Note this resolves commands that ride along with the audio (enqueue, pause,
-        announcements), so it deliberately puts the rendering output ahead of the
-        native player. Volume and mute are control-plane instead and resolve through
+        Resolves commands that travel with the audio (enqueue, pause, announcements),
+        so the output that renders the audio outranks the native player. Volume and
+        mute are control-plane instead and resolve through
         :meth:`Player._get_protocol_player_for_feature`, which orders differently.
+
+        :param player: The player the command was issued on.
+        :param required_feature: The feature the resolved target has to support.
+        :param require_active: Only accept the output that is already rendering,
+            instead of falling back to an idle one.
         """
         # If we have an active protocol, use that
         if (
@@ -1877,10 +1879,22 @@ class ProtocolLinkingMixin:
         # if the player natively supports the required feature, use that
         if required_feature in player.supported_features:
             return player
-        # Otherwise, use the best available linked protocol. The same priority as
-        # _select_best_output_protocol is applied, so a command that has to start audio
-        # on an idle player (e.g. an announcement) lands on the output that regular
-        # playback would have picked, instead of on whichever protocol linked first.
+
+        # An output the user explicitly picked owns the audio, so a command that has to
+        # start playback on an idle player follows it rather than the priority below.
+        preferred = self.mass.config.get_raw_player_config_value(
+            player.player_id, CONF_PREFERRED_OUTPUT_PROTOCOL
+        )
+        if preferred and preferred not in ("auto", "native"):
+            if (
+                (preferred_player := self.mass.players.get_player(str(preferred)))
+                and preferred_player.available_for_playback
+                and required_feature in preferred_player.supported_features
+            ):
+                return preferred_player
+
+        # Otherwise, use the best available linked protocol, ordered by the same
+        # priority that regular playback selection applies.
         for linked in sorted(player.linked_output_protocols, key=lambda x: x.priority):
             if (
                 (protocol_player := self.mass.players.get_player(linked.output_protocol_id))

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1882,16 +1882,22 @@ class ProtocolLinkingMixin:
 
         # An output the user explicitly picked owns the audio, so a command that has to
         # start playback on an idle player follows it rather than the priority below.
+        # The stored value survives a relink, so it only counts while it still names one
+        # of this player's own outputs.
         preferred = self.mass.config.get_raw_player_config_value(
             player.player_id, CONF_PREFERRED_OUTPUT_PROTOCOL
         )
         if preferred and preferred not in ("auto", "native"):
-            if (
-                (preferred_player := self.mass.players.get_player(str(preferred)))
-                and preferred_player.available_for_playback
-                and required_feature in preferred_player.supported_features
-            ):
-                return preferred_player
+            for linked in player.linked_output_protocols:
+                if linked.output_protocol_id != preferred:
+                    continue
+                if (
+                    (preferred_player := self.mass.players.get_player(str(preferred)))
+                    and preferred_player.available_for_playback
+                    and required_feature in preferred_player.supported_features
+                ):
+                    return preferred_player
+                break
 
         # Otherwise, use the best available linked protocol, ordered by the same
         # priority that regular playback selection applies.

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1844,10 +1844,15 @@ class ProtocolLinkingMixin:
         require_active: bool = False,
     ) -> Player | None:
         """
-        Get the best player(protocol) to send control commands to.
+        Get the best player(protocol) to send audio-path commands to.
 
-        Prefers the active output protocol, otherwise uses the first available
-        protocol player that supports the needed feature.
+        Prefers the active output protocol, otherwise the best available protocol
+        player that supports the needed feature.
+
+        Note this resolves commands that ride along with the audio (enqueue, pause,
+        announcements), so it deliberately puts the rendering output ahead of the
+        native player. Volume and mute are control-plane instead and resolve through
+        :meth:`Player._get_protocol_player_for_feature`, which orders differently.
         """
         # If we have an active protocol, use that
         if (
@@ -1872,8 +1877,11 @@ class ProtocolLinkingMixin:
         # if the player natively supports the required feature, use that
         if required_feature in player.supported_features:
             return player
-        # Otherwise, use the first available linked protocol
-        for linked in player.linked_output_protocols:
+        # Otherwise, use the best available linked protocol. The same priority as
+        # _select_best_output_protocol is applied, so a command that has to start audio
+        # on an idle player (e.g. an announcement) lands on the output that regular
+        # playback would have picked, instead of on whichever protocol linked first.
+        for linked in sorted(player.linked_output_protocols, key=lambda x: x.priority):
             if (
                 (protocol_player := self.mass.players.get_player(linked.output_protocol_id))
                 and protocol_player.available_for_playback

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1479,8 +1479,7 @@ class Player(ABC):
         # this resolves independently from volume_control, so a device whose interfaces
         # advertise volume and mute separately (DLNA derives both from its own
         # RenderingControl actions) can end up with the two controls on different
-        # siblings. use the output-scoped variants when the resolution has to stay
-        # inside one signal path.
+        # siblings.
         if protocol_player := self._get_protocol_player_for_feature(
             PlayerFeature.VOLUME_MUTE, require_active=False
         ):
@@ -2167,11 +2166,15 @@ class Player(ABC):
         """
         Get player(protocol) which has the given PlayerFeature.
 
-        This resolves control-plane features (volume, mute), so the native player wins
-        even while a protocol renders the audio: a device's own volume is its own volume,
-        whichever interface the sound arrives on. Commands that ride along with the audio
-        resolve through PlayerController._get_control_target instead, which puts the
-        rendering output first and orders the fallback by output protocol priority.
+        Resolves control-plane features (volume, mute), so the native player wins even
+        while a protocol renders the audio: a device's own volume is its own volume,
+        whichever interface the sound arrives on. Commands that travel with the audio
+        resolve through :meth:`PlayerController._get_control_target` instead, which
+        prefers the rendering output.
+
+        :param feature: The feature the resolved player has to support.
+        :param require_active: Only accept the output that is already rendering,
+            instead of falling back to an idle one.
         """
         # prefer native player
         if feature in self.supported_features:

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -2194,18 +2194,24 @@ class Player(ABC):
             # doesn't support the feature, return None
             return None
 
-        # fallback to preferred protocol from config
+        # fallback to preferred protocol from config. the stored value survives a
+        # relink, so it only counts while it still names one of this player's own
+        # outputs - otherwise the command would land on another speaker.
         preferred_conf = self.mass.config.get_raw_player_config_value(
             self.player_id, CONF_PREFERRED_OUTPUT_PROTOCOL
         )
         if preferred_conf and preferred_conf not in ("auto", "native"):
             preferred_protocol = str(preferred_conf)
-            if (
-                (_player := self.mass.players.get_player(preferred_protocol))
-                and _player.available_for_playback
-                and feature in _player.supported_features
-            ):
-                return _player
+            for linked in self.linked_output_protocols:
+                if linked.output_protocol_id != preferred_protocol:
+                    continue
+                if (
+                    (_player := self.mass.players.get_player(preferred_protocol))
+                    and _player.available_for_playback
+                    and feature in _player.supported_features
+                ):
+                    return _player
+                break
 
         # Otherwise, use the first available linked protocol.
         # Prefer protocols that can process commands without active streaming

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1475,7 +1475,12 @@ class Player(ABC):
         if PlayerFeature.VOLUME_MUTE in self.supported_features:
             # player supports native mute control, always prefer that
             return PLAYER_CONTROL_NATIVE
-        # check for protocol player with mute support, and use that if found
+        # check for protocol player with mute support, and use that if found.
+        # this resolves independently from volume_control, so a device whose interfaces
+        # advertise volume and mute separately (DLNA derives both from its own
+        # RenderingControl actions) can end up with the two controls on different
+        # siblings. use the output-scoped variants when the resolution has to stay
+        # inside one signal path.
         if protocol_player := self._get_protocol_player_for_feature(
             PlayerFeature.VOLUME_MUTE, require_active=False
         ):
@@ -2159,7 +2164,15 @@ class Player(ABC):
         feature: PlayerFeature,
         require_active: bool = True,
     ) -> Player | None:
-        """Get player(protocol) which has the given PlayerFeature."""
+        """
+        Get player(protocol) which has the given PlayerFeature.
+
+        This resolves control-plane features (volume, mute), so the native player wins
+        even while a protocol renders the audio: a device's own volume is its own volume,
+        whichever interface the sound arrives on. Commands that ride along with the audio
+        resolve through PlayerController._get_control_target instead, which puts the
+        rendering output first and orders the fallback by output protocol priority.
+        """
         # prefer native player
         if feature in self.supported_features:
             return self

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -1384,19 +1384,13 @@ class TestGetControlTarget:
         Without an active output the fallback picks the highest priority protocol.
 
         An announcement on an idle player reaches this path, so it has to land on the
-        same output that regular playback would have selected rather than on whichever
-        protocol happened to link first.
+        same output that regular playback selection would have chosen.
         """
         controller = PlayerController(mock_mass)
         mock_mass.players = controller
 
         universal_provider = MockProvider("universal_player", mass=mock_mass)
-        universal_player = MockPlayer(
-            universal_provider,
-            "universal_123",
-            "Kantoor",
-            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
-        )
+        universal_player = MockPlayer(universal_provider, "universal_123", "Kantoor")
         universal_player._attr_supported_features = set()
 
         sendspin_player = MockPlayer(
@@ -1439,6 +1433,71 @@ class TestGetControlTarget:
             universal_player, PlayerFeature.PLAY_ANNOUNCEMENT, require_active=False
         )
         assert target == airplay_player
+
+    def test_fallback_follows_preferred_output_protocol(self, mock_mass: MagicMock) -> None:
+        """An explicitly preferred output beats the priority order."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+
+        def _get_raw_player_config_value(
+            _player_id: str, key: str, default: str | int | None = None
+        ) -> str | int | None:
+            if key == CONF_PREFERRED_OUTPUT_PROTOCOL:
+                return "sendspin_AABBCCDDEEFF"
+            if key == "min_volume":
+                return 0
+            if key == "max_volume":
+                return 100
+            return default
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_get_raw_player_config_value
+        )
+
+        universal_player = MockPlayer(
+            MockProvider("universal_player", mass=mock_mass), "universal_123", "Kantoor"
+        )
+        universal_player._attr_supported_features = set()
+        sendspin_player = MockPlayer(
+            MockProvider("sendspin", mass=mock_mass),
+            "sendspin_AABBCCDDEEFF",
+            "Kantoor Sendspin",
+            player_type=PlayerType.PROTOCOL,
+        )
+        sendspin_player._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)
+        airplay_player = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "airplay_AABBCCDDEEFF",
+            "Kantoor AirPlay",
+            player_type=PlayerType.PROTOCOL,
+        )
+        airplay_player._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)
+
+        controller._players = {
+            "universal_123": universal_player,
+            "sendspin_AABBCCDDEEFF": sendspin_player,
+            "airplay_AABBCCDDEEFF": airplay_player,
+        }
+        # airplay outranks sendspin, but the user picked sendspin
+        universal_player.set_linked_output_protocols(
+            [
+                LinkedOutputProtocol(
+                    output_protocol_id="airplay_AABBCCDDEEFF",
+                    protocol_domain="airplay",
+                    priority=10,
+                ),
+                LinkedOutputProtocol(
+                    output_protocol_id="sendspin_AABBCCDDEEFF",
+                    protocol_domain="sendspin",
+                    priority=40,
+                ),
+            ]
+        )
+
+        target = controller._get_control_target(
+            universal_player, PlayerFeature.PLAY_ANNOUNCEMENT, require_active=False
+        )
+        assert target == sendspin_player
 
     def test_require_active_skips_the_fallback(self, mock_mass: MagicMock) -> None:
         """With require_active there is no fallback to an idle linked protocol."""

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -1376,6 +1376,111 @@ class TestSelectBestOutputProtocol:
         assert airplay_output.available is False
 
 
+class TestGetControlTarget:
+    """Tests for resolving the target of an audio-path command."""
+
+    def test_fallback_follows_protocol_priority(self, mock_mass: MagicMock) -> None:
+        """
+        Without an active output the fallback picks the highest priority protocol.
+
+        An announcement on an idle player reaches this path, so it has to land on the
+        same output that regular playback would have selected rather than on whichever
+        protocol happened to link first.
+        """
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+
+        universal_provider = MockProvider("universal_player", mass=mock_mass)
+        universal_player = MockPlayer(
+            universal_provider,
+            "universal_123",
+            "Kantoor",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        universal_player._attr_supported_features = set()
+
+        sendspin_player = MockPlayer(
+            MockProvider("sendspin", mass=mock_mass),
+            "sendspin_AABBCCDDEEFF",
+            "Kantoor Sendspin",
+            player_type=PlayerType.PROTOCOL,
+        )
+        sendspin_player._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)
+        airplay_player = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "airplay_AABBCCDDEEFF",
+            "Kantoor AirPlay",
+            player_type=PlayerType.PROTOCOL,
+        )
+        airplay_player._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)
+
+        controller._players = {
+            "universal_123": universal_player,
+            "sendspin_AABBCCDDEEFF": sendspin_player,
+            "airplay_AABBCCDDEEFF": airplay_player,
+        }
+        # sendspin links first, but airplay outranks it
+        universal_player.set_linked_output_protocols(
+            [
+                LinkedOutputProtocol(
+                    output_protocol_id="sendspin_AABBCCDDEEFF",
+                    protocol_domain="sendspin",
+                    priority=40,
+                ),
+                LinkedOutputProtocol(
+                    output_protocol_id="airplay_AABBCCDDEEFF",
+                    protocol_domain="airplay",
+                    priority=10,
+                ),
+            ]
+        )
+
+        target = controller._get_control_target(
+            universal_player, PlayerFeature.PLAY_ANNOUNCEMENT, require_active=False
+        )
+        assert target == airplay_player
+
+    def test_require_active_skips_the_fallback(self, mock_mass: MagicMock) -> None:
+        """With require_active there is no fallback to an idle linked protocol."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+
+        universal_player = MockPlayer(
+            MockProvider("universal_player", mass=mock_mass),
+            "universal_123",
+            "Kantoor",
+        )
+        universal_player._attr_supported_features = set()
+        airplay_player = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "airplay_AABBCCDDEEFF",
+            "Kantoor AirPlay",
+            player_type=PlayerType.PROTOCOL,
+        )
+        airplay_player._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)
+
+        controller._players = {
+            "universal_123": universal_player,
+            "airplay_AABBCCDDEEFF": airplay_player,
+        }
+        universal_player.set_linked_output_protocols(
+            [
+                LinkedOutputProtocol(
+                    output_protocol_id="airplay_AABBCCDDEEFF",
+                    protocol_domain="airplay",
+                    priority=10,
+                )
+            ]
+        )
+
+        assert (
+            controller._get_control_target(
+                universal_player, PlayerFeature.PLAY_ANNOUNCEMENT, require_active=True
+            )
+            is None
+        )
+
+
 class TestPlayerGrouping:
     """Tests for player grouping scenarios."""
 

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -1499,6 +1499,68 @@ class TestGetControlTarget:
         )
         assert target == sendspin_player
 
+    def test_fallback_ignores_preference_for_another_players_output(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A preference left behind by a relink does not steal another speaker's output."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+
+        def _get_raw_player_config_value(
+            _player_id: str, key: str, default: str | int | None = None
+        ) -> str | int | None:
+            if key == CONF_PREFERRED_OUTPUT_PROTOCOL:
+                return "airplay_998877665544"
+            if key == "min_volume":
+                return 0
+            if key == "max_volume":
+                return 100
+            return default
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_get_raw_player_config_value
+        )
+
+        universal_player = MockPlayer(
+            MockProvider("universal_player", mass=mock_mass), "universal_123", "Kantoor"
+        )
+        universal_player._attr_supported_features = set()
+        own_player = MockPlayer(
+            MockProvider("sendspin", mass=mock_mass),
+            "sendspin_AABBCCDDEEFF",
+            "Kantoor Sendspin",
+            player_type=PlayerType.PROTOCOL,
+        )
+        own_player._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)
+        # the preference now points at an output belonging to a different speaker
+        other_player = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "airplay_998877665544",
+            "Woonkamer AirPlay",
+            player_type=PlayerType.PROTOCOL,
+        )
+        other_player._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)
+
+        controller._players = {
+            "universal_123": universal_player,
+            "sendspin_AABBCCDDEEFF": own_player,
+            "airplay_998877665544": other_player,
+        }
+        universal_player.set_linked_output_protocols(
+            [
+                LinkedOutputProtocol(
+                    output_protocol_id="sendspin_AABBCCDDEEFF",
+                    protocol_domain="sendspin",
+                    priority=40,
+                )
+            ]
+        )
+
+        target = controller._get_control_target(
+            universal_player, PlayerFeature.PLAY_ANNOUNCEMENT, require_active=False
+        )
+        assert target == own_player
+
     def test_require_active_skips_the_fallback(self, mock_mass: MagicMock) -> None:
         """With require_active there is no fallback to an idle linked protocol."""
         controller = PlayerController(mock_mass)

--- a/tests/models/test_player_controls.py
+++ b/tests/models/test_player_controls.py
@@ -592,6 +592,22 @@ class TestPreferredOutputProtocolAutoValue:
         )
         assert player.power_control == PLAYER_CONTROL_NONE
 
+    def test_preferred_pointing_at_another_players_output_is_ignored(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A preference left behind by a relink does not steal another speaker's output."""
+        own = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_SET})
+        other = _create_protocol_player(mock_mass, "other_proto", {PlayerFeature.VOLUME_SET})
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": own, "other_proto": other})
+        )
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect({CONF_PREFERRED_OUTPUT_PROTOCOL: "other_proto"})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(player, [_make_protocol_link("proto_a")])
+        assert player.volume_control == "proto_a"
+
 
 class TestActiveOutputProtocolClearCancellation:
     """Test that setting the active output protocol cancels a pending clear."""

--- a/tests/models/test_player_controls.py
+++ b/tests/models/test_player_controls.py
@@ -92,11 +92,12 @@ def _create_protocol_player(
 def _make_protocol_link(
     protocol_id: str,
     priority: int = 0,
+    protocol_domain: str = _PROTO_DOMAIN,
 ) -> LinkedOutputProtocol:
     """Create a protocol link for testing."""
     return LinkedOutputProtocol(
         output_protocol_id=protocol_id,
-        protocol_domain=_PROTO_DOMAIN,
+        protocol_domain=protocol_domain,
         priority=priority,
     )
 
@@ -448,6 +449,86 @@ class TestProtocolPlayerPreferActive:
             ],
         )
         assert player.volume_control == "proto_b"
+
+
+class TestControlProtocolPriority:
+    """Test the domain priority that orders the ambient volume/mute fallback."""
+
+    def _get_player_lookup(self, players: dict[str, MockPlayer]) -> Any:
+        """Create a side_effect that looks up players by ID."""
+
+        def _lookup(pid: str) -> MockPlayer | None:
+            return players.get(pid)
+
+        return _lookup
+
+    def test_prefers_always_reachable_domain_over_link_order(self, mock_mass: MagicMock) -> None:
+        """A domain that takes commands while idle wins from one that linked earlier."""
+        airplay = _create_protocol_player(mock_mass, "airplay_child", {PlayerFeature.VOLUME_SET})
+        cast = _create_protocol_player(mock_mass, "cast_child", {PlayerFeature.VOLUME_SET})
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"airplay_child": airplay, "cast_child": cast})
+        )
+        player = _create_player(mock_mass)
+        # airplay links first, but only cast can take a volume command while idle
+        _link_protocols(
+            player,
+            [
+                _make_protocol_link("airplay_child", protocol_domain="airplay"),
+                _make_protocol_link("cast_child", protocol_domain="chromecast"),
+            ],
+        )
+        assert player.volume_control == "cast_child"
+
+    def test_unknown_domain_sorts_last(self, mock_mass: MagicMock) -> None:
+        """A domain outside the priority table loses from a known one."""
+        other = _create_protocol_player(mock_mass, "other_child", {PlayerFeature.VOLUME_SET})
+        sendspin = _create_protocol_player(mock_mass, "sendspin_child", {PlayerFeature.VOLUME_SET})
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"other_child": other, "sendspin_child": sendspin})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(
+            player,
+            [
+                _make_protocol_link("other_child", protocol_domain="something_else"),
+                _make_protocol_link("sendspin_child", protocol_domain="sendspin"),
+            ],
+        )
+        assert player.volume_control == "sendspin_child"
+
+    def test_volume_and_mute_may_land_on_different_siblings(self, mock_mass: MagicMock) -> None:
+        """
+        Volume and mute resolve independently, so they can pick different interfaces.
+
+        A DLNA renderer derives VOLUME_SET and VOLUME_MUTE from separate
+        RenderingControl actions, so it may advertise one without the other. The
+        ambient controls then split across siblings; only the output-scoped
+        variants keep a resolution inside one signal path.
+        """
+        dlna = _create_protocol_player(mock_mass, "dlna_child", {PlayerFeature.VOLUME_SET})
+        airplay = _create_protocol_player(
+            mock_mass,
+            "airplay_child",
+            {PlayerFeature.VOLUME_SET, PlayerFeature.VOLUME_MUTE},
+        )
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"dlna_child": dlna, "airplay_child": airplay})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(
+            player,
+            [
+                _make_protocol_link("dlna_child", protocol_domain="dlna"),
+                _make_protocol_link("airplay_child", protocol_domain="airplay"),
+            ],
+        )
+        # dlna outranks airplay for volume, but has no mute to offer
+        assert player.volume_control == "dlna_child"
+        assert player.mute_control == "airplay_child"
+        # the output-scoped variants stay within the named signal path
+        assert player.volume_control_for_output("dlna_child") == "dlna_child"
+        assert player.mute_control_for_output("dlna_child") == PLAYER_CONTROL_NONE
 
 
 class TestPreferredOutputProtocolAutoValue:

--- a/tests/models/test_player_controls.py
+++ b/tests/models/test_player_controls.py
@@ -451,8 +451,8 @@ class TestProtocolPlayerPreferActive:
         assert player.volume_control == "proto_b"
 
 
-class TestControlProtocolPriority:
-    """Test the domain priority that orders the ambient volume/mute fallback."""
+class TestControlDomainPriority:
+    """Test the protocol domain order that the ambient volume/mute fallback applies."""
 
     def _get_player_lookup(self, players: dict[str, MockPlayer]) -> Any:
         """Create a side_effect that looks up players by ID."""
@@ -462,8 +462,8 @@ class TestControlProtocolPriority:
 
         return _lookup
 
-    def test_prefers_always_reachable_domain_over_link_order(self, mock_mass: MagicMock) -> None:
-        """A domain that takes commands while idle wins from one that linked earlier."""
+    def test_prefers_domain_that_takes_commands_while_idle(self, mock_mass: MagicMock) -> None:
+        """A domain that accepts commands while idle owns the volume."""
         airplay = _create_protocol_player(mock_mass, "airplay_child", {PlayerFeature.VOLUME_SET})
         cast = _create_protocol_player(mock_mass, "cast_child", {PlayerFeature.VOLUME_SET})
         mock_mass.players.get_player = MagicMock(


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5674. Two separate resolvers pick which linked output protocol a feature is sent to, and their fallback orders disagreed. `_get_control_target` walked `linked_output_protocols` in whatever order the protocols happened to link in, while playback selection sorts by output protocol priority.

In practice this only showed up for announcements: on an idle player whose parent has no native announce support, the announcement could land on a different output than the one regular playback would have chosen — for example on the Sendspin interface of a speaker that also has AirPlay, purely because Sendspin was discovered first. Every other caller requires an already-active output, so it never reached that fallback.

The fallback now follows the same order as playback selection: an output the user explicitly picked wins, otherwise the highest priority one. So an announcement starts audio on the output the speaker would normally use.

Reviewing that turned up a second, sharper problem in the same area: the stored preference is not cleared when a protocol is re-linked to a different speaker, and neither resolver checked that it still pointed at one of the player's own outputs. A leftover preference could therefore send an announcement — or the volume and mute commands — to a completely different speaker. Both now only honour the preference while it still names one of the player's own linked outputs.

While auditing this I also confirmed two things that are deliberate and are now documented in the code rather than left as traps:

- The two resolvers order differently on purpose. Volume and mute are control-plane (a device's own volume is its own volume, whichever interface carries the sound), so they prefer the native player; enqueue/pause/announce ride along with the audio and prefer the rendering output.
- The announcement path deliberately does not publish its pick as the active output protocol — doing so would make an idle player report as playing for the length of the clip and refuse the next announcement.

**Related issue (if applicable):**

- follow-up to #5674

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
