### PR TITLE
A muted player stays muted when you change its volume

### DIFF
--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -490,7 +490,8 @@ class AnnouncementsMixin:
             async with TaskManager(self.mass) as tg:
                 for volume_player_id, prev_volume in prev_volumes.items():
                     tg.create_task(self._handle_cmd_volume_set(volume_player_id, prev_volume))
-            # restore mute after the volume, because setting a volume unmutes the player again
+            # restore mute after the volume: a fake mute is simulated with the volume itself,
+            # so it only sticks once the level it hides behind is back in place
             async with TaskManager(self.mass) as tg:
                 for muted_player in muted_players:
                     tg.create_task(self._set_announcement_mute(muted_player, True))
@@ -742,7 +743,8 @@ class AnnouncementsMixin:
         async with TaskManager(self.mass) as tg:
             for volume_player_id, prev_volume in prev_volumes.items():
                 tg.create_task(self._handle_cmd_volume_set(volume_player_id, prev_volume))
-        # restore mute after the volume, because setting a volume unmutes the player again
+        # restore mute after the volume: a fake mute is simulated with the volume itself,
+        # so it only sticks once the level it hides behind is back in place
         async with TaskManager(self.mass) as tg:
             for muted_player_id in prev_muted:
                 if not (muted_player := self.get_player(muted_player_id)):

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3664,24 +3664,9 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             await self.cmd_group_volume(player_id, volume_level)
             return
 
-        # Check if player has mute lock (set when individually muted in a group)
-        # If locked, don't auto-unmute when volume changes
-        has_mute_lock = self._has_active_mute_lock(player)
-        if (
-            not has_mute_lock
-            # the live value is what cmd_volume_mute checks, so a control change that
-            # has not reached the player state yet may not send us into a failing unmute
-            and player.mute_control not in (PLAYER_CONTROL_NONE, PLAYER_CONTROL_FAKE)
-            and player.state.volume_muted
-        ):
-            # if player is muted and not locked, we unmute it first
-            # skip this for fake mute since it uses volume to simulate mute
-            self.logger.debug(
-                "Unmuting player %s before setting volume",
-                player.state.name,
-            )
-            await self.cmd_volume_mute(player_id, False)
-
+        # A muted player stays muted: only an explicit unmute lifts it, and the level
+        # set here is the one it plays at once that happens. Fake mute is the exception,
+        # because it is simulated with the volume itself.
         if self._stays_silent_on_volume_change(player):
             # a locked player stays silent, the volume it holds is the one
             # that gets restored once it is unmuted again
@@ -3690,7 +3675,6 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             # for, which is then not the level this player ends up at
             record_target = True
         else:
-            # always reset fake mute when controlling volume
             player.extra_data.pop(ATTR_FAKE_MUTE, None)
 
         if record_target:

--- a/music_assistant/providers/bose_soundtouch/player.py
+++ b/music_assistant/providers/bose_soundtouch/player.py
@@ -191,9 +191,10 @@ class BoseSoundTouchPlayer(Player):
 
     async def volume_set(self, volume_level: int) -> None:
         """Handle VOLUME_SET command on the player."""
-        await self._client.set_volume(volume_level, mute=False)
+        # the device takes volume and mute in one call, so pass the mute it already
+        # holds: a volume change is not an unmute
+        await self._client.set_volume(volume_level, mute=bool(self.volume_muted))
         self._attr_volume_level = volume_level
-        self._attr_volume_muted = False
         self.update_state()
 
     async def volume_mute(self, muted: bool) -> None:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -2471,21 +2471,22 @@ class TestGroupVolumeOrdering:
         assert players["member"].state.volume_level == 10
         assert players["leader"].state.volume_level == 80
 
