### PR TITLE
Sonos no longer restarts Spotify instead of your queue

### DIFF
--- a/music_assistant/providers/sonos/const.py
+++ b/music_assistant/providers/sonos/const.py
@@ -77,8 +77,9 @@ PLAYER_SOURCE_MAP = {
 # Seconds an external source may sit paused before we consider its session ended.
 # Sonos keeps a source like Spotify Connect loaded and paused indefinitely, also once the
 # app released the speaker, and offers nothing to tell an abandoned session apart from a
-# real pause - so the only signal left is how long it has been sitting there.
-EXTERNAL_PAUSE_IDLE_TIMEOUT = 15
+# real pause - so time is the only signal left. Kept generous on purpose: a source that
+# refuses to resume is ended right away, without waiting for this to pass.
+EXTERNAL_PAUSE_IDLE_TIMEOUT = 30
 
 UNSUPPORTED_MODELS_NATIVE_ANNOUNCEMENTS = ("Play:1", "Play:3")
 NON_HIRES_MODELS = (

--- a/music_assistant/providers/sonos/const.py
+++ b/music_assistant/providers/sonos/const.py
@@ -74,6 +74,12 @@ PLAYER_SOURCE_MAP = {
     ),
 }
 
+# Seconds an external source may sit paused before we consider its session ended.
+# Sonos keeps a source like Spotify Connect loaded and paused indefinitely, also once the
+# app released the speaker, and offers nothing to tell an abandoned session apart from a
+# real pause - so the only signal left is how long it has been sitting there.
+EXTERNAL_PAUSE_IDLE_TIMEOUT = 15
+
 UNSUPPORTED_MODELS_NATIVE_ANNOUNCEMENTS = ("Play:1", "Play:3")
 NON_HIRES_MODELS = (
     "Play:1",

--- a/music_assistant/providers/sonos/const.py
+++ b/music_assistant/providers/sonos/const.py
@@ -74,12 +74,12 @@ PLAYER_SOURCE_MAP = {
     ),
 }
 
-# Seconds an external source may sit paused before we consider its session ended.
+# Seconds a source may sit paused before we consider its session ended.
 # Sonos keeps a source like Spotify Connect loaded and paused indefinitely, also once the
 # app released the speaker, and offers nothing to tell an abandoned session apart from a
-# real pause - so time is the only signal left. Kept generous on purpose: a source that
-# refuses to resume is ended right away, without waiting for this to pass.
-EXTERNAL_PAUSE_IDLE_TIMEOUT = 30
+# real pause - so time is the only signal left. Kept generous because this is what a real
+# pause is given before the speaker stops reporting what it was playing.
+EXTERNAL_PAUSE_IDLE_TIMEOUT = 60
 
 UNSUPPORTED_MODELS_NATIVE_ANNOUNCEMENTS = ("Play:1", "Play:3")
 NON_HIRES_MODELS = (

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -38,6 +38,7 @@ from music_assistant.constants import (
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player
 from music_assistant.providers.sonos.const import (
+    EXTERNAL_PAUSE_IDLE_TIMEOUT,
     NON_HIRES_MODELS,
     PLAYBACK_STATE_MAP,
     PLAYER_SOURCE_MAP,
@@ -91,6 +92,7 @@ class SonosPlayer(Player):
         self.connected: bool = False
         self._listen_task: asyncio.Task[None] | None = None
         self.sonos_queue: SonosQueue = SonosQueue()
+        self._external_pause_since: float | None = None
 
     @property
     def group_controller(self) -> SonosGroup:
@@ -203,6 +205,7 @@ class SonosPlayer(Player):
         for task_id in (
             f"sonos_reconnect_{self.player_id}",
             f"restore_airplay_group_{self.player_id}",
+            f"sonos_external_pause_{self.player_id}",
         ):
             # a timer that already fired lives on as a task under the same id,
             # so both are needed to cover the pending and the running case
@@ -654,6 +657,7 @@ class SonosPlayer(Player):
                 current_media.uri = container["id"]["objectId"]
 
         self._attr_current_media = current_media
+        self._expire_stale_external_pause()
 
     async def on_protocol_playback(
         self,
@@ -857,6 +861,28 @@ class SonosPlayer(Player):
             self.player_id,
             [x.title for x in self.sonos_queue.items],
         )
+
+    def _expire_stale_external_pause(self) -> None:
+        """Report an external source that has been paused for a while as no longer active."""
+        if self._attr_playback_state != PlaybackState.PAUSED:
+            self._external_pause_since = None
+            return
+        if self._external_pause_since is None:
+            self._external_pause_since = time.time()
+            # nothing changes on the Sonos side when the session goes stale, so there is no
+            # event to react to: re-evaluate our own state once the grace period has passed
+            self.mass.call_later(
+                EXTERNAL_PAUSE_IDLE_TIMEOUT + 1,
+                self.on_player_event,
+                None,
+                task_id=f"sonos_external_pause_{self.player_id}",
+            )
+            return
+        if (time.time() - self._external_pause_since) < EXTERNAL_PAUSE_IDLE_TIMEOUT:
+            return
+        self._attr_playback_state = PlaybackState.IDLE
+        self._attr_active_source = None
+        self._attr_current_media = None
 
     def _extract_mac_from_player_id(self) -> str | None:
         """

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -884,25 +884,24 @@ class SonosPlayer(Player):
             return
         if self._external_pause_since is None:
             self._external_pause_since = time.time()
-            # nothing changes on the Sonos side when the session goes stale, so there is no
-            # event to react to: re-evaluate our own state once the grace period has passed
-            self.mass.call_later(
-                EXTERNAL_PAUSE_IDLE_TIMEOUT + 1,
-                self.on_player_event,
-                None,
-                task_id=f"sonos_external_pause_{self.player_id}",
-            )
-            return
-        if (time.time() - self._external_pause_since) >= EXTERNAL_PAUSE_IDLE_TIMEOUT:
+        elif (time.time() - self._external_pause_since) >= EXTERNAL_PAUSE_IDLE_TIMEOUT:
             self._mark_external_source_ended()
+            return
+        # nothing changes on the Sonos side when the session goes stale, so there is no event
+        # to react to. Keep the check armed rather than relying on a single timer: an update
+        # that bails out early (a reconnect, a group parent we do not know yet) would
+        # otherwise consume it and leave the source paused for good.
+        self.mass.call_later(
+            EXTERNAL_PAUSE_IDLE_TIMEOUT + 1,
+            self.on_player_event,
+            None,
+            task_id=f"sonos_external_pause_{self.player_id}",
+        )
 
     def _mark_external_source_ended(self) -> None:
-        """
-        Stop presenting the source Sonos has loaded as something that can be resumed.
-
-        Backdating the pause is what makes this stick: the updates that follow rebuild the
-        state from Sonos, which keeps reporting the very same source as paused.
-        """
+        """Stop presenting the source Sonos has loaded as something that can be resumed."""
+        # the updates that follow rebuild the state from Sonos, which keeps reporting the very
+        # same source as paused, so backdating the pause is what keeps this applied
         self._external_pause_since = time.time() - EXTERNAL_PAUSE_IDLE_TIMEOUT
         self._attr_playback_state = PlaybackState.IDLE
         self._attr_active_source = None

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -249,7 +249,9 @@ class SonosPlayer(Player):
         try:
             await self.group_controller.play()
         except FailedCommand as err:
-            if self._attr_active_source is None:
+            if self._attr_active_source is None or "groupCoordinatorChanged" in str(err):
+                # only a source Sonos loaded itself can go away like this, and a coordinator
+                # change is a race condition rather than a source that disappeared
                 raise
             # the loaded source refused to resume, so it is not merely paused after all
             self.logger.debug(

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -246,7 +246,20 @@ class SonosPlayer(Player):
         if self.client.player.is_passive:
             self.logger.debug("Ignore PLAY command: Player is synced to another player.")
             return
-        await self.group_controller.play()
+        try:
+            await self.group_controller.play()
+        except FailedCommand as err:
+            if self._attr_active_source is None:
+                raise
+            # the loaded source refused to resume, so it is not merely paused after all
+            self.logger.debug(
+                "Source %s on Sonos player %s can not be resumed: %s",
+                self._attr_active_source,
+                self.player_id,
+                err,
+            )
+            self._mark_external_source_ended()
+            self.update_state()
 
     async def stop(self) -> None:
         """Handle STOP command on the player."""
@@ -878,8 +891,17 @@ class SonosPlayer(Player):
                 task_id=f"sonos_external_pause_{self.player_id}",
             )
             return
-        if (time.time() - self._external_pause_since) < EXTERNAL_PAUSE_IDLE_TIMEOUT:
-            return
+        if (time.time() - self._external_pause_since) >= EXTERNAL_PAUSE_IDLE_TIMEOUT:
+            self._mark_external_source_ended()
+
+    def _mark_external_source_ended(self) -> None:
+        """
+        Stop presenting the source Sonos has loaded as something that can be resumed.
+
+        Backdating the pause is what makes this stick: the updates that follow rebuild the
+        state from Sonos, which keeps reporting the very same source as paused.
+        """
+        self._external_pause_since = time.time() - EXTERNAL_PAUSE_IDLE_TIMEOUT
         self._attr_playback_state = PlaybackState.IDLE
         self._attr_active_source = None
         self._attr_current_media = None

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -2,13 +2,20 @@
 
 import asyncio
 import logging
+import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import ConnectionTimeoutError
 from aiosonos.exceptions import CannotConnect
+from music_assistant_models.enums import PlaybackState
+from music_assistant_models.player import PlayerMedia
 
 from music_assistant.mass import MusicAssistant
+from music_assistant.providers.sonos.const import (
+    EXTERNAL_PAUSE_IDLE_TIMEOUT,
+    SOURCE_SPOTIFY,
+)
 from music_assistant.providers.sonos.player import SonosPlayer
 
 
@@ -229,4 +236,94 @@ async def test_on_unload_survives_a_failing_disconnect(timer_mass: MusicAssistan
     await player.on_unload()
 
     assert player.connected is False
+    assert timer_mass._tracked_timers == {}
+
+
+def _make_externally_paused_player() -> tuple[SonosPlayer, MagicMock]:
+    """Create a player reporting a paused external source, as Sonos does for Spotify Connect."""
+    player, mass = _make_player()
+    player._external_pause_since = None
+    player._attr_playback_state = PlaybackState.PAUSED
+    player._attr_active_source = SOURCE_SPOTIFY
+    player._attr_current_media = PlayerMedia(uri="spotify:track:1", title="Shout")
+    return player, mass
+
+
+def test_a_paused_external_source_is_left_alone_at_first() -> None:
+    """Test a source that just paused stays resumable, so a real pause still works."""
+    player, mass = _make_externally_paused_player()
+
+    player._expire_stale_external_pause()
+
+    assert player._attr_playback_state is PlaybackState.PAUSED
+    assert player._attr_active_source == SOURCE_SPOTIFY
+    # Sonos reports nothing when the session goes stale, so we must come back to it ourselves
+    assert mass.call_later.call_args.kwargs["task_id"] == "sonos_external_pause_sonos_player"
+
+
+def test_a_source_paused_within_the_grace_period_stays_resumable() -> None:
+    """Test a genuine pause can still be resumed from MA for as long as the grace period lasts."""
+    player, _ = _make_externally_paused_player()
+    player._external_pause_since = time.time() - EXTERNAL_PAUSE_IDLE_TIMEOUT + 5
+
+    player._expire_stale_external_pause()
+
+    assert player._attr_playback_state is PlaybackState.PAUSED
+    assert player._attr_active_source == SOURCE_SPOTIFY
+    assert player._attr_current_media is not None
+
+
+def test_an_external_source_paused_for_too_long_is_reported_as_idle() -> None:
+    """Test an abandoned session stops looking resumable, so play starts our own queue."""
+    player, _ = _make_externally_paused_player()
+    player._external_pause_since = time.time() - EXTERNAL_PAUSE_IDLE_TIMEOUT - 1
+
+    player._expire_stale_external_pause()
+
+    assert player._attr_playback_state is PlaybackState.IDLE
+    assert player._attr_active_source is None
+    assert player._attr_current_media is None
+
+
+def test_the_pause_clock_only_runs_while_the_player_reports_paused() -> None:
+    """Test resuming the source clears the clock, so a later pause gets the full grace period."""
+    player, _ = _make_externally_paused_player()
+    player._expire_stale_external_pause()
+    assert player._external_pause_since is not None
+
+    player._attr_playback_state = PlaybackState.PLAYING
+    player._expire_stale_external_pause()
+
+    assert player._external_pause_since is None
+
+
+def test_playback_that_is_not_paused_is_never_expired() -> None:
+    """Test our own playback (already mapped to idle by Sonos) never starts the clock."""
+    player, mass = _make_player()
+    player._external_pause_since = None
+    player._attr_playback_state = PlaybackState.IDLE
+    player._attr_active_source = None
+    player._attr_current_media = None
+
+    player._expire_stale_external_pause()
+
+    assert player._external_pause_since is None
+    mass.call_later.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_unload_cancels_a_pending_external_pause_check(
+    timer_mass: MusicAssistant,
+) -> None:
+    """Test unloading a player leaves no timer behind to re-evaluate a paused source."""
+    player, _ = _bind_player(timer_mass)
+    player._external_pause_since = None
+    player._attr_playback_state = PlaybackState.PAUSED
+    player._attr_active_source = SOURCE_SPOTIFY
+    player._attr_current_media = None
+    player._expire_stale_external_pause()
+    assert timer_mass._tracked_timers != {}
+
+    await player.on_unload()
+
     assert timer_mass._tracked_timers == {}

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -254,7 +254,7 @@ def _make_externally_paused_player() -> tuple[SonosPlayer, MagicMock, MagicMock]
 def _refuse_to_resume(client: MagicMock) -> None:
     """Let the speaker reject the play command, as it does for a session it no longer has."""
     client.player.is_passive = False
-    client.player.group.play = AsyncMock(side_effect=FailedCommand("ERROR_NOT_FOUND"))
+    client.player.group.play = AsyncMock(side_effect=FailedCommand("ERROR_PLAYBACK_FAILED"))
 
 
 def test_a_paused_external_source_is_left_alone_at_first() -> None:
@@ -375,3 +375,19 @@ async def test_a_failing_play_on_our_own_queue_still_raises() -> None:
 
     with pytest.raises(FailedCommand):
         await player.play()
+
+
+@pytest.mark.asyncio
+async def test_a_coordinator_change_does_not_end_a_live_source() -> None:
+    """Test the race the speaker reports while regrouping is not read as a source that is gone."""
+    player, _, client = _make_externally_paused_player()
+    client.player.is_passive = False
+    client.player.group.play = AsyncMock(
+        side_effect=FailedCommand("ERROR_PLAYBACK_FAILED groupCoordinatorChanged")
+    )
+
+    with pytest.raises(FailedCommand):
+        await player.play()
+
+    assert player._attr_playback_state is PlaybackState.PAUSED
+    assert player._attr_active_source == SOURCE_SPOTIFY

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import ConnectionTimeoutError
-from aiosonos.exceptions import CannotConnect
+from aiosonos.exceptions import CannotConnect, FailedCommand
 from music_assistant_models.enums import PlaybackState
 from music_assistant_models.player import PlayerMedia
 
@@ -239,19 +239,27 @@ async def test_on_unload_survives_a_failing_disconnect(timer_mass: MusicAssistan
     assert timer_mass._tracked_timers == {}
 
 
-def _make_externally_paused_player() -> tuple[SonosPlayer, MagicMock]:
+def _make_externally_paused_player() -> tuple[SonosPlayer, MagicMock, MagicMock]:
     """Create a player reporting a paused external source, as Sonos does for Spotify Connect."""
-    player, mass = _make_player()
+    mass = MagicMock()
+    mass.closing = False
+    player, client = _bind_player(mass)
     player._external_pause_since = None
     player._attr_playback_state = PlaybackState.PAUSED
     player._attr_active_source = SOURCE_SPOTIFY
     player._attr_current_media = PlayerMedia(uri="spotify:track:1", title="Shout")
-    return player, mass
+    return player, mass, client
+
+
+def _refuse_to_resume(client: MagicMock) -> None:
+    """Let the speaker reject the play command, as it does for a session it no longer has."""
+    client.player.is_passive = False
+    client.player.group.play = AsyncMock(side_effect=FailedCommand("ERROR_NOT_FOUND"))
 
 
 def test_a_paused_external_source_is_left_alone_at_first() -> None:
     """Test a source that just paused stays resumable, so a real pause still works."""
-    player, mass = _make_externally_paused_player()
+    player, mass, _ = _make_externally_paused_player()
 
     player._expire_stale_external_pause()
 
@@ -263,7 +271,7 @@ def test_a_paused_external_source_is_left_alone_at_first() -> None:
 
 def test_a_source_paused_within_the_grace_period_stays_resumable() -> None:
     """Test a genuine pause can still be resumed from MA for as long as the grace period lasts."""
-    player, _ = _make_externally_paused_player()
+    player, _, _ = _make_externally_paused_player()
     player._external_pause_since = time.time() - EXTERNAL_PAUSE_IDLE_TIMEOUT + 5
 
     player._expire_stale_external_pause()
@@ -275,7 +283,7 @@ def test_a_source_paused_within_the_grace_period_stays_resumable() -> None:
 
 def test_an_external_source_paused_for_too_long_is_reported_as_idle() -> None:
     """Test an abandoned session stops looking resumable, so play starts our own queue."""
-    player, _ = _make_externally_paused_player()
+    player, _, _ = _make_externally_paused_player()
     player._external_pause_since = time.time() - EXTERNAL_PAUSE_IDLE_TIMEOUT - 1
 
     player._expire_stale_external_pause()
@@ -287,7 +295,7 @@ def test_an_external_source_paused_for_too_long_is_reported_as_idle() -> None:
 
 def test_the_pause_clock_only_runs_while_the_player_reports_paused() -> None:
     """Test resuming the source clears the clock, so a later pause gets the full grace period."""
-    player, _ = _make_externally_paused_player()
+    player, _, _ = _make_externally_paused_player()
     player._expire_stale_external_pause()
     assert player._external_pause_since is not None
 
@@ -327,3 +335,43 @@ async def test_on_unload_cancels_a_pending_external_pause_check(
     await player.on_unload()
 
     assert timer_mass._tracked_timers == {}
+
+
+@pytest.mark.asyncio
+async def test_a_source_that_refuses_to_resume_is_ended_right_away() -> None:
+    """Test a dead session does not have to sit out the grace period to be given up on."""
+    player, _, client = _make_externally_paused_player()
+    _refuse_to_resume(client)
+
+    await player.play()
+
+    assert player._attr_playback_state is PlaybackState.IDLE
+    assert player._attr_active_source is None
+    assert player._attr_current_media is None
+
+
+@pytest.mark.asyncio
+async def test_an_ended_source_is_not_picked_back_up_from_what_sonos_reports() -> None:
+    """Test the next update does not resurrect the source Sonos still reports as paused."""
+    player, _, client = _make_externally_paused_player()
+    _refuse_to_resume(client)
+    await player.play()
+
+    # Sonos keeps reporting the very same paused source on every update that follows
+    player._attr_playback_state = PlaybackState.PAUSED
+    player._attr_active_source = SOURCE_SPOTIFY
+    player._expire_stale_external_pause()
+
+    assert player._attr_playback_state is PlaybackState.IDLE
+    assert player._attr_active_source is None
+
+
+@pytest.mark.asyncio
+async def test_a_failing_play_on_our_own_queue_still_raises() -> None:
+    """Test a failure that is not about a stale external source is not swallowed."""
+    player, _, client = _make_externally_paused_player()
+    player._attr_active_source = None
+    _refuse_to_resume(client)
+
+    with pytest.raises(FailedCommand):
+        await player.play()

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import ConnectionTimeoutError
+from aiosonos.api.models import MusicService
+from aiosonos.api.models import PlayBackState as SonosPlayBackState
 from aiosonos.exceptions import CannotConnect, FailedCommand
 from music_assistant_models.enums import PlaybackState
 from music_assistant_models.player import PlayerMedia
@@ -391,3 +393,59 @@ async def test_a_coordinator_change_does_not_end_a_live_source() -> None:
 
     assert player._attr_playback_state is PlaybackState.PAUSED
     assert player._attr_active_source == SOURCE_SPOTIFY
+
+
+def _speaker_reporting_paused_spotify() -> tuple[SonosPlayer, MagicMock]:
+    """Create a connected player whose speaker reports the Spotify Connect state we captured."""
+    mass = MagicMock()
+    mass.closing = False
+    player, client = _bind_player(mass)
+    player.connected = True
+    player._attr_source_list = []
+    player._attr_group_members = []
+    player._attr_can_group_with = set()
+    player._provider = MagicMock(instance_id="sonos")
+    player._external_pause_since = None
+    client.player.is_coordinator = True
+    client.player.group_members = ["sonos_player"]
+    group = client.player.group
+    group.playback_state = SonosPlayBackState.PLAYBACK_STATE_PAUSED
+    group.position = 42.0
+    group.container_type = "spotify.connect"
+    group.active_service = MusicService.SPOTIFY
+    group.playback_metadata = {
+        "container": {"name": "Spotify", "service": {"name": "Spotify"}},
+        "currentItem": {"id": "1", "track": {"name": "Shout"}},
+    }
+    return player, mass
+
+
+def test_update_attributes_reports_a_long_paused_source_as_idle() -> None:
+    """Test the whole path, from what the speaker reports to the state we hand to MA."""
+    player, _ = _speaker_reporting_paused_spotify()
+
+    player.update_attributes()
+    while_paused = (player._attr_playback_state, player._attr_active_source)
+    assert while_paused == (PlaybackState.PAUSED, SOURCE_SPOTIFY)
+
+    # the speaker keeps reporting the very same paused source once the session goes stale
+    player._external_pause_since = time.time() - EXTERNAL_PAUSE_IDLE_TIMEOUT - 1
+    player.update_attributes()
+
+    assert player._attr_playback_state is PlaybackState.IDLE
+    assert player._attr_active_source is None
+    assert player._attr_current_media is None
+
+
+def test_the_pause_check_stays_armed_until_the_grace_period_is_over() -> None:
+    """Test an update that arrives meanwhile cannot consume the only pending check."""
+    player, mass = _speaker_reporting_paused_spotify()
+
+    player.update_attributes()
+    player.update_attributes()
+
+    assert mass.call_later.call_count == 2
+    delay, callback, event = mass.call_later.call_args.args
+    assert delay > EXTERNAL_PAUSE_IDLE_TIMEOUT
+    assert callback == player.on_player_event
+    assert event is None


### PR DESCRIPTION
# What does this implement/fix?

Pressing play in Music Assistant on a Sonos speaker could restart Spotify instead of starting your Music Assistant queue.

Sonos keeps a source like Spotify Connect loaded and reported as *paused* long after the stream was abandoned — even once the speaker has been deselected in the Spotify app. Playback commands from Music Assistant then went to that dead session, so pressing play resumed Spotify. Switching back to Music Assistant only worked when the speaker happened to clear the source on its own, which is why it seemed random.

Sonos offers nothing that tells an abandoned session apart from a real pause, so such a source is now reported as idle in two cases: when the speaker rejects a play command for it, and otherwise once it has been sitting paused for a minute. Normal queue handling takes over from there, for play as well as resume.

Pausing an external source from Music Assistant and picking it straight back up still works.

**Related issue (if applicable):**

- Reported on Discord

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Give up on a source the speaker refuses to resume, since a rejected play command means the session is gone
- Otherwise report a source that has been paused for longer than a minute as idle, clearing the stale source and media along with it
- Keep re-checking the state ourselves until that grace period is over, since Sonos sends no event when a session goes stale
- Cancel that pending check when the player is unloaded

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
