### PR TITLE
Restricted users no longer end up with an empty library

### DIFF
--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -314,6 +314,9 @@ class ProviderConfigMixin:
             raise RuntimeError(msg)
         self.remove(conf_key)
         await self.mass.unload_provider(instance_id, True)
+        # a user access filter is an allow-list of provider instance ids, so it must not be
+        # left pointing at a provider that no longer exists
+        await self.mass.webserver.auth.remove_from_user_filters(provider_instance_ids=[instance_id])
         if existing["type"] == "music":
             # cleanup entries in library
             await self.mass.music.cleanup_provider(instance_id)

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1657,6 +1657,11 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                 self.mass.config.remove(key)
             if self.get_player(pid) is None:
                 self.mass.player_queues.purge_saved_queue(pid)
+        # a user access filter is an allow-list of player ids, so it must not be left
+        # pointing at a player whose config was just wiped
+        self.mass.create_task(
+            self.mass.webserver.auth.remove_from_user_filters(player_ids=player_ids)
+        )
 
     def scale_volume_to_device(self, player_id: str, logical_volume: int) -> int:
         """Scale logical volume (0-100) to device volume (min_volume-max_volume)."""

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -122,6 +122,8 @@ class AuthenticationManager:
         )
         # Stops concurrent exchanges from passing the rate limit check before failures land
         self._join_code_exchange_lock = asyncio.Lock()
+        # Serialises the read-modify-write of the user access filters
+        self._user_filter_lock = asyncio.Lock()
         self._access_revoked_callbacks: list[Callable[[User], None]] = []
 
     async def setup(self) -> None:
@@ -1958,37 +1960,40 @@ class AuthenticationManager:
         """Rewrite the access filters of all users, dropping the entries that are not kept."""
         if keep_provider is None and keep_player is None:
             return
