### PR TITLE
AirPlay speakers keep the volume they are set to

### DIFF
--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -843,7 +843,11 @@ class AnnouncementsMixin:
         :param announce_player: The player (or linked protocol) that plays the announcement.
         """
         volume_control = player.volume_control_for_output(announce_player.player_id)
-        if volume_control in (PLAYER_CONTROL_NATIVE, announce_player.player_id):
+        if volume_control == PLAYER_CONTROL_NATIVE:
+            # A native volume lives on the player itself, so only its own output can
+            # apply it: a linked protocol rendering the audio has no way to reach it.
+            return announce_player.player_id == player.player_id
+        if volume_control == announce_player.player_id:
             # the volume lives on the device the announcing output talks to
             return True
         # a bridge player riding on the announcing output forwards its volume to it

--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -334,6 +334,12 @@ Handled in `_handle_dacp_request()` in [provider.py](provider.py):
 | `device-prevent-playback=1` | Device switched to another source or powered off |
 | `device-prevent-playback=0` | Device ready for playback again |
 
+### Volume Ownership
+
+An AirPlay volume command sets the receiver's own volume, and that level stays behind on the device after the session ends. Music Assistant therefore only sends one when nothing else owns the volume of this output: on a device that is also reachable through a native provider or another protocol (a Sonos speaker, an AV receiver), the stream simply plays at the level the device is already set to, and volume stays with that provider.
+
+A volume is still sent when the AirPlay output itself is the resolved volume control, when a mute has to travel with the stream, and when a session asks for a specific level (an announcement).
+
 ### Volume Feedback
 
 Devices can report their own volume changes back over DACP; Music Assistant applies them unless `ignore_volume` is set. Genuine Apple devices are auto-set to ignore these reports (they manage volume internally).

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -561,8 +561,8 @@ class AirPlayPlayer(Player):
 
     async def volume_set(self, volume_level: int) -> None:
         """Send VOLUME_SET command to given player."""
-        # Record before sending: the connect-time volume resync reads this attribute,
-        # so a send that suspends first would let the resync push the stale level.
+        # Record before sending: the connect-time volume push reads this attribute,
+        # so a send that suspends first would let that push send the stale level.
         self._attr_volume_level = volume_level
         if self.stream and self.stream.running and self.volume_muted is not True:
             await self.stream.send_cli_command(f"VOLUME={volume_level}")
@@ -842,8 +842,8 @@ class AirPlayPlayer(Player):
             return
         # The mute belongs to a control that does not own this output (a sibling interface,
         # the receiver itself, or nothing at all). Our mute is a latch that only an explicit
-        # unmute clears, so leaving it set would start the stream silent and swallow every
-        # volume command after it.
+        # unmute clears, so leaving it set would report a mute we do not own and turn the
+        # next volume command into a silent one.
         self._attr_volume_muted = False
         self.update_state()
 

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -9,7 +9,6 @@ import time
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
-from music_assistant_models.constants import PLAYER_CONTROL_NATIVE
 from music_assistant_models.enums import (
     ConfigEntryType,
     ContentType,
@@ -813,35 +812,40 @@ class AirPlayPlayer(Player):
             bit_depth=24,
         )
 
-    def sync_volume_state(self, *, adopt_parent_volume: bool = True) -> None:
+    @property
+    def owns_volume(self) -> bool:
         """
-        Sync volume and mute from the parent player if needed.
+        Return True if this output is the resolved owner of its own volume.
 
