### PR TITLE
Group WiiM and generic LinkPlay speakers together

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1772,12 +1772,17 @@ class Player(ABC):
     @property
     def grouping_locked(self) -> bool:
         """
-        Return whether grouping must be suppressed in this player's exposed state.
+        Return whether ALL grouping must be suppressed in this player's exposed state.
 
-        A provider may lock grouping, for example while a device is in an externally-created
-        cross-backend group that Music Assistant keeps read-only, or while its control API is
-        unreachable. While locked, ``SET_MEMBERS`` is withdrawn and no group targets are
-        offered in the final state, even ones a linked protocol player would otherwise add.
+        This is the broad, final lock: while it holds, ``SET_MEMBERS`` is withdrawn and no
+        group targets are offered in the final state, even ones a linked protocol player
+        would otherwise supply. It must therefore be reserved for a genuinely read-only
+        topology — for example a device in an externally-created cross-backend group that
+        Music Assistant keeps read-only — and NOT used merely because a device's own native
+        grouping capability is unavailable. A provider that only wants to disable its native
+        grouping path (e.g. while its control API is unreachable) should instead withhold the
+        native ``SET_MEMBERS`` from ``supported_features`` and return no native
+        ``can_group_with`` candidates, leaving core free to still group via a linked protocol.
         """
         return False
 

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -774,7 +774,7 @@ class NativeGroupCoordinator:
             slaves = await client.get_slaves_info()
         except WiiMError as err:
             raise PlayerCommandFailed(
-                f"Failed to read the slave list of leader {member.player_id}'s group: {err}"
+                f"Failed to read the leader's slave list while resolving {member.player_id}: {err}"
             ) from err
         for slave in slaves:
             if (

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -118,8 +118,12 @@ class NativeGroupCoordinator:
         Return every reachable peer of either backend this player may group with.
 
         Core applies the final grouping filter and auto-ungroups a known follower before
-        regrouping it, so only a follower of a leader MA has NOT discovered is excluded
-        here (it cannot be cleanly moved); every other reachable peer is a candidate.
+        regrouping it. A follower of a leader MA has NOT discovered is excluded (it cannot
+        be cleanly moved), and two generic devices are only paired when they share a known,
+        matching router-based multiroom generation, so the UI never offers a generic pair
+        that the command path would then reject. Cross-backend generation cannot be known
+        without a device read, so those pairs stay candidates and fail closed at command
+        time if incompatible.
 
         :param player: The player requesting its grouping candidates.
         """
@@ -133,6 +137,7 @@ class NativeGroupCoordinator:
             if peer.native_available
             and peer.player_id != player.player_id
             and not self._is_unknown_leader_follower(peer.player_id)
+            and self._offerable_pair(player, peer)
         }
 
     # --- Topology feeders ---
@@ -275,6 +280,14 @@ class NativeGroupCoordinator:
             affected: dict[str, NativePlayer] = {leader.player_id: leader}
             for member in (*add_members, *remove_members):
                 affected[member.player_id] = member
+                # joining a member dissolves any group it currently leads, so its followers
+                # are mutated too and must be locked against a concurrent address rebuild.
+                for follower_id in self.members_of(member.player_id):
+                    if follower_id == member.player_id:
+                        continue
+                    follower = self._mass.players.get_player(follower_id)
+                    if getattr(follower, "linkplay_backend", None) in _NATIVE_BACKENDS:
+                        affected[follower_id] = cast("NativePlayer", follower)
             async with AsyncExitStack() as stack:
                 for player_id in sorted(affected):
                     if (lock := self._rebuild_lock_for(affected[player_id])) is not None:
@@ -293,12 +306,14 @@ class NativeGroupCoordinator:
         try:
             # full validation before any hardware mutation, so an unknown, unreachable or
             # generation-incompatible target fails the whole request before any speaker has
-            # joined or left, rather than leaving a partially formed group behind.
+            # joined or left, rather than leaving a partially mutated group behind.
             self._guard_regroupable(leader)
             join_plan: dict[str, tuple[DeviceInfo | None, DeviceInfo | None] | None] = {}
             for member in add_members:
                 self._guard_regroupable(member)
                 join_plan[member.player_id] = await self._prevalidate_join(leader, member)
+            for member in remove_members:
+                self._prevalidate_leave(leader, member)
             for member in add_members:
                 await self._join(leader, member, join_plan[member.player_id])
             for member in remove_members:
@@ -355,6 +370,25 @@ class NativeGroupCoordinator:
             )
         return leader_info, member_info
 
+    def _prevalidate_leave(self, leader: NativePlayer, member: NativePlayer) -> None:
+        """
+        Validate a removal before any mutation, so a bad target fails the whole batch.
+
+        A same-backend generic follower leaves over its own client, so an unreachable one
+        cannot be detached and must fail up front rather than half-way through the batch.
+        Cross-backend and official removals go through the always-reachable leader (SDK
+        ungroup or leader-side kick), so the follower's own reachability is not required.
+
+        :param leader: The leader the member would leave.
+        :param member: The member that would leave the leader.
+        """
+        if (
+            leader.linkplay_backend == BACKEND_GENERIC
+            and member.linkplay_backend == BACKEND_GENERIC
+            and not member.native_available
+        ):
+            raise PlayerCommandFailed(f"{member.player_id} is not reachable to leave its group")
+
     def _native_players(self) -> list[NativePlayer]:
         """Return this provider's players that belong to either native backend."""
         return [
@@ -369,6 +403,24 @@ class NativeGroupCoordinator:
             self.role_of(player_id) == NativeGroupRole.FOLLOWER
             and self.leader_of(player_id) is None
         )
+
+    def _offerable_pair(self, player: NativePlayer, peer: NativePlayer) -> bool:
+        """
+        Return whether two players may be offered as a grouping pair in the UI.
+
+        Two generic devices are only offered when their cached generations are both known,
+        router-based and matching; any pair involving an official device is offered and
+        validated at command time, where the live device generation is read.
+
+        :param player: The player requesting candidates.
+        :param peer: The candidate peer being considered.
+        """
+        if player.linkplay_backend == BACKEND_GENERIC and peer.linkplay_backend == BACKEND_GENERIC:
+            return linkplay_group_compatible(
+                getattr(player, "cached_device_info", None),
+                getattr(peer, "cached_device_info", None),
+            )
+        return True
 
     def _rebuild(self) -> None:
         """Recompute roles and membership, then push state to every changed player."""

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -118,18 +118,20 @@ class NativeGroupCoordinator:
         Return every reachable peer of either backend this player may group with.
 
         Core applies the final grouping filter and auto-ungroups a known follower before
-        regrouping it. A follower of a leader MA has NOT discovered is excluded (it cannot
-        be cleanly moved), and two generic devices are only paired when they share a known,
-        matching router-based multiroom generation, so the UI never offers a generic pair
-        that the command path would then reject. Cross-backend generation cannot be known
-        without a device read, so those pairs stay candidates and fail closed at command
-        time if incompatible.
+        regrouping it. A device whose own native grouping API is unreachable offers no native
+        peers (grouping via a linked protocol is decided separately by core), and a follower
+        of a leader MA has NOT discovered is excluded (it cannot be cleanly moved). Two generic
+        devices are only paired when they share a known, matching router-based multiroom
+        generation, so the UI never offers a generic pair that the command path would then
+        reject. Cross-backend generation cannot be known without a device read, so those pairs
+        stay candidates and fail closed at command time if incompatible.
 
         :param player: The player requesting its grouping candidates.
         """
-        if self._is_unknown_leader_follower(player.player_id):
-            # this device follows a group MA has not discovered: it cannot be cleanly
-            # detached, so it must not be offered any grouping candidates of its own.
+        if not player.native_available or self._is_unknown_leader_follower(player.player_id):
+            # the requesting device cannot lead a native group right now (its grouping API is
+            # unreachable, or it follows a group MA has not discovered and cannot be moved),
+            # so it offers no native candidates of its own.
             return set()
         return {
             peer.player_id

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -475,14 +475,19 @@ class NativeGroupCoordinator:
         """
         Validate a removal before any mutation, so a bad target fails the whole batch.
 
-        A same-backend generic follower leaves over its own client, so an unreachable one
-        cannot be detached and must fail up front rather than half-way through the batch.
+        Only a member the leader still owns is actually detached; one the freshly refreshed
+        leader no longer lists (moved away or absent) is an idempotent skip in :meth:`_leave`,
+        so its reachability is irrelevant and must not abort the batch. For a member still
+        owned, a same-backend generic follower leaves over its own client, so an unreachable
+        one cannot be detached and fails up front rather than half-way through the batch.
         Cross-backend and official removals go through the always-reachable leader (SDK
         ungroup or leader-side kick), so the follower's own reachability is not required.
 
         :param leader: The leader the member would leave.
         :param member: The member that would leave the leader.
         """
+        if member.player_id not in self.members_of(leader.player_id):
+            return
         if (
             leader.linkplay_backend == BACKEND_GENERIC
             and member.linkplay_backend == BACKEND_GENERIC

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -274,13 +274,14 @@ class NativeGroupCoordinator:
         async with self._command_lock:
             add_members = [self._require_member(mid) for mid in player_ids_to_add or []]
             remove_members = [self._require_member(mid) for mid in player_ids_to_remove or []]
-            # read each low-level addition's live group up front: joining it dissolves the
-            # group it currently leads, and a stale cache could miss a follower it gained
-            # since its last refresh, so the lock set and validation below must see the
-            # current followers, not a stale snapshot.
-            for member in add_members:
-                if not self._is_official_pair(leader, member):
-                    await self.refresh_leader(member, force=True)
+            # authoritative preflight: read the leader's and every addition's live group
+            # before deriving any lock or plan, and fail the whole batch if a device's fresh
+            # state cannot be obtained. This ensures a device that externally became a
+            # follower (or gained followers) since its last poll is validated on live state,
+            # never repurposed from a stale cache.
+            for player in (leader, *add_members):
+                if not await self.refresh_leader(player, force=True):
+                    raise PlayerCommandFailed(f"Cannot read the group state of {player.player_id}")
             # a concurrent address rebuild on any involved generic device must not swap its
             # client or move its address mid-command; hold each device's rebuild lock for the
             # whole check/mutate/verify sequence. Acquiring in sorted player-id order gives a
@@ -330,13 +331,6 @@ class NativeGroupCoordinator:
                 )
             for member in remove_members:
                 self._prevalidate_leave(leader, member)
-            # a removal reads the leader's live slave list; confirm it is readable now, before
-            # any join mutates the group, so a combined batch cannot join earlier members and
-            # only then discover the leader is unreadable and leave the group half-applied.
-            if remove_members and not await self.refresh_leader(leader, force=True):
-                raise PlayerCommandFailed(
-                    f"Cannot read the group state of leader {leader.player_id}"
-                )
             for member in add_members:
                 await self._join(leader, member, join_plan[member.player_id])
             for member in remove_members:
@@ -709,12 +703,18 @@ class NativeGroupCoordinator:
             raise PlayerCommandFailed(f"Failed to ungroup {member.player_id}: {err}") from err
 
     async def _leader_slave_ip(self, client: WiiMClient, member: NativePlayer) -> str | None:
-        """Resolve a follower's address from the leader's own slave list."""
+        """
+        Resolve a follower's address from the leader's own slave list.
+
+        Returns ``None`` only when the list is read but does not (yet) contain the member;
+        a failed read raises a chained typed error rather than masquerading as "no address".
+        """
         try:
             slaves = await client.get_slaves_info()
         except WiiMError as err:
-            self._provider.logger.debug("Failed to read leader slave list: %s", err)
-            return None
+            raise PlayerCommandFailed(
+                f"Failed to read the slave list of leader {member.player_id}'s group: {err}"
+            ) from err
         for slave in slaves:
             if (
                 isinstance(slave, dict)
@@ -767,16 +767,19 @@ class NativeGroupCoordinator:
             f"{member.player_id} did not {verb} the group led by {leader.player_id}"
         )
 
-    async def _device_info(self, player: NativePlayer) -> DeviceInfo | None:
+    async def _device_info(self, player: NativePlayer) -> DeviceInfo:
         """
-        Read a player's device info for the compatibility gate, best-effort.
+        Read a player's device info for the compatibility gate.
+
+        A failed read raises a chained typed error rather than being collapsed into a
+        "None" that the compatibility gate would then misreport as an incompatible or
+        legacy device, hiding the real API failure from the caller.
 
         :param player: The player whose device info to read.
         """
         try:
             return await player.make_command_client().get_device_info_model()
         except WiiMError as err:
-            self._provider.logger.debug(
-                "Could not read device info for %s: %s", player.player_id, err
-            )
-            return None
+            raise PlayerCommandFailed(
+                f"Could not read device info for {player.player_id}: {err}"
+            ) from err

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from contextlib import AsyncExitStack
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, cast
 
@@ -99,6 +100,18 @@ class NativeGroupCoordinator:
     def leader_of(self, player_id: str) -> str | None:
         """Return the leader a follower belongs to, or None when not a follower."""
         return self._reverse.get(player_id)
+
+    def is_unknown_leader_follower(self, player_id: str) -> bool:
+        """
+        Return whether a player follows a leader MA has not discovered.
+
+        Such a device belongs to an externally-created group MA cannot see the leader of,
+        so it can be neither cleanly detached nor safely regrouped and must have grouping
+        withdrawn entirely.
+
+        :param player_id: The player to check.
+        """
+        return self._is_unknown_leader_follower(player_id)
 
     def can_group_with(self, player: NativePlayer) -> set[str]:
         """
@@ -253,24 +266,94 @@ class NativeGroupCoordinator:
         # the same member under a different leader must not interleave with this command's
         # live check, mutation and verification.
         async with self._command_lock:
-            await self._apply_members(leader, player_ids_to_add, player_ids_to_remove)
+            add_members = [self._require_member(mid) for mid in player_ids_to_add or []]
+            remove_members = [self._require_member(mid) for mid in player_ids_to_remove or []]
+            # a concurrent address rebuild on any involved generic device must not swap its
+            # client or move its address mid-command; hold each device's rebuild lock for the
+            # whole check/mutate/verify sequence. Acquiring in sorted player-id order gives a
+            # deadlock-free order, and the recursive dissolve below never re-takes them.
+            affected: dict[str, NativePlayer] = {leader.player_id: leader}
+            for member in (*add_members, *remove_members):
+                affected[member.player_id] = member
+            async with AsyncExitStack() as stack:
+                for player_id in sorted(affected):
+                    if (lock := self._rebuild_lock_for(affected[player_id])) is not None:
+                        await stack.enter_async_context(lock)
+                await self._apply_members(leader, add_members, remove_members)
 
     # --- Private helpers ---
 
     async def _apply_members(
         self,
         leader: NativePlayer,
-        player_ids_to_add: list[str] | None,
-        player_ids_to_remove: list[str] | None,
+        add_members: list[NativePlayer],
+        remove_members: list[NativePlayer],
     ) -> None:
-        """Run the add/remove grouping operations for a leader (caller holds the lock)."""
+        """Validate the whole batch, then run the grouping operations (caller holds locks)."""
         try:
-            for member_id in player_ids_to_add or []:
-                await self._join(leader, self._require_member(member_id))
-            for member_id in player_ids_to_remove or []:
-                await self._leave(leader, self._require_member(member_id))
+            # full validation before any hardware mutation, so an unknown, unreachable or
+            # generation-incompatible target fails the whole request before any speaker has
+            # joined or left, rather than leaving a partially formed group behind.
+            self._guard_regroupable(leader)
+            join_plan: dict[str, tuple[DeviceInfo | None, DeviceInfo | None] | None] = {}
+            for member in add_members:
+                self._guard_regroupable(member)
+                join_plan[member.player_id] = await self._prevalidate_join(leader, member)
+            for member in add_members:
+                await self._join(leader, member, join_plan[member.player_id])
+            for member in remove_members:
+                await self._leave(leader, member)
         finally:
             await self.refresh_leader(leader, force=True)
+
+    def _rebuild_lock_for(self, player: NativePlayer) -> asyncio.Lock | None:
+        """Return the per-device rebuild lock that grouping must hold, if the backend has one."""
+        return getattr(player, "grouping_rebuild_lock", None)
+
+    def _guard_regroupable(self, player: NativePlayer) -> None:
+        """
+        Assert a player can take part in an MA-driven grouping command right now.
+
+        A device that follows a leader MA has not discovered belongs to an external group
+        that cannot be cleanly detached, so it can be neither a leader nor a member here.
+        Re-checked at command time because core may have cached the request (or it may have
+        waited on the command lock) since the candidate set was computed.
+
+        :param player: The leader or member to validate.
+        """
+        if self._is_unknown_leader_follower(player.player_id):
+            raise PlayerCommandFailed(
+                f"Cannot regroup {player.player_id}: it follows a group MA has not discovered"
+            )
+
+    async def _prevalidate_join(
+        self, leader: NativePlayer, member: NativePlayer
+    ) -> tuple[DeviceInfo | None, DeviceInfo | None] | None:
+        """
+        Validate an addition before any mutation and return the device info the join needs.
+
+        Same-backend official joins are validated by the SDK itself (returns ``None``);
+        every other combination must reach both devices and share a known, matching
+        router-based multiroom generation, failing closed on an unreadable or legacy device.
+
+        :param leader: The leader the member would join.
+        :param member: The member that would join the leader.
+        """
+        if (
+            leader.linkplay_backend == BACKEND_OFFICIAL
+            and member.linkplay_backend == BACKEND_OFFICIAL
+        ):
+            return None
+        if not leader.native_ip:
+            raise PlayerCommandFailed(f"Cannot group {member.player_id}: leader address unknown")
+        leader_info = await self._device_info(leader)
+        member_info = await self._device_info(member)
+        if not linkplay_group_compatible(leader_info, member_info):
+            raise PlayerCommandFailed(
+                f"Cannot group {member.player_id} with {leader.player_id}: incompatible or "
+                "legacy Wi-Fi Direct LinkPlay multiroom"
+            )
+        return leader_info, member_info
 
     def _native_players(self) -> list[NativePlayer]:
         """Return this provider's players that belong to either native backend."""
@@ -399,15 +482,13 @@ class NativeGroupCoordinator:
             raise PlayerCommandFailed(f"Cannot group unknown or unsupported player {player_id}")
         return cast("NativePlayer", member)
 
-    async def _join(self, leader: NativePlayer, member: NativePlayer) -> None:
+    async def _join(
+        self,
+        leader: NativePlayer,
+        member: NativePlayer,
+        join_info: tuple[DeviceInfo | None, DeviceInfo | None] | None,
+    ) -> None:
         """Join a member to a leader over the correct backend path and verify it."""
-        if self._is_unknown_leader_follower(member.player_id):
-            # re-check at command time: another player's cached can_group_with may still
-            # list this device after a live refresh flipped only its internal role. It
-            # follows a group MA has not discovered and cannot be cleanly detached first.
-            raise PlayerCommandFailed(
-                f"Cannot group {member.player_id}: it follows a group MA has not discovered"
-            )
         if (
             leader.linkplay_backend == BACKEND_OFFICIAL
             and member.linkplay_backend == BACKEND_OFFICIAL
@@ -419,7 +500,8 @@ class NativeGroupCoordinator:
             except WiimException as err:
                 raise PlayerCommandFailed(f"Failed to group {member.player_id}: {err}") from err
         else:
-            await self._low_level_join(leader, member)
+            assert join_info is not None  # a low-level join is always prevalidated
+            await self._low_level_join(leader, member, join_info[0])
         await self._verify_membership(leader, member, joined=True)
         # the member is now a follower and manages no members of its own; drop any slave
         # list it cached while it was a leader so a later leave cannot resurrect a ghost
@@ -428,26 +510,21 @@ class NativeGroupCoordinator:
         self.set_leader_slaves(member.player_id, [])
         self.set_self_role(member.player_id, True)
 
-    async def _low_level_join(self, leader: NativePlayer, member: NativePlayer) -> None:
+    async def _low_level_join(
+        self, leader: NativePlayer, member: NativePlayer, leader_info: DeviceInfo | None
+    ) -> None:
         """Join a member to a leader over the low-level LinkPlay client (generic or mixed)."""
         if not (leader_ip := leader.native_ip):
             raise PlayerCommandFailed(f"Cannot group {member.player_id}: leader address unknown")
-        # a Wi-Fi Direct join moves the follower onto the leader's private network, where MA
-        # can no longer poll or control it, and a cross-generation group is unsupported. Only
-        # group two devices that both use a known, matching router-based multiroom generation,
-        # rather than form an uncontrollable or broken group.
-        leader_info = await self._device_info(leader)
-        member_info = await self._device_info(member)
-        if not linkplay_group_compatible(leader_info, member_info):
-            raise PlayerCommandFailed(
-                f"Cannot group {member.player_id} with {leader.player_id}: incompatible or "
-                "legacy Wi-Fi Direct LinkPlay multiroom"
-            )
         # the low-level join_slave (unlike the official SDK) does not disband a member that
         # leads its own group, so dissolve that group first: otherwise its followers are
         # orphaned once the member becomes this leader's follower.
-        if followers := [m for m in self.members_of(member.player_id) if m != member.player_id]:
-            await self._apply_members(member, None, followers)
+        if followers := [
+            self._require_member(m)
+            for m in self.members_of(member.player_id)
+            if m != member.player_id
+        ]:
+            await self._apply_members(member, [], followers)
         try:
             await member.make_command_client().join_slave(leader_ip, master_device_info=leader_info)
         except WiiMError as err:

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -596,6 +596,17 @@ class NativeGroupCoordinator:
                 # following a leader MA has not discovered: a follower with no known leader
                 # (leader_of stays None), still suppressed and not groupable.
                 role[player_id] = NativeGroupRole.FOLLOWER
+            elif any(
+                match_slave_uuid_to_player_id(uuid, registered) is None
+                for uuid in self._raw_slaves.get(player_id, ())
+            ):
+                # leads a native group whose slaves MA cannot resolve to registered players:
+                # it manages no members here (members_of stays empty), but it is NOT
+                # standalone, so it is never offered for a second (linked-protocol) group on
+                # top of its existing hardware group — which matters most during an API outage
+                # when that native group cannot be dissolved. A stale entry that still resolves
+                # to a registered player (a follower that moved away) is not treated as leading.
+                role[player_id] = NativeGroupRole.LEADER
             else:
                 role[player_id] = NativeGroupRole.STANDALONE
 

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -308,10 +308,18 @@ class NativeGroupCoordinator:
             # generation-incompatible target fails the whole request before any speaker has
             # joined or left, rather than leaving a partially mutated group behind.
             self._guard_regroupable(leader)
+            # a low-level (generic or mixed) join needs the leader's device info for the
+            # compatibility gate and the join itself; read it once for the whole batch and
+            # reuse it, rather than re-fetching it for every member.
+            leader_info: DeviceInfo | None = None
+            if any(not self._is_official_pair(leader, member) for member in add_members):
+                leader_info = await self._device_info(leader)
             join_plan: dict[str, tuple[DeviceInfo | None, DeviceInfo | None] | None] = {}
             for member in add_members:
                 self._guard_regroupable(member)
-                join_plan[member.player_id] = await self._prevalidate_join(leader, member)
+                join_plan[member.player_id] = await self._prevalidate_join(
+                    leader, member, leader_info
+                )
             for member in remove_members:
                 self._prevalidate_leave(leader, member)
             for member in add_members:
@@ -341,8 +349,19 @@ class NativeGroupCoordinator:
                 f"Cannot regroup {player.player_id}: it follows a group MA has not discovered"
             )
 
+    @staticmethod
+    def _is_official_pair(leader: NativePlayer, member: NativePlayer) -> bool:
+        """Return whether both players are official WiiM devices (the SDK grouping path)."""
+        return (
+            leader.linkplay_backend == BACKEND_OFFICIAL
+            and member.linkplay_backend == BACKEND_OFFICIAL
+        )
+
     async def _prevalidate_join(
-        self, leader: NativePlayer, member: NativePlayer
+        self,
+        leader: NativePlayer,
+        member: NativePlayer,
+        leader_info: DeviceInfo | None,
     ) -> tuple[DeviceInfo | None, DeviceInfo | None] | None:
         """
         Validate an addition before any mutation and return the device info the join needs.
@@ -353,15 +372,12 @@ class NativeGroupCoordinator:
 
         :param leader: The leader the member would join.
         :param member: The member that would join the leader.
+        :param leader_info: The leader's device info, read once for the whole batch.
         """
-        if (
-            leader.linkplay_backend == BACKEND_OFFICIAL
-            and member.linkplay_backend == BACKEND_OFFICIAL
-        ):
+        if self._is_official_pair(leader, member):
             return None
         if not leader.native_ip:
             raise PlayerCommandFailed(f"Cannot group {member.player_id}: leader address unknown")
-        leader_info = await self._device_info(leader)
         member_info = await self._device_info(member)
         if not linkplay_group_compatible(leader_info, member_info):
             raise PlayerCommandFailed(
@@ -570,13 +586,25 @@ class NativeGroupCoordinator:
             raise PlayerCommandFailed(f"Cannot group {member.player_id}: leader address unknown")
         # the low-level join_slave (unlike the official SDK) does not disband a member that
         # leads its own group, so dissolve that group first: otherwise its followers are
-        # orphaned once the member becomes this leader's follower.
+        # orphaned once the member becomes this leader's follower. Read the member's live
+        # group here rather than trusting the cache, which could miss a follower it gained
+        # since its last refresh.
+        if not await self.refresh_leader(member, force=True):
+            raise PlayerCommandFailed(
+                f"Cannot group {member.player_id}: its own group state is unreadable"
+            )
         if followers := [
             self._require_member(m)
             for m in self.members_of(member.player_id)
             if m != member.player_id
         ]:
             await self._apply_members(member, [], followers)
+        # every managed follower is now detached; a remaining live slave is unmanaged and
+        # would be orphaned by the join, so fail closed rather than strand it.
+        if self._raw_slaves.get(member.player_id):
+            raise PlayerCommandFailed(
+                f"Cannot group {member.player_id}: it still leads slaves MA cannot dissolve"
+            )
         try:
             await member.make_command_client().join_slave(leader_ip, master_device_info=leader_info)
         except WiiMError as err:

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -330,6 +330,13 @@ class NativeGroupCoordinator:
                 )
             for member in remove_members:
                 self._prevalidate_leave(leader, member)
+            # a removal reads the leader's live slave list; confirm it is readable now, before
+            # any join mutates the group, so a combined batch cannot join earlier members and
+            # only then discover the leader is unreadable and leave the group half-applied.
+            if remove_members and not await self.refresh_leader(leader, force=True):
+                raise PlayerCommandFailed(
+                    f"Cannot read the group state of leader {leader.player_id}"
+                )
             for member in add_members:
                 await self._join(leader, member, join_plan[member.player_id])
             for member in remove_members:

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -271,39 +271,57 @@ class NativeGroupCoordinator:
         # core only locks the command's own leader, so serialize here: a concurrent move of
         # the same member under a different leader must not interleave with this command's
         # live check, mutation and verification.
-        async with self._command_lock:
+        async with self._command_lock, AsyncExitStack() as stack:
             add_members = [self._require_member(mid) for mid in player_ids_to_add or []]
             remove_members = [self._require_member(mid) for mid in player_ids_to_remove or []]
-            # authoritative preflight: read the leader's and every addition's live group
-            # before deriving any lock or plan, and fail the whole batch if a device's fresh
-            # state cannot be obtained. This ensures a device that externally became a
-            # follower (or gained followers) since its last poll is validated on live state,
-            # never repurposed from a stale cache.
+            held: set[str] = set()
+            # Phase 1: lock the leader and the explicit targets before reading their live
+            # state, so a concurrent address rebuild cannot swap a generic client mid-read
+            # and have the command act on a stale-address topology.
+            await self._acquire_rebuild_locks(stack, [leader, *add_members, *remove_members], held)
+            # authoritative preflight, now under lock: read the leader's and every addition's
+            # live group and fail the whole batch if a fresh read cannot be obtained, so a
+            # device that externally became a follower (or gained followers) since its last
+            # poll is validated on live state, never repurposed from a stale cache.
             for player in (leader, *add_members):
                 if not await self.refresh_leader(player, force=True):
                     raise PlayerCommandFailed(f"Cannot read the group state of {player.player_id}")
-            # a concurrent address rebuild on any involved generic device must not swap its
-            # client or move its address mid-command; hold each device's rebuild lock for the
-            # whole check/mutate/verify sequence. Acquiring in sorted player-id order gives a
-            # deadlock-free order, and the recursive dissolve below never re-takes them.
-            affected: dict[str, NativePlayer] = {leader.player_id: leader}
+            # Phase 2: joining a member dissolves the followers that read just revealed, so
+            # lock them too before any mutation. The recursive dissolve never re-takes locks.
+            followers: list[NativePlayer] = []
             for member in (*add_members, *remove_members):
-                affected[member.player_id] = member
-                # joining a member dissolves any group it currently leads, so its followers
-                # are mutated too and must be locked against a concurrent address rebuild.
                 for follower_id in self.members_of(member.player_id):
                     if follower_id == member.player_id:
                         continue
                     follower = self._mass.players.get_player(follower_id)
                     if getattr(follower, "linkplay_backend", None) in _NATIVE_BACKENDS:
-                        affected[follower_id] = cast("NativePlayer", follower)
-            async with AsyncExitStack() as stack:
-                for player_id in sorted(affected):
-                    if (lock := self._rebuild_lock_for(affected[player_id])) is not None:
-                        await stack.enter_async_context(lock)
-                await self._apply_members(leader, add_members, remove_members)
+                        followers.append(cast("NativePlayer", follower))
+            await self._acquire_rebuild_locks(stack, followers, held)
+            await self._apply_members(leader, add_members, remove_members)
 
     # --- Private helpers ---
+
+    async def _acquire_rebuild_locks(
+        self, stack: AsyncExitStack, players: list[NativePlayer], held: set[str]
+    ) -> None:
+        """
+        Acquire the not-yet-held rebuild locks of the given players in a deterministic order.
+
+        Acquiring in sorted player-id order and skipping already-held devices keeps the
+        overall order stable across the command's two locking phases; the command lock
+        serializes whole commands, so this can never deadlock against another command, and
+        an address rebuild only ever holds a single device's lock.
+
+        :param stack: The exit stack that releases every acquired lock when the command ends.
+        :param players: The players whose rebuild locks to acquire.
+        :param held: The set of player ids whose locks are already held, updated in place.
+        """
+        for player in sorted(players, key=lambda candidate: candidate.player_id):
+            if player.player_id in held:
+                continue
+            held.add(player.player_id)
+            if (lock := self._rebuild_lock_for(player)) is not None:
+                await stack.enter_async_context(lock)
 
     async def _apply_members(
         self,

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -191,8 +191,9 @@ class NativeGroupCoordinator:
         :param force: Read now even if the slow TTL has not elapsed.
         :return: Whether a fresh group state was actually read and applied.
         """
-        if not player.native_ip:
-            # no address to command yet (never seen or currently unavailable)
+        if not player.native_ip or not player.native_available:
+            # no reachable address to command yet (never seen or currently unavailable);
+            # keep the cached topology instead of doing a request that will only time out.
             return False
         lock = self._refresh_locks.setdefault(player.player_id, asyncio.Lock())
         async with lock:
@@ -273,6 +274,13 @@ class NativeGroupCoordinator:
         async with self._command_lock:
             add_members = [self._require_member(mid) for mid in player_ids_to_add or []]
             remove_members = [self._require_member(mid) for mid in player_ids_to_remove or []]
+            # read each low-level addition's live group up front: joining it dissolves the
+            # group it currently leads, and a stale cache could miss a follower it gained
+            # since its last refresh, so the lock set and validation below must see the
+            # current followers, not a stale snapshot.
+            for member in add_members:
+                if not self._is_official_pair(leader, member):
+                    await self.refresh_leader(member, force=True)
             # a concurrent address rebuild on any involved generic device must not swap its
             # client or move its address mid-command; hold each device's rebuild lock for the
             # whole check/mutate/verify sequence. Acquiring in sorted player-id order gives a
@@ -314,7 +322,7 @@ class NativeGroupCoordinator:
             leader_info: DeviceInfo | None = None
             if any(not self._is_official_pair(leader, member) for member in add_members):
                 leader_info = await self._device_info(leader)
-            join_plan: dict[str, tuple[DeviceInfo | None, DeviceInfo | None] | None] = {}
+            join_plan: dict[str, tuple[DeviceInfo | None, tuple[NativePlayer, ...]] | None] = {}
             for member in add_members:
                 self._guard_regroupable(member)
                 join_plan[member.player_id] = await self._prevalidate_join(
@@ -362,13 +370,16 @@ class NativeGroupCoordinator:
         leader: NativePlayer,
         member: NativePlayer,
         leader_info: DeviceInfo | None,
-    ) -> tuple[DeviceInfo | None, DeviceInfo | None] | None:
+    ) -> tuple[DeviceInfo | None, tuple[NativePlayer, ...]] | None:
         """
-        Validate an addition before any mutation and return the device info the join needs.
+        Validate an addition before any mutation and return the plan the join needs.
 
         Same-backend official joins are validated by the SDK itself (returns ``None``);
         every other combination must reach both devices and share a known, matching
-        router-based multiroom generation, failing closed on an unreadable or legacy device.
+        router-based multiroom generation. The member's own live group was read before the
+        locks were taken, so it is validated here too: it must not still lead any slave MA
+        cannot dissolve (it would be orphaned once the member becomes a follower). The
+        managed followers to dissolve are captured so execution needs no further read.
 
         :param leader: The leader the member would join.
         :param member: The member that would join the leader.
@@ -384,7 +395,24 @@ class NativeGroupCoordinator:
                 f"Cannot group {member.player_id} with {leader.player_id}: incompatible or "
                 "legacy Wi-Fi Direct LinkPlay multiroom"
             )
-        return leader_info, member_info
+        if self._leads_unmanaged_slave(member):
+            raise PlayerCommandFailed(
+                f"Cannot group {member.player_id}: it still leads slaves MA cannot dissolve"
+            )
+        followers = tuple(
+            self._require_member(follower_id)
+            for follower_id in self.members_of(member.player_id)
+            if follower_id != member.player_id
+        )
+        return leader_info, followers
+
+    def _leads_unmanaged_slave(self, member: NativePlayer) -> bool:
+        """Return whether the member's live slave list holds a slave MA cannot resolve."""
+        registered = {player.player_id for player in self._native_players()}
+        return any(
+            match_slave_uuid_to_player_id(uuid, registered) is None
+            for uuid in self._raw_slaves.get(member.player_id, ())
+        )
 
     def _prevalidate_leave(self, leader: NativePlayer, member: NativePlayer) -> None:
         """
@@ -554,13 +582,10 @@ class NativeGroupCoordinator:
         self,
         leader: NativePlayer,
         member: NativePlayer,
-        join_info: tuple[DeviceInfo | None, DeviceInfo | None] | None,
+        plan: tuple[DeviceInfo | None, tuple[NativePlayer, ...]] | None,
     ) -> None:
         """Join a member to a leader over the correct backend path and verify it."""
-        if (
-            leader.linkplay_backend == BACKEND_OFFICIAL
-            and member.linkplay_backend == BACKEND_OFFICIAL
-        ):
+        if self._is_official_pair(leader, member):
             leader_udn = cast("WiimPlayer", leader).native_device_udn
             member_udn = cast("WiimPlayer", member).native_device_udn
             try:
@@ -568,8 +593,8 @@ class NativeGroupCoordinator:
             except WiimException as err:
                 raise PlayerCommandFailed(f"Failed to group {member.player_id}: {err}") from err
         else:
-            assert join_info is not None  # a low-level join is always prevalidated
-            await self._low_level_join(leader, member, join_info[0])
+            assert plan is not None  # a low-level join is always prevalidated
+            await self._low_level_join(leader, member, plan[0], plan[1])
         await self._verify_membership(leader, member, joined=True)
         # the member is now a follower and manages no members of its own; drop any slave
         # list it cached while it was a leader so a later leave cannot resurrect a ghost
@@ -579,32 +604,20 @@ class NativeGroupCoordinator:
         self.set_self_role(member.player_id, True)
 
     async def _low_level_join(
-        self, leader: NativePlayer, member: NativePlayer, leader_info: DeviceInfo | None
+        self,
+        leader: NativePlayer,
+        member: NativePlayer,
+        leader_info: DeviceInfo | None,
+        followers: tuple[NativePlayer, ...],
     ) -> None:
         """Join a member to a leader over the low-level LinkPlay client (generic or mixed)."""
         if not (leader_ip := leader.native_ip):
             raise PlayerCommandFailed(f"Cannot group {member.player_id}: leader address unknown")
         # the low-level join_slave (unlike the official SDK) does not disband a member that
-        # leads its own group, so dissolve that group first: otherwise its followers are
-        # orphaned once the member becomes this leader's follower. Read the member's live
-        # group here rather than trusting the cache, which could miss a follower it gained
-        # since its last refresh.
-        if not await self.refresh_leader(member, force=True):
-            raise PlayerCommandFailed(
-                f"Cannot group {member.player_id}: its own group state is unreadable"
-            )
-        if followers := [
-            self._require_member(m)
-            for m in self.members_of(member.player_id)
-            if m != member.player_id
-        ]:
-            await self._apply_members(member, [], followers)
-        # every managed follower is now detached; a remaining live slave is unmanaged and
-        # would be orphaned by the join, so fail closed rather than strand it.
-        if self._raw_slaves.get(member.player_id):
-            raise PlayerCommandFailed(
-                f"Cannot group {member.player_id}: it still leads slaves MA cannot dissolve"
-            )
+        # leads its own group, so dissolve the followers prevalidation captured from its live
+        # group first: otherwise they are orphaned once the member becomes a follower itself.
+        if followers:
+            await self._apply_members(member, [], list(followers))
         try:
             await member.make_command_client().join_slave(leader_ip, master_device_info=leader_info)
         except WiiMError as err:

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -40,6 +40,7 @@ VERIFY_POLL_INTERVAL = 1.0
 # a burst of them heals discovery-order misses just once.
 RECONCILE_DEBOUNCE = 1.0
 RECONCILE_TASK_ID = "wiim_native_reconcile"
+REPUBLISH_TASK_ID = "wiim_native_republish"
 
 _NATIVE_BACKENDS = (BACKEND_OFFICIAL, BACKEND_GENERIC)
 
@@ -166,17 +167,23 @@ class NativeGroupCoordinator:
         self._self_follower.discard(player_id)
         return True
 
-    def set_leader_slaves(self, player_id: str, raw_slave_uuids: list[str]) -> bool:
+    def set_leader_slaves(
+        self, player_id: str, raw_slave_uuids: list[str], observed_at: float | None = None
+    ) -> bool:
         """
         Record a leader's raw slave-uuid list from a topology read.
 
         :param player_id: The leader that reported the slave list.
         :param raw_slave_uuids: The slave uuids exactly as the device reported them.
+        :param observed_at: The monotonic time the read that produced this list *started*.
+            The single-owner tie-break ranks claims by this, so a longer-running older read
+            that completes late cannot outrank a newer read; defaults to now for a list set
+            directly (e.g. cleared on a confirmed join), which is a genuine "now" observation.
         :return: Whether the recorded list differs from the previously cached one.
         """
         changed = self._raw_slaves.get(player_id) != raw_slave_uuids
         self._raw_slaves[player_id] = raw_slave_uuids
-        self._refreshed_at[player_id] = time.monotonic()
+        self._refreshed_at[player_id] = time.monotonic() if observed_at is None else observed_at
         return changed
 
     async def refresh_leader(self, player: NativePlayer, *, force: bool = False) -> bool:
@@ -205,6 +212,10 @@ class NativeGroupCoordinator:
             ):
                 return False
             client = player.make_command_client()
+            # stamp the read by when it STARTED, so a longer-running older observation that
+            # completes after a newer one cannot win the single-owner tie-break and move a
+            # follower back to a stale leader.
+            observed_at = time.monotonic()
             try:
                 info = await client.get_device_group_info()
                 if info.role == "slave":
@@ -230,7 +241,7 @@ class NativeGroupCoordinator:
             # official backend builds one per call) does not re-probe the device
             player.store_command_capabilities(client.capabilities)
             self.set_self_role(player.player_id, is_follower)
-            self.set_leader_slaves(player.player_id, raw)
+            self.set_leader_slaves(player.player_id, raw, observed_at=observed_at)
         await self.reconcile()
         return True
 
@@ -244,6 +255,18 @@ class NativeGroupCoordinator:
     def schedule_reconcile(self) -> None:
         """Schedule a debounced reconcile, coalescing bursts into one rebuild."""
         self._mass.call_later(RECONCILE_DEBOUNCE, self.reconcile, task_id=RECONCILE_TASK_ID)
+
+    def schedule_republish(self) -> None:
+        """
+        Schedule every native player to re-publish its state, coalescing bursts.
+
+        A player's ``can_group_with`` depends on its peers' native availability and
+        compatibility, but a peer's health/metadata transition does not change the topology
+        and so is not picked up by :meth:`reconcile`. This forces every native player to
+        recompute and re-publish, so no peer keeps a stale candidate set that would offer a
+        native command the coordinator then rejects.
+        """
+        self._mass.call_later(RECONCILE_DEBOUNCE, self._republish_all, task_id=REPUBLISH_TASK_ID)
 
     async def reconcile(self) -> None:
         """Rebuild the topology indexes from the cached slave lists and notify changes."""
@@ -270,12 +293,25 @@ class NativeGroupCoordinator:
         :param player_ids_to_add: Player ids to join to this leader's group.
         :param player_ids_to_remove: Player ids to remove from this leader's group.
         """
+        add_ids = player_ids_to_add or []
+        remove_ids = player_ids_to_remove or []
+        # reject a contradictory request before any work: core can forward the same id in
+        # both lists when the parent membership is stale but the child still reports synced_to,
+        # and joining then immediately removing it is never the intent.
+        if len(set(add_ids)) != len(add_ids) or len(set(remove_ids)) != len(remove_ids):
+            raise PlayerCommandFailed(
+                f"Duplicate member id in grouping request on {leader.player_id}"
+            )
+        if conflicting := set(add_ids) & set(remove_ids):
+            raise PlayerCommandFailed(
+                f"Cannot add and remove the same member on {leader.player_id}: {conflicting}"
+            )
         # core only locks the command's own leader, so serialize here: a concurrent move of
         # the same member under a different leader must not interleave with this command's
         # live check, mutation and verification.
         async with self._command_lock, AsyncExitStack() as stack:
-            add_members = [self._require_member(mid) for mid in player_ids_to_add or []]
-            remove_members = [self._require_member(mid) for mid in player_ids_to_remove or []]
+            add_members = [self._require_member(mid) for mid in add_ids]
+            remove_members = [self._require_member(mid) for mid in remove_ids]
             held: set[str] = set()
             # Phase 1: lock the leader and the explicit targets before reading their live
             # state, so a concurrent address rebuild cannot swap a generic client mid-read
@@ -461,6 +497,11 @@ class NativeGroupCoordinator:
             for player in self._provider.players
             if getattr(player, "linkplay_backend", None) in _NATIVE_BACKENDS
         ]
