### PR TITLE
Music from a NAS comes back on its own after a short outage

### DIFF
--- a/music_assistant/providers/filesystem_cloud/base.py
+++ b/music_assistant/providers/filesystem_cloud/base.py
@@ -183,6 +183,7 @@ class CloudFileSystemProvider(LocalFileSystemProvider):
 
     async def unload(self, is_removed: bool = False) -> None:
         """Handle unload/close of the provider."""
+        await super().unload(is_removed)
         if self._unregister_stream_route is not None:
             self._unregister_stream_route()
 
@@ -263,6 +264,13 @@ class CloudFileSystemProvider(LocalFileSystemProvider):
     # ------------------------------------------------------------------
     # filesystem hooks (these are what the parent calls)
     # ------------------------------------------------------------------
+
+    async def _is_reachable(self) -> bool:
+        """Return whether the cloud storage can be read."""
+        # this provider has no local path to stat, so ask the API for the root listing;
+        # an outage (or expired credentials) surfaces as a raised error
+        await self._scandir("", use_cache=False)
+        return True
 
     async def _scandir(self, path: str, use_cache: bool = True) -> list[FileSystemItem]:
         """

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -178,7 +178,6 @@ class LocalFileSystemProvider(MusicProvider):
     _SYNC_CONCURRENCY: ClassVar[int] = 16
     _sync_tracks: bool = True
     _sync_playlists: bool = True
-    _availability_probe: asyncio.TimerHandle | None = None
 
     def __init__(
         self,
@@ -1210,30 +1209,40 @@ class LocalFileSystemProvider(MusicProvider):
         """Return whether the storage backing this provider can be read."""
         return bool(await isdir(self.base_path))
 
+    @property
+    def _availability_probe_id(self) -> str:
+        """Return the timer id of this provider's reachability checks."""
+        return f"filesystem_availability_probe_{self.instance_id}"
+
     def _schedule_availability_probe(self) -> None:
         """Arm the next reachability check."""
