### PR TITLE
Remote access: one stuck client can no longer stall album art for the rest of the session

### DIFF
--- a/music_assistant/controllers/webserver/README.md
+++ b/music_assistant/controllers/webserver/README.md
@@ -296,7 +296,9 @@ applied on top. `http_proxy` carries nothing else, so there the reply is a JSON 
 (`type`, `id`, `status`, `headers`, `size`) followed by the body as raw binary messages — the
 image costs its own size and no more. Those binary messages carry no request id, so the
 gateway holds the channel for a whole reply: replies go out one at a time rather than
-interleaving, which a channel that sends one message at a time would do anyway.
+interleaving, which a channel that sends one message at a time would do anyway. A client that
+stops draining is given a bounded time per frame, after which the reply is abandoned where it
+stands — so a reply can end short of its announced `size`, and the next header is what follows.
 
 `ma-api` and `http_proxy` size their bulk frames to the channel's `max_message_size`, the lower of
 our own 256 KiB ceiling and what the peer advertises in its SDP — and libdatachannel assumes

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -56,6 +56,17 @@ DATA_CHANNEL_CHUNK_OVERHEAD = 128
 # so this sits close to libdatachannel's 256 KiB cap; the channel's negotiated limit still wins.
 HTTP_PROXY_BODY_CHUNK_SIZE = 192 * 1024
 
+# How long one proxied frame may wait for the client to drain its receive buffer. That wait
+# holds the channel's send lock and a semaphore slot, so a client that stops draining would
+# otherwise park both for the life of the session.
+HTTP_PROXY_SEND_TIMEOUT = 10
+
+# Budget for one proxied fetch, in place of aiohttp's five minute default: the response body
+# is buffered whole and holds a semaphore slot until it has been handed to the client.
+# Both budgets sit inside the 30 seconds a client waits before it abandons a proxied request,
+# so neither works on (or answers) a request nobody is listening for any more.
+HTTP_PROXY_FETCH_TIMEOUT = aiohttp.ClientTimeout(total=20)
+
 DEFAULT_SENDSPIN_URL = f"ws://localhost:{SENDSPIN_SERVER_PORT}/sendspin"
 
 # Labels of the data channels the gateway routes, next to the client's own API channel
@@ -567,7 +578,12 @@ class WebRTCGateway:
                 # this dial never leaves the host: TLS verification would fail on the bind
                 # address, and an unfollowed redirect cannot take the unverified dial off-host
                 async with self.http_session.request(
-                    method, local_http_url, headers=headers, ssl=False, allow_redirects=False
+                    method,
+                    local_http_url,
+                    headers=headers,
+                    ssl=False,
+                    allow_redirects=False,
+                    timeout=HTTP_PROXY_FETCH_TIMEOUT,
                 ) as response:
                     body = await response.read()
                     await self._send_http_proxy_response(
@@ -578,6 +594,16 @@ class WebRTCGateway:
                         body,
                         send_lock,
                     )
