### PR TITLE
Give up on a streaming app that was left paused, on more speakers

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -1031,6 +1031,11 @@ DEFAULT_PROVIDERS: Final[set[tuple[str, bool]]] = {
     ("ambient_sounds", False),
 }
 
+# Seconds an external source may sit paused before we consider its session ended.
+# Kept generous because this is what a real pause is given before we stop presenting
+# the source as something the user can resume.
+EXTERNAL_PAUSE_IDLE_TIMEOUT: Final[int] = 60
+
 EXTERNAL_SOURCES: Final[set[str]] = {
     # list of sources that are definitely considered "external"
     # values are matched case-insensitive against the player's active_source

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -1032,8 +1032,10 @@ DEFAULT_PROVIDERS: Final[set[tuple[str, bool]]] = {
 }
 
 # Seconds an external source may sit paused before we consider its session ended.
-# Kept generous because this is what a real pause is given before we stop presenting
-# the source as something the user can resume.
+# Devices keep a source like Spotify Connect loaded and paused indefinitely, also once
+# the app released the speaker, and offer nothing that tells an abandoned session apart
+# from a real pause - so time is the only signal left. Kept generous because this is
+# what a real pause is given before we stop presenting the source as resumable.
 EXTERNAL_PAUSE_IDLE_TIMEOUT: Final[int] = 60
 
 EXTERNAL_SOURCES: Final[set[str]] = {

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -387,6 +387,12 @@ class Player(ABC):
     _attr_setup_reason: str | None = None
     _attr_supported_sample_rates: list[tuple[int, int]] | None = None
     _attr_underlying_player_id: str | None = None
+    # Seconds an external source may sit paused before its session is considered ended.
+    # Set this on players whose device keeps a source such as Spotify Connect loaded and
+    # paused after the app released it, offering nothing that tells an abandoned session
+    # apart from a real pause - time is then the only signal left. Leave at None for
+    # devices that report a source they no longer play as stopped by themselves.
+    _attr_external_pause_idle_timeout: int | None = None
 
     def __init__(self, provider: PlayerProvider, player_id: str) -> None:
         """Initialize the Player."""
@@ -417,6 +423,7 @@ class Player(ABC):
         self._extra_attributes: dict[str, Any] = {}
         self._on_unload_callbacks: list[Callable[[], None]] = []
         self.__active_mass_source: str | None = None
+        self.__external_pause_since: float | None = None
         self.__initialized = asyncio.Event()
         # Change-tracking internals for update_state:
         # - state_dirty forces a recalculation (state derived from other
@@ -1157,6 +1164,11 @@ class Player(ABC):
 
     async def on_unload(self) -> None:
         """Handle logic when the player is unloaded from the Player controller."""
+        if self._attr_external_pause_idle_timeout is not None:
+            # a timer that already fired lives on as a task under the same id,
+            # so both are needed to cover the pending and the running case
+            self.mass.cancel_timer(f"external_pause_{self.player_id}")
+            self.mass.cancel_task(f"external_pause_{self.player_id}")
         for callback in self._on_unload_callbacks:
             try:
                 callback()
@@ -1921,6 +1933,7 @@ class Player(ABC):
         for key in list(self._cache):
             if key not in _CONFIG_CACHED_PROPS:
                 del self._cache[key]
+        self.__expire_stale_external_pause()
         new_snapshot = self.__collect_input_snapshot()
         if (
             not force_update
@@ -1972,6 +1985,23 @@ class Player(ABC):
             self.mass.players.signal_player_state_update(
                 self, changed_values, media_position_jumped=media_position_jumped
             )
+
+    @final
+    def mark_external_source_ended(self) -> None:
+        """
+        Stop presenting the external source the device has loaded as something to resume.
+
+        Call this when the device makes clear that the session is gone, for example when
+        it refuses to resume playback. Normal queue handling takes over from there.
+        """
+        if (timeout := self._attr_external_pause_idle_timeout) is not None:
+            # the updates that follow rebuild the state from the device, which keeps
+            # reporting the very same source as paused, so backdating the pause is what
+            # keeps this applied
+            self.__external_pause_since = time.time() - timeout
+        self._attr_playback_state = PlaybackState.IDLE
+        self._attr_active_source = None
+        self._attr_current_media = None
 
     @final
     def set_current_media(  # noqa: PLR0913
@@ -3261,6 +3291,43 @@ class Player(ABC):
     def __ne__(self, other: object) -> bool:
         """Check inequality of two Player objects."""
         return not self.__eq__(other)
+
+    @final
+    def __external_source_active(self) -> bool:
+        """Return whether the source the player reports for itself is an external one."""
+        source = self._attr_active_source
+        if source is None or source == self.player_id:
+            return False
+        return self.mass.player_queues.get(source) is None
+
+    @final
+    def __expire_stale_external_pause(self) -> None:
+        """Report an external source that has been paused for a while as no longer active."""
+        if (timeout := self._attr_external_pause_idle_timeout) is None:
+            return
+        if (
+            self._attr_playback_state != PlaybackState.PAUSED
+            # while an output protocol renders the audio, MA owns playback and the
+            # source the device reports for itself is overruled anyway
+            or self.active_output_protocol not in (None, "native")
+            or not self.__external_source_active()
+        ):
+            self.__external_pause_since = None
+            return
+        if self.__external_pause_since is None:
+            self.__external_pause_since = time.time()
+        elif (time.time() - self.__external_pause_since) >= timeout:
+            self.mark_external_source_ended()
+            return
+        # nothing changes on the device side when the session goes stale, so there is no
+        # event to react to. Keep the check armed rather than relying on a single timer:
+        # an update that bails out early would otherwise consume it and leave the source
+        # paused for good.
+        self.mass.call_later(
+            timeout + 1,
+            self.update_state,
+            task_id=f"external_pause_{self.player_id}",
+        )
 
 
 __all__ = [

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -424,6 +424,7 @@ class Player(ABC):
         self._on_unload_callbacks: list[Callable[[], None]] = []
         self.__active_mass_source: str | None = None
         self.__external_pause_since: float | None = None
+        self.__ended_external_source: str | None = None
         self.__initialized = asyncio.Event()
         # Change-tracking internals for update_state:
         # - state_dirty forces a recalculation (state derived from other
@@ -1165,10 +1166,7 @@ class Player(ABC):
     async def on_unload(self) -> None:
         """Handle logic when the player is unloaded from the Player controller."""
         if self._attr_external_pause_idle_timeout is not None:
-            # a timer that already fired lives on as a task under the same id,
-            # so both are needed to cover the pending and the running case
             self.mass.cancel_timer(f"external_pause_{self.player_id}")
-            self.mass.cancel_task(f"external_pause_{self.player_id}")
         for callback in self._on_unload_callbacks:
             try:
                 callback()
@@ -1993,12 +1991,14 @@ class Player(ABC):
 
         Call this when the device makes clear that the session is gone, for example when
         it refuses to resume playback. Normal queue handling takes over from there.
+        Call :meth:`update_state` afterwards to publish the change.
         """
-        if (timeout := self._attr_external_pause_idle_timeout) is not None:
+        if self._attr_active_source is not None:
             # the updates that follow rebuild the state from the device, which keeps
-            # reporting the very same source as paused, so backdating the pause is what
-            # keeps this applied
-            self.__external_pause_since = time.time() - timeout
+            # reporting the very same source as paused, so remembering which source we
+            # gave up on is what keeps this applied
+            self.__ended_external_source = self._attr_active_source
+        self.__external_pause_since = None
         self._attr_playback_state = PlaybackState.IDLE
         self._attr_active_source = None
         self._attr_current_media = None
@@ -3295,6 +3295,9 @@ class Player(ABC):
     @final
     def __external_source_active(self) -> bool:
         """Return whether the source the player reports for itself is an external one."""
+        # deliberately the raw source rather than the resolved one of
+        # _has_external_source_active: what has to expire is what the device itself keeps
+        # reporting, not what the group or protocol it belongs to resolves that to
         source = self._attr_active_source
         if source is None or source == self.player_id:
             return False
@@ -3313,7 +3316,16 @@ class Player(ABC):
             or not self.__external_source_active()
         ):
             self.__external_pause_since = None
+            if self._attr_playback_state == PlaybackState.PLAYING:
+                # the device plays again, so the source we gave up on is live once more
+                self.__ended_external_source = None
             return
+        if self._attr_active_source == self.__ended_external_source:
+            # the device keeps handing us the source we already gave up on
+            self.mark_external_source_ended()
+            return
+        # any other source is a session of its own and gets the full grace period
+        self.__ended_external_source = None
         if self.__external_pause_since is None:
             self.__external_pause_since = time.time()
         elif (time.time() - self.__external_pause_since) >= timeout:

--- a/music_assistant/providers/hass_players/player.py
+++ b/music_assistant/providers/hass_players/player.py
@@ -19,6 +19,7 @@ from music_assistant.constants import (
     CONF_ENTRY_ENABLE_ICY_METADATA_HIDDEN,
     CONF_ENTRY_HTTP_PROFILE_FORCED_2,
     CONF_ENTRY_OUTPUT_CODEC_DEFAULT_MP3,
+    EXTERNAL_PAUSE_IDLE_TIMEOUT,
     HIDDEN_ANNOUNCE_VOLUME_CONFIG_ENTRIES,
     create_output_codec_config_entry,
 )
@@ -51,6 +52,10 @@ DEFAULT_PLAYER_CONFIG_ENTRIES = (CONF_ENTRY_OUTPUT_CODEC_DEFAULT_MP3,)
 
 class HomeAssistantPlayer(Player):
     """Home Assistant Player implementation."""
+
+    # the wrapped entity keeps reporting an abandoned external session as paused, and
+    # Home Assistant pushes no event when it goes stale.
+    _attr_external_pause_idle_timeout = EXTERNAL_PAUSE_IDLE_TIMEOUT
 
     def __init__(
         self,

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -13,7 +13,7 @@ from music_assistant_models.player import DeviceInfo, PlayerSource
 from pyheos import Heos, HeosError, const
 from pyheos import PlayState as HeosPlayState
 
-from music_assistant.constants import VERBOSE_LOG_LEVEL
+from music_assistant.constants import EXTERNAL_PAUSE_IDLE_TIMEOUT, VERBOSE_LOG_LEVEL
 from music_assistant.models.player import Player, PlayerMedia
 from music_assistant.providers.heos.helpers import media_uri_from_now_playing_media
 
@@ -42,6 +42,10 @@ PLAYER_FEATURES = {
 
 class HeosPlayer(Player):
     """HeosPlayer in Music Assistant."""
+
+    # HEOS keeps a source it loaded itself reported as paused once the app walked away,
+    # and pushes no event when that session goes stale.
+    _attr_external_pause_idle_timeout = EXTERNAL_PAUSE_IDLE_TIMEOUT
 
     _heos: Heos
     _heos_queue: Heos

--- a/music_assistant/providers/sonos/const.py
+++ b/music_assistant/providers/sonos/const.py
@@ -74,13 +74,6 @@ PLAYER_SOURCE_MAP = {
     ),
 }
 
-# Seconds a source may sit paused before we consider its session ended.
-# Sonos keeps a source like Spotify Connect loaded and paused indefinitely, also once the
-# app released the speaker, and offers nothing to tell an abandoned session apart from a
-# real pause - so time is the only signal left. Kept generous because this is what a real
-# pause is given before the speaker stops reporting what it was playing.
-EXTERNAL_PAUSE_IDLE_TIMEOUT = 60
-
 UNSUPPORTED_MODELS_NATIVE_ANNOUNCEMENTS = ("Play:1", "Play:3")
 NON_HIRES_MODELS = (
     "Play:1",

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -33,12 +33,12 @@ from music_assistant_models.player import OutputProtocol, PlayerMedia
 from music_assistant.constants import (
     CONF_ENTRY_HTTP_PROFILE_DEFAULT_2,
     CONF_ENTRY_PREFER_WAV_FOR_LIVE_SOURCES_DEFAULT_ENABLED,
+    EXTERNAL_PAUSE_IDLE_TIMEOUT,
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player
 from music_assistant.providers.sonos.const import (
-    EXTERNAL_PAUSE_IDLE_TIMEOUT,
     NON_HIRES_MODELS,
     PLAYBACK_STATE_MAP,
     PLAYER_SOURCE_MAP,
@@ -80,6 +80,8 @@ class SonosQueue:
 class SonosPlayer(Player):
     """Holds the details of the (discovered) Sonosplayer."""
 
+    _attr_external_pause_idle_timeout = EXTERNAL_PAUSE_IDLE_TIMEOUT
+
     def __init__(
         self,
         prov: SonosPlayerProvider,
@@ -92,7 +94,6 @@ class SonosPlayer(Player):
         self.connected: bool = False
         self._listen_task: asyncio.Task[None] | None = None
         self.sonos_queue: SonosQueue = SonosQueue()
-        self._external_pause_since: float | None = None
 
     @property
     def group_controller(self) -> SonosGroup:
@@ -205,7 +206,6 @@ class SonosPlayer(Player):
         for task_id in (
             f"sonos_reconnect_{self.player_id}",
             f"restore_airplay_group_{self.player_id}",
-            f"sonos_external_pause_{self.player_id}",
         ):
             # a timer that already fired lives on as a task under the same id,
             # so both are needed to cover the pending and the running case
@@ -260,7 +260,7 @@ class SonosPlayer(Player):
                 self.player_id,
                 err,
             )
-            self._mark_external_source_ended()
+            self.mark_external_source_ended()
             self.update_state()
 
     async def stop(self) -> None:
@@ -672,7 +672,6 @@ class SonosPlayer(Player):
                 current_media.uri = container["id"]["objectId"]
 
         self._attr_current_media = current_media
-        self._expire_stale_external_pause()
 
     async def on_protocol_playback(
         self,
@@ -876,36 +875,6 @@ class SonosPlayer(Player):
             self.player_id,
             [x.title for x in self.sonos_queue.items],
         )
-
-    def _expire_stale_external_pause(self) -> None:
-        """Report an external source that has been paused for a while as no longer active."""
-        if self._attr_playback_state != PlaybackState.PAUSED:
-            self._external_pause_since = None
-            return
-        if self._external_pause_since is None:
-            self._external_pause_since = time.time()
-        elif (time.time() - self._external_pause_since) >= EXTERNAL_PAUSE_IDLE_TIMEOUT:
-            self._mark_external_source_ended()
-            return
-        # nothing changes on the Sonos side when the session goes stale, so there is no event
-        # to react to. Keep the check armed rather than relying on a single timer: an update
-        # that bails out early (a reconnect, a group parent we do not know yet) would
-        # otherwise consume it and leave the source paused for good.
-        self.mass.call_later(
-            EXTERNAL_PAUSE_IDLE_TIMEOUT + 1,
-            self.on_player_event,
-            None,
-            task_id=f"sonos_external_pause_{self.player_id}",
-        )
-
-    def _mark_external_source_ended(self) -> None:
-        """Stop presenting the source Sonos has loaded as something that can be resumed."""
-        # the updates that follow rebuild the state from Sonos, which keeps reporting the very
-        # same source as paused, so backdating the pause is what keeps this applied
-        self._external_pause_since = time.time() - EXTERNAL_PAUSE_IDLE_TIMEOUT
-        self._attr_playback_state = PlaybackState.IDLE
-        self._attr_active_source = None
-        self._attr_current_media = None
 
     def _extract_mac_from_player_id(self) -> str | None:
         """

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -118,6 +118,7 @@ class WiimPlayer(Player):
 
     async def on_unload(self) -> None:
         """Handle logic when the player is unloaded from the Player controller."""
+        await super().on_unload()
         self.device.general_event_callback = None
         self.device.av_transport_event_callback = None
         self.device.rendering_control_event_callback = None

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -12,7 +12,10 @@ from wiim import PlayingStatus, WiimDevice
 from wiim.exceptions import WiimDeviceException, WiimRequestException
 from wiim.models import WiimGroupRole
 
-from music_assistant.constants import create_sample_rates_config_entry
+from music_assistant.constants import (
+    EXTERNAL_PAUSE_IDLE_TIMEOUT,
+    create_sample_rates_config_entry,
+)
 from music_assistant.helpers.upnp import create_didl_metadata
 from music_assistant.models.player import Player, PlayerMedia
 
@@ -43,6 +46,10 @@ SDK_TO_MA_STATE: dict[PlayingStatus, PlaybackState] = {
 
 class WiimPlayer(Player):
     """Wiim Player in Music Assistant."""
+
+    # the device only pushes state changes, so a source it keeps reported as paused after
+    # the app released it is never corrected on its own.
+    _attr_external_pause_idle_timeout = EXTERNAL_PAUSE_IDLE_TIMEOUT
 
     def __init__(
         self,

--- a/tests/models/test_player_external_pause.py
+++ b/tests/models/test_player_external_pause.py
@@ -1,0 +1,186 @@
+"""Tests for giving up on an external source that has been paused for too long."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import PlaybackState
+
+from music_assistant.constants import EXTERNAL_PAUSE_IDLE_TIMEOUT
+from tests.common import MockPlayer, MockProvider
+
+EXTERNAL_SOURCE = "spotify"
+
+
+@pytest.fixture
+def mock_mass() -> MagicMock:
+    """Create a mock MusicAssistant instance."""
+    mass = MagicMock()
+    mass.closing = False
+    mass.config.get_raw_player_config_value = MagicMock(
+        side_effect=lambda _player_id, _key, default=None: default
+    )
+    mass.player_queues.get = MagicMock(return_value=None)
+    mass.players.scale_volume_from_device = MagicMock(side_effect=lambda _player_id, volume: volume)
+    return mass
+
+
+@pytest.fixture
+def player(mock_mass: MagicMock) -> MockPlayer:
+    """Create a player reporting a paused external source, with the check opted in."""
+    provider = MockProvider("test_provider", mass=mock_mass)
+    player = MockPlayer(provider, "player_1", "Player 1")
+    player._attr_external_pause_idle_timeout = EXTERNAL_PAUSE_IDLE_TIMEOUT
+    player._attr_playback_state = PlaybackState.PAUSED
+    player._attr_active_source = EXTERNAL_SOURCE
+    player.set_current_media(uri="spotify:track:1", title="Shout")
+    player.update_state()
+    return player
+
+
+def _backdate_pause(player: MockPlayer, seconds: float) -> None:
+    """Pretend the source has already been sitting paused for the given time."""
+    player._Player__external_pause_since = time.time() - seconds  # type: ignore[attr-defined]
+
+
+def test_a_source_that_just_paused_stays_resumable(
+    player: MockPlayer, mock_mass: MagicMock
+) -> None:
+    """Test a real pause is still handed to the source, so pausing and resuming works."""
+    assert player.state.playback_state is PlaybackState.PAUSED
+    assert player.state.active_source == EXTERNAL_SOURCE
+    # the device reports nothing when the session goes stale, so we come back to it ourselves
+    armed_checks = [
+        call
+        for call in mock_mass.call_later.call_args_list
+        if call.kwargs.get("task_id") == "external_pause_player_1"
+    ]
+    assert len(armed_checks) == 1
+    assert armed_checks[0].args[0] > EXTERNAL_PAUSE_IDLE_TIMEOUT
+
+
+def test_a_source_paused_within_the_grace_period_stays_resumable(player: MockPlayer) -> None:
+    """Test a genuine pause survives for as long as the grace period lasts."""
+    _backdate_pause(player, EXTERNAL_PAUSE_IDLE_TIMEOUT - 5)
+
+    player.update_state()
+
+    assert player.state.playback_state is PlaybackState.PAUSED
+    assert player.state.active_source == EXTERNAL_SOURCE
+    assert player.state.current_media is not None
+
+
+def test_a_source_paused_for_too_long_is_reported_as_idle(player: MockPlayer) -> None:
+    """Test an abandoned session stops looking resumable, so play starts our own queue."""
+    _backdate_pause(player, EXTERNAL_PAUSE_IDLE_TIMEOUT + 1)
+
+    player.update_state()
+
+    assert player.state.playback_state is PlaybackState.IDLE
+    assert player._attr_current_media is None
+    # the player's own queue is reachable again, which is what makes the play button work
+    assert player.state.active_source == player.player_id
+
+
+def test_an_ended_source_is_not_picked_back_up_from_what_the_device_reports(
+    player: MockPlayer,
+) -> None:
+    """Test the next update does not resurrect the source the device still reports as paused."""
+    player.mark_external_source_ended()
+
+    player._attr_playback_state = PlaybackState.PAUSED
+    player._attr_active_source = EXTERNAL_SOURCE
+    player.update_state()
+
+    assert player.state.playback_state is PlaybackState.IDLE
+    assert player.state.active_source == player.player_id
+
+
+def test_resuming_the_source_gives_a_later_pause_the_full_grace_period(
+    player: MockPlayer,
+) -> None:
+    """Test the clock only runs while the player reports paused."""
+    _backdate_pause(player, EXTERNAL_PAUSE_IDLE_TIMEOUT - 5)
+    player._attr_playback_state = PlaybackState.PLAYING
+    player.update_state()
+
+    player._attr_playback_state = PlaybackState.PAUSED
+    player.update_state()
+
+    assert player.state.playback_state is PlaybackState.PAUSED
+    assert player.state.active_source == EXTERNAL_SOURCE
+
+
+def test_our_own_paused_playback_is_never_expired(player: MockPlayer) -> None:
+    """Test pausing the Music Assistant queue is left alone, however long it lasts."""
+    player._attr_active_source = player.player_id
+    _backdate_pause(player, EXTERNAL_PAUSE_IDLE_TIMEOUT + 1)
+
+    player.update_state()
+
+    assert player.state.playback_state is PlaybackState.PAUSED
+
+
+def test_a_paused_queue_source_is_never_expired(player: MockPlayer, mock_mass: MagicMock) -> None:
+    """Test a source that resolves to a Music Assistant queue is not treated as external."""
+    mock_mass.player_queues.get = MagicMock(return_value=MagicMock())
+    _backdate_pause(player, EXTERNAL_PAUSE_IDLE_TIMEOUT + 1)
+
+    player.update_state()
+
+    assert player.state.playback_state is PlaybackState.PAUSED
+
+
+def test_a_source_rendered_by_an_output_protocol_is_never_expired(player: MockPlayer) -> None:
+    """Test playback that Music Assistant renders itself is left to the protocol player."""
+    player.set_active_output_protocol("airplay_player_1")
+    _backdate_pause(player, EXTERNAL_PAUSE_IDLE_TIMEOUT + 1)
+
+    player.update_state()
+
+    assert player._attr_playback_state is PlaybackState.PAUSED
+    assert player._attr_active_source == EXTERNAL_SOURCE
+
+
+def test_a_player_that_does_not_opt_in_keeps_its_paused_source(
+    mock_mass: MagicMock,
+) -> None:
+    """Test devices that report an abandoned source as stopped themselves are untouched."""
+    provider = MockProvider("test_provider", mass=mock_mass)
+    player = MockPlayer(provider, "player_2", "Player 2")
+    player._attr_playback_state = PlaybackState.PAUSED
+    player._attr_active_source = EXTERNAL_SOURCE
+    player.update_state()
+    _backdate_pause(player, EXTERNAL_PAUSE_IDLE_TIMEOUT + 1)
+
+    player.update_state()
+
+    assert player.state.playback_state is PlaybackState.PAUSED
+    assert player.state.active_source == EXTERNAL_SOURCE
+
+
+@pytest.mark.asyncio
+async def test_unloading_leaves_no_pending_check_behind(
+    player: MockPlayer, mock_mass: MagicMock
+) -> None:
+    """Test unloading a player cancels the check that would re-evaluate its paused source."""
+    await player.on_unload()
+
+    mock_mass.cancel_timer.assert_any_call("external_pause_player_1")
+    mock_mass.cancel_task.assert_any_call("external_pause_player_1")
+
+
+@pytest.mark.asyncio
+async def test_unloading_a_player_that_does_not_opt_in_cancels_nothing(
+    mock_mass: MagicMock,
+) -> None:
+    """Test the check is not cleaned up for players that never armed it."""
+    provider = MockProvider("test_provider", mass=mock_mass)
+    player = MockPlayer(provider, "player_2", "Player 2")
+
+    await player.on_unload()
+
+    mock_mass.cancel_timer.assert_not_called()
+    mock_mass.cancel_task.assert_not_called()

--- a/tests/models/test_player_external_pause.py
+++ b/tests/models/test_player_external_pause.py
@@ -89,13 +89,44 @@ def test_an_ended_source_is_not_picked_back_up_from_what_the_device_reports(
 ) -> None:
     """Test the next update does not resurrect the source the device still reports as paused."""
     player.mark_external_source_ended()
+    player.update_state()
+    assert player.state.playback_state is PlaybackState.IDLE
 
+    # the device keeps reporting the very same paused source on every update that follows
     player._attr_playback_state = PlaybackState.PAUSED
     player._attr_active_source = EXTERNAL_SOURCE
     player.update_state()
 
     assert player.state.playback_state is PlaybackState.IDLE
     assert player.state.active_source == player.player_id
+
+
+def test_a_source_that_starts_playing_again_is_given_a_fresh_start(player: MockPlayer) -> None:
+    """Test a source we gave up on is trusted again once the device really plays it."""
+    player.mark_external_source_ended()
+    player.update_state()
+
+    player._attr_playback_state = PlaybackState.PLAYING
+    player._attr_active_source = EXTERNAL_SOURCE
+    player.update_state()
+    player._attr_playback_state = PlaybackState.PAUSED
+    player.update_state()
+
+    assert player.state.playback_state is PlaybackState.PAUSED
+    assert player.state.active_source == EXTERNAL_SOURCE
+
+
+def test_another_source_is_not_tarred_with_the_same_brush(player: MockPlayer) -> None:
+    """Test giving up on one source does not shorten the grace period of the next."""
+    player.mark_external_source_ended()
+    player.update_state()
+
+    player._attr_playback_state = PlaybackState.PAUSED
+    player._attr_active_source = "tidal"
+    player.update_state()
+
+    assert player.state.playback_state is PlaybackState.PAUSED
+    assert player.state.active_source == "tidal"
 
 
 def test_resuming_the_source_gives_a_later_pause_the_full_grace_period(
@@ -169,7 +200,6 @@ async def test_unloading_leaves_no_pending_check_behind(
     await player.on_unload()
 
     mock_mass.cancel_timer.assert_any_call("external_pause_player_1")
-    mock_mass.cancel_task.assert_any_call("external_pause_player_1")
 
 
 @pytest.mark.asyncio
@@ -183,4 +213,3 @@ async def test_unloading_a_player_that_does_not_opt_in_cancels_nothing(
     await player.on_unload()
 
     mock_mass.cancel_timer.assert_not_called()
-    mock_mass.cancel_task.assert_not_called()

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -13,11 +12,9 @@ from aiosonos.exceptions import CannotConnect, FailedCommand
 from music_assistant_models.enums import PlaybackState
 from music_assistant_models.player import PlayerMedia
 
+from music_assistant.constants import EXTERNAL_PAUSE_IDLE_TIMEOUT
 from music_assistant.mass import MusicAssistant
-from music_assistant.providers.sonos.const import (
-    EXTERNAL_PAUSE_IDLE_TIMEOUT,
-    SOURCE_SPOTIFY,
-)
+from music_assistant.providers.sonos.const import SOURCE_SPOTIFY
 from music_assistant.providers.sonos.player import SonosPlayer
 
 
@@ -246,7 +243,6 @@ def _make_externally_paused_player() -> tuple[SonosPlayer, MagicMock, MagicMock]
     mass = MagicMock()
     mass.closing = False
     player, client = _bind_player(mass)
-    player._external_pause_since = None
     player._attr_playback_state = PlaybackState.PAUSED
     player._attr_active_source = SOURCE_SPOTIFY
     player._attr_current_media = PlayerMedia(uri="spotify:track:1", title="Shout")
@@ -257,86 +253,6 @@ def _refuse_to_resume(client: MagicMock) -> None:
     """Let the speaker reject the play command, as it does for a session it no longer has."""
     client.player.is_passive = False
     client.player.group.play = AsyncMock(side_effect=FailedCommand("ERROR_PLAYBACK_FAILED"))
-
-
-def test_a_paused_external_source_is_left_alone_at_first() -> None:
-    """Test a source that just paused stays resumable, so a real pause still works."""
-    player, mass, _ = _make_externally_paused_player()
-
-    player._expire_stale_external_pause()
-
-    assert player._attr_playback_state is PlaybackState.PAUSED
-    assert player._attr_active_source == SOURCE_SPOTIFY
-    # Sonos reports nothing when the session goes stale, so we must come back to it ourselves
-    assert mass.call_later.call_args.kwargs["task_id"] == "sonos_external_pause_sonos_player"
-
-
-def test_a_source_paused_within_the_grace_period_stays_resumable() -> None:
-    """Test a genuine pause can still be resumed from MA for as long as the grace period lasts."""
-    player, _, _ = _make_externally_paused_player()
-    player._external_pause_since = time.time() - EXTERNAL_PAUSE_IDLE_TIMEOUT + 5
-
-    player._expire_stale_external_pause()
-
-    assert player._attr_playback_state is PlaybackState.PAUSED
-    assert player._attr_active_source == SOURCE_SPOTIFY
-    assert player._attr_current_media is not None
-
-
-def test_an_external_source_paused_for_too_long_is_reported_as_idle() -> None:
-    """Test an abandoned session stops looking resumable, so play starts our own queue."""
-    player, _, _ = _make_externally_paused_player()
-    player._external_pause_since = time.time() - EXTERNAL_PAUSE_IDLE_TIMEOUT - 1
-
-    player._expire_stale_external_pause()
-
-    assert player._attr_playback_state is PlaybackState.IDLE
-    assert player._attr_active_source is None
-    assert player._attr_current_media is None
-
-
-def test_the_pause_clock_only_runs_while_the_player_reports_paused() -> None:
-    """Test resuming the source clears the clock, so a later pause gets the full grace period."""
-    player, _, _ = _make_externally_paused_player()
-    player._expire_stale_external_pause()
-    assert player._external_pause_since is not None
-
-    player._attr_playback_state = PlaybackState.PLAYING
-    player._expire_stale_external_pause()
-
-    assert player._external_pause_since is None
-
-
-def test_playback_that_is_not_paused_is_never_expired() -> None:
-    """Test our own playback (already mapped to idle by Sonos) never starts the clock."""
-    player, mass = _make_player()
-    player._external_pause_since = None
-    player._attr_playback_state = PlaybackState.IDLE
-    player._attr_active_source = None
-    player._attr_current_media = None
-
-    player._expire_stale_external_pause()
-
-    assert player._external_pause_since is None
-    mass.call_later.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_on_unload_cancels_a_pending_external_pause_check(
-    timer_mass: MusicAssistant,
-) -> None:
-    """Test unloading a player leaves no timer behind to re-evaluate a paused source."""
-    player, _ = _bind_player(timer_mass)
-    player._external_pause_since = None
-    player._attr_playback_state = PlaybackState.PAUSED
-    player._attr_active_source = SOURCE_SPOTIFY
-    player._attr_current_media = None
-    player._expire_stale_external_pause()
-    assert timer_mass._tracked_timers != {}
-
-    await player.on_unload()
-
-    assert timer_mass._tracked_timers == {}
 
 
 @pytest.mark.asyncio
@@ -350,22 +266,6 @@ async def test_a_source_that_refuses_to_resume_is_ended_right_away() -> None:
     assert player._attr_playback_state is PlaybackState.IDLE
     assert player._attr_active_source is None
     assert player._attr_current_media is None
-
-
-@pytest.mark.asyncio
-async def test_an_ended_source_is_not_picked_back_up_from_what_sonos_reports() -> None:
-    """Test the next update does not resurrect the source Sonos still reports as paused."""
-    player, _, client = _make_externally_paused_player()
-    _refuse_to_resume(client)
-    await player.play()
-
-    # Sonos keeps reporting the very same paused source on every update that follows
-    player._attr_playback_state = PlaybackState.PAUSED
-    player._attr_active_source = SOURCE_SPOTIFY
-    player._expire_stale_external_pause()
-
-    assert player._attr_playback_state is PlaybackState.IDLE
-    assert player._attr_active_source is None
 
 
 @pytest.mark.asyncio
@@ -405,7 +305,6 @@ def _speaker_reporting_paused_spotify() -> tuple[SonosPlayer, MagicMock]:
     player._attr_group_members = []
     player._attr_can_group_with = set()
     player._provider = MagicMock(instance_id="sonos")
-    player._external_pause_since = None
     client.player.is_coordinator = True
     client.player.group_members = ["sonos_player"]
     group = client.player.group
@@ -420,32 +319,14 @@ def _speaker_reporting_paused_spotify() -> tuple[SonosPlayer, MagicMock]:
     return player, mass
 
 
-def test_update_attributes_reports_a_long_paused_source_as_idle() -> None:
-    """Test the whole path, from what the speaker reports to the state we hand to MA."""
+def test_a_paused_connect_session_is_reported_as_a_paused_spotify_source() -> None:
+    """Test what the speaker reports for Spotify Connect becomes a resumable source."""
     player, _ = _speaker_reporting_paused_spotify()
 
     player.update_attributes()
-    while_paused = (player._attr_playback_state, player._attr_active_source)
-    assert while_paused == (PlaybackState.PAUSED, SOURCE_SPOTIFY)
 
-    # the speaker keeps reporting the very same paused source once the session goes stale
-    player._external_pause_since = time.time() - EXTERNAL_PAUSE_IDLE_TIMEOUT - 1
-    player.update_attributes()
-
-    assert player._attr_playback_state is PlaybackState.IDLE
-    assert player._attr_active_source is None
-    assert player._attr_current_media is None
-
-
-def test_the_pause_check_stays_armed_until_the_grace_period_is_over() -> None:
-    """Test an update that arrives meanwhile cannot consume the only pending check."""
-    player, mass = _speaker_reporting_paused_spotify()
-
-    player.update_attributes()
-    player.update_attributes()
-
-    assert mass.call_later.call_count == 2
-    delay, callback, event = mass.call_later.call_args.args
-    assert delay > EXTERNAL_PAUSE_IDLE_TIMEOUT
-    assert callback == player.on_player_event
-    assert event is None
+    assert player._attr_playback_state is PlaybackState.PAUSED
+    assert player._attr_active_source == SOURCE_SPOTIFY
+    # giving up on such a source once it goes stale is handled for every player alike,
+    # so the speaker only has to opt in
+    assert player._attr_external_pause_idle_timeout == EXTERNAL_PAUSE_IDLE_TIMEOUT

--- a/tests/providers/sonos/test_player.py
+++ b/tests/providers/sonos/test_player.py
@@ -319,14 +319,15 @@ def _speaker_reporting_paused_spotify() -> tuple[SonosPlayer, MagicMock]:
     return player, mass
 
 
-def test_a_paused_connect_session_is_reported_as_a_paused_spotify_source() -> None:
-    """Test what the speaker reports for Spotify Connect becomes a resumable source."""
+def test_a_paused_connect_session_is_handed_to_the_stale_source_check() -> None:
+    """Test what the speaker reports for Spotify Connect reaches the shared grace period."""
     player, _ = _speaker_reporting_paused_spotify()
 
-    player.update_attributes()
+    player.on_player_event(None)
 
     assert player._attr_playback_state is PlaybackState.PAUSED
     assert player._attr_active_source == SOURCE_SPOTIFY
-    # giving up on such a source once it goes stale is handled for every player alike,
-    # so the speaker only has to opt in
+    # giving up on such a source is handled for every player alike, from update_state,
+    # so the speaker only has to opt in and let the state calculation see it
     assert player._attr_external_pause_idle_timeout == EXTERNAL_PAUSE_IDLE_TIMEOUT
+    player.update_state.assert_called_once()  # type: ignore[attr-defined]


### PR DESCRIPTION
# What does this implement/fix?

Speakers can keep a source like Spotify Connect loaded and reported as *paused* long
after the app abandoned it, offering nothing that tells such a dead session apart from
a real pause. Playback commands then go to that dead session, so pressing play resumes
the app instead of starting your Music Assistant queue.

That was fixed for Sonos in #5688. The same handling now lives with the players in
general, so a speaker that behaves this way only has to opt in. It is switched on for
HEOS, WiiM and Home Assistant players, which all keep such a source paused indefinitely
with nothing that ever corrects it. No reports for those yet — this is applying a known
fix where the same shape exists, rather than waiting for it to be hit.

Pausing an external source from Music Assistant and picking it straight back up still
works, and pausing your own queue is never affected.

**Related issue (if applicable):**

- Follow-up to #5688

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Move the grace period for a paused external source out of the Sonos provider, so any player can use it
- Switch it on for HEOS, WiiM and Home Assistant players
- Only give up on a source that is really external, never on Music Assistant's own playback or on audio we render ourselves
- Keep giving up right away on a source a speaker refuses to resume

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
