### PR TITLE
Non-UTF-8 filename tests no longer fail on macOS

### DIFF
--- a/tests/providers/filesystem/test_helpers.py
+++ b/tests/providers/filesystem/test_helpers.py
@@ -3,6 +3,7 @@
 import errno
 import logging
 import os
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Self
 from unittest.mock import patch
@@ -351,10 +352,27 @@ class _BrokenEntry:
         raise self._err
 
 
+class _NamedEntry:
+    """Directory entry carrying only a name, for names a filesystem may refuse to create."""
+
+    def __init__(self, parent: str, name: str) -> None:
+        self.name = name
+        self.path = os.path.join(parent, name)
+
+    # no is_dir/is_file on purpose: the name guard has to skip this entry before anything
+    # reads its type, so a call site that lost the guard fails loudly here instead of
+    # quietly dropping the entry and leaving the test green
+    def __getattr__(self, name: str) -> object:
+        raise AssertionError(f"'{self.name}' must be skipped on its name, before .{name}")
+
+
+_ScanEntry = _BrokenEntry | _NamedEntry | os.DirEntry[str]
+
+
 class _FakeScanDir:
     """Stand-in for the os.scandir iterator, which is also a context manager."""
 
-    def __init__(self, entries: list[_BrokenEntry]) -> None:
+    def __init__(self, entries: Sequence[_ScanEntry]) -> None:
         self._entries = iter(entries)
 
     def __enter__(self) -> Self:
@@ -366,7 +384,7 @@ class _FakeScanDir:
     def __iter__(self) -> Self:
         return self
 
-    def __next__(self) -> _BrokenEntry:
+    def __next__(self) -> _ScanEntry:
         return next(self._entries)
 
 
@@ -474,6 +492,12 @@ def test_scan_errors_describe_names_examples() -> None:
     assert len(errors.failed_paths) == helpers.MAX_REPORTED_FAILED_PATHS
 
 
+# 0xDF is "ß" in Latin-1 and not valid UTF-8. os.fsdecode is what os.scandir uses to build
+# DirEntry.name, so this is exactly what a real scan hands the guard for such a file, while
+# needing no file on disk - filesystems that enforce UTF-8 names refuse to create one.
+UNDECODABLE_NAME = os.fsdecode(b"Stra\xdfe.mp3")
+
+
 def test_recursive_iter_skips_names_that_are_not_valid_utf8(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -485,13 +509,17 @@ def test_recursive_iter_skips_names_that_are_not_valid_utf8(
     (#6042). Emoji are valid UTF-8 and must keep scanning.
     """
     (tmp_path / "track 🎧.mp3").write_bytes(b"x")
-    # 0xDF is "ß" in Latin-1 and not valid UTF-8, so os returns it surrogate-escaped
-    undecodable = os.path.join(os.fsencode(str(tmp_path)), b"Stra\xdfe.mp3")
-    with open(undecodable, "wb") as _file:
-        _file.write(b"x")
-
     errors = helpers.ScanErrors()
-    with caplog.at_level(logging.WARNING):
+    real_scandir = os.scandir
+
+    def fake_scandir(path: str | os.PathLike[str]) -> _FakeScanDir:
+        with real_scandir(path) as entries:
+            return _FakeScanDir([*entries, _NamedEntry(str(path), UNDECODABLE_NAME)])
+
+    with (
+        caplog.at_level(logging.WARNING),
+        patch("os.scandir", side_effect=fake_scandir),
+    ):
         items = list(
             helpers.recursive_iter(
                 str(tmp_path), str(tmp_path), SUPPORTED, logging.getLogger("test"), errors
@@ -515,15 +543,32 @@ def test_sorted_scandir_skips_names_that_are_not_valid_utf8(
     asked for it (#6042).
     """
     (tmp_path / "track 🎧.mp3").write_bytes(b"x")
-    undecodable = os.path.join(os.fsencode(str(tmp_path)), b"Stra\xdfe.mp3")
-    with open(undecodable, "wb") as _file:
-        _file.write(b"x")
+    real_scandir = os.scandir
 
-    with caplog.at_level(logging.WARNING):
+    def fake_scandir(path: str | os.PathLike[str]) -> _FakeScanDir:
+        with real_scandir(path) as entries:
+            return _FakeScanDir([*entries, _NamedEntry(str(path), UNDECODABLE_NAME)])
+
+    with (
+        caplog.at_level(logging.WARNING),
+        patch("os.scandir", side_effect=fake_scandir),
+    ):
         items = helpers.sorted_scandir(str(tmp_path), str(tmp_path))
 
     assert [item.relative_path for item in items] == ["track 🎧.mp3"]
     assert "Stra\\xdfe.mp3" in caplog.text
+
+
+def test_skip_undecodable_name_passes_valid_names(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that the guard passes valid names without warning, whatever their encoding."""
+    log = logging.getLogger("test")
+    with caplog.at_level(logging.WARNING):
+        assert not helpers._skip_undecodable_name("track.mp3", log)
+        assert not helpers._skip_undecodable_name("Straße.mp3", log)
+        # 4-byte UTF-8 takes the same path as the 2-byte name above
+        assert not helpers._skip_undecodable_name("track 🎧.mp3", log)
+
+    assert not caplog.records
 
 
 def test_scan_errors_reset_on_successful_read() -> None:


### PR DESCRIPTION
# What does this implement/fix?

The two tests added in #5563 create a file whose name is not valid UTF-8. APFS refuses such a name outright (`OSError: [Errno 92] Illegal byte sequence`), so `pytest` fails on `dev` on macOS. CI only runs on Linux, where ext4 stores those bytes happily, so it stayed green.

The name is now injected into the directory listing instead of being written to disk, so both tests keep running on every platform.

Changes:

- both scan tests inject the undecodable name via `os.scandir`, reusing the fake-entry helpers already in this file
- added a small test for the guard's plain and non-ASCII cases

**Related issue (if applicable):**

- follow-up to #5563

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
