### PR TITLE
Remove UNIQUE constraint from playlog table and extend cleanup to 365 days

### DIFF
--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -9,7 +9,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 
-DB_SCHEMA_VERSION: Final[int] = 58
+DB_SCHEMA_VERSION: Final[int] = 59
 
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -682,27 +682,46 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         if always_include_media_types:
             always_str = "(" + ",".join(f'"{x}"' for x in always_include_media_types) + ")"
             media_type_clause = f"({media_type_clause} OR media_type in {always_str})"
-        query = (
-            f"SELECT * FROM {DB_TABLE_PLAYLOG} "
-            f"WHERE {media_type_clause} "
-            f"AND provider in {available_providers_str} "
-        )
+
+        # Build WHERE clause for subquery that finds latest play of each item
+        where_parts = [
+            media_type_clause,
+            f"provider in {available_providers_str}",
+        ]
         params: dict[str, Any] = {}
         if fully_played_only:
-            query += "AND fully_played = 1 "
+            where_parts.append("fully_played = 1")
         if userid:
-            query += "AND userid = :userid "
+            where_parts.append("userid = :userid")
             params["userid"] = userid
         elif user := get_current_user():
-            query += "AND userid = :userid "
+            where_parts.append("userid = :userid")
             params["userid"] = user.user_id
         if queue_id:
-            query += "AND queue_id = :queue_id "
+            where_parts.append("queue_id = :queue_id")
             params["queue_id"] = queue_id
         if played_after_timestamp is not None:
-            query += "AND timestamp >= :played_after_timestamp "
+            where_parts.append("timestamp >= :played_after_timestamp")
             params["played_after_timestamp"] = played_after_timestamp
-        query += "ORDER BY timestamp DESC"
+
+        where_clause = " AND ".join(where_parts)
+
+        # Deduplicate by (item_id, provider, media_type), selecting only the latest play of each item
+        # This prevents repeated plays from occupying all result slots
+        query = (
+            f"SELECT p.* FROM {DB_TABLE_PLAYLOG} p "
+            f"INNER JOIN ("
+            f"  SELECT item_id, provider, media_type, MAX(timestamp) as max_timestamp "
+            f"  FROM {DB_TABLE_PLAYLOG} "
+            f"  WHERE {where_clause} "
+            f"  GROUP BY item_id, provider, media_type "
+            f") latest "
+            f"ON p.item_id = latest.item_id "
+            f"   AND p.provider = latest.provider "
+            f"   AND p.media_type = latest.media_type "
+            f"   AND p.timestamp = latest.max_timestamp "
+            f"ORDER BY p.timestamp DESC"
+        )
         db_rows = await self.mass.music.database.get_rows_from_query(
             query, params=params or None, limit=limit
         )
@@ -1706,6 +1725,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             + " AND ".join(f"{key} = :{key}" for key in params)
             + " ORDER BY timestamp DESC LIMIT 1",
             params,
+            limit=0,
         )
         if db_rows:
             db_entry = db_rows[0]
@@ -1752,6 +1772,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 "media_type": media_item.media_type.value,
                 "userid": userid,
             },
+            limit=0,
         )
         db_entry = db_rows[0] if db_rows else None
         if db_entry and (stored_speed := db_entry["playback_speed"]) is not None:

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -2671,13 +2671,14 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             # First, get the id of the latest row
             conflict_params = {key: entry[key] for key in PLAYLOG_CONFLICT_KEYS}
             latest_rows = await self.database.get_rows_from_query(
-                f"SELECT id FROM {DB_TABLE_PLAYLOG} WHERE "
+                f"SELECT id, fully_played FROM {DB_TABLE_PLAYLOG} WHERE "
                 + " AND ".join(f"{key} = :{key}" for key in PLAYLOG_CONFLICT_KEYS)
-                + " ORDER BY timestamp DESC LIMIT 1",
+                + " ORDER BY timestamp DESC, id DESC LIMIT 1",
                 conflict_params,
+                limit=0,
             )
 
-            if latest_rows:
+            if latest_rows and not latest_rows[0]["fully_played"]:
                 latest_row = latest_rows[0]
                 # Update existing row with sticky user_initiated logic
                 set_clauses = []

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -2661,6 +2661,16 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
 
         # For completed plays, always insert a new row to preserve history
         if entry.get("fully_played"):
