### PR TITLE
Announcements now respect the configured volume on speakers whose volume is handled elsewhere

### DIFF
--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -19,7 +19,7 @@ from math import ceil
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.auth import Scope
-from music_assistant_models.constants import PLAYER_CONTROL_NONE
+from music_assistant_models.constants import PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_NONE
 from music_assistant_models.enums import (
     MediaType,
     PlaybackState,
@@ -465,14 +465,28 @@ class AnnouncementsMixin:
             for member_id in player.state.group_members or (player.player_id,)
             if (muted_player := self.get_player(member_id)) and muted_player.state.volume_muted
         ]
+        prev_volume: int | None = None
         try:
             async with TaskManager(self.mass) as tg:
                 for muted_player in muted_players:
                     tg.create_task(self._set_announcement_mute(muted_player, False))
             announcement_volume = self.get_announcement_volume(player.player_id, volume_level)
+            if announcement_volume is not None and not self._output_owns_volume(
+                player, announce_player
+            ):
+                # The level is resolved on the scale of the control that owns the player's
+                # volume, so an output that does not own it cannot apply it: whatever that
+                # output sets is either discarded or stacks on top of the control that is
+                # already attenuating on the device. Apply it through the control instead
+                # and let the provider announce at the level the device now plays at.
+                prev_volume = await self._set_announcement_volume(player, announcement_volume)
+                announcement_volume = None
             await announce_player.play_announcement(announcement, announcement_volume)
         finally:
             # the provider only returns once the announcement finished playing
+            if prev_volume is not None:
+                await self._handle_cmd_volume_set(player.player_id, prev_volume)
+            # restore mute after the volume, because setting a volume unmutes the player again
             async with TaskManager(self.mass) as tg:
                 for muted_player in muted_players:
                     tg.create_task(self._set_announcement_mute(muted_player, True))
@@ -818,6 +832,46 @@ class AnnouncementsMixin:
             announcement_volume,
         )
         await self._handle_cmd_volume_set(volume_player.player_id, announcement_volume)
+
+    def _output_owns_volume(self, player: Player, announce_player: Player) -> bool:
+        """
+        Return True if the announcing output can apply the announcement volume itself.
+
+        :param player: The player the announcement is played on.
+        :param announce_player: The player (or linked protocol) that plays the announcement.
+        """
+        volume_control = player.volume_control_for_output(announce_player.player_id)
+        if volume_control in (PLAYER_CONTROL_NATIVE, announce_player.player_id):
+            # the volume lives on the device the announcing output talks to
+            return True
+        # a bridge player riding on the announcing output forwards its volume to it
+        if control_player := self.get_player(volume_control):
+            return control_player.underlying_player_id == announce_player.player_id
+        return False
+
+    async def _set_announcement_volume(
+        self, player: Player, announcement_volume: int
+    ) -> int | None:
+        """
+        Apply the announcement volume through the player's own volume control.
+
+        :param player: The player to set the announcement volume on.
+        :param announcement_volume: The resolved announcement volume level.
+        :return: The level to restore once the announcement finished, or None when the
+            volume was left untouched.
+        """
+        if player.state.volume_control == PLAYER_CONTROL_NONE:
+            # nothing in the signal path can set a volume at all
+            return None
+        if (prev_volume := player.state.volume_level) is None or prev_volume == announcement_volume:
+            return None
+        self.logger.debug(
+            "Announcement to player %s - setting temporary volume (%s)...",
+            player.state.name,
+            announcement_volume,
+        )
+        await self._handle_cmd_volume_set(player.player_id, announcement_volume)
+        return prev_volume
 
     async def _set_announcement_mute(self, player: Player, muted: bool) -> None:
         """

--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -465,7 +465,8 @@ class AnnouncementsMixin:
             for member_id in player.state.group_members or (player.player_id,)
             if (muted_player := self.get_player(member_id)) and muted_player.state.volume_muted
         ]
-        prev_volume: int | None = None
+        # filled while the announcement volume is applied below
+        prev_volumes: dict[str, int] = {}
         try:
             async with TaskManager(self.mass) as tg:
                 for muted_player in muted_players:
@@ -479,13 +480,14 @@ class AnnouncementsMixin:
                 # output sets is either discarded or stacks on top of the control that is
                 # already attenuating on the device. Apply it through the control instead
                 # and let the provider announce at the level the device now plays at.
-                prev_volume = await self._set_announcement_volume(player, announcement_volume)
+                await self._set_announcement_volume(player, announcement_volume, prev_volumes)
                 announcement_volume = None
             await announce_player.play_announcement(announcement, announcement_volume)
         finally:
             # the provider only returns once the announcement finished playing
-            if prev_volume is not None:
-                await self._handle_cmd_volume_set(player.player_id, prev_volume)
+            async with TaskManager(self.mass) as tg:
+                for volume_player_id, prev_volume in prev_volumes.items():
+                    tg.create_task(self._handle_cmd_volume_set(volume_player_id, prev_volume))
             # restore mute after the volume, because setting a volume unmutes the player again
             async with TaskManager(self.mass) as tg:
                 for muted_player in muted_players:
@@ -850,28 +852,28 @@ class AnnouncementsMixin:
         return False
 
     async def _set_announcement_volume(
-        self, player: Player, announcement_volume: int
-    ) -> int | None:
+        self, player: Player, announcement_volume: int, prev_volumes: dict[str, int]
+    ) -> None:
         """
         Apply the announcement volume through the player's own volume control.
 
         :param player: The player to set the announcement volume on.
         :param announcement_volume: The resolved announcement volume level.