-        for row in await self.database.get_rows("users", limit=0):
-            updates: dict[str, str] = {}
-            for column, keep_func in (
-                ("provider_filter", keep_provider),
-                ("player_filter", keep_player),
-            ):
-                if keep_func is None:
-                    continue
-                current: list[str] = json_loads(row[column])
-                remaining = [x for x in current if keep_func(x)]
-                if remaining == current:
-                    continue
-                updates[column] = json_dumps(remaining)
-                dropped = ", ".join(x for x in current if x not in remaining)
-                if remaining:
-                    self.logger.info(
-                        "Removed %s from the %s of user '%s'", dropped, column, row["username"]
-                    )
-                else:
-                    # An empty filter means unrestricted. A user whose entries are all gone is
-                    # deliberately left unrestricted, the alternative being an account that
-                    # can see nothing at all.
-                    self.logger.warning(
-                        "Removed the last entries (%s) from the %s of user '%s'. "
-                        "This user is no longer restricted, adjust the access settings if needed.",
-                        dropped,
-                        column,
-                        row["username"],
-                    )
-            if updates:
-                await self.database.update("users", {"user_id": row["user_id"]}, updates)
+        # removing a provider wipes the config of its players one by one, so without the lock
+        # those rewrites would read the same filter and each undo the other's removal
+        async with self._user_filter_lock:
+            for row in await self.database.get_rows("users", limit=0):
+                updates: dict[str, str] = {}
+                for column, keep_func in (
+                    ("provider_filter", keep_provider),
+                    ("player_filter", keep_player),
+                ):
+                    if keep_func is None:
+                        continue
+                    current: list[str] = json_loads(row[column])
+                    remaining = [x for x in current if keep_func(x)]
+                    if remaining == current:
+                        continue
+                    updates[column] = json_dumps(remaining)
+                    dropped = ", ".join(x for x in current if x not in remaining)
+                    if remaining:
+                        self.logger.info(
+                            "Removed %s from the %s of user '%s'", dropped, column, row["username"]
+                        )
+                    else:
+                        # An empty filter means unrestricted. A user whose entries are all gone is
+                        # deliberately left unrestricted, the alternative being an account that
+                        # can see nothing at all.
+                        self.logger.warning(
+                            "Removed the last entries (%s) from the %s of user '%s'. This user is "
+                            "no longer restricted, adjust the access settings if needed.",
+                            dropped,
+                            column,
+                            row["username"],
+                        )
+                if updates:
+                    await self.database.update("users", {"user_id": row["user_id"]}, updates)
 
     async def _migrate_playlog_to_first_user(self, user_id: str) -> None:
         """

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -7,7 +7,7 @@ import contextlib
 import hashlib
 import logging
 import secrets
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Collection, Mapping
 from datetime import datetime, timedelta
 from sqlite3 import IntegrityError, OperationalError
 from typing import TYPE_CHECKING, Any, cast
@@ -27,7 +27,13 @@ from music_assistant_models.errors import (
     InvalidDataError,
 )
 
-from music_assistant.constants import DB_TABLE_PLAYLOG, HOMEASSISTANT_SYSTEM_USER, MASS_LOGGER_NAME
+from music_assistant.constants import (
+    CONF_PLAYERS,
+    CONF_PROVIDERS,
+    DB_TABLE_PLAYLOG,
+    HOMEASSISTANT_SYSTEM_USER,
+    MASS_LOGGER_NAME,
+)
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     ROLE_SCOPES,
     get_current_client_id,
@@ -139,6 +145,9 @@ class AuthenticationManager:
 
         # migrate the Home Assistant system user of pre-existing installs to the service role
         await self._migrate_system_user_role()
+
+        # repair filters that were left pointing at removed providers/players
+        await self._prune_stale_user_filters()
 
         self._schedule_join_code_cleanup()
 
@@ -1245,6 +1254,27 @@ class AuthenticationManager:
             return refreshed_user
         return target_user
 
+    async def remove_from_user_filters(
+        self,
+        provider_instance_ids: Collection[str] = (),
+        player_ids: Collection[str] = (),
+    ) -> None:
+        """
+        Remove the given providers and/or players from the access filters of all users.
+
+        Call this when a provider or player is permanently removed, so no user is left with
+        an access filter that points at something that no longer exists.
+
+        :param provider_instance_ids: Instance IDs of the removed providers.
+        :param player_ids: IDs of the removed players.
+        """
+        await self._rewrite_user_filters(
+            keep_provider=(lambda x: x not in provider_instance_ids)
+            if provider_instance_ids
+            else None,
+            keep_player=(lambda x: x not in player_ids) if player_ids else None,
+        )
+
     @api_command("auth/user/update")
     async def update_user_profile(
         self,
@@ -1908,6 +1938,57 @@ class AuthenticationManager:
             self.logger.info(
                 "Updated Home Assistant system user role to %s", UserRole.SERVICE.value
             )
+
+    async def _prune_stale_user_filters(self) -> None:
+        """Drop user access filter entries for providers or players that no longer exist."""
+        known_providers = set(self.mass.config.get(CONF_PROVIDERS, {}))
+        known_players = set(self.mass.config.get(CONF_PLAYERS, {}))
+        # an empty config section means nothing is configured yet, which must not be
+        # mistaken for everything having been removed
+        await self._rewrite_user_filters(
+            keep_provider=(lambda x: x in known_providers) if known_providers else None,
+            keep_player=(lambda x: x in known_players) if known_players else None,
+        )
+
+    async def _rewrite_user_filters(
+        self,
+        keep_provider: Callable[[str], bool] | None,
+        keep_player: Callable[[str], bool] | None,
+    ) -> None:
+        """Rewrite the access filters of all users, dropping the entries that are not kept."""
+        if keep_provider is None and keep_player is None:
+            return
+        for row in await self.database.get_rows("users", limit=1000):
+            updates: dict[str, str] = {}
+            for column, keep_func in (
+                ("provider_filter", keep_provider),
+                ("player_filter", keep_player),
+            ):
+                if keep_func is None:
+                    continue
+                current: list[str] = json_loads(row[column])
+                remaining = [x for x in current if keep_func(x)]
+                if remaining == current:
+                    continue
+                updates[column] = json_dumps(remaining)
+                dropped = ", ".join(x for x in current if x not in remaining)
+                if remaining:
+                    self.logger.info(
+                        "Removed %s from the %s of user '%s'", dropped, column, row["username"]
+                    )
+                else:
+                    # An empty filter means unrestricted. A user whose entries are all gone is
+                    # deliberately left unrestricted, the alternative being an account that
+                    # can see nothing at all.
+                    self.logger.warning(
+                        "Removed the last entries (%s) from the %s of user '%s'. "
+                        "This user is no longer restricted, adjust the access settings if needed.",
+                        dropped,
+                        column,
+                        row["username"],
+                    )
+            if updates:
+                await self.database.update("users", {"user_id": row["user_id"]}, updates)
 
     async def _migrate_playlog_to_first_user(self, user_id: str) -> None:
         """

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1958,7 +1958,7 @@ class AuthenticationManager:
         """Rewrite the access filters of all users, dropping the entries that are not kept."""
         if keep_provider is None and keep_player is None:
             return
