### PR TITLE
Keep WiiM speaker state in sync when updates stop arriving

### DIFF
--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, cast
 from music_assistant_models.enums import IdentifierType, PlaybackState, PlayerFeature, PlayerType
 from music_assistant_models.player import DeviceInfo
 from wiim import PlayingStatus, WiimDevice
-from wiim.exceptions import WiimDeviceException, WiimRequestException
+from wiim.exceptions import WiimException
 from wiim.models import WiimGroupRole
 
 from music_assistant.constants import (
@@ -47,8 +47,8 @@ SDK_TO_MA_STATE: dict[PlayingStatus, PlaybackState] = {
 class WiimPlayer(Player):
     """Wiim Player in Music Assistant."""
 
-    # the device only pushes state changes, so a source it keeps reported as paused after
-    # the app released it is never corrected on its own.
+    # the device reports a source the app released as plain 'paused', indistinguishable
+    # from a real pause, so only the grace period can tell us the session is over.
     _attr_external_pause_idle_timeout = EXTERNAL_PAUSE_IDLE_TIMEOUT
 
     def __init__(
@@ -112,8 +112,9 @@ class WiimPlayer(Player):
         self._attr_poll_interval = 5
 
     async def poll(self) -> None:
-        """Poll player for state updates to prevent position drift."""
+        """Poll player for transport state and position updates."""
         await self._sync_position()
+        await self._refresh_device_status()
         self._attr_poll_interval = 5 if self._attr_playback_state == PlaybackState.PLAYING else 30
 
     async def on_unload(self) -> None:
@@ -162,7 +163,7 @@ class WiimPlayer(Player):
         self._ma_stream_uri = stream_url
         try:
             await self.device.async_play(uri=stream_url, metadata=didl_metadata)
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             # The device never took our stream, so the guard must not outlive the attempt.
             self._ma_stream_uri = None
             self._handle_command_error("play_media", err)
@@ -186,14 +187,14 @@ class WiimPlayer(Player):
                 NextURI=stream_url,
                 NextURIMetaData=didl_metadata,
             )
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             self.logger.warning("Enqueue failed on %s: %s", self._attr_name, err)
 
     async def play(self) -> None:
         """Play command."""
         try:
             await self.device.async_play()
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             self._handle_command_error("play", err)
             return
         await self._sync_position()
@@ -202,7 +203,7 @@ class WiimPlayer(Player):
         """Pause command."""
         try:
             await self.device.async_pause()
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             self._handle_command_error("pause", err)
             return
         await self._sync_position()
@@ -214,7 +215,7 @@ class WiimPlayer(Player):
         self._ma_stream_uri = None
         try:
             await self.device.async_stop()
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             self._handle_command_error("stop", err)
             return
         self._update_ma_state_from_sdk_cache()
@@ -223,7 +224,7 @@ class WiimPlayer(Player):
         """Seek to position in seconds."""
         try:
             await self.device.async_seek(position)
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             self._handle_command_error("seek", err)
 
     async def volume_set(self, volume_level: int) -> None:
@@ -237,7 +238,7 @@ class WiimPlayer(Player):
             volume_level = max(0, min(100, volume_level))
             await self.device._http_command_ok("setPlayerCmd:vol:{}", str(volume_level))
             self.device.volume = volume_level
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             self._handle_command_error("volume_set", err)
             return
         self._update_ma_state_from_sdk_cache()
@@ -246,7 +247,7 @@ class WiimPlayer(Player):
         """Handle VOLUME MUTE command on the player."""
         try:
             await self.device.async_set_mute(muted)
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             self._handle_command_error("volume_mute", err)
             return
         self._update_ma_state_from_sdk_cache()
@@ -263,7 +264,7 @@ class WiimPlayer(Player):
             return
         try:
             await self.device.async_set_play_mode(sdk_mode)
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             self._handle_command_error("select_source", err)
             return
         self._update_ma_state_from_sdk_cache()
@@ -307,7 +308,7 @@ class WiimPlayer(Player):
                         await self._wiim_controller.async_ungroup_device(
                             cast("WiimPlayer", member).device.udn
                         )
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             self._handle_command_error("set_members", err)
         finally:
             exit_sdk_uri = self.device.current_media.uri if self.device.current_media else None
@@ -510,15 +511,28 @@ class WiimPlayer(Player):
         """Re-subscribe to UPnP events and update state."""
         try:
             await self.device.ensure_subscriptions()
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             self.logger.warning("Failed to re-subscribe for %s: %s", self._attr_name, err)
+        self._update_ma_state_from_sdk_cache()
+
+    async def _refresh_device_status(self) -> None:
+        """Fetch fresh transport state, play mode and volume from the device."""
+        if not self.device.available:
+            # the SDK owns availability detection and recovery; querying a device it
+            # already gave up on only holds up the poll of every other player.
+            return
+        try:
+            await self.device.async_update_http_status()
+        except WiimException as err:
+            self.logger.debug("Failed to refresh status for %s: %s", self._attr_name, err)
+            return
         self._update_ma_state_from_sdk_cache()
 
     async def _sync_position(self) -> None:
         """Fetch fresh position from the device and update state."""
         try:
             await self.device.sync_device_duration_and_position()
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             self.logger.debug("Failed to sync position for %s: %s", self._attr_name, err)
             return
         media = self.device.current_media
@@ -535,15 +549,13 @@ class WiimPlayer(Player):
         """Refresh multiroom status from devices, then update all WiiM players."""
         try:
             await self._wiim_controller.async_update_all_multiroom_status()
-        except (WiimDeviceException, WiimRequestException) as err:
+        except WiimException as err:
             self.logger.debug("Failed to refresh multiroom status: %s", err)
         for player in self.provider.players:
             if isinstance(player, WiimPlayer):
                 player._update_ma_state_from_sdk_cache()
 
-    def _handle_command_error(
-        self, action: str, err: WiimDeviceException | WiimRequestException
-    ) -> None:
+    def _handle_command_error(self, action: str, err: WiimException) -> None:
         """Handle a command error by logging and refreshing state."""
         self.logger.warning("Command '%s' failed on %s: %s", action, self._attr_name, err)
         self._update_ma_state_from_sdk_cache()

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from music_assistant_models.enums import PlaybackState, PlayerFeature
 from wiim import PlayingStatus
-from wiim.exceptions import WiimDeviceException, WiimRequestException
+from wiim.exceptions import (
+    WiimDeviceException,
+    WiimInvalidDataException,
+    WiimRequestException,
+)
 
 from music_assistant.models.player import PlayerMedia
 from music_assistant.providers.wiim.constants import PLAYER_ID_PREFIX, SOURCE_NETWORK
@@ -37,6 +41,7 @@ def mock_wiim_device() -> MagicMock:
     device.async_set_mute = AsyncMock()
     device.async_set_play_mode = AsyncMock()
     device.sync_device_duration_and_position = AsyncMock()
+    device.async_update_http_status = AsyncMock()
     device.disconnect = AsyncMock()
     device.ensure_subscriptions = AsyncMock()
     device.general_event_callback = None
@@ -369,6 +374,32 @@ class TestErrorHandling:
         player.update_state.assert_called()
 
     @pytest.mark.asyncio
+    async def test_volume_set_survives_invalid_data_from_device(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """A speaker answering a volume command with something other than OK must not throw."""
+        mock_wiim_device._http_command_ok = AsyncMock(
+            side_effect=WiimInvalidDataException("did not return 'OK'")
+        )
+        player = WiimPlayer(provider=mock_provider, player_id="uuid:test", device=mock_wiim_device)
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+        await player.volume_set(42)
+        assert player._attr_available is True
+
+    @pytest.mark.asyncio
+    async def test_select_source_survives_invalid_data_from_device(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """A speaker rejecting a source change must not throw out of the command."""
+        mock_wiim_device.async_set_play_mode = AsyncMock(
+            side_effect=WiimInvalidDataException("did not return 'OK'")
+        )
+        player = WiimPlayer(provider=mock_provider, player_id="uuid:test", device=mock_wiim_device)
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+        await player.select_source("bluetooth")
+        assert player._attr_available is True
+
+    @pytest.mark.asyncio
     async def test_stop_error_refreshes_state(
         self, mock_provider: MagicMock, mock_wiim_device: MagicMock
     ) -> None:
@@ -566,3 +597,67 @@ class TestStalePositionOnNewStream:
 
         assert player._attr_elapsed_time == 42
         assert player._attr_elapsed_time_last_updated > 1000.0
+
+
+class TestPollRefreshesTransportState:
+    """Polling must correct state the device stopped pushing events for."""
+
+    def _make_player(self, provider: MagicMock, device: MagicMock) -> WiimPlayer:
+        player = WiimPlayer(provider=provider, player_id="uuid:test", device=device)
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+        return player
+
+    @pytest.mark.asyncio
+    async def test_poll_fetches_device_status(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """A poll must ask the device for its transport state, not just its position."""
+        player = self._make_player(mock_provider, mock_wiim_device)
+
+        await player.poll()
+
+        mock_wiim_device.async_update_http_status.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_poll_applies_stop_reported_after_missed_events(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """A device that went to stop while events were lost must no longer read as paused."""
+        player = self._make_player(mock_provider, mock_wiim_device)
+        player._attr_playback_state = PlaybackState.PAUSED
+        mock_wiim_device.play_mode = SOURCE_NETWORK
+
+        async def _report_stopped() -> None:
+            mock_wiim_device.playing_status = PlayingStatus.STOPPED
+
+        mock_wiim_device.async_update_http_status = AsyncMock(side_effect=_report_stopped)
+
+        await player.poll()
+
+        assert player._attr_playback_state == PlaybackState.IDLE
+
+    @pytest.mark.asyncio
+    async def test_poll_survives_invalid_data_from_device(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """A 'Failed' or unparsable status response must not escape the poll."""
+        mock_wiim_device.async_update_http_status = AsyncMock(
+            side_effect=WiimInvalidDataException("Command getStatusEx returned 'Failed'")
+        )
+        player = self._make_player(mock_provider, mock_wiim_device)
+
+        await player.poll()
+
+        mock_wiim_device.sync_device_duration_and_position.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_poll_skips_status_of_unavailable_device(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """A device the SDK already gave up on must not be queried again by the poll."""
+        mock_wiim_device.available = False
+        player = self._make_player(mock_provider, mock_wiim_device)
+
+        await player.poll()
+
+        mock_wiim_device.async_update_http_status.assert_not_awaited()


### PR DESCRIPTION
# What does this implement/fix?

WiiM playback state was effectively event-driven only. The provider's poll fetched
the playback position and nothing else, so once a speaker stopped pushing UPnP
events its state could stay frozen — a track that had ended still showing as
playing or paused, with nothing able to correct it.

The WiiM SDK already exposes a method that reads the speaker's real transport
state over HTTP, it just was never called after startup. The poll now uses it, so
what Music Assistant shows follows the speaker again even when events go missing.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- The WiiM poll now refreshes the speaker's play state, source and volume, instead of only its position.
- Speakers that answer a command with an error instead of a plain refusal no longer let that error escape the command — this affected volume and source changes.
- A speaker the SDK has already marked unreachable is no longer queried by the poll.
- Added tests for the above.

Two notes on what this does not change. The 60s grace period for an abandoned
streaming app (#5701) stays: the speaker reports a released session as a plain
pause, so there is still no reliable signal to replace the timer with. And a
source that started playing while updates were missing is still not picked up —
this fixes stop and pause detection, not "started playing externally".

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
