### PR TITLE
Hue lights sync no longer restarts when you change brightness or colour mode

### DIFF
--- a/music_assistant/providers/hue_entertainment/bridge.py
+++ b/music_assistant/providers/hue_entertainment/bridge.py
@@ -34,17 +34,14 @@ from music_assistant.providers.sendspin.bridge_role import (
 
 from .analyzer import HueAudioAnalyzer
 from .constants import (
-    CONF_BRIGHTNESS,
     CONF_CLIENTKEY,
-    CONF_COLOR_MODE,
-    CONF_HUE_LATENCY_MS,
     CONF_USERNAME,
-    DEFAULT_HUE_LATENCY_MS,
     SPECTRUM_BINS,
     SPECTRUM_F_MAX,
     SPECTRUM_F_MIN,
     SPECTRUM_SCALE,
 )
+from .settings import get_brightness, get_color_mode, get_hue_latency_ms
 
 if TYPE_CHECKING:
     from aiosendspin.models.core import ServerStatePayload
@@ -109,24 +106,14 @@ class HueEntertainmentBridge:
         self._start_task: asyncio.Task[None] | None = None
         self._render_handle: asyncio.TimerHandle | None = None
         self._entertainment_starting: bool = False
-        self._hue_latency_us: int = (
-            int(
-                float(
-                    str(
-                        self.provider.config.get_value(CONF_HUE_LATENCY_MS)
-                        or DEFAULT_HUE_LATENCY_MS
-                    )
-                )
-            )
-            * 1000
-        )
+        self._hue_latency_us: int = get_hue_latency_ms(self.provider.config) * 1000
 
     async def start(self) -> None:
         """Start the bridge — register as an in-process Sendspin visualizer client."""
         self._analyzer = HueAudioAnalyzer(
             channels=self.area.channels,
-            color_mode=str(self.provider.config.get_value(CONF_COLOR_MODE) or "smooth"),
-            brightness=int(float(str(self.provider.config.get_value(CONF_BRIGHTNESS) or 100))),
+            color_mode=get_color_mode(self.provider.config),
+            brightness=get_brightness(self.provider.config),
         )
 
         client_id = f"hue-{self.area.id.replace('-', '')[:16]}"

--- a/music_assistant/providers/hue_entertainment/constants.py
+++ b/music_assistant/providers/hue_entertainment/constants.py
@@ -18,6 +18,8 @@ CONF_HUE_LATENCY_MS: Final[str] = "hue_latency_ms"
 COLOR_MODES: Final[tuple[str, ...]] = ("smooth", "ambient", "flashing", "energetic")
 DEFAULT_COLOR_MODE: Final[str] = COLOR_MODES[0]
 
+DEFAULT_BRIGHTNESS: Final[int] = 100
+
 DEFAULT_HUE_LATENCY_MS: Final[int] = 20
 
 HUE_MDNS_TYPE: Final[str] = "_hue._tcp.local."

--- a/music_assistant/providers/hue_entertainment/provider.py
+++ b/music_assistant/providers/hue_entertainment/provider.py
@@ -27,9 +27,11 @@ from .constants import (
     CONF_COLOR_MODE,
     CONF_HUE_LATENCY_MS,
     CONF_USERNAME,
+    DEFAULT_BRIGHTNESS,
     DEFAULT_COLOR_MODE,
     DEFAULT_HUE_LATENCY_MS,
 )
+from .settings import get_brightness, get_color_mode, get_hue_latency_ms
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ProviderConfig
@@ -68,7 +70,7 @@ class HueEntertainmentProvider(PluginProvider):
             ConfigEntry(
                 key=CONF_BRIGHTNESS,
                 type=ConfigEntryType.INTEGER,
-                default_value=100,
+                default_value=DEFAULT_BRIGHTNESS,
                 range=(0, 100),
                 category="settings",
             ),
@@ -221,14 +223,11 @@ class HueEntertainmentProvider(PluginProvider):
         }
         if changed_keys and changed_keys <= settings_keys and self._bridge_manager:
             self._bridge_manager.update_settings(
-                color_mode=str(config.get_value(CONF_COLOR_MODE) or "smooth"),
-                brightness=int(float(str(config.get_value(CONF_BRIGHTNESS) or 100))),
-                hue_latency_ms=int(
-                    float(str(config.get_value(CONF_HUE_LATENCY_MS) or DEFAULT_HUE_LATENCY_MS))
-                ),
+                color_mode=get_color_mode(config),
+                brightness=get_brightness(config),
+                hue_latency_ms=get_hue_latency_ms(config),
             )
             self.config = config
             return
 