+            except TimeoutError:
+                self.logger.warning("Timeout proxying %s %s", method, local_http_url)
+                await self._send_http_proxy_response(
+                    channel,
+                    request_id,
+                    504,
+                    {"Content-Type": "text/plain"},
+                    b"Gateway Timeout",
+                    send_lock,
+                )
             except Exception as err:
                 self.logger.exception("Error handling HTTP proxy request")
                 await self._send_http_proxy_response(
@@ -605,45 +631,65 @@ class WebRTCGateway:
             JSON header followed by the body as raw binary frames. Without it the response goes
             out hex-encoded inside one JSON message, as clients on the API channel expect.
         """
-        if send_lock is None:
-            await self._send_chunked(
-                channel,
-                json.dumps(
-                    {
-                        "type": "http-proxy-response",
-                        "id": request_id,
-                        "status": status,
-                        "headers": headers,
-                        "body": body.hex(),
-                    }
-                ),
-            )
-            return
-
-        header = json.dumps(
-            {
-                "type": "http-proxy-response",
-                "id": request_id,
-                "status": status,
-                "headers": headers,
-                "size": len(body),
-            }
-        )
-        # The body frames carry no request id, so an interleaved response would be
-        # indistinguishable from this one's body: hold the channel for header plus body.
-        # Responses therefore queue whole rather than frame by frame, which costs nothing on
-        # a channel that already sends one message at a time.
-        async with send_lock:
-            await self._send_on_channel(channel, header)
-            if channel is None or not channel.is_open:
+        try:
+            if send_lock is None:
+                await self._send_chunked(
+                    channel,
+                    json.dumps(
+                        {
+                            "type": "http-proxy-response",
+                            "id": request_id,
+                            "status": status,
+                            "headers": headers,
+                            "body": body.hex(),
+                        }
+                    ),
+                    timeout=HTTP_PROXY_SEND_TIMEOUT,
+                )
                 return
-            # a peer that advertises no limit in its SDP is assumed to accept only 64 KiB
-            chunk_size = min(HTTP_PROXY_BODY_CHUNK_SIZE, channel.max_message_size)
-            for offset in range(0, len(body), chunk_size):
-                await self._send_on_channel(channel, body[offset : offset + chunk_size])
 
-    async def _send_chunked(self, channel: DataChannel | None, text: str) -> None:
-        """Send a text message on a data channel, chunking it if it exceeds the size limit."""
+            header = json.dumps(
+                {
+                    "type": "http-proxy-response",
+                    "id": request_id,
+                    "status": status,
+                    "headers": headers,
+                    "size": len(body),
+                }
+            )
+            # The body frames carry no request id, so an interleaved response would be
+            # indistinguishable from this one's body: hold the channel for header plus body.
+            # Responses therefore queue whole rather than frame by frame, which costs nothing on
+            # a channel that already sends one message at a time.
+            async with send_lock:
+                await self._send_on_channel(channel, header, timeout=HTTP_PROXY_SEND_TIMEOUT)
+                if channel is None or not channel.is_open:
+                    return
+                # a peer that advertises no limit in its SDP is assumed to accept only 64 KiB
+                chunk_size = min(HTTP_PROXY_BODY_CHUNK_SIZE, channel.max_message_size)
+                for offset in range(0, len(body), chunk_size):
+                    await self._send_on_channel(
+                        channel,
+                        body[offset : offset + chunk_size],
+                        timeout=HTTP_PROXY_SEND_TIMEOUT,
+                    )
+        except TimeoutError:
+            # abandon this response rather than keep the send lock (and the semaphore slot the
+            # caller holds) on a client that is no longer taking what it asked for
+            self.logger.warning(
+                "Timeout sending proxy response %s: client is not draining the channel",
+                request_id,
+            )
+
+    async def _send_chunked(
+        self, channel: DataChannel | None, text: str, timeout: float | None = None
+    ) -> None:
+        """
+        Send a text message on a data channel, chunking it if it exceeds the size limit.
+
+        :param timeout: Seconds a single frame may wait for the client to drain, raising
+            TimeoutError once it elapses. Waits indefinitely when omitted.
+        """
         # reading the limit off a closed channel raises, and it has nothing left to receive
         if channel is None or channel.is_closed:
             return
@@ -651,7 +697,7 @@ class WebRTCGateway:
         limit = channel.max_message_size
         data = text.encode()
         if len(data) <= min(DATA_CHANNEL_CHUNK_SIZE, limit):
-            await self._send_on_channel(channel, text)
+            await self._send_on_channel(channel, text, timeout=timeout)
             return
 
         # Oversized messages are split into base64 frames the client reassembles by group id
@@ -680,6 +726,7 @@ class WebRTCGateway:
                         "b64": base64.b64encode(piece).decode(),
                     }
                 ),
+                timeout=timeout,
             )
 
     async def _close_session(self, session_id: str) -> None:
@@ -998,12 +1045,22 @@ class WebRTCGateway:
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
-    async def _send_on_channel(self, channel: DataChannel | None, data: str | bytes) -> None:
-        """Send data on a data channel if it is currently open."""
+    async def _send_on_channel(
+        self, channel: DataChannel | None, data: str | bytes, timeout: float | None = None
+    ) -> None:
+        """
+        Send data on a data channel if it is currently open.
+
+        :param timeout: Seconds to wait for the client to drain enough of its receive buffer
+            to take this message, raising TimeoutError once it elapses. A send only suspends
+            before it hands over any bytes, so a timed-out message is never half-delivered.
+            Waits indefinitely when omitted.
+        """
         if channel is None or not channel.is_open:
             return
         try:
-            await channel.send(data)
+            async with asyncio.timeout(timeout):
+                await channel.send(data)
         except ConnectionClosedError:
             pass
         except RTCError as err:

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -32,6 +32,7 @@ from music_assistant.controllers.webserver.remote_access import (
 )
 from music_assistant.controllers.webserver.remote_access.gateway import (
     DATA_CHANNEL_CHUNK_SIZE,
+    HTTP_PROXY_CONCURRENCY,
     WebRTCGateway,
     WebRTCSession,
     _is_usable_ice_url,
@@ -40,6 +41,8 @@ from music_assistant.helpers.webrtc_certificate import (
     _generate_certificate,
     _remote_id_from_certificate,
 )
+
+_GATEWAY_MODULE = "music_assistant.controllers.webserver.remote_access.gateway"
 
 
 async def test_remote_id_from_certificate() -> None:
@@ -1588,6 +1591,189 @@ async def test_a_second_http_proxy_channel_is_refused(cert_pems: tuple[str, str]
         assert session.channels["http_proxy"].channel is cast("DataChannel", first)
     finally:
         await gateway._close_session("duplicate-session")
+
+
+class _StallingProxyChannel(_FakeBidiChannel):
+    """
+    Proxy-channel stand-in whose sends park until the test lets them through.
+
+    Stands in for a client that stopped draining what it asked for: a real ``send`` then
+    waits on the channel's drain event, which is what parks the gateway's write-back.
+
+    :param stall_after: Let this many messages through before parking, matching a real
+        channel that only waits once its buffer holds something.
+    """
+
+    def __init__(self, stall_after: int = 0) -> None:
+        super().__init__(label="http_proxy")
+        self.drained = asyncio.Event()
+        self.abandoned = 0
+        self._stall_after = stall_after
+
+    async def send(self, data: str | bytes) -> None:
+        if len(self.sent) >= self._stall_after:
+            try:
+                await self.drained.wait()
+            except asyncio.CancelledError:
+                self.abandoned += 1
+                raise
+        await super().send(data)
+
+
+async def test_a_client_that_stops_draining_does_not_hold_the_proxy_channel(
+    cert_pems: tuple[str, str], caplog: pytest.LogCaptureFixture
+) -> None:
+    """A response the client never takes is abandoned instead of parking the send lock."""
+    gateway = _proxy_gateway(cert_pems)
+    gateway.logger = logging.getLogger("test_webrtc_stalled_send")
+    # the header goes out and the body frame is what parks, as on a channel that only waits
+    # once its buffer holds something
+    channel = _StallingProxyChannel(stall_after=1)
+    send_lock = asyncio.Lock()
+
+    with (
+        patch(f"{_GATEWAY_MODULE}.HTTP_PROXY_SEND_TIMEOUT", 0.05),
+        caplog.at_level(logging.WARNING, logger="test_webrtc_stalled_send"),
+    ):
+        await asyncio.wait_for(
+            gateway._send_http_proxy_response(
+                cast("DataChannel", channel), "img-stalled", 200, {}, b"art-bytes", send_lock
+            ),
+            timeout=5,
+        )
+
+    # the reply ends short of its announced size rather than half-way into a frame
+    assert json.loads(cast("str", channel.sent[0]))["size"] == len(b"art-bytes")
+    assert channel.sent[1:] == []
+    assert not send_lock.locked()
+    assert "Timeout sending proxy response img-stalled" in caplog.text
+
+
+async def test_a_stalled_response_does_not_block_the_next_one(cert_pems: tuple[str, str]) -> None:
+    """One wedged response must not stop the rest of the art for the life of the session."""
+    http_session = _FakeHttpSession()
+    http_session.response_body = b"\xff\xd8second-image"
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "proxy-stalled-session")
+    proxy_channel = _StallingProxyChannel(stall_after=1)
+    pc.offer_channel(proxy_channel)
+    try:
+        await _wait_for(lambda: "http_proxy" in session.channels)
+
+        with patch(f"{_GATEWAY_MODULE}.HTTP_PROXY_SEND_TIMEOUT", 0.05):
+            proxy_channel.feed(_proxy_request("img-stalls", "/imageproxy/stalls"))
+            await _wait_for(lambda: proxy_channel.abandoned >= 1)
+
+        proxy_channel.drained.set()
+        proxy_channel.feed(_proxy_request("img-next", "/imageproxy/next"))
+        await _wait_for(lambda: len(proxy_channel.sent) >= 3)
+
+        # the abandoned reply is the header alone; the next one follows it whole
+        assert json.loads(cast("str", proxy_channel.sent[0]))["id"] == "img-stalls"
+        response, body = _read_proxy_response(proxy_channel.sent[1:])
+        assert response["id"] == "img-next"
+        assert body == b"\xff\xd8second-image"
+    finally:
+        await gateway._close_session("proxy-stalled-session")
+
+
+async def test_a_stalled_response_frees_its_slot_for_other_requests(
+    cert_pems: tuple[str, str],
+) -> None:
+    """Wedged write-backs must not leave the gateway-wide proxy budget exhausted."""
+    http_session = _FakeHttpSession()
+    http_session.response_body = b"art-bytes"
+    gateway = _routing_gateway(cert_pems, http_session)
+    channel = _StallingProxyChannel()
+    send_lock = asyncio.Lock()
+
+    with patch(f"{_GATEWAY_MODULE}.HTTP_PROXY_SEND_TIMEOUT", 0.05):
+        # take the whole budget, so a single slot left behind is enough to fail this
+        requests = [
+            asyncio.ensure_future(
+                gateway._handle_http_proxy_request(
+                    cast("DataChannel", channel),
+                    {"id": f"img-{index}", "method": "GET", "path": f"/imageproxy/{index}"},
+                    send_lock,
+                )
+            )
+            for index in range(HTTP_PROXY_CONCURRENCY)
+        ]
+        try:
+            await asyncio.wait_for(asyncio.gather(*requests), timeout=15)
+        finally:
+            for request in requests:
+                request.cancel()
+
+    for _ in range(HTTP_PROXY_CONCURRENCY):
+        await asyncio.wait_for(gateway._http_proxy_semaphore.acquire(), timeout=5)
+
+
+async def test_http_proxy_fetch_carries_an_explicit_timeout(cert_pems: tuple[str, str]) -> None:
+    """The proxied fetch must be bounded rather than left on aiohttp's five minute default."""
+    cert_pem, key_pem = cert_pems
+    mock_session = Mock()
+    captured_kwargs: dict[str, Any] = {}
+
+    def fake_request(_method: str, _url: str, **kwargs: Any) -> AsyncMock:
+        captured_kwargs.update(kwargs)
+        response = AsyncMock()
+        response.status = 200
+        response.headers = {}
+        response.read = AsyncMock(return_value=b"")
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=response)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    mock_session.request = fake_request
+
+    gateway = WebRTCGateway(
+        http_session=mock_session,
+        remote_id="TEST-REMOTE-ID",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+    )
+
+    await gateway._handle_http_proxy_request(None, {"id": "1", "method": "GET", "path": "/info"})
+
+    timeout = cast("aiohttp.ClientTimeout", captured_kwargs["timeout"])
+    assert timeout.total is not None
+    assert timeout.total < 300
+
+
+async def test_a_timed_out_fetch_answers_the_client(cert_pems: tuple[str, str]) -> None:
+    """A fetch that runs out of time still answers, so the client is not left waiting."""
+
+    def timing_out_request(_method: str, _url: str, **_kwargs: Any) -> AsyncMock:
+        # aiohttp hands out its context manager first and only raises once the body is read
+        response = AsyncMock()
+        response.status = 200
+        response.headers = {}
+        response.read = AsyncMock(side_effect=TimeoutError)
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=response)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    http_session = _FakeHttpSession()
+    http_session.request = timing_out_request  # type: ignore[assignment]
+    gateway = _routing_gateway(cert_pems, http_session)
+    session, pc = _register_routed_session(gateway, "proxy-timeout-session")
+    proxy_channel = _FakeBidiChannel(label="http_proxy")
+    pc.offer_channel(proxy_channel)
+    try:
+        await _wait_for(lambda: "http_proxy" in session.channels)
+
+        proxy_channel.feed(_proxy_request("img-slow", "/imageproxy/slow"))
+        await _wait_for(lambda: len(proxy_channel.sent) >= 2)
+
+        response, body = _read_proxy_response(proxy_channel.sent)
+        assert response["id"] == "img-slow"
+        assert response["status"] == 504
+        assert body == b"Gateway Timeout"
+    finally:
+        await gateway._close_session("proxy-timeout-session")
 
 
 class _FakeDataChannel:


### PR DESCRIPTION
# What does this implement/fix?

Remote access proxies album art over its own WebRTC data channel. Both the fetch and the write-back were unbounded: a client that stops draining its receive buffer parks the write-back forever, which holds that channel's send lock and one of the six gateway-wide proxy slots for the life of the session. From then on no further art goes out on that channel, while the API channel keeps looking healthy.

Found by code inspection while looking into a report of album art dying on a cast dashboard, so this is hardening rather than a fix for a reproduced bug.

- Bound each proxied frame's wait for the client to drain (10s); a reply the client never takes is dropped with a warning instead of parking the lock and the slot
- Give the proxied fetch an explicit 20s budget instead of relying on aiohttp's 5 minute default, and answer a timed-out fetch with a 504 rather than a stack trace. Both budgets sit inside the 30s a client waits before abandoning a proxied request
- Note in the webserver README that a reply can now end short of its announced size
- Tests covering both timeouts, plus that a stalled reply no longer blocks the next one or exhausts the proxy budget

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