+
+    def _republish_all(self) -> None:
+        """Re-publish the state of every registered native player."""
+        for player in self._native_players():
+            player.on_native_group_update()
 
     def _is_unknown_leader_follower(self, player_id: str) -> bool:
         """Return whether a player follows a leader MA has not discovered."""

--- a/music_assistant/providers/wiim/grouping.py
+++ b/music_assistant/providers/wiim/grouping.py
@@ -1,0 +1,605 @@
+"""Native multiroom topology coordinator shared by both WiiM backends."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, cast
+
+from music_assistant_models.errors import PlayerCommandFailed
+from pywiim import WiiMError
+from wiim.exceptions import WiimException
+
+from .constants import BACKEND_GENERIC, BACKEND_OFFICIAL
+from .helpers import linkplay_group_compatible, match_slave_uuid_to_player_id
+
+if TYPE_CHECKING:
+    from pywiim import WiiMClient
+    from pywiim.models import DeviceInfo
+
+    from .linkplay_player import LinkPlayPlayer
+    from .player import WiimPlayer
+    from .provider import WiimProvider
+
+    # Either backend's player; both expose the small grouping surface used here.
+    type NativePlayer = WiimPlayer | LinkPlayPlayer
+
+# A leader's slave list is only re-read this often on the ordinary player poll; forced
+# refreshes (grouping commands, RenderingControl slave events, moves) bypass the TTL so a
+# real change is never delayed by it.
+SLAVE_TTL = 60.0
+
+# A device accepts a grouping command before its role has propagated, so membership is
+# polled up to this long before a still-mismatched role is declared a no-op.
+VERIFY_MAX_WAIT = 10.0
+VERIFY_POLL_INTERVAL = 1.0
+
+# Registration/availability announcements are coalesced into a single IO-free reconcile so
+# a burst of them heals discovery-order misses just once.
+RECONCILE_DEBOUNCE = 1.0
+RECONCILE_TASK_ID = "wiim_native_reconcile"
+
+_NATIVE_BACKENDS = (BACKEND_OFFICIAL, BACKEND_GENERIC)
+
+
+class NativeGroupRole(StrEnum):
+    """A player's role in the native multiroom topology."""
+
+    LEADER = "leader"
+    FOLLOWER = "follower"
+    STANDALONE = "standalone"
+
+
+class NativeGroupCoordinator:
+    """
+    The single native topology authority across both WiiM backends.
+
+    It owns which players are leaders, followers or standalone and who belongs to which
+    group; the official SDK and the linked protocol players remain the playback/state
+    authorities. Topology is rebuilt from the raw slave-uuid lists that leaders report
+    (read over a low-level command client) and resolved against the currently registered
+    players, so a discovery-order miss self-heals on the next reconcile.
+    """
+
+    def __init__(self, provider: WiimProvider) -> None:
+        """Initialize the coordinator for a provider instance."""
+        self._provider = provider
+        self._mass = provider.mass
+        self._lock = asyncio.Lock()
+        # serializes grouping commands so concurrent moves targeting the same member from
+        # different leaders cannot interleave their check/mutate/verify phases
+        self._command_lock = asyncio.Lock()
+        # leader player_id -> raw slave uuids from its last successful topology read
+        self._raw_slaves: dict[str, list[str]] = {}
+        self._refreshed_at: dict[str, float] = {}
+        # per-leader lock so overlapping refreshes cannot apply out of order
+        self._refresh_locks: dict[str, asyncio.Lock] = {}
+        # players that report themselves as a follower (of a possibly unknown leader)
+        self._self_follower: set[str] = set()
+        # atomically rebuilt indexes; readers see a consistent snapshot between awaits
+        self._members: dict[str, list[str]] = {}
+        self._reverse: dict[str, str] = {}
+        self._role: dict[str, NativeGroupRole] = {}
+
+    # --- Topology queries (lock-free, read the last rebuilt snapshot) ---
+
+    def role_of(self, player_id: str) -> NativeGroupRole:
+        """Return the native topology role of a player."""
+        return self._role.get(player_id, NativeGroupRole.STANDALONE)
+
+    def members_of(self, player_id: str) -> list[str]:
+        """
+        Return the group member ids for a leader (leader first), else an empty list.
+
+        :param player_id: The player whose managed members to return.
+        """
+        return list(self._members.get(player_id, ()))
+
+    def leader_of(self, player_id: str) -> str | None:
+        """Return the leader a follower belongs to, or None when not a follower."""
+        return self._reverse.get(player_id)
+
+    def can_group_with(self, player: NativePlayer) -> set[str]:
+        """
+        Return every reachable peer of either backend this player may group with.
+
+        Core applies the final grouping filter and auto-ungroups a known follower before
+        regrouping it, so only a follower of a leader MA has NOT discovered is excluded
+        here (it cannot be cleanly moved); every other reachable peer is a candidate.
+
+        :param player: The player requesting its grouping candidates.
+        """
+        if self._is_unknown_leader_follower(player.player_id):
+            # this device follows a group MA has not discovered: it cannot be cleanly
+            # detached, so it must not be offered any grouping candidates of its own.
+            return set()
+        return {
+            peer.player_id
+            for peer in self._native_players()
+            if peer.native_available
+            and peer.player_id != player.player_id
+            and not self._is_unknown_leader_follower(peer.player_id)
+        }
+
+    # --- Topology feeders ---
+
+    def set_self_role(self, player_id: str, is_follower: bool) -> bool:
+        """
+        Record a player's own report of whether it is a follower.
+
+        This is the fallback for a device following a leader MA has not discovered: the
+        leader never lists it here, but the device itself knows it is grouped. The
+        recorded value only takes effect on the next reconcile.
+
+        :param player_id: The player reporting its own role.
+        :param is_follower: Whether the device reports itself as a follower.
+        :return: Whether this changed the player's recorded self-follower state.
+        """
+        if is_follower:
+            if player_id in self._self_follower:
+                return False
+            self._self_follower.add(player_id)
+            return True
+        if player_id not in self._self_follower:
+            return False
+        self._self_follower.discard(player_id)
+        return True
+
+    def set_leader_slaves(self, player_id: str, raw_slave_uuids: list[str]) -> bool:
+        """
+        Record a leader's raw slave-uuid list from a topology read.
+
+        :param player_id: The leader that reported the slave list.
+        :param raw_slave_uuids: The slave uuids exactly as the device reported them.
+        :return: Whether the recorded list differs from the previously cached one.
+        """
+        changed = self._raw_slaves.get(player_id) != raw_slave_uuids
+        self._raw_slaves[player_id] = raw_slave_uuids
+        self._refreshed_at[player_id] = time.monotonic()
+        return changed
+
+    async def refresh_leader(self, player: NativePlayer, *, force: bool = False) -> bool:
+        """
+        Re-read a player's live group state over its command client and reconcile.
+
+        A live read yields both the device's own role (the self-follower signal) and, when
+        it leads, its slave list. Reads for one player are serialized so overlapping
+        refreshes cannot apply an older response after a newer one, and a failed read keeps
+        the previous state so a temporarily unreachable device loses neither its members
+        nor its self-role.
+
+        :param player: The player whose live group state to read.
+        :param force: Read now even if the slow TTL has not elapsed.
+        :return: Whether a fresh group state was actually read and applied.
+        """
+        if not player.native_ip:
+            # no address to command yet (never seen or currently unavailable)
+            return False
+        lock = self._refresh_locks.setdefault(player.player_id, asyncio.Lock())
+        async with lock:
+            # re-check the TTL inside the lock: a concurrent refresh may have just run
+            if not force and (
+                time.monotonic() - self._refreshed_at.get(player.player_id, 0.0) < SLAVE_TTL
+            ):
+                return False
+            client = player.make_command_client()
+            try:
+                info = await client.get_device_group_info()
+                if info.role == "slave":
+                    is_follower, raw = True, []
+                else:
+                    # a non-slave is a leader or solo, but get_device_group_info both
+                    # swallows a failed slave-list read (reporting solo) and can report a
+                    # master with empty slave uuids when it derived them from status ip
+                    # strings; read the authoritative getSlaveList so members resolve and a
+                    # transient failure retains the cached topology (handled below).
+                    is_follower = False
+                    raw = self._normalize_slave_uuids(await client.get_slaves_info())
+            except WiiMError as err:
+                self._provider.logger.debug(
+                    "Failed to read group state for %s: %s", player.player_id, err
+                )
+                return False
+            # the player may have been unregistered/replaced during the await; never apply
+            # a stale device response to a different registered instance
+            if self._mass.players.get_player(player.player_id) is not player:
+                return False
+            # reuse the capabilities this read detected so a later fresh command client (the
+            # official backend builds one per call) does not re-probe the device
+            player.store_command_capabilities(client.capabilities)
+            self.set_self_role(player.player_id, is_follower)
+            self.set_leader_slaves(player.player_id, raw)
+        await self.reconcile()
+        return True
+
+    def unregister(self, player_id: str) -> None:
+        """Drop a permanently removed player from the topology cache."""
+        self._raw_slaves.pop(player_id, None)
+        self._refreshed_at.pop(player_id, None)
+        self._refresh_locks.pop(player_id, None)
+        self._self_follower.discard(player_id)
+
+    def schedule_reconcile(self) -> None:
+        """Schedule a debounced reconcile, coalescing bursts into one rebuild."""
+        self._mass.call_later(RECONCILE_DEBOUNCE, self.reconcile, task_id=RECONCILE_TASK_ID)
+
+    async def reconcile(self) -> None:
+        """Rebuild the topology indexes from the cached slave lists and notify changes."""
+        async with self._lock:
+            self._rebuild()
+
+    # --- Grouping commands ---
+
+    async def set_members(
+        self,
+        leader: NativePlayer,
+        player_ids_to_add: list[str] | None,
+        player_ids_to_remove: list[str] | None,
+    ) -> None:
+        """
+        Add or remove native group members for a leader, spanning both backends.
+
+        Same-backend official operations keep the SDK path; every other combination joins
+        or removes the follower over the low-level LinkPlay client. Every operation is
+        verified against the leader's own live slave list (not the follower's role, which
+        is unreachable for a legacy Wi-Fi Direct follower) and raises on a no-op.
+
+        :param leader: The player the grouping command was issued on.
+        :param player_ids_to_add: Player ids to join to this leader's group.
+        :param player_ids_to_remove: Player ids to remove from this leader's group.
+        """
+        # core only locks the command's own leader, so serialize here: a concurrent move of
+        # the same member under a different leader must not interleave with this command's
+        # live check, mutation and verification.
+        async with self._command_lock:
+            await self._apply_members(leader, player_ids_to_add, player_ids_to_remove)
+
+    # --- Private helpers ---
+
+    async def _apply_members(
+        self,
+        leader: NativePlayer,
+        player_ids_to_add: list[str] | None,
+        player_ids_to_remove: list[str] | None,
+    ) -> None:
+        """Run the add/remove grouping operations for a leader (caller holds the lock)."""
+        try:
+            for member_id in player_ids_to_add or []:
+                await self._join(leader, self._require_member(member_id))
+            for member_id in player_ids_to_remove or []:
+                await self._leave(leader, self._require_member(member_id))
+        finally:
+            await self.refresh_leader(leader, force=True)
+
+    def _native_players(self) -> list[NativePlayer]:
+        """Return this provider's players that belong to either native backend."""
+        return [
+            cast("NativePlayer", player)
+            for player in self._provider.players
+            if getattr(player, "linkplay_backend", None) in _NATIVE_BACKENDS
+        ]
+
+    def _is_unknown_leader_follower(self, player_id: str) -> bool:
+        """Return whether a player follows a leader MA has not discovered."""
+        return (
+            self.role_of(player_id) == NativeGroupRole.FOLLOWER
+            and self.leader_of(player_id) is None
+        )
+
+    def _rebuild(self) -> None:
+        """Recompute roles and membership, then push state to every changed player."""
+        registered: dict[str, NativePlayer] = {
+            player.player_id: player for player in self._native_players()
+        }
+        # a fresh topology read for an unregistered player can never arrive, so its cached
+        # slave list (and self-reported role) is stale forever: drop it here.
+        for stale_id in [pid for pid in self._raw_slaves if pid not in registered]:
+            self.unregister(stale_id)
+        for stale_id in [pid for pid in self._self_follower if pid not in registered]:
+            self._self_follower.discard(stale_id)
+
+        candidate_members: dict[str, list[str]] = {}
+        for leader_id, raw in self._raw_slaves.items():
+            resolved = [
+                member_id
+                for uuid in raw
+                if (member_id := match_slave_uuid_to_player_id(uuid, registered)) is not None
+                and member_id != leader_id
+            ]
+            if resolved:
+                candidate_members[leader_id] = resolved
+
+        # a follower can be claimed by only one leader: while a moved device's old leader
+        # still has it in its (not-yet-refreshed) cached list, the most recently refreshed
+        # leader wins so one player never shows in two groups. Ties break on the leader id
+        # so the winner is fully deterministic.
+        owner: dict[str, str] = {}
+        for leader_id, resolved in candidate_members.items():
+            leader_key = (self._refreshed_at.get(leader_id, 0.0), leader_id)
+            for member_id in resolved:
+                incumbent = owner.get(member_id)
+                if incumbent is None or leader_key > (
+                    self._refreshed_at.get(incumbent, 0.0),
+                    incumbent,
+                ):
+                    owner[member_id] = leader_id
+
+        # a device that is itself another leader's follower cannot also be a leader; its own
+        # (stale) slave list is ignored so nested/ghost groups never form.
+        members: dict[str, list[str]] = {}
+        for leader_id, resolved in candidate_members.items():
+            if leader_id in owner:
+                continue
+            owned = [member_id for member_id in resolved if owner.get(member_id) == leader_id]
+            if owned:
+                members[leader_id] = [leader_id, *owned]
+        reverse: dict[str, str] = {
+            member_id: leader_id
+            for leader_id, group in members.items()
+            for member_id in group
+            if member_id != leader_id
+        }
+        role: dict[str, NativeGroupRole] = {}
+        for player_id in registered:
+            if player_id in members:
+                role[player_id] = NativeGroupRole.LEADER
+            elif player_id in reverse:
+                role[player_id] = NativeGroupRole.FOLLOWER
+            elif player_id in self._self_follower:
+                # following a leader MA has not discovered: a follower with no known leader
+                # (leader_of stays None), still suppressed and not groupable.
+                role[player_id] = NativeGroupRole.FOLLOWER
+            else:
+                role[player_id] = NativeGroupRole.STANDALONE
+
+        old_members, old_reverse, old_role = self._members, self._reverse, self._role
+        old_unknown = {
+            player_id
+            for player_id in registered
+            if old_role.get(player_id) == NativeGroupRole.FOLLOWER and player_id not in old_reverse
+        }
+        new_unknown = {
+            player_id
+            for player_id in registered
+            if role[player_id] == NativeGroupRole.FOLLOWER and player_id not in reverse
+        }
+        # a change in which players follow an undiscovered leader flips every peer's
+        # can_group_with (those followers are excluded there), so all players must
+        # re-publish; otherwise only those whose own role/membership actually changed.
+        if old_unknown != new_unknown:
+            changed_ids = list(registered)
+        else:
+            changed_ids = [
+                player_id
+                for player_id in registered
+                if old_role.get(player_id, NativeGroupRole.STANDALONE) != role[player_id]
+                or old_members.get(player_id, []) != members.get(player_id, [])
+                or old_reverse.get(player_id) != reverse.get(player_id)
+            ]
+        # atomic swap: readers between awaits always see one consistent snapshot
+        self._members, self._reverse, self._role = members, reverse, role
+        # notify members-publishers (a leader in the old OR new snapshot) before followers:
+        # a follower's synced_to scans its leaders' cached group_members, so an old leader
+        # shedding it and a new leader gaining it must both refresh first.
+        changed_ids.sort(
+            key=lambda player_id: not (old_members.get(player_id) or members.get(player_id))
+        )
+        for player_id in changed_ids:
+            registered[player_id].on_native_group_update()
+
+    def _require_member(self, player_id: str) -> NativePlayer:
+        """
+        Return the registered native player for a grouping target.
+
+        :param player_id: The member id supplied to the grouping command.
+        """
+        member = self._mass.players.get_player(player_id)
+        if getattr(member, "linkplay_backend", None) not in _NATIVE_BACKENDS:
+            raise PlayerCommandFailed(f"Cannot group unknown or unsupported player {player_id}")
+        return cast("NativePlayer", member)
+
+    async def _join(self, leader: NativePlayer, member: NativePlayer) -> None:
+        """Join a member to a leader over the correct backend path and verify it."""
+        if self._is_unknown_leader_follower(member.player_id):
+            # re-check at command time: another player's cached can_group_with may still
+            # list this device after a live refresh flipped only its internal role. It
+            # follows a group MA has not discovered and cannot be cleanly detached first.
+            raise PlayerCommandFailed(
+                f"Cannot group {member.player_id}: it follows a group MA has not discovered"
+            )
+        if (
+            leader.linkplay_backend == BACKEND_OFFICIAL
+            and member.linkplay_backend == BACKEND_OFFICIAL
+        ):
+            leader_udn = cast("WiimPlayer", leader).native_device_udn
+            member_udn = cast("WiimPlayer", member).native_device_udn
+            try:
+                await self._provider.wiim_controller.async_join_group(leader_udn, [member_udn])
+            except WiimException as err:
+                raise PlayerCommandFailed(f"Failed to group {member.player_id}: {err}") from err
+        else:
+            await self._low_level_join(leader, member)
+        await self._verify_membership(leader, member, joined=True)
+        # the member is now a follower and manages no members of its own; drop any slave
+        # list it cached while it was a leader so a later leave cannot resurrect a ghost
+        # group, and record its follower role so it stays suppressed even if its leader is
+        # unregistered before the member's next live read (whose TTL was just advanced).
+        self.set_leader_slaves(member.player_id, [])
+        self.set_self_role(member.player_id, True)
+
+    async def _low_level_join(self, leader: NativePlayer, member: NativePlayer) -> None:
+        """Join a member to a leader over the low-level LinkPlay client (generic or mixed)."""
+        if not (leader_ip := leader.native_ip):
+            raise PlayerCommandFailed(f"Cannot group {member.player_id}: leader address unknown")
+        # a Wi-Fi Direct join moves the follower onto the leader's private network, where MA
+        # can no longer poll or control it, and a cross-generation group is unsupported. Only
+        # group two devices that both use a known, matching router-based multiroom generation,
+        # rather than form an uncontrollable or broken group.
+        leader_info = await self._device_info(leader)
+        member_info = await self._device_info(member)
+        if not linkplay_group_compatible(leader_info, member_info):
+            raise PlayerCommandFailed(
+                f"Cannot group {member.player_id} with {leader.player_id}: incompatible or "
+                "legacy Wi-Fi Direct LinkPlay multiroom"
+            )
+        # the low-level join_slave (unlike the official SDK) does not disband a member that
+        # leads its own group, so dissolve that group first: otherwise its followers are
+        # orphaned once the member becomes this leader's follower.
+        if followers := [m for m in self.members_of(member.player_id) if m != member.player_id]:
+            await self._apply_members(member, None, followers)
+        try:
+            await member.make_command_client().join_slave(leader_ip, master_device_info=leader_info)
+        except WiiMError as err:
+            raise PlayerCommandFailed(f"Failed to group {member.player_id}: {err}") from err
+
+    async def _leave(self, leader: NativePlayer, member: NativePlayer) -> None:
+        """Remove a member from a leader over the correct backend path and verify it."""
+        # confirm, from the leader's own live slave list, that the member is currently this
+        # leader's follower. A member that is solo or grouped under a different leader is not
+        # detached (idempotent), so another leader's follower is safe.
+        if not await self.refresh_leader(leader, force=True):
+            raise PlayerCommandFailed(
+                f"Could not read the group state of leader {leader.player_id}"
+            )
+        if member.player_id not in self.members_of(leader.player_id):
+            return
+        if (
+            leader.linkplay_backend == BACKEND_OFFICIAL
+            and member.linkplay_backend == BACKEND_OFFICIAL
+        ):
+            await self._official_detach(leader, member)
+        elif (
+            leader.linkplay_backend == BACKEND_GENERIC
+            and member.linkplay_backend == BACKEND_GENERIC
+        ):
+            # a same-backend generic follower always sits on the router network, so it can
+            # leave itself.
+            try:
+                await member.make_command_client().leave_group()
+            except WiiMError as err:
+                raise PlayerCommandFailed(f"Failed to ungroup {member.player_id}: {err}") from err
+        else:
+            # a cross-backend follower is kicked from the leader, which is always reachable
+            # and knows its address even on a private Wi-Fi Direct network.
+            await self._leader_side_detach(leader, member)
+        await self._verify_membership(leader, member, joined=False)
+        # the member is confirmed no longer this leader's follower; clear any stale
+        # self-follower flag from its last live read so its state and grouping unblock now
+        # instead of on its next poll (a concurrently discovered new leader still wins,
+        # because the reverse index outranks the self-follower flag on reconcile).
+        if self.set_self_role(member.player_id, False):
+            await self.reconcile()
+
+    async def _official_detach(self, leader: NativePlayer, member: NativePlayer) -> None:
+        """Ungroup an official follower via the SDK, falling back to a leader-side kick."""
+        member_udn = cast("WiimPlayer", member).native_device_udn
+        try:
+            await self._provider.wiim_controller.async_ungroup_device(member_udn)
+        except WiimException as err:
+            raise PlayerCommandFailed(f"Failed to ungroup {member.player_id}: {err}") from err
+        # the SDK ungroups from its own managed cache and can silently no-op on a
+        # recovered/external group; if the leader still lists the follower, kick it from the
+        # leader (as the mixed path does).
+        if await self.refresh_leader(leader, force=True) and member.player_id in self.members_of(
+            leader.player_id
+        ):
+            await self._leader_side_detach(leader, member)
+
+    async def _leader_side_detach(self, leader: NativePlayer, member: NativePlayer) -> None:
+        """
+        Remove a follower by kicking it from the leader.
+
+        The leader is always reachable and knows the follower's address (even the private
+        Wi-Fi Direct one), so kicking from the leader works where a leave sent to the
+        follower's own LAN address would not.
+
+        :param leader: The leader the follower belongs to.
+        :param member: The follower to remove.
+        """
+        client = leader.make_command_client()
+        if not (slave_ip := await self._leader_slave_ip(client, member)):
+            raise PlayerCommandFailed(
+                f"Could not resolve {member.player_id}'s address on leader {leader.player_id}"
+            )
+        # a freshly built command client has no cached group role, so prime it as master
+        # (state-only, no request) to satisfy kick_slave's master guard; membership was
+        # already confirmed from the leader's live slave list above.
+        await client.create_group()
+        try:
+            await client.kick_slave(slave_ip)
+        except WiiMError as err:
+            raise PlayerCommandFailed(f"Failed to ungroup {member.player_id}: {err}") from err
+
+    async def _leader_slave_ip(self, client: WiiMClient, member: NativePlayer) -> str | None:
+        """Resolve a follower's address from the leader's own slave list."""
+        try:
+            slaves = await client.get_slaves_info()
+        except WiiMError as err:
+            self._provider.logger.debug("Failed to read leader slave list: %s", err)
+            return None
+        for slave in slaves:
+            if (
+                isinstance(slave, dict)
+                and match_slave_uuid_to_player_id(slave.get("uuid"), (member.player_id,))
+                == member.player_id
+            ):
+                ip = slave.get("ip")
+                return ip if isinstance(ip, str) and ip else None
+        return None
+
+    @staticmethod
+    def _normalize_slave_uuids(slaves_info: list[dict[str, Any]]) -> list[str]:
+        """Extract the slave uuids from a raw getSlaveList response (addressable entries)."""
+        return [
+            (slave.get("uuid") or "").replace("uuid:", "")
+            for slave in slaves_info
+            if isinstance(slave, dict) and slave.get("ip")
+        ]
+
+    async def _verify_membership(
+        self, leader: NativePlayer, member: NativePlayer, *, joined: bool
+    ) -> None:
+        """
+        Confirm a grouping op took effect against the leader's own live slave list.
+
+        Verification is leader-side because a legacy Wi-Fi Direct follower moves onto the
+        leader's private network and is unreachable from the LAN, while the leader always
+        reports its slaves. A device accepts a grouping command before its role has
+        propagated, so the leader's list is polled until it matches (or a bounded timeout
+        elapses); a failed read fails closed.
+
+        :param leader: The leader the command targeted.
+        :param member: The player whose membership was expected to change.
+        :param joined: Whether the member was expected to join (True) or leave.
+        """
+        deadline = time.monotonic() + VERIFY_MAX_WAIT
+        while True:
+            if not await self.refresh_leader(leader, force=True):
+                raise PlayerCommandFailed(
+                    f"Could not confirm grouping of {member.player_id}: "
+                    f"no fresh topology for leader {leader.player_id}"
+                )
+            if (member.player_id in self.members_of(leader.player_id)) == joined:
+                return
+            if time.monotonic() >= deadline:
+                break
+            await asyncio.sleep(VERIFY_POLL_INTERVAL)
+        verb = "join" if joined else "leave"
+        raise PlayerCommandFailed(
+            f"{member.player_id} did not {verb} the group led by {leader.player_id}"
+        )
+
+    async def _device_info(self, player: NativePlayer) -> DeviceInfo | None:
+        """
+        Read a player's device info for the compatibility gate, best-effort.
+
+        :param player: The player whose device info to read.
+        """
+        try:
+            return await player.make_command_client().get_device_info_model()
+        except WiiMError as err:
+            self._provider.logger.debug(
+                "Could not read device info for %s: %s", player.player_id, err
+            )
+            return None

