### PR TITLE
Fix Home Assistant players showing an external source while Music Assistant is playing

### DIFF
--- a/music_assistant/providers/hass_players/player.py
+++ b/music_assistant/providers/hass_players/player.py
@@ -110,6 +110,8 @@ class HomeAssistantPlayer(Player):
 
         self.extra_data["hass_supported_features"] = hass_supported_features
         self._hass_attributes: dict[str, Any] = {}
+        self._ma_playback_active = False
+        self._reports_stream_url = False
 
         # Add External source to support next/prev commands when playing external content
         self._attr_source_list.append(
@@ -212,6 +214,7 @@ class HomeAssistantPlayer(Player):
             if PlayerFeature.PAUSE in self.supported_features:
                 await self.pause()
         finally:
+            self._ma_playback_active = False
             self._attr_current_media = None
             self.update_state()
 
@@ -296,6 +299,7 @@ class HomeAssistantPlayer(Player):
         )
 
         # Optimistically update state
+        self._ma_playback_active = True
         self._attr_current_media = media
         self._attr_elapsed_time = 0
         self._attr_elapsed_time_last_updated = time.time()
@@ -358,6 +362,9 @@ class HomeAssistantPlayer(Player):
             self._attr_available = state["s"] not in UNAVAILABLE_STATES
             if PlayerFeature.POWER in self.supported_features:
                 self._attr_powered = state["s"] not in OFF_STATES
+            if self._attr_playback_state == PlaybackState.IDLE:
+                # the entity stopped playing, so our session ended with it
+                self._ma_playback_active = False
         if "a" in state:
             self._update_attributes(state["a"])
         self.update_state()
@@ -432,15 +439,23 @@ class HomeAssistantPlayer(Player):
                 self._update_hass_features(hass_supported_features)
 
         # Check for external playback (not from Music Assistant).
-        # Without media_content_id we cannot reliably determine the source,
-        # so we later only react to state updates that include it.
+        # Not every integration echoes the stream URL we handed it back in
+        # media_content_id; some report device or cloud provided metadata instead. Only
+        # entities that were seen echoing it can be judged by it - for the others the
+        # play command we issued is the only thing that tells the two sources apart.
+        # Without either signal we cannot determine the source, so we later only react
+        # to state updates that include a media_content_id.
         media_content_id = self._hass_attributes.get("media_content_id", "")
-        is_ma_playback = media_content_id.startswith(self.mass.streams.base_url)
+        if media_content_id.startswith(self.mass.streams.base_url):
+            self._reports_stream_url = True
+            is_ma_playback = True
+        else:
+            is_ma_playback = not self._reports_stream_url and self._ma_playback_active
         media_title = self._hass_attributes.get("media_title")
 
