### PR TITLE
Stop flagging safe dependencies as having no license

### DIFF
--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -30,6 +30,11 @@ COMPATIBLE_LICENSES = {
     "Unlicense",
     "CC0",
     "Public Domain",
+    # compact spellings that would not survive the boundary check as a suffix of the name above
+    "PSFL",
+    "ISCL",
+    "LGPLv2",
+    "LGPLv3",
 }
 
 # SPDX identifiers accepted in a PEP 639 `license_expression`
@@ -603,11 +608,10 @@ def _names_license(license_upper: str, name: str) -> bool:
     :param name: The license name to look for, e.g. "MPL-2.0".
     """
     # tolerate spelling variants of the separators, so that "MPL 2.0" is read as "MPL-2.0", but
-    # match on word boundaries, so the name cannot be assembled out of unrelated words ("this
-    # copyright" holding an "ISC", or "mitigation" a "MIT"). A single letter may follow, for the
-    # version and "License" markers real packages write ("LGPLv3", "PSFL")
+    # match whole words only, so the name is neither assembled out of unrelated ones ("this
+    # copyright" holding an "ISC") nor read out of one that merely starts the same ("MITigation")
     parts = [re.escape(part) for part in re.findall(r"[A-Z0-9]+", name.upper())]
-    return re.search(rf"\b{r'[^A-Z0-9]*'.join(parts)}(?![A-Z]{{2}})", license_upper) is not None
+    return re.search(rf"\b{r'[^A-Z0-9]*'.join(parts)}(?![A-Z0-9])", license_upper) is not None
 
 
 def _is_spdx_operator(token: str) -> bool:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -31,6 +31,32 @@ COMPATIBLE_LICENSES = {
     "CC0",
 }
 
+# SPDX identifiers accepted in a PEP 639 `license_expression`
+COMPATIBLE_SPDX_LICENSES = {
+    "0BSD",
+    "APACHE-2.0",
+    "BSD-2-CLAUSE",
+    "BSD-3-CLAUSE",
+    "BSL-1.0",
+    "CC0-1.0",
+    "ISC",
+    "LGPL-2.1-ONLY",
+    "LGPL-2.1-OR-LATER",
+    "LGPL-3.0-ONLY",
+    "LGPL-3.0-OR-LATER",
+    "MIT",
+    "MIT-0",
+    "MIT-CMU",
+    "MPL-2.0",
+    "PSF-2.0",
+    "PYTHON-2.0",
+    "UNLICENSE",
+    "ZLIB",
+}
+
+# License families that are incompatible with the project (LGPL excluded)
+PROBLEMATIC_LICENSES = ("GPL", "AGPL", "SSPL")
+
 # Common packages to check for typosquatting (popular Python packages)
 POPULAR_PACKAGES = {
     "requests",
@@ -91,6 +117,29 @@ def check_typosquatting(package_name: str) -> str | None:
     return None
 
 
+def get_package_license(info: dict[str, Any]) -> str:
+    """
+    Resolve the license of a package from its PyPI metadata.
+
+    :param info: The `info` section of the PyPI JSON response.
+    """
+    # packages that adopted PEP 639 declare an SPDX expression, which is more precise than the
+    # free-form field and the classifiers, and is usually the only license metadata they carry
+    if license_expression := (info.get("license_expression") or "").strip():
+        return license_expression
+
+    if license_str := (info.get("license") or "").strip():
+        return license_str
+
+    for classifier in info.get("classifiers") or []:
+        # the license itself is the last segment, e.g. "License :: OSI Approved :: MIT License"
+        parts = [part.strip() for part in classifier.split("::")]
+        if parts[0] == "License" and len(parts) > 2:
+            return parts[-1]
+
+    return "Unknown"
+
+
 def check_license_compatibility(license_str: str) -> tuple[bool, str]:
     """
     Check if license is compatible with the project.
@@ -101,15 +150,22 @@ def check_license_compatibility(license_str: str) -> tuple[bool, str]:
         return False, "No license information"
 
     license_upper = license_str.upper()
+    spdx_compatible = _evaluate_spdx_expression(license_str)
 
-    # Check against compatible licenses
-    for compatible in COMPATIBLE_LICENSES:
-        if compatible.upper() in license_upper:
-            return True, f"Compatible ({license_str})"
+    if spdx_compatible:
+        return True, f"Compatible ({license_str})"
+
+    # only fall back to plain substring matching when the string is not an SPDX expression we
+    # understand, so a copyleft term cannot be masked by a permissive one elsewhere in it
+    if spdx_compatible is None:
+        # ignore punctuation so spelling variants such as "MPL 2.0" match "MPL-2.0"
+        squashed = re.sub(r"[^A-Z0-9]", "", license_upper)
+        for compatible in COMPATIBLE_LICENSES:
+            if re.sub(r"[^A-Z0-9]", "", compatible.upper()) in squashed:
+                return True, f"Compatible ({license_str})"
 
     # Check for problematic licenses
-    problematic = ["GPL", "AGPL", "SSPL"]
-    for problem in problematic:
+    for problem in PROBLEMATIC_LICENSES:
         if problem in license_upper and "LGPL" not in license_upper:
             return False, f"Incompatible copyleft license ({license_str})"
 
@@ -202,7 +258,8 @@ def check_package(package_name: str) -> dict[str, Any]:
 
     # Run automated security checks
     typosquat_check = check_typosquatting(package_name)