--- a/music_assistant/providers/wiim/helpers.py
+++ b/music_assistant/providers/wiim/helpers.py
@@ -10,47 +10,15 @@ from wiim.consts import MANUFACTURER_AUDIO_PRO, MANUFACTURER_WIIM
 from .constants import PLAYER_ID_PREFIX
 
 if TYPE_CHECKING:
-    from pywiim.models import DeviceInfo as PywiimDeviceInfo
+    from collections.abc import Iterable
 
-    from music_assistant.models.player import Player
+    from pywiim.models import DeviceInfo as PywiimDeviceInfo
 
 # Manufacturers handled by the official WiiM/Linkplay SDK. Everything else that
 # still speaks the LinkPlay API (e.g. Edifier) is driven by the generic backend.
 OFFICIAL_MANUFACTURERS = (MANUFACTURER_WIIM, MANUFACTURER_AUDIO_PRO)
 
 _HEX = re.compile(r"^[0-9a-fA-F]+$")
-
-
-def is_in_mixed_group(player: Player) -> bool:
-    """
-    Return whether a player is in an externally-created cross-backend (mixed) group.
-
-    A group is mixed when this player leads a group that includes a member on another
-    backend, or another registered player on a different backend currently lists this
-    player as a member. Such groups are read-only until cross-backend grouping is
-    supported, so grouping is withdrawn while it holds. The check reads only the players
-    already registered by the provider, so it needs no extra device requests.
-
-    :param player: The player to check, expected to carry a ``linkplay_backend`` marker.
-    """
-    own_backend = getattr(player, "linkplay_backend", None)
-    own_members = player._attr_group_members
-    if own_members and own_members[0] == player.player_id:
-        for member_id in own_members[1:]:
-            member = player.mass.players.get_player(member_id)
-            if member is not None and getattr(member, "linkplay_backend", None) != own_backend:
-                return True
-    for other in player.provider.players:
-        if other is player or getattr(other, "linkplay_backend", None) == own_backend:
-            continue
-        other_members = other._attr_group_members
-        if (
-            other_members
-            and other_members[0] == other.player_id
-            and player.player_id in other_members[1:]
-        ):
-            return True
-    return False
 
 
 def linkplay_group_compatible(
@@ -126,6 +94,33 @@ def linkplay_slave_uuid_to_player_id(slave_uuid: str) -> str | None:
     if (udn := linkplay_slave_uuid_to_udn(slave_uuid)) is None:
         return None
     return f"{PLAYER_ID_PREFIX}{udn}"
+
+
+def match_slave_uuid_to_player_id(
+    slave_uuid: str | None, candidate_player_ids: Iterable[str]
+) -> str | None:
+    """
+    Resolve a slave-list UUID to one of the given registered player ids.
+
+    Both backends key their players on the UPnP UDN, so a slave reported in either the
+    24-char HTTP or full 32-hex form is matched against the candidate ids by their
+    normalized hex, spanning the official and generic backends.
+
+    :param slave_uuid: The UUID of a slave device as reported in the slave list.
+    :param candidate_player_ids: The player ids to match the slave against.
+    """
+    if not slave_uuid or (udn := linkplay_slave_uuid_to_udn(slave_uuid)) is None:
+        return None
+    target_hex = udn.removeprefix("uuid:").replace("-", "").upper()
+    for player_id in candidate_player_ids:
+        if not player_id.startswith(PLAYER_ID_PREFIX):
+            continue
+        candidate_hex = (
+            player_id[len(PLAYER_ID_PREFIX) :].removeprefix("uuid:").replace("-", "").upper()
+        )
+        if candidate_hex == target_hex:
+            return player_id
+    return None
 
 
 def _wmrm_major(device_info: PywiimDeviceInfo) -> int | None:

--- a/music_assistant/providers/wiim/linkplay_player.py
+++ b/music_assistant/providers/wiim/linkplay_player.py
@@ -152,16 +152,22 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
 
     @property
     def grouping_locked(self) -> bool:
-        """Withdraw ALL grouping only while following a group MA has not discovered."""
+        """Withdraw ALL grouping only when this device cannot be safely regrouped."""
         # grouping_locked is the broad, final lock: it suppresses native AND linked-protocol
-        # grouping. It must therefore be reserved for a genuinely read-only topology, not for
-        # native capability being unavailable. An unknown-leader follower belongs to an
-        # external group whose leader MA cannot see, so it can be neither detached nor
-        # regrouped, and without this lock core would re-offer it as a grouping target through
-        # its linked DLNA/AirPlay protocols. LinkPlay API health only gates NATIVE grouping,
-        # which is handled by supported_features and the coordinator's can_group_with, so a
-        # reachable linked protocol can still form a group while the LinkPlay API is down.
-        return self._native_groups.is_unknown_leader_follower(self.player_id)
+        # grouping, so it is reserved for a device that genuinely cannot be regrouped, not
+        # for native capability merely being unavailable. Two cases qualify:
+        #  - an unknown-leader follower belongs to an external group whose leader MA cannot
+        #    see, so it can be neither detached nor regrouped; and
+        #  - a device already in a native hardware group (leader or follower) whose LinkPlay
+        #    API has dropped: adding it to a linked-protocol group would first need a native
+        #    auto-ungroup that cannot run, and core would proceed anyway, leaving it in both
+        #    groups. A standalone shell has nothing to leave, so it may still group via a
+        #    linked protocol while the API is down (native grouping stays gated separately by
+        #    supported_features and the coordinator's can_group_with).
+        if self._native_groups.is_unknown_leader_follower(self.player_id):
+            return True
+        role = self._native_groups.role_of(self.player_id)
+        return not self._linkplay_available and role is not NativeGroupRole.STANDALONE
 
     @property
     def playback_state(self) -> PlaybackState:

--- a/music_assistant/providers/wiim/linkplay_player.py
+++ b/music_assistant/providers/wiim/linkplay_player.py
@@ -152,13 +152,16 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
 
     @property
     def grouping_locked(self) -> bool:
-        """Withdraw grouping while unreachable or following a group MA has not discovered."""
-        # An unknown-leader follower belongs to an external group whose leader MA cannot
-        # see; without this lock core would re-offer it as a grouping target through its
-        # linked DLNA/AirPlay protocols and let that external group be repurposed.
-        return not self._linkplay_available or self._native_groups.is_unknown_leader_follower(
-            self.player_id
-        )
+        """Withdraw ALL grouping only while following a group MA has not discovered."""
+        # grouping_locked is the broad, final lock: it suppresses native AND linked-protocol
+        # grouping. It must therefore be reserved for a genuinely read-only topology, not for
+        # native capability being unavailable. An unknown-leader follower belongs to an
+        # external group whose leader MA cannot see, so it can be neither detached nor
+        # regrouped, and without this lock core would re-offer it as a grouping target through
+        # its linked DLNA/AirPlay protocols. LinkPlay API health only gates NATIVE grouping,
+        # which is handled by supported_features and the coordinator's can_group_with, so a
+        # reachable linked protocol can still form a group while the LinkPlay API is down.
+        return self._native_groups.is_unknown_leader_follower(self.player_id)
 
     @property
     def playback_state(self) -> PlaybackState:

--- a/music_assistant/providers/wiim/linkplay_player.py
+++ b/music_assistant/providers/wiim/linkplay_player.py
@@ -281,6 +281,7 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
                     "Failed to reach LinkPlay device %s at %s: %s", self.name, new_ip, err
                 )
                 return
+            was_available = self._linkplay_available
             self._client = new_client
             self._cached_device_info = device_info
             self._description_url = description_url
@@ -289,6 +290,10 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
             self._attr_device_info.add_identifier(IdentifierType.IP_ADDRESS, new_ip)
         # Re-read the topology from the new address so a stale entry never survives a move.
         await self._native_groups.refresh_leader(self, force=True)
+        if not was_available:
+            # recovering from an outage flips native availability, so peers must re-publish
+            # to stop excluding this device from their grouping candidates.
+            self._native_groups.schedule_republish()
         self.update_state()
 
     # --- Internals ---

--- a/music_assistant/providers/wiim/linkplay_player.py
+++ b/music_assistant/providers/wiim/linkplay_player.py
@@ -228,6 +228,13 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
         # role/membership are derived by the coordinator, not from this player's own
         # attributes, so force a recalculation (e.g. synced_to) even when idle.
         self._attr_group_members = self._native_groups.members_of(self.player_id)
+        if self._is_native_follower and self.active_output_protocol is not None:
+            # a native follower gets audio from its leader at the hardware level, not from a
+            # linked protocol. Clear any active output so the final state mirrors the leader
+            # (synced_to) or falls back to idle instead of a stale DLNA/AirPlay player, which
+            # the base otherwise prioritizes over synced_to. It is left cleared on leaving:
+            # normal playback reselects an output DLNA-first / by user preference.
+            self.set_active_output_protocol(None)
         self.mark_state_dirty()
         self.update_state()
 

--- a/music_assistant/providers/wiim/linkplay_player.py
+++ b/music_assistant/providers/wiim/linkplay_player.py
@@ -300,14 +300,22 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
         """Refresh the LinkPlay grouping API reachability and cached device info."""
         # Serialize with async_handle_address_change so an in-flight read against the old
         # client cannot land after a validated client swap and overwrite it with stale state.
+        health_changed = False
         async with self._rebuild_lock:
+            was_available = self._linkplay_available
             try:
                 self._cached_device_info = await self._client.get_device_info_model()
             except WiiMError as err:
                 if self._linkplay_available:
                     self.logger.debug("LinkPlay API unreachable for %s: %s", self.name, err)
                 self._linkplay_available = False
+                health_changed = was_available
                 self.update_state()
-                return
-            self._linkplay_available = True
-            self.update_state()
+            else:
+                self._linkplay_available = True
+                health_changed = not was_available
+                self.update_state()
+        if health_changed:
+            # this shell's native availability just flipped, which changes whether every peer
+            # can offer it as a native grouping candidate; make them re-publish.
+            self._native_groups.schedule_republish()

--- a/music_assistant/providers/wiim/linkplay_player.py
+++ b/music_assistant/providers/wiim/linkplay_player.py
@@ -104,12 +104,12 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
 
     async def setup(self) -> None:
         """Handle logic when the player is set up in the Player controller."""
-        # The discovery probe already fetched and validated the device info and primed it
-        # on this shell, so only re-read reachability when it did not. The coordinator then
-        # does an initial live topology read; the regular poll refreshes both from here on.
+        # The discovery probe already fetched and validated the device info and primed it on
+        # this shell, so only re-read reachability when it did not. The provider reads the
+        # live topology right after registration (a read taken here would be discarded, as
+        # setup runs before the player is registered); the regular poll refreshes both.
         if self._cached_device_info is None:
             await self._refresh_reachability()
-        await self._native_groups.refresh_leader(self, force=True)
 
     async def poll(self) -> None:
         """Poll the device for reachability and push its native group topology."""

--- a/music_assistant/providers/wiim/linkplay_player.py
+++ b/music_assistant/providers/wiim/linkplay_player.py
@@ -12,16 +12,23 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.enums import IdentifierType, PlayerFeature, PlayerType
+from music_assistant_models.enums import (
+    IdentifierType,
+    PlaybackState,
+    PlayerFeature,
+    PlayerType,
+)
 from music_assistant_models.player import DeviceInfo
 from pywiim import WiiMClient, WiiMError
 
 from music_assistant.models.protocol_backed_player import ProtocolBackedPlayer
 
 from .constants import BACKEND_GENERIC, PLAYER_ID_PREFIX
+from .grouping import NativeGroupRole
 
 if TYPE_CHECKING:
     from async_upnp_client.client import UpnpDevice
+    from music_assistant_models.player import PlayerMedia
     from pywiim.models import DeviceInfo as PywiimDeviceInfo
 
     from music_assistant.models.player import Player
@@ -61,8 +68,10 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
         # Health of the LinkPlay HTTP API, separate from playback availability (which the
         # base derives from linked protocols): it gates the native grouping capability.
         # A device info primed from the discovery probe means the API is reachable.
-        # Set before super().__init__ because the base reads supported_features during init.
+        # Set before super().__init__ because the base reads supported_features and the
+        # follower-suppressed playback state (via the coordinator) during init.
         self._linkplay_available = device_info is not None
+        self._native_groups: NativeGroupCoordinator = provider.native_groups
         super().__init__(provider, player_id)
         # Low-level LinkPlay HTTP client over MA's shared aiohttp session. Its close()
         # would close that shared session, so it is never closed here.
@@ -73,7 +82,6 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
         # Cached pywiim device info, refreshed on poll and passed to a follower's
         # join_slave so it can pick the correct (router vs WiFi-Direct) join mode.
         self._cached_device_info: PywiimDeviceInfo | None = device_info
-        self._native_groups: NativeGroupCoordinator = provider.native_groups
         self._rebuild_lock = asyncio.Lock()
 
         self._attr_name = upnp_device.friendly_name or player_id
@@ -138,9 +146,43 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
         return host
 
     @property
+    def grouping_rebuild_lock(self) -> asyncio.Lock:
+        """Return the lock the coordinator holds so grouping and address rebuilds serialize."""
+        return self._rebuild_lock
+
+    @property
     def grouping_locked(self) -> bool:
-        """Suppress grouping while the LinkPlay grouping API is unreachable."""
-        return not self._linkplay_available
+        """Withdraw grouping while unreachable or following a group MA has not discovered."""
+        # An unknown-leader follower belongs to an external group whose leader MA cannot
+        # see; without this lock core would re-offer it as a grouping target through its
+        # linked DLNA/AirPlay protocols and let that external group be repurposed.
+        return not self._linkplay_available or self._native_groups.is_unknown_leader_follower(
+            self.player_id
+        )
+
+    @property
+    def playback_state(self) -> PlaybackState:
+        """Suppress delegated playback while natively grouped as a follower."""
+        if self._is_native_follower:
+            # a native follower plays its leader's stream at the hardware level; a known
+            # leader's state is mirrored by core through synced_to, an undiscovered one
+            # reports idle rather than the shell's stale linked-protocol playback.
+            return PlaybackState.IDLE
+        return super().playback_state
+
+    @property
+    def current_media(self) -> PlayerMedia | None:
+        """Suppress delegated media while natively grouped as a follower."""
+        if self._is_native_follower:
+            return None
+        return super().current_media
+
+    @property
+    def active_source(self) -> str | None:
+        """Suppress the delegated active source while natively grouped as a follower."""
+        if self._is_native_follower:
+            return None
+        return super().active_source
 
     @property
     def prefer_native_grouping(self) -> bool:
@@ -238,6 +280,11 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
     def _backing_protocol_player_ids(self) -> list[str]:
         """Return the ids of the linked protocol players backing this shell's playback."""
         return [linked.output_protocol_id for linked in self.linked_output_protocols]
+
+    @property
+    def _is_native_follower(self) -> bool:
+        """Whether the coordinator currently resolves this shell as a native follower."""
+        return self._native_groups.role_of(self.player_id) == NativeGroupRole.FOLLOWER
 
     async def _refresh_reachability(self) -> None:
         """Refresh the LinkPlay grouping API reachability and cached device info."""

--- a/music_assistant/providers/wiim/linkplay_player.py
+++ b/music_assistant/providers/wiim/linkplay_player.py
@@ -10,18 +10,15 @@ adds device identity and native LinkPlay multiroom grouping/topology on top.
 from __future__ import annotations
 
 import asyncio
-from contextlib import AsyncExitStack
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import IdentifierType, PlayerFeature, PlayerType
-from music_assistant_models.errors import PlayerCommandFailed, UnsupportedFeaturedException
 from music_assistant_models.player import DeviceInfo
 from pywiim import WiiMClient, WiiMError
 
 from music_assistant.models.protocol_backed_player import ProtocolBackedPlayer
 
 from .constants import BACKEND_GENERIC, PLAYER_ID_PREFIX
-from .helpers import is_in_mixed_group, linkplay_group_compatible, linkplay_slave_uuid_to_udn
 
 if TYPE_CHECKING:
     from async_upnp_client.client import UpnpDevice
@@ -29,16 +26,12 @@ if TYPE_CHECKING:
 
     from music_assistant.models.player import Player
 
+    from .grouping import NativeGroupCoordinator
     from .provider import WiimProvider
 
 # The device is polled for reachability and native group topology only; playback state
 # comes from the linked protocol players, so a slow interval is plenty.
 POLL_INTERVAL = 30
-
-# A native multiroom join/leave is fire-and-forget and the group takes a few seconds to
-# settle, so the leader's topology is re-read a few times before a change is rejected.
-GROUP_VERIFY_ATTEMPTS = 5
-GROUP_VERIFY_INTERVAL = 1.5
 
 
 class LinkPlayPlayer(ProtocolBackedPlayer):
@@ -46,8 +39,9 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
     Generic LinkPlay player shell in Music Assistant.
 
     Playback/state/volume are delegated to the linked DLNA/AirPlay protocol players via
-    the protocol-linking system; this player natively owns only device identity and
-    same-backend LinkPlay multiroom grouping, driven by the low-level public WiiMClient.
+    the protocol-linking system; this player natively owns only device identity and native
+    LinkPlay multiroom grouping, driven by the low-level public WiiMClient. Topology is
+    resolved by the provider's shared coordinator across both WiiM backends.
     """
 
     _attr_type = PlayerType.PLAYER
@@ -79,6 +73,7 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
         # Cached pywiim device info, refreshed on poll and passed to a follower's
         # join_slave so it can pick the correct (router vs WiFi-Direct) join mode.
         self._cached_device_info: PywiimDeviceInfo | None = device_info
+        self._native_groups: NativeGroupCoordinator = provider.native_groups
         self._rebuild_lock = asyncio.Lock()
 
         self._attr_name = upnp_device.friendly_name or player_id
@@ -102,21 +97,22 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
     async def setup(self) -> None:
         """Handle logic when the player is set up in the Player controller."""
         # The discovery probe already fetched and validated the device info and primed it
-        # on this shell, so setup only needs an initial native-group topology read; the
-        # regular poll refreshes reachability and device info from here on.
+        # on this shell, so only re-read reachability when it did not. The coordinator then
+        # does an initial live topology read; the regular poll refreshes both from here on.
         if self._cached_device_info is None:
-            await self._refresh_linkplay()
-            return
-        async with self._rebuild_lock:
-            try:
-                await self._update_group_members()
-            except WiiMError as err:
-                self.logger.debug("Failed to read group topology for %s: %s", self.name, err)
-        self.update_state()
+            await self._refresh_reachability()
+        await self._native_groups.refresh_leader(self, force=True)
 
     async def poll(self) -> None:
-        """Poll the device for reachability and native group topology."""
-        await self._refresh_linkplay()
+        """Poll the device for reachability and push its native group topology."""
+        await self._refresh_reachability()
+        await self._native_groups.refresh_leader(self, force=True)
+
+    async def on_unload(self) -> None:
+        """Handle logic when the player is unloaded from the Player controller."""
+        await super().on_unload()
+        self._native_groups.unregister(self.player_id)
+        self._native_groups.schedule_reconcile()
 
     # --- Properties ---
 
@@ -131,43 +127,67 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
         return self._cached_device_info
 
     @property
+    def native_available(self) -> bool:
+        """Return whether the native LinkPlay grouping API is currently reachable."""
+        return self._linkplay_available
+
+    @property
+    def native_ip(self) -> str | None:
+        """Return the device's current IP address, if known."""
+        host: str | None = self._client.host
+        return host
+
+    @property
     def grouping_locked(self) -> bool:
-        """Suppress grouping while the LinkPlay API is unreachable or the group is mixed."""
-        return not self._linkplay_available or self._in_mixed_group
+        """Suppress grouping while the LinkPlay grouping API is unreachable."""
+        return not self._linkplay_available
 
     @property
     def prefer_native_grouping(self) -> bool:
-        """Group compatible generic LinkPlay speakers natively, not via a linked protocol."""
+        """Group compatible LinkPlay speakers natively, not via a linked protocol."""
         return self._linkplay_available
 
     @property
     def supported_features(self) -> set[PlayerFeature]:
-        """Return the supported features; native grouping needs a reachable, non-mixed group."""
+        """Return the supported features; native grouping needs a reachable grouping API."""
         features = super().supported_features
-        # Native multiroom grouping needs the LinkPlay HTTP API to be reachable and the
-        # device to not be in an externally-created mixed group (read-only until layer 2).
-        if self._linkplay_available and not self._in_mixed_group:
+        if self._linkplay_available:
             return features
         return features - {PlayerFeature.SET_MEMBERS}
 
     @property
     def can_group_with(self) -> set[str]:
-        """Return the ids of the reachable, compatible generic LinkPlay peers to group with."""
-        if not self._linkplay_available or self._in_mixed_group:
-            return set()
-        return {
-            player.player_id
-            for player in self.provider.players
-            if isinstance(player, LinkPlayPlayer)
-            and player is not self
-            and player._linkplay_available
-            and not player._in_mixed_group
-            and linkplay_group_compatible(self._cached_device_info, player._cached_device_info)
-        }
+        """Return the ids of the reachable peers of either backend this player can group with."""
+        return self._native_groups.can_group_with(self)
 
     def is_native_group_compatible(self, other: Player) -> bool:
-        """Only reachable, compatible generic LinkPlay peers group natively."""
+        """Only reachable coordinator-approved peers of either backend group natively."""
         return other.player_id in self.can_group_with
+
+    def make_command_client(self) -> WiiMClient:
+        """
+        Return this player's low-level LinkPlay command client.
+
+        The generic backend already owns a client bound to the shared session for the
+        device's current address; it is reused for topology reads and grouping commands
+        and must never be closed.
+        """
+        return self._client
+
+    def store_command_capabilities(self, capabilities: dict[str, Any]) -> None:
+        """
+        Ignore detected capabilities; the generic backend reuses one persistent client.
+
+        :param capabilities: The capabilities a command client detected for this device.
+        """
+
+    def on_native_group_update(self) -> None:
+        """Re-publish state after the topology coordinator changed this player's role."""
+        # role/membership are derived by the coordinator, not from this player's own
+        # attributes, so force a recalculation (e.g. synced_to) even when idle.
+        self._attr_group_members = self._native_groups.members_of(self.player_id)
+        self.mark_state_dirty()
+        self.update_state()
 
     # --- Player commands ---
 
@@ -177,70 +197,7 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
         player_ids_to_remove: list[str] | None = None,
     ) -> None:
         """Handle SET_MEMBERS command on the player."""
