### PR TITLE
Failed tracks are no longer requested twice from the same provider

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -299,6 +299,7 @@ class StreamsAudio:
             # Remember the last AudioError so we can re-raise its (actionable)
             # message instead of the generic MediaNotFoundError below.
             last_audio_error: AudioError | None = None
+            attempted: set[tuple[str, str]] = set()
             for allow_other_provider in (False, True):
                 if streamdetails:
                     break
@@ -314,11 +315,19 @@ class StreamsAudio:
                         and prov_media.provider_instance not in preferred_providers
                     ):
                         continue
+                    # the second pass is there to widen to providers the steering held back,
+                    # not to give a mapping a second chance: without a user provider filter
+                    # the first pass already tried them all, so re-attempting one just buys
+                    # the same failure at the cost of another provider round-trip
+                    attempt = (prov_media.provider_instance, prov_media.item_id)
+                    if attempt in attempted:
+                        continue
                     # guard that provider is available
                     provider = mass.get_provider(prov_media.provider_instance)
                     if not provider:
                         self.logger.debug(f"Skipping {prov_media} - provider not available")
                         continue  # provider not available ?
+                    attempted.add(attempt)
                     # get streamdetails from provider; music and plugin providers
                     # share this signature, so either type can own the item.
                     try:

--- a/tests/controllers/streams/test_streamdetails_provider_attempts.py
+++ b/tests/controllers/streams/test_streamdetails_provider_attempts.py
@@ -6,11 +6,13 @@ providers the user's provider filter steers to, the second widens to the rest. W
 provider filter every mapping counts as preferred, so both passes cover the same set and a
 mapping that failed would be asked again -- doubling the cost of every failure, which for a
 just-in-time renderer like AI Radio means a second full text-to-speech render.
+
+The mappings below are given distinct qualities wherever order matters, so the pass the
+loop reaches them in is fixed rather than left to the iteration order of a set.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -22,28 +24,37 @@ from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.controllers.streams.audio import StreamsAudio
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
 INSTANCE = "ai_radio--abc"
 OTHER_INSTANCE = "tidal--xyz"
 ITEM_ID = "session123_0"
 
 
