### PR TITLE
Playlists from stations with an unusual charset no longer fail to load

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -960,8 +960,8 @@ class StreamsAudio:
         ) as resp:
             resp.raise_for_status()
             raw_data = await resp.read()
-            encoding = resp.charset or await detect_charset(raw_data)
-            master_m3u_data = raw_data.decode(encoding)
+            encoding = await detect_charset(raw_data, preferred=resp.charset)
+            master_m3u_data = raw_data.decode(encoding, errors="replace")
         substreams = parse_m3u(master_m3u_data)
         # There is a chance that we did not get a master playlist with subplaylists
         # but just a single master/sub playlist with the actual audio stream(s)

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -302,7 +302,7 @@ async def fetch_playlist(
         ) as resp:
             try:
                 raw_data = await resp.content.read(64 * 1024)
-                encoding = resp.charset or await detect_charset(raw_data)
+                encoding = await detect_charset(raw_data, preferred=resp.charset)
                 playlist_data = raw_data.decode(encoding, errors="replace")
             except (ValueError, UnicodeDecodeError) as err:
                 msg = f"Could not decode playlist {url}"

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1604,13 +1604,24 @@ async def close_async_generator(agen: AsyncGenerator[Any]) -> None:
     await agen.aclose()
 
 
-async def detect_charset(data: bytes, fallback: str = "utf-8") -> str:
+async def detect_charset(data: bytes, fallback: str = "utf-8", preferred: str | None = None) -> str:
     """
     Detect the charset to decode the given raw text with.
 
     :param data: The raw text bytes to inspect.
     :param fallback: Charset to return when the charset can not be determined.
+    :param preferred: Charset declared by the source, taken over detection when usable.
     """
