### PR TITLE
Group volume no longer undoes a speaker you turned down yourself

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1806,7 +1806,16 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
         # enforce volume limits when volume changes externally
         if "volume_level" in changed_values:
-            self._enforce_volume_limits(player)
+            corrected = self._enforce_volume_limits(player)
+            # a level set on the device itself makes the reference a group volume change
+            # interpolates from obsolete. a member on its way to a level we did send
+            # reports levels too, and a group only ever reports what its members are at,
+            # so neither of those counts. a correction always is the device's own doing:
+            # the levels we command never fall outside the configured range
+            if player.state.type != PlayerType.GROUP and (
+                corrected or self._unexpired_volume_target(player) is None
+            ):
+                self._invalidate_group_volume_snapshot(player_id)
         # dispatch to internal state update subscribers (with changed_values)
         self._dispatch_state_update_subscribers(player, changed_values)
 
@@ -1968,12 +1977,13 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         # scaling down: each child interpolates from its snapshot value toward 0.
         # this ensures the relative balance is preserved and all children converge
         # to 0 and 100 at the extremes. the snapshot is invalidated when a child's
-        # individual volume changes or group membership changes.
+        # individual volume or the group membership changes, and rebuilt when the
+        # children it holds are no longer the ones being adjusted.
         # the levels a nudge steps from are the ones the members were last commanded, so
         # the snapshot has to read the same source, or a change a member has not confirmed
         # yet puts the reference above the level being set and turns a step up into one down
         snapshot: dict[str, int] | None = group_player.extra_data.get(ATTR_GROUP_VOLUME_SNAPSHOT)
-        if snapshot is None or not all(c.player_id in snapshot for c in children):
+        if snapshot is None or snapshot.keys() != {c.player_id for c in children}:
             snapshot = {c.player_id: self._volume_nudge_base(c) or 0 for c in children}
             group_player.extra_data[ATTR_GROUP_VOLUME_SNAPSHOT] = snapshot
 
@@ -2525,21 +2535,27 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         )
         return min_volume, max_volume
 
-    def _enforce_volume_limits(self, player: Player) -> None:
-        """Clamp device volume to min/max range when changed externally."""
+    def _enforce_volume_limits(self, player: Player) -> bool:
+        """
+        Clamp device volume to min/max range when changed externally.
+
+        :param player: The player to check the volume of.
+        :return: True if the volume was outside the configured range and got corrected.
+        """
         player_id = player.player_id
         min_volume, max_volume = self._get_volume_limits(player_id)
         if min_volume == 0 and max_volume == 100:
-            return
+            return False
         # state.volume_level is the resolved logical volume, available for all
         # volume control types; a device volume outside the configured range
         # surfaces here as a value outside 0-100 (scaling does not clamp)
         logical_volume = player.state.volume_level
         if logical_volume is None or 0 <= logical_volume <= 100:
-            return
+            return False
         clamped = max(0, min(100, logical_volume))
         # correct via the regular volume-set path so scaling and redirection apply
         self.mass.create_task(self._handle_cmd_volume_set(player_id, clamped))