-        # For other changes (host, credentials), do a full reload
         await super().update_config(config, changed_keys)

--- a/music_assistant/providers/hue_entertainment/provider.py
+++ b/music_assistant/providers/hue_entertainment/provider.py
@@ -213,8 +213,13 @@ class HueEntertainmentProvider(PluginProvider):
         Settings like brightness/color_mode can be updated
         without a full provider reload.
         """
-        settings_keys = {CONF_BRIGHTNESS, CONF_COLOR_MODE, CONF_HUE_LATENCY_MS}
-        if changed_keys & settings_keys and self._bridge_manager:
+        # changed_keys arrive namespaced as 'values/<key>'; only skip the reload when
+        # every changed key can be applied in place (anything else, including the
+        # log level, still needs the base implementation).
+        settings_keys = {
+            f"values/{key}" for key in (CONF_BRIGHTNESS, CONF_COLOR_MODE, CONF_HUE_LATENCY_MS)
+        }
+        if changed_keys and changed_keys <= settings_keys and self._bridge_manager:
             self._bridge_manager.update_settings(
                 color_mode=str(config.get_value(CONF_COLOR_MODE) or "smooth"),
                 brightness=int(float(str(config.get_value(CONF_BRIGHTNESS) or 100))),

--- a/music_assistant/providers/hue_entertainment/settings.py
+++ b/music_assistant/providers/hue_entertainment/settings.py
@@ -1,0 +1,48 @@
+"""Readers for the Hue Lights Sync playback settings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .constants import (
+    CONF_BRIGHTNESS,
+    CONF_COLOR_MODE,
+    CONF_HUE_LATENCY_MS,
+    DEFAULT_BRIGHTNESS,
+    DEFAULT_COLOR_MODE,
+    DEFAULT_HUE_LATENCY_MS,
+)
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ProviderConfig
+
+
+def get_color_mode(config: ProviderConfig) -> str:
+    """
+    Return the configured visualization mode.
+
+    :param config: Provider config to read the setting from.
+    """
+    value = config.get_value(CONF_COLOR_MODE)
+    return DEFAULT_COLOR_MODE if value is None else str(value)
+
+
+def get_brightness(config: ProviderConfig) -> int:
+    """
+    Return the configured brightness percentage.
+
+    :param config: Provider config to read the setting from.
+    """
+    value = config.get_value(CONF_BRIGHTNESS)
+    # stored numbers can come back as float or str, so normalize before truncating
+    return DEFAULT_BRIGHTNESS if value is None else int(float(str(value)))
+
+
+def get_hue_latency_ms(config: ProviderConfig) -> int:
+    """
+    Return the configured latency compensation in milliseconds.
+
+    :param config: Provider config to read the setting from.
+    """
+    value = config.get_value(CONF_HUE_LATENCY_MS)
+    return DEFAULT_HUE_LATENCY_MS if value is None else int(float(str(value)))

