### PR TITLE
Clean up unused source options on Sonos S1 speakers

### DIFF
--- a/music_assistant/providers/sonos_s1/constants.py
+++ b/music_assistant/providers/sonos_s1/constants.py
@@ -3,13 +3,7 @@
 from __future__ import annotations
 
 from music_assistant_models.enums import PlaybackState, PlayerFeature
-from soco.core import (
-    MUSIC_SRC_AIRPLAY,
-    MUSIC_SRC_LINE_IN,
-    MUSIC_SRC_RADIO,
-    MUSIC_SRC_SPOTIFY_CONNECT,
-    MUSIC_SRC_TV,
-)
+from soco.core import MUSIC_SRC_LINE_IN, MUSIC_SRC_TV
 
 from music_assistant.models.player import PlayerSource
 
@@ -29,27 +23,15 @@ PLAYER_FEATURES = (
 )
 
 # Source Mapping
-SOURCES_MAP = {
-    MUSIC_SRC_LINE_IN: "Line-in",
-    MUSIC_SRC_TV: "TV",
-    MUSIC_SRC_RADIO: "Radio",
-    MUSIC_SRC_SPOTIFY_CONNECT: "Spotify",
-    MUSIC_SRC_AIRPLAY: "AirPlay",
-}
-
-SOURCE_AIRPLAY = "AirPlay"
 SOURCE_LINEIN = "Line-in"
-SOURCE_SPOTIFY_CONNECT = "Spotify Connect"
 SOURCE_TV = "TV"
 