+        return True
 
     def _forward_state_update(
         self, player: Player, changed_values: dict[str, tuple[Any, Any]]

--- a/tests/common.py
+++ b/tests/common.py
@@ -235,6 +235,9 @@ class MockProvider:
         self.dashboards = MagicMock()
         self.logger = logging.getLogger(f"test.{domain}")
         self.unloading = False
+        # tests that let their players signal state updates fill this with the
+        # players of this provider, the way a real provider reports them
+        self.players: list[Player] = []
 
 
 class MockPlayer(Player):

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -2741,6 +2741,152 @@ class TestVolumeNudgeTarget:
         assert device.commands == [55, 55, 60, 60]
 
 
+class TestGroupVolumeReference:
+    """A group volume adjustment interpolates from the levels its members are really at."""
+
+    def _make_group(
+        self, mock_mass: MagicMock, first_volume: int = 50, second_volume: int = 50
+    ) -> tuple[PlayerController, dict[str, MockPlayer], dict[str, list[int]]]:
+        """
+        Build a group player with two members, at the given volumes.
+
+        :param first_volume: Volume level the first member starts at.
+        :param second_volume: Volume level the second member starts at.
+        :return: The controller, the players by id and the volumes commanded per member.
+        """
+        controller = PlayerController(mock_mass)
+        controller.config = _volume_step_config(5)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        commands: dict[str, list[int]] = {}
+        members: dict[str, MockPlayer] = {}
+        for player_id, volume in (("member_1", first_volume), ("member_2", second_volume)):
+            member = MockPlayer(provider, player_id, player_id.title())
+            member._attr_volume_level = volume
+            commands[player_id] = []
+
+            async def _volume_set(volume: int, _recorded: list[int] = commands[player_id]) -> None:
+                _recorded.append(volume)
+
+            member.volume_set = AsyncMock(side_effect=_volume_set)  # type: ignore[method-assign]
+            members[player_id] = member
+        group = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
+        group._attr_group_members = list(members)
+        players = {"group": group, **members}
+        controller._players = dict(players)
+        provider.players = list(players.values())
+        mock_mass.players = controller
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        for player in players.values():
+            player.set_initialized()
+            player._cache.clear()
+            player.update_state(signal_event=False)
+        # a second, forced pass so the group derives its group volume from the members
+        for player in players.values():
+            player.update_state(force_update=True, signal_event=False)
+        return controller, players, commands
+
+    def _report(self, player: MockPlayer, volume: int) -> None:
+        """Let the player report the given volume level, the way its provider would."""
+        player._attr_volume_level = volume
+        player._cache.clear()
+        player.update_state(force_update=True)
+
+    async def test_a_member_turned_down_on_the_device_keeps_its_level(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A group nudge up may not undo a member that was turned down on the device."""
+        controller, players, commands = self._make_group(mock_mass)
+        await controller.cmd_group_volume_up("group")
+        self._report(players["member_1"], 55)
+        self._report(players["member_2"], 55)
+
+        with patch.object(players_controller, "VOLUME_TARGET_EXPIRY", 0):
+            # the member is turned down on the device itself, well after that command
+            self._report(players["member_2"], 20)
+            await controller.cmd_group_volume_up("group")
+
+        # the group steps from 55 to 60, and the member keeps its (much lower) share
+        assert commands["member_1"] == [55, 60]
+        assert commands["member_2"] == [55, 29]
+
+    async def test_a_member_reporting_the_level_it_was_given_keeps_the_balance(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Members confirming a group nudge may not become the reference themselves."""
+        controller, players, commands = self._make_group(mock_mass)
+        await controller.cmd_volume_set("member_2", 20)
+        self._report(players["member_2"], 20)
+
+        await controller.cmd_group_volume_up("group")
+        self._report(players["member_1"], 55)
+        self._report(players["member_2"], 28)
+        await controller.cmd_group_volume_down("group")
+
+        # stepping back down to where the group started restores the balance it had
+        assert commands["member_1"] == [55, 50]
+        assert commands["member_2"] == [20, 28, 20]
+
+    async def test_a_member_that_dropped_off_no_longer_sets_the_reference(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A group nudge up may not turn the group down over an unreachable member."""
+        controller, players, commands = self._make_group(
+            mock_mass, first_volume=30, second_volume=80
+        )
+        await controller.cmd_group_volume_up("group")
+        self._report(players["member_1"], 48)
+        self._report(players["member_2"], 85)
+
+        # the loudest member drops off the network; a permanent group keeps it as a member
+        players["member_2"]._attr_available = False
+        players["member_2"]._cache.clear()
+        players["member_2"].update_state(force_update=True)
+        await controller.cmd_group_volume_up("group")
+
+        assert commands["member_1"] == [48, 53]
+        assert commands["member_2"] == [85]
+
+    async def test_a_group_reporting_its_own_volume_keeps_the_balance(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A group that reports a volume of its own may not reset its own reference."""
+        controller, players, commands = self._make_group(
+            mock_mass, first_volume=50, second_volume=20
+        )
+        await controller.cmd_group_volume_up("group")
+        self._report(players["member_1"], 55)
+        self._report(players["member_2"], 28)
+        # a cast group reports the volume of its members as its own
+        self._report(players["group"], 55)
+        await controller.cmd_group_volume_down("group")
+
+        assert commands["member_1"] == [55, 50]
+        assert commands["member_2"] == [28, 20]
+
+    async def test_a_member_clamped_to_its_volume_limit_keeps_that_level(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Correcting a volume that ran past its limit is not a level the group commanded."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_player_config_stub(min_volume=20)
+        )
+        use_real_create_task(mock_mass)
+        # with a min volume of 20 the members report device volumes of 20-100 for 0-100
+        controller, players, commands = self._make_group(
+            mock_mass, first_volume=60, second_volume=60
+        )
+        await controller.cmd_group_volume_up("group")
+        self._report(players["member_1"], 64)
+        self._report(players["member_2"], 64)
+
+        # the member is turned below its own minimum, so it is corrected back up to 0
+        self._report(players["member_2"], 10)
+        await controller.cmd_group_volume_up("group")
+
+        assert commands["member_1"] == [64, 68]
+        assert commands["member_2"] == [64, 20, 28]
+
+
 class TestFakeMuteInGroup:
     """A fake muted player in a group follows the mute lock, just like a native mute."""
 


### PR DESCRIPTION
# What does this implement/fix?

When you adjust the volume of a group, Music Assistant moves every speaker while keeping their relative balance, using a cached reference of where the speakers were. That reference was not updated when a speaker's volume was changed on the device itself (a knob, its own app, another controller), and it was also kept when a speaker dropped out of the group.

Two things went wrong because of that:

- You turn one speaker down by hand, then nudge the group volume up — the speaker jumps straight back up, undoing what you just did.
- A speaker in a permanent group goes offline while it was the loudest one — the next group volume **up** turns the remaining speakers **down** instead.

**Changes:**

- A volume change coming from the speaker itself now refreshes the reference the group is adjusted from. A speaker confirming a level Music Assistant just sent it does not, so the balance is still preserved across repeated presses.
- The same applies to a speaker that was corrected because it ran past its configured volume limit.
- The reference is rebuilt whenever the set of speakers being adjusted changes, not only when a new one appears.
- A group that reports a volume of its own (Chromecast groups do) no longer resets its own reference.
- Added tests covering each case.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