-        self._cancel_availability_probe()
-        self._availability_probe = self.mass.call_later(
+        self.mass.call_later(
             AVAILABILITY_PROBE_INTERVAL,
             self._probe_availability,
-            task_id=f"filesystem_availability_probe_{self.instance_id}",
+            task_id=self._availability_probe_id,
         )
 
     def _cancel_availability_probe(self) -> None:
         """Stop checking for the storage coming back."""
-        if self._availability_probe is not None:
-            self._availability_probe.cancel()
-            self._availability_probe = None
+        self.mass.cancel_timer(self._availability_probe_id)
 
     async def _probe_availability(self) -> None:
         """Mark the provider available again once its storage can be read."""
-        self._availability_probe = None
         try:
             reachable = await self._is_reachable()
-        except Exception as err:
-            # any failure to reach the storage means it is still gone
+        except MusicAssistantError as err:
+            # storage that is simply still gone, which is what this loop waits for
             self.logger.debug("%s is still unreachable: %s", self.name, err)
             reachable = False
+        except Exception:
+            # an unexpected failure must not end the loop, since it is what brings the
+            # provider back, but it is a defect rather than an outage so it is logged loudly
+            self.logger.exception("Reachability check for %s failed", self.name)
+            reachable = False
+        if self.unloading:
+            # the provider was torn down while this check was running; re-arming here
+            # would leave a timer firing against an instance nothing owns anymore
+            return
         if reachable:
             self.logger.info("%s is reachable again", self.name)
             self._set_available(True)

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -89,6 +89,7 @@ from music_assistant.models.music_provider import MusicProvider
 
 from .constants import (
     AUDIOBOOK_EXTENSIONS,
+    AVAILABILITY_PROBE_INTERVAL,
     CACHE_CATEGORY_ALBUM_INFO,
     CACHE_CATEGORY_ARTIST_INFO,
     CACHE_CATEGORY_AUDIOBOOK_CHAPTERS,
@@ -177,6 +178,7 @@ class LocalFileSystemProvider(MusicProvider):
     _SYNC_CONCURRENCY: ClassVar[int] = 16
     _sync_tracks: bool = True
     _sync_playlists: bool = True
+    _availability_probe: asyncio.TimerHandle | None = None
 
     def __init__(
         self,
@@ -261,6 +263,10 @@ class LocalFileSystemProvider(MusicProvider):
                 translation_args=[self.base_path],
             )
         await self.check_write_access()
+
+    async def unload(self, is_removed: bool = False) -> None:
+        """Handle unload/close of the provider."""
+        self._cancel_availability_probe()
 
     async def get_diagnostics(self) -> dict[str, SerializableType]:
         """Return diagnostics info for this provider to include in diagnostics reports."""
@@ -1194,7 +1200,45 @@ class LocalFileSystemProvider(MusicProvider):
         if self.available == available:
             return
         self.available = available
+        if available:
+            self._cancel_availability_probe()
+        else:
+            self._schedule_availability_probe()
         self.mass.signal_event(EventType.PROVIDERS_UPDATED, data=self.mass.get_providers())
+
+    async def _is_reachable(self) -> bool:
+        """Return whether the storage backing this provider can be read."""
+        return bool(await isdir(self.base_path))
+
+    def _schedule_availability_probe(self) -> None:
+        """Arm the next reachability check."""
+        self._cancel_availability_probe()
+        self._availability_probe = self.mass.call_later(
+            AVAILABILITY_PROBE_INTERVAL,
+            self._probe_availability,
+            task_id=f"filesystem_availability_probe_{self.instance_id}",
+        )
+
+    def _cancel_availability_probe(self) -> None:
+        """Stop checking for the storage coming back."""
+        if self._availability_probe is not None:
+            self._availability_probe.cancel()
+            self._availability_probe = None
+
+    async def _probe_availability(self) -> None:
+        """Mark the provider available again once its storage can be read."""
+        self._availability_probe = None
+        try:
+            reachable = await self._is_reachable()
+        except Exception as err:
+            # any failure to reach the storage means it is still gone
+            self.logger.debug("%s is still unreachable: %s", self.name, err)
+            reachable = False
+        if reachable:
+            self.logger.info("%s is reachable again", self.name)
+            self._set_available(True)
+            return
+        self._schedule_availability_probe()
 
     async def _process_item_async(
         self,

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -266,6 +266,9 @@ class LocalFileSystemProvider(MusicProvider):
     async def unload(self, is_removed: bool = False) -> None:
         """Handle unload/close of the provider."""
         self._cancel_availability_probe()
+        # a check that already started runs as a task under the same id, and it would
+        # otherwise keep talking to storage this unload is in the middle of tearing down
+        self.mass.cancel_task(self._availability_probe_id)
 
     async def get_diagnostics(self) -> dict[str, SerializableType]:
         """Return diagnostics info for this provider to include in diagnostics reports."""

--- a/music_assistant/providers/filesystem_local/constants.py
+++ b/music_assistant/providers/filesystem_local/constants.py
@@ -177,3 +177,7 @@ CACHE_CATEGORY_PODCAST_EPISODES: Final[int] = 8
 PARTIAL_LISTING_CACHE_EXPIRATION: Final[int] = 300
 
 DEFAULT_AUDIOBOOK_PODCAST_GENRE: Final[str] = "Spoken Word"
+
+# how often storage that went away during a scan is re-checked, so the provider comes
+# back within minutes instead of waiting for the next scheduled sync
+AVAILABILITY_PROBE_INTERVAL: Final[int] = 300

--- a/music_assistant/providers/filesystem_nfs/provider.py
+++ b/music_assistant/providers/filesystem_nfs/provider.py
@@ -160,6 +160,7 @@ class NFSFileSystemProvider(LocalFileSystemProvider):
 
         Called when provider is deregistered (e.g. MA exiting or config reloading).
         """
+        await super().unload(is_removed)
         await unmount(self.mount_path, self.logger)
 
     async def get_diagnostics(self) -> dict[str, SerializableType]:

--- a/music_assistant/providers/filesystem_smb/__init__.py
+++ b/music_assistant/providers/filesystem_smb/__init__.py
@@ -154,6 +154,7 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
 
         Called when provider is deregistered (e.g. MA exiting or config reloading).
         """
+        await super().unload(is_removed)
         await unmount(self.base_path, self.logger)
 
     async def get_diagnostics(self) -> dict[str, SerializableType]:

--- a/music_assistant/providers/webdav/provider.py
+++ b/music_assistant/providers/webdav/provider.py
@@ -118,6 +118,14 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
         )
         self.write_access = False
 
+    async def _is_reachable(self) -> bool:
+        """Return whether the WebDAV server can be reached."""
+        # base_path is the server url here, so the parent's directory stat cannot answer this
+        await webdav_test_connection(
+            self._session, self.base_url, self.username, self.password, timeout=10
+        )
+        return True
+
     def _build_authenticated_url(self, file_path: str) -> str:
         """Build authenticated WebDAV URL with properly encoded credentials."""
         webdav_url = build_webdav_url(self.base_url, file_path)

--- a/music_assistant/providers/webdav/provider.py
+++ b/music_assistant/providers/webdav/provider.py
@@ -118,14 +118,6 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
         )
         self.write_access = False
 
-    async def _is_reachable(self) -> bool:
-        """Return whether the WebDAV server can be reached."""
-        # base_path is the server url here, so the parent's directory stat cannot answer this
-        await webdav_test_connection(
-            self._session, self.base_url, self.username, self.password, timeout=10
-        )
-        return True
-
     def _build_authenticated_url(self, file_path: str) -> str:
         """Build authenticated WebDAV URL with properly encoded credentials."""
         webdav_url = build_webdav_url(self.base_url, file_path)
@@ -370,3 +362,11 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
     def _get_chapter_path(self, relative_path: str) -> str:
         """Return authenticated WebDAV URL for a chapter file."""
         return self._build_authenticated_url(relative_path)
+
+    async def _is_reachable(self) -> bool:
+        """Return whether the WebDAV server can be reached."""
+        # base_path is the server url here, so the parent's directory stat cannot answer this
+        await webdav_test_connection(
+            self._session, self.base_url, self.username, self.password, timeout=10
+        )
+        return True

--- a/tests/providers/filesystem/test_sync_resilience.py
+++ b/tests/providers/filesystem/test_sync_resilience.py
@@ -252,6 +252,10 @@ async def test_unload_stops_checking() -> None:
     cast("MagicMock", provider.mass.cancel_timer).assert_called_once_with(
         provider._availability_probe_id
     )
+    # a check that already started is a task under the same id, and must stop too
+    cast("MagicMock", provider.mass.cancel_task).assert_called_once_with(
+        provider._availability_probe_id
+    )
 
 
 async def test_probe_does_not_rearm_after_the_provider_is_unloaded() -> None:

--- a/tests/providers/filesystem/test_sync_resilience.py
+++ b/tests/providers/filesystem/test_sync_resilience.py
@@ -1,10 +1,11 @@
 """Tests for filesystem provider sync behavior when the storage misbehaves."""
 
 import errno
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import ProviderUnavailableError
 
 from music_assistant.providers.filesystem_local import LocalFileSystemProvider
 from music_assistant.providers.filesystem_local.constants import (
@@ -49,6 +50,18 @@ def _create_provider() -> LocalFileSystemProvider:
     provider._process_deletions = AsyncMock()  # type: ignore[method-assign]
     provider._process_orphaned_albums_and_artists = AsyncMock()  # type: ignore[method-assign]
     provider._set_available = MagicMock()  # type: ignore[method-assign]
+    return provider
+
+
+def _create_unavailable_provider() -> LocalFileSystemProvider:
+    """Create a provider already flagged down, with real availability handling."""
+    with patch.object(LocalFileSystemProvider, "__init__", lambda *_a, **_kw: None):
+        provider = LocalFileSystemProvider.__new__(LocalFileSystemProvider)
+    provider.config = MagicMock()
+    provider.logger = MagicMock()
+    provider.mass = MagicMock()
+    provider.base_path = "/media"
+    provider.available = False
     return provider
 
 
@@ -169,3 +182,73 @@ async def test_sync_aborts_on_fatal_scan_error() -> None:
     provider._process_deletions.assert_not_called()  # type: ignore[attr-defined]
     provider._process_orphaned_albums_and_artists.assert_not_called()  # type: ignore[attr-defined]
     provider._set_available.assert_called_once_with(False)  # type: ignore[attr-defined]
+
+
+async def test_aborted_sync_starts_checking_for_the_storage() -> None:
+    """A scan aborted by the circuit breaker leaves a reachability check running."""
+    provider = _create_provider()
+    provider.base_path = "/media"
+    # exercise the real availability handling rather than the mock _create_provider installs
+    provider._set_available = LocalFileSystemProvider._set_available.__get__(  # type: ignore[method-assign]
+        provider, LocalFileSystemProvider
+    )
+    provider._enumerate_files_for_sync = _enumerate_result(  # type: ignore[method-assign]
+        failed_dirs=20, fatal=True
+    )
+
+    await provider.sync_library(MediaType.TRACK)
+
+    assert provider.available is False
+    assert provider._availability_probe is not None
+
+
+async def test_probe_keeps_waiting_while_the_storage_is_gone() -> None:
+    """A provider whose storage is still missing stays down and checks again later."""
+    provider = _create_unavailable_provider()
+    call_later = cast("MagicMock", provider.mass.call_later)
+    provider._is_reachable = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+    await provider._probe_availability()
+
+    assert provider.available is False
+    assert call_later.call_count == 1
+
+
+async def test_probe_brings_the_provider_back() -> None:
+    """The provider becomes available again as soon as its storage can be read."""
+    provider = _create_unavailable_provider()
+    call_later = cast("MagicMock", provider.mass.call_later)
+    provider._is_reachable = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    await provider._probe_availability()
+
+    assert provider.available is True
+    # recovered, so no further check is scheduled
+    assert call_later.call_count == 0
+
+
+async def test_probe_treats_an_error_as_still_unreachable() -> None:
+    """A provider whose reachability check raises keeps waiting instead of coming back."""
+    provider = _create_unavailable_provider()
+    call_later = cast("MagicMock", provider.mass.call_later)
+    provider._is_reachable = AsyncMock(  # type: ignore[method-assign]
+        side_effect=ProviderUnavailableError("cloud api down")
+    )
+
+    await provider._probe_availability()
+
+    assert provider.available is False
+    assert call_later.call_count == 1
+
+
+async def test_unload_stops_checking() -> None:
+    """Unloading a provider that went down leaves no timer behind."""
+    provider = _create_unavailable_provider()
+    provider._schedule_availability_probe()
+    timer = provider._availability_probe
+
+    await provider.unload()
+
+    assert timer is not None
+    timer.cancel.assert_called_once()  # type: ignore[attr-defined]
+    assert provider._availability_probe is None

--- a/tests/providers/filesystem/test_sync_resilience.py
+++ b/tests/providers/filesystem/test_sync_resilience.py
@@ -62,6 +62,7 @@ def _create_unavailable_provider() -> LocalFileSystemProvider:
     provider.mass = MagicMock()
     provider.base_path = "/media"
     provider.available = False
+    provider.unloading = False
     return provider
 
 
@@ -199,7 +200,7 @@ async def test_aborted_sync_starts_checking_for_the_storage() -> None:
     await provider.sync_library(MediaType.TRACK)
 
     assert provider.available is False
-    assert provider._availability_probe is not None
+    cast("MagicMock", provider.mass.call_later).assert_called_once()
 
 
 async def test_probe_keeps_waiting_while_the_storage_is_gone() -> None:
@@ -245,10 +246,26 @@ async def test_unload_stops_checking() -> None:
     """Unloading a provider that went down leaves no timer behind."""
     provider = _create_unavailable_provider()
     provider._schedule_availability_probe()
-    timer = provider._availability_probe
 
     await provider.unload()
 
-    assert timer is not None
-    timer.cancel.assert_called_once()  # type: ignore[attr-defined]
-    assert provider._availability_probe is None
+    cast("MagicMock", provider.mass.cancel_timer).assert_called_once_with(
+        provider._availability_probe_id
+    )
+
+
+async def test_probe_does_not_rearm_after_the_provider_is_unloaded() -> None:
+    """A check still running when the provider is torn down must not schedule another."""
+    provider = _create_unavailable_provider()
+    call_later = cast("MagicMock", provider.mass.call_later)
+
+    async def _unload_midway() -> bool:
+        # the provider is torn down while this check is in flight
+        provider.unloading = True
+        return False
+
+    provider._is_reachable = _unload_midway  # type: ignore[method-assign]
+
+    await provider._probe_availability()
+
+    assert call_later.call_count == 0

--- a/tests/providers/filesystem_cloud/test_base.py
+++ b/tests/providers/filesystem_cloud/test_base.py
@@ -351,6 +351,17 @@ async def test_enumerate_root_error_aborts() -> None:
     assert scan_errors.fatal is not None
 
 
+async def test_is_reachable_asks_the_api_for_the_root() -> None:
+    """Cloud storage has no local path to stat, so reachability is a live root listing."""
+    provider = _make_provider()
+
+    assert await provider._is_reachable() is True
+
+    provider.fail_list = {ROOT_ID}
+    with pytest.raises(ProviderUnavailableError):
+        await provider._is_reachable()
+
+
 async def test_enumerate_stops_on_directory_cycle() -> None:
     """A path re-appearing during the walk must be visited only once."""
     provider = _make_provider()

--- a/tests/providers/webdav/test_scan.py
+++ b/tests/providers/webdav/test_scan.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from music_assistant_models.errors import ProviderUnavailableError
 
 from music_assistant.providers.filesystem_local.helpers import FileSystemItem, ScanErrors
 from music_assistant.providers.webdav.helpers import WebDAVItem
@@ -150,3 +151,21 @@ async def test_enumerate_does_not_loop_on_special_chars(special: str) -> None:
     )
 
     assert cur_filenames == {f"{special}/t.mp3"}
+
+
+async def test_is_reachable_asks_the_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A WebDAV url cannot be stat'ed, so reachability is a live request to the server."""
+    provider = _make_provider()
+    provider.verify_ssl = True
+    provider.mass = MagicMock()
+
+    test_connection = AsyncMock()
+    monkeypatch.setattr(
+        "music_assistant.providers.webdav.provider.webdav_test_connection", test_connection
+    )
+    assert await provider._is_reachable() is True
+    test_connection.assert_awaited_once()
+
+    test_connection.side_effect = ProviderUnavailableError("server down")
+    with pytest.raises(ProviderUnavailableError):
+        await provider._is_reachable()


### PR DESCRIPTION
# What does this implement/fix?

When a library scan runs into storage that has gone away (a NAS rebooting, a share dropping out), the provider marks itself unavailable so a half-finished scan can't wipe the library. Until now only a *complete* library sync cleared that flag again — up to twelve hours later, and never from the artist or album sync tasks at all.

For the whole of that window everything belonging to the provider stays out of reach even though the storage may have come back in seconds. Album art is the most visible casualty: covers stop loading, and a cast dashboard or Nest display keeps showing a placeholder until it is restarted.

Changes:

- A provider that went down now re-checks its storage every few minutes and comes back as soon as it can be read.
- The check is deliberately cheap: a single directory stat for local, SMB and NFS. Cloud storage has no local path, so it asks the API for its root listing instead.
- The check stops when the provider recovers or is unloaded.
- How an aborted or incomplete scan protects the library is unchanged — the flag was never what guarded that.

**Related issue (if applicable):**

- follow-up to #5076, which called this out as a separate change

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