-    async def test_a_muted_leader_does_not_wait_on_its_own_group_command(
+    async def test_a_muted_leader_keeps_its_mute_on_a_group_volume_change(
         self, mock_mass: MagicMock
     ) -> None:
-        """A muted sync leader is unmuted by a group volume change without blocking."""
+        """A muted sync leader keeps its mute through a group volume change without blocking."""
         controller, players = self._make_synced_pair(mock_mass)
         players["leader"]._attr_volume_muted = True
         players["leader"].update_state(force_update=True, signal_event=False)
 
         # a sync leader is a member of its own group, so the fan-out sets the volume
-        # (and unmutes) the very player the group command is running for
+        # of the very player the group command is running for. This must not deadlock
+        # on a nested cmd_volume_mute call under the group's own volume lock.
         async with asyncio.timeout(5):
             await controller.cmd_group_volume("leader", 30)
 
         players["leader"].update_state()
-        assert players["leader"].state.volume_muted is False
+        assert players["leader"].state.volume_muted is True
         assert players["leader"].state.volume_level == 30
 
 
@@ -3271,7 +3272,12 @@ class TestGroupMuteOnNonGroupPlayer:
 
 
 class TestMuteLockAfterUngroup:
-    """A mute lock is only honored while the player it belongs to is still grouped."""
+    """
+    Mute persistence across a volume-set command.
+
+    A native mute is never lifted by a volume command, grouped or not. A fake mute
+    lock is honored only while the player it belongs to is still grouped.
+    """
 
     def _make_synced_pair(
         self, mock_mass: MagicMock, member_mute_control: str
@@ -3328,8 +3334,10 @@ class TestMuteLockAfterUngroup:
         assert players["member"].state.volume_level == 70
         assert players["member"].state.volume_muted is False
 
-    async def test_natively_muted_player_is_unmuted_again(self, mock_mass: MagicMock) -> None:
-        """A natively muted player is auto-unmuted by a volume change once its group is gone."""
+    async def test_natively_muted_player_keeps_its_mute_after_ungroup(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A natively muted player keeps its mute on a volume change, group gone or not."""
         controller, players = self._make_synced_pair(mock_mass, PLAYER_CONTROL_NATIVE)
         mute = AsyncMock(
             side_effect=lambda muted: setattr(players["member"], "_attr_volume_muted", muted)
@@ -3340,10 +3348,10 @@ class TestMuteLockAfterUngroup:
 
         await controller.cmd_volume_set("member", 70)
 
-        assert mute.await_args_list == [call(True), call(False)]
+        mute.assert_awaited_once_with(True)
         players["member"].update_state()
         assert players["member"].state.volume_level == 70
-        assert players["member"].state.volume_muted is False
+        assert players["member"].state.volume_muted is True
 
     async def test_still_grouped_player_keeps_its_lock(self, mock_mass: MagicMock) -> None:
         """A muted player that is still grouped stays silent on a volume change."""
@@ -3360,7 +3368,7 @@ class TestMuteLockAfterUngroup:
         self, mock_mass: MagicMock
     ) -> None:
         """A protocol player inherits the lock of the parent it renders for, group and all."""
-        controller, players = self._make_synced_pair(mock_mass, PLAYER_CONTROL_NATIVE)
+        controller, players = self._make_synced_pair(mock_mass, PLAYER_CONTROL_FAKE)
         member = players["member"]
         protocol_player = MockPlayer(
             MockProvider("sendspin", instance_id="sendspin", mass=mock_mass),
@@ -3372,13 +3380,11 @@ class TestMuteLockAfterUngroup:
             PlayerFeature.VOLUME_SET,
             PlayerFeature.VOLUME_MUTE,
         }
-        protocol_player._attr_volume_muted = True
+        protocol_player._attr_volume_level = 50
+        protocol_player.volume_set = AsyncMock(  # type: ignore[method-assign]
+            side_effect=lambda volume: setattr(protocol_player, "_attr_volume_level", volume)
+        )
         protocol_player.set_protocol_parent_id("member")
-        # an unmute on a protocol player is redirected to the parent it renders for
-        mute = AsyncMock()
-        member.volume_mute = mute  # type: ignore[method-assign]
-        protocol_player.volume_mute = AsyncMock()  # type: ignore[method-assign]
-        protocol_player.volume_set = AsyncMock()  # type: ignore[method-assign]
         controller._players["proto_member"] = protocol_player
         member.set_linked_output_protocols(
             [
@@ -3392,16 +3398,25 @@ class TestMuteLockAfterUngroup:
         protocol_player.set_initialized()
         protocol_player.update_state(signal_event=False)
         member.refresh_state(signal_event=False)
-        member.extra_data[ATTR_MUTE_LOCK] = True
 
-        # a group volume change reaches the protocol player through the internal handler
+        # the lock is earned by the parent while it is still grouped. The internal
+        # handler is used to fake-mute the protocol player itself, bypassing the
+        # public command's auto-resolve to its parent, so the fake-mute flag ends
+        # up on the protocol player and the fake-mute volume path applies to it
+        await controller.cmd_volume_mute("member", True)
+        await controller._handle_cmd_volume_mute(protocol_player, PLAYER_CONTROL_FAKE, True)
+
+        # while the parent holds the lock, a volume command for the protocol player
+        # is forced to 0 (stays silent) instead of releasing its fake mute
         await controller._handle_cmd_volume_set("proto_member", 70)
-        mute.assert_not_awaited()
+        protocol_player.update_state()
+        assert protocol_player.state.volume_level == 0
 
         self._dissolve_group(players)
         await controller._handle_cmd_volume_set("proto_member", 70)
 
-        mute.assert_awaited_once_with(False)
+        protocol_player.update_state()
+        assert protocol_player.state.volume_level == 70
 
 
 class TestCurrentMediaTimeUpdates:


### PR DESCRIPTION
# What does this implement/fix?

Changing the volume of a muted player silently unmuted it. Muting is something the user chose, so a volume command should not undo it: the level set while muted is simply the one the player comes back at when it is unmuted again.

Volume and mute are now independent for any player that can treat them that way. Fake mute is the exception, since it is simulated with the volume itself.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- a volume command no longer unmutes the player it is sent to
- a muted player in a group keeps its mute through a group volume change
- fake mute still follows the volume, because that is how it is simulated

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
