### PR TITLE
AirPlay speakers no longer need a deepened buffer by default

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -110,26 +110,14 @@ AIRPLAY_CLOCK_READY_LEAD_MS: Final[int] = 500
 # Default receiver buffer depth per device family: (manufacturer wildcard,
 # model wildcard, firmware wildcard) -> depth in ms, matched case-insensitively
 # in order, first match wins; unmatched devices stay on Automatic (the binary's
-# stock depth). LinkPlay pipelines starve at the stock depth - silent renderer
-# behind a perfectly healthy session - so their queue is deepened, at the cost
-# of slower warm seeks (the depth IS the audible latency of a seek or skip) and,
-# past ~2 s of effective depth, of the binary's post-commit clock verification,
-# which stops arming once the depth plus 500 ms outruns a late joiner's anchor.
-# Extend the table as field reports identify more starving devices.
-AIRPLAY_BUFFER_DEPTH_DEFAULTS: Final[tuple[tuple[str, str, str, int], ...]] = (
-    # The newer LinkPlay platform names Linkplay as the manufacturer (WiiM, ...).
-    # 1750 ms is what a WiiM needs once it is also master of a native multiroom
-    # group.
-    ("linkplay*", "*", "*", 1750),
-    # The older LinkPlay platform ships under OEM brands (Edifier, ...) but
-    # marks the platform in its firmware string. It starves far deeper: an
-    # Edifier MS50A stays silent at 2250 ms and renders from 2500 ms, which is
-    # the 2250 ms pipeline the same device declares as its RAOP latency plus the
-    # binary's delivery margin. Every shallower value - including the 1750 ms
-    # this row used to inherit from the row above - is below what the device
-    # itself asks for.
-    ("*", "*", "p20.linkplay.*", 2500),
-)
+# stock depth). The table is EMPTY since the buffered (type 103) stream became
+# the auto-route for the receivers that used to need a deepened queue: the
+# LinkPlay pipelines that starved on the realtime stream (WiiM at 1750 ms,
+# Edifier MS50A silent below 2500 ms) manage their own buffer on the buffered
+# stream and play fine on Automatic. The per-player depth setting remains as
+# an advanced override; extend the table only for devices that starve on the
+# route they actually take.
+AIRPLAY_BUFFER_DEPTH_DEFAULTS: Final[tuple[tuple[str, str, str, int], ...]] = ()
 # Per-player override of the splice receiver-queue depth in ms (0 = automatic).
 CONF_BUFFER_DEPTH: Final[str] = "buffer_depth"
 # How long a plain (non-join) START waits for the binary's [STATUS] started ack.

--- a/tests/providers/airplay/test_helpers.py
+++ b/tests/providers/airplay/test_helpers.py
@@ -243,13 +243,17 @@ def _mass_serving_info(info: dict[str, Any], status: int = 200) -> MagicMock:
 
 
 def test_default_buffer_depth_family_table() -> None:
-    """The family table maps both LinkPlay generations to the deep queue."""
-    # Newer platform: Linkplay named as manufacturer.
+    """
+    Every family defaults to Automatic since buffered became the auto-route.
+
+    The LinkPlay generations that used to need a deepened realtime queue
+    (WiiM 1750 ms, Edifier MS50A 2500 ms) manage their own buffer on the
+    buffered stream; the per-player depth setting remains as the manual
+    override for field reports.
+    """
     assert (
-        default_buffer_depth("Linkplay Technology Inc.", "WiiM Pro Receiver", "p20.4.8.814756")
-        == 1750
+        default_buffer_depth("Linkplay Technology Inc.", "WiiM Pro Receiver", "p20.4.8.814756") == 0
     )
-    # Older platform: OEM brand, the platform only marked in fv.
-    assert default_buffer_depth("Edifier Inc", "Edifier MS50A", "p20.Linkplay.4.6.430230") == 2500
+    assert default_buffer_depth("Edifier Inc", "Edifier MS50A", "p20.Linkplay.4.6.430230") == 0
     assert default_buffer_depth("Sonos", "Era 100", "p20.96.0-79160") == 0
     assert default_buffer_depth("Apple Inc.", "AppleTV11,1", None) == 0

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -312,30 +312,26 @@ async def test_cli_args_no_ptp_shared_when_daemon_alive_but_not_ready() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cli_args_linkplay_gets_deeper_buffer() -> None:
+async def test_cli_args_no_family_buffer_defaults() -> None:
     """
-    LinkPlay-family devices get the deep receiver queue from the family table.
+    Every device family stays on Automatic depth: no --latency by default.
 
-    Both platform generations must match - the newer names Linkplay as
-    manufacturer, the older only marks the platform in fv under OEM brands -
-    and they starve at different depths, so each generation carries its own
-    value rather than the older one inheriting the newer one's.
+    The LinkPlay generations that used to get a deepened realtime queue from
+    the family table manage their own buffer on the buffered stream, so the
+    table ships empty and only the per-player setting adds the argument.
     """
     player = _make_player()
     player.device_info.manufacturer = "Linkplay Technology Inc."
     args = await _build_args(player)
-    assert _arg_value(args, "--latency") == "1750"
+    assert "--latency" not in args
     assert "--ptp-shared" in args
 
-    # Old platform: OEM brand, the Linkplay token only in fv. Starves far
-    # deeper than the newer platform above.
     player = _make_player()
     player.device_info.manufacturer = "Edifier Inc"
     player.airplay_discovery_info.decoded_properties["fv"] = "p20.Linkplay.4.6.430230"
     args = await _build_args(player)
-    assert _arg_value(args, "--latency") == "2500"
+    assert "--latency" not in args
 
-    # Non-LinkPlay devices stay on the binary's stock depth.
     player = _make_player()
     args = await _build_args(player)
     assert "--latency" not in args


### PR DESCRIPTION
# What does this implement/fix?

cliairplay now auto-selects the buffered AirPlay 2 stream for receivers that advertise it (music-assistant/airplay-cli#66), and on that stream those receivers manage their own audio buffer. The LinkPlay device families that starved on the realtime stream — and therefore got a deepened default buffer depth (WiiM 1750 ms, Edifier 2500 ms), which also made pausing take seconds — now play fine on Automatic, so the family defaults table ships empty. The per-player buffer depth setting stays available as a manual override.

Applies once the next cliairplay release with buffered streaming is pinned.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5618

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
