### PR TITLE
Stop asking for a password on AirPlay devices that never had one

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -56,6 +56,12 @@ CONF_PASSWORD: Final[str] = "password"
 # password, so the player keeps asking for setup across restarts until a working
 # password is entered.
 CONF_PASSWORD_INVALID: Final[str] = "password_invalid"
+# Provider marker that the stored password verdicts were reviewed once. Releases
+# that could not tell a password challenge apart from a flat refusal wrote the
+# key above for both, so what they left behind is no evidence about a password
+# and is dropped a single time; a device that really challenges marks itself
+# again on its next connect.
+CONF_PASSWORD_MARKERS_REVIEWED: Final[str] = "password_markers_reviewed"
 CONF_IGNORE_VOLUME: Final[str] = "ignore_volume"
 CONF_ENCRYPTION: Final[str] = "encryption"
 # Advanced per-device streaming mode: pins the protocol/timing lane for

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -21,6 +21,7 @@ from zeroconf.asyncio import AsyncServiceInfo
 
 from music_assistant.constants import (
     CONF_LOG_LEVEL,
+    CONF_PLAYERS,
     CONF_PROVIDERS,
     VERBOSE_LOG_LEVEL,
 )
@@ -223,7 +224,7 @@ class AirPlayProvider(PlayerProvider):
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         self._set_pyatv_log_level()
-        await self._drop_unverified_password_markers()
+        self._drop_unverified_password_markers()
         self._companion_info_by_address: dict[str, AsyncServiceInfo] = {}
         self._mrp_info_by_address: dict[str, AsyncServiceInfo] = {}
         # Shared audible instants for in-flight announcements, keyed by
@@ -1175,7 +1176,7 @@ class AirPlayProvider(PlayerProvider):
             with suppress(Exception):
                 await writer.wait_closed()
 
