### PR TITLE
Don't parse error pages as radio playlists

### DIFF
--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -300,6 +300,9 @@ async def fetch_playlist(
         async with mass.http_session.get(
             encoded_request_url(url), allow_redirects=True, timeout=ClientTimeout(total=5)
         ) as resp:
+            # an error page is still a body: without this check the HTML of a 404 or 503
+            # parses into entries whose paths are markup instead of stream urls
+            resp.raise_for_status()
             raw_data = await resp.content.read(64 * 1024)
             encoding = await detect_charset(raw_data, preferred=resp.charset)
             playlist_data = raw_data.decode(encoding, errors="replace")

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -300,8 +300,7 @@ async def fetch_playlist(
         async with mass.http_session.get(
             encoded_request_url(url), allow_redirects=True, timeout=ClientTimeout(total=5)
         ) as resp:
-            # an error page is still a body: without this check the HTML of a 404 or 503
-            # parses into entries whose paths are markup instead of stream urls
+            # an error page is still a body: its markup would otherwise parse into entries
             resp.raise_for_status()
             raw_data = await resp.content.read(64 * 1024)
             encoding = await detect_charset(raw_data, preferred=resp.charset)

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -1110,8 +1110,7 @@ async def test_fetch_playlist_error_status() -> None:
     """
     An error response is rejected instead of parsed.
 
-    The error page of a station that is down is a body like any other, and every one
-    of its markup lines otherwise becomes a playlist entry pointing at nothing.
+    Without the status check every markup line of the error page becomes an entry.
     """
     error_page = (
         b"<html>\n<head><title>404 Not Found</title></head>\n"

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -1020,9 +1020,18 @@ class _FakeContent:
 class _FakeResponse:
     """Stand-in for the aiohttp response of a playlist fetch."""
 
-    def __init__(self, raw_data: bytes, charset: str | None) -> None:
+    def __init__(self, raw_data: bytes, charset: str | None, status: int = 200) -> None:
         self.charset = charset
         self.content = _FakeContent(raw_data)
+        self.status = status
+
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise client_exceptions.ClientResponseError(
+                request_info=MagicMock(),
+                history=(),
+                status=self.status,
+            )
 
     async def __aenter__(self) -> Self:
         return self
@@ -1054,15 +1063,16 @@ class _FailingRequest:
         return None
 
 
-def _mass_serving(raw_data: bytes, charset: str | None = None) -> Any:
+def _mass_serving(raw_data: bytes, charset: str | None = None, status: int = 200) -> Any:
     """
     Return a mock mass whose http session serves the given playlist bytes.
 
     :param raw_data: Raw response body handed to fetch_playlist.
     :param charset: Charset the server declares in its Content-Type header, if any.
+    :param status: HTTP status the server answers with.
     """
     mass = MagicMock()
-    mass.http_session.get = MagicMock(return_value=_FakeResponse(raw_data, charset))
+    mass.http_session.get = MagicMock(return_value=_FakeResponse(raw_data, charset, status))
     return mass
 
 
@@ -1090,6 +1100,24 @@ async def test_fetch_playlist_timeout() -> None:
 async def test_fetch_playlist_client_error() -> None:
     """A connection failure is reported as invalid data instead of surfacing raw."""
     mass = _mass_failing(client_exceptions.ClientConnectionError("boom"))
+
+    with pytest.raises(InvalidDataError, match="Error while fetching playlist"):
+        await fetch_playlist(mass, "http://example.com/station.m3u")
+
+
+@pytest.mark.asyncio
+async def test_fetch_playlist_error_status() -> None:
+    """
+    An error response is rejected instead of parsed.
+
+    The error page of a station that is down is a body like any other, and every one
+    of its markup lines otherwise becomes a playlist entry pointing at nothing.
+    """
+    error_page = (
+        b"<html>\n<head><title>404 Not Found</title></head>\n"
+        b"<body>\n<center><h1>404 Not Found</h1></center>\n</body>\n</html>\n"
+    )
+    mass = _mass_serving(error_page, status=404)
 
     with pytest.raises(InvalidDataError, match="Error while fetching playlist"):
         await fetch_playlist(mass, "http://example.com/station.m3u")


### PR DESCRIPTION
# What does this implement/fix?

When we fetch a radio station's playlist file, we never looked at the HTTP status code. So if the station's server was down or the playlist had moved, we handed the returned error page straight to the playlist parser — and every line of that HTML became a "track". Depending on the provider that ended up as a bogus stream URL, or as a confusing "Empty playlist" message in the log that pointed at the wrong problem.

Now a failing playlist request is reported as a failed request.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
