### PR TITLE
AirPlay speakers on a Sendspin bridge now report the volume and mute they are really at

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -934,15 +934,21 @@ class AirPlayPlayer(Player):
             # it would start the stream hard muted, so keep our own last known
             # volume instead.
             return False
-        # The parent's state volume is logical (0-100), while a volume command reaches
-        # this player already scaled into the parent's min/max range - which is what
-        # the level we hold has to stay on for the two to agree.
-        parent_volume = self.mass.players.scale_volume_to_device(
-            parent_player.player_id, parent_player.state.volume_level
-        )
-        if self._attr_volume_level == parent_volume:
+        # The parent's state volume is logical (0-100) while a volume command reaches
+        # this player already scaled into the parent's min/max range, so the two are
+        # compared on the parent's scale: a level that already reads back as the
+        # parent's is left alone rather than re-derived, which for a range that does
+        # not divide evenly would round it a step further away on every stream.
+        parent_id = parent_player.player_id
+        if (
+            self._attr_volume_level is not None
+            and self.mass.players.scale_volume_from_device(parent_id, self._attr_volume_level)
+            == parent_player.state.volume_level
+        ):
             return False
-        self._attr_volume_level = parent_volume
+        self._attr_volume_level = self.mass.players.scale_volume_to_device(
+            parent_id, parent_player.state.volume_level
+        )
         self.mass.config.set_raw_player_config_value(
             self.player_id, CONF_STORED_VOLUME, self._attr_volume_level
         )

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -934,9 +934,15 @@ class AirPlayPlayer(Player):
             # it would start the stream hard muted, so keep our own last known
             # volume instead.
             return False
-        if self._attr_volume_level == parent_player.state.volume_level:
+        # The parent's state volume is logical (0-100), while a volume command reaches
+        # this player already scaled into the parent's min/max range - which is what
+        # the level we hold has to stay on for the two to agree.
+        parent_volume = self.mass.players.scale_volume_to_device(
+            parent_player.player_id, parent_player.state.volume_level
+        )
+        if self._attr_volume_level == parent_volume:
             return False
-        self._attr_volume_level = parent_player.state.volume_level
+        self._attr_volume_level = parent_volume
         self.mass.config.set_raw_player_config_value(
             self.player_id, CONF_STORED_VOLUME, self._attr_volume_level
         )

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -21,7 +21,7 @@ import asyncio
 import time
 from collections import deque
 from contextlib import suppress
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from aiosendspin.models.core import ClientHelloPayload
 from aiosendspin.models.core import DeviceInfo as SendspinDeviceInfo
@@ -140,6 +140,10 @@ BRIDGE_TRANSPORT_RECOVERY_GUARD_SECONDS: float = 30.0
 # which is typically absent from mDNS for far longer than the first. Once they
 # run out the player stays out and idle.
 BRIDGE_REJOIN_ATTEMPT_DELAYS: tuple[int, ...] = (5, 30)
+
+# Player state fields that mean the AirPlay side moved the volume or the mute, so
+# the bridge role's copy of it has to follow.
+_VOLUME_STATE_FIELDS: frozenset[str] = frozenset({"volume_level", "volume_muted"})
 
 
 def get_bridge_client_id(airplay_player: AirPlayPlayer) -> str | None:
@@ -428,6 +432,7 @@ class SendspinAirPlayBridge:
                 on_stream_start=self._on_bridge_stream_start,
                 on_stream_end=self._on_bridge_stream_end,
                 initial_volume=self.airplay_player.volume_level or 25,
+                initial_muted=bool(self.airplay_player.volume_muted),
             )
             self._bridge_role.setup_audio_requirements()
             self._refresh_bridge_timing()
@@ -450,6 +455,22 @@ class SendspinAirPlayBridge:
                 self._bridge_role = None
 
         self.logger.debug("Sendspin bridge stopped for %s", self.airplay_player.display_name)