-    async def _drop_unverified_password_markers(self) -> None:
+    def _drop_unverified_password_markers(self) -> None:
         """
         Clear the stored "password rejected" verdicts left by earlier releases, once.
 
@@ -1189,17 +1190,18 @@ class AirPlayProvider(PlayerProvider):
             self.instance_id, CONF_PASSWORD_MARKERS_REVIEWED, False
         ):
             return
-        for player_config in await self.mass.config.get_player_configs(self.instance_id):
+        # walks the stored configs rather than get_player_configs(), which drops
+        # every protocol player - the type each non-Apple receiver is registered
+        # as - and only lists the ones discovered so far
+        for player_id, raw_conf in self.mass.config.get(CONF_PLAYERS, {}).items():
+            if not isinstance(raw_conf, dict) or raw_conf.get("provider") != self.instance_id:
+                continue
             if not self.mass.config.get_raw_player_config_value(
-                player_config.player_id, CONF_PASSWORD_INVALID, False
+                player_id, CONF_PASSWORD_INVALID, False
             ):
                 continue
-            self.logger.info(
-                "Clearing the unverified password marker on %s", player_config.player_id
-            )
-            self.mass.config.set_raw_player_config_value(
-                player_config.player_id, CONF_PASSWORD_INVALID, False
-            )
+            self.logger.info("Clearing the unverified password marker on %s", player_id)
+            self.mass.config.set_raw_player_config_value(player_id, CONF_PASSWORD_INVALID, False)
         # last, so a failure part-way through leaves the review to be retried on
         # the next load instead of stranding the players it never reached
         self.mass.config.set_raw_provider_config_value(

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -1189,9 +1189,6 @@ class AirPlayProvider(PlayerProvider):
             self.instance_id, CONF_PASSWORD_MARKERS_REVIEWED, False
         ):
             return
-        self.mass.config.set_raw_provider_config_value(
-            self.instance_id, CONF_PASSWORD_MARKERS_REVIEWED, True
-        )
         for player_config in await self.mass.config.get_player_configs(self.instance_id):
             if not self.mass.config.get_raw_player_config_value(
                 player_config.player_id, CONF_PASSWORD_INVALID, False
@@ -1203,3 +1200,8 @@ class AirPlayProvider(PlayerProvider):
             self.mass.config.set_raw_player_config_value(
                 player_config.player_id, CONF_PASSWORD_INVALID, False
             )
+        # last, so a failure part-way through leaves the review to be retried on
+        # the next load instead of stranding the players it never reached
+        self.mass.config.set_raw_provider_config_value(
+            self.instance_id, CONF_PASSWORD_MARKERS_REVIEWED, True
+        )

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -41,6 +41,8 @@ from .constants import (
     CLI_PROBLEM_MARKERS,
     COMPANION_DISCOVERY_TYPE,
     CONF_IGNORE_VOLUME,
+    CONF_PASSWORD_INVALID,
+    CONF_PASSWORD_MARKERS_REVIEWED,
     CONF_STORED_VOLUME,
     CONF_VERBOSE_PTP_LOGGING,
     DACP_DISCOVERY_TYPE,
@@ -221,6 +223,7 @@ class AirPlayProvider(PlayerProvider):
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         self._set_pyatv_log_level()
+        await self._drop_unverified_password_markers()
         self._companion_info_by_address: dict[str, AsyncServiceInfo] = {}
         self._mrp_info_by_address: dict[str, AsyncServiceInfo] = {}
         # Shared audible instants for in-flight announcements, keyed by
@@ -1171,3 +1174,32 @@ class AirPlayProvider(PlayerProvider):
             writer.close()
             with suppress(Exception):
                 await writer.wait_closed()
+
+    async def _drop_unverified_password_markers(self) -> None:
+        """
+        Clear the stored "password rejected" verdicts left by earlier releases, once.
+
+        Those releases marked a player whenever the binary reported an auth-shaped
+        rejection, without separating a password challenge from a device that
+        refused the handshake outright. The refusals put players that have no
+        password at all into a setup flow only a password could leave, so the
+        verdicts are dropped and left to be earned again on the next connect.
+        """
+        if self.mass.config.get_raw_provider_config_value(
+            self.instance_id, CONF_PASSWORD_MARKERS_REVIEWED, False
+        ):
+            return
+        self.mass.config.set_raw_provider_config_value(
+            self.instance_id, CONF_PASSWORD_MARKERS_REVIEWED, True
+        )
+        for player_config in await self.mass.config.get_player_configs(self.instance_id):
+            if not self.mass.config.get_raw_player_config_value(
+                player_config.player_id, CONF_PASSWORD_INVALID, False
+            ):
+                continue
+            self.logger.info(
+                "Clearing the unverified password marker on %s", player_config.player_id
+            )
+            self.mass.config.set_raw_player_config_value(
+                player_config.player_id, CONF_PASSWORD_INVALID, False
+            )

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -72,6 +72,10 @@ if TYPE_CHECKING:
 # and only the pending ack is answered with a failure.
 CLI_ERROR_AUTH_REQUIRED: Final[str] = "auth_required"
 CLI_ERROR_AUTH_FAILED: Final[str] = "auth_failed"
+# A receiver that wants a password challenges with 401. A 403 is a flat refusal
+# of the pairing handshake itself, which no password can satisfy, so it must not
+# be read as a verdict on one.
+CLI_STATUS_REFUSED: Final[int] = 403
 CLI_ERROR_START_FAILED: Final[str] = "start_failed"
 CLI_ERROR_FLUSH_FAILED: Final[str] = "flush_failed"
 CLI_ERROR_ANNOUNCE_FAILED: Final[str] = "announce_failed"
@@ -1817,6 +1821,8 @@ class AirPlayStream:
         timeout the callers already handle.
         """
         error = self._connect_error
+        if error and error.http_status == CLI_STATUS_REFUSED:
+            return self._connection_refused_error()
         if error and error.code == CLI_ERROR_AUTH_REQUIRED:
             return self._password_required_error()
         if error and error.code == CLI_ERROR_AUTH_FAILED:
@@ -1835,6 +1841,15 @@ class AirPlayStream:
             f"{self.player.display_name} requires a password. "
             "Run the setup for this player to enter it.",
             translation_key="password_required",
+        )
+
+    def _connection_refused_error(self) -> PlayerCommandFailed:
+        """Return the error for a device that declined the handshake outright."""
+        return PlayerCommandFailed(
+            f"{self.player.display_name} refused the connection. "
+            "Run the setup for this player to pair it again.",
+            translation_key="connection_refused",
+            translation_owner=self.player.translation_owner,
         )
 
     def _parse_error_status(self, line: str) -> None:
