### PR TITLE
Set C.UTF-8 locale in Docker base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -179,6 +179,9 @@ RUN set -x \
 
 FROM python:${PYTHON_VERSION}-slim-trixie
 
+# Ensure UTF-8 encoding across system
+ENV LANG=C.UTF-8
+
 # Enable non-free and contrib repositories for codec libraries
 # (trixie uses the deb822 sources format)
 RUN sed -i 's/^Components: .*/Components: main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources


### PR DESCRIPTION
In minimal base images like python:3.14-slim-trixie, the default system locale falls back to POSIX/ASCII (C). When mounting external volumes (such as Local, SMB, or NFS shares) containing files or folders with non-ASCII/ Unicode characters, file and directory names are improperly rendered.

Setting LANG=C.UTF-8 forces glibc, underlying C libraries locale detection to use multi-byte UTF-8 encoding for mounted filesystems and subprocesses.

This variable is set in the final stage of Dockerfile.base so all downstream server builds and development add-ons inherit it automatically.

# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

**Related issue (if applicable):**

- proper handling of non-ASCII and Unicode file and directory names across all file providers (Local, SMB, NFS)
- zero overhead on Docker image size, as C.UTF-8 is natively supported by glibc/Debian without requiring extra locale packages
- consistent filesystem path decoding regardless of host environment variables
- related PR: #5653

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
