### PR TITLE
Volume and mute always come from the control that owns them

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3673,15 +3673,13 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             await player_control.volume_set(device_volume)
             return
         if protocol_player := self.get_player(player.state.volume_control):
-            # redirect to protocol player volume control.
-            # forward the already-scaled device volume so the min/max limits configured
-            # on this (user-facing) player are honored; the protocol player has no
-            # limits of its own, so its scaling is an identity pass-through.
+            # forward the already-scaled device volume: the limits configured on this
+            # (user-facing) player are the only ones that apply to the command
             self.logger.debug(
                 "Redirecting volume command to protocol player %s",
                 protocol_player.provider.manifest.name,
             )
-            await self._handle_cmd_volume_set(protocol_player.player_id, device_volume)
+            await protocol_player.volume_set(device_volume)
             return
 
     @staticmethod

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -2620,33 +2620,16 @@ class Player(ABC):
             return None
         # handle protocol player as volume control
         if control := self.mass.players.get_player(volume_control):
-            control_volume = control.volume_level
-            if (
-                control_volume == 0
-                and control.player_id != self.active_output_protocol
-                and any(
-                    linked.output_protocol_id == control.player_id
-                    for linked in self.linked_output_protocols
-                )
-            ):
-                # A linked protocol interface that is not actively rendering audio
-                # may report volume 0 while the device is in standby (e.g. the cast
-                # side of some devices), which doesn't reflect the real device volume.
-                # Treat it as unknown so we fall back to other sources instead of
-                # propagating a spurious hard mute.
-                control_volume = None
-            if control_volume is not None:
-                return self.mass.players.scale_volume_from_device(self.player_id, control_volume)
+            if control.volume_level is None:
+                return None
+            return self.mass.players.scale_volume_from_device(self.player_id, control.volume_level)
         # handle player control for volume if set
         if player_control := self.mass.players.get_player_control(volume_control):
-            if player_control.volume_level is not None:
-                return self.mass.players.scale_volume_from_device(
-                    self.player_id, player_control.volume_level
-                )
-        # control not (yet) available or has no volume, fall back to native
-        if self.volume_level is None:
-            return None
-        return self.mass.players.scale_volume_from_device(self.player_id, self.volume_level)
+            return self.mass.players.scale_volume_from_device(
+                self.player_id, player_control.volume_level
+            )
+        # the configured control is not (yet) registered, so its level is unknown
+        return None
 
     @cached_property
     @final
@@ -2661,14 +2644,12 @@ class Player(ABC):
             return None
         # handle protocol player as mute control
         if control := self.mass.players.get_player(mute_control):
-            if control.volume_muted is not None:
-                return control.volume_muted
+            return control.volume_muted
         # handle player control for mute if set
         if player_control := self.mass.players.get_player_control(mute_control):
-            if player_control.volume_muted is not None:
-                return player_control.volume_muted
-        # control not (yet) available or has no mute state, fall back to native
-        return self.volume_muted
+            return player_control.volume_muted
+        # the configured control is not (yet) registered, so its state is unknown
+        return None
 
     @cached_property
     @final

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -2628,7 +2628,6 @@ class Player(ABC):
             return self.mass.players.scale_volume_from_device(
                 self.player_id, player_control.volume_level
             )
-        # the configured control is not (yet) registered, so its level is unknown
         return None
 
     @cached_property
@@ -2648,7 +2647,6 @@ class Player(ABC):
         # handle player control for mute if set
         if player_control := self.mass.players.get_player_control(mute_control):
             return player_control.volume_muted
-        # the configured control is not (yet) registered, so its state is unknown
         return None
 
     @cached_property

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -590,7 +590,12 @@ class ChromecastPlayer(Player):
 
         # update player status
         self._attr_name = self.cast_info.friendly_name