-        add_ids = player_ids_to_add or []
-        remove_ids = player_ids_to_remove or []
-        # Prevalidate the whole batch before taking any locks, so an obviously bad request
-        # fails fast without contending for a device that a rebuild may be using.
-        self._validate_leader_state()
-        if len(set(add_ids)) != len(add_ids) or len(set(remove_ids)) != len(remove_ids):
-            raise PlayerCommandFailed(f"Duplicate member id in grouping request on {self.name}")
-        if conflicting := set(add_ids) & set(remove_ids):
-            raise PlayerCommandFailed(
-                f"Cannot add and remove the same member on {self.name}: {conflicting}"
-            )
-        # Resolve every target to a same-backend member (rejects unknown/cross-backend/self).
-        to_add = [(mid, self._require_linkplay_member(mid)) for mid in add_ids]
-        to_remove = [(mid, self._require_linkplay_member(mid)) for mid in remove_ids]
-        self._validate_additions(to_add)
-        # Lock this leader and every affected member for the entire mutation + verification.
-        # Acquiring in sorted player_id order gives every caller the same lock ordering, so
-        # concurrent grouping requests that share a device serialize instead of deadlocking,
-        # a concurrent address rebuild on any involved device waits its turn, and unrelated
-        # players keep their locks free.
-        affected: dict[str, LinkPlayPlayer] = {self.player_id: self}
-        for _, member in (*to_add, *to_remove):
-            affected[member.player_id] = member
-        async with AsyncExitStack() as stack:
-            for player_id in sorted(affected):
-                await stack.enter_async_context(affected[player_id]._rebuild_lock)
-            # Revalidate now the locks are held: a rebuild or poll may have changed a
-            # device's reachability, swapped its client or moved its IP since prevalidation.
-            self._validate_leader_state()
-            self._validate_additions(to_add)
-            try:
-                # Identify which removals we still own from the leader's live topology and
-                # prevalidate their health before any hardware change, so a batch containing
-                # an unreachable current member fails whole rather than half-applied. Targets
-                # already absent (e.g. moved to another group) stay idempotent skips.
-                current_slaves = await self._current_slave_ids() if to_remove else set()
-                for member_id, member in to_remove:
-                    if member.player_id in current_slaves and (
-                        not member._linkplay_available or member._cached_device_info is None
-                    ):
-                        raise PlayerCommandFailed(f"{member_id} is not reachable for grouping")
-                for member_id, member in to_add:
-                    await member._client.join_slave(
-                        self._client.host, master_device_info=self._cached_device_info
-                    )
-                    await self._verify_group_change(member, member_id, expect_slave=True)
-                for member_id, member in to_remove:
-                    if member.player_id not in current_slaves:
-                        # a removal target that has since moved to another (possibly read-only
-                        # mixed) group is left alone instead of being torn out of it
-                        self.logger.debug(
-                            "%s is no longer a member of %s; skipping leave",
-                            member_id,
-                            self.name,
-                        )
-                        continue
-                    await member._client.leave_group()
-                    await self._verify_group_change(member, member_id, expect_slave=False)
-            except WiiMError as err:
-                raise PlayerCommandFailed(f"set_members failed on {self.name}: {err}") from err
-            finally:
-                self.mass.create_task(
-                    self._refresh_linkplay(), task_id=f"linkplay_refresh_{self.player_id}"
-                )
+        await self._native_groups.set_members(self, player_ids_to_add, player_ids_to_remove)
 
     async def async_handle_address_change(
         self, new_ip: str, upnp_device: UpnpDevice, description_url: str
@@ -248,8 +205,8 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
         """
         Rebuild the low-level client against a new device address.
 
-        The replacement is validated before the old client is dropped, so a failed
-        rebuild leaves the existing client intact for a later retry.
+        The replacement is validated before the old client is dropped, so a failed rebuild
+        leaves the existing client intact for a later retry.
 
         :param new_ip: The device's new IP address.
         :param upnp_device: The UPnP device freshly probed at the new location.
@@ -272,12 +229,9 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
             self._upnp_device = upnp_device
             self._linkplay_available = True
             self._attr_device_info.add_identifier(IdentifierType.IP_ADDRESS, new_ip)
-            try:
-                await self._update_group_members()
-            except WiiMError as err:
-                # The rebuild succeeded; a stale topology read must not undo it.
-                self.logger.debug("Failed to read group topology for %s: %s", self.name, err)
-            self.update_state()
+        # Re-read the topology from the new address so a stale entry never survives a move.
+        await self._native_groups.refresh_leader(self, force=True)
+        self.update_state()
 
     # --- Internals ---
 
@@ -285,9 +239,9 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
         """Return the ids of the linked protocol players backing this shell's playback."""
         return [linked.output_protocol_id for linked in self.linked_output_protocols]
 
-    async def _refresh_linkplay(self) -> None:
-        """Refresh reachability, cached device info and native group topology."""
-        # Serialize with async_handle_address_change so an in-flight poll against the old
+    async def _refresh_reachability(self) -> None:
+        """Refresh the LinkPlay grouping API reachability and cached device info."""
+        # Serialize with async_handle_address_change so an in-flight read against the old
         # client cannot land after a validated client swap and overwrite it with stale state.
         async with self._rebuild_lock:
             try:
@@ -296,133 +250,7 @@ class LinkPlayPlayer(ProtocolBackedPlayer):
                 if self._linkplay_available:
                     self.logger.debug("LinkPlay API unreachable for %s: %s", self.name, err)
                 self._linkplay_available = False
-                # Keep the last known group members: an unreachable device may still be in a
-                # (possibly mixed) hardware group, and dropping the topology here would let the
-                # still-reachable side re-expose SET_MEMBERS. grouping_locked already blocks
-                # this shell's own commands while unreachable.
                 self.update_state()
                 return
             self._linkplay_available = True
-            try:
-                await self._update_group_members()
-            except WiiMError as err:
-                # A transient topology read must not drop a real hardware group; the last
-                # known members are kept until a successful read replaces them.
-                self.logger.debug("Failed to read group topology for %s: %s", self.name, err)
             self.update_state()
-
-    async def _update_group_members(self) -> None:
-        """Map this device's native slave list onto MA group member ids (leader first)."""
-        # get_slaves_info() raises on a failed request (unlike get_device_group_info, which
-        # masks a failed slave read as "solo"), so a transient blip cannot silently clear a
-        # real group. It returns the slaves only for a master; a follower/solo returns none.
-        slaves = await self._client.get_slaves_info()
-        members = [self.player_id]
-        for slave in slaves:
-            resolved = self._resolve_member_player_id(slave.get("uuid"))
-            if resolved and resolved not in members:
-                members.append(resolved)
-        self._attr_group_members = members if len(members) > 1 else []
-
-    async def _current_slave_ids(self) -> set[str]:
-        """Return the player ids this leader currently reports as its native group slaves."""
-        slaves = await self._client.get_slaves_info()
-        return {
-            resolved
-            for slave in slaves
-            if (resolved := self._resolve_member_player_id(slave.get("uuid"))) is not None
-        }
-
-    @property
-    def _in_mixed_group(self) -> bool:
-        """Whether this device is in an externally-created mixed (cross-backend) group."""
-        return is_in_mixed_group(self)
-
-    def _require_linkplay_member(self, player_id: str) -> LinkPlayPlayer:
-        """
-        Return a same-backend member for a grouping command.
-
-        MA-created grouping stays within the generic LinkPlay backend; a request that
-        targets this player itself or any other backend is rejected rather than cast.
-        """
-        if player_id == self.player_id:
-            raise UnsupportedFeaturedException(f"Cannot group {self.name} with itself")
-        member = self.mass.players.get_player(player_id)
-        if not isinstance(member, LinkPlayPlayer):
-            raise UnsupportedFeaturedException(
-                f"Cannot group {player_id} with {self.name}: cross-backend grouping is unsupported"
-            )
-        return member
-
-    def _validate_leader_state(self) -> None:
-        """Assert this leader's LinkPlay API is reachable and it owns a regroupable group."""
-        if not self._linkplay_available or self._cached_device_info is None:
-            raise PlayerCommandFailed(f"{self.name} is not reachable for grouping")
-        if self._in_mixed_group:
-            raise PlayerCommandFailed(
-                f"{self.name} is in an externally-created mixed group and cannot be regrouped"
-            )
-
-    def _validate_additions(self, to_add: list[tuple[str, LinkPlayPlayer]]) -> None:
-        """
-        Assert every addition is reachable and of a compatible multiroom generation.
-
-        :param to_add: The resolved (id, member) pairs that would join this leader.
-        """
-        for member_id, member in to_add:
-            if not member._linkplay_available or member._cached_device_info is None:
-                raise PlayerCommandFailed(f"{member_id} is not reachable for grouping")
-            if member._in_mixed_group:
-                raise PlayerCommandFailed(
-                    f"{member_id} is in an externally-created mixed group and cannot be regrouped"
-                )
-            if not linkplay_group_compatible(self._cached_device_info, member._cached_device_info):
-                raise UnsupportedFeaturedException(
-                    f"Cannot group {member_id} with {self.name}: "
-                    "incompatible LinkPlay multiroom generation"
-                )
-
-    async def _verify_group_change(
-        self, member: LinkPlayPlayer, member_id: str, expect_slave: bool
-    ) -> None:
-        """Confirm a grouping operation actually took effect on THIS leader's group."""
-        for attempt in range(GROUP_VERIFY_ATTEMPTS):
-            try:
-                slaves = await self._client.get_slaves_info()
-            except WiiMError as err:
-                raise PlayerCommandFailed(
-                    f"Could not verify grouping of {member_id} on {self.name}: {err}"
-                ) from err
-            current_members = {
-                resolved
-                for slave in slaves
-                if (resolved := self._resolve_member_player_id(slave.get("uuid"))) is not None
-            }
-            if (member.player_id in current_members) == expect_slave:
-                return
-            # The group is still settling; wait briefly and re-read before giving up.
-            if attempt + 1 < GROUP_VERIFY_ATTEMPTS:
-                await asyncio.sleep(GROUP_VERIFY_INTERVAL)
-        verb = "join" if expect_slave else "leave"
-        raise PlayerCommandFailed(f"{member_id} did not {verb} the group led by {self.name}")
-
-    def _resolve_member_player_id(self, slave_uuid: str | None) -> str | None:
-        """
-        Resolve a slave's UUID (24-char HTTP or full UDN form) to a registered player id.
-
-        Matches against players already registered by this provider (in either backend)
-        and ignores members that do not resolve to a known player.
-
-        :param slave_uuid: The slave's UUID from the native group topology.
-        """
-        if not slave_uuid or (udn := linkplay_slave_uuid_to_udn(slave_uuid)) is None:
-            return None
-        target_hex = udn.removeprefix("uuid:").replace("-", "").upper()
-        for player in self.provider.players:
-            player_id = player.player_id
-            if not player_id.startswith(PLAYER_ID_PREFIX):
-                continue
-            udn_hex = player_id[len(PLAYER_ID_PREFIX) :].removeprefix("uuid:").replace("-", "")
-            if udn_hex.upper() == target_hex:
-                return player_id
-        return None

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import time
 import typing
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import IdentifierType, PlaybackState, PlayerFeature, PlayerType
-from music_assistant_models.errors import PlayerCommandFailed, UnsupportedFeaturedException
+from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.player import DeviceInfo
+from pywiim import WiiMClient
 from wiim import PlayingStatus, WiimDevice
 from wiim.exceptions import WiimException
-from wiim.models import WiimGroupRole
 
 from music_assistant.constants import (
     EXTERNAL_PAUSE_IDLE_TIMEOUT,
@@ -24,19 +24,19 @@ from .constants import (
     BACKEND_OFFICIAL,
     INPUT_MODE_SOURCES,
     PASSIVE_SOURCES,
-    PLAYER_ID_PREFIX,
     SOURCE_AIRPLAY,
     SOURCE_ID_TO_INPUT_MODE,
     SOURCE_NETWORK,
     SOURCE_SPOTIFY,
     SOURCE_UNKNOWN,
 )
-from .helpers import is_in_mixed_group
+from .grouping import NativeGroupRole
 
 if TYPE_CHECKING:
     from async_upnp_client.client import UpnpService, UpnpStateVariable
     from music_assistant_models.config_entries import ConfigEntry
 
+    from .grouping import NativeGroupCoordinator
     from .provider import WiimProvider
 
 SDK_TO_MA_STATE: dict[PlayingStatus, PlaybackState] = {
@@ -101,36 +101,71 @@ class WiimPlayer(Player):
         self._last_logged_sdk_uri: str | None = None
         self._last_logged_sdk_status: PlayingStatus | None = None
         self._ma_stream_uri: str | None = None
+        self._native_groups: NativeGroupCoordinator = provider.native_groups
+        # a copy of the low-level client's detected capabilities, reused to pre-seed each
+        # fresh command client so topology reads do not re-probe the device
+        self._command_capabilities: dict[str, Any] | None = None
 
     @property
     def supported_features(self) -> set[PlayerFeature]:
-        """Return supported features; grouping is withdrawn in a read-only mixed group."""
-        if self._in_mixed_group:
-            return self._attr_supported_features - {PlayerFeature.SET_MEMBERS}
+        """Return the supported features of the player."""
         return self._attr_supported_features
 
     @property
-    def grouping_locked(self) -> bool:
-        """Suppress grouping while in a read-only externally-created mixed group."""
-        return self._in_mixed_group
+    def native_available(self) -> bool:
+        """Return whether the device is currently reachable for grouping commands."""
+        return self.device.available
+
+    @property
+    def native_ip(self) -> str | None:
+        """Return the device's current IP address, if known."""
+        return self.device.ip_address
+
+    @property
+    def native_device_udn(self) -> str:
+        """Return the device UDN used for official SDK grouping commands."""
+        return self.device.udn
 
     @property
     def can_group_with(self) -> set[str]:
-        """Return the ids of the other official WiiM players this player can group with."""
-        if self._in_mixed_group:
-            return set()
-        return {
-            player.player_id
-            for player in self.provider.players
-            if isinstance(player, WiimPlayer)
-            and player.available
-            and player.player_id != self.player_id
-            and not player._in_mixed_group
-        }
+        """Return the ids of the peers of either backend this player can group with."""
+        return self._native_groups.can_group_with(self)
 
     def is_native_group_compatible(self, other: Player) -> bool:
-        """Only other official WiiM players group natively (never a generic LinkPlay shell)."""
+        """Only reachable coordinator-approved peers of either backend group natively."""
         return other.player_id in self.can_group_with
+
+    def make_command_client(self) -> WiiMClient:
+        """
+        Return a command-only LinkPlay client bound to this device's current address.
+
+        The official backend owns playback and eventing through the WiiM SDK; this
+        low-level client is used only for native topology reads and cross-backend grouping
+        commands, borrows the shared session and is never closed. Any capabilities detected
+        by an earlier client are passed on so a fresh client does not re-probe the device.
+        """
+        if not (ip := self.device.ip_address):
+            raise PlayerCommandFailed(f"Cannot command {self.player_id}: device address unknown")
+        capabilities = dict(self._command_capabilities) if self._command_capabilities else None
+        return WiiMClient(ip, session=self.mass.http_session, capabilities=capabilities)
+
+    def store_command_capabilities(self, capabilities: dict[str, Any]) -> None:
+        """
+        Cache a copy of a command client's detected capabilities for later reuse.
+
+        :param capabilities: The capabilities a command client detected for this device.
+        """
+        # an empty dict means detection has not produced anything to reuse; caching it would
+        # wrongly mark future clients as already-detected and skip real probing
+        if capabilities:
+            self._command_capabilities = dict(capabilities)
+
+    def on_native_group_update(self) -> None:
+        """Re-publish state after the topology coordinator changed this player's role."""
+        # role/membership are derived by the coordinator, not from this player's own
+        # attributes, so force a recalculation (e.g. synced_to) even when idle.
+        self.mark_state_dirty()
+        self._update_ma_state_from_sdk_cache()
 
     # --- Lifecycle ---
 
@@ -149,11 +184,15 @@ class WiimPlayer(Player):
         """Poll player for transport state and position updates."""
         await self._sync_position()
         await self._refresh_device_status()
+        # slow, TTL-gated re-read of the native slave list (no busy polling loop)
+        await self._native_groups.refresh_leader(self)
         self._attr_poll_interval = 5 if self._attr_playback_state == PlaybackState.PLAYING else 30
 
     async def on_unload(self) -> None:
         """Handle logic when the player is unloaded from the Player controller."""
         await super().on_unload()
+        self._native_groups.unregister(self.player_id)
+        self._native_groups.schedule_reconcile()
         self.device.general_event_callback = None
         self.device.av_transport_event_callback = None
         self.device.rendering_control_event_callback = None
@@ -302,34 +341,6 @@ class WiimPlayer(Player):
         player_ids_to_remove: list[str] | None = None,
     ) -> None:
         """Handle SET_MEMBERS command on the player."""
-        if self._in_mixed_group:
-            raise UnsupportedFeaturedException(
-                f"{self._attr_name} is in an externally-created mixed group and cannot be regrouped"
-            )
-        add_ids = player_ids_to_add or []
-        remove_ids = player_ids_to_remove or []
-        if len(set(add_ids)) != len(add_ids) or len(set(remove_ids)) != len(remove_ids):
-            raise PlayerCommandFailed(f"Duplicate member id in grouping request on {self.name}")
-        if conflicting := set(add_ids) & set(remove_ids):
-            raise PlayerCommandFailed(
-                f"Cannot add and remove the same member on {self.name}: {conflicting}"
-            )
-        # Resolve and validate the whole batch before any hardware call, so a stale, moved,
-        # mixed or cross-backend target can never leave the group partially mutated.
-        to_add = [self._require_wiim_member(mid) for mid in add_ids]
-        to_remove = [self._require_wiim_member(mid) for mid in remove_ids]
-        if to_remove:
-            # Only ungroup members this leader still owns per the freshest SDK snapshot: a
-            # target that has since moved to another (possibly read-only mixed) group must
-            # not be torn out of it.
-            current_member_udns = set(
-                self._wiim_controller.get_group_snapshot(self.device.udn).member_udns
-            )
-            for member in to_remove:
-                if member.device.udn not in current_member_udns:
-                    raise PlayerCommandFailed(
-                        f"{member.player_id} is no longer a member of {self.name}"
-                    )
         queue = self.mass.player_queues.get(self.player_id)
         pq_data = self.mass.player_queues.queue_data_or_none(self.player_id) if queue else None
         entry_sdk_uri = self.device.current_media.uri if self.device.current_media else None
@@ -348,17 +359,7 @@ class WiimPlayer(Player):
             self.device.playing_status,
         )
         try:
-            if to_add:
-                await self._wiim_controller.async_join_group(
-                    self.device.udn, [member.device.udn for member in to_add]
-                )
-            for member in to_remove:
-                await self._wiim_controller.async_ungroup_device(member.device.udn)
-        except WiimException as err:
-            # Log and refresh state as for any command, but surface grouping failures to the
-            # caller: a swallowed error would report a join/leave as succeeded.
-            self._handle_command_error("set_members", err)
-            raise PlayerCommandFailed(f"set_members failed on {self.name}: {err}") from err
+            await self._native_groups.set_members(self, player_ids_to_add, player_ids_to_remove)
         finally:
             exit_sdk_uri = self.device.current_media.uri if self.device.current_media else None
             self.logger.debug(
@@ -410,7 +411,9 @@ class WiimPlayer(Player):
         self._update_ma_state_from_sdk_cache()
         for sv in state_variables:
             if sv.name == "LastChange" and sv.value and "Slave" in str(sv.value):
-                self.mass.create_task(self._refresh_multiroom())
+                # a slave was added/removed: force a live topology + self-role re-read,
+                # deduplicated so a burst of events coalesces into one refresh.
+                self._schedule_topology_refresh()
                 break
 
     def _handle_sdk_play_queue_event(
@@ -436,9 +439,14 @@ class WiimPlayer(Player):
         self._attr_volume_level = self.device.volume
         self._attr_volume_muted = self.device.is_muted
 
-        # Followers have their state derived by MA from the leader.
-        snapshot = self._wiim_controller.get_group_snapshot(self.device.udn)
-        if snapshot.role == WiimGroupRole.FOLLOWER:
+        # The coordinator is the single native topology authority across both backends; this
+        # mapper only reads the role, never writes it. The self-follower signal is fed from a
+        # live group read on the poll/event refresh path.
+        if self._native_groups.role_of(self.player_id) == NativeGroupRole.FOLLOWER:
+            # Following a leader (possibly a generic one): MA derives playback from the
+            # leader, so this player publishes only its own volume/mute here and manages no
+            # members of its own.
+            self._attr_group_members = []
             self.update_state()
             return
 
@@ -451,7 +459,7 @@ class WiimPlayer(Player):
             self._attr_playback_state = new_state
 
         # Group members
-        self._update_group_state(snapshot.member_udns)
+        self._attr_group_members = self._native_groups.members_of(self.player_id)
 
         if play_mode and play_mode != SOURCE_NETWORK and play_mode in INPUT_MODE_SOURCES:
             self._attr_active_source = INPUT_MODE_SOURCES[play_mode].id
@@ -601,46 +609,10 @@ class WiimPlayer(Player):
         self.logger.warning("Command '%s' failed on %s: %s", action, self._attr_name, err)
         self._update_ma_state_from_sdk_cache()
 
-    def _update_group_state(self, member_udns: tuple[str, ...]) -> None:
-        """Map the SDK's group snapshot to the managed group members."""
-        managed_member_ids = [
-            f"{PLAYER_ID_PREFIX}{member_udn}"
-            for member_udn in member_udns
-            if member_udn != self.device.udn
-            and self.mass.players.get_player(f"{PLAYER_ID_PREFIX}{member_udn}")
-        ]
-        self._attr_group_members = (
-            [self.player_id, *managed_member_ids] if managed_member_ids else []
+    def _schedule_topology_refresh(self) -> None:
+        """Schedule a live topology + self-role re-read, preempting any stale one."""
+        self.mass.create_task(
+            self._native_groups.refresh_leader(self, force=True),
+            task_id=f"wiim_topology_{self.player_id}",
+            abort_existing=True,
         )
-
-    @property
-    def _in_mixed_group(self) -> bool:
-        """Whether this device is in an externally-created mixed (cross-backend) group."""
-        return is_in_mixed_group(self)
-
-    def _require_wiim_member(self, player_id: str) -> WiimPlayer:
-        """
-        Return a same-backend, groupable member for a grouping command.
-
-        A request targeting this player itself, an unknown player, another backend
-        (e.g. a generic LinkPlay shell) or a device locked in an externally-created
-        mixed group is rejected with a typed error rather than applied.
-
-        :param player_id: The id of the member to resolve and validate.
-        """
-        if player_id == self.player_id:
-            raise UnsupportedFeaturedException(f"Cannot group {self.name} with itself")
-        member = self.mass.players.get_player(player_id)
-        if member is None:
-            raise PlayerCommandFailed(
-                f"{player_id} is not a known player for grouping on {self.name}"
-            )
-        if not isinstance(member, WiimPlayer):
-            raise UnsupportedFeaturedException(
-                f"Cannot group {player_id} with {self.name}: cross-backend grouping is unsupported"
-            )
-        if member._in_mixed_group:
-            raise PlayerCommandFailed(
-                f"{player_id} is in an externally-created mixed group and cannot be regrouped"
-            )
-        return member

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -594,16 +594,6 @@ class WiimPlayer(Player):
             self._attr_elapsed_time_last_updated = time.time()
         self._update_ma_state_from_sdk_cache()
 
-    async def _refresh_multiroom(self) -> None:
-        """Refresh multiroom status from devices, then update all WiiM players."""
-        try:
-            await self._wiim_controller.async_update_all_multiroom_status()
-        except WiimException as err:
-            self.logger.debug("Failed to refresh multiroom status: %s", err)
-        for player in self.provider.players:
-            if isinstance(player, WiimPlayer):
-                player._update_ma_state_from_sdk_cache()
-
     def _handle_command_error(self, action: str, err: WiimException) -> None:
         """Handle a command error by logging and refreshing state."""
         self.logger.warning("Command '%s' failed on %s: %s", action, self._attr_name, err)

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -606,10 +606,14 @@ class WiimPlayer(Player):
     def _publish_follower_state(self) -> None:
         """Publish the volume-only state of a native follower and clear its playback."""
         # MA derives a follower's playback from the leader, so this player publishes only
-        # its own volume/mute and manages no members. Reset the raw playback state so a
-        # self-reported follower whose leader MA has not discovered (no synced_to parent)
-        # does not keep publishing its stale pre-group state; a known follower still mirrors
-        # its resolved leader through synced_to.
+        # its own volume/mute and manages no members. Clear any active output first so the
+        # final state mirrors the leader (synced_to) or falls back to idle instead of a
+        # stale linked protocol, which the base otherwise prioritizes over synced_to; it is
+        # left cleared on leaving, where normal playback reselects an output. Reset the raw
+        # playback state too so a self-reported follower whose leader MA has not discovered
+        # (no synced_to parent) does not keep publishing its stale pre-group state.
+        if self.active_output_protocol is not None:
+            self.set_active_output_protocol(None)
         self._attr_playback_state = PlaybackState.IDLE
         self._attr_active_source = None
         self._attr_current_media = None

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -605,19 +605,18 @@ class WiimPlayer(Player):
 
     def _publish_follower_state(self) -> None:
         """Publish the volume-only state of a native follower and clear its playback."""
-        # MA derives a follower's playback from the leader, so this player publishes only
-        # its own volume/mute and manages no members. Clear any active output first so the
-        # final state mirrors the leader (synced_to) or falls back to idle instead of a
-        # stale linked protocol, which the base otherwise prioritizes over synced_to; it is
-        # left cleared on leaving, where normal playback reselects an output. Reset the raw
-        # playback state too so a self-reported follower whose leader MA has not discovered
-        # (no synced_to parent) does not keep publishing its stale pre-group state.
-        if self.active_output_protocol is not None:
-            self.set_active_output_protocol(None)
+        # MA derives a follower's playback from the leader, so this player publishes only its
+        # own volume/mute and manages no members. Clear the follower-owned state first so the
+        # active-output clear below (which publishes immediately) never emits the stale
+        # pre-group playback, then drop any active output so the final state mirrors the
+        # leader (synced_to) or falls back to idle instead of a stale linked protocol; it is
+        # left cleared on leaving, where normal playback reselects an output.
         self._attr_playback_state = PlaybackState.IDLE
         self._attr_active_source = None
         self._attr_current_media = None
         self._attr_group_members = []
+        if self.active_output_protocol is not None:
+            self.set_active_output_protocol(None)
         self.update_state()
 
     def _schedule_topology_refresh(self) -> None:

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -434,7 +434,9 @@ class WiimPlayer(Player):
 
     def _update_ma_state_from_sdk_cache(self) -> None:
         """Update MA state from SDK's cache/HTTP poll attributes."""
+        was_available = self._attr_available
         self._attr_available = self.device.available
+        self._republish_peers_if_availability_changed(was_available)
         if self.device.name != self._attr_name:
             self._attr_name = self.device.name
 
@@ -602,6 +604,13 @@ class WiimPlayer(Player):
         """Handle a command error by logging and refreshing state."""
         self.logger.warning("Command '%s' failed on %s: %s", action, self._attr_name, err)
         self._update_ma_state_from_sdk_cache()
+
+    def _republish_peers_if_availability_changed(self, was_available: bool) -> None:
+        """Re-publish every native peer when this device's availability just flipped."""
+        # availability changes whether every peer can offer this device as a native grouping
+        # candidate, which no topology reconcile would otherwise pick up.
+        if was_available != self._attr_available:
+            self._native_groups.schedule_republish()
 
     def _publish_follower_state(self) -> None:
         """Publish the volume-only state of a native follower and clear its playback."""

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -46,10 +46,6 @@ SDK_TO_MA_STATE: dict[PlayingStatus, PlaybackState] = {
     PlayingStatus.LOADING: PlaybackState.PLAYING,
 }
 
-# A burst of RenderingControl Slave events is coalesced into one forced topology re-read
-# after this delay, so sustained event traffic cannot starve reconciliation.
-TOPOLOGY_REFRESH_DEBOUNCE = 1.0
-
 
 class WiimPlayer(Player):
     """Wiim Player in Music Assistant."""
@@ -633,12 +629,13 @@ class WiimPlayer(Player):
         self.update_state()
 
     def _schedule_topology_refresh(self) -> None:
-        """Schedule a debounced live topology + self-role re-read, coalescing event bursts."""
-        # a burst of RenderingControl Slave events must not repeatedly cancel and restart the
-        # HTTP read (which would starve reconciliation and hammer the device); the shared
-        # task_id makes each event reschedule one final forced refresh after a short delay.
-        self.mass.call_later(
-            TOPOLOGY_REFRESH_DEBOUNCE,
+        """Force one live topology + self-role re-read, deduplicated over Slave-event bursts."""
+        # abort_existing=False deduplicates on the shared task_id: while a forced read is in
+        # flight, further events neither start a second read (leading-edge throttle) nor
+        # cancel the running one, so a burst neither hammers the device nor starves
+        # reconciliation. Passing the coroutine function lets the runtime drop a deduplicated
+        # call cleanly.
+        self.mass.create_task(
             self._native_groups.refresh_leader,
             self,
             task_id=f"wiim_topology_{self.player_id}",

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -46,6 +46,10 @@ SDK_TO_MA_STATE: dict[PlayingStatus, PlaybackState] = {
     PlayingStatus.LOADING: PlaybackState.PLAYING,
 }
 
+# A burst of RenderingControl Slave events is coalesced into one forced topology re-read
+# after this delay, so sustained event traffic cannot starve reconciliation.
+TOPOLOGY_REFRESH_DEBOUNCE = 1.0
+
 
 class WiimPlayer(Player):
     """Wiim Player in Music Assistant."""
@@ -629,9 +633,14 @@ class WiimPlayer(Player):
         self.update_state()
 
     def _schedule_topology_refresh(self) -> None:
-        """Schedule a live topology + self-role re-read, preempting any stale one."""
-        self.mass.create_task(
-            self._native_groups.refresh_leader(self, force=True),
+        """Schedule a debounced live topology + self-role re-read, coalescing event bursts."""
+        # a burst of RenderingControl Slave events must not repeatedly cancel and restart the
+        # HTTP read (which would starve reconciliation and hammer the device); the shared
+        # task_id makes each event reschedule one final forced refresh after a short delay.
+        self.mass.call_later(
+            TOPOLOGY_REFRESH_DEBOUNCE,
+            self._native_groups.refresh_leader,
+            self,
             task_id=f"wiim_topology_{self.player_id}",
-            abort_existing=True,
+            force=True,
         )

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -131,6 +131,14 @@ class WiimPlayer(Player):
         """Return the ids of the peers of either backend this player can group with."""
         return self._native_groups.can_group_with(self)
 
+    @property
+    def grouping_locked(self) -> bool:
+        """Withdraw grouping while following a group MA has not discovered."""
+        # An unknown-leader follower belongs to an external group MA cannot see the leader
+        # of; locking here keeps core from offering it as a grouping target for a regroup
+        # the coordinator would then have to refuse.
+        return self._native_groups.is_unknown_leader_follower(self.player_id)
+
     def is_native_group_compatible(self, other: Player) -> bool:
         """Only reachable coordinator-approved peers of either backend group natively."""
         return other.player_id in self.can_group_with
@@ -443,11 +451,7 @@ class WiimPlayer(Player):
         # mapper only reads the role, never writes it. The self-follower signal is fed from a
         # live group read on the poll/event refresh path.
         if self._native_groups.role_of(self.player_id) == NativeGroupRole.FOLLOWER:
-            # Following a leader (possibly a generic one): MA derives playback from the
-            # leader, so this player publishes only its own volume/mute here and manages no
-            # members of its own.
-            self._attr_group_members = []
-            self.update_state()
+            self._publish_follower_state()
             return
 
         media = self.device.current_media
@@ -598,6 +602,19 @@ class WiimPlayer(Player):
         """Handle a command error by logging and refreshing state."""
         self.logger.warning("Command '%s' failed on %s: %s", action, self._attr_name, err)
         self._update_ma_state_from_sdk_cache()
+
+    def _publish_follower_state(self) -> None:
+        """Publish the volume-only state of a native follower and clear its playback."""
+        # MA derives a follower's playback from the leader, so this player publishes only
+        # its own volume/mute and manages no members. Reset the raw playback state so a
+        # self-reported follower whose leader MA has not discovered (no synced_to parent)
+        # does not keep publishing its stale pre-group state; a known follower still mirrors
+        # its resolved leader through synced_to.
+        self._attr_playback_state = PlaybackState.IDLE
+        self._attr_active_source = None
+        self._attr_current_media = None
+        self._attr_group_members = []
+        self.update_state()
 
     def _schedule_topology_refresh(self) -> None:
         """Schedule a live topology + self-role re-read, preempting any stale one."""

--- a/music_assistant/providers/wiim/provider.py
+++ b/music_assistant/providers/wiim/provider.py
@@ -23,6 +23,7 @@ from music_assistant.helpers.util import (
 from music_assistant.models.player_provider import PlayerProvider
 
 from .constants import PLAYER_ID_PREFIX
+from .grouping import NativeGroupCoordinator
 from .helpers import is_official_manufacturer
 from .linkplay_player import LinkPlayPlayer
 from .player import WiimPlayer
@@ -61,6 +62,8 @@ class WiimProvider(PlayerProvider):
             logging.getLogger("wiim").setLevel(max(self.logger.level + 10, logging.WARNING))
 
         self.wiim_controller = WiimController(self.mass.http_session_no_ssl)
+        # The single native multiroom topology authority shared by both backends.
+        self.native_groups = NativeGroupCoordinator(self)
         # UPnP identity probe used to classify a discovered device (official WiiM/Audio Pro
         # vs a generic LinkPlay device such as Edifier). The description.xml is served over
         # plain HTTP; no UPnP eventing is used by the generic backend.
@@ -147,6 +150,9 @@ class WiimProvider(PlayerProvider):
             )
             await player.setup()
             await self.mass.players.register_or_update(player)
+            # a newly registered leader may already list this device, and this device may
+            # lead others: reconcile so discovery-order misses on either side self-heal.
+            self.native_groups.schedule_reconcile()
             self.logger.info("WiiM player registered: %s (%s)", wiim_dev.name, player_id)
         except Exception:
             self.logger.exception("Failed to register WiiM player %s", wiim_dev.name)
@@ -185,6 +191,9 @@ class WiimProvider(PlayerProvider):
         )
         await player.setup()
         await self.mass.players.register_or_update(player)
+        # a newly registered leader may already list this device, and this device may lead
+        # others: reconcile so discovery-order misses on either side self-heal.
+        self.native_groups.schedule_reconcile()
         self.logger.info("LinkPlay player registered: %s (%s)", player.name, player_id)
 
     def _candidate_locations(

--- a/music_assistant/providers/wiim/provider.py
+++ b/music_assistant/providers/wiim/provider.py
@@ -150,8 +150,11 @@ class WiimProvider(PlayerProvider):
             )
             await player.setup()
             await self.mass.players.register_or_update(player)
-            # a newly registered leader may already list this device, and this device may
-            # lead others: reconcile so discovery-order misses on either side self-heal.
+            # read the live topology now the player is registered (setup runs before
+            # registration, so the coordinator would discard a read taken there), then
+            # reconcile so any leader that already lists this device, or that it leads,
+            # self-heals regardless of discovery order.
+            await self.native_groups.refresh_leader(player, force=True)
             self.native_groups.schedule_reconcile()
             self.logger.info("WiiM player registered: %s (%s)", wiim_dev.name, player_id)
         except Exception:
@@ -191,8 +194,11 @@ class WiimProvider(PlayerProvider):
         )
         await player.setup()
         await self.mass.players.register_or_update(player)
-        # a newly registered leader may already list this device, and this device may lead
-        # others: reconcile so discovery-order misses on either side self-heal.
+        # read the live topology now the player is registered (setup runs before
+        # registration, so the coordinator would discard a read taken there), then
+        # reconcile so any leader that already lists this device, or that it leads,
+        # self-heals regardless of discovery order.
+        await self.native_groups.refresh_leader(player, force=True)
         self.native_groups.schedule_reconcile()
         self.logger.info("LinkPlay player registered: %s (%s)", player.name, player_id)
 

--- a/tests/providers/wiim/test_grouping.py
+++ b/tests/providers/wiim/test_grouping.py
@@ -1649,3 +1649,50 @@ class TestBatchValidation:
         coordinator, _ = _make_coordinator(me, peer)
 
         assert coordinator.can_group_with(me) == {FOLLOWER_ID}
+
+    async def test_add_remove_conflict_rejected(self) -> None:
+        """The same id in both add and remove is a contradictory request and is rejected."""
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=_leader_client([]))
+        member = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, member)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], [FOLLOWER_ID])
+        provider.wiim_controller.async_join_group.assert_not_called()
+
+    async def test_duplicate_ids_rejected(self) -> None:
+        """A duplicate id within a single add/remove list is rejected up front."""
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=_leader_client([]))
+        member = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, member)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID, FOLLOWER_ID], None)
+        provider.wiim_controller.async_join_group.assert_not_called()
+
+    async def test_newer_observation_wins_ownership_despite_later_apply(self) -> None:
+        """A follower belongs to the most recently OBSERVED leader, not the last one applied."""
+        other_leader_id = "wiim_uuid:22222222-3333-4444-5555-666666666666"
+        leader_a = _make_player(LEADER_ID, BACKEND_GENERIC)
+        leader_b = _make_player(other_leader_id, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(leader_a, leader_b, follower)
+
+        # leader B observed the follower more recently, but leader A's older observation is
+        # applied afterwards (a longer-running read that completed late)
+        coordinator.set_leader_slaves(other_leader_id, [FOLLOWER_HTTP_UUID], observed_at=200.0)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID], observed_at=100.0)
+        await coordinator.reconcile()
+
+        assert coordinator.leader_of(FOLLOWER_ID) == other_leader_id
+
+    async def test_republish_all_republishes_every_native_player(self) -> None:
+        """schedule_republish's work re-publishes every registered native player's state."""
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        peer = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, _ = _make_coordinator(leader, peer)
+
+        coordinator._republish_all()
+
+        leader.on_native_group_update.assert_called_once()
+        peer.on_native_group_update.assert_called_once()

--- a/tests/providers/wiim/test_grouping.py
+++ b/tests/providers/wiim/test_grouping.py
@@ -1633,3 +1633,19 @@ class TestBatchValidation:
             await coordinator.set_members(leader, [FOLLOWER_ID], None)
         assert isinstance(exc_info.value.__cause__, WiiMError)
         member_client.join_slave.assert_not_called()
+
+    async def test_unavailable_requester_offers_no_native_peers(self) -> None:
+        """A device whose own grouping API is unreachable offers no native candidates."""
+        me = _make_player(LEADER_ID, BACKEND_GENERIC, available=False)
+        peer = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(me, peer)
+
+        assert coordinator.can_group_with(me) == set()
+
+    async def test_available_requester_still_offers_peers(self) -> None:
+        """A reachable device is unaffected: it still offers its available native peers."""
+        me = _make_player(LEADER_ID, BACKEND_GENERIC)
+        peer = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(me, peer)
+
+        assert coordinator.can_group_with(me) == {FOLLOWER_ID}

