### PR TITLE
Announcements no longer play at the wrong volume on AirPlay speakers with several interfaces

### DIFF
--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -365,7 +365,13 @@ async def _announce_with_session(
                     if prev_volume is not None and prev_volume != volume_level:
                         prev_volumes[member] = prev_volume
                         await member.volume_set(volume_level)
-            session = AirPlayStreamSession(provider, sync_clients, session_pcm_format, announcement)
+            session = AirPlayStreamSession(
+                provider,
+                sync_clients,
+                session_pcm_format,
+                announcement,
+                requested_volume=volume_level,
+            )
             await session.start(render.get_stream(session_pcm_format))
             player._transitioning = False
         # The clip is anchored: wait out the start lead plus the clip and the

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -836,7 +836,7 @@ class AirPlayPlayer(Player):
         parent_player = self.mass.players.get_player(self.protocol_parent_id)
         if not parent_player:
             return
-        volume_changed = adopt_parent_volume and self._sync_volume_level(parent_player)
+        volume_changed = self._sync_volume_level(parent_player, adopt_parent_volume)
         mute_changed = self._sync_mute_state(parent_player)
         if volume_changed or mute_changed:
             self.update_state()
@@ -899,8 +899,15 @@ class AirPlayPlayer(Player):
         progress = int(metadata.corrected_elapsed_time or 0)
         self.mass.create_task(self.stream.send_metadata(progress, metadata))
 
-    def _sync_volume_level(self, parent_player: Player) -> bool:
-        """Adopt the parent's volume level if it owns this output, return True if changed."""
+    def _sync_volume_level(self, parent_player: Player, adopt_parent_volume: bool) -> bool:
+        """
+        Adopt the parent's volume level if it owns this output, return True if changed.
+
+        :param parent_player: The parent player to resolve the volume control against.
+        :param adopt_parent_volume: False to keep our own level where we would otherwise
+            adopt the parent's. The unity gain reset still applies: a control that owns
+            the volume of this output attenuates on the device itself.
+        """
         volume_control = parent_player.volume_control_for_output(self.player_id)
         if volume_control == PLAYER_CONTROL_NATIVE:
             # Native parent volume is on the receiver/amplifier scale.
@@ -914,6 +921,8 @@ class AirPlayPlayer(Player):
                 return False
             self._attr_volume_level = 100
             return True
+        if not adopt_parent_volume:
+            return False
         if parent_player.state.volume_level is None:
             return False
         if parent_player.state.volume_level == 0:

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -813,7 +813,7 @@ class AirPlayPlayer(Player):
             bit_depth=24,
         )
 
-    def sync_volume_state(self) -> None:
+    def sync_volume_state(self, adopt_parent_volume: bool = True) -> None:
         """
         Sync volume and mute from the parent player if needed.
 
@@ -825,13 +825,18 @@ class AirPlayPlayer(Player):
 
         Both controls are resolved against this player as the rendering output, so which
         control is deemed to own them does not depend on the parent already pointing at us.
+
+        :param adopt_parent_volume: Set to False when the volume of the stream about to start
+            was explicitly requested by the caller, so the parent's level does not overwrite
+            it. The mute release always runs: a latch left behind by another control would
+            silence the stream regardless of the level it plays at.
         """
         if not self.protocol_parent_id:
             return
         parent_player = self.mass.players.get_player(self.protocol_parent_id)
         if not parent_player:
             return
-        volume_changed = self._sync_volume_level(parent_player)
+        volume_changed = adopt_parent_volume and self._sync_volume_level(parent_player)
         mute_changed = self._sync_mute_state(parent_player)
         if volume_changed or mute_changed:
             self.update_state()

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -813,7 +813,7 @@ class AirPlayPlayer(Player):
             bit_depth=24,
         )
 
-    def sync_volume_state(self, adopt_parent_volume: bool = True) -> None:
+    def sync_volume_state(self, *, adopt_parent_volume: bool = True) -> None:
         """
         Sync volume and mute from the parent player if needed.
 
@@ -836,7 +836,9 @@ class AirPlayPlayer(Player):
         parent_player = self.mass.players.get_player(self.protocol_parent_id)
         if not parent_player:
             return
-        volume_changed = self._sync_volume_level(parent_player, adopt_parent_volume)
+        volume_changed = self._sync_volume_level(
+            parent_player, adopt_parent_volume=adopt_parent_volume
+        )
         mute_changed = self._sync_mute_state(parent_player)
         if volume_changed or mute_changed:
             self.update_state()
@@ -899,7 +901,7 @@ class AirPlayPlayer(Player):
         progress = int(metadata.corrected_elapsed_time or 0)
         self.mass.create_task(self.stream.send_metadata(progress, metadata))
 
-    def _sync_volume_level(self, parent_player: Player, adopt_parent_volume: bool) -> bool:
+    def _sync_volume_level(self, parent_player: Player, *, adopt_parent_volume: bool) -> bool:
         """
         Adopt the parent's volume level if it owns this output, return True if changed.
 

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncGenerator, Coroutine
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.enums import ContentType, MediaType, PlaybackState
+from music_assistant_models.enums import ContentType, PlaybackState
 from music_assistant_models.errors import MusicAssistantError, PlayerCommandFailed
 
 from music_assistant.constants import CONF_SYNC_ADJUST