+    if preferred:
+        # a declared charset is only worth anything if Python has a codec for it:
+        # servers do send misspelled or plain made-up names in their Content-Type
+        try:
+            codecs.lookup(preferred)
+        except LookupError:
+            LOGGER.debug("Ignoring unknown charset: %s", preferred)
+        else:
+            return preferred
+
     if data.startswith(codecs.BOM_UTF8):
         return "utf-8-sig"
     try:

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1612,6 +1612,11 @@ async def detect_charset(data: bytes, fallback: str = "utf-8", preferred: str | 
     :param fallback: Charset to return when the charset can not be determined.
     :param preferred: Charset declared by the source, taken over detection when usable.
     """
+    # a BOM outranks the declared charset: it names the very same UTF-8 but, unlike
+    # the declared name, also gets the marker itself stripped off the decoded text
+    if data.startswith(codecs.BOM_UTF8):
+        return "utf-8-sig"
+
     if preferred:
         # a declared charset is only worth anything if Python has a codec for it:
         # servers do send misspelled or plain made-up names in their Content-Type
@@ -1622,8 +1627,6 @@ async def detect_charset(data: bytes, fallback: str = "utf-8", preferred: str | 
         else:
             return preferred
 
-    if data.startswith(codecs.BOM_UTF8):
-        return "utf-8-sig"
     try:
         data.decode()
     except UnicodeDecodeError:

--- a/tests/controllers/streams/test_hls_substream.py
+++ b/tests/controllers/streams/test_hls_substream.py
@@ -1,0 +1,75 @@
+"""Tests for HLS master playlist selection on the streams controller."""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Self
+from unittest.mock import MagicMock
+
+import pytest
+
+from music_assistant.controllers.streams.audio import StreamsAudio
+
+MASTER_PLAYLIST = (
+    "#EXTM3U\n"
+    '#EXT-X-STREAM-INF:BANDWIDTH=64000,CODECS="mp4a.40.2"\n'
+    "https://radio.example.com/low.m3u8\n"
+    '#EXT-X-STREAM-INF:BANDWIDTH=320000,CODECS="mp4a.40.2"\n'
+    "https://radio.example.com/high.m3u8\n"
+)
+
+
+class _FakeResponse:
+    """Stand-in for the aiohttp response of a master playlist fetch."""
+
+    def __init__(self, raw_data: bytes, charset: str | None) -> None:
+        self._raw_data = raw_data
+        self.charset = charset
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        """Accept the response as a successful one."""
+
+    async def read(self) -> bytes:
+        return self._raw_data
+
+
+def _streams_audio(raw_data: bytes, charset: str | None) -> StreamsAudio:
+    """Build a streams audio controller whose HTTP session serves the given playlist."""
+    mass = MagicMock()
+    mass.http_session_no_ssl.get = MagicMock(return_value=_FakeResponse(raw_data, charset))
+    return StreamsAudio(mass)
+
+
+class TestGetHlsSubstream:
+    """get_hls_substream picks the best child playlist of an HLS master playlist."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_charset_falls_back_to_detection(self) -> None:
+        """
+        A charset the remote server made up must not break substream selection.
+
+        Stations do send names Python has no codec for, which decode() answers with a
+        LookupError that no caller on this path catches.
+        """
+        controller = _streams_audio(MASTER_PLAYLIST.encode(), charset="utf8mb4")
+        substream = await controller.get_hls_substream("https://radio.example.com/master.m3u8")
+        assert substream.path == "https://radio.example.com/high.m3u8"
+
+    @pytest.mark.asyncio
+    async def test_undecodable_byte_degrades_instead_of_raising(self) -> None:
+        """One bad byte costs a character, not the whole stream."""
+        raw_data = MASTER_PLAYLIST.encode().replace(b"#EXTM3U", b"#EXTM3U\n#\xff")
+        controller = _streams_audio(raw_data, charset="utf-8")
+        substream = await controller.get_hls_substream("https://radio.example.com/master.m3u8")
+        assert substream.path == "https://radio.example.com/high.m3u8"

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -117,6 +117,12 @@ class TestDetectCharset:
         raw = CYRILLIC_CUE.encode("cp1251")
         assert await detect_charset(raw, preferred="cp1251") == "cp1251"
 
+    async def test_byte_order_mark_beats_the_declared_charset(self) -> None:
+        """A source declaring plain utf-8 must not leave its own BOM in the text."""
+        raw = codecs.BOM_UTF8 + CYRILLIC_CUE.encode()
+        encoding = await detect_charset(raw, preferred="utf-8")
+        assert raw.decode(encoding) == CYRILLIC_CUE
+
     async def test_unknown_declared_charset_is_ignored(self) -> None:
         """A charset name Python has no codec for must not reach decode()."""
         raw = CYRILLIC_CUE.encode("cp1251")

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -112,6 +112,17 @@ class TestDetectCharset:
         """Bytes that hold no readable text at all fall back to the given charset."""
         assert await detect_charset(b"\xff\x00\xff", fallback="cp1257") == "cp1257"
 
+    async def test_declared_charset_wins_over_detection(self) -> None:
+        """A charset the source declares itself beats guessing at the bytes."""
+        raw = CYRILLIC_CUE.encode("cp1251")
+        assert await detect_charset(raw, preferred="cp1251") == "cp1251"
+
+    async def test_unknown_declared_charset_is_ignored(self) -> None:
+        """A charset name Python has no codec for must not reach decode()."""
+        raw = CYRILLIC_CUE.encode("cp1251")
+        encoding = await detect_charset(raw, preferred="utf8mb4")
+        assert raw.decode(encoding) == CYRILLIC_CUE
+
 
 class TestGetSourceIpForTarget:
     """get_source_ip_for_target reports the interface the routing table egresses from."""


### PR DESCRIPTION
# What does this implement/fix?

When we fetch an HLS master playlist or a remote M3U/PLS playlist, we take the charset straight from the server's `Content-Type` header. That value is never checked, so a station that sends a misspelled or made-up charset name makes the decode blow up on a charset Python has no codec for, and HLS stream selection fails before playback can start. The HLS path also decoded strictly, so a single bad byte in an otherwise fine playlist killed it as well.

A declared charset is now only used when Python actually has a codec for it, and otherwise we fall back to detecting it from the bytes, like we already do everywhere else.

## Changes

- Validate the server-declared charset before decoding, falling back to charset detection when it is unusable.
- Decode HLS master playlists leniently, so one bad byte costs a character instead of the stream.
- Strip a byte order mark even when the source declares a charset, so it no longer ends up as a junk entry in an imported playlist.
- Added tests for each case.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