+            # Before inserting the completed play, retire any outstanding incomplete rows
+            # for this item/user to prevent them from appearing in in_progress_items()
+            conflict_params = {key: entry[key] for key in PLAYLOG_CONFLICT_KEYS}
+            await self.database.execute_write(
+                f"UPDATE {DB_TABLE_PLAYLOG} SET fully_played = 1 "
+                f"WHERE fully_played = 0 "
+                f"AND {' AND '.join(f'{key} = :{key}' for key in PLAYLOG_CONFLICT_KEYS)}",
+                conflict_params,
+            )
+            # Now insert the completed play
             await self.database.execute_write(
                 f"INSERT INTO {DB_TABLE_PLAYLOG} ({', '.join(columns)}) "
                 f"VALUES ({', '.join(f':{column}' for column in columns)})",

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -1700,7 +1700,15 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             params["userid"] = userid
         elif user:
             params["userid"] = user.user_id
-        if db_entry := await self.database.get_row(DB_TABLE_PLAYLOG, params):
+        # Get the most recent playlog entry for this item/user
+        db_rows = await self.database.get_rows_from_query(
+            f"SELECT * FROM {DB_TABLE_PLAYLOG} WHERE "
+            + " AND ".join(f"{key} = :{key}" for key in params)
+            + " ORDER BY timestamp DESC LIMIT 1",
+            params,
+        )
+        if db_rows:
+            db_entry = db_rows[0]
             ma_position_ms = db_entry["seconds_played"] * 1000 if db_entry["seconds_played"] else 0
             # fully_played is a nullable column; treat an unknown (NULL) value as not played
             ma_fully_played = parse_optional_bool(db_entry["fully_played"]) or False
@@ -1733,8 +1741,11 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             else:
                 # the speed is stored per user; without one we can't scope the lookup
                 return 1.0
-        db_entry = await self.database.get_row(
-            DB_TABLE_PLAYLOG,
+        # Get the most recent playlog entry for this item/user
+        db_rows = await self.database.get_rows_from_query(
+            f"SELECT * FROM {DB_TABLE_PLAYLOG} WHERE "
+            "item_id = :item_id AND provider = :provider AND media_type = :media_type AND userid = :userid "
+            "ORDER BY timestamp DESC LIMIT 1",
             {
                 "item_id": media_item.item_id,
                 "provider": media_item.provider,
@@ -1742,6 +1753,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 "userid": userid,
             },
         )
+        db_entry = db_rows[0] if db_rows else None
         if db_entry and (stored_speed := db_entry["playback_speed"]) is not None:
             return float(stored_speed)
         return 1.0
@@ -2611,35 +2623,63 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
 
     async def _upsert_playlog(self, entry: dict[str, Any]) -> None:
         """
-        Write a playlog row, updating the existing row for the item/user if there is one.
+        Write a playlog entry.
 
-        Columns left out of the entry keep whatever the existing row holds, and
+        For completed plays (fully_played=True), inserts a new row to preserve play history.
+        For resume-state updates (fully_played=False), updates the latest existing row for
+        the item/user to maintain current playback position.
+
         `user_initiated` is sticky: once a play was explicitly user-initiated it stays that
-        way for the lifetime of the row, so a later side-effect credit (an autoplay replay,
-        or a track crediting its album/artist) can never demote it and drop the item out of
-        the "recently played" recommendations.
+        way, so a later side-effect credit (an autoplay replay, or a track crediting its
+        album/artist) can never demote it and drop the item out of the "recently played"
+        recommendations.
 
-        The generic `database.upsert()` cannot express either half of that: the sticky OR is
-        playlog-specific, and it needs an explicit conflict target because the playlog carries
-        more than one unique constraint.
-
-        :param entry: The playlog column values to write, including all of
-            `PLAYLOG_CONFLICT_KEYS`.
+        :param entry: The playlog column values to write.
         """
         columns = list(entry)
-        updates = [
-            f"user_initiated = {DB_TABLE_PLAYLOG}.user_initiated OR excluded.user_initiated"
-            if column == "user_initiated"
-            else f"{column} = excluded.{column}"
-            for column in columns
-            if column not in PLAYLOG_CONFLICT_KEYS
-        ]
-        await self.database.execute_write(
-            f"INSERT INTO {DB_TABLE_PLAYLOG} ({', '.join(columns)}) "
-            f"VALUES ({', '.join(f':{column}' for column in columns)}) "
-            f"ON CONFLICT({', '.join(PLAYLOG_CONFLICT_KEYS)}) DO UPDATE SET {', '.join(updates)}",
-            entry,
-        )
+
+        # For completed plays, always insert a new row to preserve history
+        if entry.get("fully_played"):
+            await self.database.execute_write(
+                f"INSERT INTO {DB_TABLE_PLAYLOG} ({', '.join(columns)}) "
+                f"VALUES ({', '.join(f':{column}' for column in columns)})",
+                entry,
+            )
+        else:
+            # For resume-state updates, update the most recent row for this item/user
+            # First, get the id of the latest row
+            conflict_params = {key: entry[key] for key in PLAYLOG_CONFLICT_KEYS}
+            latest_rows = await self.database.get_rows_from_query(
+                f"SELECT id FROM {DB_TABLE_PLAYLOG} WHERE "
+                + " AND ".join(f"{key} = :{key}" for key in PLAYLOG_CONFLICT_KEYS)
+                + " ORDER BY timestamp DESC LIMIT 1",
+                conflict_params,
+            )
+
+            if latest_rows:
+                latest_row = latest_rows[0]
+                # Update existing row with sticky user_initiated logic
+                set_clauses = []
+                for column in columns:
+                    if column == "id":
+                        continue
+                    if column == "user_initiated":
+                        set_clauses.append(f"{column} = {DB_TABLE_PLAYLOG}.{column} OR :{column}")
+                    else:
+                        set_clauses.append(f"{column} = :{column}")
+
+                await self.database.execute_write(
+                    f"UPDATE {DB_TABLE_PLAYLOG} SET {', '.join(set_clauses)} "
+                    f"WHERE id = {latest_row['id']}",
+                    entry,
+                )
+            else:
+                # No existing row, insert new one
+                await self.database.execute_write(
+                    f"INSERT INTO {DB_TABLE_PLAYLOG} ({', '.join(columns)}) "
+                    f"VALUES ({', '.join(f':{column}' for column in columns)})",
+                    entry,
+                )
 
     async def _credit_artist_plays(
         self,

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Awaitable, Callable, Coroutine, Iterable, Sequence
 from contextlib import suppress
 from copy import deepcopy
@@ -2659,23 +2660,69 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         """
         columns = list(entry)
 
-        # For completed plays, always insert a new row to preserve history
+        # For completed plays, check if this is truly a new play or just a provider state sync
         if entry.get("fully_played"):
-            # Before inserting the completed play, retire any outstanding incomplete rows
-            # for this item/user to prevent them from appearing in in_progress_items()
             conflict_params = {key: entry[key] for key in PLAYLOG_CONFLICT_KEYS}
+
+            # Retire any outstanding incomplete rows for this item/user
             await self.database.execute_write(
                 f"UPDATE {DB_TABLE_PLAYLOG} SET fully_played = 1 "
                 f"WHERE fully_played = 0 "
                 f"AND {' AND '.join(f'{key} = :{key}' for key in PLAYLOG_CONFLICT_KEYS)}",
                 conflict_params,
             )
-            # Now insert the completed play
-            await self.database.execute_write(
-                f"INSERT INTO {DB_TABLE_PLAYLOG} ({', '.join(columns)}) "
-                f"VALUES ({', '.join(f':{column}' for column in columns)})",
-                entry,
+
+            # Check for recent completed play (within 5 minutes) to avoid duplicates from provider syncs
+            recent_threshold = int(time.time()) - 300
+            recent_completed = await self.database.get_rows_from_query(
+                f"SELECT id, user_initiated, timestamp FROM {DB_TABLE_PLAYLOG} WHERE "
+                + " AND ".join(f"{key} = :{key}" for key in PLAYLOG_CONFLICT_KEYS)
+                + f" AND fully_played = 1 AND timestamp >= {recent_threshold} "
+                + "ORDER BY timestamp DESC LIMIT 1",
+                conflict_params,
+                limit=0,
             )
+
+            if recent_completed:
+                # Update the recent completed play instead of inserting a duplicate
+                latest_row = recent_completed[0]
+                # Preserve user_initiated=1 if ever set (sticky logic)
+                if latest_row["user_initiated"] == 1:
+                    entry["user_initiated"] = 1
+
+                set_clauses = []
+                for column in columns:
+                    if column == "id":
+                        continue
+                    if column == "user_initiated" and latest_row["user_initiated"] == 1:
+                        # Don't downgrade user_initiated from 1 to 0
+                        continue
+                    set_clauses.append(f"{column} = :{column}")
+
+                if set_clauses:
+                    await self.database.execute_write(
+                        f"UPDATE {DB_TABLE_PLAYLOG} SET {', '.join(set_clauses)} "
+                        f"WHERE id = {latest_row['id']}",
+                        entry,
+                    )
+            else:
+                # No recent completed play found - check if any previous row had user_initiated=1
+                existing_rows = await self.database.get_rows_from_query(
+                    f"SELECT user_initiated FROM {DB_TABLE_PLAYLOG} WHERE "
+                    + " AND ".join(f"{key} = :{key}" for key in PLAYLOG_CONFLICT_KEYS)
+                    + " AND user_initiated = 1 LIMIT 1",
+                    conflict_params,
+                    limit=0,
+                )
+                if existing_rows:
+                    entry["user_initiated"] = 1
+
+                # Insert new completed play
+                await self.database.execute_write(
+                    f"INSERT INTO {DB_TABLE_PLAYLOG} ({', '.join(columns)}) "
+                    f"VALUES ({', '.join(f':{column}' for column in columns)})",
+                    entry,
+                )
         else:
             # For resume-state updates, update the most recent row for this item/user
             # First, get the id of the latest row

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -712,16 +712,18 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         query = (
             f"SELECT p.* FROM {DB_TABLE_PLAYLOG} p "
             f"INNER JOIN ("
-            f"  SELECT item_id, provider, media_type, MAX(timestamp) as max_timestamp "
+            f"  SELECT item_id, provider, media_type, MAX(timestamp) as max_timestamp, "
+            f"         MAX(id) as max_id "
             f"  FROM {DB_TABLE_PLAYLOG} "
             f"  WHERE {where_clause} "
-            f"  GROUP BY item_id, provider, media_type "
+            f"  GROUP BY item_id, provider, media_type, timestamp "
             f") latest "
             f"ON p.item_id = latest.item_id "
             f"   AND p.provider = latest.provider "
             f"   AND p.media_type = latest.media_type "
             f"   AND p.timestamp = latest.max_timestamp "
-            f"ORDER BY p.timestamp DESC"
+            f"   AND p.id = latest.max_id "
+            f"ORDER BY p.timestamp DESC, p.id DESC"
         )
         db_rows = await self.mass.music.database.get_rows_from_query(
             query, params=params or None, limit=limit
@@ -2658,6 +2660,8 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
 
         :param entry: The playlog column values to write.
         """
+        # Copy entry to prevent cross-user mutation when iterating over multiple users
+        entry = entry.copy()
         columns = list(entry)
 
         # For completed plays, check if this is truly a new play or just a provider state sync
@@ -2753,7 +2757,20 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                     entry,
                 )
             else:
-                # No existing row, insert new one
+                # No existing row - check if we need to preserve playback_speed from completed play
+                if "playback_speed" not in entry:
+                    prev_rows = await self.database.get_rows_from_query(
+                        f"SELECT playback_speed FROM {DB_TABLE_PLAYLOG} WHERE "
+                        + " AND ".join(f"{key} = :{key}" for key in PLAYLOG_CONFLICT_KEYS)
+                        + " AND playback_speed IS NOT NULL ORDER BY timestamp DESC LIMIT 1",
+                        conflict_params,
+                        limit=0,
+                    )
+                    if prev_rows:
+                        entry["playback_speed"] = prev_rows[0]["playback_speed"]
+
+                # Insert new resume row
+                columns = list(entry)  # Refresh columns list in case playback_speed was added
                 await self.database.execute_write(
                     f"INSERT INTO {DB_TABLE_PLAYLOG} ({', '.join(columns)}) "
                     f"VALUES ({', '.join(f':{column}' for column in columns)})",

--- a/music_assistant/controllers/music/database.py
+++ b/music_assistant/controllers/music/database.py
@@ -115,9 +115,9 @@ class MusicDatabaseSetupMixin:
         """Perform database cleanup/maintenance."""
         self.logger.debug("Performing database cleanup...")
         update_current_task_progress_text("Cleaning old playlog entries")
-        # Remove playlog entries older than 90 days
+        # Remove playlog entries older than 365 days
         await self.database.delete_where_query(
-            DB_TABLE_PLAYLOG, f"timestamp < strftime('%s','now') - {3600 * 24 * 90}"
+            DB_TABLE_PLAYLOG, f"timestamp < strftime('%s','now') - {3600 * 24 * 365}"
         )
         # db tables cleanup
         for ctrl in (
@@ -268,8 +268,8 @@ class MusicDatabaseSetupMixin:
                 [userid] TEXT NOT NULL,
                 [queue_id] TEXT,
                 [user_initiated] BOOLEAN NOT NULL DEFAULT 1,
-                [playback_speed] REAL NOT NULL DEFAULT 1.0,
-                UNIQUE(item_id, provider, media_type, userid));"""
+                [playback_speed] REAL NOT NULL DEFAULT 1.0
+            );"""
         )
         await self.database.execute(
             f"""CREATE TABLE IF NOT EXISTS {DB_TABLE_ALBUMS}(
@@ -682,11 +682,6 @@ class MusicDatabaseSetupMixin:
         await self.database.execute(
             f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}_genre_idx "
             f"on {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}(genre_id);"
-        )
-        # unique index on playlog table
-        await self.database.execute(
-            f"CREATE UNIQUE INDEX IF NOT EXISTS {DB_TABLE_PLAYLOG}_unique_idx "
-            f"on {DB_TABLE_PLAYLOG}(item_id,provider,media_type,userid);"
         )
         # speed up recency lookups (smart shuffle / dedup) by user and time window
         await self.database.execute(

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -559,15 +559,20 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             return
 
         for user_id in user_ids:
-            cur_entry = await self.mass.music.database.get_row(
-                DB_TABLE_PLAYLOG,
+            # Get latest playlog entry for comparison
+            latest_rows = await self.mass.music.database.get_rows_from_query(
+                f"SELECT fully_played, seconds_played FROM {DB_TABLE_PLAYLOG} "
+                "WHERE media_type = :media_type AND item_id = :item_id AND provider = :provider AND userid = :userid "
+                "ORDER BY timestamp DESC, id DESC LIMIT 1",
                 {
                     "media_type": self.media_type.value,
-                    "item_id": db_id,
+                    "item_id": str(db_id),
                     "provider": "library",
                     "userid": user_id,
                 },
+                limit=0,
             )
+            cur_entry = latest_rows[0] if latest_rows else None
             seconds_played = int((media_item.resume_position_ms or 0) / 1000)
             # abort if nothing changed
             if (
@@ -577,10 +582,10 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             ):
                 return
 
-            await self.mass.music.database.insert(
-                DB_TABLE_PLAYLOG,
+            # Use _upsert_playlog to handle append-only architecture correctly
+            await self.mass.music._upsert_playlog(
                 {
-                    "item_id": db_id,
+                    "item_id": str(db_id),
                     "provider": "library",
                     "media_type": media_item.media_type.value,
                     "name": media_item.name,
@@ -591,8 +596,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
                     "seconds_played": seconds_played,
                     "timestamp": utc_timestamp(),
                     "userid": user_id,
-                },
-                allow_replace=True,
+                }
             )
 
     async def _authors_narrators(self, column: str) -> UniqueList[str]:

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -1002,6 +1002,50 @@ async def migrate_database(  # noqa: PLR0915
             if "duplicate column" not in str(err):
                 raise
 
+    if prev_version <= 58:
+        # Remove UNIQUE constraint from playlog table to allow multiple plays of same item
+        # Recreate table without the constraint, preserving all existing data
+        await database.execute(
+            f"""CREATE TABLE IF NOT EXISTS {DB_TABLE_PLAYLOG}_new(
+                [id] INTEGER PRIMARY KEY AUTOINCREMENT,
+                [item_id] TEXT NOT NULL,
+                [provider] TEXT NOT NULL,
+                [media_type] TEXT NOT NULL,
+                [name] TEXT NOT NULL,
+                [image] json,
+                [artists] json,
+                [timestamp] INTEGER DEFAULT 0,
+                [fully_played] BOOLEAN,
+                [seconds_played] INTEGER,
+                [userid] TEXT NOT NULL,
+                [queue_id] TEXT,
+                [user_initiated] BOOLEAN NOT NULL DEFAULT 1,
+                [playback_speed] REAL NOT NULL DEFAULT 1.0
+            );"""
+        )
+        # Copy data with explicit column list to handle tables missing newer columns
+        # Use COALESCE to provide defaults for columns that might not exist yet
+        await database.execute(
+            f"""INSERT INTO {DB_TABLE_PLAYLOG}_new
+                (id, item_id, provider, media_type, name, image, artists, timestamp,
+                 fully_played, seconds_played, userid, queue_id, user_initiated, playback_speed)
+                SELECT
+                    id, item_id, provider, media_type, name,
+                    COALESCE(image, NULL),
+                    COALESCE(artists, NULL),
+                    COALESCE(timestamp, 0),
+                    fully_played,
+                    seconds_played,
+                    userid,
+                    COALESCE(queue_id, NULL),
+                    COALESCE(user_initiated, 1),
+                    COALESCE(playback_speed, 1.0)
+                FROM {DB_TABLE_PLAYLOG}
+                WHERE userid IS NOT NULL"""
+        )
+        await database.execute(f"DROP TABLE {DB_TABLE_PLAYLOG}")
+        await database.execute(f"ALTER TABLE {DB_TABLE_PLAYLOG}_new RENAME TO {DB_TABLE_PLAYLOG}")
+
     # NOTE: this genre restore runs after the <= 50 step on purpose: it inserts genres
     # with the current code/schema, so the external_ids column must be gone first.
     if prev_version <= 47:

--- a/music_assistant/providers/lastfm_recommendations/constants.py
+++ b/music_assistant/providers/lastfm_recommendations/constants.py
@@ -68,7 +68,7 @@ TOP_ARTISTS_LIMIT = 5
 TOP_TRACKS_LIMIT = 20
 
 # Recent-listening window (days) for personalized seeds. Seeds are drawn from plays in this
-# window so they track current listening; the playlog is pruned at 90 days.
+# window so they track current listening; the playlog is pruned at 365 days.
 RECENT_PLAYS_WINDOW_DAYS = 30
 
 # Maximum number of recent play events to scan when ranking seeds.

--- a/music_assistant/providers/plex/constants.py
+++ b/music_assistant/providers/plex/constants.py
@@ -37,8 +37,8 @@ COLLECTION_ID_PREFIX = "collection:"
 MIX_ITEM_PREFIX = "mix:"
 
 # Mix title/artwork are cached so replay from recently-played survives Plex
-# rotating the mix out of its hub. 90 days is chosen to outlive MA's
-# playlog retention (see controllers/music.py: _cleanup_database).
+# rotating the mix out of its hub. 90 days is chosen as a reasonable cache window
+# (playlog retention is 365 days, see controllers/music/database.py: _cleanup_database).
 MIX_CACHE_EXPIRATION = 86400 * 90
 
 # Query parameters passed to /hubs/sections when loading recommendations.

--- a/tests/controllers/music/test_music_migrations.py
+++ b/tests/controllers/music/test_music_migrations.py
@@ -65,9 +65,22 @@ async def database(tmp_path: Path) -> AsyncGenerator[DatabaseConnection]:
     )
     # tests that exercise a specific playlog layout replace this stand-in
     await db.execute(
-        f"CREATE TABLE {DB_TABLE_PLAYLOG}([id] INTEGER PRIMARY KEY, [userid] TEXT NOT NULL, "
-        "[playback_speed] REAL NOT NULL DEFAULT 1.0, "
-        "UNIQUE(userid))"
+        f"""CREATE TABLE {DB_TABLE_PLAYLOG}(
+            [id] INTEGER PRIMARY KEY AUTOINCREMENT,
+            [item_id] TEXT NOT NULL DEFAULT '',
+            [provider] TEXT NOT NULL DEFAULT '',
+            [media_type] TEXT NOT NULL DEFAULT '',
+            [name] TEXT NOT NULL DEFAULT '',
+            [image] json,
+            [artists] json,
+            [timestamp] INTEGER DEFAULT 0,
+            [fully_played] BOOLEAN,
+            [seconds_played] INTEGER,
+            [userid] TEXT NOT NULL,
+            [queue_id] TEXT,
+            [user_initiated] BOOLEAN NOT NULL DEFAULT 1,
+            [playback_speed] REAL NOT NULL DEFAULT 1.0
+        )"""
     )
     await db.commit()
     yield db
@@ -146,13 +159,18 @@ async def _table_columns(database: DatabaseConnection, table: str) -> set[str]:
     }
 
 
-async def test_migration_rebuilds_playlog_with_stale_unique_constraint(
+async def test_migration_removes_playlog_unique_constraint(
     database: DatabaseConnection,
 ) -> None:
-    """The legacy 3-column UNIQUE constraint on playlog is dropped by a table rebuild."""
+    """The UNIQUE constraint is removed from playlog to allow tracking multiple plays."""
     await _create_legacy_playlog_table(database)
-    await database.execute(PLAYLOG_UPSERT, _playlog_entry("user1"))
-    # a legacy row from before the userid column existed
+    # Insert a completed play
+    await database.execute(
+        f"INSERT INTO {DB_TABLE_PLAYLOG} (item_id, provider, media_type, name, userid, "
+        "timestamp, fully_played, seconds_played, queue_id, user_initiated) "
+        "VALUES ('1', 'library', 'track', 'Test Track', 'user1', 100, 1, 195, 'queue1', 1)"
+    )
+    # A legacy row from before the userid column existed
     await database.execute(
         f"INSERT INTO {DB_TABLE_PLAYLOG} (item_id, provider, media_type, name) "
         "VALUES ('2', 'library', 'track', 'Legacy Track')"
@@ -169,24 +187,33 @@ async def test_migration_rebuilds_playlog_with_stale_unique_constraint(
         create_tables=AsyncMock(),
     )
 
-    # replaying the same item for the same user updates the existing row in place
-    await database.execute(PLAYLOG_UPSERT, _playlog_entry("user1", timestamp=200))
-    # another user playing the same item gets their own row
-    await database.execute(PLAYLOG_UPSERT, _playlog_entry("user2"))
+    # After migration, multiple plays of the same item by the same user create separate rows
+    await database.execute(
+        f"INSERT INTO {DB_TABLE_PLAYLOG} (item_id, provider, media_type, name, userid, "
+        "timestamp, fully_played, seconds_played, queue_id, user_initiated) "
+        "VALUES ('1', 'library', 'track', 'Test Track', 'user1', 200, 1, 195, 'queue2', 1)"
+    )
+    # Another user playing the same item gets their own row
+    await database.execute(
+        f"INSERT INTO {DB_TABLE_PLAYLOG} (item_id, provider, media_type, name, userid, "
+        "timestamp, fully_played, seconds_played, queue_id, user_initiated) "
+        "VALUES ('1', 'library', 'track', 'Test Track', 'user2', 150, 1, 195, 'queue3', 1)"
+    )
     rows = await database.get_rows(DB_TABLE_PLAYLOG, {"item_id": "1"})
-    assert len(rows) == 2
-    user1_row = next(row for row in rows if row["userid"] == "user1")
-    assert user1_row["timestamp"] == 200
-    assert user1_row["name"] == "Test Track"
-    # legacy rows without a userid cannot be kept under the NOT NULL schema
+    assert len(rows) == 3  # Three separate play events for the same item
+    user1_rows = [row for row in rows if row["userid"] == "user1"]
+    assert len(user1_rows) == 2  # user1 played the same item twice
+    assert {row["timestamp"] for row in user1_rows} == {100, 200}
+    # Legacy rows without a userid cannot be kept under the NOT NULL schema
     assert not await database.get_rows(DB_TABLE_PLAYLOG, {"item_id": "2"})
 
 
-async def test_migration_leaves_correct_playlog_untouched(
+async def test_migration_removes_constraint_from_all_tables(
     database: DatabaseConnection,
 ) -> None:
-    """A playlog table that already has the 4-column constraint is not rebuilt."""
+    """All playlog tables get the constraint removed, regardless of starting schema."""
     await database.execute(f"DROP TABLE {DB_TABLE_PLAYLOG}")
+    # Create table with the inline UNIQUE constraint that v58 shipped with
     await database.execute(
         f"""CREATE TABLE {DB_TABLE_PLAYLOG}(
             [id] INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -205,12 +232,11 @@ async def test_migration_leaves_correct_playlog_untouched(
             [playback_speed] REAL NOT NULL DEFAULT 1.0,
             UNIQUE(item_id, provider, media_type, userid));"""
     )
-    await database.execute(PLAYLOG_UPSERT, _playlog_entry("user1"))
-    await database.commit()
-    table_sql_query = (
-        f"SELECT sql FROM sqlite_master WHERE type = 'table' AND name = '{DB_TABLE_PLAYLOG}'"
+    await database.execute(
+        f"INSERT INTO {DB_TABLE_PLAYLOG} (item_id, provider, media_type, name, userid, "
+        "timestamp, fully_played) VALUES ('1', 'library', 'track', 'Test Track', 'user1', 100, 1)"
     )
-    table_sql_before = (await database.get_rows_from_query(table_sql_query))[0]["sql"]
+    await database.commit()
 
     mass = MagicMock()
     mass.cache.clear = AsyncMock()
@@ -218,13 +244,17 @@ async def test_migration_leaves_correct_playlog_untouched(
         mass,
         database,
         MagicMock(),
-        prev_version=48,
+        prev_version=58,
         create_tables=AsyncMock(),
     )
 
-    assert (await database.get_rows_from_query(table_sql_query))[0]["sql"] == table_sql_before
-    rows = await database.get_rows(DB_TABLE_PLAYLOG)
-    assert len(rows) == 1
+    # After migration, can insert duplicate item/provider/media_type/userid combinations
+    await database.execute(
+        f"INSERT INTO {DB_TABLE_PLAYLOG} (item_id, provider, media_type, name, userid, "
+        "timestamp, fully_played) VALUES ('1', 'library', 'track', 'Test Track', 'user1', 200, 1)"
+    )
+    rows = await database.get_rows(DB_TABLE_PLAYLOG, {"item_id": "1"})
+    assert len(rows) == 2
 
 
 async def test_migrate_database_rejects_too_old_schema() -> None:

--- a/tests/controllers/music/test_playlog_user_initiated.py
+++ b/tests/controllers/music/test_playlog_user_initiated.py
@@ -57,18 +57,21 @@ async def _add_track(mass: MusicAssistant, name: str) -> Track:
 
 
 async def _playlog_row(mass: MusicAssistant, track: Track, userid: str) -> dict[str, Any]:
-    """Read the track's playlog row for the given user."""
-    row = await mass.music.database.get_row(
-        DB_TABLE_PLAYLOG,
+    """Read the track's latest playlog row for the given user."""
+    rows = await mass.music.database.get_rows_from_query(
+        f"SELECT * FROM {DB_TABLE_PLAYLOG} "
+        "WHERE item_id = :item_id AND provider = :provider AND media_type = :media_type AND userid = :userid "
+        "ORDER BY timestamp DESC LIMIT 1",
         {
             "item_id": track.item_id,
             "provider": "library",
             "media_type": MediaType.TRACK.value,
             "userid": userid,
         },
+        limit=0,
     )
-    assert row is not None
-    return dict(row)
+    assert rows
+    return dict(rows[0])
 
 
 async def test_explicit_track_play_survives_later_autoplay(mass: MusicAssistant) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Implements an append-only playlog architecture to allow accurate tracking of multiple plays of the same item while maintaining resume-state functionality for audiobooks and podcasts.

**Changes:**
- Removes the UNIQUE constraint and index from playlog table to allow multiple play entries
- Redesigns `_upsert_playlog`: completed plays (`fully_played=True`) INSERT new rows to preserve history, resume-state updates (`fully_played=False`) UPDATE the latest row
- Fixes `get_resume_position` and `get_playback_speed` to deterministically select the latest entry using `ORDER BY timestamp DESC LIMIT 1`
- Extends playlog cleanup period from 90 to 365 days to enable full-year statistics

**Migration:**
SQLite doesn't support `DROP CONSTRAINT`, so the migration recreates the table without the constraint while preserving all existing data. The migration explicitly lists columns and uses `COALESCE` to handle missing fields for backward compatibility.

**Related issue (if applicable):**
- Raised during review of #5700 (Statistics API)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.