-        AirPlay players only report their volume level when we are actually streaming to them
-        and we remember the last used/reported volume level in the player config by default
-        but if we have a parent player, that may know better about the current volume level,
-        so we try to sync from that parent player if possible. If another control owns
-        the parent's volume, we play at unity gain instead.
-
-        Both controls are resolved against this player as the rendering output, so which
-        control is deemed to own them does not depend on the parent already pointing at us.
-
-        :param adopt_parent_volume: Set to False when the volume of the stream about to start
-            was explicitly requested by the caller, so the parent's level does not overwrite
-            it. The mute release always runs: a latch left behind by another control would
-            silence the stream regardless of the level it plays at.
+        AirPlay volume is the receiver's own volume: setting it writes through to the
+        device and persists there after the session ends. It may therefore only be set
+        when no other control owns the volume of this output.
         """
-        if not self.protocol_parent_id:
+        if not (parent_id := self.protocol_parent_id):
+            # a standalone AirPlay player has no other interface to defer to
+            return True
+        if not (parent_player := self.mass.players.get_player(parent_id)):
+            return True
+        return self._control_routes_to_self(parent_player.volume_control_for_output(self.player_id))
+
+    def release_foreign_mute_latch(self) -> None:
+        """Clear our mute latch when another control owns the mute of this output."""
+        if not self._attr_volume_muted:
+            # nothing latched, so nothing that could silence this stream
             return
-        parent_player = self.mass.players.get_player(self.protocol_parent_id)
-        if not parent_player:
+        if not (parent_id := self.protocol_parent_id):
             return
-        volume_changed = self._sync_volume_level(
-            parent_player, adopt_parent_volume=adopt_parent_volume
-        )
-        mute_changed = self._sync_mute_state(parent_player)
-        if volume_changed or mute_changed:
-            self.update_state()
+        if not (parent_player := self.mass.players.get_player(parent_id)):
+            return
+        if self._control_routes_to_self(parent_player.mute_control_for_output(self.player_id)):
+            # our own mute, applied through the parent
+            return
+        # The mute belongs to a control that does not own this output (a sibling interface,
+        # the receiver itself, or nothing at all). Our mute is a latch that only an explicit
+        # unmute clears, so leaving it set would start the stream silent and swallow every
+        # volume command after it.
+        self._attr_volume_muted = False
+        self.update_state()
 
     async def on_config_updated(self) -> None:
         """Handle logic when the player config is updated."""
@@ -900,76 +904,6 @@ class AirPlayPlayer(Player):
             return
         progress = int(metadata.corrected_elapsed_time or 0)
         self.mass.create_task(self.stream.send_metadata(progress, metadata))
-
-    def _sync_volume_level(self, parent_player: Player, *, adopt_parent_volume: bool) -> bool:
-        """
-        Adopt the parent's volume level if it owns this output, return True if changed.
-
-        :param parent_player: The parent player to resolve the volume control against.
-        :param adopt_parent_volume: False to keep our own level where we would otherwise
-            adopt the parent's. The unity gain reset still applies: a control that owns
-            the volume of this output attenuates on the device itself.
-        """
-        volume_control = parent_player.volume_control_for_output(self.player_id)
-        if volume_control == PLAYER_CONTROL_NATIVE:
-            # Native parent volume is on the receiver/amplifier scale.
-            # Keep the AirPlay child volume learned from DACP feedback instead.
-            return False
-        if not self._control_routes_to_self(volume_control):
-            # Another control (e.g. DLNA/Chromecast hardware volume) owns the parent's
-            # volume; play at unity gain so we don't attenuate on top of it.
-            # Not persisted, so the last software volume survives a switch back.
-            if self._attr_volume_level == 100:
-                return False
-            self._attr_volume_level = 100
-            return True
-        if not adopt_parent_volume:
-            return False
-        if parent_player.state.volume_level is None:
-            return False
-        if parent_player.state.volume_level == 0:
-            # A parent volume of 0 usually means the (idle) sibling interface
-            # feeding the parent doesn't know the real device volume, e.g. the
-            # cast side of the same device reports 0 while in standby. Adopting
-            # it would start the stream hard muted, so keep our own last known
-            # volume instead.
-            return False
-        # The parent's state volume is logical (0-100) while a volume command reaches
-        # this player already scaled into the parent's min/max range, so the two are
-        # compared on the parent's scale: a level that already reads back as the
-        # parent's is left alone rather than re-derived, which for a range that does
-        # not divide evenly would round it a step further away on every stream.
-        parent_id = parent_player.player_id
-        if (
-            self._attr_volume_level is not None
-            and self.mass.players.scale_volume_from_device(parent_id, self._attr_volume_level)
-            == parent_player.state.volume_level
-        ):
-            return False
-        self._attr_volume_level = self.mass.players.scale_volume_to_device(
-            parent_id, parent_player.state.volume_level
-        )
-        self.mass.config.set_raw_player_config_value(
-            self.player_id, CONF_STORED_VOLUME, self._attr_volume_level
-        )
-        return True
-
-    def _sync_mute_state(self, parent_player: Player) -> bool:
-        """Release a mute owned by another control, return True if changed."""
-        if not self._attr_volume_muted:
-            # nothing latched, so nothing that could silence this stream
-            return False
-        if self._control_routes_to_self(parent_player.mute_control_for_output(self.player_id)):
-            # our own mute, applied through the parent
-            return False
-        # The mute belongs to a control that does not own this output (a sibling interface,
-        # the receiver itself, or nothing at all). Our mute is a latch that only an explicit
-        # unmute clears, so leaving it set would start the stream silent and swallow every
-        # volume command after it. The parent's mute state is deliberately not adopted here:
-        # it is resolved through the ambient control, which is the very thing that may be
-        # pointing at another interface.
-        self._attr_volume_muted = False
-        return True
 
     def _control_routes_to_self(self, control: str) -> bool:
         """Return True if the given (resolved) control routes to this player."""

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -752,9 +752,9 @@ class SendspinAirPlayBridge:
             # starting together cannot both find their group still undecided.
             self._use_shared_ptp = self._resolve_shared_ptp()
             # Connecting is what re-sends VOLUME= to the device, so this is the one
-            # place the sync belongs: a kept process never reaches here and would
-            # otherwise be left playing at a volume nobody told it about.
-            self.airplay_player.sync_volume_state()
+            # place the mute release belongs: a kept process never reaches here and
+            # would otherwise stay silenced by a latch another control owns.
+            self.airplay_player.release_foreign_mute_latch()
             await stream.connect(self._use_shared_ptp)
             await stream.wait_for_connection()
             if asyncio.current_task() is not self._airplay_stream_start_task:

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -751,9 +751,8 @@ class SendspinAirPlayBridge:
             # Resolving and recording the decision never awaits, so two bridges
             # starting together cannot both find their group still undecided.
             self._use_shared_ptp = self._resolve_shared_ptp()
-            # Connecting is what re-sends VOLUME= to the device, so this is the one
-            # place the mute release belongs: a kept process never reaches here and
-            # would otherwise stay silenced by a latch another control owns.
+            # A cold connect is the only path that can still act on the latch, so the
+            # release belongs here: a kept process never reaches this point.
             self.airplay_player.release_foreign_mute_latch()
             await stream.connect(self._use_shared_ptp)
             await stream.wait_for_connection()

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -345,13 +345,21 @@ class AirPlayStream:
         # back audio rendering until they receive track metadata; deferring it
         # can keep them silent past the commanded start.
         await self._send_current_metadata(send_artwork=False)
-        # Send the mute-aware volume right away — audio can start within a
-        # second now that metadata goes out immediately — and repeat it after
-        # 2 seconds because some players ignore the first volume command
-        # (https://github.com/music-assistant/support/issues/3330). The repeat reads
-        # the level when it fires, so it never replays a value that changed since.
-        await self._send_current_volume()
-        self.mass.call_later(2, self._send_current_volume)
+        # An AirPlay volume command writes the receiver's own volume and persists there
+        # after the session ends, so it is only sent when nothing else owns this output's
+        # volume: otherwise the device keeps playing at the level its own app or remote is
+        # set to. A latched mute would start the stream silent, and a volume explicitly
+        # requested for this session (an announcement) is not an unsolicited push.
+        if (
+            self.player.owns_volume
+            or self.player.volume_muted
+            or (self.session is not None and self.session.requested_volume is not None)
+        ):
+            # Repeat after 2 seconds because some players ignore the first volume command
+            # (https://github.com/music-assistant/support/issues/3330). The repeat reads
+            # the level when it fires, so it never replays a value that changed since.
+            await self._send_current_volume()
+            self.mass.call_later(2, self._send_current_volume)
         # settle artwork and the position on top of the identity push above
         self.player.on_player_media_updated()
 
@@ -996,8 +1004,6 @@ class AirPlayStream:
             cli_binary,
             "--protocol",
             protocol_arg,
-            "--volume",
-            str(self.player.volume_level),
             "--dacp",
             prov.dacp_id,
             "--activeremote",

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -76,7 +76,7 @@ class AirPlayStreamSession:
         :param media: Queue media that owns the stream session.
         :param requested_volume: Volume level explicitly requested for this session (an
             announcement volume), already applied to its members. Omit for a regular
-            stream, which leaves the receiver at the volume it is already set to.
+            stream, which only carries a volume when this output owns it.
         """
         assert sync_clients
         self.prov = airplay_provider

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -75,8 +75,8 @@ class AirPlayStreamSession:
         :param pcm_format: PCM format of the input stream.
         :param media: Queue media that owns the stream session.
         :param requested_volume: Volume level explicitly requested for this session (an
-            announcement volume), already applied to its members. Omit to let the members
-            take their level from their parent player as usual.
+            announcement volume), already applied to its members. Omit for a regular
+            stream, which leaves the receiver at the volume it is already set to.
         """
         assert sync_clients
         self.prov = airplay_provider
@@ -1023,10 +1023,7 @@ class AirPlayStreamSession:
         """
         # joining a session supersedes any pending automatic group re-join
         airplay_player.cancel_group_rejoin()