--- a/tests/providers/hue_entertainment/test_settings.py
+++ b/tests/providers/hue_entertainment/test_settings.py
@@ -1,0 +1,85 @@
+"""
+Tests for the Hue Lights Sync settings readers.
+
+Brightness and latency both accept 0 as a valid value (the config entries
+declare ranges of 0-100 and 0-3000), so the readers must fall back to the
+default only when nothing is configured.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+from music_assistant_models.enums import ConfigEntryType, ProviderType
+
+from music_assistant.providers.hue_entertainment.constants import (
+    CONF_BRIGHTNESS,
+    CONF_COLOR_MODE,
+    CONF_HUE_LATENCY_MS,
+    DEFAULT_BRIGHTNESS,
+    DEFAULT_COLOR_MODE,
+    DEFAULT_HUE_LATENCY_MS,
+)
+from music_assistant.providers.hue_entertainment.settings import (
+    get_brightness,
+    get_color_mode,
+    get_hue_latency_ms,
+)
+
+
+def _config(**values: ConfigValueType) -> ProviderConfig:
+    """Build a ProviderConfig holding only the given settings."""
+    entries = {}
+    for key, value in values.items():
+        entry = ConfigEntry(key=key, type=ConfigEntryType.STRING)
+        entry.value = value
+        entries[key] = entry
+    return ProviderConfig(
+        type=ProviderType.PLUGIN,
+        domain="hue_entertainment",
+        instance_id="hue_entertainment--test",
+        values=entries,
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(0, 0), (50, 50), (100, 100), ("75", 75), (62.5, 62)],
+    ids=["zero", "mid", "max", "string", "float"],
+)
+def test_get_brightness(value: ConfigValueType, expected: int) -> None:
+    """Brightness is read as-is, including 0."""
+    assert get_brightness(_config(**{CONF_BRIGHTNESS: value})) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(0, 0), (120, 120), ("250", 250)],
+    ids=["zero", "mid", "string"],
+)
+def test_get_hue_latency_ms(value: ConfigValueType, expected: int) -> None:
+    """Latency is read as-is, including 0."""
+    assert get_hue_latency_ms(_config(**{CONF_HUE_LATENCY_MS: value})) == expected
+
+
+def test_get_color_mode() -> None:
+    """Colour mode is read as-is."""
+    assert get_color_mode(_config(**{CONF_COLOR_MODE: "ambient"})) == "ambient"
+
+
+@pytest.mark.parametrize(
+    ("reader", "default"),
+    [
+        (get_brightness, DEFAULT_BRIGHTNESS),
+        (get_hue_latency_ms, DEFAULT_HUE_LATENCY_MS),
+        (get_color_mode, DEFAULT_COLOR_MODE),
+    ],
+    ids=["brightness", "latency", "color_mode"],
+)
+def test_unset_setting_falls_back_to_default(
+    reader: Callable[[ProviderConfig], int | str], default: int | str
+) -> None:
+    """An unconfigured setting yields the default."""
+    assert reader(_config()) == default

--- a/tests/providers/hue_entertainment/test_update_config.py
+++ b/tests/providers/hue_entertainment/test_update_config.py
@@ -1,0 +1,134 @@
+"""
+Tests for ``HueEntertainmentProvider.update_config`` routing.
+
+Brightness, colour mode and latency are applied to the running bridges in
+place; anything else falls through to the base implementation, which reloads
+the provider and therefore drops the entertainment session and the virtual
+players. The changed keys are derived from the real ``Config.update()`` here
+rather than hardcoded, so the test keeps tracking the ``values/`` namespacing
+the models package produces.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+from music_assistant_models.enums import ConfigEntryType, ProviderType
+
+from music_assistant.constants import CONF_LOG_LEVEL
+from music_assistant.models.provider import Provider
+from music_assistant.providers.hue_entertainment.constants import (
+    CONF_BRIGHTNESS,
+    CONF_COLOR_MODE,
+    CONF_HUE_LATENCY_MS,
+)
+from music_assistant.providers.hue_entertainment.provider import HueEntertainmentProvider
+
+
+async def _make_config() -> ProviderConfig:
+    """Build a ProviderConfig holding the provider's own entries plus the log level."""
+    provider = HueEntertainmentProvider.__new__(HueEntertainmentProvider)
+    entries = list(await provider.get_config_entries())
+    entries.append(ConfigEntry(key=CONF_LOG_LEVEL, type=ConfigEntryType.STRING, default_value=None))
+    values = {entry.key: entry for entry in entries}
+    for entry in values.values():
+        entry.value = entry.default_value
+    return ProviderConfig(
+        type=ProviderType.PLUGIN,
+        domain="hue_entertainment",
+        instance_id="hue_entertainment--test",
+        values=values,
+    )
+
+
+def _make_provider(config: ProviderConfig) -> tuple[HueEntertainmentProvider, MagicMock]:
+    """Build a provider with a mocked bridge manager, skipping the framework init."""
+    provider = HueEntertainmentProvider.__new__(HueEntertainmentProvider)
+    provider.mass = MagicMock()
+    provider.config = config
+    provider.logger = logging.getLogger("test")
+    bridge_manager = MagicMock()
+    provider._bridge_manager = bridge_manager
+    return provider, bridge_manager
+
+
+async def test_settings_change_applies_in_place() -> None:
+    """A brightness change updates the bridges without reloading the provider."""
+    config = await _make_config()
+    provider, bridge_manager = _make_provider(config)
+    changed_keys = config.update({CONF_BRIGHTNESS: 50})
+
+    # Guards the premise of the routing: the models package namespaces value keys.
+    assert changed_keys == {f"values/{CONF_BRIGHTNESS}"}
+
+    with patch.object(Provider, "update_config", new_callable=AsyncMock) as base_update:
+        await provider.update_config(config, changed_keys)
+
+    bridge_manager.update_settings.assert_called_once()
+    assert bridge_manager.update_settings.call_args.kwargs["brightness"] == 50
+    base_update.assert_not_awaited()
+    assert provider.config is config
+
+
+@pytest.mark.parametrize(
+    "update",
+    [
+        {CONF_COLOR_MODE: "ambient"},
+        {CONF_HUE_LATENCY_MS: 120},
+        {CONF_BRIGHTNESS: 50, CONF_COLOR_MODE: "ambient", CONF_HUE_LATENCY_MS: 120},
+    ],
+    ids=["color_mode", "latency", "all_settings"],
+)
+async def test_every_in_place_setting_skips_the_reload(update: dict[str, ConfigValueType]) -> None:
+    """Each hot-applyable setting - and any combination of them - avoids the reload."""
+    config = await _make_config()
+    provider, bridge_manager = _make_provider(config)
+    changed_keys = config.update(update)
+
+    with patch.object(Provider, "update_config", new_callable=AsyncMock) as base_update:
+        await provider.update_config(config, changed_keys)
+
+    bridge_manager.update_settings.assert_called_once()
+    base_update.assert_not_awaited()
+
+
+async def test_other_change_falls_through_to_reload() -> None:
+    """A log level change is left to the base implementation."""
+    config = await _make_config()
+    provider, bridge_manager = _make_provider(config)
+    changed_keys = config.update({CONF_LOG_LEVEL: "DEBUG"})
+
+    with patch.object(Provider, "update_config", new_callable=AsyncMock) as base_update:
+        await provider.update_config(config, changed_keys)
+
+    bridge_manager.update_settings.assert_not_called()
+    base_update.assert_awaited_once_with(config, changed_keys)
+
+
+async def test_mixed_change_falls_through_to_reload() -> None:
+    """A setting changed alongside another key must not skip the base implementation."""
+    config = await _make_config()
+    provider, bridge_manager = _make_provider(config)
+    changed_keys = config.update({CONF_BRIGHTNESS: 50, CONF_LOG_LEVEL: "DEBUG"})
+
+    with patch.object(Provider, "update_config", new_callable=AsyncMock) as base_update:
+        await provider.update_config(config, changed_keys)
+
+    bridge_manager.update_settings.assert_not_called()
+    base_update.assert_awaited_once_with(config, changed_keys)
+
+
+async def test_settings_change_without_bridge_manager_falls_through() -> None:
+    """Without running bridges there is nothing to update in place."""
+    config = await _make_config()
+    provider, _ = _make_provider(config)
+    provider._bridge_manager = None
+    changed_keys = config.update({CONF_BRIGHTNESS: 50})
+
+    with patch.object(Provider, "update_config", new_callable=AsyncMock) as base_update:
+        await provider.update_config(config, changed_keys)
+
+    base_update.assert_awaited_once_with(config, changed_keys)

