### PR TITLE
Explain how volume reaches a Sendspin-bridged AirPlay speaker

### DIFF
--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -467,6 +467,9 @@ class SendspinAirPlayBridge:
         """
         if not self._bridge_role:
             return
+        # The level goes in on the same scale a volume command comes out on, which
+        # is what lets a command the role just sent read back equal instead of
+        # bouncing between the two.
         self._bridge_role.update_player_state(
             volume=self.airplay_player.volume_level,
             muted=bool(self.airplay_player.volume_muted),
@@ -954,10 +957,21 @@ class SendspinAirPlayBridge:
 
     def _on_volume_change(self, volume: int) -> None:
         """Forward volume changes to the AirPlay player."""
+        # The role is the parent's volume control while the bridge streams, so a
+        # volume from Music Assistant arrives here having already passed control
+        # resolution and been scaled into the parent's min/max range - this is the
+        # last leg of that command, not a new one. Sending it back through the
+        # controller would scale it a second time and return here over the same
+        # route, walking the speaker down a step on every pass. A volume a Sendspin
+        # controller set instead never passed the parent, which makes it an
+        # externally changed volume like any other: the limits are enforced on the
+        # parent's state update once this lands.
         self.mass.create_task(self.airplay_player.volume_set(volume))
 
     def _on_mute_change(self, muted: bool) -> None:
         """Forward mute changes to the AirPlay player."""
+        # Resolved through the parent like the volume above, so it is applied here
+        # rather than sent back around the controller.
         self.mass.create_task(self.airplay_player.volume_mute(muted))
 
     def _on_bridge_stream_end(self) -> None:

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -467,9 +467,8 @@ class SendspinAirPlayBridge:
         """
         if not self._bridge_role:
             return