-SOURCE_MAPPING = {
-    MUSIC_SRC_AIRPLAY: SOURCE_AIRPLAY,
+# Line-in and TV are the only sources this provider can report or switch to.
+LINEIN_SOURCE_MAPPING = {
     MUSIC_SRC_TV: SOURCE_TV,
     MUSIC_SRC_LINE_IN: SOURCE_LINEIN,
-    MUSIC_SRC_SPOTIFY_CONNECT: SOURCE_SPOTIFY_CONNECT,
 }
 
-LINEIN_SOURCES = (MUSIC_SRC_TV, MUSIC_SRC_LINE_IN)
 LINEIN_SOURCE_IDS = (SOURCE_TV, SOURCE_LINEIN)
 
 PLAYER_SOURCE_MAP = {
@@ -68,22 +50,6 @@ PLAYER_SOURCE_MAP = {
         can_play_pause=False,
         can_next_previous=False,
         can_seek=False,
-    ),
-    SOURCE_AIRPLAY: PlayerSource(
-        id=SOURCE_AIRPLAY,
-        name="AirPlay",
-        passive=True,
-        can_play_pause=True,
-        can_next_previous=True,
-        can_seek=True,
-    ),
-    SOURCE_SPOTIFY_CONNECT: PlayerSource(
-        id=SOURCE_SPOTIFY_CONNECT,
-        name="Spotify Connect",
-        passive=True,
-        can_play_pause=True,
-        can_next_previous=True,
-        can_seek=True,
     ),
 }
 

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -793,8 +793,8 @@ class SonosPlayer(Player):
             return
         uri = track_info["uri"]
         if not uri:
-            # an empty transport means nothing is loaded, so no source is active either;
-            # stopping a line-in source clears the transport, so this is a normal path
+            # no current track means nothing is loaded, so no source is active either.
+            # Stopping a line-in source empties the transport, so this is a normal path.
             self._attr_elapsed_time = None
             self._attr_elapsed_time_last_updated = None
             self._attr_active_source = None

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -32,7 +32,7 @@ from .constants import (
     COMMAND_POLL_DELAY,
     DURATION_SECONDS,
     LINEIN_SOURCE_IDS,
-    LINEIN_SOURCES,
+    LINEIN_SOURCE_MAPPING,
     NEVER_TIME,
     PLAYER_FEATURES,
     PLAYER_SOURCE_MAP,
@@ -41,7 +41,6 @@ from .constants import (
     RESUB_COOLDOWN_SECONDS,
     SONOS_STATE_TRANSITIONING,
     SOURCE_LINEIN,
-    SOURCE_MAPPING,
     SOURCE_TV,
     SUBSCRIPTION_SERVICES,
     SUBSCRIPTION_TIMEOUT,
@@ -792,12 +791,18 @@ class SonosPlayer(Player):
         except SonosUpdateError as err:
             self.logger.warning("Fetching track info failed: %s", err)
             return
-        if not track_info["uri"]:
-            return
         uri = track_info["uri"]
+        if not uri:
+            # an empty transport means nothing is loaded, so no source is active either;
+            # stopping a line-in source clears the transport, so this is a normal path
+            self._attr_elapsed_time = None
+            self._attr_elapsed_time_last_updated = None
+            self._attr_active_source = None
+            self._attr_current_media = None
+            return
 
         audio_source = self.soco.music_source_from_uri(uri)
-        if (source_id := SOURCE_MAPPING.get(audio_source)) and audio_source in LINEIN_SOURCES:
+        if source_id := LINEIN_SOURCE_MAPPING.get(audio_source):
             self._attr_elapsed_time = None
             self._attr_elapsed_time_last_updated = None
             self._attr_active_source = source_id

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -175,9 +175,9 @@ def _set_transport_state(sonos_player: SonosPlayer, state: str) -> None:
     sonos_player.soco.get_current_transport_info.return_value = {"current_transport_state": state}
 
 
-def _set_track_uri(sonos_player: SonosPlayer, uri: str) -> None:
+def _set_track_info(sonos_player: SonosPlayer, uri: str, position: str = "") -> None:
     """Make the mocked speaker report the given track uri, classified as SoCo would."""
-    sonos_player.soco.get_current_track_info.return_value = {"uri": uri}
+    sonos_player.soco.get_current_track_info.return_value = {"uri": uri, "position": position}
     sonos_player.soco.music_source_from_uri = SoCo.music_source_from_uri
 
 
@@ -218,7 +218,7 @@ def test_transitional_event_shortens_the_poll_interval(sonos_player: SonosPlayer
 
 def test_line_in_is_reported_as_the_active_source(sonos_player: SonosPlayer) -> None:
     """A speaker playing line-in reports it as its source and offers it in the source list."""
-    _set_track_uri(sonos_player, "x-rincon-stream:RINCON_000E58AAAAAA01400")
+    _set_track_info(sonos_player, "x-rincon-stream:RINCON_000E58AAAAAA01400")
 
     sonos_player._set_basic_track_info()
 
@@ -228,19 +228,31 @@ def test_line_in_is_reported_as_the_active_source(sonos_player: SonosPlayer) -> 
 
 def test_source_is_cleared_once_the_speaker_has_nothing_loaded(sonos_player: SonosPlayer) -> None:
     """Stopping line-in empties the transport, which must not leave the source behind."""
-    _set_track_uri(sonos_player, "x-rincon-stream:RINCON_000E58AAAAAA01400")
+    _set_track_info(sonos_player, "x-rincon-stream:RINCON_000E58AAAAAA01400")
     sonos_player._set_basic_track_info()
 
-    _set_track_uri(sonos_player, "")
+    _set_track_info(sonos_player, "")
     sonos_player._set_basic_track_info()
 
     assert sonos_player._attr_active_source is None
+
+
+def test_media_is_cleared_once_the_speaker_has_nothing_loaded(sonos_player: SonosPlayer) -> None:
+    """A stopped speaker must not keep reporting the track it was playing."""
+    _set_track_info(sonos_player, "http://192.168.1.2:8097/track.flac", position="0:00:42")
+    sonos_player._set_basic_track_info()
+
+    _set_track_info(sonos_player, "")
+    sonos_player._set_basic_track_info()
+
     assert sonos_player._attr_current_media is None
+    assert sonos_player._attr_elapsed_time is None
+    assert sonos_player._attr_elapsed_time_last_updated is None
 
 
 def test_spotify_connect_is_not_reported_as_a_source(sonos_player: SonosPlayer) -> None:
-    """S1 speakers cannot be controlled while streamed to, so such sources stay unreported."""
-    _set_track_uri(sonos_player, "x-sonos-vli:RINCON_000E58AAAAAA01400:2,spotify:abc")
+    """Line-in and TV are the only sources this provider reports."""
+    _set_track_info(sonos_player, "x-sonos-vli:RINCON_000E58AAAAAA01400:2,spotify:abc")
 
     sonos_player._set_basic_track_info()
 

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from music_assistant_models.enums import IdentifierType, MediaType, PlaybackState
 from music_assistant_models.errors import PlayerCommandFailed
+from soco.core import SoCo
 from soco.exceptions import SoCoException
 
 from music_assistant.mass import MusicAssistant
@@ -20,6 +21,7 @@ from music_assistant.providers.sonos_s1 import player as player_module
 from music_assistant.providers.sonos_s1.constants import (
     AVAILABILITY_TIMEOUT,
     POLL_INTERVAL,
+    SOURCE_LINEIN,
     SUBSCRIPTION_SERVICES,
     TRANSITION_POLL_INTERVAL,
 )
@@ -173,6 +175,12 @@ def _set_transport_state(sonos_player: SonosPlayer, state: str) -> None:
     sonos_player.soco.get_current_transport_info.return_value = {"current_transport_state": state}
 
 
+def _set_track_uri(sonos_player: SonosPlayer, uri: str) -> None:
+    """Make the mocked speaker report the given track uri, classified as SoCo would."""
+    sonos_player.soco.get_current_track_info.return_value = {"uri": uri}
+    sonos_player.soco.music_source_from_uri = SoCo.music_source_from_uri
+
+
 def test_transitional_state_shortens_the_poll_interval(sonos_player: SonosPlayer) -> None:
     """A transitional transport state keeps the last known state and is watched closely."""
     sonos_player._attr_playback_state = PlaybackState.IDLE
@@ -206,6 +214,38 @@ def test_transitional_event_shortens_the_poll_interval(sonos_player: SonosPlayer
     sonos_player._handle_avtransport_event(event)
 
     assert sonos_player.poll_interval == TRANSITION_POLL_INTERVAL
+
+
+def test_line_in_is_reported_as_the_active_source(sonos_player: SonosPlayer) -> None:
+    """A speaker playing line-in reports it as its source and offers it in the source list."""
+    _set_track_uri(sonos_player, "x-rincon-stream:RINCON_000E58AAAAAA01400")
+
+    sonos_player._set_basic_track_info()
+
+    assert sonos_player._attr_active_source == SOURCE_LINEIN
+    assert [source.id for source in sonos_player._attr_source_list] == [SOURCE_LINEIN]
+
+
+def test_source_is_cleared_once_the_speaker_has_nothing_loaded(sonos_player: SonosPlayer) -> None:
+    """Stopping line-in empties the transport, which must not leave the source behind."""
+    _set_track_uri(sonos_player, "x-rincon-stream:RINCON_000E58AAAAAA01400")
+    sonos_player._set_basic_track_info()
+
+    _set_track_uri(sonos_player, "")
+    sonos_player._set_basic_track_info()
+
+    assert sonos_player._attr_active_source is None
+    assert sonos_player._attr_current_media is None
+
+
+def test_spotify_connect_is_not_reported_as_a_source(sonos_player: SonosPlayer) -> None:
+    """S1 speakers cannot be controlled while streamed to, so such sources stay unreported."""
+    _set_track_uri(sonos_player, "x-sonos-vli:RINCON_000E58AAAAAA01400:2,spotify:abc")
+
+    sonos_player._set_basic_track_info()
+
+    assert sonos_player._attr_active_source is None
+    assert sonos_player._attr_source_list == []
 
 
 async def test_repeated_commands_collapse_to_one_pending_poll(


### PR DESCRIPTION
# What does this implement/fix?

The Sonos S1 provider defined AirPlay and Spotify Connect as selectable player sources, but they could never actually be reported — the code that fills the source list only ever handles Line-in and TV. S1 speakers also can't be paused or skipped while something else is streaming to them, so advertising those sources would have been wrong anyway.

Also noticed while cleaning up: when a Sonos S1 speaker has nothing loaded (after stopping Line-in or TV), the provider held on to the source and track it last saw. Nothing visible in the UI today, but a follow-up stop command took a needless detour because of it. That state is now cleared.

## Changes

- Removed the AirPlay and Spotify Connect source definitions (plus a leftover unused source table)
- Clear the remembered source, track and position when the speaker has nothing loaded
- Added tests covering Line-in, the cleared state, and the unsupported sources

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