-        if media_content_id and is_ma_playback:
-            # MA playback - ensure active_source points to player_id for queue lookup.
-            # The actual current_media will be set by MA's queue controller.
+        if is_ma_playback:
+            # MA playback - the queue controller resolves the active source and
+            # provides the actual current_media.
             self._attr_active_source = None
         elif (
             media_content_id

--- a/music_assistant/providers/hass_players/player.py
+++ b/music_assistant/providers/hass_players/player.py
@@ -16,6 +16,7 @@ from music_assistant_models.enums import (
 from music_assistant_models.media_items import MediaItemImage
 
 from music_assistant.constants import (
+    ATTR_ANNOUNCEMENT_IN_PROGRESS,
     CONF_ENTRY_ENABLE_ICY_METADATA_HIDDEN,
     CONF_ENTRY_HTTP_PROFILE_FORCED_2,
     CONF_ENTRY_OUTPUT_CODEC_DEFAULT_MP3,
@@ -111,6 +112,7 @@ class HomeAssistantPlayer(Player):
         self.extra_data["hass_supported_features"] = hass_supported_features
         self._hass_attributes: dict[str, Any] = {}
         self._ma_playback_active = False
+        self._ma_playback_started = False
         self._reports_stream_url = False
 
         # Add External source to support next/prev commands when playing external content
@@ -215,6 +217,7 @@ class HomeAssistantPlayer(Player):
                 await self.pause()
         finally:
             self._ma_playback_active = False
+            self._ma_playback_started = False
             self._attr_current_media = None
             self.update_state()
 
@@ -300,6 +303,9 @@ class HomeAssistantPlayer(Player):
 
         # Optimistically update state
         self._ma_playback_active = True
+        # the entity may still be reporting the previous session, so our stream only
+        # counts as started once it is seen playing
+        self._ma_playback_started = False
         self._attr_current_media = media
         self._attr_elapsed_time = 0
         self._attr_elapsed_time_last_updated = time.time()
@@ -362,9 +368,7 @@ class HomeAssistantPlayer(Player):
             self._attr_available = state["s"] not in UNAVAILABLE_STATES
             if PlayerFeature.POWER in self.supported_features:
                 self._attr_powered = state["s"] not in OFF_STATES
-            if self._attr_playback_state == PlaybackState.IDLE:
-                # the entity stopped playing, so our session ended with it
-                self._ma_playback_active = False
+            self._track_ma_playback(state["s"])
         if "a" in state:
             self._update_attributes(state["a"])
         self.update_state()
@@ -438,13 +442,17 @@ class HomeAssistantPlayer(Player):
                 self.extra_data["hass_supported_features"] = hass_supported_features
                 self._update_hass_features(hass_supported_features)
 
+        if self.extra_data.get(ATTR_ANNOUNCEMENT_IN_PROGRESS):
+            # the media attributes describe the announcement instead of the source that
+            # is restored afterwards, so they tell us nothing about who owns playback
+            return
+
         # Check for external playback (not from Music Assistant).
         # Not every integration echoes the stream URL we handed it back in
         # media_content_id; some report device or cloud provided metadata instead. Only
         # entities that were seen echoing it can be judged by it - for the others the
-        # play command we issued is the only thing that tells the two sources apart.
-        # Without either signal we cannot determine the source, so we later only react
-        # to state updates that include a media_content_id.
+        # play command we issued is what tells the two sources apart. Without either
+        # signal the source stays as it was.
         media_content_id = self._hass_attributes.get("media_content_id", "")
         if media_content_id.startswith(self.mass.streams.base_url):
             self._reports_stream_url = True
@@ -485,6 +493,22 @@ class HomeAssistantPlayer(Player):
             ):
                 self._attr_current_media = None
                 self._attr_active_source = None
+
+    def _track_ma_playback(self, hass_state: str) -> None:
+        """
+        Follow the entity's state to tell whether the stream MA handed it is still playing.
+
+        :param hass_state: The raw state as reported by the entity.
+        """
+        if self.extra_data.get(ATTR_ANNOUNCEMENT_IN_PROGRESS):
+            # an announcement takes the entity over, its states say nothing about our stream
+            return
+        if self._attr_playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
+            self._ma_playback_started = True
+        elif hass_state not in UNAVAILABLE_STATES and self._ma_playback_started:
+            # the entity played our stream and stopped again, so the session ended with it
+            self._ma_playback_active = False
+            self._ma_playback_started = False
 
     def _get_image_url(self, attributes: dict[str, Any]) -> str | None:
         """Get the image URL from the attributes."""

--- a/music_assistant/providers/hass_players/player.py
+++ b/music_assistant/providers/hass_players/player.py
@@ -306,6 +306,9 @@ class HomeAssistantPlayer(Player):
         # the entity may still be reporting the previous session, so our stream only
         # counts as started once it is seen playing
         self._ma_playback_started = False
+        # a source the entity played before is over, and it may never report an
+        # attribute change to tell us so
+        self._attr_active_source = None
         self._attr_current_media = media
         self._attr_elapsed_time = 0
         self._attr_elapsed_time_last_updated = time.time()
@@ -444,7 +447,9 @@ class HomeAssistantPlayer(Player):
 
         if self.extra_data.get(ATTR_ANNOUNCEMENT_IN_PROGRESS):
             # the media attributes describe the announcement instead of the source that
-            # is restored afterwards, so they tell us nothing about who owns playback
+            # is restored afterwards, so they tell us nothing about who owns playback.
+            # Drop the announcement's id so a later partial update can not judge by it.
+            self._hass_attributes.pop("media_content_id", None)
             return
 
         # Check for external playback (not from Music Assistant).

--- a/tests/providers/hass_players/test_external_playback.py
+++ b/tests/providers/hass_players/test_external_playback.py
@@ -1,0 +1,131 @@
+"""Tests for telling Music Assistant playback apart from external playback."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import PlaybackState
+from music_assistant_models.player import PlayerMedia
+
+from music_assistant.providers.hass_players.player import HomeAssistantPlayer
+
+BASE_URL = "http://10.0.0.5:8097"
+PLAYER_ID = "media_player.bedroom"
+
+
+def _make_player() -> HomeAssistantPlayer:
+    """Create a HomeAssistantPlayer with mocked dependencies."""
+    player = HomeAssistantPlayer.__new__(HomeAssistantPlayer)
+    mass = MagicMock()
+    mass.closing = False
+    mass.streams.base_url = BASE_URL
+    mass.streams.resolve_stream_url = AsyncMock(return_value=f"{BASE_URL}/flow/s1/q1/i1/x.mp3")
+    player.mass = mass
+    player.logger = logging.getLogger("test.hass_players.player")
+    player._player_id = PLAYER_ID
+    player._provider = MagicMock()
+    player._provider.mass = mass
+    player._extra_data = {}
+    player.hass = MagicMock()
+    player.hass.call_service = AsyncMock()
+    player._hass_attributes = {}
+    player._attr_supported_features = set()
+    player._attr_source_list = []
+    player._attr_group_members = []
+    player._attr_playback_state = PlaybackState.IDLE
+    player._attr_active_source = None
+    player._attr_current_media = None
+    player._ma_playback_active = False
+    player._reports_stream_url = False
+    player.update_state = MagicMock()  # type: ignore[misc, method-assign]
+    return player
+
+
+def _external_attributes(content_id: str = "spotify:track:42") -> dict[str, Any]:
+    """Return HA state attributes for content MA did not hand the entity."""
+    return {
+        "media_content_id": content_id,
+        "media_title": "Some Song",
+        "media_artist": "Some Artist",
+    }
+
+
+async def test_ma_playback_detected_when_entity_hides_the_stream_url() -> None:
+    """An entity that reports its own metadata instead of our URL is still MA playback."""
+    player = _make_player()
+    media = PlayerMedia(uri="library://track/1", title="MA Track")
+    player._ma_playback_active = True
+    player._attr_current_media = media
+    player._attr_playback_state = PlaybackState.PLAYING
+
+    player._update_attributes(_external_attributes())
+
+    assert player._attr_active_source is None
+    # the queue controller provides the media, so the entity may not overwrite it
+    assert player._attr_current_media is media
+
+
+async def test_external_playback_detected_without_ma_session() -> None:
+    """Playback that MA did not start is reported as an external source."""
+    player = _make_player()
+    player._attr_playback_state = PlaybackState.PLAYING
+
+    player._update_attributes(_external_attributes())
+
+    assert player._attr_active_source == "External"
+    assert player._attr_current_media is not None
+    assert player._attr_current_media.title == "Some Song"
+
+
+async def test_entity_echoing_stream_url_still_detects_takeover() -> None:
+    """An entity that reports our stream URL is judged by it, also mid-session."""
+    player = _make_player()
+    player._ma_playback_active = True
+    player._attr_playback_state = PlaybackState.PLAYING
+
+    player._update_attributes(
+        {"media_content_id": f"{BASE_URL}/flow/s1/q1/i1/x.mp3", "media_title": "MA Track"}
+    )
+    assert player._attr_active_source is None
+    assert player._reports_stream_url is True
+
+    # another app takes the speaker over while MA still considers its session open
+    player._update_attributes(_external_attributes())
+
+    assert player._attr_active_source == "External"
+
+
+async def test_idle_entity_ends_the_ma_session() -> None:
+    """Playback that starts after the entity went idle is external again."""
+    player = _make_player()
+    player._ma_playback_active = True
+    player._attr_playback_state = PlaybackState.PLAYING
+
+    player.update_from_compressed_state({"s": "idle"})
+    assert player._ma_playback_active is False
+
+    player._attr_playback_state = PlaybackState.PLAYING
+    player._update_attributes(_external_attributes())
+
+    assert player._attr_active_source == "External"
+
+
+async def test_play_media_starts_the_ma_session() -> None:
+    """A play command from MA marks the session as ours."""
+    player = _make_player()
+
+    await player.play_media(PlayerMedia(uri="library://track/1", title="MA Track"))
+
+    assert player._ma_playback_active is True
+
+
+async def test_stop_ends_the_ma_session() -> None:
+    """A stop command from MA releases the session."""
+    player = _make_player()
+    player._ma_playback_active = True
+
+    await player.stop()
+
+    assert player._ma_playback_active is False

--- a/tests/providers/hass_players/test_external_playback.py
+++ b/tests/providers/hass_players/test_external_playback.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 from music_assistant_models.enums import PlaybackState
 from music_assistant_models.player import PlayerMedia
 
+from music_assistant.constants import ATTR_ANNOUNCEMENT_IN_PROGRESS
 from music_assistant.providers.hass_players.player import HomeAssistantPlayer
 
 BASE_URL = "http://10.0.0.5:8097"
@@ -38,6 +39,7 @@ def _make_player() -> HomeAssistantPlayer:
     player._attr_active_source = None
     player._attr_current_media = None
     player._ma_playback_active = False
+    player._ma_playback_started = False
     player._reports_stream_url = False
     player.update_state = MagicMock()  # type: ignore[misc, method-assign]
     return player
@@ -100,14 +102,13 @@ async def test_entity_echoing_stream_url_still_detects_takeover() -> None:
 async def test_idle_entity_ends_the_ma_session() -> None:
     """Playback that starts after the entity went idle is external again."""
     player = _make_player()
-    player._ma_playback_active = True
-    player._attr_playback_state = PlaybackState.PLAYING
 
+    await player.play_media(PlayerMedia(uri="library://track/1", title="MA Track"))
+    player.update_from_compressed_state({"s": "playing"})
     player.update_from_compressed_state({"s": "idle"})
     assert player._ma_playback_active is False
 
-    player._attr_playback_state = PlaybackState.PLAYING
-    player._update_attributes(_external_attributes())
+    player.update_from_compressed_state({"s": "playing", "a": _external_attributes()})
 
     assert player._attr_active_source == "External"
 
@@ -119,6 +120,53 @@ async def test_play_media_starts_the_ma_session() -> None:
     await player.play_media(PlayerMedia(uri="library://track/1", title="MA Track"))
 
     assert player._ma_playback_active is True
+
+
+async def test_late_idle_of_previous_session_is_ignored() -> None:
+    """An entity reporting the stop of the previous track late keeps our session ours."""
+    player = _make_player()
+    player._ma_playback_active = True
+    player._ma_playback_started = True
+    player._attr_playback_state = PlaybackState.PLAYING
+
+    # switching tracks stops the entity first, so its idle can arrive after our play
+    await player.play_media(PlayerMedia(uri="library://track/2", title="Next Track"))
+    player.update_from_compressed_state({"s": "idle"})
+    player.update_from_compressed_state({"s": "playing", "a": _external_attributes()})
+
+    assert player._ma_playback_active is True
+    assert player._attr_active_source is None
+
+
+async def test_power_on_state_does_not_end_the_ma_session() -> None:
+    """An entity that reports powering on before it plays keeps our session ours."""
+    player = _make_player()
+
+    await player.play_media(PlayerMedia(uri="library://track/1", title="MA Track"))
+    player.update_from_compressed_state({"s": "on"})
+    player.update_from_compressed_state({"s": "playing", "a": _external_attributes()})
+
+    assert player._attr_active_source is None
+
+
+async def test_announcement_does_not_disturb_source_detection() -> None:
+    """An announcement neither ends our session nor proves the entity reports our URL."""
+    player = _make_player()
+    player._attr_playback_state = PlaybackState.PLAYING
+    player._update_attributes(_external_attributes())
+    assert player._attr_active_source == "External"
+
+    player.extra_data[ATTR_ANNOUNCEMENT_IN_PROGRESS] = True
+    player.update_from_compressed_state(
+        {
+            "s": "playing",
+            "a": {"media_content_id": f"{BASE_URL}/announcement/{PLAYER_ID}.mp3"},
+        }
+    )
+    player.update_from_compressed_state({"s": "idle"})
+
+    assert player._reports_stream_url is False
+    assert player._attr_active_source == "External"
 
 
 async def test_stop_ends_the_ma_session() -> None:

--- a/tests/providers/hass_players/test_external_playback.py
+++ b/tests/providers/hass_players/test_external_playback.py
@@ -122,6 +122,19 @@ async def test_play_media_starts_the_ma_session() -> None:
     assert player._ma_playback_active is True
 
 
+async def test_play_media_takes_over_from_an_external_source() -> None:
+    """Starting MA playback drops the external source without waiting for the entity."""
+    player = _make_player()
+    player._attr_playback_state = PlaybackState.PLAYING
+    player._update_attributes(_external_attributes())
+    assert player._attr_active_source == "External"
+
+    # the entity may never report an attribute change to announce the handover
+    await player.play_media(PlayerMedia(uri="library://track/1", title="MA Track"))
+
+    assert player._attr_active_source is None
+
+
 async def test_late_idle_of_previous_session_is_ignored() -> None:
     """An entity reporting the stop of the previous track late keeps our session ours."""
     player = _make_player()
@@ -167,6 +180,12 @@ async def test_announcement_does_not_disturb_source_detection() -> None:
 
     assert player._reports_stream_url is False
     assert player._attr_active_source == "External"
+
+    # an unrelated update after the announcement may not pick the announcement up either
+    player.extra_data[ATTR_ANNOUNCEMENT_IN_PROGRESS] = False
+    player.update_from_compressed_state({"s": "playing", "a": {"volume_level": 0.5}})
+
+    assert player._reports_stream_url is False
 
 
 async def test_stop_ends_the_ma_session() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant decided whether a Home Assistant player was playing our audio by checking if the entity reported our stream URL back. Not every integration does that — some report their own metadata instead (xiaomi_miot builds it from the Xiaomi cloud) — so those players were always marked as playing an "External" source, even while MA was streaming to them. The queue then stayed inactive and empty, breaking the queue view and anything reading `active_queue`, such as the player card.

MA now also takes the play command it issued into account. Entities that do report our stream URL are still judged by it, so playback started outside MA on those players keeps being detected as before.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6038

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
