### PR TITLE
Use .nfo files to determine artist/album-folder when scanning local library

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -1750,6 +1750,49 @@ class LocalFileSystemProvider(MusicProvider):
         )
         return resolved
 
+    def _resolve_directory_by_file(
+        self, filename: str, track_path: str | None, start_dir: str | None = None
+    ) -> str | None:
+        """
+        Try to identify a directory by testing for a specific file.
+
+        Search for artist or album directory by walking up the tree and test
+        for existence of a specific file (for example "artist.nfo" or "album.nfo").
+
+        Meant to be used as a fallback when no other search method yields a valid path for album or artist.
+
+        The search is capped to go up two directories, but stops at the root of our filesystem.
+
+        :param filename: The filename to search.
+        :param start_dir: Directory to start the search in. Will be used as start if not None.
+        :param track_path: Path of the track. Will be used as start if start_dir is omitted or None.
+        """
+        start_search = start_dir if start_dir is not None else track_path
+
+        if start_search is not None:
+            full_path = self.get_absolute_path(start_search)
+            path_obj = Path(full_path)
+            path_root_obj = Path(self.base_path)
+
+            parent_dir = path_obj.parent
+            matched_dir: Path | None = None
+            for _ in range(3):
+                search = os.path.join(parent_dir, filename)
+                if os.path.exists(search):
+                    matched_dir = parent_dir
+                    break
+
+                if parent_dir.samefile(path_root_obj):
+                    # Reached root dir, stop.
+                    break
+
+                parent_dir = parent_dir.parent
+
+            if matched_dir:
+                return get_relative_path(self.base_path, matched_dir.as_posix())
+
+        return None
+
     def _match_album_artist(
         self, album: Album | None, name: str, mbid: str | None
     ) -> Artist | ItemMapping | None:
@@ -1777,6 +1820,7 @@ class LocalFileSystemProvider(MusicProvider):
         sort_name: str | None = None,
         mbid: str | None = None,
         artist_path: str | None = None,
+        track_path: str | None = None,
     ) -> Artist:
         """Parse full (album) Artist."""
         if not artist_path:
@@ -1806,6 +1850,12 @@ class LocalFileSystemProvider(MusicProvider):
                             break
                     if artist_path:
                         break
+
+        if artist_path is None:
+            # if we haven't found the path yet, try to find it by searching artist.nfo.
+            artist_path = self._resolve_directory_by_file(
+                filename="artist.nfo", start_dir=album_dir, track_path=track_path
+            )
 
         # prefer (short lived) cache for a bit more speed
         if artist_path and (
@@ -2225,6 +2275,10 @@ class LocalFileSystemProvider(MusicProvider):
         track_dir = os.path.dirname(track_path)
         album_dir = get_album_dir(track_dir, track_tags.album)
 
+        if album_dir is None:
+            # if we haven't found the path yet, try to find it by searching album.nfo.
+            album_dir = self._resolve_directory_by_file(filename="album.nfo", track_path=track_path)
+
         if album_dir and (
             cache := await self.cache.get(
                 key=album_dir,
@@ -2246,7 +2300,7 @@ class LocalFileSystemProvider(MusicProvider):
             )
             for name, mbid, sort_name in resolved_album_artists:
                 artist = await self._parse_artist(
-                    name, album_dir=album_dir, sort_name=sort_name, mbid=mbid
+                    name, album_dir=album_dir, sort_name=sort_name, mbid=mbid, track_path=track_path
                 )
                 album_artists.append(artist)
         else:
@@ -2261,7 +2315,11 @@ class LocalFileSystemProvider(MusicProvider):
                 )
                 album_artist_str = possible_artist_folder.rsplit(os.sep)[-1]
                 album_artists = UniqueList(
-                    [await self._parse_artist(name=album_artist_str, album_dir=album_dir)]
+                    [
+                        await self._parse_artist(
+                            name=album_artist_str, album_dir=album_dir, track_path=track_path
+                        )
+                    ]
                 )
             # fallback to track artists (if defined by user)
             elif fallback_action == "track_artist":
@@ -2271,7 +2329,9 @@ class LocalFileSystemProvider(MusicProvider):
                 )
                 album_artists = UniqueList(
                     [
-                        await self._parse_artist(name=track_artist_str, album_dir=album_dir)
+                        await self._parse_artist(
+                            name=track_artist_str, album_dir=album_dir, track_path=track_path
+                        )
                         for track_artist_str in track_tags.artists
                     ]
                 )

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -1750,7 +1750,7 @@ class LocalFileSystemProvider(MusicProvider):
         )
         return resolved
 
