### PR TITLE
Read the AirPlay password flag the same way on every device

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -335,10 +335,6 @@ BASE_PLAYER_FEATURES: Final[set[PlayerFeature]] = {
 PIN_REQUIRED = 0x8
 PASSWORD_BIT = 0x80
 LEGACY_PAIRING_BIT = 0x200
-# Observed on tvOS when an AirPlay password is set. Apple TVs keep PASSWORD_BIT
-# raised at all times (it marks their onscreen-code capability, not a password),
-# so this is the only flags-based password signal they give.
-ATV_PASSWORD_BIT = 0x1000
 
 # Provider setting: opt-in for the shared PTP daemon's per-packet timing trace
 # (Announce/Sync/Follow_Up) when verbose logging is active. Off by default —

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -34,7 +34,6 @@ from .constants import (
     AIRPLAY_HIRES_SAMPLE_RATES,
     AIRPLAY_PCM_FORMAT,
     AIRPLAY_REJOIN_ATTEMPT_DELAYS,
-    ATV_PASSWORD_BIT,
     BASE_PLAYER_FEATURES,
     CONF_AIRPLAY_CREDENTIALS,
     CONF_BUFFER_DEPTH,
@@ -244,17 +243,13 @@ class AirPlayPlayer(Player):
     @property
     def password_required(self) -> bool:
         """Return if the device announces that it is password protected."""
-        # Three announcement forms, verified against live devices: receivers
-        # publish the classic pw boolean and/or the password bit in sf/flags,
-        # except Apple TVs - they keep the password bit raised at all times, so
-        # for them only the tvOS-specific flags bit counts. Enforcement can also
-        # exist WITHOUT any announcement (stale TXT after the password was
-        # enabled); that case is caught at connect time via password_invalid.
-        flags = self._get_flags()
-        if flags & ATV_PASSWORD_BIT:
-            return True
-        is_apple_tv = (self.device_info.model or "").startswith("AppleTV")
-        if flags & PASSWORD_BIT and not is_apple_tv:
+        # Two announcement forms, verified against live devices (including Apple
+        # TVs, which raise the password bit only while a password is actually
+        # set): receivers publish the password bit in sf/flags and/or the classic
+        # pw boolean. Enforcement can also exist WITHOUT any announcement (stale
+        # TXT after the password was enabled); that case is caught at connect
+        # time via password_invalid.
+        if self._get_flags() & PASSWORD_BIT:
             return True
         if raop_info := self.raop_discovery_info:
             return (raop_info.decoded_properties.get("pw") or "").lower() == "true"

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -168,7 +168,7 @@ def test_requires_pin_pairing(
         ({b"flags": b"0x4"}, None, False),
         ({b"sf": b"0x80"}, None, True),
         ({b"flags": b"0x90"}, None, True),
-        ({b"flags": b"0x1000"}, None, True),
+        ({b"flags": b"0x1000"}, None, False),
         (None, {b"flags": "0x80"}, True),
         (None, {b"sf": b"0x81"}, True),
         (None, {b"flags": b"0x4"}, False),
@@ -183,7 +183,7 @@ def test_password_required(
     raop_properties: dict[bytes, bytes] | None,
     expected: bool,
 ) -> None:
-    """Test the flags-based password announcements (non-Apple-TV model)."""
+    """Test the flags-based password announcements."""
     if aiplay_properties is not None:
         aiplay_discovery_info = MagicMock()
         aiplay_discovery_info.properties = aiplay_properties
@@ -1645,24 +1645,35 @@ def test_announced_password_without_one_stored_needs_setup(
     assert airplay_player.setup_reason == "password_required"
 
 
-def test_apple_tv_password_bit_alone_does_not_need_setup(airplay_player: AirPlayPlayer) -> None:
-    """Apple TVs raise the generic password bit at all times; it means nothing there."""
-    # a paired Apple TV without a password set must not be sent back into setup
-    _set_password_discovery(airplay_player, flags="0x4c4", paired=True)
-    airplay_player.device_info.model = "AppleTV14,1"
+def test_apple_tv_without_a_password_does_not_need_setup(airplay_player: AirPlayPlayer) -> None:
+    """An Apple TV that announces no password must not be sent into setup."""
+    # flags as published by tvOS with "Require Password" off
+    _set_password_discovery(airplay_player, flags="0x644", paired=True)
+    airplay_player.device_info.manufacturer = "Apple"
+    airplay_player.device_info.model = "Apple TV 4K Gen2"
 
     assert airplay_player.password_required is False
     assert airplay_player.needs_setup is False
 
 
 def test_apple_tv_with_a_password_set_needs_setup(airplay_player: AirPlayPlayer) -> None:
-    """The tvOS-specific flags bit is the Apple TV's only password announcement."""
-    _set_password_discovery(airplay_player, flags="0x14c4")
-    airplay_player.device_info.model = "AppleTV11,1"
+    """An Apple TV announces its password through the same bit as every other receiver."""
+    # the same device with "Require Password" on: the password bit replaces the pairing bit
+    _set_password_discovery(airplay_player, flags="0x4c4")
+    airplay_player.device_info.manufacturer = "Apple"
+    airplay_player.device_info.model = "Apple TV 4K Gen2"
 
     assert airplay_player.password_required is True
     assert airplay_player.needs_setup is True
     assert airplay_player.setup_reason == "password_required"
+
+
+def test_silent_primary_bit_is_not_a_password_announcement(airplay_player: AirPlayPlayer) -> None:
+    """The SilentPrimary flags bit says nothing about a password and must not force setup."""
+    _set_password_discovery(airplay_player, flags="0x1644", paired=True)
+
+    assert airplay_player.password_required is False
+    assert airplay_player.needs_setup is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant read the AirPlay password announcement differently for Apple TVs: the standard password flag was ignored for them, and a separate bit (`0x1000`) was trusted instead. Testing against a live Apple TV on tvOS 27.0 shows that reading is wrong — toggling "Require Password" moves the standard flag (`0x644` ⇄ `0x4c4`) and never touches `0x1000`, which the AirPlay spec documents as SilentPrimary, unrelated to passwords.

Nothing changes for any device seen so far: the Apple TV exception could never fire (it tested a model string that discovery never produces), and no observed device raises `0x1000`. This aligns the code with how the devices actually behave, and drops a bit that would otherwise report a password where there is none.

- Honour the standard password flag on every device, Apple TVs included
- Stop treating SilentPrimary as a password announcement
- Replace the Apple TV tests with the flags the devices really publish

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