@@ -65,6 +65,7 @@ class AirPlayStreamSession:
         sync_clients: list[AirPlayPlayer],
         pcm_format: AudioFormat,
         media: PlayerMedia,
+        requested_volume: int | None = None,
     ) -> None:
         """
         Initialize AirPlayStreamSession.
@@ -73,12 +74,16 @@ class AirPlayStreamSession:
         :param sync_clients: List of AirPlay players to stream to.
         :param pcm_format: PCM format of the input stream.
         :param media: Queue media that owns the stream session.
+        :param requested_volume: Volume level explicitly requested for this session (an
+            announcement volume), already applied to its members. Omit to let the members
+            take their level from their parent player as usual.
         """
         assert sync_clients
         self.prov = airplay_provider
         self.mass = airplay_provider.mass
         self.pcm_format = pcm_format
         self.media = media
+        self.requested_volume = requested_volume
         self.sync_clients = sync_clients
         self._audio_source_task: asyncio.Task[None] | None = None
         self._player_ffmpeg: dict[str, FFMpeg] = {}
@@ -1018,12 +1023,10 @@ class AirPlayStreamSession:
         """
         # joining a session supersedes any pending automatic group re-join
         airplay_player.cancel_group_rejoin()
-        # sync volume/mute from parent player if needed. An announcement carries a volume
-        # that was explicitly requested for it, so the parent's level must not replace it:
-        # the level set here is what the connecting stream hands to the receiver.
-        airplay_player.sync_volume_state(
-            adopt_parent_volume=self.media.media_type != MediaType.ANNOUNCEMENT
-        )
+        # sync volume/mute from parent player if needed. A volume requested for this session
+        # is already applied to its members, so the parent's level must not replace it:
+        # the level held here is what the connecting stream hands to the receiver.
+        airplay_player.sync_volume_state(adopt_parent_volume=self.requested_volume is None)
         if airplay_player.stream and airplay_player.stream.running:
             await airplay_player.stream.stop()
         stream_pcm_format = airplay_player.get_stream_pcm_format(self.pcm_format)

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncGenerator, Coroutine
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.enums import ContentType, PlaybackState
+from music_assistant_models.enums import ContentType, MediaType, PlaybackState
 from music_assistant_models.errors import MusicAssistantError, PlayerCommandFailed
 
 from music_assistant.constants import CONF_SYNC_ADJUST
@@ -1018,8 +1018,12 @@ class AirPlayStreamSession:
         """
         # joining a session supersedes any pending automatic group re-join
         airplay_player.cancel_group_rejoin()
