### PR TITLE
Group volume no longer settles on the wrong value after a drag

### DIFF
--- a/music_assistant/controllers/players/constants.py
+++ b/music_assistant/controllers/players/constants.py
@@ -8,3 +8,4 @@ class PlayerLockPurpose(StrEnum):
 
     PLAYBACK = "playback"
     VOLUME = "volume"
+    GROUP_VOLUME = "group_volume"

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -21,7 +21,7 @@ import contextlib
 import time
 import weakref
 from collections.abc import AsyncIterator
-from contextlib import AbstractAsyncContextManager, suppress
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope
@@ -871,7 +871,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             # treat as normal player volume change
             await self.cmd_volume_set(player_id, volume_level)
             return
-        async with self._group_volume_lock(group_player):
+        async with self.get_player_lock(group_player.player_id, PlayerLockPurpose.GROUP_VOLUME):
             await self.set_group_volume(group_player, volume_level)
 
     @api_command("players/cmd/group_volume_up", required_scope=Scope.PLAYERS_CONTROL)
@@ -884,10 +884,11 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         """
         player = self.get_player(player_id, True)
         assert player is not None  # for type checker
-        # hold the lock across the read too, so a repeated nudge can not read a
-        # group volume that an earlier nudge has not applied yet
-        async with self._group_volume_lock(player):
-            cur_volume = player.state.group_volume
+        # step from the volume of the group as a whole, which is not the volume of the
+        # addressed player when the command is addressed to one of its synced members
+        group_player = self._resolve_group_volume_player(player) or player
+        async with self.get_player_lock(group_player.player_id, PlayerLockPurpose.GROUP_VOLUME):
+            cur_volume = group_player.state.group_volume
             if cur_volume is None:
                 return
             new_volume = min(100, cur_volume + self._get_volume_step(cur_volume))
@@ -903,8 +904,9 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         """
         player = self.get_player(player_id, True)
         assert player is not None  # for type checker
-        async with self._group_volume_lock(player):
-            cur_volume = player.state.group_volume
+        group_player = self._resolve_group_volume_player(player) or player
+        async with self.get_player_lock(group_player.player_id, PlayerLockPurpose.GROUP_VOLUME):
+            cur_volume = group_player.state.group_volume
             if cur_volume is None:
                 return
             new_volume = max(0, cur_volume - self._get_volume_step(cur_volume))
@@ -3548,10 +3550,15 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         """
         Return the player whose group a group volume command applies to.
 
-        Returns None if the given player is not grouped at all.
+        Returns None if the given player is not grouped at all. Commands addressed to a
+        synced member and to its sync leader resolve to the same player, so they read
+        and guard one and the same group.
 
         :param player: The player the command was addressed to.
         """
+        # the group volume lock this resolves to may not share the VOLUME purpose:
+        # set_group_volume sets the volume of the members concurrently and a sync leader
+        # is a member of its own group, so a group command would wait on its own lock.
         if player.state.type == PlayerType.GROUP or player.state.group_members:
             # dedicated group player or sync leader
             return player
@@ -3559,21 +3566,6 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             # a synced player follows its sync leader
             return self.get_player(player.state.synced_to)
         return None
-
-    def _group_volume_lock(self, player: Player) -> AbstractAsyncContextManager[None]:
-        """
-        Return the lock that guards the group volume of the given player's group.
-
-        A command addressed to a synced member and one addressed to its sync leader
-        adjust one and the same group, so both are guarded by the lock of the leader.
-
-        :param player: The player the command was addressed to.
-        """
-        # Group volume may not share the VOLUME purpose: set_group_volume sets the volume
-        # of the members concurrently and a sync leader is a member of its own group, so
-        # it would end up waiting on the lock its own group command holds.
-        group_player = self._resolve_group_volume_player(player) or player
-        return self.get_player_lock(group_player.player_id, PlayerLockPurpose.GROUP_VOLUME)
 
     async def _set_member_volume(self, player_id: str, volume_level: int) -> None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -21,7 +21,7 @@ import contextlib
 import time
 import weakref
 from collections.abc import AsyncIterator
