### PR TITLE
Handle servers that declare an unusable character set

### DIFF
--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -300,13 +300,9 @@ async def fetch_playlist(
         async with mass.http_session.get(
             encoded_request_url(url), allow_redirects=True, timeout=ClientTimeout(total=5)
         ) as resp:
-            try:
-                raw_data = await resp.content.read(64 * 1024)
-                encoding = await detect_charset(raw_data, preferred=resp.charset)
-                playlist_data = raw_data.decode(encoding, errors="replace")
-            except (ValueError, UnicodeDecodeError) as err:
-                msg = f"Could not decode playlist {url}"
-                raise InvalidDataError(msg) from err
+            raw_data = await resp.content.read(64 * 1024)
+            encoding = await detect_charset(raw_data, preferred=resp.charset)
+            playlist_data = raw_data.decode(encoding, errors="replace")
     except TimeoutError as err:
         msg = f"Timeout while fetching playlist {url}"
         raise InvalidDataError(msg) from err

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1618,12 +1618,13 @@ async def detect_charset(data: bytes, fallback: str = "utf-8", preferred: str | 
         return "utf-8-sig"
 
     if preferred:
-        # a declared charset is only worth anything if Python has a codec for it:
-        # servers do send misspelled or plain made-up names in their Content-Type
+        # a declared charset is only worth anything if Python can actually decode text with
+        # it: servers do send misspelled or plain made-up names in their Content-Type, and a
+        # handful of names that do resolve to a codec still cannot decode text (base64, idna)
         try:
-            codecs.lookup(preferred)
-        except LookupError:
-            LOGGER.debug("Ignoring unknown charset: %s", preferred)
+            data[:16].decode(preferred, errors="replace")
+        except (LookupError, ValueError) as err:
+            LOGGER.debug("Ignoring unusable charset %s: %s", preferred, err)
         else:
             return preferred
 

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -129,6 +129,13 @@ class TestDetectCharset:
         encoding = await detect_charset(raw, preferred="utf8mb4")
         assert raw.decode(encoding) == CYRILLIC_CUE
 
+    @pytest.mark.parametrize("charset", ["base64", "zlib", "rot_13", "idna", "undefined"])
+    async def test_declared_charset_that_cannot_decode_text_is_ignored(self, charset: str) -> None:
+        """A charset name that resolves to a codec but cannot decode text is ignored."""
+        raw = CYRILLIC_CUE.encode("cp1251")
+        encoding = await detect_charset(raw, preferred=charset)
+        assert raw.decode(encoding) == CYRILLIC_CUE
+
 
 class TestGetSourceIpForTarget:
     """get_source_ip_for_target reports the interface the routing table egresses from."""


### PR DESCRIPTION
# What does this implement/fix?

When we fetch a remote playlist or stream, we honour the character set the server declares in its
headers. We only checked that the name was one Python knows, which isn't the same as it being usable
for reading text — a handful of names pass that check but can't decode text at all, and would then
fail at the moment we tried to read the playlist.

We now accept a declared character set only if it can actually decode text, and otherwise fall back
to detecting it from the content, which is what already happens for made-up or misspelled names.

That also makes the error handling around the playlist read redundant, so it's gone.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- `detect_charset` now validates a declared charset by trying it, instead of only looking up the name
- Dropped the now-redundant decode error handler in `fetch_playlist`
- Added tests covering charset names that resolve to a codec but can't decode text

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
