### PR TITLE
Fix Spotify playlists failing to load

### DIFF
--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -625,23 +625,40 @@ class SpotifyProvider(MusicProvider):
             await self.get_playlist(prov_playlist_id)
             use_global = await self._playlist_requires_global_token(prov_playlist_id)
 
-        result: list[Track] = []
         page_size = 50
         offset = page * page_size
+        known_global = use_global
 
-        meta = await self._get_playlist_pagination_meta(uri, page, use_global)
-        cache_checksum = meta["etag"]
-        total = meta["total"]
+        while True:
+            try:
+                meta = await self._get_playlist_pagination_meta(uri, page, use_global)
+                cache_checksum = meta["etag"]
+                total = meta["total"]
 
-        # Spotify has started returning 5xx for offset >= total on some
-        # playlists (notably algorithmic ones like Daily Mix). The retry
-        # storm that follows surfaces as "No playable items found".
-        if total and offset >= total:
-            return result
+                # Spotify has started returning 5xx for offset >= total on some
+                # playlists (notably algorithmic ones like Daily Mix). The retry
+                # storm that follows surfaces as "No playable items found".
+                if total and offset >= total:
+                    spotify_result = {"total": total, "items": []}
+                else:
+                    spotify_result = await self._get_data_with_caching(
+                        uri,
+                        cache_checksum,
+                        limit=page_size,
+                        offset=offset,
+                        use_global_session=use_global,
+                    )
+                break
+            except MediaNotFoundError:
+                if use_global or not self.dev_session_active:
+                    raise
+                # Development Mode exposes metadata but restricts items for non-owned playlists.
+                use_global = True
 
-        spotify_result = await self._get_data_with_caching(
-            uri, cache_checksum, limit=page_size, offset=offset, use_global_session=use_global
-        )
+        if use_global and not known_global:
+            await self._set_playlist_requires_global_token(prov_playlist_id)
+
+        result: list[Track] = []
         total = spotify_result.get("total", 0)
         items = spotify_result.get("items", [])
         # playlists/{id}/items is transitioning from item["track"] to item["item"]

--- a/tests/providers/spotify/test_playlist_tracks.py
+++ b/tests/providers/spotify/test_playlist_tracks.py
@@ -5,6 +5,9 @@ from collections import OrderedDict
 from typing import Any, NamedTuple
 from unittest.mock import AsyncMock, MagicMock, call
 
+import pytest
+from music_assistant_models.errors import MediaNotFoundError
+
 from music_assistant.providers.spotify.provider import (
     _PLAYLIST_PAGINATION_STATE_LIMIT,
     SpotifyProvider,
@@ -22,6 +25,7 @@ class SpotifyPlaylistHarness(NamedTuple):
     requires_global: AsyncMock
     get_metadata: AsyncMock
     get_page: AsyncMock
+    set_global: AsyncMock
 
 
 def _make_provider(instance_id: str = "spotify--test") -> SpotifyPlaylistHarness:
@@ -32,6 +36,7 @@ def _make_provider(instance_id: str = "spotify--test") -> SpotifyPlaylistHarness
     provider.logger = MagicMock()
     provider._sp_user = {"id": "test-user", "display_name": "Test User"}
     provider._playlist_pagination_states = OrderedDict()
+    provider.dev_session_active = True
 
     mass = MagicMock()
     mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
@@ -44,10 +49,12 @@ def _make_provider(instance_id: str = "spotify--test") -> SpotifyPlaylistHarness
     requires_global = AsyncMock(return_value=False)
     get_metadata = AsyncMock()
     get_page = AsyncMock()
+    set_global = AsyncMock()
     provider.get_playlist = get_playlist  # type: ignore[method-assign]
     provider._playlist_requires_global_token = requires_global  # type: ignore[method-assign]
     provider._get_paginated_meta = get_metadata  # type: ignore[method-assign]
     provider._get_data_with_caching = get_page  # type: ignore[method-assign]
+    provider._set_playlist_requires_global_token = set_global  # type: ignore[method-assign]
 
     return SpotifyPlaylistHarness(
         provider,
@@ -55,6 +62,7 @@ def _make_provider(instance_id: str = "spotify--test") -> SpotifyPlaylistHarness
         requires_global,
         get_metadata,
         get_page,
+        set_global,
     )
 
 
@@ -368,6 +376,99 @@ async def test_session_paths_do_not_share_pagination_metadata() -> None:
         (args.args[1], args.kwargs["use_global_session"])
         for args in harness.get_page.await_args_list
     ] == [("dev-etag", False), ("global-etag", True)]