-        self._attr_volume_level = round(status.volume_level * 100)
+        # A device with no cast app running can report volume 0 while its real volume is
+        # set through another interface (combo devices expose a cast endpoint next to
+        # their own protocol), so keep that unknown instead of reporting a hard mute.
+        volume_level = round(status.volume_level * 100)
+        cast_idle = self.cc.app_id in (None, IDLE_APP_ID)
+        self._attr_volume_level = None if cast_idle and volume_level == 0 else volume_level
         self._attr_volume_muted = status.volume_muted
         self.update_state()
         if self.on_app_status_changed is not None:

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -590,12 +590,17 @@ class ChromecastPlayer(Player):
 
         # update player status
         self._attr_name = self.cast_info.friendly_name
-        # A device with no cast app running can report volume 0 while its real volume is
-        # set through another interface (combo devices expose a cast endpoint next to
-        # their own protocol), so keep that unknown instead of reporting a hard mute.
+        # A combo device exposes this cast endpoint next to its own protocol and can
+        # report volume 0 over it while its real volume is set through that other
+        # interface, so keep that unknown instead of reporting a hard mute. A cast
+        # device that is a player in its own right always reports its own volume.
         volume_level = round(status.volume_level * 100)
         cast_idle = self.cc.app_id in (None, IDLE_APP_ID)
-        self._attr_volume_level = None if cast_idle and volume_level == 0 else volume_level
+        self._attr_volume_level = (
+            None
+            if cast_idle and volume_level == 0 and self.type == PlayerType.PROTOCOL
+            else volume_level
+        )
         self._attr_volume_muted = status.volume_muted
         self.update_state()
         if self.on_app_status_changed is not None:

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -825,7 +825,7 @@ class HomeAssistantProvider(PluginProvider):
             if not hass_state:
                 control.volume_muted = False
             elif entity_platform == "media_player":
-                control.volume_muted = hass_state["attributes"].get("volume_muted")
+                control.volume_muted = bool(hass_state["attributes"].get("is_volume_muted"))
             else:
                 control.volume_muted = hass_state["state"] not in OFF_STATES
             control.mute_set = partial(self._handle_player_control_mute_set, entity_id)
@@ -915,7 +915,7 @@ class HomeAssistantProvider(PluginProvider):
             if player_control.supports_volume and "volume_level" in attributes:
                 player_control.volume_level = int(attributes.get("volume_level", 0) * 100)
             if player_control.supports_mute and "is_volume_muted" in attributes:
-                player_control.volume_muted = attributes.get("is_volume_muted")
+                player_control.volume_muted = bool(attributes.get("is_volume_muted"))
         self.mass.players.update_player_control(entity_id)
 
     async def _fetch_states(self, entity_ids: list[str]) -> list[State]:

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -234,12 +234,7 @@ class SonosPlayer(Player):
 
         :param muted: bool if player should be muted.
         """
-        if not muted and self.volume_level:
-            # when Sonos is playing via Airplay and is muted, we will need to explicitly
-            # send the volume level after unmute as the Airplay cli is still at volume 0
-            await self.client.player.set_volume(volume=self.volume_level, muted=muted)
-        else:
-            await self.client.player.set_volume(muted=muted)
+        await self.client.player.set_volume(muted=muted)
 
     async def play(self) -> None:
         """Handle PLAY command on the player."""

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1737,6 +1737,35 @@ class TestVolumeScalingOnRedirect:
         protocol.volume_set.assert_awaited_once_with(50)
 
     @pytest.mark.asyncio
+    async def test_protocol_redirect_applies_the_limits_only_once(
+        self, controller: PlayerController, mock_mass: MagicMock
+    ) -> None:
+        """Limits configured on the protocol player do not scale the command a second time."""
+
+        def _conf(_player_id: str, key: str, default: object = None) -> object:
+            if key == "min_volume":
+                return 0
+            if key == "max_volume":
+                # both players carry a limit; only the addressed one may apply
+                return 50
+            return default
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_conf)
+
+        protocol = self._volume_player("protocol_player", PLAYER_CONTROL_NATIVE)
+        user = self._volume_player("user_player", "protocol_player")
+        players = {"user_player": user, "protocol_player": protocol}
+
+        with (
+            patch.object(controller, "get_player", side_effect=players.get),
+            patch.object(controller, "_get_active_audio_source", return_value=None),
+        ):
+            controller._controls = {}
+            await controller._handle_cmd_volume_set("user_player", 100)
+
+        protocol.volume_set.assert_awaited_once_with(50)
+
+    @pytest.mark.asyncio
     async def test_external_control_redirect_forwards_scaled_volume(
         self, controller: PlayerController, mock_mass: MagicMock
     ) -> None:

--- a/tests/models/test_player_volume.py
+++ b/tests/models/test_player_volume.py
@@ -2,10 +2,10 @@
 Tests for Player model final volume/mute state resolution.
 
 Covers __final_volume_level and __final_volume_muted_state, which read the
-volume/mute exclusively from the control that volume_control/mute_control
-resolves to: a missing control player falls back to the player's own native
-state, but a resolved control that reports None (or isn't registered at all)
-yields an unknown (None) final state.
+final volume/mute exclusively from whichever control volume_control/mute_control
+resolves to (native, a protocol player, or an external player control). The
+final state is None (unknown) whenever that resolved control itself reports
+no value.
 """
 
 from __future__ import annotations