-        # The level goes in on the same scale a volume command comes out on, which
-        # is what lets a command the role just sent read back equal instead of
-        # bouncing between the two.
+        # Both sides hold the device-scale level, so a value read back here compares
+        # equal to the one the role just sent instead of bouncing between the two.
         self._bridge_role.update_player_state(
             volume=self.airplay_player.volume_level,
             muted=bool(self.airplay_player.volume_muted),
@@ -957,21 +956,22 @@ class SendspinAirPlayBridge:
 
     def _on_volume_change(self, volume: int) -> None:
         """Forward volume changes to the AirPlay player."""
-        # The role is the parent's volume control while the bridge streams, so a
-        # volume from Music Assistant arrives here having already passed control
-        # resolution and been scaled into the parent's min/max range - this is the
-        # last leg of that command, not a new one. Sending it back through the
-        # controller would scale it a second time and return here over the same
-        # route, walking the speaker down a step on every pass. A volume a Sendspin
-        # controller set instead never passed the parent, which makes it an
-        # externally changed volume like any other: the limits are enforced on the
-        # parent's state update once this lands.
+        # The level is already on the AirPlay device's scale, so it is applied as-is.
+        # Where the role is the parent's volume control - a parent with no volume of
+        # its own, while the bridge streams - a volume from Music Assistant arrives
+        # here having passed the controller and been scaled into the parent's min/max
+        # range, so routing it back through cmd_volume_set would scale it a second
+        # time and return over the same route, settling the speaker below the level
+        # that was asked for. A volume a Sendspin controller set never passed the
+        # parent at all: that is an externally changed volume like any other, clamped
+        # to the limits on the parent's state update.
         self.mass.create_task(self.airplay_player.volume_set(volume))
 
     def _on_mute_change(self, muted: bool) -> None:
         """Forward mute changes to the AirPlay player."""
-        # Resolved through the parent like the volume above, so it is applied here
-        # rather than sent back around the controller.
+        # Applied here for the same reason as the volume above. A mute has no scale
+        # to get wrong, but it would come straight back through the role, and an
+        # unchanged mute is not a command the controller drops.
         self.mass.create_task(self.airplay_player.volume_mute(muted))
 
     def _on_bridge_stream_end(self) -> None:

--- a/music_assistant/providers/sendspin/bridge_role.py
+++ b/music_assistant/providers/sendspin/bridge_role.py
@@ -178,9 +178,8 @@ class BridgePlayerRole(Role):
         """
         Set volume and notify bridge.
 
-        The level is on the scale the role reports, which is the one the bridge
-        seeded it with and keeps current through update_player_state, so it is
-        handed to the callback unchanged.
+        The level is on the scale the role reports, and is stored, announced to
+        the client and handed to the bridge unchanged.
         """
         self._volume = volume
         self._emit_volume_changed()

--- a/music_assistant/providers/sendspin/bridge_role.py
+++ b/music_assistant/providers/sendspin/bridge_role.py
@@ -175,7 +175,13 @@ class BridgePlayerRole(Role):
         return self._muted
 
     def set_player_volume(self, volume: int) -> None:
-        """Set volume and notify bridge."""
+        """
+        Set volume and notify bridge.
+
+        The level is on the scale the role reports, which is the one the bridge
+        seeded it with and keeps current through update_player_state, so it is
+        handed to the callback unchanged.
+        """
         self._volume = volume
         self._emit_volume_changed()
         if self._on_volume_change_cb:

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -3187,11 +3187,9 @@ def test_a_volume_from_the_role_is_not_resolved_a_second_time() -> None:
     """
     A volume the role delivers reaches the speaker as-is, not via the controller.
 
-    The role is the parent's volume control while the bridge streams, so the level
-    has already been scaled into the parent's min/max range on its way here. Sending
-    it back through the controller would scale it again and arrive back over the
-    same route, so a speaker limited to 60 would keep stepping down instead of
-    landing on the level that was asked for.
+    The level arrives on the device's own scale, already resolved and scaled where
+    it came from Music Assistant, so sending it back through the controller would
+    resolve it a second time and return over the same route.
     """
     bridge, role = _make_bridge_with_role(volume=40)
     player = cast("MagicMock", bridge.airplay_player)

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -3181,3 +3181,26 @@ def test_a_volume_set_through_the_bridge_settles_in_one_pass() -> None:
 
     assert role.get_player_volume() == 70
     client._signal_event.assert_not_called()
+
+
+def test_a_volume_from_the_role_is_not_resolved_a_second_time() -> None:
+    """
+    A volume the role delivers reaches the speaker as-is, not via the controller.
+
+    The role is the parent's volume control while the bridge streams, so the level
+    has already been scaled into the parent's min/max range on its way here. Sending
+    it back through the controller would scale it again and arrive back over the
+    same route, so a speaker limited to 60 would keep stepping down instead of
+    landing on the level that was asked for.
+    """
+    bridge, role = _make_bridge_with_role(volume=40)
+    player = cast("MagicMock", bridge.airplay_player)
+    players_ctrl = cast("MagicMock", bridge.mass).players
+
+    role.set_player_volume(60)
+    role.set_player_mute(True)
+
+    player.volume_set.assert_called_once_with(60)
+    player.volume_mute.assert_called_once_with(True)
+    players_ctrl.cmd_volume_set.assert_not_called()
+    players_ctrl.cmd_volume_mute.assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

The volume and mute callbacks on the Sendspin bridge hand their value straight to the AirPlay player instead of going through the player controller, which reads like they skip the volume limits and the control resolution. They don't. The level arrives on the AirPlay device's own scale, and where the speaker has no volume of its own to resolve to, the bridge role is what the player's volume resolves to while it streams - so a volume from Music Assistant has already been through the controller and been scaled into the configured min/max range by the time it gets here. It is the last leg of that command, not a new one.

Routing it back through the controller would scale it a second time and arrive again over the same route, so a speaker limited to 60 would settle below the level it was asked for. A volume a Sendspin controller set never passed the player at all, which makes it an externally changed volume like any other - clamped to the limits on the next state update, the same as a volume changed on the speaker itself.

No behaviour change.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- the AirPlay bridge's volume and mute callbacks explain which scale they receive, and when the role is what the player's volume resolves to
- noted that a volume set from a Sendspin controller is an externally changed volume, with the limits enforced on the player's state update
- the bridge role states that a volume it delivers is on the scale it reports
- added a test covering that a volume from the role reaches the speaker unchanged

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