--- a/tests/providers/wiim/test_grouping.py
+++ b/tests/providers/wiim/test_grouping.py
@@ -1,0 +1,1372 @@
+"""Tests for the native multiroom topology coordinator shared by both backends."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.errors import PlayerCommandFailed
+from pywiim import WiiMError
+from wiim.exceptions import WiimException
+
+from music_assistant.providers.wiim.constants import BACKEND_GENERIC, BACKEND_OFFICIAL
+from music_assistant.providers.wiim.grouping import NativeGroupCoordinator, NativeGroupRole
+
+# Two verified LinkPlay identities: the leader and a follower whose 24-char HTTP
+# slave uuid maps to the follower's UDN-derived player id.
+LEADER_ID = "wiim_uuid:11111111-2222-3333-4444-555555555555"
+LEADER_MASTER_UUID = "11111111-2222-3333-4444-555555555555"
+OTHER_MASTER_UUID = "99999999-8888-7777-6666-555555555555"
+FOLLOWER_HTTP_UUID = "A1B2C3D4E5F6A7B8C9D0E1F2"
+FOLLOWER_ID = "wiim_uuid:A1B2C3D4-E5F6-A7B8-C9D0-E1F2A1B2C3D4"
+
+
+def _ginfo(role: str, master: str | None = LEADER_MASTER_UUID) -> MagicMock:
+    """Build a fake DeviceGroupInfo for a follower/solo device (role + master uuid)."""
+    return MagicMock(role=role, master_uuid=master, slave_uuids=[])
+
+
+def _leader_info(slave_uuids: list[str]) -> MagicMock:
+    """Build a fake DeviceGroupInfo for a master device with the given slave uuids."""
+    return MagicMock(role="master", master_uuid=None, slave_uuids=slave_uuids)
+
+
+def _leader_client(slaves: list[str]) -> MagicMock:
+    """
+    Build a leader command client whose live group info reflects a mutable slave list.
+
+    Tests mutate ``slaves`` (directly or from a grouping command's side effect) so the
+    leader-side verification observes the membership the command produced on the device.
+    ``get_slaves_info`` derives a stable per-uuid ip and ``kick_slave`` removes the slave
+    at that ip, mirroring how a follower is removed from the leader.
+    """
+
+    def _ip_for(index: int) -> str:
+        return f"192.168.1.{50 + index}"
+
+    async def _info() -> MagicMock:
+        return MagicMock(
+            role="master" if slaves else "solo", slave_uuids=list(slaves), master_uuid=None
+        )
+
+    async def _slaves_info() -> list[dict[str, str]]:
+        return [{"uuid": uuid, "ip": _ip_for(i)} for i, uuid in enumerate(slaves)]
+
+    async def _kick(slave_ip: str) -> None:
+        for i, uuid in enumerate(list(slaves)):
+            if _ip_for(i) == slave_ip:
+                slaves.remove(uuid)
+                break
+
+    client = MagicMock()
+    client.get_device_group_info = AsyncMock(side_effect=_info)
+    client.get_slaves_info = AsyncMock(side_effect=_slaves_info)
+    client.get_device_info_model = AsyncMock(
+        return_value=MagicMock(needs_wifi_direct_multiroom=False, wmrm_version="4.2")
+    )
+    client.capabilities = {"probed": True}
+    client.create_group = AsyncMock()
+    client.kick_slave = AsyncMock(side_effect=_kick)
+    return client
+
+
+def _member_client() -> MagicMock:
+    """Build a follower command-client stub for a mixed-group join target."""
+    client = MagicMock()
+    client.capabilities = {"probed": True}
+    client.get_device_info_model = AsyncMock(
+        return_value=MagicMock(needs_wifi_direct_multiroom=False, wmrm_version="4.2")
+    )
+    return client
+
+
+def _make_player(
+    player_id: str,
+    backend: str,
+    *,
+    available: bool = True,
+    ip: str | None = "192.168.1.10",
+    command_client: MagicMock | None = None,
+    live_role: str = "solo",
+    live_master: str | None = None,
+) -> MagicMock:
+    """Build a fake native player exposing exactly the coordinator's needed surface."""
+    player = MagicMock()
+    player.player_id = player_id
+    player.linkplay_backend = backend
+    player.native_available = available
+    player.native_ip = ip
+    player.native_device_udn = player_id.removeprefix("wiim_")
+    if command_client is None:
+        command_client = MagicMock()
+        command_client.capabilities = {"probed": True}
+        command_client.get_device_group_info = AsyncMock(
+            return_value=MagicMock(role=live_role, master_uuid=live_master, slave_uuids=[])
+        )
+        command_client.get_slaves_info = AsyncMock(return_value=[])
+        command_client.get_device_info_model = AsyncMock(
+            return_value=MagicMock(needs_wifi_direct_multiroom=False, wmrm_version="4.2")
+        )
+    player.make_command_client = MagicMock(return_value=command_client)
+    player.store_command_capabilities = MagicMock()
+    player.on_native_group_update = MagicMock()
+    return player
+
+
+@pytest.fixture(autouse=True)
+def _fast_membership_verify(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Collapse the grouping verification retry to a single immediate check in tests."""
+    monkeypatch.setattr("music_assistant.providers.wiim.grouping.VERIFY_MAX_WAIT", 0.0)
+    monkeypatch.setattr("music_assistant.providers.wiim.grouping.VERIFY_POLL_INTERVAL", 0.0)
+
+
+def _make_coordinator(*players: MagicMock) -> tuple[NativeGroupCoordinator, MagicMock]:
+    """Create a coordinator over a provider whose player list is the given players."""
+    provider = MagicMock()
+    provider.players = list(players)
+    provider.mass = MagicMock()
+    provider.logger = MagicMock()
+    provider.wiim_controller = MagicMock(
+        async_join_group=AsyncMock(), async_ungroup_device=AsyncMock()
+    )
+    by_id = {player.player_id: player for player in players}
+    provider.mass.players.get_player.side_effect = by_id.get
+    return NativeGroupCoordinator(provider), provider
+
+
+class TestTopologyResolution:
+    """Reconcile resolves raw slave uuids against registered players, both directions."""
+
+    async def test_generic_leader_resolves_generic_follower(self) -> None:
+        """A generic leader's slave uuid resolves to its registered generic follower."""
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+
+        assert coordinator.role_of(LEADER_ID) == NativeGroupRole.LEADER
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+        assert coordinator.members_of(LEADER_ID) == [LEADER_ID, FOLLOWER_ID]
+        assert coordinator.leader_of(FOLLOWER_ID) == LEADER_ID
+
+    async def test_official_leader_resolves_generic_follower(self) -> None:
+        """An official leader lists a generic follower (mixed group), leader first."""
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+
+        assert coordinator.members_of(LEADER_ID) == [LEADER_ID, FOLLOWER_ID]
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+
+    async def test_unknown_slave_is_skipped(self) -> None:
+        """A slave uuid that resolves to no registered player is ignored."""
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(leader)
+
+        coordinator.set_leader_slaves(LEADER_ID, ["FFFFFFFFFFFFFFFFFFFFFFFF"])
+        await coordinator.reconcile()
+
+        assert coordinator.role_of(LEADER_ID) == NativeGroupRole.STANDALONE
+        assert coordinator.members_of(LEADER_ID) == []
+
+    async def test_follower_leadership_is_ignored(self) -> None:
+        """A device that is another leader's follower cannot also be a leader."""
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        # follower still has a stale self-leadership entry while also being a slave
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        coordinator.set_leader_slaves(FOLLOWER_ID, ["FFFFFFFFFFFFFFFFFFFFFFFF"])
+        await coordinator.reconcile()
+
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+        assert coordinator.members_of(FOLLOWER_ID) == []
+
+    async def test_moved_follower_belongs_to_one_group(self) -> None:
+        """
+        A moved follower shows in only one group.
+
+        While it still lingers in its old leader's not-yet-refreshed cached list,
+        the most recently refreshed leader wins so it never appears in two groups.
+        """
+        old_leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        new_leader = _make_player("wiim_uuid:99999999-8888-7777-6666-555555555555", BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(old_leader, new_leader, follower)
+
+        # old leader read the follower first; the new leader read it more recently
+        coordinator.set_leader_slaves(old_leader.player_id, [FOLLOWER_HTTP_UUID])
+        coordinator.set_leader_slaves(new_leader.player_id, [FOLLOWER_HTTP_UUID])
+        coordinator._refreshed_at[old_leader.player_id] = 100.0
+        coordinator._refreshed_at[new_leader.player_id] = 200.0
+        await coordinator.reconcile()
+
+        assert coordinator.leader_of(FOLLOWER_ID) == new_leader.player_id
+        assert coordinator.members_of(new_leader.player_id) == [new_leader.player_id, FOLLOWER_ID]
+        assert coordinator.members_of(old_leader.player_id) == []
+        assert coordinator.role_of(old_leader.player_id) == NativeGroupRole.STANDALONE
+
+
+class TestReconcileNotifications:
+    """Reconcile pushes state only to players whose role or membership changed."""
+
+    async def test_only_changed_players_notified(self) -> None:
+        """A newly formed group notifies the leader and follower exactly once."""
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+
+        leader.on_native_group_update.assert_called_once()
+        follower.on_native_group_update.assert_called_once()
+
+    async def test_moved_follower_is_notified_even_when_role_unchanged(self) -> None:
+        """A follower moving between leaders (still FOLLOWER) is still notified."""
+        other_leader_id = "wiim_uuid:22222222-3333-4444-5555-666666666666"
+        leader_a = _make_player(LEADER_ID, BACKEND_GENERIC)
+        leader_b = _make_player(other_leader_id, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(leader_a, leader_b, follower)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        coordinator._refreshed_at[LEADER_ID] = 100.0
+        await coordinator.reconcile()
+        follower.on_native_group_update.reset_mock()
+
+        # move to leader B: role stays FOLLOWER and members stays [], only the leader changes
+        coordinator.set_leader_slaves(LEADER_ID, [])
+        coordinator.set_leader_slaves(other_leader_id, [FOLLOWER_HTTP_UUID])
+        coordinator._refreshed_at[other_leader_id] = 200.0
+        await coordinator.reconcile()
+
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+        assert coordinator.leader_of(FOLLOWER_ID) == other_leader_id
+        follower.on_native_group_update.assert_called_once()
+
+    async def test_stale_reverse_mapping_removed_atomically(self) -> None:
+        """When a leader drops a follower, that follower's reverse mapping is cleared."""
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(leader, follower)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+
+        # the leader is now alone again
+        coordinator.set_leader_slaves(LEADER_ID, [])
+        await coordinator.reconcile()
+
+        assert coordinator.leader_of(FOLLOWER_ID) is None
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.STANDALONE
+        assert coordinator.role_of(LEADER_ID) == NativeGroupRole.STANDALONE
+
+    async def test_leaders_notified_before_followers(self) -> None:
+        """A follower reads its leader's cached members, so the leader publishes first."""
+        order: list[str] = []
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        leader.on_native_group_update = MagicMock(side_effect=lambda: order.append("leader"))
+        follower.on_native_group_update = MagicMock(side_effect=lambda: order.append("follower"))
+        # register the follower first so the natural iteration order would notify it first
+        coordinator, _ = _make_coordinator(follower, leader)
+
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+
+        assert order == ["leader", "follower"]
+
+    async def test_dissolve_notifies_old_leader_before_follower(self) -> None:
+        """On a dissolve the old leader clears its members before the follower rescans."""
+        order: list[str] = []
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        # register the follower first so the natural iteration order would notify it first
+        coordinator, _ = _make_coordinator(follower, leader)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+        leader.on_native_group_update = MagicMock(side_effect=lambda: order.append("leader"))
+        follower.on_native_group_update = MagicMock(side_effect=lambda: order.append("follower"))
+
+        # dissolve: the leader drops the follower, both become standalone
+        coordinator.set_leader_slaves(LEADER_ID, [])
+        await coordinator.reconcile()
+
+        assert order.index("leader") < order.index("follower")
+
+    async def test_move_notifies_both_leaders_before_follower(self) -> None:
+        """Moving a follower publishes both the old and new leader before the follower."""
+        other_leader_id = "wiim_uuid:22222222-3333-4444-5555-666666666666"
+        order: list[str] = []
+        leader_a = _make_player(LEADER_ID, BACKEND_GENERIC)
+        leader_b = _make_player(other_leader_id, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        # register the follower first so the natural order would notify it first
+        coordinator, _ = _make_coordinator(follower, leader_a, leader_b)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        coordinator._refreshed_at[LEADER_ID] = 100.0
+        await coordinator.reconcile()
+        leader_a.on_native_group_update = MagicMock(side_effect=lambda: order.append("a"))
+        leader_b.on_native_group_update = MagicMock(side_effect=lambda: order.append("b"))
+        follower.on_native_group_update = MagicMock(side_effect=lambda: order.append("follower"))
+
+        # move the follower from leader A to leader B
+        coordinator.set_leader_slaves(LEADER_ID, [])
+        coordinator.set_leader_slaves(other_leader_id, [FOLLOWER_HTTP_UUID])
+        coordinator._refreshed_at[other_leader_id] = 200.0
+        await coordinator.reconcile()
+
+        assert order.index("follower") == len(order) - 1  # follower is notified last
+        assert "a" in order  # both leaders published before it
+        assert "b" in order
+
+    async def test_unknown_follower_transition_notifies_all_players(self) -> None:
+        """An unknown-leader-follower change flips every peer's can_group_with, so all re-publish."""
+        me = _make_player(LEADER_ID, BACKEND_GENERIC)
+        peer = _make_player("wiim_uuid:peer", BACKEND_OFFICIAL)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(me, peer, follower)
+
+        # the device becomes an unknown-leader follower: every peer loses it as a candidate
+        coordinator.set_self_role(FOLLOWER_ID, True)
+        await coordinator.reconcile()
+        me.on_native_group_update.assert_called_once()
+        peer.on_native_group_update.assert_called_once()
+
+        for player in (me, peer, follower):
+            player.on_native_group_update.reset_mock()
+
+        # it returns to standalone: every peer regains it as a candidate
+        coordinator.set_self_role(FOLLOWER_ID, False)
+        await coordinator.reconcile()
+        me.on_native_group_update.assert_called_once()
+        peer.on_native_group_update.assert_called_once()
+        follower.on_native_group_update.assert_called_once()
+
+
+class TestSelfHealing:
+    """Topology heals as players register and as the slow TTL elapses."""
+
+    async def test_discovery_order_miss_heals_on_registration(self) -> None:
+        """A follower discovered after its leader is placed on the next reconcile."""
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        coordinator, provider = _make_coordinator(leader)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+        assert coordinator.members_of(LEADER_ID) == []  # follower not registered yet
+
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        provider.players.append(follower)
+        await coordinator.reconcile()
+
+        assert coordinator.members_of(LEADER_ID) == [LEADER_ID, FOLLOWER_ID]
+
+    async def test_ttl_gates_official_refresh(self) -> None:
+        """An official leader re-reads its live group state only once per TTL unless forced."""
+        client = MagicMock()
+        client.get_device_group_info = AsyncMock(return_value=_ginfo("solo", None))
+        client.get_slaves_info = AsyncMock(return_value=[])
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=client)
+        coordinator, _ = _make_coordinator(leader)
+
+        await coordinator.refresh_leader(leader, force=True)
+        await coordinator.refresh_leader(leader)  # within TTL -> skipped
+        assert client.get_device_group_info.await_count == 1
+
+        await coordinator.refresh_leader(leader, force=True)  # forced -> reads again
+        assert client.get_device_group_info.await_count == 2
+
+    async def test_failed_refresh_keeps_previous_members(self) -> None:
+        """A temporarily unreachable leader keeps the members it last resolved."""
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        client = MagicMock()
+        client.get_device_group_info = AsyncMock(
+            side_effect=[_leader_info([FOLLOWER_HTTP_UUID]), WiiMError("offline")]
+        )
+        client.get_slaves_info = AsyncMock(
+            return_value=[{"uuid": FOLLOWER_HTTP_UUID, "ip": "192.168.1.50"}]
+        )
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        await coordinator.refresh_leader(leader, force=True)
+        assert coordinator.members_of(LEADER_ID) == [LEADER_ID, FOLLOWER_ID]
+
+        await coordinator.refresh_leader(leader, force=True)  # read fails
+        assert coordinator.members_of(LEADER_ID) == [LEADER_ID, FOLLOWER_ID]
+
+    async def test_solo_with_failing_slave_list_keeps_members(self) -> None:
+        """A master reported as 'solo' by a failed slave-list read keeps its members."""
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        client = MagicMock()
+        # get_device_group_info swallows a failed slave-list read and reports solo
+        client.get_device_group_info = AsyncMock(return_value=_ginfo("solo", None))
+        client.get_slaves_info = AsyncMock(side_effect=WiiMError("slave list offline"))
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=client)
+        coordinator, _ = _make_coordinator(leader, follower)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+        assert coordinator.members_of(LEADER_ID) == [LEADER_ID, FOLLOWER_ID]
+
+        # the strict slave-list read fails, so the refresh is non-destructive
+        assert await coordinator.refresh_leader(leader, force=True) is False
+        assert coordinator.members_of(LEADER_ID) == [LEADER_ID, FOLLOWER_ID]
+
+    async def test_genuine_solo_clears_members(self) -> None:
+        """A leader whose strict slave-list read is truly empty drops its members."""
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        client = MagicMock()
+        client.get_device_group_info = AsyncMock(return_value=_ginfo("solo", None))
+        client.get_slaves_info = AsyncMock(return_value=[])
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=client)
+        coordinator, _ = _make_coordinator(leader, follower)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+        assert coordinator.members_of(LEADER_ID) == [LEADER_ID, FOLLOWER_ID]
+
+        assert await coordinator.refresh_leader(leader, force=True) is True
+        assert coordinator.members_of(LEADER_ID) == []
+
+    async def test_concurrent_reconcile_is_serialized(self) -> None:
+        """Concurrent reconciles are serialized and leave a consistent snapshot."""
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(leader, follower)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+
+        await asyncio.gather(coordinator.reconcile(), coordinator.reconcile())
+
+        assert coordinator.members_of(LEADER_ID) == [LEADER_ID, FOLLOWER_ID]
+        assert coordinator.leader_of(FOLLOWER_ID) == LEADER_ID
+
+
+class TestCanGroupWith:
+    """can_group_with widens to available peers of either backend, minus self."""
+
+    def test_lists_available_peers_of_both_backends(self) -> None:
+        """An official player can group with available official and generic peers."""
+        me = _make_player(LEADER_ID, BACKEND_OFFICIAL)
+        generic_peer = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        official_peer = _make_player("wiim_uuid:official-peer", BACKEND_OFFICIAL)
+        coordinator, _ = _make_coordinator(me, generic_peer, official_peer)
+
+        assert coordinator.can_group_with(me) == {FOLLOWER_ID, "wiim_uuid:official-peer"}
+
+    def test_excludes_unavailable_and_self(self) -> None:
+        """Unavailable peers and the player itself are excluded from the candidates."""
+        me = _make_player(LEADER_ID, BACKEND_OFFICIAL)
+        offline_peer = _make_player(FOLLOWER_ID, BACKEND_GENERIC, available=False)
+        coordinator, _ = _make_coordinator(me, offline_peer)
+
+        assert coordinator.can_group_with(me) == set()
+
+    async def test_unavailable_member_retained_in_topology(self) -> None:
+        """A registered but unavailable follower stays a member yet is not groupable."""
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, available=False)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+
+        assert coordinator.members_of(LEADER_ID) == [LEADER_ID, FOLLOWER_ID]
+        assert FOLLOWER_ID not in coordinator.can_group_with(leader)
+
+    async def test_known_follower_can_be_moved_to_another_leader(self) -> None:
+        """A follower with a known leader stays groupable (core auto-ungroups it)."""
+        me = _make_player("wiim_uuid:official-peer", BACKEND_OFFICIAL)
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(me, leader, follower)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+
+        # the follower has a known leader, so it may still be offered as a target
+        assert FOLLOWER_ID in coordinator.can_group_with(me)
+
+    async def test_unknown_leader_follower_is_excluded(self) -> None:
+        """A follower of a leader MA has not discovered cannot be cleanly moved."""
+        me = _make_player("wiim_uuid:official-peer", BACKEND_OFFICIAL)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(me, follower)
+        coordinator.set_self_role(FOLLOWER_ID, True)  # follows an undiscovered leader
+        await coordinator.reconcile()
+
+        assert coordinator.can_group_with(me) == set()
+
+    async def test_unknown_leader_follower_offered_no_candidates(self) -> None:
+        """A device that itself follows an undiscovered leader gets no candidates."""
+        me = _make_player(LEADER_ID, BACKEND_GENERIC)
+        peer = _make_player("wiim_uuid:official-peer", BACKEND_OFFICIAL)
+        coordinator, _ = _make_coordinator(me, peer)
+        coordinator.set_self_role(LEADER_ID, True)  # follows an undiscovered leader
+        await coordinator.reconcile()
+
+        assert coordinator.can_group_with(me) == set()
+
+
+class TestSameBackendGrouping:
+    """Same-backend grouping keeps each backend's native path, verified leader-side."""
+
+    async def test_official_add_uses_sdk_controller(self) -> None:
+        """Two official players are joined via the WiiM SDK controller and verified."""
+        slaves: list[str] = []
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=_leader_client(slaves))
+        follower = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, follower)
+
+        async def _join(*_args: object, **_kwargs: object) -> None:
+            slaves.append(FOLLOWER_HTTP_UUID)  # the device joins the follower
+
+        provider.wiim_controller.async_join_group = AsyncMock(side_effect=_join)
+
+        await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+        provider.wiim_controller.async_join_group.assert_awaited_once_with(
+            leader.native_device_udn, [follower.native_device_udn]
+        )
+
+    async def test_official_remove_uses_sdk_controller(self) -> None:
+        """A managed official member is ungrouped via the SDK, no leader-side kick."""
+        slaves = [FOLLOWER_HTTP_UUID]
+        leader_client = _leader_client(slaves)
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=leader_client)
+        follower = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, follower)
+
+        async def _ungroup(*_args: object, **_kwargs: object) -> None:
+            slaves.clear()  # the SDK removes the follower
+
+        provider.wiim_controller.async_ungroup_device = AsyncMock(side_effect=_ungroup)
+
+        await coordinator.set_members(leader, None, [FOLLOWER_ID])
+
+        provider.wiim_controller.async_ungroup_device.assert_awaited_once_with(
+            follower.native_device_udn
+        )
+        leader_client.kick_slave.assert_not_called()  # SDK removal took effect
+
+    async def test_official_recovered_remove_issues_leader_side_kick(self) -> None:
+        """When the SDK no-ops on a recovered group, the leader kicks the follower."""
+        slaves = [FOLLOWER_HTTP_UUID]
+        leader_client = _leader_client(slaves)  # its kick_slave removes the follower
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=leader_client)
+        follower = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, follower)
+        provider.wiim_controller.async_ungroup_device = AsyncMock()  # SDK no-op
+
+        await coordinator.set_members(leader, None, [FOLLOWER_ID])
+
+        provider.wiim_controller.async_ungroup_device.assert_awaited_once()
+        leader_client.kick_slave.assert_awaited_once_with("192.168.1.50")
+
+    async def test_official_join_no_op_raises(self) -> None:
+        """An SDK join the device ignored (leader never lists it) surfaces a typed failure."""
+        slaves: list[str] = []
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=_leader_client(slaves))
+        follower = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, follower)
+        provider.wiim_controller.async_join_group = AsyncMock()  # device ignores the join
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+    async def test_official_leave_no_op_raises(self) -> None:
+        """When neither the SDK nor the leader-side kick takes effect, a failure is raised."""
+        slaves = [FOLLOWER_HTTP_UUID]
+        leader_client = _leader_client(slaves)
+        leader_client.kick_slave = AsyncMock()  # the kick also no-ops (does not remove)
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=leader_client)
+        follower = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, follower)
+        provider.wiim_controller.async_ungroup_device = AsyncMock()  # SDK no-op
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, None, [FOLLOWER_ID])
+        leader_client.kick_slave.assert_awaited_once()  # the leader-side kick was attempted
+
+    async def test_official_join_failure_raises_typed(self) -> None:
+        """An SDK error (WiimException, not pywiim's) is mapped to PlayerCommandFailed."""
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=_leader_client([]))
+        follower = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, follower)
+        provider.wiim_controller.async_join_group = AsyncMock(
+            side_effect=WiimException("HTTP API not available")
+        )
+
+        with pytest.raises(PlayerCommandFailed) as exc_info:
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        assert isinstance(exc_info.value.__cause__, WiimException)
+
+    async def test_official_remove_failure_raises_typed(self) -> None:
+        """An SDK ungroup error is mapped to PlayerCommandFailed with chaining."""
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, command_client=_leader_client([FOLLOWER_HTTP_UUID])
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, follower)
+        provider.wiim_controller.async_ungroup_device = AsyncMock(
+            side_effect=WiimException("device gone")
+        )
+
+        with pytest.raises(PlayerCommandFailed) as exc_info:
+            await coordinator.set_members(leader, None, [FOLLOWER_ID])
+        assert isinstance(exc_info.value.__cause__, WiimException)
+
+    async def test_generic_add_uses_low_level_join_and_verifies(self) -> None:
+        """Two generic players use the low-level join_slave and confirm leader-side."""
+        slaves: list[str] = []
+        member_client = _member_client()
+
+        async def _join(*_args: object, **_kwargs: object) -> None:
+            slaves.append(FOLLOWER_HTTP_UUID)
+
+        member_client.join_slave = AsyncMock(side_effect=_join)
+        leader = _make_player(
+            LEADER_ID, BACKEND_GENERIC, ip="192.168.1.30", command_client=_leader_client(slaves)
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+        member_client.join_slave.assert_awaited_once()
+        assert member_client.join_slave.await_args.args[0] == "192.168.1.30"
+
+    async def test_generic_join_no_op_raises(self) -> None:
+        """A low-level join the device ignores raises PlayerCommandFailed."""
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()  # device ignores it
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC, command_client=_leader_client([]))
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+    async def test_generic_remove_uses_low_level_leave(self) -> None:
+        """A generic member leaves via the low-level client and is verified."""
+        slaves = [FOLLOWER_HTTP_UUID]
+        member_client = _member_client()
+
+        async def _leave() -> None:
+            slaves.clear()
+
+        member_client.leave_group = AsyncMock(side_effect=_leave)
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC, command_client=_leader_client(slaves))
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        await coordinator.set_members(leader, None, [FOLLOWER_ID])
+
+        member_client.leave_group.assert_awaited_once()
+
+    async def test_generic_incompatible_group_raises(self) -> None:
+        """An incompatible same-backend group surfaces a typed failure, not a no-op."""
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()
+        # the member is a legacy Wi-Fi Direct device: the compatibility gate refuses it
+        member_client.get_device_info_model = AsyncMock(
+            return_value=MagicMock(needs_wifi_direct_multiroom=True, wmrm_version="4.2")
+        )
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC, command_client=_leader_client([]))
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        member_client.join_slave.assert_not_called()
+
+    async def test_join_clears_joined_members_cached_slaves(self) -> None:
+        """A member that was a leader has its cached slave list cleared once it joins."""
+        slaves: list[str] = []
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=_leader_client(slaves))
+        member = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, member)
+        # the member had its own follower cached from when it was itself a leader
+        coordinator.set_leader_slaves(FOLLOWER_ID, ["A1B2C3D4E5F6A7B8C9D0E1F2"])
+
+        async def _join(*_args: object, **_kwargs: object) -> None:
+            slaves.append(FOLLOWER_HTTP_UUID)
+
+        provider.wiim_controller.async_join_group = AsyncMock(side_effect=_join)
+
+        await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+        # the stale list is cleared so a later leave cannot resurrect a ghost group
+        assert coordinator._raw_slaves.get(FOLLOWER_ID) == []
+
+
+class TestExpectedLeaderVerification:
+    """Grouping is verified against the leader the command targeted."""
+
+    async def test_leave_clears_self_follower_immediately(self) -> None:
+        """A confirmed leave clears the member's stale self-follower flag at once."""
+        slaves = [FOLLOWER_HTTP_UUID]
+        member_client = _member_client()
+
+        async def _leave() -> None:
+            slaves.clear()
+
+        member_client.leave_group = AsyncMock(side_effect=_leave)
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC, command_client=_leader_client(slaves))
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+        # the follower reported itself a slave on its last live read
+        coordinator.set_self_role(FOLLOWER_ID, True)
+        await coordinator.reconcile()
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+
+        await coordinator.set_members(leader, None, [FOLLOWER_ID])
+
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.STANDALONE
+
+    async def test_leave_keeps_follower_when_new_reverse_leader_wins(self) -> None:
+        """Clearing the self-flag on leave still yields FOLLOWER under a new known leader."""
+        other_leader_id = "wiim_uuid:22222222-3333-4444-5555-666666666666"
+        slaves_a = [FOLLOWER_HTTP_UUID]
+        member_client = _member_client()
+
+        async def _leave() -> None:
+            slaves_a.clear()
+
+        member_client.leave_group = AsyncMock(side_effect=_leave)
+        leader_a = _make_player(LEADER_ID, BACKEND_GENERIC, command_client=_leader_client(slaves_a))
+        leader_b = _make_player(other_leader_id, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader_a, leader_b, follower)
+        coordinator.set_self_role(FOLLOWER_ID, True)
+        # concurrently, leader B has discovered the follower as its slave
+        coordinator.set_leader_slaves(other_leader_id, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+
+        await coordinator.set_members(leader_a, None, [FOLLOWER_ID])
+
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+        assert coordinator.leader_of(FOLLOWER_ID) == other_leader_id
+
+    async def test_join_landing_on_other_leader_raises(self) -> None:
+        """A join that never appears in this leader's slave list is a no-op failure."""
+        # the device "joined" but not this leader, so the leader never lists it
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=_leader_client([]))
+        follower = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, follower)
+        provider.wiim_controller.async_join_group = AsyncMock()
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+    async def test_remove_of_member_not_under_leader_is_idempotent(self) -> None:
+        """A member the leader does not list is not detached (solo or another leader)."""
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=_leader_client([]))
+        member_client = _member_client()
+        member_client.leave_group = AsyncMock()
+        follower = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL, command_client=member_client)
+        coordinator, provider = _make_coordinator(leader, follower)
+
+        await coordinator.set_members(leader, None, [FOLLOWER_ID])
+
+        provider.wiim_controller.async_ungroup_device.assert_not_called()
+        member_client.leave_group.assert_not_called()
+
+    async def test_join_fails_closed_when_leader_unreadable(self) -> None:
+        """If the leader's live list cannot be read, the join is not confirmed."""
+        leader_client = MagicMock()
+        leader_client.get_device_group_info = AsyncMock(side_effect=WiiMError("offline"))
+        leader_client.get_device_info_model = AsyncMock(return_value=MagicMock())
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=leader_client)
+        follower = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, follower)
+        provider.wiim_controller.async_join_group = AsyncMock()
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+
+class TestMixedGrouping:
+    """Cross-backend grouping commands the follower, verified from the leader's list."""
+
+    async def test_mixed_add_joins_follower_to_leader_ip(self) -> None:
+        """A cross-backend add sends a low-level join to the follower's leader IP."""
+        slaves: list[str] = []
+        member_client = _member_client()
+
+        async def _join_slave(*_args: object, **_kwargs: object) -> None:
+            slaves.append(FOLLOWER_HTTP_UUID)
+
+        member_client.join_slave = AsyncMock(side_effect=_join_slave)
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=_leader_client(slaves)
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+        member_client.join_slave.assert_awaited_once()
+        assert member_client.join_slave.await_args.args[0] == leader.native_ip
+        member_client.close.assert_not_called()
+
+    async def test_mixed_add_of_unknown_leader_follower_raises(self) -> None:
+        """Joining a member that follows an undiscovered group fails typed at command time."""
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=_leader_client([])
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+        coordinator.set_self_role(FOLLOWER_ID, True)  # follows an undiscovered leader
+        await coordinator.reconcile()
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        member_client.join_slave.assert_not_called()
+
+    async def test_mixed_add_dissolves_members_existing_group_first(self) -> None:
+        """A member that leads its own group is dissolved before joining as a follower."""
+        sub_id = "wiim_uuid:B1B2C3D4-E5F6-A7B8-C9D0-E1F2B1B2C3D4"
+        sub_http_uuid = "B1B2C3D4E5F6A7B8C9D0E1F2"
+        # the member currently leads a generic sub-follower; leaving drops it from the
+        # member's own live slave list, which the dissolve verification then reads.
+        member_slaves = [sub_http_uuid]
+
+        async def _sub_leave() -> None:
+            member_slaves.remove(sub_http_uuid)
+
+        sub_client = _member_client()
+        sub_client.leave_group = AsyncMock(side_effect=_sub_leave)
+        sub_follower = _make_player(sub_id, BACKEND_GENERIC, command_client=sub_client)
+        member_client = _leader_client(member_slaves)
+        member = _make_player(
+            FOLLOWER_ID, BACKEND_GENERIC, ip="192.168.1.40", command_client=member_client
+        )
+        new_slaves: list[str] = []
+        member_client.join_slave = AsyncMock(
+            side_effect=lambda *_a, **_k: new_slaves.append(FOLLOWER_HTTP_UUID)
+        )
+        leader = _make_player(
+            LEADER_ID,
+            BACKEND_OFFICIAL,
+            ip="192.168.1.20",
+            command_client=_leader_client(new_slaves),
+        )
+        coordinator, _ = _make_coordinator(leader, member, sub_follower)
+        coordinator.set_leader_slaves(FOLLOWER_ID, [sub_http_uuid])
+        await coordinator.reconcile()
+        assert coordinator.members_of(FOLLOWER_ID) == [FOLLOWER_ID, sub_id]
+
+        await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+        sub_client.leave_group.assert_awaited_once()  # the member's group was dissolved
+        member_client.join_slave.assert_awaited_once()  # before the member itself joined
+        assert member_client.join_slave.await_args.args[0] == leader.native_ip
+
+    async def test_mixed_remove_kicks_follower_from_leader(self) -> None:
+        """A cross-backend/recovered remove kicks the follower from the leader."""
+        slaves = [FOLLOWER_HTTP_UUID]
+        leader_client = _leader_client(slaves)  # its kick_slave removes the follower
+        member_client = _member_client()
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=leader_client
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        await coordinator.set_members(leader, None, [FOLLOWER_ID])
+
+        leader_client.kick_slave.assert_awaited_once_with("192.168.1.50")
+        # the fresh command client is primed as master so kick_slave's guard passes
+        leader_client.create_group.assert_awaited_once()
+        member_client.leave_group.assert_not_called()  # the follower is not commanded directly
+
+    async def test_mixed_add_generic_leader_official_follower(self) -> None:
+        """The follower direction also works: generic leader, official follower."""
+        slaves: list[str] = []
+        member_client = _member_client()
+
+        async def _join_slave(*_args: object, **_kwargs: object) -> None:
+            slaves.append(FOLLOWER_HTTP_UUID)
+
+        member_client.join_slave = AsyncMock(side_effect=_join_slave)
+        leader = _make_player(
+            LEADER_ID, BACKEND_GENERIC, ip="192.168.1.30", command_client=_leader_client(slaves)
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+        assert member_client.join_slave.await_args.args[0] == "192.168.1.30"
+        member_client.close.assert_not_called()
+
+    async def test_mixed_join_no_op_raises(self) -> None:
+        """A join the leader never lists surfaces a typed failure."""
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()  # device ignores it
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=_leader_client([])
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+    async def test_mixed_remove_no_op_raises(self) -> None:
+        """A follower the leader still lists after a leave surfaces a typed failure."""
+        leader_client = _leader_client([FOLLOWER_HTTP_UUID])
+        leader_client.kick_slave = AsyncMock()  # device ignores the kick (does not remove)
+        member_client = _member_client()
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=leader_client
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, None, [FOLLOWER_ID])
+        leader_client.kick_slave.assert_awaited_once()
+
+    async def test_missing_leader_ip_raises(self) -> None:
+        """A mixed add with an unknown leader address fails typed instead of guessing."""
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip=None, command_client=_leader_client([])
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        member_client.join_slave.assert_not_called()
+
+    async def test_mixed_add_rejects_wifi_direct_leader(self) -> None:
+        """A mixed join to a legacy Wi-Fi Direct leader fails typed instead of stranding the follower."""
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()
+        leader_client = _leader_client([])
+        leader_client.get_device_info_model = AsyncMock(
+            return_value=MagicMock(needs_wifi_direct_multiroom=True)
+        )
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=leader_client
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        member_client.join_slave.assert_not_called()
+
+    async def test_mixed_add_rejects_wifi_direct_member(self) -> None:
+        """A mixed join of a legacy Wi-Fi Direct follower is refused too, not only the leader."""
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()
+        # the follower itself is the legacy device; pywiim would pick Wi-Fi Direct for it
+        member_client.get_device_info_model = AsyncMock(
+            return_value=MagicMock(needs_wifi_direct_multiroom=True)
+        )
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=_leader_client([])
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        member_client.join_slave.assert_not_called()
+
+    async def test_join_records_member_self_follower(self) -> None:
+        """A confirmed join records the member's follower role so an unregistered leader can't strand it."""
+        slaves: list[str] = []
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock(
+            side_effect=lambda *_a, **_k: slaves.append(FOLLOWER_HTTP_UUID)
+        )
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=_leader_client(slaves)
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, provider = _make_coordinator(leader, follower)
+
+        await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        assert coordinator.leader_of(FOLLOWER_ID) == LEADER_ID
+
+        # the leader is unregistered before the member's next live read; the recorded
+        # self-follower role keeps the member suppressed rather than groupable
+        provider.players.remove(leader)
+        coordinator.unregister(LEADER_ID)
+        await coordinator.reconcile()
+
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+        assert coordinator.leader_of(FOLLOWER_ID) is None
+        assert coordinator.can_group_with(follower) == set()
+
+    async def test_remove_fails_typed_when_slave_list_unreadable(self) -> None:
+        """A remove whose leader slave-list read fails raises instead of silently no-op'ing."""
+        client = MagicMock()
+        # the leader reads as 'solo' only because its slave-list endpoint is failing
+        client.get_device_group_info = AsyncMock(return_value=_ginfo("solo", None))
+        client.get_slaves_info = AsyncMock(side_effect=WiiMError("slave list offline"))
+        client.get_device_info_model = AsyncMock(
+            return_value=MagicMock(needs_wifi_direct_multiroom=False, wmrm_version="4.2")
+        )
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=client)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=_member_client())
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, None, [FOLLOWER_ID])
+
+    async def test_api_error_is_chained(self) -> None:
+        """A device API error during a mixed join is chained into the typed failure."""
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock(side_effect=WiiMError("boom"))
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=_leader_client([])
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        with pytest.raises(PlayerCommandFailed) as exc_info:
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        assert isinstance(exc_info.value.__cause__, WiiMError)
+
+    async def test_mixed_join_passes_leader_device_info(self) -> None:
+        """The leader's device info is passed so pywiim can pick the join mode."""
+        slaves: list[str] = []
+        leader_info = MagicMock(needs_wifi_direct_multiroom=False, wmrm_version="4.2")
+        leader_client = _leader_client(slaves)
+        leader_client.get_device_info_model = AsyncMock(return_value=leader_info)
+        member_client = _member_client()
+
+        async def _join_slave(*_args: object, **_kwargs: object) -> None:
+            slaves.append(FOLLOWER_HTTP_UUID)
+
+        member_client.join_slave = AsyncMock(side_effect=_join_slave)
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=leader_client
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+        assert member_client.join_slave.await_args.kwargs["master_device_info"] is leader_info
+
+    async def test_join_waits_for_role_to_propagate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A join whose membership appears a moment later is not declared a no-op."""
+        monkeypatch.setattr("music_assistant.providers.wiim.grouping.VERIFY_MAX_WAIT", 5.0)
+        reads = {"count": 0}
+
+        async def _slaves() -> list[dict[str, str]]:
+            reads["count"] += 1
+            # the follower only shows up in the leader's slave list on the second read
+            return (
+                [{"uuid": FOLLOWER_HTTP_UUID, "ip": "192.168.1.50"}] if reads["count"] >= 2 else []
+            )
+
+        leader_client = MagicMock()
+        leader_client.get_device_group_info = AsyncMock(return_value=_ginfo("solo", None))
+        leader_client.get_slaves_info = AsyncMock(side_effect=_slaves)
+        leader_client.get_device_info_model = AsyncMock(
+            return_value=MagicMock(needs_wifi_direct_multiroom=False, wmrm_version="4.2")
+        )
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=leader_client
+        )
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+        assert reads["count"] >= 2  # it retried until the membership propagated
+
+
+class TestSetMembersLifecycle:
+    """set_members always refreshes the leader's topology, even after a failure."""
+
+    async def test_forces_leader_refresh_on_success(self) -> None:
+        """After a successful command the leader's live group state is re-read."""
+        slaves: list[str] = []
+        client = _leader_client(slaves)
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=client)
+        follower = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader, follower)
+
+        async def _join(*_args: object, **_kwargs: object) -> None:
+            slaves.append(FOLLOWER_HTTP_UUID)
+
+        provider.wiim_controller.async_join_group = AsyncMock(side_effect=_join)
+
+        await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+        client.get_device_group_info.assert_awaited()
+
+    async def test_forces_leader_refresh_after_failure(self) -> None:
+        """A failed command still refreshes the leader topology before propagating."""
+        client = _leader_client([])
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=client)
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock(side_effect=WiiMError("boom"))
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, follower)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        client.get_device_group_info.assert_awaited()
+
+    async def test_unknown_member_raises(self) -> None:
+        """A grouping target that is not a registered native player fails typed."""
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL)
+        coordinator, provider = _make_coordinator(leader)
+        provider.mass.players.get_player.side_effect = None
+        provider.mass.players.get_player.return_value = None
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, ["wiim_uuid:ghost"], None)
+
+
+class TestRegistrationCleanup:
+    """Unregistering a player drops its topology cache entry."""
+
+    async def test_unregister_drops_stale_leadership(self) -> None:
+        """A removed leader's cached members disappear on the next reconcile."""
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, provider = _make_coordinator(leader, follower)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+
+        provider.players.remove(leader)
+        coordinator.unregister(LEADER_ID)
+        await coordinator.reconcile()
+
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.STANDALONE
+
+    async def test_reconcile_drops_cache_for_unregistered_leader(self) -> None:
+        """Cache entries for players no longer registered are pruned during reconcile."""
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, provider = _make_coordinator(leader, follower)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        await coordinator.reconcile()
+
+        provider.players.remove(leader)  # gone, but no explicit unregister
+        await coordinator.reconcile()
+
+        assert LEADER_ID not in coordinator._raw_slaves  # pruned
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.STANDALONE
+
+    async def test_refresh_discards_response_for_replaced_player(self) -> None:
+        """A read finishing after the player was replaced is not applied to the new one."""
+        client = MagicMock()
+        client.get_device_group_info = AsyncMock(return_value=_leader_info([FOLLOWER_HTTP_UUID]))
+        client.get_slaves_info = AsyncMock(
+            return_value=[{"uuid": FOLLOWER_HTTP_UUID, "ip": "192.168.1.50"}]
+        )
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=client)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, provider = _make_coordinator(leader, follower)
+        # a fast unregister/re-register replaced the player instance during the read
+        replacement = _make_player(LEADER_ID, BACKEND_OFFICIAL)
+        provider.mass.players.get_player.side_effect = {
+            LEADER_ID: replacement,
+            FOLLOWER_ID: follower,
+        }.get
+
+        result = await coordinator.refresh_leader(leader, force=True)
+
+        assert result is False
+        assert coordinator.members_of(LEADER_ID) == []  # stale response not applied
+
+
+class TestSelfReportedFollower:
+    """A device following a leader MA has not discovered still reports as a follower."""
+
+    async def test_self_role_yields_follower_without_known_leader(self) -> None:
+        """A self-reported follower is FOLLOWER even though its leader is unknown."""
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(follower)
+
+        coordinator.set_self_role(FOLLOWER_ID, True)
+        await coordinator.reconcile()
+
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+        assert coordinator.leader_of(FOLLOWER_ID) is None
+
+    async def test_self_reported_follower_excluded_from_can_group_with(self) -> None:
+        """A self-reported follower is not offered as a grouping target."""
+        me = _make_player(LEADER_ID, BACKEND_OFFICIAL)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(me, follower)
+
+        coordinator.set_self_role(FOLLOWER_ID, True)
+        await coordinator.reconcile()
+
+        assert coordinator.can_group_with(me) == set()
+
+    async def test_known_leader_takes_precedence_over_self_role(self) -> None:
+        """A resolved reverse leader is preferred; leader_of returns the known leader."""
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC)
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(leader, follower)
+        coordinator.set_leader_slaves(LEADER_ID, [FOLLOWER_HTTP_UUID])
+        coordinator.set_self_role(FOLLOWER_ID, True)
+        await coordinator.reconcile()
+
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+        assert coordinator.leader_of(FOLLOWER_ID) == LEADER_ID
+
+    async def test_self_role_cleared_returns_to_standalone(self) -> None:
+        """Clearing the self-follower flag returns the player to standalone."""
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(follower)
+        coordinator.set_self_role(FOLLOWER_ID, True)
+        await coordinator.reconcile()
+
+        coordinator.set_self_role(FOLLOWER_ID, False)
+        await coordinator.reconcile()
+
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.STANDALONE
+
+    async def test_unregister_clears_self_role(self) -> None:
+        """Unregistering a player drops its self-reported follower flag."""
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(follower)
+        coordinator.set_self_role(FOLLOWER_ID, True)
+        await coordinator.reconcile()
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+
+        coordinator.unregister(FOLLOWER_ID)
+        await coordinator.reconcile()
+
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.STANDALONE
+
+    async def test_refresh_feeds_self_follower_from_live_role(self) -> None:
+        """A live read reporting 'slave' under an unknown leader yields a follower role."""
+        client = MagicMock()
+        # follower of a leader MA does not manage (its master is not a registered player)
+        client.get_device_group_info = AsyncMock(return_value=_ginfo("slave", OTHER_MASTER_UUID))
+        player = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL, command_client=client)
+        coordinator, _ = _make_coordinator(player)
+
+        await coordinator.refresh_leader(player, force=True)
+
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+        assert coordinator.leader_of(FOLLOWER_ID) is None
+
+    async def test_live_self_role_retained_on_failed_refresh(self) -> None:
+        """A failed live read keeps the last self-role instead of clearing it."""
+        client = MagicMock()
+        client.get_device_group_info = AsyncMock(
+            side_effect=[_ginfo("slave", OTHER_MASTER_UUID), WiiMError("offline")]
+        )
+        player = _make_player(FOLLOWER_ID, BACKEND_OFFICIAL, command_client=client)
+        coordinator, _ = _make_coordinator(player)
+
+        await coordinator.refresh_leader(player, force=True)
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+
+        await coordinator.refresh_leader(player, force=True)  # read fails
+        assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
+
+
+class TestConcurrentRefresh:
+    """Overlapping refreshes for one leader must not apply out of order."""
+
+    async def test_same_leader_refresh_is_serialized(self) -> None:
+        """Concurrent forced refreshes for one leader run one at a time."""
+        concurrency = {"current": 0, "max": 0}
+
+        async def _slow_read() -> MagicMock:
+            concurrency["current"] += 1
+            concurrency["max"] = max(concurrency["max"], concurrency["current"])
+            await asyncio.sleep(0.01)
+            concurrency["current"] -= 1
+            return _ginfo("solo", None)
+
+        client = MagicMock()
+        client.get_device_group_info = AsyncMock(side_effect=_slow_read)
+        client.get_slaves_info = AsyncMock(return_value=[])
+        leader = _make_player(LEADER_ID, BACKEND_OFFICIAL, command_client=client)
+        coordinator, _ = _make_coordinator(leader)
+
+        await asyncio.gather(
+            coordinator.refresh_leader(leader, force=True),
+            coordinator.refresh_leader(leader, force=True),
+        )
+
+        assert client.get_device_group_info.await_count == 2
+        assert concurrency["max"] == 1  # the reads never overlapped
+
+
+class TestCommandSerialization:
+    """Grouping commands are serialized so concurrent moves cannot interleave."""
+
+    async def test_concurrent_commands_do_not_interleave(self) -> None:
+        """A second command waits for the first to finish its whole sequence."""
+        other_leader_id = "wiim_uuid:22222222-3333-4444-5555-666666666666"
+        other_follower_http = "C1B2C3D4E5F6A7B8C9D0E1F2"
+        other_follower_id = "wiim_uuid:C1B2C3D4-E5F6-A7B8-C9D0-E1F2C1B2C3D4"
+        gate = asyncio.Event()
+        order: list[str] = []
+
+        slaves_a: list[str] = []
+        member_a_client = _member_client()
+
+        async def _join_a(*_args: object, **_kwargs: object) -> None:
+            order.append("a")
+            await gate.wait()  # hold the first command mid-sequence
+            slaves_a.append(FOLLOWER_HTTP_UUID)
+
+        member_a_client.join_slave = AsyncMock(side_effect=_join_a)
+
+        slaves_b: list[str] = []
+        member_b_client = _member_client()
+
+        async def _join_b(*_args: object, **_kwargs: object) -> None:
+            order.append("b")
+            slaves_b.append(other_follower_http)
+
+        member_b_client.join_slave = AsyncMock(side_effect=_join_b)
+
+        leader_a = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=_leader_client(slaves_a)
+        )
+        member_a = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_a_client)
+        leader_b = _make_player(
+            other_leader_id,
+            BACKEND_OFFICIAL,
+            ip="192.168.1.21",
+            command_client=_leader_client(slaves_b),
+        )
+        member_b = _make_player(other_follower_id, BACKEND_GENERIC, command_client=member_b_client)
+        coordinator, _ = _make_coordinator(leader_a, member_a, leader_b, member_b)
+
+        task_a = asyncio.create_task(coordinator.set_members(leader_a, [FOLLOWER_ID], None))
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if order == ["a"]:
+                break
+        assert order == ["a"]  # the first command is mid-sequence, holding the lock
+
+        task_b = asyncio.create_task(coordinator.set_members(leader_b, [other_follower_id], None))
+        for _ in range(50):
+            await asyncio.sleep(0)
+        assert order == ["a"]  # the second command is blocked behind the first
+
+        gate.set()
+        await asyncio.gather(task_a, task_b)
+        assert order == ["a", "b"]  # only after the first finished did the second run

