### PR TITLE
Announcements no longer leave older AirPlay speakers at the announcement volume

### DIFF
--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -50,7 +50,7 @@ from .constants import (
 from .stream_session import AirPlayStreamSession
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import AsyncGenerator, Iterable
 
     from music_assistant_models.media_items import AudioFormat
     from music_assistant_models.player import PlayerMedia
@@ -375,7 +375,11 @@ async def _announce_with_session(
                 announcement,
                 requested_volume=volume_level,
             )
-            await session.start(render.get_stream(session_pcm_format))
+            # The clip is served with its silence tail: the legacy RAOP flow
+            # reports end of stream the moment the last fed sample is audible,
+            # and a volume command is dropped once a stream has ended - so
+            # without the tail the restore below never reaches the speaker.
+            await session.start(_clip_with_tail(render, session_pcm_format))
             player._transitioning = False
         # The clip is anchored: wait out the start lead plus the clip, then the
         # pad that covers the jitter between the anchored and the true audible
@@ -606,6 +610,26 @@ async def _render_clip_file(render: AnnouncementRender, pcm_format: AudioFormat)
     clip = bytearray()
     async for chunk in render.get_stream(pcm_format):
         clip.extend(chunk)
+    clip.extend(_clip_silence_tail(pcm_format))
+    return await asyncio.to_thread(_write_clip_file, clip)
+
+
+async def _clip_with_tail(
+    render: AnnouncementRender, pcm_format: AudioFormat
+) -> AsyncGenerator[bytes]:
+    """
+    Yield the announcement clip followed by the trailing silence.
+
+    :param render: The (finished) announcement render to read.
+    :param pcm_format: The raw PCM format to yield.
+    """
+    async for chunk in render.get_stream(pcm_format):
+        yield chunk
+    yield _clip_silence_tail(pcm_format)
+
+
+def _clip_silence_tail(pcm_format: AudioFormat) -> bytes:
+    """Return the silence tail appended to an announcement clip, in the given PCM format."""
     # Wire sizes come from the content type: at 24-bit the stdin carrier is
     # s32le while bit_depth stays 24, so bit_depth-derived sizes are wrong.
     bytes_per_sample = {
@@ -615,8 +639,7 @@ async def _render_clip_file(render: AnnouncementRender, pcm_format: AudioFormat)
         ContentType.PCM_F32LE: 4,
     }.get(pcm_format.content_type, pcm_format.bit_depth // 8)
     trail_frames = int(pcm_format.sample_rate * AIRPLAY_ANNOUNCE_DUCK_TAIL_S)
-    clip.extend(bytes(trail_frames * bytes_per_sample * pcm_format.channels))
-    return await asyncio.to_thread(_write_clip_file, clip)
+    return bytes(trail_frames * bytes_per_sample * pcm_format.channels)
 
 
 def _write_clip_file(data: bytes | bytearray) -> str:

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -223,11 +223,13 @@ AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS: Final[int] = 2000
 # and out itself. <= -60 mutes the music entirely. -18 dB puts the music
 # clearly in the background under speech (-12 was field-judged too shallow).
 AIRPLAY_ANNOUNCE_DUCK_DB: Final[int] = -18
-# Silence appended to every announcement clip file. The binary holds the duck
-# for the whole file, so this keeps the music ducked past the announcement -
-# the volume restore lands inside this cushion instead of racing the duck's
-# 200 ms tail ramp (a restore that lands after the ramp plays a moment of
-# full-level music at the still-bumped device volume).
+# Silence appended to every announcement clip, so the volume restore has a
+# cushion to land in. Mixed over live playback the binary holds the duck for
+# the whole clip, so the restore lands while the music is still ducked instead
+# of racing the duck's 200 ms tail ramp (a restore that lands after the ramp
+# plays a moment of full-level music at the still-bumped device volume). On a
+# dedicated announcement session it keeps the stream alive past the clip, which
+# is what a volume command needs to reach the receiver at all.
 AIRPLAY_ANNOUNCE_DUCK_TAIL_S: Final[float] = 1.0
 # On top of the lead to the commanded instant: how long to wait for a member's
 # announce_started before treating that member as not announcing. An outdated

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -16,6 +16,7 @@ from music_assistant.providers.airplay import announce
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_ANNOUNCE_AT_MARGIN_MS,
     AIRPLAY_ANNOUNCE_DUCK_DB,
+    AIRPLAY_ANNOUNCE_DUCK_TAIL_S,
     AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS,
     AIRPLAY_PCM_FORMAT,
 )
@@ -50,7 +51,8 @@ def _make_render(duration: float = 1.5) -> MagicMock:
     render.wait_finished = AsyncMock(return_value=duration)
 
     async def get_stream(_output_format: Any) -> AsyncGenerator[bytes]:
-        yield b"\x00" * 64
+        # non-silent, so a clip is distinguishable from the silence around it
+        yield b"\xff" * 64
 
     render.get_stream = get_stream
     return render
@@ -401,6 +403,42 @@ async def test_session_path_restores_the_volume_when_the_clip_is_cut_short() -> 
 
     # the session is still up here, so the restore reaches the receiver
     assert events == ["volume=60", "volume=25", "stop"]
+
+
+@pytest.mark.asyncio
+async def test_session_path_serves_the_clip_with_its_silence_tail() -> None:
+    """The dedicated session keeps feeding past the clip, so the volume restore lands in time."""
+    player = _make_player("solo")
+    player.playback_state = PlaybackState.IDLE
+    player._get_sync_clients = MagicMock(return_value=[player])
+    player._get_session_pcm_format = AsyncMock(return_value=HIRES_PCM_FORMAT)
+    render = _make_render(duration=0.01)
+    player.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
+    served = bytearray()
+
+    with (
+        patch.object(announce, "AirPlayStreamSession") as session_cls,
+        patch.object(announce, "AIRPLAY_ANNOUNCE_SESSION_DRAIN_S", 0.0),
+    ):
+
+        async def start(source: AsyncGenerator[bytes]) -> None:
+            async for chunk in source:
+                served.extend(chunk)
+
+        session = session_cls.return_value
+        session.start = AsyncMock(side_effect=start)
+        session.stop = AsyncMock()
+        session.start_time = 0.0
+        await announce.play_announcement(player, _make_announcement(), None)
+
+    # the tail is sized on the content type: this format carries 24 bit over an
+    # s32le wire, so a bit_depth-derived size would come out a quarter short
+    tail_bytes = (
+        int(HIRES_PCM_FORMAT.sample_rate * AIRPLAY_ANNOUNCE_DUCK_TAIL_S)
+        * 4
+        * HIRES_PCM_FORMAT.channels
+    )
+    assert served == b"\xff" * 64 + bytes(tail_bytes)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

When an announcement plays on an idle AirPlay speaker it runs as its own short stream, and afterwards the speaker's volume is put back to what it was. On older (AirPlay 1 / RAOP) speakers that restore never arrived: the speaker reports the stream as finished the moment the last bit of audio is heard, and Music Assistant does not send volume commands over a finished stream. The speaker was left sitting at the announcement volume until the next time something played on it.

Announcements mixed over music already end with a moment of silence for exactly this kind of breathing room; the dedicated announcement stream now does the same, so the restore lands while the stream is still there.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- The dedicated announcement stream now ends with the same trailing silence the mixed-over-music announcements already use.
- Both paths share one helper for that silence instead of each sizing it themselves.
- Added a test covering it.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
