### PR TITLE
Fix pause on Sonos S1 speakers stopping playback instead

### DIFF
--- a/music_assistant/providers/sonos_s1/constants.py
+++ b/music_assistant/providers/sonos_s1/constants.py
@@ -12,8 +12,12 @@ CONF_NETWORK_SCAN = "network_scan"
 CONF_HOUSEHOLD_ID = "household_id"
 
 # Player Features
+# PAUSE is advertised unconditionally: whether a speaker can pause depends on what it has
+# loaded rather than on the model, so pause() reads that back from the speaker itself and
+# falls back to stop when it is refused.
 PLAYER_FEATURES = (
     PlayerFeature.PLAY_MEDIA,
+    PlayerFeature.PAUSE,
     PlayerFeature.SET_MEMBERS,
     PlayerFeature.VOLUME_MUTE,
     PlayerFeature.VOLUME_SET,

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import IdentifierType, MediaType, PlaybackState
+from music_assistant_models.enums import IdentifierType, MediaType, PlaybackState, PlayerFeature
 from music_assistant_models.errors import PlayerCommandFailed
 from soco.core import SoCo
 from soco.exceptions import SoCoException
@@ -142,6 +142,11 @@ class _RecordingSoco:
     def pause(self) -> None:
         """Pause playback on the speaker."""
         self.paused = True
+
+
+def test_pause_is_advertised_as_a_supported_feature(sonos_player: SonosPlayer) -> None:
+    """Without the feature the player controller converts every pause into a stop."""
+    assert PlayerFeature.PAUSE in sonos_player.supported_features
 
 
 async def test_pause_queries_the_speaker_off_the_event_loop(sonos_player: SonosPlayer) -> None:

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -125,6 +125,11 @@ async def test_play_media_builds_didl_from_stream_url(sonos_player: SonosPlayer)
     assert "library://track/123" not in call_args.kwargs["meta"]
 
 
+def test_pause_is_advertised_as_a_supported_feature(sonos_player: SonosPlayer) -> None:
+    """Without the feature the player controller converts every pause into a stop."""
+    assert PlayerFeature.PAUSE in sonos_player.supported_features
+
+
 class _RecordingSoco:
     """Minimal soco stand-in that records the thread its speaker query ran on."""
 
@@ -142,11 +147,6 @@ class _RecordingSoco:
     def pause(self) -> None:
         """Pause playback on the speaker."""
         self.paused = True
-
-
-def test_pause_is_advertised_as_a_supported_feature(sonos_player: SonosPlayer) -> None:
-    """Without the feature the player controller converts every pause into a stop."""
-    assert PlayerFeature.PAUSE in sonos_player.supported_features
 
 
 async def test_pause_queries_the_speaker_off_the_event_loop(sonos_player: SonosPlayer) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Pressing pause on a Sonos S1 speaker stopped playback instead of pausing it. Resuming then had to rebuild the stream from scratch rather than picking up where the speaker left off.

The S1 provider never told Music Assistant that its speakers can pause, even though the pause code was there and working. The player controller only sends pause to players that advertise support for it, so every pause was quietly turned into a stop. The pause button stayed visible and enabled the whole time, since the UI decides that from the active source rather than from the player, which is why this looked like a broken button rather than a missing feature.

The flag was lost in the player model refactor (#2249) and missed by the follow-up fix (#2523), which restored the other features that went with it.

Changes:

- Advertise pause support on Sonos S1 speakers again.
- Added a test so the flag cannot silently disappear a third time.

Speakers that genuinely cannot pause what they are playing, such as line-in and TV, are unaffected: the provider already asks the speaker before pausing and falls back to stop when it refuses.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