--- a/tests/providers/wiim/test_grouping.py
+++ b/tests/providers/wiim/test_grouping.py
@@ -78,6 +78,9 @@ def _member_client() -> MagicMock:
     client.get_device_info_model = AsyncMock(
         return_value=MagicMock(needs_wifi_direct_multiroom=False, wmrm_version="4.2")
     )
+    # a join reads the member's own live group first (it must lead nothing); default solo
+    client.get_device_group_info = AsyncMock(return_value=MagicMock(role="solo"))
+    client.get_slaves_info = AsyncMock(return_value=[])
     return client
 
 
@@ -1468,3 +1471,79 @@ class TestBatchValidation:
         coordinator, _ = _make_coordinator(me, peer)
 
         assert coordinator.can_group_with(me) == {FOLLOWER_ID}
+
+    async def test_join_fails_closed_when_member_leads_unmanaged_slave(self) -> None:
+        """A member still leading an addressable slave MA cannot resolve is not orphaned."""
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()
+        member_client.get_device_group_info = AsyncMock(return_value=MagicMock(role="master"))
+        # the slave resolves to no registered player, so it cannot be cleanly dissolved
+        member_client.get_slaves_info = AsyncMock(
+            return_value=[{"uuid": "FFFFFFFFFFFFFFFFFFFFFFFF", "ip": "192.168.1.77"}]
+        )
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=_leader_client([])
+        )
+        member = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, member)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        member_client.join_slave.assert_not_called()
+
+    async def test_join_dissolves_follower_gained_since_cache(self) -> None:
+        """A follower discovered only in the member's live read is still dissolved first."""
+        sub_http = "B1B2C3D4E5F6A7B8C9D0E1F2"
+        sub_id = "wiim_uuid:B1B2C3D4-E5F6-A7B8-C9D0-E1F2B1B2C3D4"
+        member_slaves = [sub_http]
+
+        async def _sub_leave() -> None:
+            member_slaves.remove(sub_http)
+
+        sub_client = _member_client()
+        sub_client.leave_group = AsyncMock(side_effect=_sub_leave)
+        sub = _make_player(sub_id, BACKEND_GENERIC, command_client=sub_client)
+        member_client = _leader_client(member_slaves)
+        new_slaves: list[str] = []
+        member_client.join_slave = AsyncMock(
+            side_effect=lambda *_a, **_k: new_slaves.append(FOLLOWER_HTTP_UUID)
+        )
+        member = _make_player(
+            FOLLOWER_ID, BACKEND_GENERIC, ip="192.168.1.40", command_client=member_client
+        )
+        leader = _make_player(
+            LEADER_ID,
+            BACKEND_OFFICIAL,
+            ip="192.168.1.20",
+            command_client=_leader_client(new_slaves),
+        )
+        # NOTE: the coordinator cache is never seeded for the member; only its live read finds sub
+        coordinator, _ = _make_coordinator(leader, member, sub)
+
+        await coordinator.set_members(leader, [FOLLOWER_ID], None)
+
+        sub_client.leave_group.assert_awaited_once()
+        member_client.join_slave.assert_awaited_once()
+
+    async def test_leader_info_read_once_per_batch(self) -> None:
+        """The leader's device info is read once for a batch, not once per added member."""
+        slaves: list[str] = []
+        leader_client = _leader_client(slaves)
+        leader = _make_player(
+            LEADER_ID, BACKEND_GENERIC, ip="192.168.1.30", command_client=leader_client
+        )
+        first_client = _member_client()
+        first_client.join_slave = AsyncMock(
+            side_effect=lambda *_a, **_k: slaves.append(FOLLOWER_HTTP_UUID)
+        )
+        second_client = _member_client()
+        second_client.join_slave = AsyncMock(
+            side_effect=lambda *_a, **_k: slaves.append(SECOND_HTTP_UUID)
+        )
+        first = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=first_client)
+        second = _make_player(SECOND_ID, BACKEND_GENERIC, command_client=second_client)
+        coordinator, _ = _make_coordinator(leader, first, second)
+
+        await coordinator.set_members(leader, [FOLLOWER_ID, SECOND_ID], None)
+
+        assert leader_client.get_device_info_model.await_count == 1

--- a/tests/providers/wiim/test_grouping.py
+++ b/tests/providers/wiim/test_grouping.py
@@ -1696,3 +1696,22 @@ class TestBatchValidation:
 
         leader.on_native_group_update.assert_called_once()
         peer.on_native_group_update.assert_called_once()
+
+    async def test_removal_of_absent_unreachable_member_is_skipped_not_aborted(self) -> None:
+        """An unreachable removal target the leader no longer lists is skipped, not fatal."""
+        slaves = [FOLLOWER_HTTP_UUID]  # the leader currently lists only the reachable member
+        good_client = _member_client()
+
+        async def _leave() -> None:
+            slaves.remove(FOLLOWER_HTTP_UUID)
+
+        good_client.leave_group = AsyncMock(side_effect=_leave)
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC, command_client=_leader_client(slaves))
+        good = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=good_client)
+        gone = _make_player(SECOND_ID, BACKEND_GENERIC, available=False)  # unreachable, not owned
+        coordinator, _ = _make_coordinator(leader, good, gone)
+
+        # removing both must not abort on the absent, unreachable target
+        await coordinator.set_members(leader, None, [FOLLOWER_ID, SECOND_ID])
+
+        good_client.leave_group.assert_awaited_once()

--- a/tests/providers/wiim/test_grouping.py
+++ b/tests/providers/wiim/test_grouping.py
@@ -1578,3 +1578,25 @@ class TestBatchValidation:
         with pytest.raises(PlayerCommandFailed):
             await coordinator.set_members(leader, [FOLLOWER_ID], None)
         member_client.join_slave.assert_not_called()
+
+    async def test_combined_batch_aborts_before_join_when_leader_unreadable(self) -> None:
+        """A combined add/remove batch does not join anything if the leader's list is unreadable."""
+        leader_client = MagicMock()
+        leader_client.capabilities = {}
+        leader_client.get_device_group_info = AsyncMock(return_value=MagicMock(role="solo"))
+        leader_client.get_slaves_info = AsyncMock(side_effect=WiiMError("offline"))
+        leader_client.get_device_info_model = AsyncMock(
+            return_value=MagicMock(needs_wifi_direct_multiroom=False, wmrm_version="4.2")
+        )
+        leader = _make_player(
+            LEADER_ID, BACKEND_GENERIC, ip="192.168.1.30", command_client=leader_client
+        )
+        add_client = _member_client()
+        add_client.join_slave = AsyncMock()
+        add_member = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=add_client)
+        remove_member = _make_player(SECOND_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(leader, add_member, remove_member)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], [SECOND_ID])
+        add_client.join_slave.assert_not_called()

--- a/tests/providers/wiim/test_grouping.py
+++ b/tests/providers/wiim/test_grouping.py
@@ -1418,6 +1418,10 @@ class TestBatchValidation:
     async def test_leader_following_unknown_group_cannot_lead(self) -> None:
         """A leader that itself follows an undiscovered group is refused before any mutation."""
         leader_client = _leader_client([])
+        # the leader's own live read reports it is a slave of a leader MA cannot see
+        leader_client.get_device_group_info = AsyncMock(
+            return_value=MagicMock(role="slave", master_uuid=OTHER_MASTER_UUID)
+        )
         leader = _make_player(
             LEADER_ID, BACKEND_GENERIC, ip="192.168.1.20", command_client=leader_client
         )
@@ -1425,8 +1429,6 @@ class TestBatchValidation:
         member_client.join_slave = AsyncMock()
         member = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
         coordinator, _ = _make_coordinator(leader, member)
-        coordinator.set_self_role(LEADER_ID, True)  # the leader follows an undiscovered group
-        await coordinator.reconcile()
 
         with pytest.raises(PlayerCommandFailed):
             await coordinator.set_members(leader, [FOLLOWER_ID], None)
@@ -1600,3 +1602,34 @@ class TestBatchValidation:
         with pytest.raises(PlayerCommandFailed):
             await coordinator.set_members(leader, [FOLLOWER_ID], [SECOND_ID])
         add_client.join_slave.assert_not_called()
+
+    async def test_addition_with_unreadable_group_aborts_batch(self) -> None:
+        """A batch fails before any join if an addition's live group cannot be read."""
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()
+        member_client.get_device_group_info = AsyncMock(side_effect=WiiMError("offline"))
+        leader = _make_player(
+            LEADER_ID, BACKEND_GENERIC, ip="192.168.1.20", command_client=_leader_client([])
+        )
+        member = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, member)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        member_client.join_slave.assert_not_called()
+
+    async def test_join_surfaces_device_info_failure(self) -> None:
+        """A device-info read error surfaces as a chained failure, not a false incompatibility."""
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()
+        member_client.get_device_info_model = AsyncMock(side_effect=WiiMError("boom"))
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=_leader_client([])
+        )
+        member = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, member)
+
+        with pytest.raises(PlayerCommandFailed) as exc_info:
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        assert isinstance(exc_info.value.__cause__, WiiMError)
+        member_client.join_slave.assert_not_called()

--- a/tests/providers/wiim/test_grouping.py
+++ b/tests/providers/wiim/test_grouping.py
@@ -111,6 +111,8 @@ def _make_player(
     player.make_command_client = MagicMock(return_value=command_client)
     player.store_command_capabilities = MagicMock()
     player.on_native_group_update = MagicMock()
+    # a modern, router-based generation so two generic peers are offerable to each other
+    player.cached_device_info = MagicMock(needs_wifi_direct_multiroom=False, wmrm_version="4.2")
     return player
 
 
@@ -1434,3 +1436,35 @@ class TestBatchValidation:
         coordinator.set_self_role(FOLLOWER_ID, False)
         await coordinator.reconcile()
         assert coordinator.is_unknown_leader_follower(FOLLOWER_ID) is False
+
+    async def test_unreachable_generic_removal_aborts_batch(self) -> None:
+        """An unreachable generic follower fails a removal batch before any detach runs."""
+        slaves = [FOLLOWER_HTTP_UUID, SECOND_HTTP_UUID]
+        good_client = _member_client()
+        good_client.leave_group = AsyncMock()
+        leader = _make_player(LEADER_ID, BACKEND_GENERIC, command_client=_leader_client(slaves))
+        good = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=good_client)
+        bad = _make_player(SECOND_ID, BACKEND_GENERIC, available=False)  # unreachable
+        coordinator, _ = _make_coordinator(leader, good, bad)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, None, [FOLLOWER_ID, SECOND_ID])
+        good_client.leave_group.assert_not_called()
+
+    def test_incompatible_generic_peer_not_offered(self) -> None:
+        """A legacy/incompatible generic peer is not offered as a grouping candidate."""
+        me = _make_player(LEADER_ID, BACKEND_GENERIC)
+        peer = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        # the peer is a legacy Wi-Fi Direct device, so the pair is guaranteed to fail
+        peer.cached_device_info = MagicMock(needs_wifi_direct_multiroom=True, wmrm_version="4.2")
+        coordinator, _ = _make_coordinator(me, peer)
+
+        assert coordinator.can_group_with(me) == set()
+
+    def test_compatible_generic_peer_is_offered(self) -> None:
+        """A modern, matching-generation generic peer is offered as a candidate."""
+        me = _make_player(LEADER_ID, BACKEND_GENERIC)
+        peer = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(me, peer)
+
+        assert coordinator.can_group_with(me) == {FOLLOWER_ID}

--- a/tests/providers/wiim/test_grouping.py
+++ b/tests/providers/wiim/test_grouping.py
@@ -1370,3 +1370,67 @@ class TestCommandSerialization:
         gate.set()
         await asyncio.gather(task_a, task_b)
         assert order == ["a", "b"]  # only after the first finished did the second run
+
+
+# a second follower identity for whole-batch validation tests
+SECOND_HTTP_UUID = "D1B2C3D4E5F6A7B8C9D0E1F2"
+SECOND_ID = "wiim_uuid:D1B2C3D4-E5F6-A7B8-C9D0-E1F2D1B2C3D4"
+
+
+class TestBatchValidation:
+    """The whole batch is validated before any speaker joins or leaves."""
+
+    async def test_incompatible_later_addition_aborts_before_any_join(self) -> None:
+        """A legacy/incompatible target later in the batch stops every join up front."""
+        good_slaves: list[str] = []
+        good_client = _member_client()
+        good_client.join_slave = AsyncMock(
+            side_effect=lambda *_a, **_k: good_slaves.append(FOLLOWER_HTTP_UUID)
+        )
+        bad_client = _member_client()
+        bad_client.join_slave = AsyncMock()
+        # the second target is a legacy Wi-Fi Direct device the compatibility gate refuses
+        bad_client.get_device_info_model = AsyncMock(
+            return_value=MagicMock(needs_wifi_direct_multiroom=True, wmrm_version="4.2")
+        )
+        leader = _make_player(
+            LEADER_ID, BACKEND_GENERIC, ip="192.168.1.20", command_client=_leader_client([])
+        )
+        good = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=good_client)
+        bad = _make_player(SECOND_ID, BACKEND_GENERIC, command_client=bad_client)
+        coordinator, _ = _make_coordinator(leader, good, bad)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID, SECOND_ID], None)
+        # the whole batch was validated first, so the compatible target never joined either
+        good_client.join_slave.assert_not_called()
+        bad_client.join_slave.assert_not_called()
+
+    async def test_leader_following_unknown_group_cannot_lead(self) -> None:
+        """A leader that itself follows an undiscovered group is refused before any mutation."""
+        leader_client = _leader_client([])
+        leader = _make_player(
+            LEADER_ID, BACKEND_GENERIC, ip="192.168.1.20", command_client=leader_client
+        )
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()
+        member = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, member)
+        coordinator.set_self_role(LEADER_ID, True)  # the leader follows an undiscovered group
+        await coordinator.reconcile()
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        member_client.join_slave.assert_not_called()
+
+    async def test_is_unknown_leader_follower_query(self) -> None:
+        """The public query flags a self-reported follower whose leader is undiscovered."""
+        follower = _make_player(FOLLOWER_ID, BACKEND_GENERIC)
+        coordinator, _ = _make_coordinator(follower)
+        coordinator.set_self_role(FOLLOWER_ID, True)
+        await coordinator.reconcile()
+        assert coordinator.is_unknown_leader_follower(FOLLOWER_ID) is True
+
+        coordinator.set_self_role(FOLLOWER_ID, False)
+        await coordinator.reconcile()
+        assert coordinator.is_unknown_leader_follower(FOLLOWER_ID) is False

--- a/tests/providers/wiim/test_grouping.py
+++ b/tests/providers/wiim/test_grouping.py
@@ -169,16 +169,18 @@ class TestTopologyResolution:
         assert coordinator.members_of(LEADER_ID) == [LEADER_ID, FOLLOWER_ID]
         assert coordinator.role_of(FOLLOWER_ID) == NativeGroupRole.FOLLOWER
 
-    async def test_unknown_slave_is_skipped(self) -> None:
-        """A slave uuid that resolves to no registered player is ignored."""
+    async def test_unknown_slave_manages_no_members_but_leads(self) -> None:
+        """A slave that resolves to no registered player yields no managed member but a leader role."""
         leader = _make_player(LEADER_ID, BACKEND_GENERIC)
         coordinator, _ = _make_coordinator(leader)
 
         coordinator.set_leader_slaves(LEADER_ID, ["FFFFFFFFFFFFFFFFFFFFFFFF"])
         await coordinator.reconcile()
 
-        assert coordinator.role_of(LEADER_ID) == NativeGroupRole.STANDALONE
+        # it manages no MA-resolvable members, but it is NOT standalone: it leads a native
+        # group MA cannot see, so it must not be offered for a second (protocol) group.
         assert coordinator.members_of(LEADER_ID) == []
+        assert coordinator.role_of(LEADER_ID) == NativeGroupRole.LEADER
 
     async def test_follower_leadership_is_ignored(self) -> None:
         """A device that is another leader's follower cannot also be a leader."""

--- a/tests/providers/wiim/test_grouping.py
+++ b/tests/providers/wiim/test_grouping.py
@@ -823,6 +823,10 @@ class TestMixedGrouping:
         """Joining a member that follows an undiscovered group fails typed at command time."""
         member_client = _member_client()
         member_client.join_slave = AsyncMock()
+        # the member's own live read reports it is a slave of a leader MA cannot see
+        member_client.get_device_group_info = AsyncMock(
+            return_value=MagicMock(role="slave", master_uuid=OTHER_MASTER_UUID)
+        )
         leader = _make_player(
             LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=_leader_client([])
         )
@@ -1547,3 +1551,30 @@ class TestBatchValidation:
         await coordinator.set_members(leader, [FOLLOWER_ID, SECOND_ID], None)
 
         assert leader_client.get_device_info_model.await_count == 1
+
+    async def test_refresh_skips_unavailable_device(self) -> None:
+        """A device that is unavailable is not polled again; its cached topology is kept."""
+        client = MagicMock()
+        client.get_device_group_info = AsyncMock()
+        player = _make_player(LEADER_ID, BACKEND_GENERIC, available=False, command_client=client)
+        coordinator, _ = _make_coordinator(player)
+
+        assert await coordinator.refresh_leader(player, force=True) is False
+        client.get_device_group_info.assert_not_called()
+
+    async def test_live_read_reveals_unknown_leader_follower_and_aborts(self) -> None:
+        """A member whose cache said standalone but now reads as a slave of an unknown leader fails."""
+        member_client = _member_client()
+        member_client.join_slave = AsyncMock()
+        member_client.get_device_group_info = AsyncMock(
+            return_value=MagicMock(role="slave", master_uuid=OTHER_MASTER_UUID)
+        )
+        leader = _make_player(
+            LEADER_ID, BACKEND_OFFICIAL, ip="192.168.1.20", command_client=_leader_client([])
+        )
+        member = _make_player(FOLLOWER_ID, BACKEND_GENERIC, command_client=member_client)
+        coordinator, _ = _make_coordinator(leader, member)  # cache starts empty (standalone)
+
+        with pytest.raises(PlayerCommandFailed):
+            await coordinator.set_members(leader, [FOLLOWER_ID], None)
+        member_client.join_slave.assert_not_called()

--- a/tests/providers/wiim/test_linkplay.py
+++ b/tests/providers/wiim/test_linkplay.py
@@ -141,6 +141,7 @@ def _mock_native_groups() -> MagicMock:
     groups.reconcile = AsyncMock()
     groups.set_members = AsyncMock()
     groups.schedule_reconcile = MagicMock()
+    groups.schedule_republish = MagicMock()
     groups.unregister = MagicMock()
     groups.is_unknown_leader_follower = MagicMock(return_value=False)
     groups.set_self_role = MagicMock(return_value=False)
@@ -755,3 +756,30 @@ class TestFinalGroupingState:
         player._linkplay_available = True
         assert PlayerFeature.SET_MEMBERS in player.supported_features
         assert player.grouping_locked is False
+
+
+class TestAvailabilityRepublish:
+    """A native-availability flip re-publishes peers so their candidate sets don't go stale."""
+
+    async def test_health_flip_republishes_peers(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """Losing the LinkPlay API re-publishes every native peer."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._linkplay_available = True
+        mock_client.get_device_info_model = AsyncMock(side_effect=WiiMError("down"))
+
+        await player._refresh_reachability()
+
+        mock_provider.native_groups.schedule_republish.assert_called()
+
+    async def test_no_republish_when_health_unchanged(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """A refresh that does not change availability does not churn peers."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._linkplay_available = True
+
+        await player._refresh_reachability()  # stays reachable
+
+        mock_provider.native_groups.schedule_republish.assert_not_called()

--- a/tests/providers/wiim/test_linkplay.py
+++ b/tests/providers/wiim/test_linkplay.py
@@ -2,19 +2,18 @@
 
 from __future__ import annotations
 
-import asyncio
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import IdentifierType, PlaybackState, PlayerFeature, PlayerType
-from music_assistant_models.errors import PlayerCommandFailed, UnsupportedFeaturedException
+from music_assistant_models.enums import IdentifierType, PlayerFeature, PlayerType
 from pywiim import WiiMError
 
 from music_assistant.controllers.players.protocol_linking import ProtocolLinkingMixin
 from music_assistant.models.player import LinkedOutputProtocol
 from music_assistant.providers.wiim.constants import PLAYER_ID_PREFIX
+from music_assistant.providers.wiim.grouping import NativeGroupRole
 from music_assistant.providers.wiim.helpers import (
     is_official_manufacturer,
     linkplay_group_compatible,
@@ -109,6 +108,8 @@ def mock_provider() -> MagicMock:
     provider = MagicMock()
     provider.instance_id = "wiim_test"
     provider.domain = "wiim"
+    provider.players = []
+    provider.native_groups = _mock_native_groups()
     provider.mass = MagicMock()
     provider.mass.players = MagicMock()
     config = MagicMock()
@@ -119,6 +120,21 @@ def mock_provider() -> MagicMock:
     config.get_value = MagicMock(return_value=None)
     provider.mass.config.get_base_player_config.return_value = config
     return provider
+
+
+def _mock_native_groups() -> MagicMock:
+    """Create a coordinator mock that reports a standalone topology by default."""
+    groups = MagicMock()
+    groups.role_of.return_value = NativeGroupRole.STANDALONE
+    groups.members_of.return_value = []
+    groups.can_group_with.return_value = set()
+    groups.refresh_leader = AsyncMock()
+    groups.reconcile = AsyncMock()
+    groups.set_members = AsyncMock()
+    groups.schedule_reconcile = MagicMock()
+    groups.unregister = MagicMock()
+    groups.set_self_role = MagicMock(return_value=False)
+    return groups
 
 
 @pytest.fixture
@@ -132,6 +148,8 @@ def mock_client() -> MagicMock:
         )
     )
     client.get_slaves_info = AsyncMock(return_value=_slaves([]))
+    client.get_device_group_info = AsyncMock(return_value=SimpleNamespace(role="solo"))
+    client.capabilities = {}
     client.join_slave = AsyncMock()
     client.leave_group = AsyncMock()
     return client
@@ -232,44 +250,38 @@ class TestHealthGating:
         player._linkplay_available = False
         assert player.prefer_native_grouping is False
 
