### PR TITLE
Prevent WiiM errors with external group members

### DIFF
--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -401,14 +401,15 @@ class WiimPlayer(Player):
             self._attr_playback_state = new_state
 
         # Group members
-        group_member_ids = (
+        managed_member_ids = [
             f"{PLAYER_ID_PREFIX}{member_udn}"
             for member_udn in snapshot.member_udns
             if member_udn != self.device.udn
-        )
-        self._attr_group_members = [
-            member_id for member_id in group_member_ids if self.mass.players.get_player(member_id)
+            and self.mass.players.get_player(f"{PLAYER_ID_PREFIX}{member_udn}")
         ]
+        self._attr_group_members = (
+            [self.player_id, *managed_member_ids] if managed_member_ids else []
+        )
 
         if play_mode and play_mode != SOURCE_NETWORK and play_mode in INPUT_MODE_SOURCES:
             self._attr_active_source = INPUT_MODE_SOURCES[play_mode].id

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -401,9 +401,13 @@ class WiimPlayer(Player):
             self._attr_playback_state = new_state
 
         # Group members
-        group_members = self._wiim_controller.get_group_members(self.device.udn)
+        group_member_ids = (
+            f"{PLAYER_ID_PREFIX}{member_udn}"
+            for member_udn in snapshot.member_udns
+            if member_udn != self.device.udn
+        )
         self._attr_group_members = [
-            f"{PLAYER_ID_PREFIX}{m.udn}" for m in group_members if m.udn != self.device.udn
+            member_id for member_id in group_member_ids if self.mass.players.get_player(member_id)
         ]
 
         if play_mode and play_mode != SOURCE_NETWORK and play_mode in INPUT_MODE_SOURCES:

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -8,7 +8,7 @@ from wiim import PlayingStatus
 from wiim.exceptions import WiimDeviceException, WiimRequestException
 
 from music_assistant.models.player import PlayerMedia
-from music_assistant.providers.wiim.constants import SOURCE_NETWORK
+from music_assistant.providers.wiim.constants import PLAYER_ID_PREFIX, SOURCE_NETWORK
 from music_assistant.providers.wiim.player import SDK_TO_MA_STATE, WiimPlayer
 
 
@@ -247,6 +247,36 @@ class TestSupportedFeatures:
         """SELECT_SOURCE should be in supported features."""
         player = WiimPlayer(provider=mock_provider, player_id="uuid:test", device=mock_wiim_device)
         assert PlayerFeature.SELECT_SOURCE in player._attr_supported_features
+
+
+class TestGroupMembers:
+    """Test group member state handling."""
+
+    def test_unmanaged_group_members_are_ignored(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """Only group members registered in Music Assistant should be reported."""
+        managed_udn = "uuid:test-wiim-002"
+        unmanaged_udn = "uuid:test-linkplay-001"
+        managed_player_id = f"{PLAYER_ID_PREFIX}{managed_udn}"
+        snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
+        snapshot.role = "leader"
+        snapshot.member_udns = (mock_wiim_device.udn, managed_udn, unmanaged_udn)
+        mock_provider.wiim_controller.get_group_members.side_effect = ValueError(
+            f"Device {unmanaged_udn} is not managed by the controller"
+        )
+        mock_provider.mass.players.get_player.side_effect = {managed_player_id: MagicMock()}.get
+        player = WiimPlayer(
+            provider=mock_provider,
+            player_id="uuid:test",
+            device=mock_wiim_device,
+        )
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player._attr_group_members == [managed_player_id]
+        mock_provider.wiim_controller.get_group_members.assert_not_called()
 
 
 class TestSourceList:

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -258,6 +258,7 @@ class TestGroupMembers:
         """Only group members registered in Music Assistant should be reported."""
         managed_udn = "uuid:test-wiim-002"
         unmanaged_udn = "uuid:test-linkplay-001"
+        leader_player_id = f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}"
         managed_player_id = f"{PLAYER_ID_PREFIX}{managed_udn}"
         snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
         snapshot.role = "leader"
@@ -268,15 +269,34 @@ class TestGroupMembers:
         mock_provider.mass.players.get_player.side_effect = {managed_player_id: MagicMock()}.get
         player = WiimPlayer(
             provider=mock_provider,
-            player_id="uuid:test",
+            player_id=leader_player_id,
             device=mock_wiim_device,
         )
         player.update_state = MagicMock()  # type: ignore[misc,method-assign]
 
         player._update_ma_state_from_sdk_cache()
 
-        assert player._attr_group_members == [managed_player_id]
+        assert player._attr_group_members == [leader_player_id, managed_player_id]
         mock_provider.wiim_controller.get_group_members.assert_not_called()
+
+    def test_only_unmanaged_group_members_reports_no_group(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """A group without any MA-managed followers should not be reported."""
+        snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
+        snapshot.role = "leader"
+        snapshot.member_udns = (mock_wiim_device.udn, "uuid:test-linkplay-001")
+        mock_provider.mass.players.get_player.return_value = None
+        player = WiimPlayer(
+            provider=mock_provider,
+            player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
+            device=mock_wiim_device,
+        )
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player._attr_group_members == []
 
 
 class TestSourceList:


### PR DESCRIPTION
# What does this implement/fix?

Prevents WiiM player updates from failing when a native group contains LinkPlay speakers that are not managed by Music Assistant.

- Keep managed group members visible in Music Assistant.
- Ignore only group members that Music Assistant cannot control.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. — Not applicable.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. — Not applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. — Not applicable.