### PR TITLE
Remove unused scandir wrapper from the local filesystem provider

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -150,7 +150,6 @@ isfile = wrap(os.path.isfile)
 ismount = wrap(os.path.ismount)
 exists = wrap(os.path.exists)
 makedirs = wrap(os.makedirs)
-scandir = wrap(os.scandir)
 
 SUPPORTED_FEATURES = {
     ProviderFeature.BROWSE,


### PR DESCRIPTION
# What does this implement/fix?

The local filesystem provider defined a module-level `scandir = wrap(os.scandir)` helper that was never called. Directory listings all go through `sorted_scandir` or the provider's own `_scandir()` method instead, so the binding was just dead weight next to the `wrap()` helpers that are genuinely in use.

**Related issue (if applicable):**

- n/a

## Changes

- Removed the unused `scandir = wrap(os.scandir)` binding from `filesystem_local/__init__.py`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable. (no test changes needed for a dead-code removal)
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a)