-    def test_can_group_with_requires_health(
+    def test_can_group_with_delegates_to_coordinator(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """A shell with an unreachable API advertises no grouping peers."""
+        """can_group_with returns exactly the coordinator's candidate set for this player."""
         player = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        peer = _make_shell(mock_provider, mock_client, mock_upnp_device, PEER_PLAYER_ID)
-        peer._linkplay_available = True
-        mock_provider.players = [player, peer]
-        player._linkplay_available = False
-        assert player.can_group_with == set()
-        player._linkplay_available = True
+        mock_provider.native_groups.can_group_with.return_value = {PEER_PLAYER_ID}
         assert player.can_group_with == {PEER_PLAYER_ID}
+        mock_provider.native_groups.can_group_with.assert_called_once_with(player)
 
-    def test_can_group_with_skips_unhealthy_peer(
+    def test_native_available_reflects_health(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """An unreachable peer is not offered as a grouping target."""
-        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        player._linkplay_available = True
-        peer = _make_shell(mock_provider, mock_client, mock_upnp_device, PEER_PLAYER_ID)
-        peer._linkplay_available = False
-        mock_provider.players = [player, peer]
-        assert player.can_group_with == set()
+        """native_available (used by the coordinator) tracks the LinkPlay API reachability."""
+        healthy = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        healthy._linkplay_available = True
+        assert healthy.native_available is True
+        assert healthy.grouping_locked is False
+        unhealthy = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        unhealthy._linkplay_available = False
+        assert unhealthy.native_available is False
+        assert unhealthy.grouping_locked is True
 
-    def test_native_group_compat_only_generic_peers(
+    def test_native_group_compat_follows_can_group_with(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """The native-compat seam only accepts reachable generic peers, never other backends."""
+        """A peer is native-compatible exactly when the coordinator offers it as a candidate."""
         player = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        player._linkplay_available = True
-        peer = _make_shell(mock_provider, mock_client, mock_upnp_device, PEER_PLAYER_ID)
-        peer._linkplay_available = True
-        mock_provider.players = [player, peer]
+        peer = MagicMock(player_id=PEER_PLAYER_ID)
+        mock_provider.native_groups.can_group_with.return_value = {PEER_PLAYER_ID}
         assert player.is_native_group_compatible(peer) is True
-        # a same-instance player of another backend (e.g. official WiiM) is not native-compatible,
-        # so the grouping layer never routes such a pair onto a native group.
-        official = MagicMock(player_id="wiim_official")
-        assert player.is_native_group_compatible(official) is False
+        other = MagicMock(player_id="wiim_uuid:not-a-candidate")
+        assert player.is_native_group_compatible(other) is False
 
 
 class TestPlaybackAvailability:
@@ -308,434 +320,60 @@ class TestPlaybackAvailability:
 
 
 class TestGrouping:
-    """Same-backend grouping uses the low-level WiiMClient GroupAPI only."""
+    """Grouping is delegated to the shared native coordinator across both backends."""
 
-    async def test_join_uses_low_level_client(
+    async def test_set_members_delegates_to_coordinator(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """Adding a member joins it to this leader via join_slave with the leader device info."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        member_client = MagicMock(join_slave=AsyncMock(), leave_group=AsyncMock())
-        member = _make_shell(mock_provider, member_client, mock_upnp_device, PEER_PLAYER_ID)
-        member._linkplay_available = True
-        mock_provider.mass.players.get_player.return_value = member
-        # after joining, the leader lists the member as a slave
-        mock_client.get_slaves_info = AsyncMock(return_value=_slaves([PEER_HTTP_UUID]))
-        mock_provider.players = [leader, member]
-        await leader.set_members(player_ids_to_add=[PEER_PLAYER_ID])
-        member_client.join_slave.assert_awaited_once()
-        args, kwargs = member_client.join_slave.call_args
-        assert args[0] == "192.168.1.50"  # leader ip
-        assert kwargs["master_device_info"] is leader.cached_device_info
-
-    async def test_leave_uses_low_level_client(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """Removing a current member calls leave_group and verifies it left the leader's group."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        member_client = MagicMock(join_slave=AsyncMock(), leave_group=AsyncMock())
-        member = _make_shell(mock_provider, member_client, mock_upnp_device, PEER_PLAYER_ID)
-        member._linkplay_available = True
-        mock_provider.mass.players.get_player.return_value = member
-        # the leader currently owns the member, then reports it gone after the leave
-        mock_client.get_slaves_info = AsyncMock(
-            side_effect=[_slaves([PEER_HTTP_UUID]), _slaves([])]
-        )
-        mock_provider.players = [leader, member]
-        await leader.set_members(player_ids_to_remove=[PEER_PLAYER_ID])
-        member_client.leave_group.assert_awaited_once()
-
-    async def test_remove_member_not_in_group_skips_leave(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """Removing a member the leader no longer owns issues no leave_group."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        member_client = MagicMock(join_slave=AsyncMock(), leave_group=AsyncMock())
-        member = _make_shell(mock_provider, member_client, mock_upnp_device, PEER_PLAYER_ID)
-        member._linkplay_available = True
-        mock_provider.mass.players.get_player.return_value = member
-        mock_provider.players = [leader, member]
-        # the leader's live topology no longer lists the member (it moved to another group)
-        mock_client.get_slaves_info = AsyncMock(return_value=_slaves([]))
-        await leader.set_members(player_ids_to_remove=[PEER_PLAYER_ID])
-        member_client.leave_group.assert_not_awaited()
-
-    async def test_unhealthy_current_removal_aborts_batch(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """An unreachable current removal target fails the batch before any leave."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        healthy_client = MagicMock(leave_group=AsyncMock())
-        healthy = _make_shell(mock_provider, healthy_client, mock_upnp_device, PEER_PLAYER_ID)
-        healthy._linkplay_available = True
-        unhealthy_client = MagicMock(leave_group=AsyncMock())
-        unhealthy = _make_shell(
-            mock_provider, unhealthy_client, mock_upnp_device, "wiim_uuid:third"
-        )
-        unhealthy._linkplay_available = False  # a current member that is unreachable
-        players = {PEER_PLAYER_ID: healthy, "wiim_uuid:third": unhealthy}
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: players.get(pid)
-        # both are current members of the leader
-        leader._current_slave_ids = AsyncMock(  # type: ignore[method-assign]
-            return_value={PEER_PLAYER_ID, "wiim_uuid:third"}
-        )
-        with pytest.raises(PlayerCommandFailed):
-            await leader.set_members(player_ids_to_remove=[PEER_PLAYER_ID, "wiim_uuid:third"])
-        healthy_client.leave_group.assert_not_awaited()
-        unhealthy_client.leave_group.assert_not_awaited()
-
-    async def test_absent_unhealthy_removal_skipped_healthy_left(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """An absent unreachable target is skipped while a healthy current member is left."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        leader._verify_group_change = AsyncMock()  # type: ignore[method-assign]
-        healthy_client = MagicMock(leave_group=AsyncMock())
-        healthy = _make_shell(mock_provider, healthy_client, mock_upnp_device, PEER_PLAYER_ID)
-        healthy._linkplay_available = True
-        absent_client = MagicMock(leave_group=AsyncMock())
-        absent = _make_shell(mock_provider, absent_client, mock_upnp_device, "wiim_uuid:third")
-        absent._linkplay_available = False  # unreachable, but no longer a member
-        players = {PEER_PLAYER_ID: healthy, "wiim_uuid:third": absent}
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: players.get(pid)
-        # only the healthy member is still owned; the unreachable one has moved away
-        leader._current_slave_ids = AsyncMock(return_value={PEER_PLAYER_ID})  # type: ignore[method-assign]
-        await leader.set_members(player_ids_to_remove=[PEER_PLAYER_ID, "wiim_uuid:third"])
-        healthy_client.leave_group.assert_awaited_once()
-        absent_client.leave_group.assert_not_awaited()
-
-    async def test_valid_removal_batch_leaves_all(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A fully valid multi-member removal leaves every current member."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        leader._verify_group_change = AsyncMock()  # type: ignore[method-assign]
-        first_client = MagicMock(leave_group=AsyncMock())
-        first = _make_shell(mock_provider, first_client, mock_upnp_device, PEER_PLAYER_ID)
-        first._linkplay_available = True
-        second_client = MagicMock(leave_group=AsyncMock())
-        second = _make_shell(mock_provider, second_client, mock_upnp_device, "wiim_uuid:third")
-        second._linkplay_available = True
-        players = {PEER_PLAYER_ID: first, "wiim_uuid:third": second}
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: players.get(pid)
-        leader._current_slave_ids = AsyncMock(  # type: ignore[method-assign]
-            return_value={PEER_PLAYER_ID, "wiim_uuid:third"}
-        )
-        await leader.set_members(player_ids_to_remove=[PEER_PLAYER_ID, "wiim_uuid:third"])
-        first_client.leave_group.assert_awaited_once()
-        second_client.leave_group.assert_awaited_once()
-
-    async def test_cross_backend_member_rejected(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A non-generic member raises a typed unsupported error (B1)."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        mock_provider.mass.players.get_player.return_value = MagicMock()  # not a LinkPlayPlayer
-        with pytest.raises(UnsupportedFeaturedException):
-            await leader.set_members(player_ids_to_add=["airplay_other"])
-
-    async def test_unreachable_leader_fails(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """Grouping fails cleanly when the leader's LinkPlay API is unreachable."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = False
-        with pytest.raises(PlayerCommandFailed):
-            await leader.set_members(player_ids_to_add=[PEER_PLAYER_ID])
-
-    async def test_group_error_becomes_command_failed(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A WiiMError from the device is surfaced as PlayerCommandFailed."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        member_client = MagicMock(join_slave=AsyncMock(side_effect=WiiMError("boom")))
-        member = _make_shell(mock_provider, member_client, mock_upnp_device, PEER_PLAYER_ID)
-        member._linkplay_available = True
-        mock_provider.mass.players.get_player.return_value = member
-        with pytest.raises(PlayerCommandFailed):
-            await leader.set_members(player_ids_to_add=[PEER_PLAYER_ID])
-
-    async def test_incompatible_generation_rejected(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A peer on an incompatible/legacy multiroom generation is rejected before joining."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        member_client = MagicMock(join_slave=AsyncMock())
-        member = _make_shell(mock_provider, member_client, mock_upnp_device, PEER_PLAYER_ID)
-        member._linkplay_available = True
-        # a legacy Wi-Fi-Direct / older-generation device that we do not group
-        member._cached_device_info = _device_info("2.0", legacy=True)
-        mock_provider.mass.players.get_player.return_value = member
-        with pytest.raises(UnsupportedFeaturedException):
-            await leader.set_members(player_ids_to_add=[PEER_PLAYER_ID])
-        member_client.join_slave.assert_not_awaited()
-
-    async def test_unverified_join_raises(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """If the member never appears in the leader's slave list, the command fails."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        member_client = MagicMock(join_slave=AsyncMock(), leave_group=AsyncMock())
-        member = _make_shell(mock_provider, member_client, mock_upnp_device, PEER_PLAYER_ID)
-        member._linkplay_available = True
-        mock_provider.mass.players.get_player.return_value = member
-        # leader keeps reporting no slaves -> join not verified
-        mock_client.get_slaves_info = AsyncMock(return_value=_slaves([]))
-        mock_provider.players = [leader, member]
-        with (
-            patch("music_assistant.providers.wiim.linkplay_player.asyncio.sleep", AsyncMock()),
-            pytest.raises(PlayerCommandFailed),
-        ):
-            await leader.set_members(player_ids_to_add=[PEER_PLAYER_ID])
-
-    async def test_join_verification_retries_until_settled(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A join that the device reports only after settling still succeeds."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        member_client = MagicMock(join_slave=AsyncMock(), leave_group=AsyncMock())
-        member = _make_shell(mock_provider, member_client, mock_upnp_device, PEER_PLAYER_ID)
-        member._linkplay_available = True
-        mock_provider.mass.players.get_player.return_value = member
-        # first read still shows no slaves (group forming), second read shows the member
-        mock_client.get_slaves_info = AsyncMock(
-            side_effect=[_slaves([]), _slaves([PEER_HTTP_UUID])]
-        )
-        mock_provider.players = [leader, member]
-        with patch("music_assistant.providers.wiim.linkplay_player.asyncio.sleep", AsyncMock()):
-            await leader.set_members(player_ids_to_add=[PEER_PLAYER_ID])
-        assert mock_client.get_slaves_info.await_count == 2
-
-    async def test_grouping_available_during_external_source(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """Native grouping stays available while a linked protocol plays an external source."""
+        """set_members forwards the add/remove batch to the coordinator unchanged."""
         player = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        player._linkplay_available = True
-        # a linked DLNA protocol player is casting an external source
-        player.set_linked_output_protocols([LinkedOutputProtocol("dlna_x", "dlna", priority=50)])
-        ext_player = MagicMock(
-            available=True,
-            active_source="spotify",
-            playback_state=PlaybackState.PLAYING,
-            supported_features={PlayerFeature.PAUSE, PlayerFeature.SEEK},
+        await player.set_members(
+            player_ids_to_add=[PEER_PLAYER_ID], player_ids_to_remove=["wiim_uuid:gone"]
         )
-        ext_player.provider.domain = "dlna"
-        mock_provider.mass.players.get_player.return_value = ext_player
-        assert PlayerFeature.SET_MEMBERS in player.supported_features
+        mock_provider.native_groups.set_members.assert_awaited_once_with(
+            player, [PEER_PLAYER_ID], ["wiim_uuid:gone"]
+        )
 
-    async def test_invalid_target_aborts_before_any_join(
+    def test_grouping_withdrawn_when_api_unreachable(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """A batch containing a cross-backend target performs no join at all (transactional)."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        valid_client = MagicMock(join_slave=AsyncMock(), leave_group=AsyncMock())
-        valid = _make_shell(mock_provider, valid_client, mock_upnp_device, PEER_PLAYER_ID)
-        valid._linkplay_available = True
-        players = {PEER_PLAYER_ID: valid, "official_x": MagicMock()}  # official = not a shell
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: players.get(pid)
-        with pytest.raises(UnsupportedFeaturedException):
-            await leader.set_members(player_ids_to_add=[PEER_PLAYER_ID, "official_x"])
-        valid_client.join_slave.assert_not_awaited()
-
-    async def test_incompatible_target_aborts_before_any_join(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A later incompatible target aborts the batch before the earlier valid join runs."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        good_client = MagicMock(join_slave=AsyncMock())
-        good = _make_shell(mock_provider, good_client, mock_upnp_device, PEER_PLAYER_ID)
-        good._linkplay_available = True
-        bad_client = MagicMock(join_slave=AsyncMock())
-        bad = _make_shell(mock_provider, bad_client, mock_upnp_device, "wiim_uuid:third")
-        bad._linkplay_available = True
-        bad._cached_device_info = _device_info("2.0", legacy=True)  # incompatible
-        players = {PEER_PLAYER_ID: good, "wiim_uuid:third": bad}
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: players.get(pid)
-        with pytest.raises(UnsupportedFeaturedException):
-            await leader.set_members(player_ids_to_add=[PEER_PLAYER_ID, "wiim_uuid:third"])
-        good_client.join_slave.assert_not_awaited()
-
-    async def test_duplicate_ids_rejected(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A duplicate member id in the request is rejected up front."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        with pytest.raises(PlayerCommandFailed):
-            await leader.set_members(player_ids_to_add=[PEER_PLAYER_ID, PEER_PLAYER_ID])
-
-    async def test_conflicting_add_and_remove_rejected(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """Adding and removing the same member in one request is rejected up front."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        with pytest.raises(PlayerCommandFailed):
-            await leader.set_members(
-                player_ids_to_add=[PEER_PLAYER_ID], player_ids_to_remove=[PEER_PLAYER_ID]
-            )
-
-    async def test_valid_batch_applies_all_members(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A fully valid multi-member batch joins every member."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        leader._verify_group_change = AsyncMock()  # type: ignore[method-assign]
-        first_client = MagicMock(join_slave=AsyncMock())
-        first = _make_shell(mock_provider, first_client, mock_upnp_device, PEER_PLAYER_ID)
-        first._linkplay_available = True
-        second_client = MagicMock(join_slave=AsyncMock())
-        second = _make_shell(mock_provider, second_client, mock_upnp_device, "wiim_uuid:third")
-        second._linkplay_available = True
-        players = {PEER_PLAYER_ID: first, "wiim_uuid:third": second}
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: players.get(pid)
-        await leader.set_members(player_ids_to_add=[PEER_PLAYER_ID, "wiim_uuid:third"])
-        first_client.join_slave.assert_awaited_once()
-        second_client.join_slave.assert_awaited_once()
+        """An unreachable LinkPlay API withdraws SET_MEMBERS and locks grouping."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._linkplay_available = False
+        assert player.grouping_locked is True
+        assert PlayerFeature.SET_MEMBERS not in player.supported_features
 
 
 class TestTopology:
-    """Native group topology is mapped to MA group members, leader first."""
+    """The coordinator publishes resolved membership onto the shell."""
 
-    async def test_master_lists_leader_first(
+    def test_on_native_group_update_publishes_leader_members(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """A master with a known slave reports [leader, follower]."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        peer = _make_shell(mock_provider, mock_client, mock_upnp_device, PEER_PLAYER_ID)
-        mock_client.get_slaves_info = AsyncMock(return_value=_slaves([PEER_HTTP_UUID]))
-        mock_provider.players = [leader, peer]
-        await leader._update_group_members()
-        assert leader._attr_group_members == [EDIFIER_PLAYER_ID, PEER_PLAYER_ID]
+        """A leader publishes exactly the members the coordinator resolved for it."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        mock_provider.native_groups.members_of.return_value = [EDIFIER_PLAYER_ID, PEER_PLAYER_ID]
+        player.on_native_group_update()
+        assert player._attr_group_members == [EDIFIER_PLAYER_ID, PEER_PLAYER_ID]
 
-    async def test_solo_has_no_members(
+    def test_on_native_group_update_clears_members_for_follower(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """A solo device manages no members."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        mock_client.get_slaves_info = AsyncMock(return_value=_slaves([]))
-        await leader._update_group_members()
-        assert leader._attr_group_members == []
+        """A standalone/follower shell publishes no members of its own."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._attr_group_members = ["stale"]
+        mock_provider.native_groups.members_of.return_value = []
+        player.on_native_group_update()
+        assert player._attr_group_members == []
 
-    async def test_follower_has_no_members(
+    async def test_poll_pushes_topology_to_coordinator(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """A follower derives its relationship from the leader, managing no members itself."""
-        follower = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        mock_client.get_slaves_info = AsyncMock(return_value=_slaves([]))
-        await follower._update_group_members()
-        assert follower._attr_group_members == []
-
-    async def test_unknown_slave_ignored(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A master whose only slave is not a registered player reports no members."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        mock_client.get_slaves_info = AsyncMock(return_value=_slaves(["001122334455667788990011"]))
-        mock_provider.players = [leader]
-        await leader._update_group_members()
-        assert leader._attr_group_members == []
-
-
-class TestMixedGroupReadOnly:
-    """An externally-created mixed group is read-only from the generic side (until layer 2)."""
-
-    def _mixed_leader(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> LinkPlayPlayer:
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        # an official WiiM member (not a LinkPlayPlayer) shares the hardware group
-        official = MagicMock()
-        official.player_id = PEER_PLAYER_ID
-        mock_provider.players = [leader, official]
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: (
-            official if pid == PEER_PLAYER_ID else None
-        )
-        mock_client.get_slaves_info = AsyncMock(return_value=_slaves([PEER_HTTP_UUID]))
-        return leader
-
-    async def test_mixed_group_detected_and_represented(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A group containing an official member is flagged mixed but still shown read-only."""
-        leader = self._mixed_leader(mock_provider, mock_client, mock_upnp_device)
-        await leader._update_group_members()
-        assert leader._in_mixed_group is True
-        assert leader._attr_group_members == [EDIFIER_PLAYER_ID, PEER_PLAYER_ID]
-
-    async def test_mixed_group_withdraws_grouping(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """Grouping feature and targets are withdrawn while in a mixed group."""
-        leader = self._mixed_leader(mock_provider, mock_client, mock_upnp_device)
-        await leader._update_group_members()
-        assert leader.grouping_locked is True
-        assert PlayerFeature.SET_MEMBERS not in leader.supported_features
-        assert leader.can_group_with == set()
-
-    async def test_mixed_group_rejects_set_members(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """Mutating a mixed group is rejected rather than partially applied."""
-        leader = self._mixed_leader(mock_provider, mock_client, mock_upnp_device)
-        await leader._update_group_members()
-        with pytest.raises(PlayerCommandFailed):
-            await leader.set_members(player_ids_to_add=[EDIFIER_PLAYER_ID])
-
-    async def test_mixed_group_member_rejected(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A member that is itself in a mixed group is rejected before any join."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        member_client = MagicMock(join_slave=AsyncMock(), leave_group=AsyncMock())
-        member = _make_shell(mock_provider, member_client, mock_upnp_device, PEER_PLAYER_ID)
-        member._linkplay_available = True
-        # the member leads an externally-created mixed group with an official (other-backend) device
-        official = MagicMock(player_id="wiim_uuid:official", linkplay_backend="official")
-        official._attr_group_members = []
-        member._attr_group_members = [PEER_PLAYER_ID, "wiim_uuid:official"]
-        mock_provider.players = [leader, member, official]
-        registered = {PEER_PLAYER_ID: member, "wiim_uuid:official": official}
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: registered.get(
-            pid
-        )
-        assert member._in_mixed_group is True
-        with pytest.raises(PlayerCommandFailed):
-            await leader.set_members(player_ids_to_add=[PEER_PLAYER_ID])
-        member_client.join_slave.assert_not_awaited()
-
-    def test_generic_follower_of_official_leader_is_mixed(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A generic device an official leader lists as a follower is read-only too."""
-        follower = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        follower._linkplay_available = True
-        follower._attr_group_members = []  # a follower manages nothing itself
-        # an official leader (other backend) currently lists this generic device
-        official_leader = MagicMock(
-            player_id="wiim_uuid:official-leader", linkplay_backend="official"
-        )
-        official_leader._attr_group_members = [official_leader.player_id, EDIFIER_PLAYER_ID]
-        mock_provider.players = [follower, official_leader]
-        assert PlayerFeature.SET_MEMBERS not in follower.supported_features
-        assert follower.can_group_with == set()
+        """A poll refreshes reachability and forces a coordinator topology read."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        await player.poll()
+        mock_client.get_device_info_model.assert_awaited()
+        mock_provider.native_groups.refresh_leader.assert_awaited_with(player, force=True)
 
 
 class TestGroupCompatibility:
@@ -773,50 +411,30 @@ class TestGroupCompatibility:
         )
         assert linkplay_group_compatible(known, unknown) is False
 
-    async def test_can_group_with_excludes_incompatible_peer(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A reachable but legacy/incompatible peer is not offered as a grouping target."""
-        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        player._linkplay_available = True
-        peer = _make_shell(mock_provider, mock_client, mock_upnp_device, PEER_PLAYER_ID)
-        peer._linkplay_available = True
-        peer._cached_device_info = _device_info("2.0", legacy=True)
-        mock_provider.players = [player, peer]
-        assert player.can_group_with == set()
-
 
 class TestRefreshResilience:
-    """A poll must survive a transient topology blip and detect an unreachable API."""
+    """A poll refreshes reachability and pushes topology without blocking on a blip."""
 
-    async def test_transient_topology_read_keeps_last_members(
+    async def test_reachable_refresh_marks_healthy(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """A failed slave-list read must not clear a real group; last members are kept."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        peer = _make_shell(mock_provider, mock_client, mock_upnp_device, PEER_PLAYER_ID)
-        mock_provider.players = [leader, peer]
-        mock_client.get_slaves_info = AsyncMock(return_value=_slaves([PEER_HTTP_UUID]))
-        await leader._refresh_linkplay()
-        assert leader._attr_group_members == [EDIFIER_PLAYER_ID, PEER_PLAYER_ID]
-        # a topology read blip must not drop the group, and the device stays available
-        mock_client.get_slaves_info = AsyncMock(side_effect=WiiMError("blip"))
-        await leader._refresh_linkplay()
-        assert leader._attr_group_members == [EDIFIER_PLAYER_ID, PEER_PLAYER_ID]
-        assert leader._linkplay_available is True
+        """A successful device-info read keeps the shell reachable and caches the info."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._linkplay_available = False
+        await player.poll()
+        assert player._linkplay_available is True
+        assert player._cached_device_info is not None
 
-    async def test_unreachable_api_marks_unhealthy_but_keeps_topology(
+    async def test_unreachable_api_marks_unhealthy(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """When unreachable the shell goes unhealthy but keeps its last known group."""
-        leader = _make_shell(mock_provider, mock_client, mock_upnp_device)
-        leader._linkplay_available = True
-        leader._attr_group_members = [EDIFIER_PLAYER_ID, PEER_PLAYER_ID]
+        """A failed device-info read marks the shell unhealthy, withdrawing grouping."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._linkplay_available = True
         mock_client.get_device_info_model = AsyncMock(side_effect=WiiMError("down"))
-        await leader._refresh_linkplay()
-        assert leader._linkplay_available is False
-        # last known topology is kept so the reachable side stays locked read-only
-        assert leader._attr_group_members == [EDIFIER_PLAYER_ID, PEER_PLAYER_ID]
+        await player.poll()
+        assert player._linkplay_available is False
+        assert player.grouping_locked is True
 
     async def test_setup_without_primed_info_does_full_refresh(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
@@ -872,172 +490,6 @@ class TestAddressChange:
                 "192.168.1.99", mock_upnp_device, "http://192.168.1.99:49152/description.xml"
             )
         assert player._client is mock_client
-
-
-class TestGroupingConcurrency:
-    """Grouping and address rebuilds serialize per device via a deterministic lock order."""
-
-    async def test_concurrent_grouping_sharing_device_serializes(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """Two leaders adding the same member never touch that member's hardware at once."""
-        overlap = {"current": 0, "max": 0}
-
-        async def _join(*_args: Any, **_kwargs: Any) -> None:
-            overlap["current"] += 1
-            overlap["max"] = max(overlap["max"], overlap["current"])
-            await asyncio.sleep(0)  # yield so a second, unserialized join could overlap
-            overlap["current"] -= 1
-
-        member_client = MagicMock(join_slave=AsyncMock(side_effect=_join), leave_group=AsyncMock())
-        member = _make_shell(mock_provider, member_client, mock_upnp_device, PEER_PLAYER_ID)
-        member._linkplay_available = True
-        leader_one = _make_shell(
-            mock_provider, MagicMock(host="192.168.1.51"), mock_upnp_device, "wiim_uuid:leader-1"
-        )
-        leader_two = _make_shell(
-            mock_provider, MagicMock(host="192.168.1.52"), mock_upnp_device, "wiim_uuid:leader-2"
-        )
-        for leader in (leader_one, leader_two):
-            leader._linkplay_available = True
-            leader._verify_group_change = AsyncMock()  # type: ignore[method-assign]
-        players = {
-            PEER_PLAYER_ID: member,
-            "wiim_uuid:leader-1": leader_one,
-            "wiim_uuid:leader-2": leader_two,
-        }
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: players.get(pid)
-        await asyncio.wait_for(
-            asyncio.gather(
-                leader_one.set_members(player_ids_to_add=[PEER_PLAYER_ID]),
-                leader_two.set_members(player_ids_to_add=[PEER_PLAYER_ID]),
-            ),
-            timeout=5,
-        )
-        # the shared member lock forced the two joins to run one after the other
-        assert overlap["max"] == 1
-        assert member_client.join_slave.await_count == 2
-
-    async def test_cross_grouping_does_not_deadlock(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """Two leaders adding each other complete because every caller locks in the same order."""
-        x_client = MagicMock(host="192.168.1.60", join_slave=AsyncMock(), leave_group=AsyncMock())
-        y_client = MagicMock(host="192.168.1.61", join_slave=AsyncMock(), leave_group=AsyncMock())
-        shell_x = _make_shell(mock_provider, x_client, mock_upnp_device, "wiim_uuid:x")
-        shell_y = _make_shell(mock_provider, y_client, mock_upnp_device, "wiim_uuid:y")
-        for shell in (shell_x, shell_y):
-            shell._linkplay_available = True
-            shell._verify_group_change = AsyncMock()  # type: ignore[method-assign]
-        players = {"wiim_uuid:x": shell_x, "wiim_uuid:y": shell_y}
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: players.get(pid)
-        # Pre-hold the lowest-ordered lock so both requests are queued and contending before
-        # either runs; a non-deterministic per-caller order would deadlock this arrangement.
-        await shell_x._rebuild_lock.acquire()
-        task_x = asyncio.create_task(shell_x.set_members(player_ids_to_add=["wiim_uuid:y"]))
-        task_y = asyncio.create_task(shell_y.set_members(player_ids_to_add=["wiim_uuid:x"]))
-        await asyncio.sleep(0)  # let both tasks reach their first lock acquisition
-        shell_x._rebuild_lock.release()
-        await asyncio.wait_for(asyncio.gather(task_x, task_y), timeout=5)
-        # each leader joined the other exactly once, with no deadlock
-        y_client.join_slave.assert_awaited_once()
-        x_client.join_slave.assert_awaited_once()
-
-    async def test_address_change_waits_for_in_flight_grouping(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A member's address rebuild blocks until the grouping holding its lock finishes."""
-        join_started = asyncio.Event()
-        release_join = asyncio.Event()
-
-        async def _join(*_args: Any, **_kwargs: Any) -> None:
-            join_started.set()
-            await release_join.wait()
-
-        member_client = MagicMock(
-            host="192.168.1.50", join_slave=AsyncMock(side_effect=_join), leave_group=AsyncMock()
-        )
-        member = _make_shell(mock_provider, member_client, mock_upnp_device, PEER_PLAYER_ID)
-        member._linkplay_available = True
-        leader = _make_shell(
-            mock_provider, MagicMock(host="192.168.1.51"), mock_upnp_device, "wiim_uuid:leader-1"
-        )
-        leader._linkplay_available = True
-        leader._verify_group_change = AsyncMock()  # type: ignore[method-assign]
-        players = {PEER_PLAYER_ID: member, "wiim_uuid:leader-1": leader}
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: players.get(pid)
-        new_client = MagicMock(host="192.168.1.99")
-        new_client.get_device_info_model = AsyncMock(return_value=SimpleNamespace(uuid=""))
-        new_client.get_slaves_info = AsyncMock(return_value=_slaves([]))
-
-        group_task = asyncio.create_task(leader.set_members(player_ids_to_add=[PEER_PLAYER_ID]))
-        await asyncio.wait_for(join_started.wait(), timeout=5)  # grouping now holds member's lock
-        with patch(
-            "music_assistant.providers.wiim.linkplay_player.WiiMClient", return_value=new_client
-        ):
-            addr_task = asyncio.create_task(
-                member.async_handle_address_change(
-                    "192.168.1.99", mock_upnp_device, "http://192.168.1.99:49152/description.xml"
-                )
-            )
-            await asyncio.sleep(0)
-            # the rebuild cannot proceed while grouping holds the member lock
-            assert not addr_task.done()
-            assert member._client is member_client
-            release_join.set()
-            await asyncio.wait_for(asyncio.gather(group_task, addr_task), timeout=5)
-        assert member._client is new_client
-
-    async def test_unrelated_player_not_locked_during_grouping(
-        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
-    ) -> None:
-        """A device outside the group request can rebuild its address while grouping runs."""
-        join_started = asyncio.Event()
-        release_join = asyncio.Event()
-
-        async def _join(*_args: Any, **_kwargs: Any) -> None:
-            join_started.set()
-            await release_join.wait()
-
-        member_client = MagicMock(
-            host="192.168.1.50", join_slave=AsyncMock(side_effect=_join), leave_group=AsyncMock()
-        )
-        member = _make_shell(mock_provider, member_client, mock_upnp_device, PEER_PLAYER_ID)
-        member._linkplay_available = True
-        leader = _make_shell(
-            mock_provider, MagicMock(host="192.168.1.51"), mock_upnp_device, "wiim_uuid:leader-1"
-        )
-        leader._linkplay_available = True
-        leader._verify_group_change = AsyncMock()  # type: ignore[method-assign]
-        other = _make_shell(
-            mock_provider, MagicMock(host="192.168.1.70"), mock_upnp_device, "wiim_uuid:other"
-        )
-        other._linkplay_available = True
-        players = {
-            PEER_PLAYER_ID: member,
-            "wiim_uuid:leader-1": leader,
-            "wiim_uuid:other": other,
-        }
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: players.get(pid)
-        new_client = MagicMock(host="192.168.1.99")
-        new_client.get_device_info_model = AsyncMock(return_value=SimpleNamespace(uuid=""))
-        new_client.get_slaves_info = AsyncMock(return_value=_slaves([]))
-
-        group_task = asyncio.create_task(leader.set_members(player_ids_to_add=[PEER_PLAYER_ID]))
-        await asyncio.wait_for(join_started.wait(), timeout=5)  # grouping holds leader + member
-        with patch(
-            "music_assistant.providers.wiim.linkplay_player.WiiMClient", return_value=new_client
-        ):
-            # the unrelated device is not part of the request, so its rebuild is not blocked
-            await asyncio.wait_for(
-                other.async_handle_address_change(
-                    "192.168.1.99", mock_upnp_device, "http://192.168.1.99:49152/description.xml"
-                ),
-                timeout=5,
-            )
-        assert other._client is new_client
-        release_join.set()
-        await asyncio.wait_for(group_task, timeout=5)
 
 
 class TestProviderRouting:

--- a/tests/providers/wiim/test_linkplay.py
+++ b/tests/providers/wiim/test_linkplay.py
@@ -7,7 +7,12 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import IdentifierType, PlayerFeature, PlayerType
+from music_assistant_models.enums import (
+    IdentifierType,
+    PlaybackState,
+    PlayerFeature,
+    PlayerType,
+)
 from pywiim import WiiMError
 
 from music_assistant.controllers.players.protocol_linking import ProtocolLinkingMixin
@@ -133,6 +138,7 @@ def _mock_native_groups() -> MagicMock:
     groups.set_members = AsyncMock()
     groups.schedule_reconcile = MagicMock()
     groups.unregister = MagicMock()
+    groups.is_unknown_leader_follower = MagicMock(return_value=False)
     groups.set_self_role = MagicMock(return_value=False)
     return groups
 
@@ -342,6 +348,32 @@ class TestGrouping:
         player._linkplay_available = False
         assert player.grouping_locked is True
         assert PlayerFeature.SET_MEMBERS not in player.supported_features
+
+    def test_unknown_leader_follower_locks_grouping(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """A reachable shell that follows an undiscovered group still withdraws grouping."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._linkplay_available = True
+        mock_provider.native_groups.is_unknown_leader_follower.return_value = True
+        assert player.grouping_locked is True
+
+    def test_grouping_rebuild_lock_serializes_with_address_change(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """The lock the coordinator holds during a command is the shell's address-rebuild lock."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        assert player.grouping_rebuild_lock is player._rebuild_lock
+
+    def test_native_follower_suppresses_playback(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """A native follower reports idle and no media instead of its delegated state."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        mock_provider.native_groups.role_of.return_value = NativeGroupRole.FOLLOWER
+        assert player.playback_state == PlaybackState.IDLE
+        assert player.current_media is None
+        assert player.active_source is None
 
 
 class TestTopology:

--- a/tests/providers/wiim/test_linkplay.py
+++ b/tests/providers/wiim/test_linkplay.py
@@ -802,3 +802,21 @@ class TestAvailabilityRepublish:
         await player._refresh_reachability()  # stays reachable
 
         mock_provider.native_groups.schedule_republish.assert_not_called()
+
+    async def test_address_change_recovery_republishes_peers(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """Recovering an unavailable shell via an address change re-publishes its peers."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._linkplay_available = False
+        new_client = MagicMock(host="192.168.1.99")
+        new_client.get_device_info_model = AsyncMock(return_value=SimpleNamespace(uuid=""))
+        new_client.get_slaves_info = AsyncMock(return_value=_slaves([]))
+        with patch(
+            "music_assistant.providers.wiim.linkplay_player.WiiMClient", return_value=new_client
+        ):
+            await player.async_handle_address_change(
+                "192.168.1.99", mock_upnp_device, "http://192.168.1.99:49152/description.xml"
+            )
+
+        mock_provider.native_groups.schedule_republish.assert_called()

--- a/tests/providers/wiim/test_linkplay.py
+++ b/tests/providers/wiim/test_linkplay.py
@@ -366,6 +366,25 @@ class TestGrouping:
         # the broad lock holds, so even a linked-protocol group is withdrawn in the final state
         assert player.grouping_locked is True
 
+    def test_api_outage_locks_a_native_group_member(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """A device already in a native group whose API drops is broadly locked (can't leave it)."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._linkplay_available = False
+        mock_provider.native_groups.role_of.return_value = NativeGroupRole.LEADER
+        # a protocol regroup would leave it in both groups, since the native ungroup can't run
+        assert player.grouping_locked is True
+
+    def test_healthy_native_group_member_not_broadly_locked(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """A reachable native group member can still be regrouped (core natively ungroups first)."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._linkplay_available = True
+        mock_provider.native_groups.role_of.return_value = NativeGroupRole.FOLLOWER
+        assert player.grouping_locked is False
+
     def test_grouping_rebuild_lock_serializes_with_address_change(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:

--- a/tests/providers/wiim/test_linkplay.py
+++ b/tests/providers/wiim/test_linkplay.py
@@ -551,6 +551,9 @@ class TestProviderRouting:
         # setup must not repeat it, and the shell is registered already reachable.
         mock_client.get_device_info_model.assert_awaited_once()
         assert registered[0]._linkplay_available is True
+        # the live topology is read only after the player is registered (a read taken during
+        # setup, before registration, would be discarded by the coordinator).
+        mock_provider.native_groups.refresh_leader.assert_awaited_with(registered[0], force=True)
 
     async def test_unreachable_device_not_registered(
         self, mock_provider: MagicMock, mock_upnp_device: MagicMock

--- a/tests/providers/wiim/test_linkplay.py
+++ b/tests/providers/wiim/test_linkplay.py
@@ -407,6 +407,45 @@ class TestTopology:
         mock_client.get_device_info_model.assert_awaited()
         mock_provider.native_groups.refresh_leader.assert_awaited_with(player, force=True)
 
+    def test_becoming_follower_clears_active_output_protocol(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """A shell that was playing through DLNA drops that output when it becomes a follower."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player.set_active_output_protocol("dlna_x")
+        mock_provider.native_groups.role_of.return_value = NativeGroupRole.FOLLOWER
+
+        player.on_native_group_update()
+
+        assert player.active_output_protocol is None
+        assert player.playback_state == PlaybackState.IDLE
+        assert player.current_media is None
+
+    def test_leaving_follower_does_not_resurrect_protocol(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """The dropped output stays cleared after leaving; normal playback reselects it."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player.set_active_output_protocol("dlna_x")
+        mock_provider.native_groups.role_of.return_value = NativeGroupRole.FOLLOWER
+        player.on_native_group_update()
+
+        mock_provider.native_groups.role_of.return_value = NativeGroupRole.STANDALONE
+        player.on_native_group_update()
+
+        assert player.active_output_protocol is None
+
+    def test_standalone_update_keeps_active_output_protocol(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """A non-follower topology update never touches the active output (no churn)."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player.set_active_output_protocol("dlna_x")
+
+        player.on_native_group_update()  # role stays standalone
+
+        assert player.active_output_protocol == "dlna_x"
+
 
 class TestGroupCompatibility:
     """Only compatible, modern router-based generic LinkPlay devices may be grouped."""

--- a/tests/providers/wiim/test_linkplay.py
+++ b/tests/providers/wiim/test_linkplay.py
@@ -124,6 +124,10 @@ def mock_provider() -> MagicMock:
     config.player_type = None
     config.get_value = MagicMock(return_value=None)
     provider.mass.config.get_base_player_config.return_value = config
+    # used by the core final-state calculation to resolve power/volume controls
+    provider.mass.config.get_raw_player_config_value = MagicMock(
+        side_effect=lambda _player_id, _key, default=None: default
+    )
     return provider
 
 
@@ -272,11 +276,9 @@ class TestHealthGating:
         healthy = _make_shell(mock_provider, mock_client, mock_upnp_device)
         healthy._linkplay_available = True
         assert healthy.native_available is True
-        assert healthy.grouping_locked is False
         unhealthy = _make_shell(mock_provider, mock_client, mock_upnp_device)
         unhealthy._linkplay_available = False
         assert unhealthy.native_available is False
-        assert unhealthy.grouping_locked is True
 
     def test_native_group_compat_follows_can_group_with(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
@@ -340,22 +342,27 @@ class TestGrouping:
             player, [PEER_PLAYER_ID], ["wiim_uuid:gone"]
         )
 
-    def test_grouping_withdrawn_when_api_unreachable(
+    def test_api_unreachable_gates_only_native_grouping(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """An unreachable LinkPlay API withdraws SET_MEMBERS and locks grouping."""
+        """An unreachable LinkPlay API withdraws only native grouping, not the broad lock."""
         player = _make_shell(mock_provider, mock_client, mock_upnp_device)
         player._linkplay_available = False
-        assert player.grouping_locked is True
+        # the broad lock stays off, so core may still group this device via a linked protocol
+        assert player.grouping_locked is False
+        # but native grouping is gated: the raw SET_MEMBERS is withdrawn ...
         assert PlayerFeature.SET_MEMBERS not in player.supported_features
+        # ... and the coordinator offers no native peers for an unreachable device
+        assert player.can_group_with == set()
 
     def test_unknown_leader_follower_locks_grouping(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """A reachable shell that follows an undiscovered group still withdraws grouping."""
+        """A reachable shell that follows an undiscovered group withdraws ALL grouping."""
         player = _make_shell(mock_provider, mock_client, mock_upnp_device)
         player._linkplay_available = True
         mock_provider.native_groups.is_unknown_leader_follower.return_value = True
+        # the broad lock holds, so even a linked-protocol group is withdrawn in the final state
         assert player.grouping_locked is True
 
     def test_grouping_rebuild_lock_serializes_with_address_change(
@@ -499,13 +506,15 @@ class TestRefreshResilience:
     async def test_unreachable_api_marks_unhealthy(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
     ) -> None:
-        """A failed device-info read marks the shell unhealthy, withdrawing grouping."""
+        """A failed device-info read marks the shell unhealthy, withdrawing NATIVE grouping."""
         player = _make_shell(mock_provider, mock_client, mock_upnp_device)
         player._linkplay_available = True
         mock_client.get_device_info_model = AsyncMock(side_effect=WiiMError("down"))
         await player.poll()
         assert player._linkplay_available is False
-        assert player.grouping_locked is True
+        # only native grouping is gated; the broad lock stays off so a linked protocol can group
+        assert PlayerFeature.SET_MEMBERS not in player.supported_features
+        assert player.grouping_locked is False
 
     async def test_setup_without_primed_info_does_full_refresh(
         self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
@@ -692,3 +701,57 @@ class TestDefaultProtocolSelection:
         player = self._shell_player(links)
         target, _ = ProtocolLinkingMixin._select_best_output_protocol(controller, player)
         assert target is players["dlna_x"]
+
+
+class TestFinalGroupingState:
+    """The FINAL state gates native grouping by API health but keeps linked-protocol grouping."""
+
+    @staticmethod
+    def _final_supported_features(player: LinkPlayPlayer) -> set[PlayerFeature]:
+        return cast(
+            "set[PlayerFeature]",
+            player._Player__final_supported_features,  # type: ignore[attr-defined]
+        )
+
+    def _link_grouping_protocol(self, player: LinkPlayPlayer, mock_provider: MagicMock) -> None:
+        """Link a DLNA protocol player that itself supports SET_MEMBERS."""
+        player.set_linked_output_protocols([LinkedOutputProtocol("dlna_x", "dlna", priority=50)])
+        protocol_player = MagicMock()
+        protocol_player.available = True
+        protocol_player.available_for_playback = True
+        protocol_player.supported_features = {PlayerFeature.SET_MEMBERS, PlayerFeature.PAUSE}
+        mock_provider.mass.players.get_player.return_value = protocol_player
+
+    def test_protocol_grouping_survives_api_outage(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """With the LinkPlay API down, a linked protocol still supplies SET_MEMBERS to the final state."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._linkplay_available = False
+        self._link_grouping_protocol(player, mock_provider)
+
+        # native raw is gated, but the broad lock is off, so the linked protocol re-adds it
+        assert PlayerFeature.SET_MEMBERS not in player.supported_features
+        assert player.grouping_locked is False
+        assert PlayerFeature.SET_MEMBERS in self._final_supported_features(player)
+
+    def test_unknown_leader_follower_withdraws_even_protocol_grouping(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """The broad lock withdraws grouping in the final state even a linked protocol would add."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._linkplay_available = True
+        mock_provider.native_groups.is_unknown_leader_follower.return_value = True
+        self._link_grouping_protocol(player, mock_provider)
+
+        assert player.grouping_locked is True
+        assert PlayerFeature.SET_MEMBERS not in self._final_supported_features(player)
+
+    def test_healthy_native_keeps_set_members(
+        self, mock_provider: MagicMock, mock_client: MagicMock, mock_upnp_device: MagicMock
+    ) -> None:
+        """A reachable, standalone shell keeps native SET_MEMBERS and no broad lock."""
+        player = _make_shell(mock_provider, mock_client, mock_upnp_device)
+        player._linkplay_available = True
+        assert PlayerFeature.SET_MEMBERS in player.supported_features
+        assert player.grouping_locked is False

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -4,23 +4,35 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import PlaybackState, PlayerFeature
-from music_assistant_models.errors import PlayerCommandFailed, UnsupportedFeaturedException
 from wiim import PlayingStatus
 from wiim.exceptions import (
     WiimDeviceException,
-    WiimException,
     WiimInvalidDataException,
     WiimRequestException,
 )
 
 from music_assistant.models.player import PlayerMedia
 from music_assistant.providers.wiim.constants import (
-    BACKEND_GENERIC,
-    BACKEND_OFFICIAL,
     PLAYER_ID_PREFIX,
     SOURCE_NETWORK,
 )
+from music_assistant.providers.wiim.grouping import NativeGroupRole
 from music_assistant.providers.wiim.player import SDK_TO_MA_STATE, WiimPlayer
+
+
+def _mock_native_groups() -> MagicMock:
+    """Create a coordinator mock that reports a standalone topology by default."""
+    groups = MagicMock()
+    groups.role_of.return_value = NativeGroupRole.STANDALONE
+    groups.members_of.return_value = []
+    groups.can_group_with.return_value = set()
+    groups.refresh_leader = AsyncMock()
+    groups.reconcile = AsyncMock()
+    groups.set_members = AsyncMock()
+    groups.schedule_reconcile = MagicMock()
+    groups.unregister = MagicMock()
+    groups.set_self_role = MagicMock(return_value=False)
+    return groups
 
 
 @pytest.fixture
@@ -85,6 +97,8 @@ def mock_provider(mock_controller: MagicMock) -> MagicMock:
     provider.manifest.domain = "wiim"
     provider.mass = MagicMock()
     provider.mass.players = MagicMock()
+    provider.players = []
+    provider.native_groups = _mock_native_groups()
 
     config = MagicMock()
     config.name = None
@@ -262,23 +276,18 @@ class TestSupportedFeatures:
 
 
 class TestGroupMembers:
-    """Test group member state handling."""
+    """Group membership is published from the coordinator's resolved topology."""
 
-    def test_unmanaged_group_members_are_ignored(
+    def test_leader_publishes_coordinator_members(
         self, mock_provider: MagicMock, mock_wiim_device: MagicMock
     ) -> None:
-        """Only group members registered in Music Assistant should be reported."""
-        managed_udn = "uuid:test-wiim-002"
-        unmanaged_udn = "uuid:test-linkplay-001"
+        """A leader publishes exactly the members the coordinator resolved for it."""
         leader_player_id = f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}"
-        managed_player_id = f"{PLAYER_ID_PREFIX}{managed_udn}"
-        snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
-        snapshot.role = "leader"
-        snapshot.member_udns = (mock_wiim_device.udn, managed_udn, unmanaged_udn)
-        mock_provider.wiim_controller.get_group_members.side_effect = ValueError(
-            f"Device {unmanaged_udn} is not managed by the controller"
-        )
-        mock_provider.mass.players.get_player.side_effect = {managed_player_id: MagicMock()}.get
+        managed_player_id = f"{PLAYER_ID_PREFIX}uuid:test-wiim-002"
+        mock_provider.native_groups.members_of.return_value = [
+            leader_player_id,
+            managed_player_id,
+        ]
         player = WiimPlayer(
             provider=mock_provider,
             player_id=leader_player_id,
@@ -289,157 +298,24 @@ class TestGroupMembers:
         player._update_ma_state_from_sdk_cache()
 
         assert player._attr_group_members == [leader_player_id, managed_player_id]
-        mock_provider.wiim_controller.get_group_members.assert_not_called()
 
-    def test_only_unmanaged_group_members_reports_no_group(
+    def test_follower_publishes_no_members(
         self, mock_provider: MagicMock, mock_wiim_device: MagicMock
     ) -> None:
-        """A group without any MA-managed followers should not be reported."""
-        snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
-        snapshot.role = "leader"
-        snapshot.member_udns = (mock_wiim_device.udn, "uuid:test-linkplay-001")
-        mock_provider.mass.players.get_player.return_value = None
+        """A follower manages no members of its own, whatever it last held."""
+        mock_provider.native_groups.role_of.return_value = NativeGroupRole.FOLLOWER
         player = WiimPlayer(
             provider=mock_provider,
             player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
             device=mock_wiim_device,
         )
         player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+        player._attr_group_members = ["stale"]
 
         player._update_ma_state_from_sdk_cache()
 
         assert player._attr_group_members == []
 
-
-class TestMixedGroupReadOnly:
-    """An externally-created mixed group is read-only from the official side (until layer 2)."""
-
-    def _leader_with_member(
-        self,
-        mock_provider: MagicMock,
-        mock_wiim_device: MagicMock,
-        member_udn: str,
-        member_backend: str,
-    ) -> WiimPlayer:
-        leader_player_id = f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}"
-        member_player_id = f"{PLAYER_ID_PREFIX}{member_udn}"
-        snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
-        snapshot.role = "leader"
-        snapshot.member_udns = (mock_wiim_device.udn, member_udn)
-        member = MagicMock(linkplay_backend=member_backend)
-        mock_provider.mass.players.get_player.side_effect = {member_player_id: member}.get
-        player = WiimPlayer(
-            provider=mock_provider, player_id=leader_player_id, device=mock_wiim_device
-        )
-        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
-        # the shared mixed-group predicate scans registered provider players
-        mock_provider.players = [player]
-        return player
-
-    def test_generic_member_makes_group_mixed_and_read_only(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """A generic LinkPlay member makes the group mixed; grouping is withdrawn."""
-        player = self._leader_with_member(
-            mock_provider, mock_wiim_device, "uuid:test-linkplay-001", BACKEND_GENERIC
-        )
-        player._update_ma_state_from_sdk_cache()
-        assert player._in_mixed_group is True
-        # the mixed group is still represented read-only (leader first)
-        assert player._attr_group_members == [
-            f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
-            f"{PLAYER_ID_PREFIX}uuid:test-linkplay-001",
-        ]
-        assert PlayerFeature.SET_MEMBERS not in player.supported_features
-        assert player.can_group_with == set()
-
-    def test_official_member_group_is_not_mixed(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """An all-official group is not mixed; grouping stays available."""
-        player = self._leader_with_member(
-            mock_provider, mock_wiim_device, "uuid:test-wiim-002", BACKEND_OFFICIAL
-        )
-        player._update_ma_state_from_sdk_cache()
-        assert player._in_mixed_group is False
-        assert PlayerFeature.SET_MEMBERS in player.supported_features
-
-    def test_mixed_to_same_backend_transition_restores_grouping(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """Leaving a mixed group restores the grouping capability on the next update."""
-        player = self._leader_with_member(
-            mock_provider, mock_wiim_device, "uuid:test-linkplay-001", BACKEND_GENERIC
-        )
-        player._update_ma_state_from_sdk_cache()
-        assert PlayerFeature.SET_MEMBERS not in player.supported_features
-        # the device becomes standalone again
-        snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
-        snapshot.role = "standalone"
-        snapshot.member_udns = (mock_wiim_device.udn,)
-        player._update_ma_state_from_sdk_cache()
-        assert PlayerFeature.SET_MEMBERS in player.supported_features
-
-    async def test_set_members_rejected_while_mixed(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """A direct set_members on a mixed group is rejected, not partially applied."""
-        player = self._leader_with_member(
-            mock_provider, mock_wiim_device, "uuid:test-linkplay-001", BACKEND_GENERIC
-        )
-        player._update_ma_state_from_sdk_cache()  # populates a mixed group
-        with pytest.raises(UnsupportedFeaturedException):
-            await player.set_members(player_ids_to_add=["wiim_uuid:other"])
-
-    def test_official_follower_of_generic_leader_is_mixed(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """An official device a generic leader lists as a follower is read-only too."""
-        player = WiimPlayer(
-            provider=mock_provider,
-            player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
-            device=mock_wiim_device,
-        )
-        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
-        player._attr_group_members = []  # a follower manages nothing itself
-        generic_leader = MagicMock(
-            player_id="wiim_uuid:generic-leader", linkplay_backend=BACKEND_GENERIC
-        )
-        generic_leader._attr_group_members = [generic_leader.player_id, player.player_id]
-        mock_provider.players = [player, generic_leader]
-        assert PlayerFeature.SET_MEMBERS not in player.supported_features
-        assert player.can_group_with == set()
-
-    def test_can_group_with_excludes_official_peer_in_mixed_group(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """An official peer locked in a generic-led mixed group is not offered as a target."""
-        leader = WiimPlayer(
-            provider=mock_provider,
-            player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
-            device=mock_wiim_device,
-        )
-        leader.update_state = MagicMock()  # type: ignore[misc,method-assign]
-        leader._attr_available = True
-        # an official peer that is a follower in a generic-led mixed group
-        peer = WiimPlayer(
-            provider=mock_provider,
-            player_id="wiim_uuid:official-peer",
-            device=mock_wiim_device,
-        )
-        peer.update_state = MagicMock()  # type: ignore[misc,method-assign]
-        peer._attr_available = True
-        peer._attr_group_members = []
-        generic_leader = MagicMock(
-            player_id="wiim_uuid:generic-leader", linkplay_backend=BACKEND_GENERIC
-        )
-        generic_leader._attr_group_members = [generic_leader.player_id, peer.player_id]
-        mock_provider.players = [leader, peer, generic_leader]
-        assert peer._in_mixed_group is True
-        assert peer.player_id not in leader.can_group_with
-
-
-class TestSourceList:
     """Test dynamic source list construction."""
 
     @pytest.mark.asyncio
@@ -815,169 +691,23 @@ class TestPollRefreshesTransportState:
         mock_wiim_device.async_update_http_status.assert_not_awaited()
 
 
-class TestSetMembersTypeSafety:
-    """Official grouping must reject cross-backend members instead of crashing."""
+class TestSetMembersDelegation:
+    """The official player delegates grouping to the shared coordinator."""
 
-    async def test_add_generic_member_raises_unsupported(
+    async def test_set_members_delegates_to_coordinator(
         self, mock_provider: MagicMock, mock_wiim_device: MagicMock
     ) -> None:
-        """Adding a non-WiimPlayer member raises a typed error rather than AttributeError."""
+        """set_members forwards the add/remove batch to the coordinator unchanged."""
         leader = WiimPlayer(
             provider=mock_provider,
             player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
             device=mock_wiim_device,
         )
-        # a registered generic LinkPlay player (no .device attribute)
-        mock_provider.mass.players.get_player.return_value = MagicMock(spec=[])
 
-        with pytest.raises(UnsupportedFeaturedException):
-            await leader.set_members(player_ids_to_add=["wiim_uuid:generic"])
-
-    async def test_add_same_backend_member_joins(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """Adding another official WiiM player joins it via the controller."""
-        leader = WiimPlayer(
-            provider=mock_provider,
-            player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
-            device=mock_wiim_device,
-        )
-        follower = MagicMock(spec=WiimPlayer)
-        follower.player_id = "wiim_uuid:follower"
-        follower.device = MagicMock()
-        follower.device.udn = "uuid:follower"
-        follower._in_mixed_group = False
-        mock_provider.mass.players.get_player.return_value = follower
-
-        await leader.set_members(player_ids_to_add=["wiim_uuid:follower"])
-
-        mock_provider.wiim_controller.async_join_group.assert_awaited_once_with(
-            mock_wiim_device.udn, ["uuid:follower"]
+        await leader.set_members(
+            player_ids_to_add=["wiim_uuid:add"], player_ids_to_remove=["wiim_uuid:remove"]
         )
 
-    def _leader(self, mock_provider: MagicMock, mock_wiim_device: MagicMock) -> WiimPlayer:
-        return WiimPlayer(
-            provider=mock_provider,
-            player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
-            device=mock_wiim_device,
+        mock_provider.native_groups.set_members.assert_awaited_once_with(
+            leader, ["wiim_uuid:add"], ["wiim_uuid:remove"]
         )
-
-    def _follower(self, player_id: str, udn: str, *, mixed: bool = False) -> MagicMock:
-        follower = MagicMock(spec=WiimPlayer)
-        follower.player_id = player_id
-        follower.device = MagicMock(udn=udn)
-        follower._in_mixed_group = mixed
-        return follower
-
-    async def test_add_remove_conflict_rejected(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """Adding and removing the same member in one request is rejected before any call."""
-        leader = self._leader(mock_provider, mock_wiim_device)
-        with pytest.raises(PlayerCommandFailed):
-            await leader.set_members(
-                player_ids_to_add=["wiim_uuid:x"], player_ids_to_remove=["wiim_uuid:x"]
-            )
-        mock_provider.wiim_controller.async_join_group.assert_not_awaited()
-        mock_provider.wiim_controller.async_ungroup_device.assert_not_awaited()
-
-    async def test_remove_current_member_ungroups(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """Removing a current member ungroups it via the controller."""
-        leader = self._leader(mock_provider, mock_wiim_device)
-        follower = self._follower("wiim_uuid:follower", "uuid:follower")
-        mock_provider.mass.players.get_player.return_value = follower
-        snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
-        snapshot.member_udns = (mock_wiim_device.udn, "uuid:follower")
-        await leader.set_members(player_ids_to_remove=["wiim_uuid:follower"])
-        mock_provider.wiim_controller.async_ungroup_device.assert_awaited_once_with("uuid:follower")
-
-    async def test_valid_batch_removes_all(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """A fully valid multi-member removal ungroups every member."""
-        leader = self._leader(mock_provider, mock_wiim_device)
-        members = {
-            "wiim_uuid:a": self._follower("wiim_uuid:a", "uuid:a"),
-            "wiim_uuid:b": self._follower("wiim_uuid:b", "uuid:b"),
-        }
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: members.get(pid)
-        snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
-        snapshot.member_udns = (mock_wiim_device.udn, "uuid:a", "uuid:b")
-        await leader.set_members(player_ids_to_remove=["wiim_uuid:a", "wiim_uuid:b"])
-        assert mock_provider.wiim_controller.async_ungroup_device.await_count == 2
-
-    async def test_remove_moved_member_untouched(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """A removal target the leader no longer owns is rejected without any ungroup."""
-        leader = self._leader(mock_provider, mock_wiim_device)
-        follower = self._follower("wiim_uuid:follower", "uuid:follower")
-        mock_provider.mass.players.get_player.return_value = follower
-        # the leader's freshest snapshot no longer lists the follower (it moved elsewhere)
-        snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
-        snapshot.member_udns = (mock_wiim_device.udn,)
-        with pytest.raises(PlayerCommandFailed):
-            await leader.set_members(player_ids_to_remove=["wiim_uuid:follower"])
-        mock_provider.wiim_controller.async_ungroup_device.assert_not_awaited()
-
-    async def test_remove_member_in_mixed_group_rejected(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """A member that has moved into a read-only mixed group is not ungrouped."""
-        leader = self._leader(mock_provider, mock_wiim_device)
-        follower = self._follower("wiim_uuid:follower", "uuid:follower", mixed=True)
-        mock_provider.mass.players.get_player.return_value = follower
-        snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
-        snapshot.member_udns = (mock_wiim_device.udn, "uuid:follower")
-        with pytest.raises(PlayerCommandFailed):
-            await leader.set_members(player_ids_to_remove=["wiim_uuid:follower"])
-        mock_provider.wiim_controller.async_ungroup_device.assert_not_awaited()
-
-    async def test_later_invalid_removal_aborts_batch(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """A later invalid removal target aborts the batch before any ungroup runs."""
-        leader = self._leader(mock_provider, mock_wiim_device)
-        members = {
-            "wiim_uuid:good": self._follower("wiim_uuid:good", "uuid:good"),
-            "wiim_uuid:bad": self._follower("wiim_uuid:bad", "uuid:bad"),
-        }
-        mock_provider.mass.players.get_player.side_effect = lambda pid, *_a, **_k: members.get(pid)
-        # only 'good' is a current member; 'bad' has moved away
-        snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
-        snapshot.member_udns = (mock_wiim_device.udn, "uuid:good")
-        with pytest.raises(PlayerCommandFailed):
-            await leader.set_members(player_ids_to_remove=["wiim_uuid:good", "wiim_uuid:bad"])
-        mock_provider.wiim_controller.async_ungroup_device.assert_not_awaited()
-
-    async def test_join_sdk_error_propagates_typed(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """A controller error while joining surfaces as a typed failure, not a false success."""
-        leader = self._leader(mock_provider, mock_wiim_device)
-        mock_provider.mass.players.get_player.return_value = self._follower(
-            "wiim_uuid:follower", "uuid:follower"
-        )
-        cause = WiimException("join boom")
-        mock_provider.wiim_controller.async_join_group.side_effect = cause
-        with pytest.raises(PlayerCommandFailed) as excinfo:
-            await leader.set_members(player_ids_to_add=["wiim_uuid:follower"])
-        assert excinfo.value.__cause__ is cause
-
-    async def test_remove_sdk_error_propagates_typed(
-        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
-    ) -> None:
-        """A controller error while ungrouping surfaces as a typed failure with its cause."""
-        leader = self._leader(mock_provider, mock_wiim_device)
-        mock_provider.mass.players.get_player.return_value = self._follower(
-            "wiim_uuid:follower", "uuid:follower"
-        )
-        snapshot = mock_provider.wiim_controller.get_group_snapshot.return_value
-        snapshot.member_udns = (mock_wiim_device.udn, "uuid:follower")
-        cause = WiimException("ungroup boom")
-        mock_provider.wiim_controller.async_ungroup_device.side_effect = cause
-        with pytest.raises(PlayerCommandFailed) as excinfo:
-            await leader.set_members(player_ids_to_remove=["wiim_uuid:follower"])
-        assert excinfo.value.__cause__ is cause

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -380,6 +380,8 @@ class TestGroupMembers:
 
         assert player.active_output_protocol is None
 
+
+class TestSourceList:
     """Test dynamic source list construction."""
 
     @pytest.mark.asyncio

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -799,3 +799,24 @@ class TestAvailabilityRepublish:
         player._update_ma_state_from_sdk_cache()
 
         mock_provider.native_groups.schedule_republish.assert_called()
+
+
+class TestTopologyRefreshDebounce:
+    """A RenderingControl Slave event burst is coalesced into one forced topology refresh."""
+
+    def test_schedule_topology_refresh_debounces_via_call_later(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """The refresh is scheduled with a shared task_id so a burst reschedules one read."""
+        player = WiimPlayer(
+            provider=mock_provider,
+            player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
+            device=mock_wiim_device,
+        )
+
+        player._schedule_topology_refresh()
+
+        mock_provider.mass.call_later.assert_called_once()
+        kwargs = mock_provider.mass.call_later.call_args.kwargs
+        assert kwargs["task_id"] == f"wiim_topology_{player.player_id}"
+        assert kwargs["force"] is True

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -804,10 +804,10 @@ class TestAvailabilityRepublish:
 class TestTopologyRefreshDebounce:
     """A RenderingControl Slave event burst is coalesced into one forced topology refresh."""
 
-    def test_schedule_topology_refresh_debounces_via_call_later(
+    def test_schedule_topology_refresh_dedups_via_task_id(
         self, mock_provider: MagicMock, mock_wiim_device: MagicMock
     ) -> None:
-        """The refresh is scheduled with a shared task_id so a burst reschedules one read."""
+        """The refresh is a leading-edge throttle: a shared task_id, without cancelling a run."""
         player = WiimPlayer(
             provider=mock_provider,
             player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
@@ -816,7 +816,8 @@ class TestTopologyRefreshDebounce:
 
         player._schedule_topology_refresh()
 
-        mock_provider.mass.call_later.assert_called_once()
-        kwargs = mock_provider.mass.call_later.call_args.kwargs
+        mock_provider.mass.create_task.assert_called_once()
+        kwargs = mock_provider.mass.create_task.call_args.kwargs
         assert kwargs["task_id"] == f"wiim_topology_{player.player_id}"
         assert kwargs["force"] is True
+        assert kwargs.get("abort_existing", False) is False

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -31,6 +31,7 @@ def _mock_native_groups() -> MagicMock:
     groups.reconcile = AsyncMock()
     groups.set_members = AsyncMock()
     groups.schedule_reconcile = MagicMock()
+    groups.schedule_republish = MagicMock()
     groups.unregister = MagicMock()
     groups.is_unknown_leader_follower = MagicMock(return_value=False)
     groups.set_self_role = MagicMock(return_value=False)
@@ -777,3 +778,24 @@ class TestSetMembersDelegation:
         mock_provider.native_groups.set_members.assert_awaited_once_with(
             leader, ["wiim_uuid:add"], ["wiim_uuid:remove"]
         )
+
+
+class TestAvailabilityRepublish:
+    """A native-availability flip re-publishes peers so their candidate sets don't go stale."""
+
+    def test_availability_flip_republishes_peers(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """When the device becomes unavailable, every native peer is re-published."""
+        player = WiimPlayer(
+            provider=mock_provider,
+            player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
+            device=mock_wiim_device,
+        )
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+        player._attr_available = True
+        mock_wiim_device.available = False
+
+        player._update_ma_state_from_sdk_cache()
+
+        mock_provider.native_groups.schedule_republish.assert_called()

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -342,6 +342,44 @@ class TestGroupMembers:
         assert locked_when_unknown is True
         assert locked_when_known is False
 
+    def test_becoming_follower_clears_active_output_protocol(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """An official device drops a still-active output when it becomes a native follower."""
+        mock_provider.native_groups.role_of.return_value = NativeGroupRole.FOLLOWER
+        player = WiimPlayer(
+            provider=mock_provider,
+            player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
+            device=mock_wiim_device,
+        )
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+        player.set_active_output_protocol("airplay_x")
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player.active_output_protocol is None
+        assert player._attr_playback_state == PlaybackState.IDLE
+
+    def test_leaving_follower_keeps_output_cleared(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """The dropped output is not restored once the device leaves the group."""
+        mock_provider.native_groups.role_of.return_value = NativeGroupRole.FOLLOWER
+        player = WiimPlayer(
+            provider=mock_provider,
+            player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
+            device=mock_wiim_device,
+        )
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+        player.set_active_output_protocol("airplay_x")
+        player._update_ma_state_from_sdk_cache()
+        assert player.active_output_protocol is None
+
+        mock_provider.native_groups.role_of.return_value = NativeGroupRole.STANDALONE
+        player._update_ma_state_from_sdk_cache()
+
+        assert player.active_output_protocol is None
+
     """Test dynamic source list construction."""
 
     @pytest.mark.asyncio

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -1,5 +1,6 @@
 """Tests for WiiM player provider."""
 
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -31,6 +32,7 @@ def _mock_native_groups() -> MagicMock:
     groups.set_members = AsyncMock()
     groups.schedule_reconcile = MagicMock()
     groups.unregister = MagicMock()
+    groups.is_unknown_leader_follower = MagicMock(return_value=False)
     groups.set_self_role = MagicMock(return_value=False)
     return groups
 
@@ -302,7 +304,7 @@ class TestGroupMembers:
     def test_follower_publishes_no_members(
         self, mock_provider: MagicMock, mock_wiim_device: MagicMock
     ) -> None:
-        """A follower manages no members of its own, whatever it last held."""
+        """A follower manages no members and clears its own delegated playback state."""
         mock_provider.native_groups.role_of.return_value = NativeGroupRole.FOLLOWER
         player = WiimPlayer(
             provider=mock_provider,
@@ -311,10 +313,34 @@ class TestGroupMembers:
         )
         player.update_state = MagicMock()  # type: ignore[misc,method-assign]
         player._attr_group_members = ["stale"]
+        pre_group_state: PlaybackState = PlaybackState.PLAYING
+        player._attr_playback_state = pre_group_state
+        pre_group_media: PlayerMedia | None = cast("PlayerMedia", MagicMock())
+        player._attr_current_media = pre_group_media
 
         player._update_ma_state_from_sdk_cache()
 
         assert player._attr_group_members == []
+        assert player._attr_playback_state == PlaybackState.IDLE
+        assert player._attr_current_media is None
+        assert player._attr_active_source is None
+
+    def test_unknown_leader_follower_locks_grouping(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """A follower of an undiscovered group withdraws grouping so it is not regrouped."""
+        mock_provider.native_groups.is_unknown_leader_follower.return_value = True
+        player = WiimPlayer(
+            provider=mock_provider,
+            player_id=f"{PLAYER_ID_PREFIX}{mock_wiim_device.udn}",
+            device=mock_wiim_device,
+        )
+        mock_provider.native_groups.is_unknown_leader_follower.return_value = True
+        locked_when_unknown = player.grouping_locked
+        mock_provider.native_groups.is_unknown_leader_follower.return_value = False
+        locked_when_known = player.grouping_locked
+        assert locked_when_unknown is True
+        assert locked_when_known is False
 
     """Test dynamic source list construction."""
 


### PR DESCRIPTION
# What does this implement/fix?

Lets Music Assistant natively group official WiiM/Audio Pro speakers together with generic LinkPlay speakers (e.g. Edifier) into a single multiroom group, in either leader direction.

Builds on top of the generic LinkPlay support (#5729) and depends on it — this PR targets that branch.

A small provider-owned `NativeGroupCoordinator` now acts as the single native topology authority across both backends (official WiiM SDK and the generic LinkPlay shell), while each SDK/protocol stays the authority for playback/state only. Group role and membership are derived from the leader's own live slave list and resolved against the registered players, so a device grouped from either backend shows the correct leader/follower/member state.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Add `NativeGroupCoordinator` as the single native topology authority across both WiiM backends (role, membership, reconcile, `can_group_with`, grouping commands).
- Route grouping by backend: official↔official via the WiiM SDK, and generic↔generic and mixed groups over the low-level LinkPlay client (follower `join_slave` / `leave_group`, leader-side kick for cross-backend removal); every operation is verified against the leader's own live slave list and raises a typed error on a no-op.
- Gate generic and mixed joins to known, router-based, same-generation devices; refuse legacy Wi-Fi Direct groups that would move a follower out of MA's reach.
- Widen `can_group_with` to compatible available players of both backends, and remove the interim read-only lock on externally-created mixed groups.
- Derive follower state from the leader for both backends (a follower publishes only its own volume/mute and manages no members of its own).
- Self-heal topology from the existing player polls and events (no extra polling loop): leaders re-read their slave list over a low-level command client on a slow TTL or when forced, and a debounced reconcile heals discovery-order misses.
- Add extensive unit tests covering all four leader/follower backend combinations, mixed grouping, verification/no-op failures, concurrency/ordering, and topology healing.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.