+
+    def sync_role_volume_state(self) -> None:
+        """
+        Adopt the AirPlay player's volume and mute into the bridge role.
+
+        The role is what the visible Sendspin player reports, so without this a
+        change made on the AirPlay side -- the device's own volume feedback, or a
+        mute released when a stream starts -- would leave the parent showing a
+        level and mute state the speaker is not at.
+        """
+        if not self._bridge_role:
+            return
+        self._bridge_role.update_player_state(
+            volume=self.airplay_player.volume_level,
+            muted=bool(self.airplay_player.volume_muted),
+        )
 
     def stop_streaming(self) -> None:
         """
@@ -1502,6 +1523,17 @@ class SendspinAirPlayBridge:
 class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinAirPlayBridge]):
     """Manages Sendspin bridges for all AirPlay players."""
 
+    def __init__(self, provider: AirPlayProvider) -> None:
+        """
+        Initialize the bridge manager.
+
+        :param provider: The AirPlay provider owning the bridged players.
+        """
+        super().__init__(provider)
+        self._unsubs.append(
+            self.mass.players.subscribe_player_state_update(self._on_player_state_updated)
+        )
+
     def resolve_shared_ptp(self, bridge: SendspinAirPlayBridge) -> bool:
         """
         Return whether a bridge's next cli process attaches to the shared PTP clock.
@@ -1597,3 +1629,12 @@ class SendspinBridgeManager(SendspinBridgeManagerBase[SendspinAirPlayBridge]):
     def _should_have_bridge(self, player: Player) -> bool:
         """Return whether an AirPlay player should have a Sendspin bridge."""
         return get_bridge_client_id(cast("AirPlayPlayer", player)) is not None
+
+    def _on_player_state_updated(
+        self, updated_player: Player, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None:
+        """Feed an AirPlay player's own volume/mute changes back into its bridge role."""
+        if not changed_values.keys() & _VOLUME_STATE_FIELDS:
+            return
+        if bridge := self._bridges.get(updated_player.player_id):
+            bridge.sync_role_volume_state()

--- a/music_assistant/providers/sendspin/bridge_role.py
+++ b/music_assistant/providers/sendspin/bridge_role.py
@@ -86,6 +86,7 @@ class BridgePlayerRole(Role):
         on_stream_start: Callable[[], None],
         on_stream_end: Callable[[], None],
         initial_volume: int = 100,
+        initial_muted: bool = False,
     ) -> None:
         """
         Wire up bridge callbacks after role creation.
@@ -96,16 +97,14 @@ class BridgePlayerRole(Role):
         :param on_stream_start: Callback when the stream starts.
         :param on_stream_end: Callback when the stream ends.
         :param initial_volume: Initial volume level (0-100).
+        :param initial_muted: Initial mute state.
         """
         self._on_audio_chunk_cb = on_audio_chunk
         self._on_volume_change_cb = on_volume_change
         self._on_mute_change_cb = on_mute_change
         self._on_stream_start_cb = on_stream_start
         self._on_stream_end_cb = on_stream_end
-        volume_changed = self._volume != initial_volume
-        self._volume = initial_volume
-        if volume_changed:
-            self._emit_volume_changed()
+        self.update_player_state(volume=initial_volume, muted=initial_muted)
 
     @property
     def role_id(self) -> str:
@@ -188,6 +187,28 @@ class BridgePlayerRole(Role):
         self._emit_volume_changed()
         if self._on_mute_change_cb:
             self._on_mute_change_cb(muted)