-def _queue_item(*instances: str) -> QueueItem:
-    """Build a queue item whose media item maps to each of the given provider instances."""
+def _mapping(
+    instance: str, item_id: str = ITEM_ID, content_type: ContentType = ContentType.MP3
+) -> ProviderMapping:
+    """
+    Build a provider mapping.
+
+    :param instance: The provider instance the mapping points at.
+    :param item_id: The item id on that provider.
+    :param content_type: Drives the mapping's quality score, which decides the order the
+        mappings are tried in. Pass a lossless type to have a mapping tried first.
+    """
+    return ProviderMapping(
+        item_id=item_id,
+        provider_domain=instance.split("--", maxsplit=1)[0],
+        provider_instance=instance,
+        audio_format=AudioFormat(content_type=content_type),
+    )
+
+
+def _queue_item(*mappings: ProviderMapping) -> QueueItem:
+    """Build a queue item whose media item carries the given provider mappings."""
     media_item = SoundEffect(
         item_id=ITEM_ID,
-        provider=instances[0],
+        provider=mappings[0].provider_instance,
         name="Intro",
-        provider_mappings={
-            ProviderMapping(
-                item_id=ITEM_ID,
-                provider_domain=instance.split("--")[0],
-                provider_instance=instance,
-            )
-            for instance in instances
-        },
+        provider_mappings=set(mappings),
     )
     return QueueItem(
         queue_id="q1",
@@ -68,7 +79,7 @@ def _streamdetails(item_id: str, media_type: MediaType, provider: str) -> Stream
 
 
 def _audio(
-    providers: dict[str, Callable[..., object]], provider_filter: list[str] | None = None
+    providers: dict[str, MagicMock], provider_filter: list[str] | None = None
 ) -> StreamsAudio:
     """
     Build a StreamsAudio whose mass resolves the given provider instances.
@@ -102,7 +113,7 @@ async def test_a_failing_provider_is_asked_only_once() -> None:
     audio = _audio({INSTANCE: provider})
 
     with pytest.raises(MediaNotFoundError):
-        await audio.get_stream_details(queue_item=_queue_item(INSTANCE))
+        await audio.get_stream_details(queue_item=_queue_item(_mapping(INSTANCE)))
 
     assert calls == [ITEM_ID]
 
@@ -126,7 +137,40 @@ async def test_the_widening_pass_still_reaches_a_provider_the_filter_held_back()
     # steer to the failing instance so the working one is only reachable via the second pass
     audio = _audio({INSTANCE: failing, OTHER_INSTANCE: working}, provider_filter=[INSTANCE])
 
-    streamdetails = await audio.get_stream_details(queue_item=_queue_item(INSTANCE, OTHER_INSTANCE))
+    streamdetails = await audio.get_stream_details(
+        # the steered mapping also sorts first, so a repeat of it would land before the
+        # widened one rather than depending on how the mapping set happens to iterate
+        queue_item=_queue_item(
+            _mapping(INSTANCE, content_type=ContentType.FLAC), _mapping(OTHER_INSTANCE)
+        )
+    )
 
     assert streamdetails.provider == OTHER_INSTANCE
     assert calls == [INSTANCE, OTHER_INSTANCE]
+
+
+async def test_two_mappings_on_one_provider_are_both_attempted() -> None:
+    """One provider carrying two items for the media item still gets asked for each."""
+    calls: list[str] = []
+
+    async def _by_item_id(item_id: str, media_type: MediaType) -> StreamDetails:
+        calls.append(item_id)
+        if item_id == "bad":
+            raise MediaNotFoundError(f"clip {item_id} failed TTS")
+        return _streamdetails(item_id, media_type, INSTANCE)
+
+    provider = MagicMock()
+    provider.get_stream_details = _by_item_id
+    audio = _audio({INSTANCE: provider})
+
+    streamdetails = await audio.get_stream_details(
+        # the failing mapping sorts first, so the good one is only reached by carrying on
+        # through the mappings rather than by a repeat attempt
+        queue_item=_queue_item(
+            _mapping(INSTANCE, item_id="bad", content_type=ContentType.FLAC),
+            _mapping(INSTANCE, item_id="good"),
+        )
+    )
+
+    assert streamdetails.item_id == "good"
+    assert calls == ["bad", "good"]

--- a/tests/controllers/streams/test_streamdetails_provider_attempts.py
+++ b/tests/controllers/streams/test_streamdetails_provider_attempts.py
@@ -1,0 +1,132 @@
+"""
+Tests that resolving streamdetails asks each provider mapping at most once.
+
+``get_stream_details`` walks the provider mappings twice: the first pass is limited to the
+providers the user's provider filter steers to, the second widens to the rest. Without a
+provider filter every mapping counts as preferred, so both passes cover the same set and a
+mapping that failed would be asked again -- doubling the cost of every failure, which for a
+just-in-time renderer like AI Radio means a second full text-to-speech render.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.media_items import AudioFormat, ProviderMapping, SoundEffect
+from music_assistant_models.queue_item import QueueItem
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.controllers.streams.audio import StreamsAudio
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+INSTANCE = "ai_radio--abc"
+OTHER_INSTANCE = "tidal--xyz"
+ITEM_ID = "session123_0"
+
+
+def _queue_item(*instances: str) -> QueueItem:
+    """Build a queue item whose media item maps to each of the given provider instances."""
+    media_item = SoundEffect(
+        item_id=ITEM_ID,
+        provider=instances[0],
+        name="Intro",
+        provider_mappings={
+            ProviderMapping(
+                item_id=ITEM_ID,
+                provider_domain=instance.split("--")[0],
+                provider_instance=instance,
+            )
+            for instance in instances
+        },
+    )
+    return QueueItem(
+        queue_id="q1",
+        queue_item_id="qi1",
+        name="Intro",
+        duration=None,
+        media_item=media_item,
+    )
+
+
+def _streamdetails(item_id: str, media_type: MediaType, provider: str) -> StreamDetails:
+    """Build the streamdetails a healthy provider would hand back."""
+    return StreamDetails(
+        provider=provider,
+        item_id=item_id,
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        media_type=media_type,
+        stream_type=StreamType.HTTP,
+        path="http://localhost/clip.mp3",
+        duration=45,
+    )
+
+
+def _audio(
+    providers: dict[str, Callable[..., object]], provider_filter: list[str] | None = None
+) -> StreamsAudio:
+    """
+    Build a StreamsAudio whose mass resolves the given provider instances.
+
+    :param providers: The provider instances the mass should hand back, by instance id.
+    :param provider_filter: The playback user's provider steering, omit for no playback user
+        (which makes every mapping on the item count as preferred).
+    """
+    mass = MagicMock()
+    mass.get_provider.side_effect = lambda instance: providers.get(instance)
+    mass.player_queues.queue_data_or_none.return_value = (
+        MagicMock(userid="user1") if provider_filter else None
+    )
+    mass.webserver.auth.get_user = AsyncMock(
+        return_value=MagicMock(provider_filter=provider_filter) if provider_filter else None
+    )
+    mass.streams.get_config_value.return_value = -17
+    return StreamsAudio(mass)
+
+
+async def test_a_failing_provider_is_asked_only_once() -> None:
+    """A mapping that fails is not asked again by the widening pass."""
+    calls: list[str] = []
+
+    async def _fail(item_id: str, _media_type: MediaType) -> StreamDetails:
+        calls.append(item_id)
+        raise MediaNotFoundError(f"clip {item_id} failed TTS")
+
+    provider = MagicMock()
+    provider.get_stream_details = _fail
+    audio = _audio({INSTANCE: provider})
+
+    with pytest.raises(MediaNotFoundError):
+        await audio.get_stream_details(queue_item=_queue_item(INSTANCE))
+
+    assert calls == [ITEM_ID]
+
+
+async def test_the_widening_pass_still_reaches_a_provider_the_filter_held_back() -> None:
+    """A mapping the steering skipped in the first pass is tried by the second."""
+    calls: list[str] = []
+
+    async def _fail(item_id: str, _media_type: MediaType) -> StreamDetails:
+        calls.append(INSTANCE)
+        raise MediaNotFoundError(f"clip {item_id} failed TTS")
+
+    async def _succeed(item_id: str, media_type: MediaType) -> StreamDetails:
+        calls.append(OTHER_INSTANCE)
+        return _streamdetails(item_id, media_type, OTHER_INSTANCE)
+
+    failing = MagicMock()
+    failing.get_stream_details = _fail
+    working = MagicMock()
+    working.get_stream_details = _succeed
+    # steer to the failing instance so the working one is only reachable via the second pass
+    audio = _audio({INSTANCE: failing, OTHER_INSTANCE: working}, provider_filter=[INSTANCE])
+
+    streamdetails = await audio.get_stream_details(queue_item=_queue_item(INSTANCE, OTHER_INSTANCE))
+
+    assert streamdetails.provider == OTHER_INSTANCE
+    assert calls == [INSTANCE, OTHER_INSTANCE]


### PR DESCRIPTION
# What does this implement/fix?

When a track or clip fails to produce streamdetails, Music Assistant asks the same provider a second time before giving up. The retry never helps — it fails again for the same reason — but it doubles the cost of every failure.

It is most visible with AI Radio: each attempt renders the spoken clip through your TTS engine from scratch. A user with a self-hosted TTS engine saw the same text rendered five times in about 100 seconds for a single clip.

The double call is not deliberate. The loop over provider mappings runs twice so playback can try the providers you steered it to before widening to the rest. When no provider steering is set, every provider counts as preferred, so the first pass already tries them all and the second pass repeats the identical set. This now tracks which mappings were already attempted, so the second pass only reaches providers the steering held back.

Measured on a failing item: 2 provider calls per attempt before, 1 after. A track that plays normally is unaffected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