-    def _resolve_directory_by_file(
+    async def _resolve_directory_by_file(
         self, filename: str, track_path: str | None, start_dir: str | None = None
     ) -> str | None:
         """
@@ -1767,29 +1767,153 @@ class LocalFileSystemProvider(MusicProvider):
         :param start_dir: Directory to start the search in. Will be used as start if not None.
         :param track_path: Path of the track. Will be used as start if start_dir is omitted or None.
         """
-        start_search = start_dir if start_dir is not None else track_path
+        start_search = start_dir
+        if start_dir is None and track_path is not None:
+            # no directory passed, use track_path.
+            # track_path contains the filename, remove it.
+            start_search = os.path.dirname(track_path)
 
         if start_search is not None:
-            full_path = self.get_absolute_path(start_search)
-            path_obj = Path(full_path)
-            path_root_obj = Path(self.base_path)
-
-            parent_dir = path_obj.parent
-            matched_dir: Path | None = None
-            for _ in range(3):
-                search = os.path.join(parent_dir, filename)
-                if os.path.exists(search):
-                    matched_dir = parent_dir
+            current_dir = start_search
+            matched_dir: str | None = None
+            for _i in range(10):
+                search = os.path.join(current_dir, filename)
+                if await self.exists(search):
+                    matched_dir = current_dir
                     break
 
-                if parent_dir.samefile(path_root_obj):
+                if current_dir == "":
                     # Reached root dir, stop.
                     break
 
-                parent_dir = parent_dir.parent
+                current_dir = os.path.dirname(current_dir)
 
             if matched_dir:
-                return get_relative_path(self.base_path, matched_dir.as_posix())
+                return get_relative_path(self.base_path, matched_dir)
+
+        return None
+
+    async def _resolve_album_directory_with_nfo(
+        self, track_path: str, track_tags: AudioTags | None = None
+    ) -> str | None:
+        """
+        Resolve the album directory by searching album.nfo.
+
+        Searches for an album.nfo-file in the track-directory and the directories above.
+
+        If an album.nfo is found, its contents are parsed and matched against the musicbrainz-id (if provided) or
+        the album name given in the tags.
+
+        If this check passes, the path of the matched directory will be returned.
+
+        :param track_path: Path of the track file.
+        :param track_tags: Extracted Tags from the file.
+        """
+        if track_tags is not None:
+            path = await self._resolve_directory_by_file(
+                filename="album.nfo", track_path=track_path
+            )
+            if path is not None:
+                filename = os.path.join(path, "album.nfo")
+                if await self.exists(filename):
+                    try:
+                        data = (await self._read_file(filename)).decode("utf-8")
+                        content = await asyncio.to_thread(xmltodict.parse, data)
+                        nfo_album = content.get("album")
+
+                        nfo_mb_album_id = clean_mbid(
+                            nfo_album.get("musicbrainzalbumid"), "album.nfo"
+                        )
+                        nfo_mb_releasegroup_id = clean_mbid(
+                            nfo_album.get("musicbrainzreleasegroupid"), "album.nfo"
+                        )
+                        nfo_album_name = nfo_album.get("title")
+
+                        track_mb_album_id = clean_mbid(track_tags.get("musicbrainzalbumid", None))
+                        track_mb_releasegroup_id = clean_mbid(
+                            track_tags.get("musicbrainzreleasegroupid", None)
+                        )
+                        track_album_name = track_tags.get("album", None)
+
+                        if track_mb_album_id is not None and track_mb_album_id == nfo_mb_album_id:
+                            self.logger.debug(
+                                "resolved album dir with album.nfo: matched musicbrainz-album-id"
+                            )
+                            return path
+
+                        if (
+                            track_mb_releasegroup_id is not None
+                            and track_mb_releasegroup_id == nfo_mb_releasegroup_id
+                        ):
+                            self.logger.debug(
+                                "resolved album dir with album.nfo: matched musicbrainz-release-group-id"
+                            )
+                            return path
+
+                        if track_album_name is not None and track_album_name == nfo_album_name:
+                            self.logger.debug(
+                                "resolved album dir with album.nfo: matched album name"
+                            )
+                            return path
+
+                        self.logger.debug('Found "%s", but nothing matched. Ignoring file.')
+
+                    except (ExpatError, KeyError) as err:
+                        self.logger.warning(
+                            "Failed to parse album NFO file %s: %s", filename, str(err)
+                        )
+
+        return None
+
+    async def _resolve_artist_directory_with_nfo(
+        self, track_path: str, mbid: str | None = None, artist_name: str | None = None
+    ) -> str | None:
+        """
+        Resolve the artist directory by searching artist.nfo.
+
+        Searches for an artist.nfo-file in the track-directory and the directories above.
+
+        If an artist.nfo is found, its contents are parsed and matched against the musicbrainz-id (if provided) or
+        the artist name given in the tags.
+
+        If this check passes, the path of the matched directory will be returned.
+
+        :param track_path: Path of the track file.
+        :param mbid: musicbrainz artist id from tags, if known.
+        :param artist_name: artist name from tags, if known.
+        """
+        path = await self._resolve_directory_by_file(filename="artist.nfo", track_path=track_path)
+        if path is not None:
+            filename = os.path.join(path, "artist.nfo")
+            if await self.exists(filename):
+                try:
+                    data = (await self._read_file(filename)).decode("utf-8")
+                    content = await asyncio.to_thread(xmltodict.parse, data)
+                    nfo_artist = content.get("artist")
+
+                    nfo_mb_artist_id = clean_mbid(
+                        nfo_artist.get("musicBrainzArtistID"), "artist.nfo"
+                    )
+                    nfo_artist_name = nfo_artist.get("name")
+
+                    if mbid is not None and mbid == nfo_mb_artist_id:
+                        self.logger.debug(
+                            "resolved artist dir with artist.nfo: matched musicbrainz-artist-id"
+                        )
+                        return path
+
+                    if artist_name is not None and artist_name == nfo_artist_name:
+                        self.logger.debug(
+                            "resolved artist dir with artist.nfo: matched artist name"
+                        )
+                        return path
+
+                    self.logger.debug('Found "%s", but nothing matched. Ignoring file.')
+
+                except (ExpatError, KeyError) as err:
+                    self.logger.warning(
+                        "Failed to parse artist NFO file %s: %s", filename, str(err)
+                    )
 
         return None
 
@@ -1851,10 +1975,10 @@ class LocalFileSystemProvider(MusicProvider):
                     if artist_path:
                         break
 
-        if artist_path is None:
+        if artist_path is None and track_path is not None:
             # if we haven't found the path yet, try to find it by searching artist.nfo.
-            artist_path = self._resolve_directory_by_file(
-                filename="artist.nfo", start_dir=album_dir, track_path=track_path
+            artist_path = await self._resolve_artist_directory_with_nfo(
+                track_path=track_path, mbid=mbid, artist_name=name
             )
 
         # prefer (short lived) cache for a bit more speed
@@ -2277,7 +2401,9 @@ class LocalFileSystemProvider(MusicProvider):
 
         if album_dir is None:
             # if we haven't found the path yet, try to find it by searching album.nfo.
-            album_dir = self._resolve_directory_by_file(filename="album.nfo", track_path=track_path)
+            album_dir = await self._resolve_album_directory_with_nfo(
+                track_path=track_path, track_tags=track_tags
+            )
 
         if album_dir and (
             cache := await self.cache.get(


### PR DESCRIPTION
# What does this implement/fix?

When normal scan fails to find artist or album directory, try to find it by artist.nfo or album.nfo as a fallback.

If the current scanner fails to find the album folder (because it's prefixed, for example), resolving of the artists will fail too, if the artist folder is not in the root directory.

With this addition the server will (only as fallback) try to search for an album.nfo or/and artist.nfo to find the corresponding directories.

This helps with folder structures like mine: `/ripped/s/some_artists/(2026) album/01 nice track.flac` when the .nfo-files are in place.

**Related issue (if applicable):**

- might help with https://github.com/music-assistant/support/issues/3994

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

## Notes:
pytest fails on my machine with:

FAILED tests/helpers/test_tags.py::test_parse_metadata_from_id3tags - AssertionError: assert 1.0 == 1.032
FAILED tests/helpers/test_tags.py::test_parse_metadata_from_filename - AssertionError: assert 1.0 == 1.032
FAILED tests/helpers/test_tags.py::test_parse_metadata_from_invalid_filename - AssertionError: assert 1.0 == 1.032

```
================================================================================================================================ FAILURES =================================================================================================================================
____________________________________________________________________________________________________________________ test_parse_metadata_from_id3tags _____________________________________________________________________________________________________________________

    async def test_parse_metadata_from_id3tags() -> None:
        """Test parsing of parsing metadata from ID3 tags."""
        filename = str(RESOURCES_DIR.joinpath("MyArtist - MyTitle.mp3"))
        _tags = await tags.async_parse_tags(filename)
        assert _tags.album == "MyAlbum"
        assert _tags.title == "MyTitle"
>       assert _tags.duration == 1.032
E       AssertionError: assert 1.0 == 1.032
E        +  where 1.0 = AudioTags(raw={'streams': [{'index': 0, 'codec_name': 'mp3', 'codec_long_name': 'MP3 (MPEG audio layer 3)', 'codec_typ...9999)]}, has_cover_image=False, filename='/home/alex/tmp_music_assistant/server/tests/fixtures/MyArtist - MyTitle.mp3').duration

tests/helpers/test_tags.py:75: AssertionError
____________________________________________________________________________________________________________________ test_parse_metadata_from_filename ____________________________________________________________________________________________________________________

    async def test_parse_metadata_from_filename() -> None:
        """Test parsing of parsing metadata from filename."""
        filename = str(RESOURCES_DIR.joinpath("MyArtist - MyTitle without Tags.mp3"))
        _tags = await tags.async_parse_tags(filename)
        assert _tags.album is None
        assert _tags.title == "MyTitle without Tags"
>       assert _tags.duration == 1.032
E       AssertionError: assert 1.0 == 1.032
E        +  where 1.0 = AudioTags(raw={'streams': [{'index': 0, 'codec_name': 'mp3', 'codec_long_name': 'MP3 (MPEG audio layer 3)', 'codec_typ...cover_image=False, filename='/home/alex/tmp_music_assistant/server/tests/fixtures/MyArtist - MyTitle without Tags.mp3').duration

tests/helpers/test_tags.py:226: AssertionError
________________________________________________________________________________________________________________ test_parse_metadata_from_invalid_filename ________________________________________________________________________________________________________________

    async def test_parse_metadata_from_invalid_filename() -> None:
        """Test parsing of parsing metadata from (invalid) filename."""
        filename = str(RESOURCES_DIR.joinpath("test.mp3"))
        _tags = await tags.async_parse_tags(filename)
        assert _tags.album is None
        assert _tags.title == "test"
>       assert _tags.duration == 1.032
E       AssertionError: assert 1.0 == 1.032
E        +  where 1.0 = AudioTags(raw={'streams': [{'index': 0, 'codec_name': 'mp3', 'codec_long_name': 'MP3 (MPEG audio layer 3)', 'codec_typ...er': 'Lavf59.16.100'}, has_cover_image=False, filename='/home/alex/tmp_music_assistant/server/tests/fixtures/test.mp3').duration

tests/helpers/test_tags.py:242: AssertionError
```


---

Manually executing ffprobe as in the test yields `"duration": "1.000000"` (but also `"start_time": "0.023021"`):
```
# ffprobe -hide_banner -loglevel error -threads 0 -show_error -show_format -show_streams -show_chapters -print_format json -i test.mp3
{
    "streams": [
        {
            "index": 0,
            "codec_name": "mp3",
            "codec_long_name": "MP3 (MPEG audio layer 3)",
            "codec_type": "audio",
            "codec_tag_string": "[0][0][0][0]",
            "codec_tag": "0x0000",
            "mime_codec_string": "mp4a.40.34",
            "sample_fmt": "fltp",
            "sample_rate": "48000",
            "channels": 2,
            "channel_layout": "stereo",
            "bits_per_sample": 0,
            "initial_padding": 0,
            "r_frame_rate": "0/0",
            "avg_frame_rate": "0/0",
            "time_base": "1/14112000",
            "start_pts": 324870,
            "start_time": "0.023021",
            "duration_ts": 14112000,
            "duration": "1.000000",
            "bit_rate": "128000",
            "disposition": {
                "default": 0,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0,
                "timed_thumbnails": 0,
                "non_diegetic": 0,
                "captions": 0,
                "descriptions": 0,
                "metadata": 0,
                "dependent": 0,
                "still_image": 0,
                "multilayer": 0
            },
            "tags": {
                "encoder": "Lavc59.18"
            }
        }
    ],
    "chapters": [

    ],
    "format": {
        "filename": "test.mp3",
        "nb_streams": 1,
        "nb_programs": 0,
        "nb_stream_groups": 0,
        "format_name": "mp3",
        "format_long_name": "MP2/3 (MPEG audio layer 2/3)",
        "start_time": "0.023021",
        "duration": "1.000000",
        "size": "16749",
        "bit_rate": "133992",
        "probe_score": 52,
        "tags": {
            "encoder": "Lavf59.16.100"
        }
    }
}
```



FFmpeg version:
```
# ffprobe -version
ffprobe version n9.0.1 Copyright (c) 2007-2026 the FFmpeg developers
built with gcc 16 (GCC)
configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-amf --enable-avisynth --enable-cuda-llvm --enable-lto --enable-fontconfig --enable-frei0r --enable-gmp --enable-gnutls --enable-gpl --enable-ladspa --enable-lcms2 --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libdav1d --enable-libdrm --enable-libdvdnav --enable-libdvdread --enable-libfreetype --enable-libfribidi --enable-libgsm --enable-libharfbuzz --enable-libiec61883 --enable-libjack --enable-libjxl --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libplacebo --enable-libpulse --enable-librav1e --enable-librsvg --enable-librubberband --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libsvtav1 --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpl --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq --enable-nvdec --enable-nvenc --enable-opencl --enable-opengl --enable-shared --enable-vapoursynth --enable-version3 --enable-vulkan --disable-decoder=magicyuv
libavutil      61.  1.101 / 61.  1.101
libavcodec     63.  1.101 / 63.  1.101
libavformat    63.  1.101 / 63.  1.101
libavdevice    63.  1.101 / 63.  1.101
libavfilter    12.  1.101 / 12.  1.101
libswscale     10.  1.101 / 10.  1.101
libswresample   7.  1.101 /  7.  1.101
```
on up to date cachyOs installation (arch).