+
+    def update_player_state(self, *, volume: int | None = None, muted: bool | None = None) -> None:
+        """
+        Adopt volume/mute state the bridged player is already in.
+
+        Use this instead of set_player_volume/set_player_mute for state that came
+        from the player's own side (device feedback, a mute applied elsewhere): the
+        bridge callbacks are not invoked, so the value is not pushed back at the
+        player it was just read from.
+
+        :param volume: Volume level (0-100) the player is at, or None to leave it.
+        :param muted: Mute state the player is in, or None to leave it.
+        """
+        changed = False
+        if volume is not None and volume != self._volume:
+            self._volume = volume
+            changed = True
+        if muted is not None and muted != self._muted:
+            self._muted = muted
+            changed = True
+        if changed:
+            self._emit_volume_changed()
 
     def on_audio_chunk(self, chunk: AudioChunk) -> None:
         """Receive audio chunk from PushStream and forward to callback."""

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -59,10 +59,12 @@ def _stub_raw_config(provider: MagicMock, stored: dict[str, object] | None = Non
 
 def _stub_volume_scaling(provider: MagicMock, min_volume: int = 0, max_volume: int = 100) -> None:
     """Apply the controller's real min/max volume scaling instead of a mock."""
+    identity = (min_volume, max_volume) == (0, 100)
     provider.mass.players.scale_volume_to_device.side_effect = lambda _player_id, logical: (
-        logical
-        if (min_volume, max_volume) == (0, 100)
-        else min_volume + (logical * (max_volume - min_volume)) // 100
+        logical if identity else min_volume + (logical * (max_volume - min_volume)) // 100
+    )
+    provider.mass.players.scale_volume_from_device.side_effect = lambda _player_id, device: (
+        device if identity else ((device - min_volume) * 100) // (max_volume - min_volume)
     )
 
 
@@ -854,6 +856,35 @@ def test_sync_volume_state_adopts_parent_volume_on_the_parents_scale(
         airplay_player.sync_volume_state()
 
     assert airplay_player._attr_volume_level == 30
+
+
+def test_sync_volume_state_keeps_a_level_already_on_the_parents_volume(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """
+    A level the parent already reports is left alone, whatever the limits round to.
+
+    A range that does not divide evenly cannot map every level back and forth
+    exactly, so re-deriving one that already agrees would walk the speaker a step
+    further down on every stream it starts.
+    """
+    _stub_volume_scaling(cast("MagicMock", airplay_player.provider), max_volume=99)
+    parent = MagicMock()
+    parent.player_id = "parent"
+    # what the parent reports for a player sitting at device level 98
+    parent.state.volume_level = 98
+    parent.volume_control_for_output.return_value = "test_player"
+    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
+    airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
+    airplay_player.set_protocol_parent_id("parent")
+    airplay_player._attr_volume_level = 98
+
+    with patch.object(AirPlayPlayer, "update_state") as mock_update:
+        airplay_player.sync_volume_state()
+
+    assert airplay_player._attr_volume_level == 98
+    airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
+    mock_update.assert_not_called()
 
 
 def test_sync_volume_state_unity_gain_when_other_control_owns_volume(

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -57,11 +57,21 @@ def _stub_raw_config(provider: MagicMock, stored: dict[str, object] | None = Non
     )
 
 
+def _stub_volume_scaling(provider: MagicMock, min_volume: int = 0, max_volume: int = 100) -> None:
+    """Apply the controller's real min/max volume scaling instead of a mock."""
+    provider.mass.players.scale_volume_to_device.side_effect = lambda _player_id, logical: (
+        logical
+        if (min_volume, max_volume) == (0, 100)
+        else min_volume + (logical * (max_volume - min_volume)) // 100
+    )
+
+
 @pytest.fixture
 def airplay_player() -> AirPlayPlayer:
     """Create a basic AirPlayPlayer with mock defaults."""
     provider = MagicMock()
     _stub_raw_config(provider)
+    _stub_volume_scaling(provider)
     return AirPlayPlayer(
         provider=provider,
         player_id="test_player",
@@ -818,6 +828,32 @@ def test_sync_volume_state_uses_parent_volume_via_bridge_control(
         42,
     )
     mock_update.assert_called_once()
+
+
+def test_sync_volume_state_adopts_parent_volume_on_the_parents_scale(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """
+    A volume limit on the parent leaves the adopted level on the same scale as a command.
+
+    Volume commands arrive here already scaled into the parent's range, so adopting
+    the parent's logical level as-is would play the speaker louder than asked and
+    read back as a volume outside the range on the next state update.
+    """
+    _stub_volume_scaling(cast("MagicMock", airplay_player.provider), max_volume=50)
+    parent = MagicMock()
+    parent.player_id = "parent"
+    parent.state.volume_level = 60
+    parent.volume_control_for_output.return_value = "test_player"
+    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
+    airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
+    airplay_player.set_protocol_parent_id("parent")
+    airplay_player._attr_volume_level = 48
+
+    with patch.object(AirPlayPlayer, "update_state"):
+        airplay_player.sync_volume_state()
+
+    assert airplay_player._attr_volume_level == 30
 
 
 def test_sync_volume_state_unity_gain_when_other_control_owns_volume(

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -3134,10 +3134,50 @@ def test_state_updates_without_a_volume_change_leave_the_role_alone() -> None:
 
 
 def test_a_player_without_a_bridge_is_ignored() -> None:
-    """A volume change on a player this manager knows nothing about is a no-op."""
-    bridge, _ = _make_bridge_with_role()
+    """A volume change on a player this manager knows nothing about leaves bridges alone."""
+    bridge, role = _make_bridge_with_role(volume=40)
     manager = _bridge_manager_for(bridge)
     other_player = MagicMock()
     other_player.player_id = "ap0011223344ff"
+    other_player.volume_level = 55
 
     manager._on_player_state_updated(other_player, {"volume_level": (40, 55)})
+
+    assert role.get_player_volume() == 40
+
+
+def test_the_manager_listens_for_the_state_updates_it_routes() -> None:
+    """
+    The bridged AirPlay players are watched for the whole life of the manager.
+
+    A protocol player emits no PLAYER_UPDATED event, so the controller's internal
+    state-update subscription is the only way their volume changes are seen.
+    """
+    manager = SendspinBridgeManager(MagicMock())
+
+    cast("MagicMock", manager.mass).players.subscribe_player_state_update.assert_called_once_with(
+        manager._on_player_state_updated
+    )
+
+
+def test_a_volume_set_through_the_bridge_settles_in_one_pass() -> None:
+    """
+    A volume coming down from Sendspin is not announced again on its way back.
+
+    The player ends up holding what the role handed it, so reading that state back
+    has to compare equal - otherwise every command would bounce between the two.
+    """
+    bridge, role = _make_bridge_with_role(volume=40)
+    player = cast("MagicMock", bridge.airplay_player)
+    client = cast("MagicMock", role._client)
+
+    role.set_player_volume(70)
+    player.volume_set.assert_called_once_with(70)
+    # the AirPlay player records the level it was handed
+    player.volume_level = 70
+    client.reset_mock()
+
+    bridge.sync_role_volume_state()
+
+    assert role.get_player_volume() == 70
+    client._signal_event.assert_not_called()

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -67,6 +67,7 @@ from music_assistant.providers.sendspin.bridge_role import (
     BRIDGE_BYTES_PER_SAMPLE,
     BRIDGE_CHANNELS,
     BRIDGE_SAMPLE_RATE,
+    BridgePlayerRole,
 )
 
 BRIDGE_BYTES_PER_SECOND = BRIDGE_SAMPLE_RATE * BRIDGE_CHANNELS * BRIDGE_BYTES_PER_SAMPLE
@@ -3015,3 +3016,128 @@ def test_an_abandoned_process_stops_deciding_for_its_group() -> None:
 
     assert abandoned._use_shared_ptp is None
     assert abandoned.active_shared_ptp is None
+
+
+# --- Volume/mute moved on the AirPlay side, fed back into the bridge role ------
+
+
+def _make_bridge_with_role(
+    volume: int | None = 40, muted: bool = False
+) -> tuple[SendspinAirPlayBridge, BridgePlayerRole]:
+    """Build a bridge whose (real) role is wired to its mocked AirPlay player."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    role = BridgePlayerRole(client=MagicMock())
+    role.set_callbacks(
+        on_audio_chunk=bridge._on_audio_chunk,
+        on_volume_change=bridge._on_volume_change,
+        on_mute_change=bridge._on_mute_change,
+        on_stream_start=bridge._on_bridge_stream_start,
+        on_stream_end=bridge._on_bridge_stream_end,
+        initial_volume=volume or 25,
+        initial_muted=muted,
+    )
+    bridge._bridge_role = role
+    player = cast("MagicMock", bridge.airplay_player)
+    player.volume_level = volume
+    player.volume_muted = muted
+    return bridge, role
+
+
+async def test_registration_seeds_the_role_with_the_state_the_speaker_is_in() -> None:
+    """
+    A bridge (re)registering adopts the volume and mute the speaker is already at.
+
+    A bridge is torn down and rebuilt on a config change, so starting from a
+    fixed unmuted default would re-create the divergence on every rebuild.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    player = cast("MagicMock", bridge.airplay_player)
+    player.volume_level = 35
+    player.volume_muted = True
+    role = MagicMock()
+    server = cast("MagicMock", bridge.sendspin_server)
+    server.register_external_player.return_value.roles_by_family.return_value = [role]
+
+    await bridge.start()
+
+    assert role.set_callbacks.call_args.kwargs["initial_volume"] == 35
+    assert role.set_callbacks.call_args.kwargs["initial_muted"] is True
+
+
+def test_device_volume_feedback_reaches_the_visible_player() -> None:
+    """
+    A volume the device reports itself is adopted by the role, not sent back to it.
+
+    The role is what the parent's volume resolves to while the bridge streams, so
+    it has to follow the speaker; forwarding it would hand the device back the
+    value it just reported.
+    """
+    bridge, role = _make_bridge_with_role(volume=40)
+    player = cast("MagicMock", bridge.airplay_player)
+    player.volume_level = 55
+
+    bridge.sync_role_volume_state()
+
+    assert role.get_player_volume() == 55
+    player.volume_set.assert_not_called()
+
+
+def test_a_mute_latched_on_the_airplay_side_shows_through_the_bridge() -> None:
+    """
+    A mute applied on the AirPlay side is visible on the Sendspin player.
+
+    While it is latched the AirPlay player swallows every volume command, so a
+    bridge still reporting the speaker as unmuted leaves nothing to explain why
+    it is silent - or to unmute it with.
+    """
+    bridge, role = _make_bridge_with_role(muted=False)
+    player = cast("MagicMock", bridge.airplay_player)
+    player.volume_muted = True
+
+    bridge.sync_role_volume_state()
+
+    assert role.get_player_muted() is True
+    player.volume_mute.assert_not_called()
+
+
+def test_an_airplay_volume_change_is_routed_to_that_player_s_bridge() -> None:
+    """A state update carrying a volume or mute change lands on the right bridge."""
+    bridge, role = _make_bridge_with_role(volume=40)
+    manager = _bridge_manager_for(bridge)
+    player = cast("MagicMock", bridge.airplay_player)
+    player.volume_level = 55
+    player.volume_muted = True
+
+    manager._on_player_state_updated(
+        player, {"volume_level": (40, 55), "volume_muted": (False, True)}
+    )
+
+    assert role.get_player_volume() == 55
+    assert role.get_player_muted() is True
+
+
+def test_state_updates_without_a_volume_change_leave_the_role_alone() -> None:
+    """
+    Every player's state update passes through, so unrelated ones do no work.
+
+    The callback runs for the whole player graph on every tick, including the
+    position updates of a playing queue.
+    """
+    bridge, role = _make_bridge_with_role(volume=40)
+    manager = _bridge_manager_for(bridge)
+    player = cast("MagicMock", bridge.airplay_player)
+    player.volume_level = 55
+
+    manager._on_player_state_updated(player, {"playback_state": ("idle", "playing")})
+
+    assert role.get_player_volume() == 40
+
+
+def test_a_player_without_a_bridge_is_ignored() -> None:
+    """A volume change on a player this manager knows nothing about is a no-op."""
+    bridge, _ = _make_bridge_with_role()
+    manager = _bridge_manager_for(bridge)
+    other_player = MagicMock()
+    other_player.player_id = "ap0011223344ff"
+
+    manager._on_player_state_updated(other_player, {"volume_level": (40, 55)})

--- a/tests/providers/sendspin/test_bridge_role.py
+++ b/tests/providers/sendspin/test_bridge_role.py
@@ -1,0 +1,107 @@
+"""
+Unit tests for the volume and mute state held by the Sendspin bridge player role.
+
+The role's copy of the volume and mute is what the visible Sendspin player
+reports, and it moves in two directions: a command coming down from Sendspin,
+which the bridge has to forward to its player, and state observed on the player
+itself, which has to reach the Sendspin side without being pushed back at the
+player it was just read from.
+"""
+
+from unittest.mock import MagicMock
+
+from aiosendspin.server import VolumeChangedEvent
+
+from music_assistant.providers.sendspin.bridge_role import BridgePlayerRole
+
+
+def _make_role(
+    *, initial_volume: int = 40, initial_muted: bool = False
+) -> tuple[BridgePlayerRole, MagicMock, MagicMock, MagicMock]:
+    """Build a wired-up bridge role with its client mock and volume/mute callbacks."""
+    client = MagicMock()
+    role = BridgePlayerRole(client=client)
+    on_volume_change = MagicMock()
+    on_mute_change = MagicMock()
+    role.set_callbacks(
+        on_audio_chunk=MagicMock(),
+        on_volume_change=on_volume_change,
+        on_mute_change=on_mute_change,
+        on_stream_start=MagicMock(),
+        on_stream_end=MagicMock(),
+        initial_volume=initial_volume,
+        initial_muted=initial_muted,
+    )
+    client.reset_mock()
+    return role, client, on_volume_change, on_mute_change
+
+
+def _emitted_volume_events(client: MagicMock) -> list[VolumeChangedEvent]:
+    """Return the volume-changed events the role emitted on its client."""
+    return [
+        call.args[0]
+        for call in client._signal_event.call_args_list
+        if isinstance(call.args[0], VolumeChangedEvent)
+    ]
+
+
+def test_wiring_the_callbacks_seeds_the_state_the_player_is_in() -> None:
+    """A bridge registering a muted player starts out reporting it as muted."""
+    role, _, _, _ = _make_role(initial_volume=35, initial_muted=True)
+
+    assert role.get_player_volume() == 35
+    assert role.get_player_muted() is True
+
+
+def test_a_command_from_sendspin_is_forwarded_to_the_bridge() -> None:
+    """A volume or mute command is applied and handed to the bridge to carry out."""
+    role, client, on_volume_change, on_mute_change = _make_role()
+
+    role.set_player_volume(70)
+    role.set_player_mute(True)
+
+    assert role.get_player_volume() == 70
+    assert role.get_player_muted() is True
+    on_volume_change.assert_called_once_with(70)
+    on_mute_change.assert_called_once_with(True)
+    assert [(event.volume, event.muted) for event in _emitted_volume_events(client)] == [
+        (70, False),
+        (70, True),
+    ]
+
+
+def test_state_observed_on_the_player_is_not_pushed_back_at_it() -> None:
+    """
+    State read off the player reaches Sendspin without being sent back down.
+
+    Forwarding it would hand the player a value it just reported, which for a
+    device that answers every volume command with feedback never settles.
+    """
+    role, client, on_volume_change, on_mute_change = _make_role()
+
+    role.update_player_state(volume=55, muted=True)
+
+    assert role.get_player_volume() == 55
+    assert role.get_player_muted() is True
+    on_volume_change.assert_not_called()
+    on_mute_change.assert_not_called()
+    assert [(event.volume, event.muted) for event in _emitted_volume_events(client)] == [(55, True)]
+
+
+def test_only_the_state_that_is_known_is_adopted() -> None:
+    """A player that cannot report a level keeps the level the role already has."""
+    role, _, _, _ = _make_role(initial_volume=40)
+
+    role.update_player_state(volume=None, muted=True)
+
+    assert role.get_player_volume() == 40
+    assert role.get_player_muted() is True
+
+
+def test_unchanged_state_is_not_announced_again() -> None:
+    """Re-reading the same volume and mute off the player is not an update."""
+    role, client, _, _ = _make_role(initial_volume=40, initial_muted=False)
+
+    role.update_player_state(volume=40, muted=False)
+
+    assert _emitted_volume_events(client) == []


### PR DESCRIPTION
# What does this implement/fix?

An AirPlay speaker driven through the Sendspin bridge could show a volume it was not playing at, or be silent while the player reported it as unmuted.

Volume and mute only ever travelled one way: from Sendspin down to the AirPlay player. Anything that moved them on the AirPlay side - the speaker reporting its own volume back over DACP, or a mute latched there - never reached the bridge, so the visible player kept reporting the old state. A latched mute was the worst case: the AirPlay player swallows every volume command while it is set, and nothing in the UI showed why.

**Related issue (if applicable):**

- follow-up on #5677

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- The bridge role can now adopt volume/mute observed on the player itself, without handing it straight back to that player.
- The AirPlay bridge manager watches its players and feeds their volume/mute changes into the bridge.
- Registering a bridge now picks up the mute state the speaker is in, not just its volume, so a rebuild no longer starts out unmuted.
- A volume adopted from the parent stays on the scale a volume command arrives on, so a speaker with a volume limit set on it no longer starts a stream louder than asked.
- Tests for both directions and the no-loop guarantee.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