-        :return: The level to restore once the announcement finished, or None when the
-            volume was left untouched.
+        :param prev_volumes: Mapping that is filled in-place with the previous volume level
+            per player id, so the caller can restore the volume even if this call fails.
         """
         if player.state.volume_control == PLAYER_CONTROL_NONE:
             # nothing in the signal path can set a volume at all
-            return None
+            return
         if (prev_volume := player.state.volume_level) is None or prev_volume == announcement_volume:
-            return None
+            return
+        prev_volumes[player.player_id] = prev_volume
         self.logger.debug(
             "Announcement to player %s - setting temporary volume (%s)...",
             player.state.name,
             announcement_volume,
         )
         await self._handle_cmd_volume_set(player.player_id, announcement_volume)
-        return prev_volume
 
     async def _set_announcement_mute(self, player: Player, muted: bool) -> None:
         """

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -15,7 +15,7 @@ import contextlib
 import time
 from collections.abc import AsyncIterator, Callable, Iterator
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -3117,6 +3117,137 @@ class TestPlayAnnouncementCleanup:
         # the length is resolved downstream while it plays
         render.wait_ready.assert_awaited_once()
         render.wait_finished.assert_not_awaited()
+
+
+class _AnnounceSetup(NamedTuple):
+    """A player announcing through a linked protocol output, with the calls it makes mocked."""
+
+    controller: PlayerController
+    parent: MockPlayer
+    output: MockPlayer
+    volume_set: AsyncMock
+    play_announcement: AsyncMock
+
+
+class TestNativeAnnouncementVolumeRouting:
+    """The announcement volume is applied through the control that owns it."""
+
+    ANNOUNCE_VOLUME = 45
+
+    def _make_setup(self, mock_mass: MagicMock, volume_control: str) -> _AnnounceSetup:
+        """
+        Create a player announcing through a linked protocol output.
+
+        The parent holds a sibling interface and a bridge riding on the announcing
+        output, so any of them can be named as its volume control.
+
+        :param volume_control: Value of the parent's volume control config entry.
+        """
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        parent = MockPlayer(provider, "parent", "Parent")
+        output = MockPlayer(provider, "output", "Output")
+        output._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)
+        output._attr_supported_features.add(PlayerFeature.VOLUME_SET)
+        sibling = MockPlayer(provider, "sibling", "Sibling")
+        sibling._attr_supported_features.add(PlayerFeature.VOLUME_SET)
+        sibling._attr_volume_level = 20
+        bridge = MockPlayer(provider, "bridge", "Bridge")
+        bridge._attr_supported_features.add(PlayerFeature.VOLUME_SET)
+        bridge._attr_underlying_player_id = "output"
+        bridge._attr_volume_level = 20
+        controller._players = {
+            "parent": parent,
+            "output": output,
+            "sibling": sibling,
+            "bridge": bridge,
+        }
+        mock_mass.players = controller
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_player_config_stub({CONF_VOLUME_CONTROL: volume_control})
+        )
+        for player in controller._players.values():
+            player._cache.clear()
+            player.update_state(signal_event=False)
+        play_announcement = AsyncMock()
+        volume_set = AsyncMock()
+        output.play_announcement = play_announcement  # type: ignore[method-assign]
+        controller._handle_cmd_volume_set = volume_set  # type: ignore[method-assign]
+        return _AnnounceSetup(controller, parent, output, volume_set, play_announcement)
+
+    async def _announce(self, setup: _AnnounceSetup) -> None:
+        """Play an announcement on the parent, rendered by the linked output."""
+        await setup.controller._play_native_announcement(
+            setup.parent, setup.output, _announcement(), self.ANNOUNCE_VOLUME
+        )
+
+    async def test_external_control_applies_the_announcement_volume(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A sibling interface owning the volume gets the announcement volume, not the output."""
+        setup = self._make_setup(mock_mass, "sibling")
+
+        await self._announce(setup)
+
+        # the output cannot attenuate what another control is already attenuating,
+        # so the level goes through that control and the output announces at unity
+        assert setup.volume_set.await_args_list == [
+            call("parent", self.ANNOUNCE_VOLUME),
+            call("parent", 20),
+        ]
+        setup.play_announcement.assert_awaited_once_with(ANY, None)
+
+    async def test_external_control_volume_restored_when_the_announcement_fails(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """The temporary volume is restored even when the announcement itself fails."""
+        setup = self._make_setup(mock_mass, "sibling")
+        setup.play_announcement.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            await self._announce(setup)
+
+        assert setup.volume_set.await_args_list[-1] == call("parent", 20)
+
+    async def test_announcing_output_keeps_the_announcement_volume(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """An output that owns the volume applies the announcement volume itself."""
+        setup = self._make_setup(mock_mass, "output")
+
+        await self._announce(setup)
+
+        setup.volume_set.assert_not_awaited()
+        setup.play_announcement.assert_awaited_once_with(ANY, self.ANNOUNCE_VOLUME)
+
+    async def test_bridge_on_the_announcing_output_keeps_the_announcement_volume(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A bridge riding on the announcing output forwards the volume to it."""
+        setup = self._make_setup(mock_mass, "bridge")
+
+        await self._announce(setup)
+
+        setup.volume_set.assert_not_awaited()
+        setup.play_announcement.assert_awaited_once_with(ANY, self.ANNOUNCE_VOLUME)
+
+    async def test_native_volume_keeps_the_announcement_volume(self, mock_mass: MagicMock) -> None:
+        """Native parent volume lives on the device the output talks to, so it applies it."""
+        setup = self._make_setup(mock_mass, PLAYER_CONTROL_NATIVE)
+
+        await self._announce(setup)
+
+        setup.volume_set.assert_not_awaited()
+        setup.play_announcement.assert_awaited_once_with(ANY, self.ANNOUNCE_VOLUME)
+
+    async def test_without_volume_control_no_volume_is_applied(self, mock_mass: MagicMock) -> None:
+        """Nothing in the signal path can set a volume, so the announcement plays as-is."""
+        setup = self._make_setup(mock_mass, PLAYER_CONTROL_NONE)
+
+        await self._announce(setup)
+
+        setup.volume_set.assert_not_awaited()
+        setup.play_announcement.assert_awaited_once_with(ANY, None)
 
 
 class TestPlayAnnouncementMessage:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -3129,6 +3129,7 @@ class _AnnounceSetup(NamedTuple):
     play_announcement: AsyncMock
 
 
+@pytest.mark.usefixtures("running_background_tasks")
 class TestNativeAnnouncementVolumeRouting:
     """The announcement volume is applied through the control that owns it."""
 
@@ -3162,6 +3163,16 @@ class TestNativeAnnouncementVolumeRouting:
             "sibling": sibling,
             "bridge": bridge,
         }