-        # sync volume/mute from parent player if needed. A volume requested for this session
-        # is already applied to its members, so the parent's level must not replace it:
-        # the level held here is what the connecting stream hands to the receiver.
-        airplay_player.sync_volume_state(adopt_parent_volume=self.requested_volume is None)
+        airplay_player.release_foreign_mute_latch()
         if airplay_player.stream and airplay_player.stream.running:
             await airplay_player.stream.stop()
         stream_pcm_format = airplay_player.get_stream_pcm_format(self.pcm_format)

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -3422,14 +3422,41 @@ class TestNativeAnnouncementVolumeRouting:
         setup.volume_set.assert_not_awaited()
         setup.play_announcement.assert_awaited_once_with(ANY, self.ANNOUNCE_VOLUME)
 
-    async def test_native_volume_keeps_the_announcement_volume(self, mock_mass: MagicMock) -> None:
-        """Native parent volume lives on the device the output talks to, so it applies it."""
+    async def test_native_volume_is_applied_through_the_parent(self, mock_mass: MagicMock) -> None:
+        """
+        A native volume lives on the parent, so the parent applies and restores it.
+
+        The rendering output has no way to reach a native parent volume, and its own
+        idea of the level can be stale, so routing through the parent keeps both the
+        announcement level and the restore on the control that actually knows it.
+        """
         setup = self._make_setup(mock_mass, PLAYER_CONTROL_NATIVE)
+        setup.parent._attr_volume_level = 20
+        setup.parent._cache.clear()
+        setup.parent.update_state(signal_event=False)
 
         await self._announce(setup)
 
