### PR TITLE
Fix Cyrillic track and album names showing as question marks

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1626,7 +1626,7 @@ async def detect_charset(data: bytes, fallback: str = "utf-8") -> str:
     from charset_normalizer import from_bytes  # noqa: PLC0415
 
     try:
-        if match := await asyncio.to_thread(lambda: from_bytes(data).best()):
+        if match := (await asyncio.to_thread(from_bytes, data)).best():
             return match.encoding
     except Exception as err:
         LOGGER.debug("Failed to detect charset: %s", err)

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 import functools
 import html
 import importlib
@@ -50,7 +51,6 @@ from music_assistant.helpers.process import check_output
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from chardet.resultdict import ResultDict
     from music_assistant_models.player import DeviceInfo
     from zeroconf.asyncio import AsyncServiceInfo
 
@@ -1605,16 +1605,29 @@ async def close_async_generator(agen: AsyncGenerator[Any]) -> None:
 
 
 async def detect_charset(data: bytes, fallback: str = "utf-8") -> str:
-    """Detect charset of raw data."""
-    # imported here to keep chardet (~18MB) out of the idle import footprint:
-    # it is only needed on the rarely-hit playlist/radio charset fallback path
-    import chardet  # noqa: PLC0415
+    """
+    Detect the charset to decode the given raw text with.
+
+    :param data: The raw text bytes to inspect.
+    :param fallback: Charset to return when the charset can not be determined.
+    """
+    if data.startswith(codecs.BOM_UTF8):
+        return "utf-8-sig"
+    try:
+        data.decode()
+    except UnicodeDecodeError:
+        pass
+    else:
+        # valid UTF-8 is never a legacy charset by accident, so skip detection
+        return "utf-8"
+
+    # imported here to keep the detector out of the idle import footprint:
+    # it is only needed for the rare text that is not UTF-8
+    from charset_normalizer import from_bytes  # noqa: PLC0415
 
     try:
-        detected: ResultDict = await asyncio.to_thread(chardet.detect, data)
-        if detected and detected["encoding"] and detected["confidence"] > 0.75:
-            assert isinstance(detected["encoding"], str)  # for type checking
-            return detected["encoding"]
+        if match := await asyncio.to_thread(lambda: from_bytes(data).best()):
+            return match.encoding
     except Exception as err:
         LOGGER.debug("Failed to detect charset: %s", err)
     return fallback

--- a/music_assistant/providers/fastmcp_server/connect/_revoke.py
+++ b/music_assistant/providers/fastmcp_server/connect/_revoke.py
@@ -38,7 +38,7 @@ LOGGER = logging.getLogger(__name__)
 # install the import succeeds (it's the same module MA's own tests use —
 # tests/test_webserver_auth.py:19-22). In this repo's minimal dev venv the
 # transitive ``music_assistant.controllers.webserver`` package can't be
-# loaded (frontend / chardet / torch are not installed), so fall back to
+# loaded (frontend / torch are not installed), so fall back to
 # no-op shims for collect-time imports. Tests mock the API methods that
 # would actually read ``current_user``, so a no-op context manager is safe
 # there. Production always hits the real branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "colorlog==6.12.0",
   "modern_colorthief==0.2.1",
   "cryptography==50.0.0",
-  "chardet>=5.2.0",
+  "charset-normalizer>=3.4.0",
   "ifaddr==0.2.0",
   "getmac==0.9.5",
   "mashumaro==3.20",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -28,7 +28,7 @@ bandcamp-async-api==0.2.2
 beat-this==1.1.0
 bidict==0.23.1
 certifi==2025.11.12
-chardet>=5.2.0
+charset-normalizer>=3.4.0
 colorlog==6.12.0
 cryptography==50.0.0
 deezer-python-gql==0.17.1

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -1,6 +1,7 @@
 """Tests for music_assistant.helpers.util helpers."""
 
 import asyncio
+import codecs
 import contextlib
 import gc
 import logging