@@ -16,7 +16,6 @@ import pytest
 from music_assistant_models.enums import PlayerFeature
 
 from music_assistant.constants import CONF_MUTE_CONTROL, CONF_VOLUME_CONTROL
-from music_assistant.models.player import LinkedOutputProtocol
 from tests.common import MockPlayer, MockProvider
 
 
@@ -36,7 +35,7 @@ def mock_mass() -> MagicMock:
 
 
 class TestFinalVolumeLevel:
-    """Test __final_volume_level fallback behaviour."""
+    """Test __final_volume_level resolution against the control volume_control resolves to."""
 
     def test_uses_control_player_when_available(self, mock_mass: MagicMock) -> None:
         """Final volume uses the control player's volume when it is present."""
@@ -99,54 +98,6 @@ class TestFinalVolumeLevel:
         player.update_state(signal_event=False)
         assert player.state.volume_level is None
 
-    def test_reports_unknown_when_no_control_is_registered(self, mock_mass: MagicMock) -> None:
-        """Final volume is unknown when no native, protocol, or external control resolves."""
-        mock_mass.config.get_raw_player_config_value = MagicMock(
-            side_effect=lambda _pid, key, *_a: (
-                "ghost_control" if key == CONF_VOLUME_CONTROL else None
-            )
-        )
-        provider = MockProvider("test", mass=mock_mass)
-        player = MockPlayer(provider, "main_player", "Main")
-        # without native VOLUME_SET support, the auto-select can not fall back to it
-        player._attr_supported_features.discard(PlayerFeature.VOLUME_SET)
-        player._attr_volume_level = 55
-
-        mock_mass.players.get_player = MagicMock(return_value=None)
-        mock_mass.players.get_player_control = MagicMock(return_value=None)
-
-        player.update_state(signal_event=False)
-        assert player.state.volume_level is None
-
-    def test_uses_zero_from_active_linked_protocol(self, mock_mass: MagicMock) -> None:
-        """Volume 0 from the linked protocol that is actively rendering is trusted."""
-        mock_mass.config.get_raw_player_config_value = MagicMock(
-            side_effect=lambda _pid, key, *_a: "cast_child" if key == CONF_VOLUME_CONTROL else None
-        )
-        provider = MockProvider("test", mass=mock_mass)
-        player = MockPlayer(provider, "main_player", "Main")
-        player._attr_volume_level = 55
-        player.set_linked_output_protocols(
-            [
-                LinkedOutputProtocol(
-                    output_protocol_id="cast_child",
-                    protocol_domain="chromecast",
-                )
-            ]
-        )
-
-        control = MagicMock()
-        control.player_id = "cast_child"
-        control.volume_level = 0
-        mock_mass.players.get_player = MagicMock(return_value=control)
-        mock_mass.players.get_player_control = MagicMock(return_value=None)
-        # With default min=0, max=100, scaling is identity
-        mock_mass.players.scale_volume_from_device = MagicMock(side_effect=lambda _pid, vol: vol)
-
-        player.set_active_output_protocol("cast_child")
-        player.update_state(signal_event=False)
-        assert player.state.volume_level == 0
-
     def test_uses_zero_from_external_control_player(self, mock_mass: MagicMock) -> None:
         """Volume 0 from an external (non-linked) control player is trusted as genuine."""
         mock_mass.config.get_raw_player_config_value = MagicMock(
@@ -169,7 +120,7 @@ class TestFinalVolumeLevel:
 
 
 class TestFinalVolumeMutedState:
-    """Test __final_volume_muted_state fallback behaviour."""
+    """Test __final_volume_muted_state resolution against the control mute_control resolves to."""
 
     def test_uses_control_player_when_available(self, mock_mass: MagicMock) -> None:
         """Final mute state uses the control player's mute state when present."""
@@ -242,30 +193,6 @@ class TestFinalVolumeMutedState:
         control = MagicMock()
         control.volume_muted = None
         mock_mass.players.get_player = MagicMock(return_value=control)
-        mock_mass.players.get_player_control = MagicMock(return_value=None)
-
-        player.update_state(signal_event=False)
-        assert player.state.volume_muted is None
-
-    def test_reports_unknown_when_no_control_is_registered(self, mock_mass: MagicMock) -> None:
-        """Final mute state is unknown when no native, protocol, or external control resolves."""
-        mock_mass.config.get_raw_player_config_value = MagicMock(
-            side_effect=lambda _pid, key, default=None: (
-                "ghost_control"
-                if key == CONF_MUTE_CONTROL
-                else 0
-                if key == "min_volume"
-                else 100
-                if key == "max_volume"
-                else default
-            ),
-        )
-        provider = MockProvider("test", mass=mock_mass)
-        player = MockPlayer(provider, "main_player", "Main")
-        # without native VOLUME_MUTE support, the auto-select can not fall back to it
-        player._attr_volume_muted = True
-
-        mock_mass.players.get_player = MagicMock(return_value=None)
         mock_mass.players.get_player_control = MagicMock(return_value=None)
 
         player.update_state(signal_event=False)

--- a/tests/models/test_player_volume.py
+++ b/tests/models/test_player_volume.py
@@ -1,9 +1,11 @@
 """
-Tests for Player model final volume/mute state fallback logic.
+Tests for Player model final volume/mute state resolution.
 
-Covers the fallback-to-native behavior in __final_volume_level and
-__final_volume_muted_state when a configured volume/mute control is
-unavailable or returns None.
+Covers __final_volume_level and __final_volume_muted_state, which read the
+volume/mute exclusively from the control that volume_control/mute_control
+resolves to: a missing control player falls back to the player's own native
+state, but a resolved control that reports None (or isn't registered at all)
+yields an unknown (None) final state.
 """
 
 from __future__ import annotations
@@ -76,8 +78,8 @@ class TestFinalVolumeLevel:
         player.update_state(signal_event=False)
         assert player.state.volume_level == 55
 
-    def test_falls_back_to_native_when_control_returns_none(self, mock_mass: MagicMock) -> None:
-        """Final volume falls back to native when the control player's volume is None."""
+    def test_reports_unknown_when_control_has_no_volume(self, mock_mass: MagicMock) -> None:
+        """Final volume is unknown when the resolved control's volume is None."""
         mock_mass.config.get_raw_player_config_value = MagicMock(
             side_effect=lambda _pid, key, *_a: (
                 "control_player" if key == CONF_VOLUME_CONTROL else None
@@ -95,35 +97,26 @@ class TestFinalVolumeLevel:
         mock_mass.players.scale_volume_from_device = MagicMock(side_effect=lambda _pid, vol: vol)
 
         player.update_state(signal_event=False)
-        assert player.state.volume_level == 42
+        assert player.state.volume_level is None
 
-    def test_ignores_zero_from_idle_linked_protocol(self, mock_mass: MagicMock) -> None:
-        """Volume 0 from a linked protocol that is not the active output is not authoritative."""
+    def test_reports_unknown_when_no_control_is_registered(self, mock_mass: MagicMock) -> None:
+        """Final volume is unknown when no native, protocol, or external control resolves."""
         mock_mass.config.get_raw_player_config_value = MagicMock(
-            side_effect=lambda _pid, key, *_a: "cast_child" if key == CONF_VOLUME_CONTROL else None
+            side_effect=lambda _pid, key, *_a: (
+                "ghost_control" if key == CONF_VOLUME_CONTROL else None
+            )
         )
         provider = MockProvider("test", mass=mock_mass)
         player = MockPlayer(provider, "main_player", "Main")
+        # without native VOLUME_SET support, the auto-select can not fall back to it
+        player._attr_supported_features.discard(PlayerFeature.VOLUME_SET)
         player._attr_volume_level = 55
-        player.set_linked_output_protocols(
-            [
-                LinkedOutputProtocol(
-                    output_protocol_id="cast_child",
-                    protocol_domain="chromecast",
-                )
-            ]
-        )
 
-        control = MagicMock()
-        control.player_id = "cast_child"
-        control.volume_level = 0
-        mock_mass.players.get_player = MagicMock(return_value=control)
+        mock_mass.players.get_player = MagicMock(return_value=None)
         mock_mass.players.get_player_control = MagicMock(return_value=None)
-        # With default min=0, max=100, scaling is identity
-        mock_mass.players.scale_volume_from_device = MagicMock(side_effect=lambda _pid, vol: vol)
 
         player.update_state(signal_event=False)
-        assert player.state.volume_level == 55
+        assert player.state.volume_level is None
 
     def test_uses_zero_from_active_linked_protocol(self, mock_mass: MagicMock) -> None:
         """Volume 0 from the linked protocol that is actively rendering is trusted."""
@@ -228,8 +221,8 @@ class TestFinalVolumeMutedState:
         player.update_state(signal_event=False)
         assert player.state.volume_muted is True
 
-    def test_falls_back_to_native_when_control_returns_none(self, mock_mass: MagicMock) -> None:
-        """Final mute state falls back to native when the control's mute is None."""
+    def test_reports_unknown_when_control_has_no_mute_state(self, mock_mass: MagicMock) -> None:
+        """Final mute state is unknown when the resolved control's mute state is None."""
         mock_mass.config.get_raw_player_config_value = MagicMock(
             side_effect=lambda _pid, key, default=None: (
                 "control_player"
@@ -252,4 +245,28 @@ class TestFinalVolumeMutedState:
         mock_mass.players.get_player_control = MagicMock(return_value=None)
 
         player.update_state(signal_event=False)
-        assert player.state.volume_muted is False
+        assert player.state.volume_muted is None
+
+    def test_reports_unknown_when_no_control_is_registered(self, mock_mass: MagicMock) -> None:
+        """Final mute state is unknown when no native, protocol, or external control resolves."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=lambda _pid, key, default=None: (
+                "ghost_control"
+                if key == CONF_MUTE_CONTROL
+                else 0
+                if key == "min_volume"
+                else 100
+                if key == "max_volume"
+                else default
+            ),
+        )
+        provider = MockProvider("test", mass=mock_mass)
+        player = MockPlayer(provider, "main_player", "Main")
+        # without native VOLUME_MUTE support, the auto-select can not fall back to it
+        player._attr_volume_muted = True
+
+        mock_mass.players.get_player = MagicMock(return_value=None)
+        mock_mass.players.get_player_control = MagicMock(return_value=None)
+
+        player.update_state(signal_event=False)
+        assert player.state.volume_muted is None

--- a/tests/providers/chromecast/test_cast_status_volume.py
+++ b/tests/providers/chromecast/test_cast_status_volume.py
@@ -5,7 +5,9 @@ A combo device (e.g. a TV or amplifier with a Cast endpoint next to its own
 protocol) reports volume 0 through its Cast interface whenever no Cast app is
 running, even though its real volume is set through the other interface. That
 0 is not authoritative and must not be reported as a hard mute, so an idle
-Cast player reporting 0 is treated as "unknown" instead.
+Cast player reporting 0 is treated as "unknown" instead. This only applies to
+a combo device's Cast endpoint (PlayerType.PROTOCOL); a standalone Google Cast
+player reporting 0 while idle is a genuine mute.
 """
 
 from __future__ import annotations
@@ -13,6 +15,7 @@ from __future__ import annotations
 from typing import cast
 from unittest.mock import MagicMock
 
+from music_assistant_models.enums import PlayerType
 from pychromecast import IDLE_APP_ID
 
 from music_assistant.providers.chromecast.constants import MASS_APP_ID
@@ -23,11 +26,12 @@ def _handle_cast_status(fake: MagicMock, status: MagicMock) -> None:
     ChromecastPlayer._handle_cast_status(cast("ChromecastPlayer", fake), status)
 
 
-def _fake_player(app_id: str | None) -> MagicMock:
+def _fake_player(app_id: str | None, player_type: PlayerType = PlayerType.PLAYER) -> MagicMock:
     """
     Build a MagicMock standing in for an ungrouped ChromecastPlayer.
 
     :param app_id: Cast application id the (mocked) Chromecast currently reports.
+    :param player_type: Player type to report, defaults to a standalone Cast player.
     """
     fake = MagicMock()
     fake.mass.closing = False
@@ -35,6 +39,7 @@ def _fake_player(app_id: str | None) -> MagicMock:
     fake.cast_info.is_multichannel_group = False
     fake.cast_info.is_audio_group = False
     fake.on_app_status_changed = None
+    fake.type = player_type
     return fake
 
 
@@ -53,8 +58,8 @@ def _cast_status(*, volume_level: float, volume_muted: bool = False) -> MagicMoc
 
 
 def test_idle_cast_reporting_zero_volume_is_unknown() -> None:
-    """No Cast app running and a reported volume of 0 is not authoritative."""
-    fake = _fake_player(app_id=None)
+    """No Cast app running on a combo device's Cast endpoint, reported 0 is not authoritative."""
+    fake = _fake_player(app_id=None, player_type=PlayerType.PROTOCOL)
 
     _handle_cast_status(fake, _cast_status(volume_level=0.0))
 
@@ -73,6 +78,15 @@ def test_idle_cast_reporting_nonzero_volume_is_kept() -> None:
 def test_active_cast_reporting_zero_volume_is_kept() -> None:
     """A Cast app actively rendering and reporting 0 volume means a genuine mute."""
     fake = _fake_player(app_id=MASS_APP_ID)
+
+    _handle_cast_status(fake, _cast_status(volume_level=0.0))
+
+    assert fake._attr_volume_level == 0
+
+
+def test_idle_standalone_cast_player_reporting_zero_volume_is_kept() -> None:
+    """A standalone Cast player (e.g. a Nest speaker) idle at 0 volume is a genuine mute."""
+    fake = _fake_player(app_id=None, player_type=PlayerType.PLAYER)
 
     _handle_cast_status(fake, _cast_status(volume_level=0.0))
 

--- a/tests/providers/chromecast/test_cast_status_volume.py
+++ b/tests/providers/chromecast/test_cast_status_volume.py
@@ -1,0 +1,79 @@
+"""
+Tests for how ChromecastPlayer reports volume from a CastStatus.
+
+A combo device (e.g. a TV or amplifier with a Cast endpoint next to its own
+protocol) reports volume 0 through its Cast interface whenever no Cast app is
+running, even though its real volume is set through the other interface. That
+0 is not authoritative and must not be reported as a hard mute, so an idle
+Cast player reporting 0 is treated as "unknown" instead.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import MagicMock
+
+from pychromecast import IDLE_APP_ID
+
+from music_assistant.providers.chromecast.constants import MASS_APP_ID
+from music_assistant.providers.chromecast.player import ChromecastPlayer
+
+
+def _handle_cast_status(fake: MagicMock, status: MagicMock) -> None:
+    ChromecastPlayer._handle_cast_status(cast("ChromecastPlayer", fake), status)
+
+
+def _fake_player(app_id: str | None) -> MagicMock:
+    """
+    Build a MagicMock standing in for an ungrouped ChromecastPlayer.
+
+    :param app_id: Cast application id the (mocked) Chromecast currently reports.
+    """
+    fake = MagicMock()
+    fake.mass.closing = False
+    fake.cc.app_id = app_id
+    fake.cast_info.is_multichannel_group = False
+    fake.cast_info.is_audio_group = False
+    fake.on_app_status_changed = None
+    return fake
+
+
+def _cast_status(*, volume_level: float, volume_muted: bool = False) -> MagicMock:
+    """
+    Build a CastStatus as the receiver reports it.
+
+    :param volume_level: Volume level (0..1) as reported by the Cast interface.
+    :param volume_muted: Mute state as reported by the Cast interface.
+    """
+    status = MagicMock()
+    status.app_id = None
+    status.volume_level = volume_level
+    status.volume_muted = volume_muted
+    return status
+
+
+def test_idle_cast_reporting_zero_volume_is_unknown() -> None:
+    """No Cast app running and a reported volume of 0 is not authoritative."""
+    fake = _fake_player(app_id=None)
+
+    _handle_cast_status(fake, _cast_status(volume_level=0.0))
+
+    assert fake._attr_volume_level is None
+
+
+def test_idle_cast_reporting_nonzero_volume_is_kept() -> None:
+    """No Cast app running but a non-zero reported volume is still real."""
+    fake = _fake_player(app_id=IDLE_APP_ID)
+
+    _handle_cast_status(fake, _cast_status(volume_level=0.35))
+
+    assert fake._attr_volume_level == 35
+
+
+def test_active_cast_reporting_zero_volume_is_kept() -> None:
+    """A Cast app actively rendering and reporting 0 volume means a genuine mute."""
+    fake = _fake_player(app_id=MASS_APP_ID)
+
+    _handle_cast_status(fake, _cast_status(volume_level=0.0))
+
+    assert fake._attr_volume_level == 0


### PR DESCRIPTION
# What does this implement/fix?

Volume and mute handling had grown a layer of compensating logic on top of the control resolution: the final state read the control that owns the volume, then quietly fell back to the player's own level when that control had no answer, and rewrote a reported zero it did not trust. A volume command redirected to a protocol player took a different route than a mute, and applied the volume limits twice.

This makes both sides follow one rule: resolve which control owns the volume, and read or write only that control.

Stacked on #5694.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- the volume and mute a player reports now come from the control that owns them; when that control has no value, the state is unknown instead of borrowed from elsewhere
- a cast endpoint with no app running reports its volume as unknown rather than zero, so it no longer needs correcting afterwards
- a volume redirected to a protocol player is delivered the same way a mute is, so the volume limits are applied by one player only
- Home Assistant mute controls read the attribute a media player actually publishes, so their mute state is known from the start
- unmuting a Sonos no longer re-sends its volume level to work around an attenuated AirPlay stream that no longer happens

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.


