### PR TITLE
Player settings that need a stream restart now apply right away

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2186,7 +2186,9 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         # if the PlayerQueue was playing, restart playback
         if resume_queue and resume_queue.state == PlaybackState.PLAYING:
             requires_restart = any(
-                v for v in config.values.values() if v.key in changed_keys and v.requires_reload
+                v.requires_reload
+                for v in config.values.values()
+                if f"values/{v.key}" in changed_keys
             )
             if requires_restart:
                 # always stop first to ensure the player uses the new config

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -50,6 +50,7 @@ from music_assistant.constants import (
     ATTR_PREVIOUS_VOLUME,
     CONF_AUTO_PLAY,
     CONF_ENTRY_TTS_PRE_ANNOUNCE,
+    CONF_ICON,
     CONF_MAX_VOLUME,
     CONF_MIN_VOLUME,
     CONF_MUTE_CONTROL,
@@ -4340,7 +4341,7 @@ class TestConfigChangeRestartsPlayback:
 
     @staticmethod
     def _prepare(mock_mass: MagicMock, queue_state: PlaybackState) -> PlayerController:
-        """Register a playing player whose queue is in the given state."""
+        """Register a player whose active queue is in the given state."""
         controller = PlayerController(mock_mass)
         player = MagicMock()
         player.state.active_source = "player_1"
@@ -4372,6 +4373,19 @@ class TestConfigChangeRestartsPlayback:
 
         await controller.on_player_config_change(
             self._config(requires_reload=False), {f"values/{CONF_OUTPUT_CODEC}"}
+        )
+
+        mock_mass.player_queues.stop.assert_not_awaited()
+        mock_mass.call_later.assert_not_called()
+
+    async def test_untouched_reload_setting_does_not_restart_playback(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Test that only a changed reload-requiring setting restarts playback."""
+        controller = self._prepare(mock_mass, PlaybackState.PLAYING)
+
+        await controller.on_player_config_change(
+            self._config(requires_reload=True), {f"values/{CONF_ICON}"}
         )
 
         mock_mass.player_queues.stop.assert_not_awaited()

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -20,7 +20,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pytest
 from music_assistant_models.auth import User, UserRole
-from music_assistant_models.config_entries import ConfigEntry, CoreConfig
+from music_assistant_models.config_entries import ConfigEntry, CoreConfig, PlayerConfig
 from music_assistant_models.constants import (
     PLAYER_CONTROL_FAKE,
     PLAYER_CONTROL_NATIVE,
@@ -53,6 +53,7 @@ from music_assistant.constants import (
     CONF_MAX_VOLUME,
     CONF_MIN_VOLUME,
     CONF_MUTE_CONTROL,
+    CONF_OUTPUT_CODEC,
     CONF_POWER_CONTROL,
     CONF_VOLUME_CONTROL,
     CONF_VOLUME_STEP,
@@ -4315,6 +4316,77 @@ class TestUnregisterTeardown:
 
         assert "boom" not in controller._players
         assert player.unloaded
+
+
+class TestConfigChangeRestartsPlayback:
+    """Test that a changed player setting which needs a reload restarts playback."""
+
+    @staticmethod
+    def _config(*, requires_reload: bool) -> PlayerConfig:
+        """Build a PlayerConfig holding a single output codec entry."""
+        return PlayerConfig(
+            provider="test_prov",
+            player_id="player_1",
+            values={
+                CONF_OUTPUT_CODEC: ConfigEntry(
+                    key=CONF_OUTPUT_CODEC,
+                    type=ConfigEntryType.STRING,
+                    label="Output codec",
+                    value="flac",
+                    requires_reload=requires_reload,
+                )
+            },
+        )
+
+    @staticmethod
+    def _prepare(mock_mass: MagicMock, queue_state: PlaybackState) -> PlayerController:
+        """Register a playing player whose queue is in the given state."""
+        controller = PlayerController(mock_mass)
+        player = MagicMock()
+        player.state.active_source = "player_1"
+        player.on_config_updated = AsyncMock()
+        controller._players = {"player_1": player}
+        queue = MagicMock()
+        queue.queue_id = "player_1"
+        queue.state = queue_state
+        mock_mass.player_queues.get = MagicMock(return_value=queue)
+        mock_mass.player_queues.stop = AsyncMock()
+        return controller
+
+    async def test_reload_setting_restarts_playback(self, mock_mass: MagicMock) -> None:
+        """Test that changing a reload-requiring setting stops and resumes the queue."""
+        controller = self._prepare(mock_mass, PlaybackState.PLAYING)
+
+        await controller.on_player_config_change(
+            self._config(requires_reload=True), {f"values/{CONF_OUTPUT_CODEC}"}
+        )
+
+        mock_mass.player_queues.stop.assert_awaited_once_with("player_1")
+        mock_mass.call_later.assert_called_once_with(
+            1, mock_mass.player_queues.resume, "player_1", False
+        )
+
+    async def test_plain_setting_does_not_restart_playback(self, mock_mass: MagicMock) -> None:
+        """Test that a setting which applies on the fly leaves playback alone."""
+        controller = self._prepare(mock_mass, PlaybackState.PLAYING)
+
+        await controller.on_player_config_change(
+            self._config(requires_reload=False), {f"values/{CONF_OUTPUT_CODEC}"}
+        )
+
+        mock_mass.player_queues.stop.assert_not_awaited()
+        mock_mass.call_later.assert_not_called()
+
+    async def test_idle_queue_is_left_alone(self, mock_mass: MagicMock) -> None:
+        """Test that a reload-requiring change does not start playback on an idle queue."""
+        controller = self._prepare(mock_mass, PlaybackState.IDLE)
+
+        await controller.on_player_config_change(
+            self._config(requires_reload=True), {f"values/{CONF_OUTPUT_CODEC}"}
+        )
+
+        mock_mass.player_queues.stop.assert_not_awaited()
+        mock_mass.call_later.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this implement/fix?

Some player settings only take effect when a new stream starts — things like the output codec, output channels, flow mode, sample rates, the HTTP profile, ICY metadata and the AirPlay sync adjust. Changing one of those while music was playing was supposed to briefly stop and resume playback so the new setting applied straight away, but that never happened: the check compared the plain setting name against the changed keys, which are stored with a `values/` prefix. As a result the setting was saved but you had to stop and start playback yourself before it did anything.

- Compare the changed setting against the correct `values/<key>` form, matching how queue settings already do it
- Added tests covering the restart, the no-restart case and an idle queue

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