-    license_compatible, license_status = check_license_compatibility(info.get("license", "Unknown"))
+    package_license = get_package_license(info)
+    license_compatible, license_status = check_license_compatibility(package_license)
 
     checks = {
         "name": package_name,
@@ -212,7 +269,7 @@ def check_package(package_name: str) -> dict[str, Any]:
         "has_homepage": bool(homepage),
         "has_source": bool(source),
         "author": info.get("author") or info.get("maintainer") or "Unknown",
-        "license": info.get("license") or "Unknown",
+        "license": package_license,
         "summary": info.get("summary", "No description"),
         "warnings": [],
         "info_items": [],
@@ -401,6 +458,94 @@ def main() -> int:
 
     print("\n✅ All packages passed basic safety checks.")
     return 0
+
+
+def _evaluate_spdx_expression(license_str: str) -> bool | None:
+    """
+    Check an SPDX license expression (PEP 639) against the allow list.
+
+    Returns None when the string is not an SPDX expression or holds an identifier that is
+    neither known-compatible nor known-problematic.
+
+    :param license_str: The license string to evaluate, e.g. "MIT OR Apache-2.0".
+    """
+    tokens = re.findall(r"\(|\)|[^\s()]+", license_str)
+    if not tokens:
+        return None
+    result = _evaluate_spdx_tokens(tokens)
+    # anything left over means we did not understand the string as a whole
+    return None if tokens else result
+
+
+def _evaluate_spdx_tokens(tokens: list[str]) -> bool | None:
+    """
+    Evaluate the leading SPDX expression, consuming the tokens it covers.
+
+    Any alternative that is compatible makes the whole expression compatible.
+
+    :param tokens: The remaining tokens of the expression.
+    """
+    result = _evaluate_spdx_term(tokens)
+    while tokens and tokens[0].upper() == "OR":
+        tokens.pop(0)
+        term = _evaluate_spdx_term(tokens)
+        if True in (result, term):
+            result = True
+        elif None in (result, term):
+            result = None
+    return result
+
+
+def _evaluate_spdx_term(tokens: list[str]) -> bool | None:
+    """
+    Evaluate the leading "AND" sequence, which binds tighter than "OR" in SPDX.
+
+    Every operand of the sequence has to be compatible on its own.
+
+    :param tokens: The remaining tokens of the expression.
+    """
+    result = _evaluate_spdx_operand(tokens)
+    while tokens and tokens[0].upper() == "AND":
+        tokens.pop(0)
+        operand = _evaluate_spdx_operand(tokens)
+        if False in (result, operand):
+            result = False
+        elif None in (result, operand):
+            result = None
+    return result
+
+
+def _evaluate_spdx_operand(tokens: list[str]) -> bool | None:
+    """
+    Evaluate a single SPDX operand: a parenthesised expression or a license identifier.
+
+    :param tokens: The remaining tokens of the expression.
+    """
+    if not tokens:
+        return None
+
+    if tokens[0] == "(":
+        tokens.pop(0)
+        result = _evaluate_spdx_tokens(tokens)
+        if not tokens or tokens.pop(0) != ")":
+            return None
+        return result
+
+    identifier = tokens.pop(0).rstrip("+").upper()
+    # a "WITH <exception>" suffix only grants extra permissions, so the identifier decides
+    if tokens and tokens[0].upper() == "WITH":
+        tokens.pop(0)
+        if not tokens:
+            return None
+        tokens.pop(0)
+
+    if not re.fullmatch(r"[A-Z0-9][A-Z0-9.-]*", identifier):
+        return None
+    if identifier in COMPATIBLE_SPDX_LICENSES:
+        return True
+    if "LGPL" not in identifier and any(prob in identifier for prob in PROBLEMATIC_LICENSES):
+        return False
+    return None
 
 
 if __name__ == "__main__":

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -174,13 +174,10 @@ def check_license_compatibility(
         return False, "No license information"
 
     license_upper = license_str.upper()
-    try:
-        spdx_compatible = _evaluate_spdx_expression(license_str)
-        # a value that reads as an expression joining licenses is precise enough to judge on the
-        # names in it alone, whichever field it came from
-        spdx_expression = spdx_expression or _joins_licenses(license_str)
-    except _SpdxSyntaxError:
-        spdx_compatible = None
+    spdx_compatible, joins_licenses = _evaluate_spdx_expression(license_str)
+    # a value that reads as an expression joining licenses is precise enough to judge on the
+    # names in it alone, whichever field it came from
+    spdx_expression = spdx_expression or joins_licenses
 
     if spdx_compatible:
         return True, f"Compatible ({license_str})"
@@ -497,27 +494,37 @@ class _SpdxSyntaxError(Exception):
     """Raised when a string does not follow the SPDX expression grammar."""
 
 
-def _evaluate_spdx_expression(license_str: str) -> bool | None:
+def _evaluate_spdx_expression(license_str: str) -> tuple[bool | None, bool]:
     """
     Check an SPDX license expression (PEP 639) against the allow list.
 
-    Returns None when it names a license that is neither known-compatible nor known-problematic,
-    and raises `_SpdxSyntaxError` when the string is not a well-formed expression.
+    Returns whether the expression is compatible, which is None when it names a license that is
+    neither known-compatible nor known-problematic or when the string is not an expression at
+    all, together with whether the part that did read as one joined several licenses.
 
     :param license_str: The license string to evaluate, e.g. "MIT OR Apache-2.0".
     """
     tokens = re.findall(r"\(|\)|[^\s()]+", license_str)
     if not tokens:
-        return None
+        return None, False
     # real expressions nest a group or two at most; refuse anything deeper rather than recursing
     # into it, and refuse outright as the fallback would match on a name nested inside
     if _max_group_depth(tokens) > MAX_SPDX_NESTING:
-        return False
-    result = _evaluate_spdx_tokens(tokens)
-    if tokens:
-        # anything left over means we did not understand the string as a whole
-        raise _SpdxSyntaxError
-    return result
+        return False, True
+
+    remaining = list(tokens)
+    try:
+        result = _evaluate_spdx_tokens(remaining)
+        if remaining:
+            # anything left over means we did not understand the string as a whole
+            raise _SpdxSyntaxError
+    except _SpdxSyntaxError:
+        result = None
+
+    # judge the shape on the tokens that were read as an expression, so that prose merely holding
+    # the word "and" is not mistaken for one, while a malformed expression still is
+    read = tokens[: len(tokens) - len(remaining)]
+    return result, any(token.upper() in ("AND", "OR", "WITH") for token in read)
 
 
 def _evaluate_spdx_tokens(tokens: list[str]) -> bool | None:
@@ -601,15 +608,6 @@ def _names_license(license_upper: str, name: str) -> bool:
     # version and "License" markers real packages write ("LGPLv3", "PSFL")
     parts = [re.escape(part) for part in re.findall(r"[A-Z0-9]+", name.upper())]
     return re.search(rf"\b{r'[^A-Z0-9]*'.join(parts)}(?![A-Z]{{2}})", license_upper) is not None
-
-
-def _joins_licenses(license_str: str) -> bool:
-    """
-    Return whether a string uses SPDX operators to combine several licenses.
-
-    :param license_str: The license string to inspect.
-    """
-    return any(token.upper() in ("AND", "OR", "WITH") for token in license_str.split())
 
 
 def _is_spdx_operator(token: str) -> bool:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -58,7 +58,7 @@ COMPATIBLE_SPDX_LICENSES = {
 # License families that are incompatible with the project (LGPL excluded)
 PROBLEMATIC_LICENSES = ("GPL", "AGPL", "SSPL")
 
-# Highest number of groups accepted in an SPDX expression
+# Deepest group nesting accepted in an SPDX expression
 MAX_SPDX_NESTING = 10
 
 # Common packages to check for typosquatting (popular Python packages)
@@ -169,19 +169,22 @@ def check_license_compatibility(license_str: str) -> tuple[bool, str]:
     if spdx_compatible:
         return True, f"Compatible ({license_str})"
 
-    # only fall back to plain substring matching when the string is not an SPDX expression we
-    # understand, so a copyleft term cannot be masked by a permissive one elsewhere in it
-    if spdx_compatible is None:
+    copyleft = "LGPL" not in license_upper and any(
+        problem in license_upper for problem in PROBLEMATIC_LICENSES
+    )
+
+    # fall back to plain substring matching for the strings the evaluator did not understand, but
+    # never when a copyleft or a PEP 639 custom license is named, as a permissive name in the
+    # string could be hiding it
+    if spdx_compatible is None and not copyleft and "LICENSEREF" not in license_upper:
         # ignore punctuation so spelling variants such as "MPL 2.0" match "MPL-2.0"
         squashed = re.sub(r"[^A-Z0-9]", "", license_upper)
         for compatible in COMPATIBLE_LICENSES:
             if re.sub(r"[^A-Z0-9]", "", compatible.upper()) in squashed:
                 return True, f"Compatible ({license_str})"
 
-    # Check for problematic licenses
-    for problem in PROBLEMATIC_LICENSES:
-        if problem in license_upper and "LGPL" not in license_upper:
-            return False, f"Incompatible copyleft license ({license_str})"
+    if copyleft:
+        return False, f"Incompatible copyleft license ({license_str})"
 
     # Unknown license
     return False, f"Unknown/unverified license ({license_str})"
@@ -486,9 +489,9 @@ def _evaluate_spdx_expression(license_str: str) -> bool | None:
     tokens = re.findall(r"\(|\)|[^\s()]+", license_str)
     if not tokens:
         return None
-    # real expressions nest a level or two at most; refuse the rest rather than recursing into
-    # them, and refuse rather than fall through, as the fallback would match on any name inside
-    if tokens.count("(") > MAX_SPDX_NESTING:
+    # real expressions nest a group or two at most; refuse anything deeper rather than recursing
+    # into it, and refuse outright as the fallback would match on a name nested inside
+    if _max_group_depth(tokens) > MAX_SPDX_NESTING:
         return False
     result = _evaluate_spdx_tokens(tokens)
     # anything left over means we did not understand the string as a whole
@@ -557,16 +560,28 @@ def _evaluate_spdx_operand(tokens: list[str]) -> bool | None:
             return None
         tokens.pop(0)
 
-    if not re.fullmatch(r"[A-Z0-9][A-Z0-9.-]*", identifier):
-        return None
-    # PEP 639 reserves this prefix for custom licenses, which are never pre-approved
-    if identifier.startswith("LICENSEREF-"):
-        return False
     if identifier in COMPATIBLE_SPDX_LICENSES:
         return True
     if "LGPL" not in identifier and any(prob in identifier for prob in PROBLEMATIC_LICENSES):
         return False
     return None
+
+
+def _max_group_depth(tokens: list[str]) -> int:
+    """
+    Return how deeply the parentheses in an expression nest.
+
+    :param tokens: The tokens of the expression.
+    """
+    depth = 0
+    deepest = 0
+    for token in tokens:
+        if token == "(":
+            depth += 1
+            deepest = max(deepest, depth)
+        elif token == ")":
+            depth = max(0, depth - 1)
+    return deepest
 
 
 if __name__ == "__main__":

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -179,10 +179,7 @@ def check_license_compatibility(
     if spdx_compatible:
         return True, f"Compatible ({license_str})"
 
-    # drop the LGPL mentions before looking for the copyleft families we do not accept, so that a
-    # GPL term next to an LGPL one is still spotted
-    without_lgpl = license_upper.replace("LGPL", "")
-    copyleft = any(problem in without_lgpl for problem in PROBLEMATIC_LICENSES)
+    copyleft = _is_copyleft(license_upper)
 
     # an SPDX expression is a validated, machine-readable field: whatever the evaluator did not
     # accept in one names a license that is not on the allow list, so guessing from the wording
@@ -566,7 +563,7 @@ def _evaluate_spdx_operand(tokens: list[str]) -> bool | None:
 
     :param tokens: The remaining tokens of the expression.
     """
-    if not tokens or tokens[0] == ")" or tokens[0].upper() in ("AND", "OR", "WITH"):
+    if not tokens or _is_spdx_operator(tokens[0]):
         raise _SpdxSyntaxError
 
     if tokens[0] == "(":
@@ -581,15 +578,33 @@ def _evaluate_spdx_operand(tokens: list[str]) -> bool | None:
     # a "WITH <exception>" suffix only grants extra permissions, so the identifier decides
     if tokens and tokens[0].upper() == "WITH":
         tokens.pop(0)
-        if not tokens:
+        if not tokens or _is_spdx_operator(tokens[0]):
             raise _SpdxSyntaxError
-        tokens.pop(0)
+        # ...but a license we refuse is not an exception, whatever it is written behind
+        if _is_copyleft(tokens.pop(0).upper()):
+            return False
 
-    if identifier in COMPATIBLE_SPDX_LICENSES:
-        return True
-    if "LGPL" not in identifier and any(prob in identifier for prob in PROBLEMATIC_LICENSES):
-        return False
-    return None
+    return True if identifier in COMPATIBLE_SPDX_LICENSES else None
+
+
+def _is_spdx_operator(token: str) -> bool:
+    """
+    Return whether a token joins or closes expressions instead of naming a license.
+
+    :param token: The token to inspect.
+    """
+    return token == ")" or token.upper() in ("AND", "OR", "WITH")
+
+
+def _is_copyleft(license_upper: str) -> bool:
+    """
+    Return whether an upper-cased license string names a copyleft family we do not accept.
+
+    :param license_upper: The upper-cased license string to inspect.
+    """
+    # drop the LGPL mentions first, so that a GPL term next to an LGPL one is still spotted
+    without_lgpl = license_upper.replace("LGPL", "")
+    return any(problem in without_lgpl for problem in PROBLEMATIC_LICENSES)
 
 
 def _max_group_depth(tokens: list[str]) -> int:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -29,6 +29,7 @@ COMPATIBLE_LICENSES = {
     "MPL-2.0",
     "Unlicense",
     "CC0",
+    "Public Domain",
 }
 
 # SPDX identifiers accepted in a PEP 639 `license_expression`
@@ -136,9 +137,10 @@ def get_package_license(info: dict[str, Any]) -> str:
 
     license_classifiers = []
     for classifier in info.get("classifiers") or []:
-        # the license itself is the last segment, e.g. "License :: OSI Approved :: MIT License"
+        # the license itself is the last segment, e.g. "License :: OSI Approved :: MIT License",
+        # except for "License :: OSI Approved", which names no license at all
         parts = [part.strip() for part in classifier.split("::")]
-        if parts[0] == "License" and len(parts) > 2:
+        if parts[0] == "License" and len(parts) > 1 and parts[-1] != "OSI Approved":
             license_classifiers.append(parts[-1])
 
     if license_classifiers:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -187,10 +187,8 @@ def check_license_compatibility(
     # do recognise there must not end up approving a copyleft or custom license next to it
     guessable = not spdx_expression and not copyleft and "LICENSEREF" not in license_upper
     if spdx_compatible is None and guessable:
-        # ignore punctuation so spelling variants such as "MPL 2.0" match "MPL-2.0"
-        squashed = re.sub(r"[^A-Z0-9]", "", license_upper)
         for compatible in COMPATIBLE_LICENSES:
-            if re.sub(r"[^A-Z0-9]", "", compatible.upper()) in squashed:
+            if _names_license(license_upper, compatible):
                 return True, f"Compatible ({license_str})"
 
     if copyleft:
@@ -585,6 +583,20 @@ def _evaluate_spdx_operand(tokens: list[str]) -> bool | None:
             return False
 
     return True if identifier in COMPATIBLE_SPDX_LICENSES else None
+
+
+def _names_license(license_upper: str, name: str) -> bool:
+    """
+    Return whether an upper-cased license string names the given license.
+
+    :param license_upper: The upper-cased license string to search.
+    :param name: The license name to look for, e.g. "MPL-2.0".
+    """
+    # tolerate spelling variants of the separators, so that "MPL 2.0" is read as "MPL-2.0", but
+    # only match from a word boundary, so the name cannot be assembled out of unrelated words
+    # ("this copyright" holding an "ISC", or "permitted" a "MIT")
+    parts = [re.escape(part) for part in re.findall(r"[A-Z0-9]+", name.upper())]
+    return re.search(rf"\b{r'[^A-Z0-9]*'.join(parts)}", license_upper) is not None
 
 
 def _is_spdx_operator(token: str) -> bool:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -29,12 +29,17 @@ COMPATIBLE_LICENSES = {
     "MPL-2.0",
     "Unlicense",
     "CC0",
-    "Public Domain",
     # compact spellings that would not survive the boundary check as a suffix of the name above
     "PSFL",
     "ISCL",
     "LGPLv2",
     "LGPLv3",
+}
+
+# Licenses recognised only as the whole value, because their wording also turns up in prose that
+# says the opposite ("this software is not in the public domain")
+EXACT_LICENSES = {
+    "Public Domain",
 }
 
 # SPDX identifiers accepted in a PEP 639 `license_expression`
@@ -195,7 +200,7 @@ def check_license_compatibility(
     # copyleft or custom license next to it
     guessable = not spdx_expression and not copyleft and "LICENSEREF" not in license_upper
     if spdx_compatible is None and guessable:
-        for compatible in COMPATIBLE_LICENSES:
+        for compatible in COMPATIBLE_LICENSES | EXACT_LICENSES:
             if _names_license(license_upper, compatible):
                 return True, f"Compatible ({license_str})"
 
@@ -610,6 +615,9 @@ def _names_license(license_upper: str, name: str) -> bool:
     # tolerate spelling variants of the separators, so that "MPL 2.0" is read as "MPL-2.0", but
     # match whole words only, so the name is neither assembled out of unrelated ones ("this
     # copyright" holding an "ISC") nor read out of one that merely starts the same ("MITigation")
+    if name in EXACT_LICENSES:
+        return license_upper.strip() == name.upper()
+
     parts = [re.escape(part) for part in re.findall(r"[A-Z0-9]+", name.upper())]
     return re.search(rf"\b{r'[^A-Z0-9]*'.join(parts)}(?![A-Z0-9])", license_upper) is not None
 

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -41,8 +41,13 @@ COMPATIBLE_SPDX_LICENSES = {
     "BSL-1.0",
     "CC0-1.0",
     "ISC",
+    "LGPL-2.0",
+    "LGPL-2.0-ONLY",
+    "LGPL-2.0-OR-LATER",
+    "LGPL-2.1",
     "LGPL-2.1-ONLY",
     "LGPL-2.1-OR-LATER",
+    "LGPL-3.0",
     "LGPL-3.0-ONLY",
     "LGPL-3.0-OR-LATER",
     "MIT",
@@ -174,9 +179,10 @@ def check_license_compatibility(
     if spdx_compatible:
         return True, f"Compatible ({license_str})"
 
-    copyleft = "LGPL" not in license_upper and any(
-        problem in license_upper for problem in PROBLEMATIC_LICENSES
-    )
+    # drop the LGPL mentions before looking for the copyleft families we do not accept, so that a
+    # GPL term next to an LGPL one is still spotted
+    without_lgpl = license_upper.replace("LGPL", "")
+    copyleft = any(problem in without_lgpl for problem in PROBLEMATIC_LICENSES)
 
     # an SPDX expression is a validated, machine-readable field: whatever the evaluator did not
     # accept in one names a license that is not on the allow list, so guessing from the wording
@@ -570,7 +576,8 @@ def _evaluate_spdx_operand(tokens: list[str]) -> bool | None:
             raise _SpdxSyntaxError
         return result
 
-    identifier = tokens.pop(0).rstrip("+").upper()
+    # a single trailing "+" is the deprecated "or later" marker and does not change the license
+    identifier = tokens.pop(0).upper().removesuffix("+")
     # a "WITH <exception>" suffix only grants extra permissions, so the identifier decides
     if tokens and tokens[0].upper() == "WITH":
         tokens.pop(0)

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -593,10 +593,11 @@ def _names_license(license_upper: str, name: str) -> bool:
     :param name: The license name to look for, e.g. "MPL-2.0".
     """
     # tolerate spelling variants of the separators, so that "MPL 2.0" is read as "MPL-2.0", but
-    # only match from a word boundary, so the name cannot be assembled out of unrelated words
-    # ("this copyright" holding an "ISC", or "permitted" a "MIT")
+    # match on word boundaries, so the name cannot be assembled out of unrelated words ("this
+    # copyright" holding an "ISC", or "mitigation" a "MIT"). A single letter may follow, for the
+    # version and "License" markers real packages write ("LGPLv3", "PSFL")
     parts = [re.escape(part) for part in re.findall(r"[A-Z0-9]+", name.upper())]
-    return re.search(rf"\b{r'[^A-Z0-9]*'.join(parts)}", license_upper) is not None
+    return re.search(rf"\b{r'[^A-Z0-9]*'.join(parts)}(?![A-Z]{{2}})", license_upper) is not None
 
 
 def _is_spdx_operator(token: str) -> bool:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -174,17 +174,23 @@ def check_license_compatibility(
         return False, "No license information"
 
     license_upper = license_str.upper()
-    spdx_compatible = _evaluate_spdx_expression(license_str)
+    try:
+        spdx_compatible = _evaluate_spdx_expression(license_str)
+        # a value that reads as an expression joining licenses is precise enough to judge on the
+        # names in it alone, whichever field it came from
+        spdx_expression = spdx_expression or _joins_licenses(license_str)
+    except _SpdxSyntaxError:
+        spdx_compatible = None
 
     if spdx_compatible:
         return True, f"Compatible ({license_str})"
 
     copyleft = _is_copyleft(license_upper)
 
-    # an SPDX expression is a validated, machine-readable field: whatever the evaluator did not
-    # accept in one names a license that is not on the allow list, so guessing from the wording
-    # would only weaken the check. For free-form fields the wording is all we have, but a name we
-    # do recognise there must not end up approving a copyleft or custom license next to it
+    # whatever the evaluator did not accept in an expression names a license that is not on the
+    # allow list, so guessing from the wording would only weaken the check. For free-form fields
+    # the wording is all we have, but a name we do recognise there must not end up approving a
+    # copyleft or custom license next to it
     guessable = not spdx_expression and not copyleft and "LICENSEREF" not in license_upper
     if spdx_compatible is None and guessable:
         for compatible in COMPATIBLE_LICENSES:
@@ -495,8 +501,8 @@ def _evaluate_spdx_expression(license_str: str) -> bool | None:
     """
     Check an SPDX license expression (PEP 639) against the allow list.
 
-    Returns None when the string is not a well-formed expression, or when it names a license
-    that is neither known-compatible nor known-problematic.
+    Returns None when it names a license that is neither known-compatible nor known-problematic,
+    and raises `_SpdxSyntaxError` when the string is not a well-formed expression.
 
     :param license_str: The license string to evaluate, e.g. "MIT OR Apache-2.0".
     """
@@ -507,13 +513,10 @@ def _evaluate_spdx_expression(license_str: str) -> bool | None:
     # into it, and refuse outright as the fallback would match on a name nested inside
     if _max_group_depth(tokens) > MAX_SPDX_NESTING:
         return False
-    try:
-        result = _evaluate_spdx_tokens(tokens)
-        if tokens:
-            # anything left over means we did not understand the string as a whole
-            raise _SpdxSyntaxError
-    except _SpdxSyntaxError:
-        return None
+    result = _evaluate_spdx_tokens(tokens)
+    if tokens:
+        # anything left over means we did not understand the string as a whole
+        raise _SpdxSyntaxError
     return result
 
 
@@ -598,6 +601,15 @@ def _names_license(license_upper: str, name: str) -> bool:
     # version and "License" markers real packages write ("LGPLv3", "PSFL")
     parts = [re.escape(part) for part in re.findall(r"[A-Z0-9]+", name.upper())]
     return re.search(rf"\b{r'[^A-Z0-9]*'.join(parts)}(?![A-Z]{{2}})", license_upper) is not None
+
+
+def _joins_licenses(license_str: str) -> bool:
+    """
+    Return whether a string uses SPDX operators to combine several licenses.
+
+    :param license_str: The license string to inspect.
+    """
+    return any(token.upper() in ("AND", "OR", "WITH") for token in license_str.split())
 
 
 def _is_spdx_operator(token: str) -> bool:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -57,6 +57,9 @@ COMPATIBLE_SPDX_LICENSES = {
 # License families that are incompatible with the project (LGPL excluded)
 PROBLEMATIC_LICENSES = ("GPL", "AGPL", "SSPL")
 
+# Highest number of groups accepted in an SPDX expression
+MAX_SPDX_NESTING = 10
+
 # Common packages to check for typosquatting (popular Python packages)
 POPULAR_PACKAGES = {
     "requests",
@@ -131,11 +134,20 @@ def get_package_license(info: dict[str, Any]) -> str:
     if license_str := (info.get("license") or "").strip():
         return license_str
 
+    license_classifiers = []
     for classifier in info.get("classifiers") or []:
         # the license itself is the last segment, e.g. "License :: OSI Approved :: MIT License"
         parts = [part.strip() for part in classifier.split("::")]
         if parts[0] == "License" and len(parts) > 2:
-            return parts[-1]
+            license_classifiers.append(parts[-1])
+
+    if license_classifiers:
+        # classifiers do not say how they relate to each other, so report the one that fails the
+        # compatibility check rather than letting a permissive entry hide a copyleft one
+        return next(
+            (name for name in license_classifiers if not check_license_compatibility(name)[0]),
+            license_classifiers[0],
+        )
 
     return "Unknown"
 
@@ -472,6 +484,10 @@ def _evaluate_spdx_expression(license_str: str) -> bool | None:
     tokens = re.findall(r"\(|\)|[^\s()]+", license_str)
     if not tokens:
         return None
+    # real expressions nest a level or two at most; refuse the rest rather than recursing into
+    # them, and refuse rather than fall through, as the fallback would match on any name inside
+    if tokens.count("(") > MAX_SPDX_NESTING:
+        return False
     result = _evaluate_spdx_tokens(tokens)
     # anything left over means we did not understand the string as a whole
     return None if tokens else result
@@ -541,6 +557,9 @@ def _evaluate_spdx_operand(tokens: list[str]) -> bool | None:
 
     if not re.fullmatch(r"[A-Z0-9][A-Z0-9.-]*", identifier):
         return None
+    # PEP 639 reserves this prefix for custom licenses, which are never pre-approved
+    if identifier.startswith("LICENSEREF-"):
+        return False
     if identifier in COMPATIBLE_SPDX_LICENSES:
         return True
     if "LGPL" not in identifier and any(prob in identifier for prob in PROBLEMATIC_LICENSES):

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -121,19 +121,21 @@ def check_typosquatting(package_name: str) -> str | None:
     return None
 
 
-def get_package_license(info: dict[str, Any]) -> str:
+def get_package_license(info: dict[str, Any]) -> tuple[str, bool]:
     """
     Resolve the license of a package from its PyPI metadata.
+
+    Returns the license and whether it is a PEP 639 SPDX expression.
 
     :param info: The `info` section of the PyPI JSON response.
     """
     # packages that adopted PEP 639 declare an SPDX expression, which is more precise than the
     # free-form field and the classifiers, and is usually the only license metadata they carry
     if license_expression := (info.get("license_expression") or "").strip():
-        return license_expression
+        return license_expression, True
 
     if license_str := (info.get("license") or "").strip():
-        return license_str
+        return license_str, False
 
     license_classifiers = []
     for classifier in info.get("classifiers") or []:
@@ -149,16 +151,19 @@ def get_package_license(info: dict[str, Any]) -> str:
         return next(
             (name for name in license_classifiers if not check_license_compatibility(name)[0]),
             license_classifiers[0],
-        )
+        ), False
 
-    return "Unknown"
+    return "Unknown", False
 
 
-def check_license_compatibility(license_str: str) -> tuple[bool, str]:
+def check_license_compatibility(
+    license_str: str, spdx_expression: bool = False
+) -> tuple[bool, str]:
     """
     Check if license is compatible with the project.
 
     :param license_str: The license string from PyPI.
+    :param spdx_expression: Whether the string is a PEP 639 SPDX expression.
     """
     if not license_str or license_str == "Unknown":
         return False, "No license information"
@@ -173,10 +178,12 @@ def check_license_compatibility(license_str: str) -> tuple[bool, str]:
         problem in license_upper for problem in PROBLEMATIC_LICENSES
     )
 
-    # fall back to plain substring matching for the strings the evaluator did not understand, but
-    # never when a copyleft or a PEP 639 custom license is named, as a permissive name in the
-    # string could be hiding it
-    if spdx_compatible is None and not copyleft and "LICENSEREF" not in license_upper:
+    # an SPDX expression is a validated, machine-readable field: whatever the evaluator did not
+    # accept in one names a license that is not on the allow list, so guessing from the wording
+    # would only weaken the check. For free-form fields the wording is all we have, but a name we
+    # do recognise there must not end up approving a copyleft or custom license next to it
+    guessable = not spdx_expression and not copyleft and "LICENSEREF" not in license_upper
+    if spdx_compatible is None and guessable:
         # ignore punctuation so spelling variants such as "MPL 2.0" match "MPL-2.0"
         squashed = re.sub(r"[^A-Z0-9]", "", license_upper)
         for compatible in COMPATIBLE_LICENSES:
@@ -275,8 +282,10 @@ def check_package(package_name: str) -> dict[str, Any]:
 
     # Run automated security checks
     typosquat_check = check_typosquatting(package_name)
-    package_license = get_package_license(info)
-    license_compatible, license_status = check_license_compatibility(package_license)
+    package_license, spdx_expression = get_package_license(info)
+    license_compatible, license_status = check_license_compatibility(
+        package_license, spdx_expression
+    )
 
     checks = {
         "name": package_name,
@@ -477,12 +486,16 @@ def main() -> int:
     return 0
 
 
+class _SpdxSyntaxError(Exception):
+    """Raised when a string does not follow the SPDX expression grammar."""
+
+
 def _evaluate_spdx_expression(license_str: str) -> bool | None:
     """
     Check an SPDX license expression (PEP 639) against the allow list.
 
-    Returns None when the string is not an SPDX expression or holds an identifier that is
-    neither known-compatible nor known-problematic.
+    Returns None when the string is not a well-formed expression, or when it names a license
+    that is neither known-compatible nor known-problematic.
 
     :param license_str: The license string to evaluate, e.g. "MIT OR Apache-2.0".
     """
@@ -493,9 +506,14 @@ def _evaluate_spdx_expression(license_str: str) -> bool | None:
     # into it, and refuse outright as the fallback would match on a name nested inside
     if _max_group_depth(tokens) > MAX_SPDX_NESTING:
         return False
-    result = _evaluate_spdx_tokens(tokens)
-    # anything left over means we did not understand the string as a whole
-    return None if tokens else result
+    try:
+        result = _evaluate_spdx_tokens(tokens)
+        if tokens:
+            # anything left over means we did not understand the string as a whole
+            raise _SpdxSyntaxError
+    except _SpdxSyntaxError:
+        return None
+    return result
 
 
 def _evaluate_spdx_tokens(tokens: list[str]) -> bool | None:
@@ -542,14 +560,14 @@ def _evaluate_spdx_operand(tokens: list[str]) -> bool | None:
 
     :param tokens: The remaining tokens of the expression.
     """
-    if not tokens:
-        return None
+    if not tokens or tokens[0] == ")" or tokens[0].upper() in ("AND", "OR", "WITH"):
+        raise _SpdxSyntaxError
 
     if tokens[0] == "(":
         tokens.pop(0)
         result = _evaluate_spdx_tokens(tokens)
         if not tokens or tokens.pop(0) != ")":
-            return None
+            raise _SpdxSyntaxError
         return result
 
     identifier = tokens.pop(0).rstrip("+").upper()
@@ -557,7 +575,7 @@ def _evaluate_spdx_operand(tokens: list[str]) -> bool | None:
     if tokens and tokens[0].upper() == "WITH":
         tokens.pop(0)
         if not tokens:
-            return None
+            raise _SpdxSyntaxError
         tokens.pop(0)
 
     if identifier in COMPATIBLE_SPDX_LICENSES:

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -212,6 +212,8 @@ def test_compatible_licenses(license_str: str) -> None:
         ("Internal use only, do not transmit", "Unknown/unverified license"),
         # a value that joins licenses is read as an expression, whichever field it came from
         ("MIT AND Proprietary", "Unknown/unverified license"),
+        ("MIT AND(Proprietary)", "Unknown/unverified license"),
+        ("MIT AND (Proprietary", "Unknown/unverified license"),
         ("Other/Proprietary License", "Unknown/unverified license"),
         # a custom license is never pre-approved, not even when its name reads permissive
         (

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -117,6 +117,10 @@ def test_get_package_license(info: dict[str, Any], expected: str) -> None:
         "Apache 2.0 License",
         # a custom license alongside one we accept still leaves a usable option
         "MIT OR LicenseRef-Proprietary",
+        # an exception only widens what the license allows, so the license itself decides
+        "Zlib WITH LLVM-exception",
+        # prose is matched on its wording; the groups in it are not an expression to refuse
+        "MIT License (a) (b) (c) (d) (e) (f) (g) (h) (i) (j) (k) (l) and so on",
     ],
 )
 def test_compatible_licenses(license_str: str) -> None:
@@ -130,8 +134,13 @@ def test_compatible_licenses(license_str: str) -> None:
     [
         ("GPL-3.0-only", "Incompatible copyleft license (GPL-3.0-only)"),
         ("AGPL-3.0-only", "Incompatible copyleft license (AGPL-3.0-only)"),
-        # a permissive term must not mask a copyleft one it is combined with
+        # a permissive term must not mask a copyleft one it is combined with, whether or not the
+        # expression around it parses
         ("MIT AND GPL-3.0-only", "Incompatible copyleft license (MIT AND GPL-3.0-only)"),
+        ("(GPL-3.0-only AND MIT", "Incompatible copyleft license"),
+        ("LicenseRef-MIT Custom", "Unknown/unverified license"),
+        # only understood in part is not understood: "Zlib" alone would be compatible
+        ("Zlib plus custom terms", "Unknown/unverified license"),
         ("GNU General Public License v3 (GPLv3)", "Incompatible copyleft license"),
         ("Frobnicate-1.0", "Unknown/unverified license (Frobnicate-1.0)"),
         ("Other/Proprietary License", "Unknown/unverified license"),

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -88,7 +88,42 @@ def pypi_info(**overrides: Any) -> dict[str, Any]:
 )
 def test_get_package_license(info: dict[str, Any], expected: str) -> None:
     """Test the license is resolved from any of the fields PyPI exposes it in."""
-    assert get_package_license(info) == expected
+    assert get_package_license(info)[0] == expected
+
+
+@pytest.mark.parametrize(
+    ("info", "expected"),
+    [
+        (pypi_info(license_expression="0BSD"), True),
+        (pypi_info(license="0BSD"), False),
+        (pypi_info(classifiers=["License :: OSI Approved :: MIT License"]), False),
+        (pypi_info(), False),
+    ],
+)
+def test_get_package_license_reports_spdx(info: dict[str, Any], expected: bool) -> None:
+    """Test only a PEP 639 expression is reported as one."""
+    assert get_package_license(info)[1] is expected
+
+
+@pytest.mark.parametrize(
+    ("license_str", "expected"),
+    [
+        # an expression is validated by PyPI, so what the evaluator rejects is simply not allowed,
+        # rather than wording we failed to read
+        ("MIT AND Frobnicate-1.0", False),
+        # a malformed expression names nothing we can check, so it is not compatible either
+        ("MIT OR AND", False),
+        ("MIT OR (Apache-2.0", False),
+        ("BSD-3-Clause-No-Nuclear-License-2014", False),
+        ("LicenseRef-Proprietary", False),
+        ("0BSD", True),
+        ("MIT OR Apache-2.0", True),
+        ("Apache-2.0 WITH LLVM-exception", True),
+    ],
+)
+def test_spdx_expressions_are_not_guessed_at(license_str: str, expected: bool) -> None:
+    """Test an SPDX expression is judged on its identifiers only."""
+    assert check_license_compatibility(license_str, True)[0] is expected
 
 
 @pytest.mark.parametrize(
@@ -138,6 +173,7 @@ def test_compatible_licenses(license_str: str) -> None:
         # expression around it parses
         ("MIT AND GPL-3.0-only", "Incompatible copyleft license (MIT AND GPL-3.0-only)"),
         ("(GPL-3.0-only AND MIT", "Incompatible copyleft license"),
+        ("MIT OR (GPL-3.0-only", "Incompatible copyleft license"),
         ("LicenseRef-MIT Custom", "Unknown/unverified license"),
         # only understood in part is not understood: "Zlib" alone would be compatible
         ("Zlib plus custom terms", "Unknown/unverified license"),

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -113,6 +113,7 @@ def test_get_package_license_reports_spdx(info: dict[str, Any], expected: bool) 
         ("MIT AND Frobnicate-1.0", False),
         # a malformed expression names nothing we can check, so it is not compatible either
         ("MIT OR AND", False),
+        ("MIT WITH OR", False),
         # "or later" is a single marker, not a way to dress up an unknown identifier
         ("MIT++++", False),
         ("LGPL-2.1+", True),
@@ -121,6 +122,8 @@ def test_get_package_license_reports_spdx(info: dict[str, Any], expected: bool) 
         ("LicenseRef-Proprietary", False),
         ("0BSD", True),
         ("MIT OR Apache-2.0", True),
+        # an alternative we do not know does not spoil one we do
+        ("Frobnicate-1.0 OR MIT", True),
         ("Apache-2.0 WITH LLVM-exception", True),
     ],
 )
@@ -157,6 +160,7 @@ def test_spdx_expressions_are_not_guessed_at(license_str: str, expected: bool) -
         "MIT OR LicenseRef-Proprietary",
         # an exception only widens what the license allows, so the license itself decides
         "Zlib WITH LLVM-exception",
+        "LGPL-3.0-only WITH LGPL-3.0-linking-exception",
         # prose is matched on its wording; the groups in it are not an expression to refuse
         "MIT License (a) (b) (c) (d) (e) (f) (g) (h) (i) (j) (k) (l) and so on",
     ],
@@ -183,6 +187,9 @@ def test_compatible_licenses(license_str: str) -> None:
         ("GNU General Public License v3 (GPLv3)", "Incompatible copyleft license"),
         # an LGPL term in the string does not excuse a GPL one standing next to it
         ("LGPL plus GPL terms", "Incompatible copyleft license"),
+        # an exception widens a license, so a copyleft one cannot be hiding behind "WITH"
+        ("MIT WITH GPL-3.0-only", "Incompatible copyleft license"),
+        ("Apache-2.0 AND MIT WITH GPL-3.0-only", "Incompatible copyleft license"),
         ("LGPL-2.1-or-later AND GPL-3.0-only", "Incompatible copyleft license"),
         ("Frobnicate-1.0", "Unknown/unverified license (Frobnicate-1.0)"),
         ("Other/Proprietary License", "Unknown/unverified license"),

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -209,6 +209,9 @@ def test_compatible_licenses(license_str: str) -> None:
         ("Redistribution is permitted for internal use only", "Unknown/unverified license"),
         ("SUBMITTED-1.0", "Unknown/unverified license"),
         ("Mitigation License 1.0", "Unknown/unverified license"),
+        # a name that merely starts like one we know is not that license
+        ("MITX", "Unknown/unverified license"),
+        ("ISC2", "Unknown/unverified license"),
         ("Internal use only, do not transmit", "Unknown/unverified license"),
         # a value that joins licenses is read as an expression, whichever field it came from
         ("MIT AND Proprietary", "Unknown/unverified license"),

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -51,6 +51,25 @@ def pypi_info(**overrides: Any) -> dict[str, Any]:
             pypi_info(classifiers=["Programming Language :: Python", "License :: OSI Approved"]),
             "Unknown",
         ),
+        # several classifiers: the one that fails the check decides, whatever its position
+        (
+            pypi_info(
+                classifiers=[
+                    "License :: OSI Approved :: MIT License",
+                    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+                ]
+            ),
+            "GNU General Public License v3 (GPLv3)",
+        ),
+        (
+            pypi_info(
+                classifiers=[
+                    "License :: OSI Approved :: Apache Software License",
+                    "License :: OSI Approved :: MIT License",
+                ]
+            ),
+            "Apache Software License",
+        ),
         # nothing at all to go on
         (pypi_info(), "Unknown"),
         (pypi_info(license="   "), "Unknown"),
@@ -85,6 +104,8 @@ def test_get_package_license(info: dict[str, Any], expected: str) -> None:
         # spelling variants of the same licenses
         "MPL 2.0",
         "Apache 2.0 License",
+        # a custom license alongside one we accept still leaves a usable option
+        "MIT OR LicenseRef-Proprietary",
     ],
 )
 def test_compatible_licenses(license_str: str) -> None:
@@ -102,8 +123,15 @@ def test_compatible_licenses(license_str: str) -> None:
         ("MIT AND GPL-3.0-only", "Incompatible copyleft license (MIT AND GPL-3.0-only)"),
         ("GNU General Public License v3 (GPLv3)", "Incompatible copyleft license"),
         ("Frobnicate-1.0", "Unknown/unverified license (Frobnicate-1.0)"),
+        # a custom license is never pre-approved, not even when its name reads permissive
+        (
+            "LicenseRef-Proprietary-MIT-Terms",
+            "Unknown/unverified license (LicenseRef-Proprietary-MIT-Terms)",
+        ),
         ("Unknown", "No license information"),
         ("", "No license information"),
+        # nesting deep enough to exhaust the stack is refused, not approved on the name inside
+        ("(" * 333 + "MIT" + ")" * 333, "Unknown/unverified license"),
     ],
 )
 def test_incompatible_licenses(license_str: str, expected_status: str) -> None:

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -1,0 +1,139 @@
+"""Tests for the license checks of the package safety script."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from scripts import check_package_safety
+from scripts.check_package_safety import (
+    check_license_compatibility,
+    check_package,
+    get_package_license,
+)
+
+
+def pypi_info(**overrides: Any) -> dict[str, Any]:
+    """
+    Return the `info` section of a PyPI JSON response.
+
+    :param overrides: Fields to set on top of the (empty) license metadata.
+    """
+    return {"license": None, "license_expression": None, "classifiers": [], **overrides}
+
+
+@pytest.mark.parametrize(
+    ("info", "expected"),
+    [
+        # PEP 639: the SPDX expression is the only license metadata (chardet 7.6.0)
+        (pypi_info(license_expression="0BSD"), "0BSD"),
+        (pypi_info(license_expression="MIT OR Apache-2.0"), "MIT OR Apache-2.0"),
+        # the SPDX expression wins over the less precise legacy field and classifiers
+        (
+            pypi_info(
+                license_expression="AGPL-3.0-only",
+                classifiers=["License :: OSI Approved :: GNU Affero General Public License v3"],
+            ),
+            "AGPL-3.0-only",
+        ),
+        # packages without an SPDX expression fall back to those
+        (pypi_info(license="Apache-2.0"), "Apache-2.0"),
+        (pypi_info(classifiers=["License :: OSI Approved :: MIT License"]), "MIT License"),
+        (
+            pypi_info(
+                license="Apache-2.0",
+                classifiers=["License :: OSI Approved :: Apache Software License"],
+            ),
+            "Apache-2.0",
+        ),
+        (
+            pypi_info(classifiers=["Programming Language :: Python", "License :: OSI Approved"]),
+            "Unknown",
+        ),
+        # nothing at all to go on
+        (pypi_info(), "Unknown"),
+        (pypi_info(license="   "), "Unknown"),
+    ],
+)
+def test_get_package_license(info: dict[str, Any], expected: str) -> None:
+    """Test the license is resolved from any of the fields PyPI exposes it in."""
+    assert get_package_license(info) == expected
+
+
+@pytest.mark.parametrize(
+    "license_str",
+    [
+        # SPDX identifiers as used in a PEP 639 expression
+        "0BSD",
+        "MIT",
+        "MIT-0",
+        "Apache-2.0",
+        "BSD-3-Clause",
+        "MPL-2.0",
+        "LGPL-2.1-or-later",
+        "MIT OR Apache-2.0",
+        "Apache-2.0 OR BSD-3-Clause",
+        "BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0",
+        "MPL-2.0 AND (Apache-2.0 OR MIT)",
+        "Apache-2.0 AND Apache-2.0 WITH LLVM-exception AND BSD-2-Clause AND MIT",
+        # legacy license strings and classifier names keep working
+        "BSD",
+        "MIT License",
+        "Apache Software License",
+        "GNU Lesser General Public License v3 (LGPLv3)",
+        # spelling variants of the same licenses
+        "MPL 2.0",
+        "Apache 2.0 License",
+    ],
+)
+def test_compatible_licenses(license_str: str) -> None:
+    """Test permissive licenses are accepted."""
+    compatible, status = check_license_compatibility(license_str)
+    assert compatible, status
+
+
+@pytest.mark.parametrize(
+    ("license_str", "expected_status"),
+    [
+        ("GPL-3.0-only", "Incompatible copyleft license (GPL-3.0-only)"),
+        ("AGPL-3.0-only", "Incompatible copyleft license (AGPL-3.0-only)"),
+        # a permissive term must not mask a copyleft one it is combined with
+        ("MIT AND GPL-3.0-only", "Incompatible copyleft license (MIT AND GPL-3.0-only)"),
+        ("GNU General Public License v3 (GPLv3)", "Incompatible copyleft license"),
+        ("Frobnicate-1.0", "Unknown/unverified license (Frobnicate-1.0)"),
+        ("Unknown", "No license information"),
+        ("", "No license information"),
+    ],
+)
+def test_incompatible_licenses(license_str: str, expected_status: str) -> None:
+    """Test copyleft and unrecognised licenses are rejected."""
+    compatible, status = check_license_compatibility(license_str)
+    assert not compatible
+    assert status.startswith(expected_status)
+
+
+def test_check_package_reads_license_expression(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test a package that only declares an SPDX expression passes the license check."""
+    metadata = {
+        "info": {
+            "version": "7.6.0",
+            "license": None,
+            "license_expression": "0BSD",
+            "classifiers": [],
+            "author": "Dan Blanchard",
+            "summary": "Universal encoding detector",
+            "project_urls": {"Homepage": "https://github.com/chardet/chardet"},
+        },
+        "releases": {
+            f"{major}.0.0": [{"upload_time": "2015-01-01T00:00:00"}] for major in range(1, 5)
+        },
+    }
+    monkeypatch.setattr(check_package_safety, "get_pypi_metadata", lambda _: metadata)
+
+    result = check_package("chardet")
+
+    assert result["license"] == "0BSD"
+    assert result["automated_checks"]["license_compatible"]
+    assert result["check_details"]["license"] == "Compatible (0BSD)"
+    assert not [warning for warning in result["warnings"] if "License" in warning]

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -70,6 +70,17 @@ def pypi_info(**overrides: Any) -> dict[str, Any]:
             ),
             "Apache Software License",
         ),
+        # two-part classifiers name a license too, and must not be hidden by a permissive one
+        (
+            pypi_info(
+                classifiers=[
+                    "License :: Other/Proprietary License",
+                    "License :: OSI Approved :: MIT License",
+                ]
+            ),
+            "Other/Proprietary License",
+        ),
+        (pypi_info(classifiers=["License :: Public Domain"]), "Public Domain"),
         # nothing at all to go on
         (pypi_info(), "Unknown"),
         (pypi_info(license="   "), "Unknown"),
@@ -123,6 +134,7 @@ def test_compatible_licenses(license_str: str) -> None:
         ("MIT AND GPL-3.0-only", "Incompatible copyleft license (MIT AND GPL-3.0-only)"),
         ("GNU General Public License v3 (GPLv3)", "Incompatible copyleft license"),
         ("Frobnicate-1.0", "Unknown/unverified license (Frobnicate-1.0)"),
+        ("Other/Proprietary License", "Unknown/unverified license"),
         # a custom license is never pre-approved, not even when its name reads permissive
         (
             "LicenseRef-Proprietary-MIT-Terms",

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -154,6 +154,8 @@ def test_spdx_expressions_are_not_guessed_at(license_str: str, expected: bool) -
         "Apache Software License",
         "GNU Lesser General Public License v3 (LGPLv3)",
         "ISC License (ISCL)",
+        "PSFL",
+        "LGPLv2+",
         "The MIT License (MIT)",
         "CC0 1.0 Universal",
         # spelling variants of the same licenses
@@ -199,6 +201,8 @@ def test_compatible_licenses(license_str: str) -> None:
         ("This copyright notice shall be included in all copies", "Unknown/unverified license"),
         ("Redistribution is permitted for internal use only", "Unknown/unverified license"),
         ("SUBMITTED-1.0", "Unknown/unverified license"),
+        ("Mitigation License 1.0", "Unknown/unverified license"),
+        ("Internal use only, do not transmit", "Unknown/unverified license"),
         ("Other/Proprietary License", "Unknown/unverified license"),
         # a custom license is never pre-approved, not even when its name reads permissive
         (

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -113,6 +113,9 @@ def test_get_package_license_reports_spdx(info: dict[str, Any], expected: bool) 
         ("MIT AND Frobnicate-1.0", False),
         # a malformed expression names nothing we can check, so it is not compatible either
         ("MIT OR AND", False),
+        # "or later" is a single marker, not a way to dress up an unknown identifier
+        ("MIT++++", False),
+        ("LGPL-2.1+", True),
         ("MIT OR (Apache-2.0", False),
         ("BSD-3-Clause-No-Nuclear-License-2014", False),
         ("LicenseRef-Proprietary", False),
@@ -178,6 +181,9 @@ def test_compatible_licenses(license_str: str) -> None:
         # only understood in part is not understood: "Zlib" alone would be compatible
         ("Zlib plus custom terms", "Unknown/unverified license"),
         ("GNU General Public License v3 (GPLv3)", "Incompatible copyleft license"),
+        # an LGPL term in the string does not excuse a GPL one standing next to it
+        ("LGPL plus GPL terms", "Incompatible copyleft license"),
+        ("LGPL-2.1-or-later AND GPL-3.0-only", "Incompatible copyleft license"),
         ("Frobnicate-1.0", "Unknown/unverified license (Frobnicate-1.0)"),
         ("Other/Proprietary License", "Unknown/unverified license"),
         # a custom license is never pre-approved, not even when its name reads permissive

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -156,6 +156,7 @@ def test_spdx_expressions_are_not_guessed_at(license_str: str, expected: bool) -
         "ISC License (ISCL)",
         "PSFL",
         "LGPLv2+",
+        "Public Domain",
         # a plain license field can hold an expression too (aiohttp publishes this one)
         "Apache-2.0 AND MIT",
         # ...while prose that merely contains the word "and" is still matched on its wording
@@ -211,6 +212,8 @@ def test_compatible_licenses(license_str: str) -> None:
         ("Mitigation License 1.0", "Unknown/unverified license"),
         # a name that merely starts like one we know is not that license
         ("MITX", "Unknown/unverified license"),
+        # prose that says the opposite of the license it names
+        ("This software is not in the public domain. All rights reserved.", "Unknown/unverified"),
         ("ISC2", "Unknown/unverified license"),
         ("Internal use only, do not transmit", "Unknown/unverified license"),
         # a value that joins licenses is read as an expression, whichever field it came from

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -156,6 +156,13 @@ def test_spdx_expressions_are_not_guessed_at(license_str: str, expected: bool) -
         "ISC License (ISCL)",
         "PSFL",
         "LGPLv2+",
+        # a plain license field can hold an expression too (aiohttp publishes this one)
+        "Apache-2.0 AND MIT",
+        # ...while prose that merely contains the word "and" is still matched on its wording
+        "MIT License\n\nPermission is hereby granted, free of charge, to any person obtaining a"
+        " copy of this software and associated documentation files, to deal in the Software"
+        " without restriction, including without limitation the rights to use and to permit"
+        " persons to whom the Software is furnished to do so.",
         "The MIT License (MIT)",
         "CC0 1.0 Universal",
         # spelling variants of the same licenses
@@ -203,6 +210,8 @@ def test_compatible_licenses(license_str: str) -> None:
         ("SUBMITTED-1.0", "Unknown/unverified license"),
         ("Mitigation License 1.0", "Unknown/unverified license"),
         ("Internal use only, do not transmit", "Unknown/unverified license"),
+        # a value that joins licenses is read as an expression, whichever field it came from
+        ("MIT AND Proprietary", "Unknown/unverified license"),
         ("Other/Proprietary License", "Unknown/unverified license"),
         # a custom license is never pre-approved, not even when its name reads permissive
         (

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -153,6 +153,9 @@ def test_spdx_expressions_are_not_guessed_at(license_str: str, expected: bool) -
         "MIT License",
         "Apache Software License",
         "GNU Lesser General Public License v3 (LGPLv3)",
+        "ISC License (ISCL)",
+        "The MIT License (MIT)",
+        "CC0 1.0 Universal",
         # spelling variants of the same licenses
         "MPL 2.0",
         "Apache 2.0 License",
@@ -192,6 +195,10 @@ def test_compatible_licenses(license_str: str) -> None:
         ("Apache-2.0 AND MIT WITH GPL-3.0-only", "Incompatible copyleft license"),
         ("LGPL-2.1-or-later AND GPL-3.0-only", "Incompatible copyleft license"),
         ("Frobnicate-1.0", "Unknown/unverified license (Frobnicate-1.0)"),
+        # a license name has to be named, not spelled out by unrelated words running together
+        ("This copyright notice shall be included in all copies", "Unknown/unverified license"),
+        ("Redistribution is permitted for internal use only", "Unknown/unverified license"),
+        ("SUBMITTED-1.0", "Unknown/unverified license"),
         ("Other/Proprietary License", "Unknown/unverified license"),
         # a custom license is never pre-approved, not even when its name reads permissive
         (


### PR DESCRIPTION
# What does this implement/fix?

The dependency security workflow flagged dependency bumps as having "no license information" for packages that are perfectly fine. Packages that moved to the modern packaging standard (PEP 639) publish their license as an SPDX expression in a new field, and the safety check only looked at the old field. Anything that had made the switch came back as unknown, turning the security status red and requiring a manual review label.

This hit `chardet` in #5724 (its license is `0BSD`, one of the most permissive there is). Checking all 112 of our dependencies against PyPI, 46 were being flagged; with this change 10 are, and all 10 are correct (7 are genuinely GPL/AGPL, 3 publish no license at all).

## Changes

- Read the license from the SPDX field first, then the old license field, then the license classifiers
- Understand SPDX license expressions such as `0BSD`, `MIT OR Apache-2.0` and `MPL-2.0 AND (Apache-2.0 OR MIT)`
- Judge those expressions on the licenses they name, instead of guessing from the wording
- Stop a permissive license name from hiding a restrictive one next to it, in an expression, in the classifiers, or behind a `WITH`
- Match license names as whole words, so `MPL 2.0` is recognised while `permitted` and `this copyright` are not
- Added tests for the license lookup and the compatibility check

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