-        # sync volume/mute from parent player if needed
-        airplay_player.sync_volume_state()
+        # sync volume/mute from parent player if needed. An announcement carries a volume
+        # that was explicitly requested for it, so the parent's level must not replace it:
+        # the level set here is what the connecting stream hands to the receiver.
+        airplay_player.sync_volume_state(
+            adopt_parent_volume=self.media.media_type != MediaType.ANNOUNCEMENT
+        )
         if airplay_player.stream and airplay_player.stream.running:
             await airplay_player.stream.stop()
         stream_pcm_format = airplay_player.get_stream_pcm_format(self.pcm_format)

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -966,6 +966,59 @@ def test_sync_volume_state_resolves_against_this_output(
     parent.mute_control_for_output.assert_called_once_with("test_player")
 
 
+def test_sync_volume_state_keeps_explicitly_requested_volume(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """
+    Keep a volume that was explicitly requested for the stream about to start.
+
+    An announcement volume is resolved and applied before the session starts, so the
+    parent's level (which on a multi-interface device may come from an idle sibling)
+    must not replace it - the level held here is what reaches the receiver.
+    """
+    parent = MagicMock()
+    parent.state.volume_level = 40
+    parent.volume_control_for_output.return_value = "test_player"
+    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
+    airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
+    airplay_player.set_protocol_parent_id("parent")
+    airplay_player._attr_volume_level = 85
+
+    with patch.object(AirPlayPlayer, "update_state") as mock_update:
+        airplay_player.sync_volume_state(adopt_parent_volume=False)
+
+    assert airplay_player._attr_volume_level == 85
+    airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
+    mock_update.assert_not_called()
+
+
+def test_sync_volume_state_clears_mute_latch_without_adopting_volume(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """A stream with an explicitly requested volume still gets its mute latch released."""
+    parent = MagicMock()
+    parent.state.volume_level = 40
+    parent.state.volume_muted = False
+    parent.volume_control_for_output.return_value = "test_player"
+    parent.mute_control_for_output.return_value = "cast_player"
+    cast_player = MagicMock()
+    cast_player.underlying_player_id = None
+    airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
+        "parent": parent,
+        "cast_player": cast_player,
+    }.get
+    airplay_player.set_protocol_parent_id("parent")
+    airplay_player._attr_volume_level = 85
+    airplay_player._attr_volume_muted = True
+
+    with patch.object(AirPlayPlayer, "update_state") as mock_update:
+        airplay_player.sync_volume_state(adopt_parent_volume=False)
+
+    assert airplay_player._attr_volume_muted is False
+    assert airplay_player._attr_volume_level == 85
+    mock_update.assert_called_once()
+
+
 # --- Pause / stop dispatch tests ---
 
 

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1018,6 +1018,7 @@ def test_sync_volume_state_keeps_unity_gain_for_explicitly_requested_volume(
         airplay_player.sync_volume_state(adopt_parent_volume=False)
 
     assert airplay_player._attr_volume_level == 100
+    airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
     mock_update.assert_called_once()
 
 

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -992,6 +992,35 @@ def test_sync_volume_state_keeps_explicitly_requested_volume(
     mock_update.assert_not_called()
 
 
+def test_sync_volume_state_keeps_unity_gain_for_explicitly_requested_volume(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """
+    Reset to unity gain even for an explicitly requested volume.
+
+    A control that owns the volume of this output attenuates on the device itself, so
+    the requested level would land on top of it.
+    """
+    parent = MagicMock()
+    parent.state.volume_level = 40
+    parent.volume_control_for_output.return_value = "cast_player"
+    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
+    cast_player = MagicMock()
+    cast_player.underlying_player_id = None
+    airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
+        "parent": parent,
+        "cast_player": cast_player,
+    }.get
+    airplay_player.set_protocol_parent_id("parent")
+    airplay_player._attr_volume_level = 85
+
+    with patch.object(AirPlayPlayer, "update_state") as mock_update:
+        airplay_player.sync_volume_state(adopt_parent_volume=False)
+
+    assert airplay_player._attr_volume_level == 100
+    mock_update.assert_called_once()
+
+
 def test_sync_volume_state_clears_mute_latch_without_adopting_volume(
     airplay_player: AirPlayPlayer,
 ) -> None:

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1878,3 +1878,33 @@ async def test_late_join_silence_pad_is_bounded_and_reports_the_residual() -> No
     tail = logger.warning.call_args.args[-1]
     assert "ahead of the group" in tail
     assert "in sync" not in tail
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("requested_volume", "expected_adopt"),
+    [(85, False), (None, True)],
+)
+async def test_start_client_keeps_a_volume_requested_for_the_session(
+    requested_volume: int | None, expected_adopt: bool
+) -> None:
+    """
+    Keep a volume requested for the session, but only when there actually is one.
+
+    An announcement without a volume strategy requests none, so its members must still
+    take their level from their parent player.
+    """
+    session = _make_session(start_time=0.0, seconds_streamed=0.0)
+    session.requested_volume = requested_volume
+    player = _make_late_joiner()
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.stream_session.AirPlayStream",
+            return_value=MagicMock(connect=AsyncMock()),
+        ),
+        patch.object(session, "_start_player_ffmpeg", AsyncMock()),
+    ):
+        await session._start_client(player, use_shared_ptp=False)
+
+    player.sync_volume_state.assert_called_once_with(adopt_parent_volume=expected_adopt)


### PR DESCRIPTION
# What does this implement/fix?

An announcement volume is worked out and applied to the AirPlay speaker just before its stream starts, but the stream-start volume sync then replaced it with the level the parent player reported. On a device that offers a Chromecast or DLNA interface next to AirPlay (a receiver or TV merged into one player), the parent reports the idle sibling interface's level while nothing is playing, so the announcement played at that level and the announcement volume setting was quietly ignored.

Follow-up to #5674, which made the volume *decision* aware of which interface carries the audio. This fixes the remaining case where the requested volume itself was overwritten.

**Related issue (if applicable):**

- follow-up to #5674

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- A stream session now carries the volume that was requested for it, and the stream-start sync keeps that level instead of adopting the parent's. Announcements without a volume strategy request no volume and still take their level from the parent, as before.
- The unity gain reset still applies: a control that owns the volume of this output attenuates on the device itself, so the requested level must not land on top of it.
- The mute release still runs for announcements, so a leftover mute cannot silence the clip (the case #5674 fixed).
- Added tests for the kept volume, the unity gain reset, the mute release and the session wiring.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