+        assert setup.volume_set.await_args_list == [
+            call("parent", self.ANNOUNCE_VOLUME),
+            call("parent", 20),
+        ]
+        setup.play_announcement.assert_awaited_once_with(ANY, None)
+
+    async def test_native_volume_on_its_own_output_is_kept_by_the_player(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player announcing on its own output can apply its native volume itself."""
+        setup = self._make_setup(mock_mass, PLAYER_CONTROL_NATIVE)
+        play_announcement = AsyncMock()
+        setup.parent.play_announcement = play_announcement  # type: ignore[method-assign]
+
+        await setup.controller._play_native_announcement(
+            setup.parent, setup.parent, _announcement(), self.ANNOUNCE_VOLUME
+        )
+
         setup.volume_set.assert_not_awaited()
-        setup.play_announcement.assert_awaited_once_with(ANY, self.ANNOUNCE_VOLUME)
+        play_announcement.assert_awaited_once_with(ANY, self.ANNOUNCE_VOLUME)
 
     async def test_without_volume_control_no_volume_is_applied(self, mock_mass: MagicMock) -> None:
         """Nothing in the signal path can set a volume, so the announcement plays as-is."""

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -736,24 +736,59 @@ async def test_volume_mute_no_stream(airplay_player: AirPlayPlayer) -> None:
         mock_update.assert_called_once()
 
 
-def test_sync_volume_state_keeps_stored_volume_for_native_parent(
-    airplay_player: AirPlayPlayer,
-) -> None:
-    """Keep the child AirPlay volume when the parent uses native volume control."""
+def test_owns_volume_true_without_protocol_parent(airplay_player: AirPlayPlayer) -> None:
+    """A standalone AirPlay player always owns its own volume."""
+    assert airplay_player.owns_volume is True
+
+
+def test_owns_volume_true_when_parent_unresolvable(airplay_player: AirPlayPlayer) -> None:
+    """A protocol parent that no longer resolves cannot own the volume either."""
+    airplay_player.mass.players.get_player.return_value = None  # type: ignore[attr-defined]
+    airplay_player.set_protocol_parent_id("parent")
+
+    assert airplay_player.owns_volume is True
+
+
+def test_owns_volume_true_when_parent_control_is_self(airplay_player: AirPlayPlayer) -> None:
+    """This output owns the volume when the parent's control resolves to it directly."""
     parent = MagicMock()
-    parent.state.volume_level = 36
-    parent.volume_control_for_output.return_value = PLAYER_CONTROL_NATIVE
-    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
+    parent.volume_control_for_output.return_value = "test_player"
     airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
     airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_level = 48
 
-    with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_state()
+    assert airplay_player.owns_volume is True
 
-    assert airplay_player._attr_volume_level == 48
-    airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
-    mock_update.assert_not_called()
+
+def test_owns_volume_true_when_parent_control_is_bridge_on_self(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """This output owns the volume when the control is a bridge riding on it."""
+    parent = MagicMock()
+    parent.volume_control_for_output.return_value = "sendspin_bridge"
+    bridge = MagicMock()
+    bridge.underlying_player_id = "test_player"
+    airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
+        "parent": parent,
+        "sendspin_bridge": bridge,
+    }.get
+    airplay_player.set_protocol_parent_id("parent")
+
+    assert airplay_player.owns_volume is True
+
+
+@pytest.mark.parametrize("control", ["dlna_player", PLAYER_CONTROL_NATIVE])
+def test_owns_volume_false_when_another_control_owns_it(
+    airplay_player: AirPlayPlayer, control: str
+) -> None:
+    """Another control (a sibling interface, or the receiver's own native control) owns it."""
+    parent = MagicMock()
+    parent.volume_control_for_output.return_value = control
+    airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
+        "parent": parent,
+    }.get
+    airplay_player.set_protocol_parent_id("parent")
+
+    assert airplay_player.owns_volume is False
 
 
 def test_update_volume_from_device_keeps_native_parent_feedback(
@@ -779,166 +814,7 @@ def test_update_volume_from_device_keeps_native_parent_feedback(
     mock_update.assert_called_once()
 
 
-def test_sync_volume_state_uses_parent_volume_when_control_is_self(
-    airplay_player: AirPlayPlayer,
-) -> None:
-    """Pull the parent volume when the parent's volume control is this player."""
-    parent = MagicMock()
-    parent.state.volume_level = 42
-    parent.volume_control_for_output.return_value = "test_player"
-    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
-    airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
-    airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_level = 48
-
-    with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_state()
-
-    assert airplay_player._attr_volume_level == 42
-    airplay_player.mass.config.set_raw_player_config_value.assert_called_once_with(  # type: ignore[attr-defined]
-        airplay_player.player_id,
-        CONF_STORED_VOLUME,
-        42,
-    )
-    mock_update.assert_called_once()
-
-
-def test_sync_volume_state_uses_parent_volume_via_bridge_control(
-    airplay_player: AirPlayPlayer,
-) -> None:
-    """Pull the parent volume when the volume control is a bridge riding on this player."""
-    parent = MagicMock()
-    parent.state.volume_level = 42
-    parent.volume_control_for_output.return_value = "sendspin_bridge"
-    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
-    bridge = MagicMock()
-    bridge.underlying_player_id = "test_player"
-    airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
-        "parent": parent,
-        "sendspin_bridge": bridge,
-    }.get
-    airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_level = 48
-
-    with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_state()
-
-    assert airplay_player._attr_volume_level == 42
-    airplay_player.mass.config.set_raw_player_config_value.assert_called_once_with(  # type: ignore[attr-defined]
-        airplay_player.player_id,
-        CONF_STORED_VOLUME,
-        42,
-    )
-    mock_update.assert_called_once()
-
-
-def test_sync_volume_state_adopts_parent_volume_on_the_parents_scale(
-    airplay_player: AirPlayPlayer,
-) -> None:
-    """
-    A volume limit on the parent leaves the adopted level on the same scale as a command.
-
-    Volume commands arrive here already scaled into the parent's range, so adopting
-    the parent's logical level as-is would play the speaker louder than asked and
-    read back as a volume outside the range on the next state update.
-    """
-    _stub_volume_scaling(cast("MagicMock", airplay_player.provider), max_volume=50)
-    parent = MagicMock()
-    parent.player_id = "parent"
-    parent.state.volume_level = 60
-    parent.volume_control_for_output.return_value = "test_player"
-    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
-    airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
-    airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_level = 48
-
-    with patch.object(AirPlayPlayer, "update_state"):
-        airplay_player.sync_volume_state()
-
-    assert airplay_player._attr_volume_level == 30
-
-
-def test_sync_volume_state_keeps_a_level_already_on_the_parents_volume(
-    airplay_player: AirPlayPlayer,
-) -> None:
-    """
-    A level the parent already reports is left alone, whatever the limits round to.
-
-    A range that does not divide evenly cannot map every level back and forth
-    exactly, so re-deriving one that already agrees would walk the speaker a step
-    further down on every stream it starts.
-    """
-    _stub_volume_scaling(cast("MagicMock", airplay_player.provider), max_volume=99)
-    parent = MagicMock()
-    parent.player_id = "parent"
-    # what the parent reports for a player sitting at device level 98
-    parent.state.volume_level = 98
-    parent.volume_control_for_output.return_value = "test_player"
-    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
-    airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
-    airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_level = 98
-
-    with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_state()
-
-    assert airplay_player._attr_volume_level == 98
-    airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
-    mock_update.assert_not_called()
-
-
-def test_sync_volume_state_unity_gain_when_other_control_owns_volume(
-    airplay_player: AirPlayPlayer,
-) -> None:
-    """Play at unity gain when the parent volume is owned by another (hardware) control."""
-    parent = MagicMock()
-    parent.state.volume_level = 30
-    parent.volume_control_for_output.return_value = "dlna_player"
-    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
-    dlna_player = MagicMock()
-    dlna_player.underlying_player_id = None
-    airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
-        "parent": parent,
-        "dlna_player": dlna_player,
-    }.get
-    airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_level = 48
-
-    with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_state()
-
-    assert airplay_player._attr_volume_level == 100
-    airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
-    mock_update.assert_called_once()
-
-
-def test_sync_volume_state_ignores_parent_volume_zero(
-    airplay_player: AirPlayPlayer,
-) -> None:
-    """
-    Keep the last known volume when the parent reports volume 0.
-
-    An idle sibling interface (e.g. the cast side of the same device in standby)
-    may feed the parent a volume of 0 that doesn't reflect the real device volume;
-    adopting it would start the stream hard muted.
-    """
-    parent = MagicMock()
-    parent.state.volume_level = 0
-    parent.volume_control_for_output.return_value = "test_player"
-    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
-    airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
-    airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_level = 48
-
-    with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_state()
-
-    assert airplay_player._attr_volume_level == 48
-    airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
-    mock_update.assert_not_called()
-
-
-def test_sync_volume_state_clears_mute_latch_owned_by_other_control(
+def test_release_foreign_mute_latch_clears_mute_owned_by_other_control(
     airplay_player: AirPlayPlayer,
 ) -> None:
     """
@@ -949,9 +825,6 @@ def test_sync_volume_state_clears_mute_latch_owned_by_other_control(
     swallow every volume command after it.
     """
     parent = MagicMock()
-    parent.state.volume_level = 40
-    parent.state.volume_muted = False
-    parent.volume_control_for_output.return_value = PLAYER_CONTROL_NATIVE
     parent.mute_control_for_output.return_value = "cast_player"
     cast_player = MagicMock()
     cast_player.underlying_player_id = None
@@ -963,157 +836,44 @@ def test_sync_volume_state_clears_mute_latch_owned_by_other_control(
     airplay_player._attr_volume_muted = True
 
     with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_state()
+        airplay_player.release_foreign_mute_latch()
 
     assert airplay_player._attr_volume_muted is False
     mock_update.assert_called_once()
 
 
-def test_sync_volume_state_keeps_mute_owned_by_this_output(
+def test_release_foreign_mute_latch_keeps_mute_owned_by_this_output(
     airplay_player: AirPlayPlayer,
 ) -> None:
     """Keep our own mute when this player owns the parent's mute."""
     parent = MagicMock()
-    parent.state.volume_level = 40
-    parent.state.volume_muted = True
-    parent.volume_control_for_output.return_value = PLAYER_CONTROL_NATIVE
     parent.mute_control_for_output.return_value = "test_player"
     airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
     airplay_player.set_protocol_parent_id("parent")
     airplay_player._attr_volume_muted = True
 
     with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_state()
+        airplay_player.release_foreign_mute_latch()
 
     assert airplay_player._attr_volume_muted is True
     mock_update.assert_not_called()
 
 
-def test_sync_volume_state_leaves_unknown_mute_untouched(
+def test_release_foreign_mute_latch_does_nothing_when_not_muted(
     airplay_player: AirPlayPlayer,
 ) -> None:
-    """Never having latched a mute is not the same as being unmuted."""
+    """Never having latched a mute is not something to act on."""
     parent = MagicMock()
-    parent.state.volume_level = 48
-    parent.state.volume_muted = False
-    parent.volume_control_for_output.return_value = PLAYER_CONTROL_NATIVE
-    parent.mute_control_for_output.return_value = "cast_player"
-    cast_player = MagicMock()
-    cast_player.underlying_player_id = None
-    airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
-        "parent": parent,
-        "cast_player": cast_player,
-    }.get
-    airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_muted = None
-
-    with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_state()
-
-    assert airplay_player._attr_volume_muted is None
-    mock_update.assert_not_called()
-
-
-def test_sync_volume_state_resolves_against_this_output(
-    airplay_player: AirPlayPlayer,
-) -> None:
-    """Both controls are resolved for this player as the rendering output."""
-    parent = MagicMock()
-    parent.state.volume_level = 40
-    parent.state.volume_muted = False
-    parent.volume_control_for_output.return_value = PLAYER_CONTROL_NATIVE
-    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
     airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
     airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_muted = True
-
-    airplay_player.sync_volume_state()
-
-    parent.volume_control_for_output.assert_called_once_with("test_player")
-    parent.mute_control_for_output.assert_called_once_with("test_player")
-
-
-def test_sync_volume_state_keeps_explicitly_requested_volume(
-    airplay_player: AirPlayPlayer,
-) -> None:
-    """
-    Keep a volume that was explicitly requested for the stream about to start.
-
-    An announcement volume is resolved and applied before the session starts, so the
-    parent's level (which on a multi-interface device may come from an idle sibling)
-    must not replace it - the level held here is what reaches the receiver.
-    """
-    parent = MagicMock()
-    parent.state.volume_level = 40
-    parent.volume_control_for_output.return_value = "test_player"
-    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
-    airplay_player.mass.players.get_player.return_value = parent  # type: ignore[attr-defined]
-    airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_level = 85
+    airplay_player._attr_volume_muted = False
 
     with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_state(adopt_parent_volume=False)
-
-    assert airplay_player._attr_volume_level == 85
-    airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
-    mock_update.assert_not_called()
-
-
-def test_sync_volume_state_keeps_unity_gain_for_explicitly_requested_volume(
-    airplay_player: AirPlayPlayer,
-) -> None:
-    """
-    Reset to unity gain even for an explicitly requested volume.
-
-    A control that owns the volume of this output attenuates on the device itself, so
-    the requested level would land on top of it.
-    """
-    parent = MagicMock()
-    parent.state.volume_level = 40
-    parent.volume_control_for_output.return_value = "cast_player"
-    parent.mute_control_for_output.return_value = PLAYER_CONTROL_NATIVE
-    cast_player = MagicMock()
-    cast_player.underlying_player_id = None
-    airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
-        "parent": parent,
-        "cast_player": cast_player,
-    }.get
-    airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_level = 85
-
-    with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_state(adopt_parent_volume=False)
-
-    assert airplay_player._attr_volume_level == 100
-    airplay_player.mass.config.set_raw_player_config_value.assert_not_called()  # type: ignore[attr-defined]
-    mock_update.assert_called_once()
-
-
-def test_sync_volume_state_clears_mute_latch_without_adopting_volume(
-    airplay_player: AirPlayPlayer,
-) -> None:
-    """A stream with an explicitly requested volume still gets its mute latch released."""
-    parent = MagicMock()
-    parent.state.volume_level = 40
-    parent.state.volume_muted = False
-    parent.volume_control_for_output.return_value = "test_player"
-    parent.mute_control_for_output.return_value = "cast_player"
-    cast_player = MagicMock()
-    cast_player.underlying_player_id = None
-    airplay_player.mass.players.get_player.side_effect = {  # type: ignore[attr-defined]
-        "parent": parent,
-        "cast_player": cast_player,
-    }.get
-    airplay_player.set_protocol_parent_id("parent")
-    airplay_player._attr_volume_level = 85
-    airplay_player._attr_volume_muted = True
-
-    with patch.object(AirPlayPlayer, "update_state") as mock_update:
-        airplay_player.sync_volume_state(adopt_parent_volume=False)
+        airplay_player.release_foreign_mute_latch()
 
     assert airplay_player._attr_volume_muted is False
-    assert airplay_player._attr_volume_level == 85
-    mock_update.assert_called_once()
+    parent.mute_control_for_output.assert_not_called()
+    mock_update.assert_not_called()
 
 
 # --- Pause / stop dispatch tests ---

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -757,6 +757,8 @@ def test_owns_volume_true_when_parent_control_is_self(airplay_player: AirPlayPla
     airplay_player.set_protocol_parent_id("parent")
 
     assert airplay_player.owns_volume is True
+    # the control must be resolved against this player as the rendering output
+    parent.volume_control_for_output.assert_called_once_with(airplay_player.player_id)
 
 
 def test_owns_volume_true_when_parent_control_is_bridge_on_self(
@@ -840,6 +842,8 @@ def test_release_foreign_mute_latch_clears_mute_owned_by_other_control(
 
     assert airplay_player._attr_volume_muted is False
     mock_update.assert_called_once()
+    # the control must be resolved against this player as the rendering output
+    parent.mute_control_for_output.assert_called_once_with(airplay_player.player_id)
 
 
 def test_release_foreign_mute_latch_keeps_mute_owned_by_this_output(

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -545,7 +545,7 @@ async def test_a_fresh_process_releases_a_foreign_mute_latch_before_it_connects(
     stream = _make_anchor_stream()
     order: list[str] = []
     cast("MagicMock", bridge.airplay_player).release_foreign_mute_latch = MagicMock(
-        side_effect=lambda: order.append("sync")
+        side_effect=lambda: order.append("release_mute")
     )
     stream.connect = AsyncMock(side_effect=lambda *_a, **_kw: order.append("connect"))
 
@@ -561,7 +561,7 @@ async def test_a_fresh_process_releases_a_foreign_mute_latch_before_it_connects(
     ):
         await bridge._start_protocol_from_chunk()
 
-    assert order == ["sync", "connect"]
+    assert order == ["release_mute", "connect"]
 
 
 async def test_a_kept_process_keeps_a_mute_latch_owned_by_another_control() -> None:

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -532,19 +532,19 @@ async def test_cold_start_connects_then_anchors_first_start() -> None:
     assert bridge._airplay_stream_ready.is_set()
 
 
-async def test_a_fresh_process_is_told_the_synced_volume_and_mute() -> None:
+async def test_a_fresh_process_releases_a_foreign_mute_latch_before_it_connects() -> None:
     """
-    A cold start syncs volume and mute from the parent before it connects.
+    A cold start releases a foreign mute latch before it connects.
 
-    Connecting is what carries that state to the device, so a sync after it
-    would not be heard until the next command.
+    Connecting is what carries that state to the device, so releasing the latch
+    after it would not be heard until the next command.
     """
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
     bridge._airplay_stream_start_task = asyncio.current_task()
     stream = _make_anchor_stream()
     order: list[str] = []
-    cast("MagicMock", bridge.airplay_player).sync_volume_state = MagicMock(
+    cast("MagicMock", bridge.airplay_player).release_foreign_mute_latch = MagicMock(
         side_effect=lambda: order.append("sync")
     )
     stream.connect = AsyncMock(side_effect=lambda *_a, **_kw: order.append("connect"))
@@ -564,13 +564,13 @@ async def test_a_fresh_process_is_told_the_synced_volume_and_mute() -> None:
     assert order == ["sync", "connect"]
 
 
-async def test_a_kept_process_keeps_the_volume_and_mute_it_plays_at() -> None:
+async def test_a_kept_process_keeps_a_mute_latch_owned_by_another_control() -> None:
     """
-    A warm handover does not re-sync volume and mute from the parent player.
+    A warm handover does not release a foreign mute latch.
 
-    Only a connect re-sends VOLUME=, so a sync over a kept process would move our
-    state away from what the speaker is playing at -- most visibly by clearing a
-    mute the device is still holding, leaving it silent with nothing to say so.
+    Only a connect re-sends VOLUME=, so releasing the latch over a kept process
+    would clear it while the device is still muted on its own end, leaving the
+    stream silent with nothing to say so.
     """
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     kept_stream = _make_anchor_stream()
@@ -591,15 +591,15 @@ async def test_a_kept_process_keeps_the_volume_and_mute_it_plays_at() -> None:
         await bridge._start_protocol_from_chunk()
 
     kept_stream.flush.assert_awaited_once_with()
-    cast("MagicMock", bridge.airplay_player).sync_volume_state.assert_not_called()
+    cast("MagicMock", bridge.airplay_player).release_foreign_mute_latch.assert_not_called()
 
 
-async def test_a_failed_warm_handover_syncs_before_its_cold_retry() -> None:
+async def test_a_failed_warm_handover_releases_the_latch_before_its_cold_retry() -> None:
     """
-    The cold retry after a failed warm handover is not left with un-synced state.
+    The cold retry after a failed warm handover still releases a foreign mute latch.
 
     That retry spawns a fresh process, which is sent whatever volume and mute it
-    finds on connect, so a mute the parent no longer owns would start it silent.
+    finds on connect, so a mute latch the parent no longer owns would start it silent.
     """
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
@@ -622,7 +622,7 @@ async def test_a_failed_warm_handover_syncs_before_its_cold_retry() -> None:
         await bridge._start_protocol_from_chunk()
 
     cold_stream.connect.assert_awaited_once_with(False)
-    cast("MagicMock", bridge.airplay_player).sync_volume_state.assert_called_once_with()
+    cast("MagicMock", bridge.airplay_player).release_foreign_mute_latch.assert_called_once_with()
 
 
 async def test_a_superseded_cold_start_never_reaches_the_receiver() -> None:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2251,6 +2251,87 @@ async def test_deferred_volume_resend_reads_the_state_when_it_fires() -> None:
 
 
 @pytest.mark.asyncio
+async def test_wait_for_connection_sends_volume_when_player_owns_it() -> None:
+    """The initial volume push is sent when this output owns its own volume."""
+    player = _make_player()
+    player.owns_volume = True
+    player.volume_muted = False
+    stream = AirPlayStream(player)
+    stream._connected.set()
+
+    with (
+        patch.object(stream, "_cli_proc", MagicMock()),
+        patch.object(stream.commands_pipe, "wait_for_reader", new=AsyncMock(return_value=True)),
+        patch.object(stream, "_send_current_metadata", new_callable=AsyncMock),
+        patch.object(stream, "send_cli_command", new_callable=AsyncMock) as send_command,
+    ):
+        await stream.wait_for_connection()
+
+    send_command.assert_awaited_with(f"VOLUME={player.volume_level}")
+
+
+@pytest.mark.asyncio
+async def test_wait_for_connection_skips_volume_when_another_control_owns_it() -> None:
+    """No unsolicited volume push when another control owns this output's volume."""
+    player = _make_player()
+    player.owns_volume = False
+    player.volume_muted = False
+    stream = AirPlayStream(player)
+    stream._connected.set()
+
+    with (
+        patch.object(stream, "_cli_proc", MagicMock()),
+        patch.object(stream.commands_pipe, "wait_for_reader", new=AsyncMock(return_value=True)),
+        patch.object(stream, "_send_current_metadata", new_callable=AsyncMock),
+        patch.object(stream, "send_cli_command", new_callable=AsyncMock) as send_command,
+    ):
+        await stream.wait_for_connection()
+
+    send_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_connection_sends_volume_when_muted_without_ownership() -> None:
+    """A latched mute is still pushed even when another control owns the volume."""
+    player = _make_player()
+    player.owns_volume = False
+    player.volume_muted = True
+    stream = AirPlayStream(player)
+    stream._connected.set()
+
+    with (
+        patch.object(stream, "_cli_proc", MagicMock()),
+        patch.object(stream.commands_pipe, "wait_for_reader", new=AsyncMock(return_value=True)),
+        patch.object(stream, "_send_current_metadata", new_callable=AsyncMock),
+        patch.object(stream, "send_cli_command", new_callable=AsyncMock) as send_command,
+    ):
+        await stream.wait_for_connection()
+
+    send_command.assert_awaited_with("VOLUME=0")
+
+
+@pytest.mark.asyncio
+async def test_wait_for_connection_sends_volume_for_a_requested_session_volume() -> None:
+    """A volume explicitly requested for the session is pushed, even without ownership."""
+    player = _make_player()
+    player.owns_volume = False
+    player.volume_muted = False
+    stream = AirPlayStream(player)
+    stream._connected.set()
+    stream.session = MagicMock(requested_volume=85)
+
+    with (
+        patch.object(stream, "_cli_proc", MagicMock()),
+        patch.object(stream.commands_pipe, "wait_for_reader", new=AsyncMock(return_value=True)),
+        patch.object(stream, "_send_current_metadata", new_callable=AsyncMock),
+        patch.object(stream, "send_cli_command", new_callable=AsyncMock) as send_command,
+    ):
+        await stream.wait_for_connection()
+
+    send_command.assert_awaited_with(f"VOLUME={player.volume_level}")
+
+
+@pytest.mark.asyncio
 async def test_wait_for_connection_fails_on_an_unread_command_pipe() -> None:
     """A binary that never attaches to the command pipe can never be anchored: fail the connect."""
     player = _make_player()

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1881,21 +1881,9 @@ async def test_late_join_silence_pad_is_bounded_and_reports_the_residual() -> No
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("requested_volume", "expected_adopt"),
-    [(85, False), (None, True)],
-)
-async def test_start_client_keeps_a_volume_requested_for_the_session(
-    requested_volume: int | None, expected_adopt: bool
-) -> None:
-    """
-    Keep a volume requested for the session, but only when there actually is one.
-
-    An announcement without a volume strategy requests none, so its members must still
-    take their level from their parent player.
-    """
+async def test_start_client_releases_a_foreign_mute_latch() -> None:
+    """A client joining the session gets its foreign mute latch released on start."""
     session = _make_session(start_time=0.0, seconds_streamed=0.0)
-    session.requested_volume = requested_volume
     player = _make_late_joiner()
 
     with (
@@ -1907,4 +1895,4 @@ async def test_start_client_keeps_a_volume_requested_for_the_session(
     ):
         await session._start_client(player, use_shared_ptp=False)
 
-    player.sync_volume_state.assert_called_once_with(adopt_parent_volume=expected_adopt)
+    player.release_foreign_mute_latch.assert_called_once_with()


### PR DESCRIPTION
# What does this implement/fix?

An AirPlay volume command does not attenuate the stream - it sets the speaker's own volume, and that level stays behind on the device after playback ends. Music Assistant was pushing a volume at the start of every stream, so it kept overwriting the level users had set on the speaker itself, and the two drifted apart.

For a device that is also reachable another way (a Sonos speaker, an AV receiver, anything with a native provider), the volume now simply stays where the user set it. Music Assistant only sends a volume when nothing else owns it.

This also removes the "play at unity gain" behaviour, which set the AirPlay volume to 100 when another control owned the volume. That assumed AirPlay was a separate gain stage in front of the device volume; it is not, so it was turning speakers up to full instead.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- no volume is sent when the stream starts, and `--volume` is no longer passed to the streaming binary
- removed the parent-volume adoption and the unity-gain reset
- a volume is still sent when the AirPlay output itself is the volume control, when a mute has to travel with the stream, and when an announcement asks for a specific level
- device-initiated volume changes over DACP keep working as before

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

