### PR TITLE
AirPlay speakers no longer stay loud after an announcement

### DIFF
--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -390,8 +390,11 @@ async def _announce_with_session(
     finally:
         player._transitioning = False
         try:
-            # Whatever the wait above did not reach (a failed or cancelled
-            # announcement) still has to be restored while the session is up.
+            # Whatever the wait above did not reach (a cancelled announcement)
+            # still has to be restored while the session is up. A session that
+            # failed to START has already stopped itself, so there the restore
+            # only settles our own state and the device is corrected by the
+            # volume the next stream pushes.
             await _restore_member_volumes(prev_volumes)
         finally:
             if session is not None:
@@ -630,13 +633,14 @@ async def _restore_member_volumes(prev_volumes: dict[AirPlayPlayer, int]) -> Non
     afterwards it would just update our own state and leave the speaker at the
     announcement level until the next stream pushes the remembered one.
 
-    The mapping is consumed, so calling this again restores nothing.
+    An entry is dropped only once its member is restored, so a later call
+    covers exactly what this one did not reach.
 
     :param prev_volumes: The level each member carried before the announcement.
     """
-    while prev_volumes:
-        member, prev_volume = prev_volumes.popitem()
-        await member.volume_set(prev_volume)
+    for member in list(prev_volumes):
+        await member.volume_set(prev_volumes[member])
+        del prev_volumes[member]
 
 
 async def _no_announce_ack() -> tuple[int, int] | None:

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -379,7 +379,10 @@ async def _announce_with_session(
             player._transitioning = False
         # The clip is anchored: wait out the start lead plus the clip, then the
         # pad that covers the jitter between the anchored and the true audible
-        # end, so the restore below cannot clip the announcement's own tail.
+        # end, so the restore below does not land on the announcement's own
+        # tail. Restoring at the end of the drain instead would be a coin flip:
+        # the binary reports its own end of stream on that same margin, and the
+        # server treats that report as the end of the stream.
         restore_pad = AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS / 1000
         await asyncio.sleep(max(0.0, session.start_time - time.time()) + duration + restore_pad)
         await _restore_member_volumes(prev_volumes)
@@ -390,8 +393,8 @@ async def _announce_with_session(
     finally:
         player._transitioning = False
         try:
-            # Whatever the wait above did not reach (a cancelled announcement)
-            # still has to be restored while the session is up. A session that
+            # Whatever the restore above did not reach (a cancelled
+            # announcement) still goes back while the session is up. A session that
             # failed to START has already stopped itself, so there the restore
             # only settles our own state and the device is corrected by the
             # volume the next stream pushes.
@@ -630,8 +633,8 @@ async def _restore_member_volumes(prev_volumes: dict[AirPlayPlayer, int]) -> Non
 
     An AirPlay volume command only reaches the receiver over a running stream,
     so this has to be called while the announcement session is still up:
-    afterwards it would just update our own state and leave the speaker at the
-    announcement level until the next stream pushes the remembered one.
+    afterwards it only settles our own state and leaves the speaker sitting at
+    the announcement level.
 
     An entry is dropped only once its member is restored, so a later call
     covers exactly what this one did not reach.

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -285,6 +285,9 @@ async def _announce_over_live_session(
         # The scheduled volume changes belong to an announcement that is no
         # longer being tracked: cancel them and restore the previous levels
         # right away (a restore of an unchanged level is a harmless re-send).
+        # This path leaves the music session running, so the restore still
+        # reaches the receiver from its own task - unlike the dedicated
+        # session, which has to be restored before it is torn down.
         for member, prev_volume, task_ids in volume_schedules:
             for task_id in task_ids:
                 member.mass.cancel_timer(task_id)
@@ -374,21 +377,28 @@ async def _announce_with_session(
             )
             await session.start(render.get_stream(session_pcm_format))
             player._transitioning = False
-        # The clip is anchored: wait out the start lead plus the clip and the
-        # receiver drain. The source ends after the clip, so the session
-        # usually ends cleanly on its own and the stop below is cleanup only.
-        await asyncio.sleep(
-            max(0.0, session.start_time - time.time()) + duration + AIRPLAY_ANNOUNCE_SESSION_DRAIN_S
-        )
+        # The clip is anchored: wait out the start lead plus the clip, then the
+        # pad that covers the jitter between the anchored and the true audible
+        # end, so the restore below cannot clip the announcement's own tail.
+        restore_pad = AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS / 1000
+        await asyncio.sleep(max(0.0, session.start_time - time.time()) + duration + restore_pad)
+        await _restore_member_volumes(prev_volumes)
+        # Let the receiver play out what it still has buffered before the stop.
+        # The source ends after the clip, so the session usually ends cleanly on
+        # its own and that stop is cleanup only.
+        await asyncio.sleep(max(0.0, AIRPLAY_ANNOUNCE_SESSION_DRAIN_S - restore_pad))
     finally:
         player._transitioning = False
-        if session is not None:
-            await session.stop()
-            # like player.stop(): an idle player must not keep showing media
-            player._attr_current_media = None
-            player.update_state()
-        for member, prev_volume in prev_volumes.items():
-            await member.volume_set(prev_volume)
+        try:
+            # Whatever the wait above did not reach (a failed or cancelled
+            # announcement) still has to be restored while the session is up.
+            await _restore_member_volumes(prev_volumes)
+        finally:
+            if session is not None:
+                await session.stop()
+                # like player.stop(): an idle player must not keep showing media
+                player._attr_current_media = None
+                player.update_state()
 
 
 def _live_members(player: AirPlayPlayer) -> list[AirPlayPlayer]:
@@ -609,6 +619,24 @@ def _write_clip_file(data: bytes | bytearray) -> str:
     with os.fdopen(fd, "wb") as clip_file:
         clip_file.write(data)
     return path
+
+
+async def _restore_member_volumes(prev_volumes: dict[AirPlayPlayer, int]) -> None:
+    """
+    Put every bumped member back on its pre-announcement volume.
+
+    An AirPlay volume command only reaches the receiver over a running stream,
+    so this has to be called while the announcement session is still up:
+    afterwards it would just update our own state and leave the speaker at the
+    announcement level until the next stream pushes the remembered one.
+
+    The mapping is consumed, so calling this again restores nothing.
+
+    :param prev_volumes: The level each member carried before the announcement.
+    """
+    while prev_volumes:
+        member, prev_volume = prev_volumes.popitem()
+        await member.volume_set(prev_volume)
 
 
 async def _no_announce_ack() -> tuple[int, int] | None:

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -34,10 +34,10 @@ def _zero_restore_pad() -> Iterator[None]:
     """
     Zero the audible-end pad for every test.
 
-    The live path holds its return (and the volume restore) until the clip's
-    audible end plus this pad; the streams below ack a long-past instant, so
-    only the pad would otherwise add real wall-clock time to every test. The
-    audible-end test overrides it with its own value.
+    Both paths hold the volume restore until the clip's audible end plus this
+    pad - the live path holds its return with it too; the streams below ack a
+    long-past instant, so only the pad would otherwise add real wall-clock time
+    to every test. The tests that assert on that timing override it themselves.
     """
     with patch.object(announce, "AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS", 0):
         yield
@@ -331,16 +331,22 @@ async def test_session_path_plays_the_clip_and_restores_the_volume() -> None:
     announcement = _make_announcement()
     render = _make_render(duration=0.01)
     player.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
-    events: list[str] = []
-    player.volume_set = AsyncMock(side_effect=lambda level: events.append(f"volume={level}"))
+    events: list[tuple[str, float]] = []
 
     with (
         patch.object(announce, "AirPlayStreamSession") as session_cls,
-        patch.object(announce, "AIRPLAY_ANNOUNCE_SESSION_DRAIN_S", 0.0),
+        patch.object(announce, "AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS", 100),
+        patch.object(announce, "AIRPLAY_ANNOUNCE_SESSION_DRAIN_S", 0.4),
     ):
+        started = time.monotonic()
+        player.volume_set = AsyncMock(
+            side_effect=lambda level: events.append((f"volume={level}", time.monotonic() - started))
+        )
         session = session_cls.return_value
         session.start = AsyncMock()
-        session.stop = AsyncMock(side_effect=lambda: events.append("stop"))
+        session.stop = AsyncMock(
+            side_effect=lambda: events.append(("stop", time.monotonic() - started))
+        )
         session.start_time = 0.0
         await announce.play_announcement(player, announcement, 60)
 
@@ -353,8 +359,13 @@ async def test_session_path_plays_the_clip_and_restores_the_volume() -> None:
     session.start.assert_awaited_once()
     session.stop.assert_awaited_once()
     # An AirPlay volume only reaches the receiver over a running stream, so the
-    # restore has to be sent before the session is stopped.
-    assert events == ["volume=60", "volume=25", "stop"]
+    # restore has to land on the clip's audible end (+ the 0.1s pad), well
+    # inside the 0.4s drain the session is stopped after.
+    assert [name for name, _ in events] == ["volume=60", "volume=25", "stop"]
+    _, restored_at = events[1]
+    _, stopped_at = events[2]
+    assert 0.1 <= restored_at < 0.3
+    assert stopped_at >= 0.4
     # the player ends idle without still showing media (like player.stop())
     assert player._attr_current_media is None
     player.update_state.assert_called()

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -361,26 +361,34 @@ async def test_session_path_plays_the_clip_and_restores_the_volume() -> None:
 
 
 @pytest.mark.asyncio
-async def test_session_path_restores_the_volume_when_the_session_fails() -> None:
-    """A session that never gets going still hands the speaker back its own volume."""
+async def test_session_path_restores_the_volume_when_the_clip_is_cut_short() -> None:
+    """An announcement cancelled mid-clip hands the speaker back its own volume."""
     player = _make_player("solo")
     player.playback_state = PlaybackState.IDLE
     player.volume_level = 25
     player._get_sync_clients = MagicMock(return_value=[player])
     player._get_session_pcm_format = AsyncMock(return_value=AIRPLAY_PCM_FORMAT)
-    render = _make_render(duration=0.01)
+    render = _make_render(duration=30)
     player.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
     events: list[str] = []
     player.volume_set = AsyncMock(side_effect=lambda level: events.append(f"volume={level}"))
 
     with patch.object(announce, "AirPlayStreamSession") as session_cls:
+        started = asyncio.Event()
         session = session_cls.return_value
-        session.start = AsyncMock(side_effect=RuntimeError("receiver refused the session"))
+        session.start = AsyncMock(side_effect=lambda _source: started.set())
         session.stop = AsyncMock(side_effect=lambda: events.append("stop"))
         session.start_time = 0.0
-        with pytest.raises(RuntimeError):
-            await announce.play_announcement(player, _make_announcement(), 60)
+        announcing = asyncio.create_task(
+            announce.play_announcement(player, _make_announcement(), 60)
+        )
+        # the session is up; the cancel lands in the clip wait that follows
+        await started.wait()
+        announcing.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await announcing
 
+    # the session is still up here, so the restore reaches the receiver
     assert events == ["volume=60", "volume=25", "stop"]
 
 

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -331,6 +331,8 @@ async def test_session_path_plays_the_clip_and_restores_the_volume() -> None:
     announcement = _make_announcement()
     render = _make_render(duration=0.01)
     player.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
+    events: list[str] = []
+    player.volume_set = AsyncMock(side_effect=lambda level: events.append(f"volume={level}"))
 
     with (
         patch.object(announce, "AirPlayStreamSession") as session_cls,
@@ -338,7 +340,7 @@ async def test_session_path_plays_the_clip_and_restores_the_volume() -> None:
     ):
         session = session_cls.return_value
         session.start = AsyncMock()
-        session.stop = AsyncMock()
+        session.stop = AsyncMock(side_effect=lambda: events.append("stop"))
         session.start_time = 0.0
         await announce.play_announcement(player, announcement, 60)
 
@@ -350,11 +352,36 @@ async def test_session_path_plays_the_clip_and_restores_the_volume() -> None:
     )
     session.start.assert_awaited_once()
     session.stop.assert_awaited_once()
-    # announcement volume before the session, previous level restored after
-    assert [call.args for call in player.volume_set.await_args_list] == [(60,), (25,)]
+    # An AirPlay volume only reaches the receiver over a running stream, so the
+    # restore has to be sent before the session is stopped.
+    assert events == ["volume=60", "volume=25", "stop"]
     # the player ends idle without still showing media (like player.stop())
     assert player._attr_current_media is None
     player.update_state.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_session_path_restores_the_volume_when_the_session_fails() -> None:
+    """A session that never gets going still hands the speaker back its own volume."""
+    player = _make_player("solo")
+    player.playback_state = PlaybackState.IDLE
+    player.volume_level = 25
+    player._get_sync_clients = MagicMock(return_value=[player])
+    player._get_session_pcm_format = AsyncMock(return_value=AIRPLAY_PCM_FORMAT)
+    render = _make_render(duration=0.01)
+    player.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
+    events: list[str] = []
+    player.volume_set = AsyncMock(side_effect=lambda level: events.append(f"volume={level}"))
+
+    with patch.object(announce, "AirPlayStreamSession") as session_cls:
+        session = session_cls.return_value
+        session.start = AsyncMock(side_effect=RuntimeError("receiver refused the session"))
+        session.stop = AsyncMock(side_effect=lambda: events.append("stop"))
+        session.start_time = 0.0
+        with pytest.raises(RuntimeError):
+            await announce.play_announcement(player, _make_announcement(), 60)
+
+    assert events == ["volume=60", "volume=25", "stop"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

When an announcement plays on an AirPlay player that is idle (so it gets its own short-lived stream), Music Assistant turns the speaker up to the announcement volume and then puts it back afterwards. That "put it back" was sent after the stream had already been torn down, so it never reached the speaker — an AirPlay volume command only travels over a running stream.

On a speaker that owns its own volume, this left it sitting at the (usually louder) announcement level. It corrected itself the next time you played something, but until then the speaker was too loud.

The volume is now handed back at the end of the clip, while the stream is still up.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- the pre-announcement volume is restored at the clip's audible end instead of after the announcement session is stopped
- a failed or cancelled announcement restores it too, still before the session is torn down
- the total announcement length is unchanged

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