@@ -18,6 +19,7 @@ from music_assistant_models.media_items import Album, ItemMapping, ProviderMappi
 
 from music_assistant.helpers import util
 from music_assistant.helpers.util import (
+    detect_charset,
     get_source_ip_for_target,
     guard_single_request,
     import_module_in_thread,
@@ -32,6 +34,50 @@ from music_assistant.models.music_provider import MusicProvider
 from tests.common import collect_loop_errors
 
 GUARDED_PROVIDER_ID = "test_guarded_prov"
+
+# a CUE sheet as Russian rips ship them: ASCII keywords with only the titles in
+# the local ANSI codepage (support #6093)
+CYRILLIC_CUE = """REM GENRE "Punk Rock"
+REM DATE 2002
+PERFORMER "Король и Шут"
+TITLE "Как в старой сказке"
+FILE "CDImage.ape" WAVE
+  TRACK 01 AUDIO
+    TITLE "Проклятый старый дом"
+    INDEX 01 00:00:00
+"""
+
+
+class TestDetectCharset:
+    """detect_charset names the charset raw text has to be decoded with."""
+
+    async def test_ascii_and_utf8_are_taken_as_utf8(self) -> None:
+        """Anything that is already valid UTF-8 needs no detection."""
+        assert await detect_charset(b'TITLE "Greatest Hits"') == "utf-8"
+        assert await detect_charset(CYRILLIC_CUE.encode()) == "utf-8"
+
+    async def test_byte_order_mark_is_stripped(self) -> None:
+        """A UTF-8 BOM must not survive into the decoded text."""
+        raw = codecs.BOM_UTF8 + CYRILLIC_CUE.encode()
+        encoding = await detect_charset(raw)
+        assert raw.decode(encoding) == CYRILLIC_CUE
+
+    @pytest.mark.parametrize("charset", ["cp1251", "cp1252"])
+    async def test_legacy_charsets_survive_a_round_trip(self, charset: str) -> None:
+        """
+        Text in a legacy charset comes back readable instead of as replacement chars.
+
+        Mostly-ASCII files such as CUE sheets hold very little non-ASCII text, so the
+        charset has to be resolved from a thin sample rather than given up on and
+        decoded as UTF-8 (support #6093).
+        """
+        source = CYRILLIC_CUE if charset != "cp1252" else 'TITLE "Müller"\n'
+        raw = source.encode(charset)
+        assert raw.decode(await detect_charset(raw)) == source
+
+    async def test_undetectable_data_uses_the_fallback(self) -> None:
+        """Bytes that hold no readable text at all fall back to the given charset."""
+        assert await detect_charset(b"\xff\xfe\x00", fallback="cp1252") == "cp1252"
 
 
 class TestGetSourceIpForTarget:

--- a/tests/providers/filesystem/test_cue_integration.py
+++ b/tests/providers/filesystem/test_cue_integration.py
@@ -191,8 +191,8 @@ class TestReadCueFile:
         assert not content.startswith("\ufeff")
 
     @pytest.mark.asyncio
-    async def test_decodes_non_utf8_tolerantly(self, tmp_path: Path) -> None:
-        """Non-UTF-8 bytes are decoded without raising."""
+    async def test_decodes_latin1_bytes(self, tmp_path: Path) -> None:
+        """Bytes that are not valid UTF-8 keep their accented characters."""
         # 0xFC is "ü" in Latin-1 but invalid as a UTF-8 continuation byte
         (tmp_path / "a.cue").write_bytes(b'TITLE "M\xfcller"\n')
         provider = _make_provider(base_path=str(tmp_path))

--- a/tests/providers/filesystem/test_cue_integration.py
+++ b/tests/providers/filesystem/test_cue_integration.py
@@ -205,10 +205,29 @@ class TestReadCueFile:
             file_size=(tmp_path / "a.cue").stat().st_size,
         )
         content = await provider._cue.read_cue_file(cue_item)
-        # ASCII surroundings are preserved; the non-UTF-8 byte may be replaced
-        # or decoded depending on what chardet detects
-        assert "TITLE" in content
-        assert "ller" in content
+        assert content == 'TITLE "Müller"\n'
+
+    @pytest.mark.asyncio
+    async def test_reads_cyrillic_cue_sheet(self, tmp_path: Path) -> None:
+        """
+        A CUE sheet in the local ANSI codepage keeps its titles readable.
+
+        Russian rips ship their CUE sheets in cp1251, so the titles have to come
+        through as Cyrillic instead of replacement characters (support #6093).
+        """
+        cue = 'PERFORMER "Король и Шут"\nTITLE "Как в старой сказке"\n'
+        (tmp_path / "a.cue").write_bytes(cue.encode("cp1251"))
+        provider = _make_provider(base_path=str(tmp_path))
+        cue_item = FileSystemItem(
+            filename="a.cue",
+            relative_path="a.cue",
+            absolute_path=str(tmp_path / "a.cue"),
+            is_dir=False,
+            checksum="1",
+            file_size=(tmp_path / "a.cue").stat().st_size,
+        )
+        content = await provider._cue.read_cue_file(cue_item)
+        assert content == cue
 
 
 class TestFindCueAudioFile:


### PR DESCRIPTION
# What does this implement/fix?

Track and album names in Cyrillic (and other non-Western) scripts showed up as `�������` instead of the real text.

CUE sheets and playlist files are often written in a legacy codepage (cp1251 for Russian rips) rather than UTF-8. We asked a charset detector what to decode them with, but only trusted its answer above a high confidence score. A CUE sheet is nearly all ASCII keywords with just a few titles in the local codepage, so that score is never reached — we fell back to UTF-8 and every non-ASCII character became a replacement character.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6093

Changes:

- Text that is already valid UTF-8 is decoded as UTF-8 without consulting a detector at all, and a leading byte order mark is stripped.
- Anything else is resolved with `charset-normalizer`, which reads these mostly-ASCII files correctly where the previous detector did not.
- Replaces the `chardet` dependency with `charset-normalizer` (already present in every install as a transitive dependency).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
