### PR TITLE
Show why AI Radio speech generation failed

### DIFF
--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -437,11 +437,11 @@ class AIRadioRenderMixin:
             tags = await async_parse_tags(path, require_duration=True)
         except (InvalidDataError, OSError) as err:
             if any(marker in str(err) for marker in TTS_SERVER_ERROR_MARKERS):
-                # the engine reports no reason (Home Assistant answers a failed render with an
-                # empty 500), so carry what the probe saw or the hint is all the user gets
+                # the engine reports no reason of its own (Home Assistant answers a failed
+                # render with an empty 500), so the probe's message is the only clue there is
                 raise MusicAssistantError(
-                    f"Error during TTS generation: {err}. Does your TTS provider have enough "
-                    "credit? Check the logs of your TTS provider for the reason."
+                    f"{err}. Does your TTS provider have enough credit? "
+                    "Check the logs of your TTS provider for the reason."
                 ) from err
             self.logger.warning("Could not determine AI Radio clip duration: %s", err)
             return None

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -437,9 +437,11 @@ class AIRadioRenderMixin:
             tags = await async_parse_tags(path, require_duration=True)
         except (InvalidDataError, OSError) as err:
             if any(marker in str(err) for marker in TTS_SERVER_ERROR_MARKERS):
+                # the engine reports no reason (Home Assistant answers a failed render with an
+                # empty 500), so carry what the probe saw or the hint is all the user gets
                 raise MusicAssistantError(
-                    "Error during TTS generation. Does your TTS provider have enough credit? "
-                    "Check the logs of your TTS provider for the reason."
+                    f"Error during TTS generation: {err}. Does your TTS provider have enough "
+                    "credit? Check the logs of your TTS provider for the reason."
                 ) from err
             self.logger.warning("Could not determine AI Radio clip duration: %s", err)
             return None

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -546,6 +546,8 @@ async def test_tts_server_error_fails_the_clip_with_an_actionable_message(
     session = renderer._sessions["sess"]
     assert session.skipped_sections == 1
     assert "enough credit" in session.last_render_error
+    # the hint is a guess, so the probe's own message has to travel with it
+    assert "Server returned 5XX" in session.last_render_error
 
 
 async def test_unmeasurable_clip_still_plays(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -530,13 +530,16 @@ def _failing_probe(message: str, monkeypatch: pytest.MonkeyPatch) -> RealProbeRe
     return renderer
 
 
+@pytest.mark.parametrize(
+    "server_error",
+    ["Server returned 5XX Server Error reply", "HTTP error 500 Internal Server Error"],
+)
 async def test_tts_server_error_fails_the_clip_with_an_actionable_message(
-    monkeypatch: pytest.MonkeyPatch,
+    server_error: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """An engine that hands out a URL it cannot render fails the clip, not the playback."""
     renderer = _failing_probe(
-        "Unable to retrieve info for http://ha.invalid/api/tts_proxy/1.mp3 "
-        "(Server returned 5XX Server Error reply)",
+        f"Unable to retrieve info for http://ha.invalid/api/tts_proxy/1.mp3 ({server_error})",
         monkeypatch,
     )
 
@@ -546,8 +549,10 @@ async def test_tts_server_error_fails_the_clip_with_an_actionable_message(
     session = renderer._sessions["sess"]
     assert session.skipped_sections == 1
     assert "enough credit" in session.last_render_error
-    # the hint is a guess, so the probe's own message has to travel with it
-    assert "Server returned 5XX" in session.last_render_error
+    # the hint is a guess, so the whole probe message travels with it - the url included,
+    # since that is what tells a failing engine apart from a failing tts server behind it
+    assert "http://ha.invalid/api/tts_proxy/1.mp3" in session.last_render_error
+    assert server_error in session.last_render_error
 
 
 async def test_unmeasurable_clip_still_plays(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# What does this implement/fix?

When an AI Radio clip fails to render, the log only showed a guess:

`Error during TTS generation. Does your TTS provider have enough credit? Check the logs of your TTS provider for the reason.`

The reason the duration probe actually reported was thrown away. A user running a self-hosted TTS server spent their time checking that server for quota problems, while the real signal - a `Server returned 5XX` on the Home Assistant `tts_proxy` URL, meaning Home Assistant's own render had failed - never reached them. Their TTS server was fine; every clip rendered successfully.

The probe's own message now travels with the hint, so the log warning and the error shown on the AI Radio session name what actually went wrong.

- Include the underlying probe error in the TTS generation failure message
- Extend the existing test to assert the probe's message survives

**Related issue (if applicable):**

- n/a (reported via Discord with logs)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