@@ -1874,13 +1889,20 @@ class AirPlayStream:
             self._announce_done.set()
             return
         self._connect_error = error
-        if error.code in (CLI_ERROR_AUTH_FAILED, CLI_ERROR_AUTH_REQUIRED):
+        if (
+            error.code in (CLI_ERROR_AUTH_FAILED, CLI_ERROR_AUTH_REQUIRED)
+            and error.http_status != CLI_STATUS_REFUSED
+        ):
             # The stored password is wrong, or the device demanded one we could
             # not supply (devices can enforce a password without announcing it -
             # e.g. an Apple TV with stale TXT records after the password was
             # enabled). Persist that so the player keeps offering its setup
             # action (across restarts) until a working password is entered,
             # instead of only failing at the next play attempt.
+            # A refusal is excluded: the binary reports one as an auth failure
+            # because it happens on the pairing leg, but the device turned the
+            # handshake away rather than judging a secret, and a player with no
+            # password would otherwise be left demanding one forever.
             self.player.set_password_invalid(True)
 
     def _parse_anchor_corrected(self, line: str) -> None:

--- a/music_assistant/providers/airplay/strings.json
+++ b/music_assistant/providers/airplay/strings.json
@@ -91,6 +91,7 @@
   "errors": {
     "invalid_pin": "Enter the numeric PIN shown on the screen of your device.",
     "authentication_failed": "The device rejected the saved password. Run the setup for this player to enter it again.",
+    "connection_refused": "The device refused the connection. Run the setup for this player to pair it again.",
     "show_dashboard_failed": "Failed to show the dashboard on {0}.",
     "pairing_backoff": "The device is refusing new pairing attempts after too many tries. Restart the device, then start pairing once and wait for the PIN.",
     "pairing_failed": "Pairing did not complete. Make sure the device is awake and reachable, then try again.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -891,6 +891,7 @@
   "provider.airplay.config_entries.verbose_ptp_logging.description": "Log the shared PTP clock daemon's per-packet timing trace (Announce/Sync/Follow_Up) when verbose logging is active. Only useful when diagnosing multi-room clock sync issues; it floods the log at ~10 lines per second.",
   "provider.airplay.config_entries.verbose_ptp_logging.label": "Verbose PTP daemon logging",
   "provider.airplay.errors.authentication_failed": "The device rejected the saved password. Run the setup for this player to enter it again.",
+  "provider.airplay.errors.connection_refused": "The device refused the connection. Run the setup for this player to pair it again.",
   "provider.airplay.errors.invalid_pin": "Enter the numeric PIN shown on the screen of your device.",
   "provider.airplay.errors.pairing_backoff": "The device is refusing new pairing attempts after too many tries. Restart the device, then start pairing once and wait for the PIN.",
   "provider.airplay.errors.pairing_failed": "Pairing did not complete. Make sure the device is awake and reachable, then try again.",

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -1006,28 +1006,29 @@ async def test_setup_player_skips_own_receiver_before_service_lookup() -> None:
 
 
 def _password_marker_provider(
-    reviewed: bool, markers: dict[str, bool]
+    reviewed: bool, markers: dict[str, bool], player_type: str = "player"
 ) -> tuple[AirPlayProvider, MagicMock]:
-    """Build a provider whose config holds the given stored password markers."""
+    """Build a provider whose stored configs hold the given password markers."""
     prov = _make_provider()
     config = cast("MagicMock", prov.mass.config)
     config.get_raw_provider_config_value.return_value = reviewed
-    config.get_player_configs = AsyncMock(
-        return_value=[MagicMock(player_id=player_id) for player_id in markers]
-    )
+    config.get.return_value = {
+        player_id: {"player_id": player_id, "provider": INSTANCE_ID, "player_type": player_type}
+        for player_id in markers
+    } | {"other": {"player_id": "other", "provider": "sonos", "player_type": "player"}}
     config.get_raw_player_config_value.side_effect = lambda player_id, _key, _default: markers[
         player_id
     ]
     return prov, config
 
 
-async def test_stale_password_markers_are_dropped_once() -> None:
+def test_stale_password_markers_are_dropped_once() -> None:
     """Verdicts from releases that could not tell a refusal apart are not trusted."""
     prov, config = _password_marker_provider(
         reviewed=False, markers={"ap_latched": True, "ap_clean": False}
     )
 
-    await prov._drop_unverified_password_markers()
+    prov._drop_unverified_password_markers()
 
     config.set_raw_player_config_value.assert_called_once_with(
         "ap_latched", "password_invalid", False
@@ -1037,7 +1038,25 @@ async def test_stale_password_markers_are_dropped_once() -> None:
     )
 
 
-async def test_password_markers_are_reviewed_only_on_the_first_load() -> None:
+def test_protocol_players_are_reviewed_too() -> None:
+    """
+    Every non-Apple receiver is registered as a protocol player.
+
+    Those are exactly the ones a password applies to, and the config controller's
+    own listing drops them, so the review has to read the stored configs itself.
+    """
+    prov, config = _password_marker_provider(
+        reviewed=False, markers={"spb_latched": True}, player_type="protocol"
+    )
+
+    prov._drop_unverified_password_markers()
+
+    config.set_raw_player_config_value.assert_called_once_with(
+        "spb_latched", "password_invalid", False
+    )
+
+
+def test_password_markers_are_reviewed_only_on_the_first_load() -> None:
     """
     A later restart must leave a fresh verdict alone.
 
@@ -1046,13 +1065,13 @@ async def test_password_markers_are_reviewed_only_on_the_first_load() -> None:
     """
     prov, config = _password_marker_provider(reviewed=True, markers={"ap_latched": True})
 
-    await prov._drop_unverified_password_markers()
+    prov._drop_unverified_password_markers()
 
     config.set_raw_player_config_value.assert_not_called()
-    config.get_player_configs.assert_not_called()
+    config.get.assert_not_called()
 
 
-async def test_a_failed_review_is_retried_on_the_next_load() -> None:
+def test_a_failed_review_is_retried_on_the_next_load() -> None:
     """
     A review that dies part-way leaves nothing behind claiming it ran.
 
@@ -1063,6 +1082,6 @@ async def test_a_failed_review_is_retried_on_the_next_load() -> None:
     config.set_raw_player_config_value.side_effect = RuntimeError("config write failed")
 
     with pytest.raises(RuntimeError):
-        await prov._drop_unverified_password_markers()
+        prov._drop_unverified_password_markers()
 
     config.set_raw_provider_config_value.assert_not_called()

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -4,9 +4,10 @@ import asyncio
 import logging
 import time
 from contextlib import AbstractContextManager
-from typing import TYPE_CHECKING, cast
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from music_assistant_models.enums import PlaybackState
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
@@ -27,9 +28,6 @@ from music_assistant.providers.airplay.sendspin_bridge import (
 from music_assistant.providers.airplay.stream import AirPlayStream
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
 from music_assistant.providers.airplay_receiver import airplay_receiver_port
-
-if TYPE_CHECKING:
-    import pytest
 
 INSTANCE_ID = "airplay"
 START_UNIX_MS = 1_750_000_000_000
@@ -1052,3 +1050,19 @@ async def test_password_markers_are_reviewed_only_on_the_first_load() -> None:
 
     config.set_raw_player_config_value.assert_not_called()
     config.get_player_configs.assert_not_called()
+
+
+async def test_a_failed_review_is_retried_on_the_next_load() -> None:
+    """
+    A review that dies part-way leaves nothing behind claiming it ran.
+
+    Marking it done regardless would strand exactly the players it never reached,
+    which is the state this review exists to undo.
+    """
+    prov, config = _password_marker_provider(reviewed=False, markers={"ap_latched": True})
+    config.set_raw_player_config_value.side_effect = RuntimeError("config write failed")
+
+    with pytest.raises(RuntimeError):
+        await prov._drop_unverified_password_markers()
+
+    config.set_raw_provider_config_value.assert_not_called()

--- a/tests/providers/airplay/test_provider.py
+++ b/tests/providers/airplay/test_provider.py
@@ -1005,3 +1005,50 @@ async def test_setup_player_skips_own_receiver_before_service_lookup() -> None:
 
     prov.mass.discovery.async_find_mdns_service.assert_not_called()
     prov.mass.players.register.assert_not_called()
+
+
+def _password_marker_provider(
+    reviewed: bool, markers: dict[str, bool]
+) -> tuple[AirPlayProvider, MagicMock]:
+    """Build a provider whose config holds the given stored password markers."""
+    prov = _make_provider()
+    config = cast("MagicMock", prov.mass.config)
+    config.get_raw_provider_config_value.return_value = reviewed
+    config.get_player_configs = AsyncMock(
+        return_value=[MagicMock(player_id=player_id) for player_id in markers]
+    )
+    config.get_raw_player_config_value.side_effect = lambda player_id, _key, _default: markers[
+        player_id
+    ]
+    return prov, config
+
+
+async def test_stale_password_markers_are_dropped_once() -> None:
+    """Verdicts from releases that could not tell a refusal apart are not trusted."""
+    prov, config = _password_marker_provider(
+        reviewed=False, markers={"ap_latched": True, "ap_clean": False}
+    )
+
+    await prov._drop_unverified_password_markers()
+
+    config.set_raw_player_config_value.assert_called_once_with(
+        "ap_latched", "password_invalid", False
+    )
+    config.set_raw_provider_config_value.assert_called_once_with(
+        INSTANCE_ID, "password_markers_reviewed", True
+    )
+
+
+async def test_password_markers_are_reviewed_only_on_the_first_load() -> None:
+    """
+    A later restart must leave a fresh verdict alone.
+
+    Once the review has run, a stored marker was written by code that separates a
+    password challenge from a refusal, so it is real and has to survive.
+    """
+    prov, config = _password_marker_provider(reviewed=True, markers={"ap_latched": True})
+
+    await prov._drop_unverified_password_markers()
+
+    config.set_raw_player_config_value.assert_not_called()
+    config.get_player_configs.assert_not_called()

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -3491,6 +3491,41 @@ async def test_auth_failed_surfaces_authentication_failed_error() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("code", ["auth_required", "auth_failed"])
+async def test_refused_connection_is_not_reported_as_a_password_problem(code: str) -> None:
+    """A device that turns the handshake away points at pairing, not at a password."""
+    stream = AirPlayStream(_make_player())
+    stream._handle_status_line(f'[STATUS] error code={code} http=403 detail="refused"')
+    stream._process_ended.set()
+
+    with (
+        patch.object(stream, "_cli_proc", MagicMock()),
+        pytest.raises(PlayerCommandFailed) as err,
+    ):
+        await stream.wait_for_connection()
+
+    assert err.value.translation_key == "connection_refused"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("code", ["auth_required", "auth_failed"])
+async def test_refused_connection_never_marks_the_password_invalid(code: str) -> None:
+    """
+    A refusal must not leave a player demanding a password it may not even have.
+
+    tvOS 26 answers the pairing handshake with 403 for reasons unrelated to any
+    secret, and the marker persists across restarts - so latching it there would
+    strand the player in a setup flow no password can complete.
+    """
+    player = _make_player()
+    stream = AirPlayStream(player)
+
+    stream._handle_status_line(f'[STATUS] error code={code} http=403 detail="refused"')
+
+    player.set_password_invalid.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_generic_connect_failure_keeps_the_timeout_semantics() -> None:
     """A non-auth failure keeps raising the plain timeout its callers already handle."""
     stream = AirPlayStream(_make_player())


### PR DESCRIPTION
# What does this implement/fix?

Some AirPlay devices turn a connection away outright rather than asking for a password — an Apple TV or HomePod on the tvOS 26 / HomePod OS 26 beta does this, for example. Music Assistant read that refusal as "your password was rejected", showed the player a password prompt, and remembered the verdict across restarts. Users with no password set on the device were left with a player permanently stuck asking for one: the marked player reports itself unavailable, so no connection is attempted that could clear the marker, and the only way out is entering a password that does not exist.

A refusal now points at pairing instead, only a real password challenge marks the stored password as bad, and the verdicts already written by earlier releases are dropped once so affected players recover on upgrade.

- Treat a refused connection as a pairing problem, not a password one
- Only remember "password rejected" when the device actually challenged for a password
- Clear the stored verdicts written before that distinction existed, once per install
- New error message telling the user to pair the device again

The underlying refusal on the beta builds is fixed separately in music-assistant/airplay-cli#68.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.