+        # an external control (e.g. a Home Assistant volume entity) is not a player
+        controller._controls = {
+            "ha_volume": PlayerControl(
+                id="ha_volume",
+                provider="hass",
+                name="Amplifier volume",
+                supports_volume=True,
+                volume_level=20,
+            )
+        }
         mock_mass.players = controller
         mock_mass.config.get_raw_player_config_value = MagicMock(
             side_effect=_player_config_stub({CONF_VOLUME_CONTROL: volume_control})
@@ -3191,6 +3202,20 @@ class TestNativeAnnouncementVolumeRouting:
 
         # the output cannot attenuate what another control is already attenuating,
         # so the level goes through that control and the output announces at unity
+        assert setup.volume_set.await_args_list == [
+            call("parent", self.ANNOUNCE_VOLUME),
+            call("parent", 20),
+        ]
+        setup.play_announcement.assert_awaited_once_with(ANY, None)
+
+    async def test_player_control_applies_the_announcement_volume(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player control owning the volume (e.g. an HA entity) gets the announcement volume."""
+        setup = self._make_setup(mock_mass, "ha_volume")
+
+        await self._announce(setup)
+
         assert setup.volume_set.await_args_list == [
             call("parent", self.ANNOUNCE_VOLUME),
             call("parent", 20),


### PR DESCRIPTION
# What does this implement/fix?

When a speaker's volume is handled by something other than the output playing the audio — an explicitly configured Home Assistant volume entity, or the Chromecast/DLNA side of a device that also has AirPlay — the announcement volume was silently ignored.

The announcement volume is worked out for the speaker as the user sees it, so it is a level on the scale of whatever control handles that speaker's volume. It was then handed to the output playing the clip, which is a different thing entirely. For an AirPlay output the level was set, then reset to full scale the moment the stream started (it must not attenuate on top of the control already doing so), so the configured announcement volume was calculated, applied and thrown away again.

It now goes to the control that actually handles the volume, and is restored when the announcement finishes. Speakers that do handle their own volume are unaffected and keep applying it themselves.

Spotted while working on #5679 and deliberately left out of scope there. Not something a user reported, hence `maintenance` — happy to relabel if you'd rather have it in the notes as a bugfix.

- The announcement volume is applied through the control that owns the speaker's volume when the output playing the clip does not own it, and restored afterwards.
- Speakers whose own output handles the volume (including a bridge riding on it) are unchanged and still apply it themselves.
- A speaker configured without any volume control no longer has a volume applied to it at all.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
