### PR TITLE
Apple TV players no longer get stuck on a paused app after losing their connection

### DIFF
--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -1217,9 +1217,7 @@ class AirPlayControlPlayer(AirPlayPlayer):
         # Without a live connection the snapshot can no longer be updated, and the
         # last one is typically an app held at paused: leaving it in place keeps
         # transport commands aimed at that app instead of the Music Assistant queue.
-        self._attr_playback_state = PlaybackState.IDLE
-        self._attr_active_source = None
-        self._attr_current_media = None
+        self.mark_external_source_ended()
         self.update_state()
 
     def _notify_companion_state_change(self) -> None:

--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -1187,6 +1187,7 @@ class AirPlayControlPlayer(AirPlayPlayer):
             self._mrp_device = None
             self._mrp_state_listener = None
             self._mrp_push_listener = None
+            self._clear_external_state()
         else:
             return
         if exception:
@@ -1206,7 +1207,20 @@ class AirPlayControlPlayer(AirPlayPlayer):
         self._mrp_state_listener = None
         self._mrp_push_listener = None
         device.close()
+        self._clear_external_state()
         self._schedule_connection()
+
+    def _clear_external_state(self) -> None:
+        """Drop the playback snapshot observed over a closed MRP connection."""
+        if self._external_state_blocked or self._attr_active_source is None:
+            return
+        # Without a live connection the snapshot can no longer be updated, and the
+        # last one is typically an app held at paused: leaving it in place keeps
+        # transport commands aimed at that app instead of the Music Assistant queue.
+        self._attr_playback_state = PlaybackState.IDLE
+        self._attr_active_source = None
+        self._attr_current_media = None
+        self.update_state()
 
     def _notify_companion_state_change(self) -> None:
         """Notify a wired-up observer that the Companion connection state changed."""

--- a/tests/providers/airplay/test_control_player.py
+++ b/tests/providers/airplay/test_control_player.py
@@ -714,7 +714,9 @@ def test_lost_mrp_connection_keeps_streaming_state() -> None:
     device = MagicMock(spec=AppleTV)
     player._mrp_device = device
     player._attr_playback_state = PlaybackState.PLAYING
-    player._attr_active_source = "airplay"
+    player._attr_active_source = "com.netflix.Netflix"
+    media = MagicMock()
+    player._attr_current_media = media
 
     with (
         patch.object(player, "update_state"),
@@ -723,7 +725,27 @@ def test_lost_mrp_connection_keeps_streaming_state() -> None:
         player._handle_connection_closed("mrp", device)
 
     assert player.playback_state == PlaybackState.PLAYING
-    assert player.active_source == "airplay"
+    assert player.active_source == "com.netflix.Netflix"
+    assert player.current_media is media
+
+
+def test_lost_companion_connection_keeps_external_state() -> None:
+    """External playback comes from MRP only, so a Companion drop leaves it alone."""
+    player = _make_control_player()
+    device = MagicMock(spec=AppleTV)
+    player._companion_device = device
+    player._mrp_device = MagicMock(spec=AppleTV)
+    player._attr_playback_state = PlaybackState.PAUSED
+    player._attr_active_source = "com.netflix.Netflix"
+
+    with (
+        patch.object(player, "update_state"),
+        patch.object(player, "_schedule_connection"),
+    ):
+        player._handle_connection_closed("companion", device)
+
+    assert player.playback_state == PlaybackState.PAUSED
+    assert player.active_source == "com.netflix.Netflix"
 
 
 async def test_mrp_retry_does_not_recycle_connected_companion() -> None:

--- a/tests/providers/airplay/test_control_player.py
+++ b/tests/providers/airplay/test_control_player.py
@@ -666,6 +666,66 @@ def test_mrp_idle_update_clears_external_media() -> None:
     assert player.current_media is None
 
 
+def test_lost_mrp_connection_clears_external_state() -> None:
+    """Losing MRP playback monitoring clears the last external snapshot."""
+    player = _make_control_player()
+    device = MagicMock(spec=AppleTV)
+    player._mrp_device = device
+    player._attr_playback_state = PlaybackState.PAUSED
+    player._attr_active_source = "com.netflix.Netflix"
+    player._attr_current_media = MagicMock()
+
+    with (
+        patch.object(player, "update_state"),
+        patch.object(player, "_schedule_connection") as schedule_connection,
+    ):
+        player._handle_connection_closed("mrp", device)
+
+    assert player.playback_state == PlaybackState.IDLE
+    assert player.active_source is None
+    assert player.current_media is None
+    schedule_connection.assert_called_once()
+
+
+def test_failed_mrp_push_updates_clear_external_state() -> None:
+    """A dropped MRP push updater clears the last external snapshot."""
+    player = _make_control_player()
+    device = MagicMock(spec=AppleTV)
+    player._mrp_device = device
+    player._attr_playback_state = PlaybackState.PAUSED
+    player._attr_active_source = "com.netflix.Netflix"
+    player._attr_current_media = MagicMock()
+
+    with (
+        patch.object(player, "update_state"),
+        patch.object(player, "_schedule_connection"),
+    ):
+        player._handle_push_error(device, RuntimeError("push failed"))
+
+    assert player.playback_state == PlaybackState.IDLE
+    assert player.active_source is None
+    assert player.current_media is None
+
+
+def test_lost_mrp_connection_keeps_streaming_state() -> None:
+    """A lost MRP connection never overrules the state owned by our own stream."""
+    player = _make_control_player()
+    player.stream = MagicMock(running=True)
+    device = MagicMock(spec=AppleTV)
+    player._mrp_device = device
+    player._attr_playback_state = PlaybackState.PLAYING
+    player._attr_active_source = "airplay"
+
+    with (
+        patch.object(player, "update_state"),
+        patch.object(player, "_schedule_connection"),
+    ):
+        player._handle_connection_closed("mrp", device)
+
+    assert player.playback_state == PlaybackState.PLAYING
+    assert player.active_source == "airplay"
+
+
 async def test_mrp_retry_does_not_recycle_connected_companion() -> None:
     """A failed MRP monitor leaves an active Companion control channel intact."""
     player = _make_control_player()


### PR DESCRIPTION
# What does this implement/fix?

When an Apple TV (or HomePod) loses its device control connection, Music Assistant kept showing whatever it last saw playing on the device. Since a paused tvOS app is deliberately shown as "paused" (many apps report idle instead), the player would stay stuck on e.g. "Netflix - paused" until it reconnected or was powered off. While stuck that way, pressing play tried to resume that app instead of the Music Assistant queue, so the queue could not be started from the player anymore.

The externally observed playback state is now cleared as soon as the connection that provided it is gone, so the player falls back to the Music Assistant queue. State owned by an active Music Assistant stream is left untouched.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Clear the external playback state, source and media when the playback monitoring connection closes or its updates fail
- Keep the state as-is while Music Assistant is streaming to the device
- Reuse the existing `mark_external_source_ended` handling for this
- Added tests

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
