### PR TITLE
Fix the base image build failing to download its client files

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -50,13 +50,15 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.appvars_token.outputs.token }}
         run: |
+          # the Accept header must not end in "+json": gh then runs the response
+          # through its JSON handling, which fails on the binary client_id.bin
           mkdir -p widevine_cdm
           gh api \
-            -H "Accept: application/vnd.github.raw+json" \
+            -H "Accept: application/vnd.github.raw" \
             "repos/music-assistant/appvars/contents/widevine_cdm_client/private_key.pem" \
             > widevine_cdm/private_key.pem
           gh api \
-            -H "Accept: application/vnd.github.raw+json" \
+            -H "Accept: application/vnd.github.raw" \
             "repos/music-assistant/appvars/contents/widevine_cdm_client/client_id.bin" \
             > widevine_cdm/client_id.bin
       - name: Log in to the GitHub container registry

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -61,6 +61,14 @@ jobs:
             -H "Accept: application/vnd.github.raw" \
             "repos/music-assistant/appvars/contents/widevine_cdm_client/client_id.bin" \
             > widevine_cdm/client_id.bin
+          # a request GitHub declines to serve raw comes back as the JSON metadata
+          # envelope with a 200, which would end up in the image unnoticed
+          for file in widevine_cdm/private_key.pem widevine_cdm/client_id.bin; do
+            if [ ! -s "$file" ] || [ "$(head -c 1 "$file")" = "{" ]; then
+              echo "Downloaded $file is empty or not the raw file content" >&2
+              exit 1
+            fi
+          done
       - name: Log in to the GitHub container registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -50,9 +50,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.appvars_token.outputs.token }}
         run: |
+          mkdir -p widevine_cdm
           # the Accept header must not end in "+json": gh then runs the response
           # through its JSON handling, which fails on the binary client_id.bin
-          mkdir -p widevine_cdm
           gh api \
             -H "Accept: application/vnd.github.raw" \
             "repos/music-assistant/appvars/contents/widevine_cdm_client/private_key.pem" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -458,7 +458,7 @@ jobs:
           GH_TOKEN: ${{ steps.appvars_token.outputs.token }}
         run: |
           gh api \
-            -H "Accept: application/vnd.github.raw+json" \
+            -H "Accept: application/vnd.github.raw" \
             "repos/music-assistant/appvars/contents/app_secrets.json" \
             > source/music_assistant/helpers/app_secrets.json
 
@@ -1587,7 +1587,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           gh api \
-            -H "Accept: application/vnd.github.raw+json" \
+            -H "Accept: application/vnd.github.raw" \
             repos/music-assistant/app.music-assistant.io/contents/channels.json \
             > "$RUNNER_TEMP/channels.json"
           current_version=$(jq -r \


### PR DESCRIPTION
# What does this implement/fix?

The base image build fails at the step that downloads the Widevine client files, with `invalid UTF-8 string`, so the base image can no longer be built.

The files are fetched with `gh api` using an `Accept` header of `application/vnd.github.raw+json`. Because that header ends in `+json`, `gh` runs the response through its JSON handling instead of writing it out untouched, and that rejects `client_id.bin` because it is binary.

The step used `curl` until it was switched to `gh api` in #4992 (25 July), so it has never worked in this form — this was simply the first base image build since that change.

Verified locally: with the `+json` suffix the download fails and leaves an empty file, without it the bytes come out identical to the source.

Changes:

- Ask GitHub for `application/vnd.github.raw` when downloading repository files in the base image and release workflows.
- Fail the base image build if a downloaded client file is empty or is not the raw file content, so a bad download can no longer end up in the published image unnoticed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