+
+
+async def test_restricted_playlist_items_metadata_retries_with_global_session() -> None:
+    """Playlist items hidden from the developer session remain available globally."""
+    harness = _make_provider()
+    harness.get_metadata.side_effect = [
+        MediaNotFoundError("developer session forbidden"),
+        {"etag": "global-etag", "total": 1},
+    ]
+    harness.get_page.return_value = _playlist_page(1, "global-track")
+
+    tracks = await harness.provider.get_playlist_tracks(PLAYLIST_ID)
+
+    assert [args.kwargs["use_global_session"] for args in harness.get_metadata.await_args_list] == [
+        False,
+        True,
+    ]
+    harness.get_page.assert_awaited_once_with(
+        f"playlists/{PLAYLIST_ID}/items",
+        "global-etag",
+        limit=50,
+        offset=0,
+        use_global_session=True,
+    )
+    harness.set_global.assert_awaited_once_with(PLAYLIST_ID)
+    assert tracks[0].item_id == "global-track"
+
+
+async def test_restricted_playlist_page_retries_with_global_session() -> None:
+    """A rejected developer-session page retries the complete request through the global session."""
+    harness = _make_provider()
+    harness.get_metadata.side_effect = [
+        {"etag": "dev-etag", "total": 1},
+        {"etag": "global-etag", "total": 1},
+    ]
+    harness.get_page.side_effect = [
+        MediaNotFoundError("developer session forbidden"),
+        _playlist_page(1, "global-track"),
+    ]
+
+    tracks = await harness.provider.get_playlist_tracks(PLAYLIST_ID)
+
+    assert [
+        (args.args[1], args.kwargs["use_global_session"])
+        for args in harness.get_page.await_args_list
+    ] == [("dev-etag", False), ("global-etag", True)]
+    harness.set_global.assert_awaited_once_with(PLAYLIST_ID)
+    assert tracks[0].item_id == "global-track"
+
+
+@pytest.mark.parametrize(
+    ("dev_session_active", "requires_global", "use_global_session"),
+    [(False, False, False), (True, True, True)],
+)
+async def test_playlist_failure_without_available_fallback_propagates(
+    dev_session_active: bool,
+    requires_global: bool,
+    use_global_session: bool,
+) -> None:
+    """Playlist failures propagate when another Spotify session cannot be tried."""
+    harness = _make_provider()
+    harness.provider.dev_session_active = dev_session_active
+    harness.requires_global.return_value = requires_global
+    harness.get_metadata.side_effect = MediaNotFoundError("playlist unavailable")
+
+    with pytest.raises(MediaNotFoundError):
+        await harness.provider.get_playlist_tracks(PLAYLIST_ID)
+
+    harness.get_metadata.assert_awaited_once_with(
+        f"playlists/{PLAYLIST_ID}/items",
+        limit=1,
+        offset=0,
+        use_global_session=use_global_session,
+    )
+    harness.set_global.assert_not_awaited()
+
+
+async def test_failed_global_playlist_fallback_is_not_cached() -> None:
+    """An unavailable playlist is not marked as requiring the global session."""
+    harness = _make_provider()
+    harness.get_metadata.side_effect = [
+        MediaNotFoundError("developer session forbidden"),
+        MediaNotFoundError("playlist unavailable"),
+    ]
+
+    with pytest.raises(MediaNotFoundError):
+        await harness.provider.get_playlist_tracks(PLAYLIST_ID)
+
+    assert [args.kwargs["use_global_session"] for args in harness.get_metadata.await_args_list] == [
+        False,
+        True,
+    ]
+    harness.set_global.assert_not_awaited()
 
 
 async def test_provider_instances_do_not_share_pagination_metadata() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Spotify developer sessions can return playlist metadata while rejecting the tracks of playlists owned by other users, causing those playlists to appear empty.

- Retry rejected playlist item requests through the global Spotify session.
- Cache successful fallbacks to avoid repeated failed requests.
- Cover both pagination metadata and page-fetch failures.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6086

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only (no code changes) — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.