-from contextlib import suppress
+from contextlib import AbstractAsyncContextManager, suppress
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope
@@ -850,7 +850,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         await self.cmd_volume_set(player_id, new_volume)
 
     @api_command("players/cmd/group_volume", required_scope=Scope.PLAYERS_CONTROL)
-    @handle_player_command(lock=PlayerLockPurpose.GROUP_VOLUME)
+    @handle_player_command
     async def cmd_group_volume(
         self,
         player_id: str,
@@ -864,54 +864,51 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         :param player_id: Player ID of group player or syncleader to handle the command.
         :param volume_level: Volume level (0..100) to set to the group.
         """
-        # Group volume gets a lock purpose of its own so that a live volume drag lands
-        # its commands in order. It may not share the VOLUME purpose: set_group_volume
-        # sets the volume of the members concurrently and a sync leader is a member of
-        # its own group, so it would end up waiting on the lock its group command holds.
         player = self.get_player(player_id, True)
         assert player is not None  # for type checker
-        if player.state.type == PlayerType.GROUP or player.state.group_members:
-            # dedicated group player or sync leader
-            await self.set_group_volume(player, volume_level)
+        group_player = self._resolve_group_volume_player(player)
+        if group_player is None:
+            # treat as normal player volume change
+            await self.cmd_volume_set(player_id, volume_level)
             return
-        if player.state.synced_to and (sync_leader := self.get_player(player.state.synced_to)):
-            # redirect to sync leader
-            await self.set_group_volume(sync_leader, volume_level)
-            return
-        # treat as normal player volume change
-        await self.cmd_volume_set(player_id, volume_level)
+        async with self._group_volume_lock(group_player):
+            await self.set_group_volume(group_player, volume_level)
 
     @api_command("players/cmd/group_volume_up", required_scope=Scope.PLAYERS_CONTROL)
-    @handle_player_command(lock=PlayerLockPurpose.GROUP_VOLUME)
+    @handle_player_command
     async def cmd_group_volume_up(self, player_id: str) -> None:
         """
         Send VOLUME_UP command to given playergroup.
 
         - player_id: player_id of the player to handle the command.
         """
-        group_player_state = self.get_player_state(player_id, True)
-        assert group_player_state
-        cur_volume = group_player_state.group_volume
-        if cur_volume is None:
-            return
-        new_volume = min(100, cur_volume + self._get_volume_step(cur_volume))
-        await self.cmd_group_volume(player_id, new_volume)
+        player = self.get_player(player_id, True)
+        assert player is not None  # for type checker
+        # hold the lock across the read too, so a repeated nudge can not read a
+        # group volume that an earlier nudge has not applied yet
+        async with self._group_volume_lock(player):
+            cur_volume = player.state.group_volume
+            if cur_volume is None:
+                return
+            new_volume = min(100, cur_volume + self._get_volume_step(cur_volume))
+            await self.cmd_group_volume(player_id, new_volume)
 
     @api_command("players/cmd/group_volume_down", required_scope=Scope.PLAYERS_CONTROL)
-    @handle_player_command(lock=PlayerLockPurpose.GROUP_VOLUME)
+    @handle_player_command
     async def cmd_group_volume_down(self, player_id: str) -> None:
         """
         Send VOLUME_DOWN command to given playergroup.
 
         - player_id: player_id of the player to handle the command.
         """
-        group_player_state = self.get_player_state(player_id, True)
-        assert group_player_state
-        cur_volume = group_player_state.group_volume
-        if cur_volume is None:
-            return
-        new_volume = max(0, cur_volume - self._get_volume_step(cur_volume))
-        await self.cmd_group_volume(player_id, new_volume)
+        player = self.get_player(player_id, True)
+        assert player is not None  # for type checker
+        async with self._group_volume_lock(player):
+            cur_volume = player.state.group_volume
+            if cur_volume is None:
+                return
+            new_volume = max(0, cur_volume - self._get_volume_step(cur_volume))
+            await self.cmd_group_volume(player_id, new_volume)
 
     @api_command("players/cmd/group_volume_mute", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
@@ -1983,7 +1980,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                 progress = volume_level / base_group
                 new_child_volume = round(child_base * progress)
             new_child_volume = max(0, min(100, new_child_volume))
-            coros.append(self._handle_cmd_volume_set(child_player.player_id, new_child_volume))
+            coros.append(self._set_member_volume(child_player.player_id, new_child_volume))
         await asyncio.gather(*coros)
 
         # notify active AudioSource once at the group level to prevent
@@ -3546,6 +3543,49 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             and not player.extra_data.get(ATTR_ANNOUNCEMENT_IN_PROGRESS)
         ):
             await self.mass.player_queues.resume(player_id)
+
+    def _resolve_group_volume_player(self, player: Player) -> Player | None:
+        """
+        Return the player whose group a group volume command applies to.
+
+        Returns None if the given player is not grouped at all.
+
+        :param player: The player the command was addressed to.
+        """
+        if player.state.type == PlayerType.GROUP or player.state.group_members:
+            # dedicated group player or sync leader
+            return player
+        if player.state.synced_to:
+            # a synced player follows its sync leader
+            return self.get_player(player.state.synced_to)
+        return None
+
+    def _group_volume_lock(self, player: Player) -> AbstractAsyncContextManager[None]:
+        """
+        Return the lock that guards the group volume of the given player's group.
+
+        A command addressed to a synced member and one addressed to its sync leader
+        adjust one and the same group, so both are guarded by the lock of the leader.
+
+        :param player: The player the command was addressed to.
+        """
+        # Group volume may not share the VOLUME purpose: set_group_volume sets the volume
+        # of the members concurrently and a sync leader is a member of its own group, so
+        # it would end up waiting on the lock its own group command holds.
+        group_player = self._resolve_group_volume_player(player) or player
+        return self.get_player_lock(group_player.player_id, PlayerLockPurpose.GROUP_VOLUME)
+
+    async def _set_member_volume(self, player_id: str, volume_level: int) -> None:
+        """
+        Set the volume of a single member as part of a group volume change.
+
+        :param player_id: player_id of the member to handle the command.
+        :param volume_level: logical volume level (0..100) to set on the member.
+        """
+        # take the volume lock of the member itself, so a group volume change and an
+        # individual volume command for that member can not overtake one another
+        async with self.get_player_lock(player_id, PlayerLockPurpose.VOLUME):
+            await self._handle_cmd_volume_set(player_id, volume_level)
 
     async def _handle_cmd_volume_set(self, player_id: str, volume_level: int) -> None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -865,8 +865,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         :param volume_level: Volume level (0..100) to set to the group.
         """
         # Group volume gets a lock purpose of its own so that a live volume drag lands
-        # its commands in order. It may not share the VOLUME purpose: the fan-out below
-        # sets the volume of the members concurrently, and a sync leader is a member of
+        # its commands in order. It may not share the VOLUME purpose: set_group_volume
+        # sets the volume of the members concurrently and a sync leader is a member of
         # its own group, so it would end up waiting on the lock its group command holds.
         player = self.get_player(player_id, True)
         assert player is not None  # for type checker

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -850,7 +850,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         await self.cmd_volume_set(player_id, new_volume)
 
     @api_command("players/cmd/group_volume", required_scope=Scope.PLAYERS_CONTROL)
-    @handle_player_command
+    @handle_player_command(lock=PlayerLockPurpose.GROUP_VOLUME)
     async def cmd_group_volume(
         self,
         player_id: str,
@@ -864,6 +864,10 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         :param player_id: Player ID of group player or syncleader to handle the command.
         :param volume_level: Volume level (0..100) to set to the group.
         """
+        # Group volume gets a lock purpose of its own so that a live volume drag lands
+        # its commands in order. It may not share the VOLUME purpose: the fan-out below
+        # sets the volume of the members concurrently, and a sync leader is a member of
+        # its own group, so it would end up waiting on the lock its group command holds.
         player = self.get_player(player_id, True)
         assert player is not None  # for type checker
         if player.state.type == PlayerType.GROUP or player.state.group_members:
@@ -878,7 +882,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         await self.cmd_volume_set(player_id, volume_level)
 
     @api_command("players/cmd/group_volume_up", required_scope=Scope.PLAYERS_CONTROL)
-    @handle_player_command
+    @handle_player_command(lock=PlayerLockPurpose.GROUP_VOLUME)
     async def cmd_group_volume_up(self, player_id: str) -> None:
         """
         Send VOLUME_UP command to given playergroup.
@@ -894,7 +898,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         await self.cmd_group_volume(player_id, new_volume)
 
     @api_command("players/cmd/group_volume_down", required_scope=Scope.PLAYERS_CONTROL)
-    @handle_player_command
+    @handle_player_command(lock=PlayerLockPurpose.GROUP_VOLUME)
     async def cmd_group_volume_down(self, player_id: str) -> None:
         """
         Send VOLUME_DOWN command to given playergroup.

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -2306,15 +2306,20 @@ class TestGroupVolumeOrdering:
     """Group volume commands that overlap are handled one after the other."""
 
     def _make_synced_pair(
-        self, mock_mass: MagicMock, slow_device: SlowDevice | None = None
+        self,
+        mock_mass: MagicMock,
+        slow_device: SlowDevice | None = None,
+        volumes: dict[str, int] | None = None,
     ) -> tuple[PlayerController, dict[str, MockPlayer]]:
         """
-        Build a leader synced to one member, both at volume 50 and mute capable.
+        Build a mute capable leader synced to one member.
 
         :param slow_device: When given, the named player takes its time to answer its
             first volume command and reports as soon as it received that command.
+        :param volumes: Volume level per player, defaults to 50 for both.
         """
         controller = PlayerController(mock_mass)
+        controller.config = _volume_step_config(5)
         provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
         players: dict[str, MockPlayer] = {}
         for player_id in ("leader", "member"):
@@ -2323,7 +2328,7 @@ class TestGroupVolumeOrdering:
                 PlayerFeature.VOLUME_SET,
                 PlayerFeature.VOLUME_MUTE,
             }
-            player._attr_volume_level = 50
+            player._attr_volume_level = (volumes or {}).get(player_id, 50)
 
             # let the mocked native volume control behave like a real device, that may
             # take long enough to answer for a later command to overtake it
@@ -2403,6 +2408,21 @@ class TestGroupVolumeOrdering:
         for player in players.values():
             player.update_state()
             assert player.state.volume_level == 30
+
+    async def test_a_nudge_from_a_member_steps_the_volume_of_the_group(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A group nudge addressed to a member steps the group, not the member itself."""
+        controller, players = self._make_synced_pair(mock_mass, volumes={"member": 40})
+        # the group sits at the volume of its loudest member, the member at its own
+        assert players["leader"].state.group_volume == 50
+        assert players["member"].state.group_volume == 40
+
+        await controller.cmd_group_volume_up("member")
+
+        for player in players.values():
+            player.update_state()
+        assert players["leader"].state.volume_level == 55
 
     async def test_an_individual_volume_command_waits_for_the_group(
         self, mock_mass: MagicMock

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -2295,6 +2295,91 @@ class TestVolumeStep:
         assert entry.range == (0, 10)
 
 
+class TestGroupVolumeOrdering:
+    """Group volume commands that overlap are handled one after the other."""
+
+    def _make_synced_pair(
+        self, mock_mass: MagicMock, delays: list[float] | None = None
+    ) -> tuple[PlayerController, dict[str, MockPlayer]]:
+        """
+        Build a leader synced to one member, both at volume 50 and mute capable.
+
+        :param delays: Response time of the mocked device for each volume command it
+            receives, in order. A command beyond the list is answered instantly.
+        """
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        players: dict[str, MockPlayer] = {}
+        for player_id in ("leader", "member"):
+            player = MockPlayer(provider, player_id, player_id.title())
+            player._attr_supported_features = {
+                PlayerFeature.VOLUME_SET,
+                PlayerFeature.VOLUME_MUTE,
+            }
+            player._attr_volume_level = 50
+            response_times = iter(delays or [])
+
+            # let the mocked native volume control behave like a real device that takes
+            # its time, so a slow command can land after a faster one issued later
+            async def _volume_set(
+                volume: int,
+                _player: MockPlayer = player,
+                _response_times: Iterator[float] = response_times,
+            ) -> None:
+                await asyncio.sleep(next(_response_times, 0))
+                _player._attr_volume_level = volume
+
+            player.volume_set = AsyncMock(side_effect=_volume_set)  # type: ignore[method-assign]
+            player.volume_mute = AsyncMock(  # type: ignore[method-assign]
+                side_effect=lambda muted, _player=player: setattr(
+                    _player, "_attr_volume_muted", muted
+                )
+            )
+            players[player_id] = player
+        players["leader"]._attr_group_members = ["member"]
+        controller._players = dict(players)
+        mock_mass.players = controller
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        for player in players.values():
+            player.set_initialized()
+            player._cache.clear()
+            player.update_state(signal_event=False)
+        # a second, forced pass so the leader derives its group volume from the member
+        for player in players.values():
+            player.update_state(force_update=True, signal_event=False)
+        return controller, players
+
+    async def test_the_last_command_decides_the_group_volume(self, mock_mass: MagicMock) -> None:
+        """A slow command may not overrule the volume of a later, faster one."""
+        controller, players = self._make_synced_pair(mock_mass, [0.2, 0.01])
+
+        first = asyncio.create_task(controller.cmd_group_volume("leader", 80))
+        await asyncio.sleep(0.02)
+        second = asyncio.create_task(controller.cmd_group_volume("leader", 30))
+        await asyncio.gather(first, second)
+
+        for player in players.values():
+            player.update_state()
+            assert player.state.volume_level == 30
+
+    async def test_a_muted_leader_does_not_wait_on_its_own_group_command(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A muted sync leader is unmuted by a group volume change without blocking."""
+        controller, players = self._make_synced_pair(mock_mass)
+        players["leader"]._attr_volume_muted = True
+        players["leader"].update_state(force_update=True, signal_event=False)
+
+        # a sync leader is a member of its own group, so the fan-out sets the volume
+        # (and unmutes) the very player the group command is running for
+        async with asyncio.timeout(5):
+            await controller.cmd_group_volume("leader", 30)
+
+        players["leader"].update_state()
+        assert players["leader"].state.volume_muted is False
+        assert players["leader"].state.volume_level == 30
+
+
 class TestFakeMuteInGroup:
     """A fake muted player in a group follows the mute lock, just like a native mute."""
 

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -63,7 +63,7 @@ from music_assistant.controllers.players import PlayerController
 from music_assistant.controllers.players.announcements import ANNOUNCEMENT_TTS_TIMEOUT
 from music_assistant.controllers.webserver.helpers.auth_middleware import current_user
 from music_assistant.helpers.tts import TTS_QUERY_TIMEOUT_SECONDS
-from music_assistant.models.player import LinkedOutputProtocol
+from music_assistant.models.player import LinkedOutputProtocol, Player
 from music_assistant.models.player_provider import PlayerProvider
 from tests.common import MockPlayer, MockProvider, create_mock_config, use_real_create_task
 
@@ -2295,17 +2295,24 @@ class TestVolumeStep:
         assert entry.range == (0, 10)
 
 
+class SlowDevice(NamedTuple):
+    """A mocked device that takes its time to answer its first volume command."""
+
+    player_id: str
+    reached: asyncio.Event
+
+
 class TestGroupVolumeOrdering:
     """Group volume commands that overlap are handled one after the other."""
 
     def _make_synced_pair(
-        self, mock_mass: MagicMock, slow_leader: asyncio.Event | None = None
+        self, mock_mass: MagicMock, slow_device: SlowDevice | None = None
     ) -> tuple[PlayerController, dict[str, MockPlayer]]:
         """
         Build a leader synced to one member, both at volume 50 and mute capable.
 
-        :param slow_leader: When given, the leader takes its time to answer its first
-            volume command and sets this event as soon as it receives that command.
+        :param slow_device: When given, the named player takes its time to answer its
+            first volume command and reports as soon as it received that command.
         """
         controller = PlayerController(mock_mass)
         provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
@@ -2322,11 +2329,11 @@ class TestGroupVolumeOrdering:
             # take long enough to answer for a later command to overtake it
             async def _volume_set(volume: int, _player: MockPlayer = player) -> None:
                 if (
-                    slow_leader is not None
-                    and _player.player_id == "leader"
-                    and not slow_leader.is_set()
+                    slow_device is not None
+                    and slow_device.player_id == _player.player_id
+                    and not slow_device.reached.is_set()
                 ):
-                    slow_leader.set()
+                    slow_device.reached.set()
                     await asyncio.sleep(0.2)
                 _player._attr_volume_level = volume
 
@@ -2352,18 +2359,67 @@ class TestGroupVolumeOrdering:
 
     async def test_the_last_command_decides_the_group_volume(self, mock_mass: MagicMock) -> None:
         """A slow command may not overrule the volume of a later, faster one."""
-        slow_leader = asyncio.Event()
+        slow_leader = SlowDevice("leader", asyncio.Event())
         controller, players = self._make_synced_pair(mock_mass, slow_leader)
 
         first = asyncio.create_task(controller.cmd_group_volume("leader", 80))
         # only send the second command once the first one reached the device
-        await slow_leader.wait()
+        await slow_leader.reached.wait()
         second = asyncio.create_task(controller.cmd_group_volume("leader", 30))
         await asyncio.gather(first, second)
 
         for player in players.values():
             player.update_state()
             assert player.state.volume_level == 30
+
+    async def test_a_command_for_a_member_waits_for_one_for_its_leader(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Addressing the same group by member or by leader may not overlap."""
+        slow_leader = SlowDevice("leader", asyncio.Event())
+        controller, players = self._make_synced_pair(mock_mass, slow_leader)
+        in_flight = 0
+        overlapped = False
+        set_group_volume = controller.set_group_volume
+
+        async def _track_overlap(group_player: Player, volume_level: int) -> None:
+            nonlocal in_flight, overlapped
+            in_flight += 1
+            overlapped = overlapped or in_flight > 1
+            try:
+                await set_group_volume(group_player, volume_level)
+            finally:
+                in_flight -= 1
+
+        controller.set_group_volume = _track_overlap  # type: ignore[method-assign]
+
+        first = asyncio.create_task(controller.cmd_group_volume("leader", 80))
+        await slow_leader.reached.wait()
+        # a synced member adjusts the very same group as its leader
+        second = asyncio.create_task(controller.cmd_group_volume("member", 30))
+        await asyncio.gather(first, second)
+
+        assert overlapped is False
+        for player in players.values():
+            player.update_state()
+            assert player.state.volume_level == 30
+
+    async def test_an_individual_volume_command_waits_for_the_group(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A member's own volume command may not be overtaken by a group change."""
+        slow_member = SlowDevice("member", asyncio.Event())
+        controller, players = self._make_synced_pair(mock_mass, slow_member)
+
+        group = asyncio.create_task(controller.cmd_group_volume("leader", 80))
+        await slow_member.reached.wait()
+        individual = asyncio.create_task(controller.cmd_volume_set("member", 10))
+        await asyncio.gather(group, individual)
+
+        for player in players.values():
+            player.update_state()
+        assert players["member"].state.volume_level == 10
+        assert players["leader"].state.volume_level == 80
 
     async def test_a_muted_leader_does_not_wait_on_its_own_group_command(
         self, mock_mass: MagicMock

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -2299,13 +2299,13 @@ class TestGroupVolumeOrdering:
     """Group volume commands that overlap are handled one after the other."""
 
     def _make_synced_pair(
-        self, mock_mass: MagicMock, delays: list[float] | None = None
+        self, mock_mass: MagicMock, slow_leader: asyncio.Event | None = None
     ) -> tuple[PlayerController, dict[str, MockPlayer]]:
         """
         Build a leader synced to one member, both at volume 50 and mute capable.
 
-        :param delays: Response time of the mocked device for each volume command it
-            receives, in order. A command beyond the list is answered instantly.
+        :param slow_leader: When given, the leader takes its time to answer its first
+            volume command and sets this event as soon as it receives that command.
         """
         controller = PlayerController(mock_mass)
         provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
@@ -2317,16 +2317,17 @@ class TestGroupVolumeOrdering:
                 PlayerFeature.VOLUME_MUTE,
             }
             player._attr_volume_level = 50
-            response_times = iter(delays or [])
 
-            # let the mocked native volume control behave like a real device that takes
-            # its time, so a slow command can land after a faster one issued later
-            async def _volume_set(
-                volume: int,
-                _player: MockPlayer = player,
-                _response_times: Iterator[float] = response_times,
-            ) -> None:
-                await asyncio.sleep(next(_response_times, 0))
+            # let the mocked native volume control behave like a real device, that may
+            # take long enough to answer for a later command to overtake it
+            async def _volume_set(volume: int, _player: MockPlayer = player) -> None:
+                if (
+                    slow_leader is not None
+                    and _player.player_id == "leader"
+                    and not slow_leader.is_set()
+                ):
+                    slow_leader.set()
+                    await asyncio.sleep(0.2)
                 _player._attr_volume_level = volume
 
             player.volume_set = AsyncMock(side_effect=_volume_set)  # type: ignore[method-assign]
@@ -2351,10 +2352,12 @@ class TestGroupVolumeOrdering:
 
     async def test_the_last_command_decides_the_group_volume(self, mock_mass: MagicMock) -> None:
         """A slow command may not overrule the volume of a later, faster one."""
-        controller, players = self._make_synced_pair(mock_mass, [0.2, 0.01])
+        slow_leader = asyncio.Event()
+        controller, players = self._make_synced_pair(mock_mass, slow_leader)
 
         first = asyncio.create_task(controller.cmd_group_volume("leader", 80))
-        await asyncio.sleep(0.02)
+        # only send the second command once the first one reached the device
+        await slow_leader.wait()
         second = asyncio.create_task(controller.cmd_group_volume("leader", 30))
         await asyncio.gather(first, second)
 


### PR DESCRIPTION
# What does this implement/fix?

Moving the group volume slider sends a stream of volume commands while you drag. Those commands were not serialized, so with a slow speaker a command from earlier in the drag could land after the last one, leaving the group a few points away from where you let go.

Group volume now uses a lock of its own, so the commands are handled in the order they were sent.

- Serialize `group_volume`, `group_volume_up` and `group_volume_down` per group
- Give group volume a separate lock purpose: the fan-out sets the volume of all members at once and a sync leader is a member of its own group, so reusing the single player volume lock would make the group command wait on itself
- Resolve the sync leader before locking, so adjusting the group from a member and from its leader guards the same group
- The fan-out now takes the volume lock of each member too, so a group volume change and an individual volume command for that member can no longer overtake each other
- Added tests for the ordering, for a muted sync leader, and for both of the above

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
