### PR TITLE
Use the WiiM SDK volume command now that the upstream fix has shipped

### DIFF
--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -230,14 +230,7 @@ class WiimPlayer(Player):
     async def volume_set(self, volume_level: int) -> None:
         """Handle VOLUME_SET command on the player."""
         try:
-            # Remove and uncomment when wiim-sdk 0.1.5+ has been released
-            # await self.device.async_set_volume(volume_level)
-            # Inlined fix from https://github.com/Linkplay2020/wiim/pull/18:
-            # async_set_volume uses a UPnP action that is unreliable; the HTTP
-            # command works. Replicates the SDK method body until 0.1.5 ships.
-            volume_level = max(0, min(100, volume_level))
-            await self.device._http_command_ok("setPlayerCmd:vol:{}", str(volume_level))
-            self.device.volume = volume_level
+            await self.device.async_set_volume(volume_level)
         except WiimException as err:
             self._handle_command_error("volume_set", err)
             return

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -342,6 +342,27 @@ class TestSourceList:
         assert "futuremode" not in source_ids
 
 
+class TestVolumeCommand:
+    """Test the volume command reaches the device."""
+
+    @pytest.mark.asyncio
+    async def test_volume_set_delegates_to_device(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """Setting the volume should reach the device and land in the player state."""
+        player = WiimPlayer(provider=mock_provider, player_id="uuid:test", device=mock_wiim_device)
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+
+        async def _apply_volume(volume_level: int) -> None:
+            mock_wiim_device.volume = volume_level
+
+        mock_wiim_device.async_set_volume = AsyncMock(side_effect=_apply_volume)
+        await player.volume_set(42)
+
+        mock_wiim_device.async_set_volume.assert_awaited_once_with(42)
+        assert player._attr_volume_level == 42
+
+
 class TestErrorHandling:
     """Test that command errors mark device unavailable."""
 

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -357,10 +357,6 @@ class TestErrorHandling:
         assert player._attr_available is True
         player.update_state.assert_called()
 
-    @pytest.mark.skip(
-        reason="volume_set inlines the HTTP fix from wiim PR#18 and no longer calls "
-        "async_set_volume; re-enable when wiim-sdk 0.1.5+ has been released"
-    )
     @pytest.mark.asyncio
     async def test_volume_set_error_refreshes_state(
         self, mock_provider: MagicMock, mock_wiim_device: MagicMock
@@ -378,7 +374,7 @@ class TestErrorHandling:
         self, mock_provider: MagicMock, mock_wiim_device: MagicMock
     ) -> None:
         """A speaker answering a volume command with something other than OK must not throw."""
-        mock_wiim_device._http_command_ok = AsyncMock(
+        mock_wiim_device.async_set_volume = AsyncMock(
             side_effect=WiimInvalidDataException("did not return 'OK'")
         )
         player = WiimPlayer(provider=mock_provider, player_id="uuid:test", device=mock_wiim_device)


### PR DESCRIPTION
# What does this implement/fix?

The WiiM provider had a temporary workaround: `volume_set()` copied the body of the SDK's
`async_set_volume()` because that method used an unreliable UPnP action. The upstream fix
has since shipped and we already pin `wiim==0.1.5`, so the copy can go and we call the SDK again.

**Related issue (if applicable):**

- upstream fix: https://github.com/Linkplay2020/wiim/pull/18

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- `volume_set()` calls `device.async_set_volume()` again instead of the inlined HTTP command
- dropped the workaround comments and the private SDK call that came with them
- re-enabled the volume error-handling test that was skipped for this workaround
- pointed the invalid-data volume test at the public SDK method so it keeps testing something
- added a test that the volume command actually reaches the device
- added a test that the volume command actually reaches the device

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