--- a/tests/providers/hue_entertainment/test_update_config.py
+++ b/tests/providers/hue_entertainment/test_update_config.py
@@ -12,13 +12,14 @@ the models package produces.
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
-from music_assistant_models.enums import ConfigEntryType, ProviderType
+from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
+from music_assistant_models.enums import ProviderType
 
-from music_assistant.constants import CONF_LOG_LEVEL
+from music_assistant.constants import CONF_LOG_LEVEL, DEFAULT_PROVIDER_CONFIG_ENTRIES
 from music_assistant.models.provider import Provider
 from music_assistant.providers.hue_entertainment.constants import (
     CONF_BRIGHTNESS,
@@ -31,8 +32,8 @@ from music_assistant.providers.hue_entertainment.provider import HueEntertainmen
 async def _make_config() -> ProviderConfig:
     """Build a ProviderConfig holding the provider's own entries plus the log level."""
     provider = HueEntertainmentProvider.__new__(HueEntertainmentProvider)
-    entries = list(await provider.get_config_entries())
-    entries.append(ConfigEntry(key=CONF_LOG_LEVEL, type=ConfigEntryType.STRING, default_value=None))
+    # the default entries are shared module-level instances; copy before setting values on them
+    entries = [*await provider.get_config_entries(), *deepcopy(DEFAULT_PROVIDER_CONFIG_ENTRIES)]
     values = {entry.key: entry for entry in entries}
     for entry in values.values():
         entry.value = entry.default_value
@@ -74,15 +75,20 @@ async def test_settings_change_applies_in_place() -> None:
 
 
 @pytest.mark.parametrize(
-    "update",
+    ("update", "expected"),
     [
-        {CONF_COLOR_MODE: "ambient"},
-        {CONF_HUE_LATENCY_MS: 120},
-        {CONF_BRIGHTNESS: 50, CONF_COLOR_MODE: "ambient", CONF_HUE_LATENCY_MS: 120},
+        ({CONF_COLOR_MODE: "ambient"}, {"color_mode": "ambient"}),
+        ({CONF_HUE_LATENCY_MS: 120}, {"hue_latency_ms": 120}),
+        (
+            {CONF_BRIGHTNESS: 0, CONF_COLOR_MODE: "ambient", CONF_HUE_LATENCY_MS: 0},
+            {"brightness": 0, "color_mode": "ambient", "hue_latency_ms": 0},
+        ),
     ],
-    ids=["color_mode", "latency", "all_settings"],
+    ids=["color_mode", "latency", "all_settings_at_zero"],
 )
-async def test_every_in_place_setting_skips_the_reload(update: dict[str, ConfigValueType]) -> None:
+async def test_every_in_place_setting_skips_the_reload(
+    update: dict[str, ConfigValueType], expected: dict[str, ConfigValueType]
+) -> None:
     """Each hot-applyable setting - and any combination of them - avoids the reload."""
     config = await _make_config()
     provider, bridge_manager = _make_provider(config)
@@ -92,6 +98,8 @@ async def test_every_in_place_setting_skips_the_reload(update: dict[str, ConfigV
         await provider.update_config(config, changed_keys)
 
     bridge_manager.update_settings.assert_called_once()
+    kwargs = bridge_manager.update_settings.call_args.kwargs
+    assert {key: kwargs[key] for key in expected} == expected
     base_update.assert_not_awaited()
 
 


### PR DESCRIPTION
# What does this implement/fix?

Changing the brightness, colour mode or latency of the Hue lights sync provider was meant to be applied to the running lights straight away. Instead every change reloaded the whole provider, which closed the connection to the Hue bridge and re-created the light players — so if music was playing, the lights dropped out and had to re-sync. The latency slider made this worst, since it applies while you drag it.

The settings check compared the plain setting names against the changed keys, which are stored with a `values/` prefix, so it never matched and always fell through to the reload.

While fixing that it turned out a brightness of 0 never worked either: 0 is a valid value for both brightness and latency, but the fallbacks treated it as "not set" and silently used 100% brightness / 20ms. That applied on startup too, so setting the lights to 0 has never done anything.

- Compare against the correct `values/<key>` form
- Only skip the reload when every changed setting can be applied in place, so a setting changed together with something else (e.g. the log level) still takes the full path
- Read the three settings through shared helpers that only fall back when nothing is configured, so 0 stays 0
- Added tests for the in-place path, the reload path, the mixed case and the zero values

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