-        for row in await self.database.get_rows("users", limit=1000):
+        for row in await self.database.get_rows("users", limit=0):
             updates: dict[str, str] = {}
             for column, keep_func in (
                 ("provider_filter", keep_provider),

--- a/tests/controllers/config/test_remove_player_config.py
+++ b/tests/controllers/config/test_remove_player_config.py
@@ -14,8 +14,12 @@ player must be detached from the removed player instead of keeping a dead parent
 Also covers removing a whole player provider: its unregistered players must have their
 DSP/queue settings and persisted queue cache wiped along with their player config,
 while players of other providers are left untouched.
+
+Finally, a removed provider or player must also disappear from the per user access
+filters, which would otherwise keep pointing at something that no longer exists.
 """
 
+import asyncio
 import logging
 from collections.abc import Callable, Generator
 from types import SimpleNamespace
@@ -41,6 +45,7 @@ from music_assistant.controllers.player_queues.constants import (
     CACHE_CATEGORY_PLAYER_QUEUE_ITEMS,
     CACHE_CATEGORY_PLAYER_QUEUE_STATE,
 )
+from music_assistant.helpers.json import json_loads
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.player import DeviceInfo, Player
 
@@ -479,3 +484,42 @@ async def test_remove_provider_config_detaches_registered_protocol_player(
     assert protocol_player.protocol_parent_id is None
     assert mass.config.get(f"{CONF_PLAYERS}/{PROTOCOL_ID}/values/{CONF_PROTOCOL_PARENT_ID}") is None
     assert _pop_scheduled_evaluation(mass)
+
+
+async def _get_user_filters(mass: MusicAssistant, user_id: str) -> tuple[list[str], list[str]]:
+    """Read the raw provider and player filter of the given user."""
+    row = await mass.webserver.auth.database.get_row("users", {"user_id": user_id})
+    assert row is not None
+    return json_loads(row["provider_filter"]), json_loads(row["player_filter"])
+
+
+async def test_remove_provider_config_strips_user_provider_filter(
+    mass: MusicAssistant,
+) -> None:
+    """Removing a provider also removes it from the access filters of restricted users."""
+    _store_provider_config(mass)
+    user = await mass.webserver.auth.create_user(
+        username="restricted",
+        provider_filter=[PLAYER_PROVIDER_DOMAIN, OTHER_PROVIDER_INSTANCE_ID],
+    )
+
+    await mass.config.remove_provider_config(PLAYER_PROVIDER_DOMAIN)
+
+    provider_filter, _ = await _get_user_filters(mass, user.user_id)
+    assert provider_filter == [OTHER_PROVIDER_INSTANCE_ID]
+
+
+async def test_remove_player_config_strips_user_player_filter(mass: MusicAssistant) -> None:
+    """Removing a player also removes it from the access filters of restricted users."""
+    _store_player_config(mass, PLAYER_ID)
+    user = await mass.webserver.auth.create_user(
+        username="restricted", player_filter=[PLAYER_ID, "other_player"]
+    )
+
+    await mass.config.remove_player_config(PLAYER_ID)
+
+    # the filter cleanup is scheduled by the (non-async) config wipe
+    deadline = asyncio.get_running_loop().time() + 5.0
+    while (await _get_user_filters(mass, user.user_id))[1] != ["other_player"]:
+        assert asyncio.get_running_loop().time() < deadline, "player filter was not cleaned up"
+        await asyncio.sleep(0.01)

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -257,6 +257,8 @@ def mock_mass() -> MagicMock:
     mass.config.set = MagicMock()
     mass.signal_event = MagicMock()
     mass.get_providers = MagicMock(return_value=[])
+    # awaited by the tests that replay the tasks scheduled during a config wipe
+    mass.webserver.auth.remove_from_user_filters = AsyncMock()
     return mass
 
 

--- a/tests/core/test_provider_unload.py
+++ b/tests/core/test_provider_unload.py
@@ -156,6 +156,8 @@ async def test_unload_provider_unregisters_hidden_players(
     mass_minimal.players = PlayerController(mass_minimal)
     mass_minimal.music = MagicMock(unschedule_provider_sync=AsyncMock())
     mass_minimal.player_queues = MagicMock()
+    # wiping a player config strips that player from the user access filters
+    mass_minimal.webserver = MagicMock(auth=MagicMock(remove_from_user_filters=AsyncMock()))
     # discovery is not set up on the minimal instance and plays no part in this test
     monkeypatch.setattr(mass_minimal.discovery, "on_provider_unload", MagicMock())
 

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -2474,6 +2474,25 @@ async def test_remove_from_user_filters_lifts_restriction(
     assert "no longer restricted" in caplog.text
 
 
+async def test_remove_from_user_filters_in_parallel(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that removals running at the same time do not undo each other.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(
+        username="twoplayers", player_filter=["player_one", "player_two"]
+    )
+
+    # removing a player provider wipes the config of each of its players on its own
+    await asyncio.gather(
+        auth_manager.remove_from_user_filters(player_ids=["player_one"]),
+        auth_manager.remove_from_user_filters(player_ids=["player_two"]),
+    )
+
+    assert await _get_filters(auth_manager, user.user_id) == ([], [])
+
+
 async def test_prune_stale_user_filters(auth_manager: AuthenticationManager) -> None:
     """
     Test that filter entries pointing at unknown providers/players are cleaned up on startup.

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -18,7 +18,7 @@ from music_assistant_models.errors import (
     UserNotFoundError,
 )
 
-from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER
+from music_assistant.constants import CONF_PLAYERS, CONF_PROVIDERS, HOMEASSISTANT_SYSTEM_USER
 from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.webserver.auth import (
     JOIN_CODE_GLOBAL_FAILURE_CEILING,
@@ -50,6 +50,7 @@ from music_assistant.controllers.webserver.helpers.auth_providers import (
     LoginRateLimiter,
 )
 from music_assistant.helpers.datetime import utc
+from music_assistant.helpers.json import json_loads
 from music_assistant.mass import MusicAssistant
 
 
@@ -2419,3 +2420,98 @@ async def test_homeassistant_system_user_has_service_role(
     migrated_user = await auth_manager.get_user(system_user.user_id)
     assert migrated_user is not None
     assert migrated_user.role == UserRole.SERVICE
+
+
+async def _get_filters(
+    auth_manager: AuthenticationManager, user_id: str
+) -> tuple[list[str], list[str]]:
+    """Read the raw provider and player filter of the given user from the database."""
+    row = await auth_manager.database.get_row("users", {"user_id": user_id})
+    assert row is not None
+    return json_loads(row["provider_filter"]), json_loads(row["player_filter"])
+
+
+async def test_remove_from_user_filters(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that a removed provider/player is stripped from the access filters of all users.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(
+        username="restricted",
+        provider_filter=["spotify--old", "jellyfin--live"],
+        player_filter=["player_gone", "player_live"],
+    )
+    unrestricted = await auth_manager.create_user(username="unrestricted")
+
+    await auth_manager.remove_from_user_filters(
+        provider_instance_ids=["spotify--old"], player_ids=["player_gone"]
+    )
+
+    provider_filter, player_filter = await _get_filters(auth_manager, user.user_id)
+    assert provider_filter == ["jellyfin--live"]
+    assert player_filter == ["player_live"]
+    # a user without restrictions must stay unrestricted
+    assert await _get_filters(auth_manager, unrestricted.user_id) == ([], [])
+
+
+async def test_remove_from_user_filters_lifts_restriction(
+    auth_manager: AuthenticationManager, caplog: pytest.LogCaptureFixture
+) -> None:
+    """
+    Test that a user whose filter loses its last entry ends up unrestricted.
+
+    :param auth_manager: AuthenticationManager instance.
+    :param caplog: Pytest log capture fixture.
+    """
+    user = await auth_manager.create_user(username="onlyspotify", provider_filter=["spotify--old"])
+
+    with caplog.at_level(logging.WARNING):
+        await auth_manager.remove_from_user_filters(provider_instance_ids=["spotify--old"])
+
+    provider_filter, _ = await _get_filters(auth_manager, user.user_id)
+    assert provider_filter == []
+    assert "no longer restricted" in caplog.text
+
+
+async def test_prune_stale_user_filters(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that filter entries pointing at unknown providers/players are cleaned up on startup.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    auth_manager.mass.config.set(
+        f"{CONF_PROVIDERS}/spotify--live", {"instance_id": "spotify--live"}
+    )
+    auth_manager.mass.config.set(f"{CONF_PLAYERS}/player_live", {"player_id": "player_live"})
+    user = await auth_manager.create_user(
+        username="stale",
+        provider_filter=["spotify--old", "spotify--live"],
+        player_filter=["player_gone", "player_live"],
+    )
+
+    await auth_manager._prune_stale_user_filters()
+
+    assert await _get_filters(auth_manager, user.user_id) == (
+        ["spotify--live"],
+        ["player_live"],
+    )
+
+
+async def test_prune_stale_user_filters_ignores_empty_config(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Test that filters are left alone when nothing is configured (yet).
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(
+        username="noconfig",
+        provider_filter=["spotify--old"],
+        player_filter=["player_gone"],
+    )
+
+    await auth_manager._prune_stale_user_filters()
+
+    assert await _get_filters(auth_manager, user.user_id) == (["spotify--old"], ["player_gone"])


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Each user has an access list holding the providers and players they are allowed to see. Removing a provider or player left its id behind in that list, and some providers get a brand new id every time they are set up again. A restricted user could therefore end up with a list that only points at things that no longer exist, so their library, search and browse came back empty with nothing in the logs to explain it.

- Take a provider or player out of every user access list when it is removed
- Clean up leftover entries on startup to repair existing installs
- Log a warning when a cleanup leaves a user with no restrictions left

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6082

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
