### PR TITLE
Stop approving dependency licenses on a partial name match

### DIFF
--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -102,8 +102,10 @@ LICENSE_TEXT_GRANTS = {
     " applications, and to alter it and redistribute it freely",
 }
 
-# Words that turn the grant written behind them into its opposite
+# Words that turn the grant written behind them into its opposite, and how many words ahead of
+# the grant they are looked for
 GRANT_NEGATIONS = ("NO", "NOT", "NEITHER", "NEVER")
+GRANT_NEGATION_REACH = 3
 
 # SPDX identifiers accepted in a PEP 639 `license_expression`
 COMPATIBLE_SPDX_LICENSES = {
@@ -669,15 +671,15 @@ def _names_license(license_str: str) -> bool:
 
     :param license_str: The license string to read, e.g. "MIT License".
     """
-    known = {_license_words(name) for name in COMPATIBLE_LICENSE_NAMES}
-    if _license_words(license_str) in known:
+    known = {_license_name_words(name) for name in COMPATIBLE_LICENSE_NAMES}
+    if _license_name_words(license_str) in known:
         return True
 
     # a value naming several licenses, whether it combines them or offers a choice, is accepted
     # only when every one of them is. The whole value is matched first, so that a name holding a
     # separator is not taken apart into pieces that name nothing
     names = [
-        _license_words(name)
+        _license_name_words(name)
         for name in re.split(r"[,/]|\band\b|\bor\b", license_str, flags=re.IGNORECASE)
         if name.strip()
     ]
@@ -694,11 +696,26 @@ def _quotes_license_text(license_str: str) -> bool:
     for grant in LICENSE_TEXT_GRANTS:
         before, found, _ = words.partition(f" {_license_words(grant)} ")
         # a grant the text denies is not one the license gives
-        preceding = before.rsplit(maxsplit=1)
-        if found and (not preceding or preceding[-1] not in GRANT_NEGATIONS):
+        preceding = before.rsplit(maxsplit=GRANT_NEGATION_REACH)[-GRANT_NEGATION_REACH:]
+        if found and not any(word in GRANT_NEGATIONS for word in preceding):
             return True
 
     return False
+
+
+def _license_name_words(name: str) -> str:
+    """
+    Return the words of a license name as one key, so spellings of it compare equal.
+
+    :param name: The license name to normalise, e.g. "MPL 2.0".
+    """
+    # a leading "The" and a trailing "License" are noise the same name is written with and without
+    words = _license_words(name).split()
+    if words[:1] == ["THE"]:
+        del words[0]
+    if words[-1:] == ["LICENSE"]:
+        del words[-1]
+    return " ".join(words)
 
 
 def _license_words(value: str) -> str:
@@ -707,16 +724,10 @@ def _license_words(value: str) -> str:
 
     :param value: The license string to normalise.
     """
-    # separators are spelled inconsistently ("MPL 2.0" for "MPL-2.0"), "licence" and "license"
-    # are the same word, and both a leading "The" and a trailing "License" are noise the same
-    # name is written with and without. Words in any script count, so that a term we cannot read
-    # keeps the value from matching a name rather than dropping out of it
-    words = re.findall(r"[^\W_]+", value.upper().replace("LICENCE", "LICENSE"))
-    if words[:1] == ["THE"]:
-        del words[0]
-    if words[-1:] == ["LICENSE"]:
-        del words[-1]
-    return " ".join(words)
+    # separators are spelled inconsistently ("MPL 2.0" for "MPL-2.0") and "licence" and "license"
+    # are the same word. Words in any script count, so that a term we cannot read keeps the value
+    # from matching a name rather than dropping out of it
+    return " ".join(re.findall(r"[^\W_]+", value.upper().replace("LICENCE", "LICENSE")))
 
 
 def _is_spdx_operator(token: str) -> bool:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -63,25 +63,32 @@ COMPATIBLE_LICENSE_NAMES = {
     "Zlib",
 }
 
-# Opening of the grant each permissive license spells out, used to recognise packages that put
-# their whole license text in the license field. The grant is what the license actually gives,
-# so it identifies the text where the heading above it would only be a name in prose.
+# The grant each permissive license spells out, used to recognise packages that put their whole
+# license text in the license field. The grant is what the license actually gives, so it
+# identifies the text where the heading above it would only be a name in prose. Each is quoted
+# far enough to cover the permission itself, so that a text restricting it reads differently.
 LICENSE_TEXT_GRANTS = {
     # MIT
-    "Permission is hereby granted, free of charge, to any person obtaining a copy",
+    "Permission is hereby granted, free of charge, to any person obtaining a copy of this"
+    " software and associated documentation files",
     # ISC
-    "Permission to use, copy, modify, and/or distribute this software for any purpose",
+    "Permission to use, copy, modify, and/or distribute this software for any purpose with or"
+    " without fee is hereby granted",
     # BSD, 2-clause and 3-clause alike
     "Redistribution and use in source and binary forms, with or without modification, are"
-    " permitted",
+    " permitted provided that the following conditions are met",
     # Apache-2.0
-    "Licensed under the Apache License, Version 2.0",
+    'Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file'
+    " except in compliance with the License",
     # MPL-2.0
-    "This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0",
+    "This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a"
+    " copy of the MPL was not distributed with this file",
     # Unlicense
-    "This is free and unencumbered software released into the public domain",
+    "This is free and unencumbered software released into the public domain. Anyone is free to"
+    " copy, modify, publish, use, compile, sell, or distribute this software",
     # Zlib
-    "Permission is granted to anyone to use this software for any purpose",
+    "Permission is granted to anyone to use this software for any purpose, including commercial"
+    " applications, and to alter it and redistribute it freely",
 }
 
 # SPDX identifiers accepted in a PEP 639 `license_expression`

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -254,8 +254,10 @@ def check_license_compatibility(
     # whatever the evaluator did not accept in an expression names a license that is not on the
     # allow list, so reading such a value further would only weaken the check. A free-form field
     # is all we have to go on, but what we recognise in it must not end up approving a copyleft
-    # license standing next to it
-    if spdx_compatible is None and not copyleft and not spdx_expression:
+    # license standing next to it, and a "LicenseRef-" value names a custom license whatever
+    # wording is packed into the identifier
+    custom = "LICENSEREF" in license_upper
+    if spdx_compatible is None and not copyleft and not custom and not spdx_expression:
         # a free-form field holds either the name of the license or the text of it; a name says
         # nothing about terms written around it, and a text is read on the grant it spells out
         if _names_license(license_str) or _quotes_license_text(license_str):
@@ -695,8 +697,9 @@ def _license_words(value: str) -> str:
     """
     # separators are spelled inconsistently ("MPL 2.0" for "MPL-2.0"), "licence" and "license"
     # are the same word, and both a leading "The" and a trailing "License" are noise the same
-    # name is written with and without
-    words = re.findall(r"[A-Z0-9]+", value.upper().replace("LICENCE", "LICENSE"))
+    # name is written with and without. Words in any script count, so that a term we cannot read
+    # keeps the value from matching a name rather than dropping out of it
+    words = re.findall(r"[^\W_]+", value.upper().replace("LICENCE", "LICENSE"))
     if words[:1] == ["THE"]:
         del words[0]
     if words[-1:] == ["LICENSE"]:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -38,26 +38,37 @@ COMPATIBLE_LICENSE_NAMES = {
     "Universal Permissive License (UPL)",
     "Zero-Clause BSD (0BSD)",
     "zlib/libpng License",
-    # spellings of the same licenses used in the free-form field
-    "Apache",
+    # spellings of the same licenses used in the free-form field. Only versioned names of the
+    # licenses whose versions differ in what they allow, so that an unversioned "Apache" cannot
+    # stand in for Apache-1.1 or an unversioned "MPL" for the reciprocal MPL-1.1
+    "2-Clause BSD",
+    "3-Clause BSD",
+    "Apache 2",
     "Apache 2.0",
+    "Apache License 2.0",
+    "Apache License, Version 2.0",
     "Apache Software License 2.0",
     "BSD",
+    "BSD-2",
     "BSD-2-Clause",
+    "BSD-3",
     "BSD-3-Clause",
     "CC0",
     "CC0 1.0",
     "CC0 1.0 Universal",
+    "Expat",
     "ISC",
     "ISCL",
     "LGPL",
     "LGPLv2",
     "LGPLv3",
     "MIT",
-    "MPL",
     "MPL 2.0",
+    "Modified BSD",
+    "New BSD",
     "PSF",
     "PSFL",
+    "Simplified BSD",
     "The MIT License (MIT)",
     "Unlicense",
     "Zlib",
@@ -244,14 +255,10 @@ def check_license_compatibility(
     # allow list, so reading such a value further would only weaken the check. A free-form field
     # is all we have to go on, but what we recognise in it must not end up approving a copyleft
     # license standing next to it
-    if spdx_compatible is None and not copyleft:
-        # a text spelling out a grant we accept states what the license gives, so it is read as
-        # that license even where its own wording happens to read like an expression
-        if _quotes_license_text(license_str):
-            return True, f"Compatible ({license_str})"
-        # a name is only the label of terms the value does not show, so it is not read out of
-        # the prose around it, nor out of an expression PyPI has already validated
-        if not spdx_expression and _names_license(license_str):
+    if spdx_compatible is None and not copyleft and not spdx_expression:
+        # a free-form field holds either the name of the license or the text of it; a name says
+        # nothing about terms written around it, and a text is read on the grant it spells out
+        if _names_license(license_str) or _quotes_license_text(license_str):
             return True, f"Compatible ({license_str})"
 
     if copyleft:
@@ -657,11 +664,17 @@ def _names_license(license_str: str) -> bool:
 
     :param license_str: The license string to read, e.g. "MIT License".
     """
-    # a value listing several licenses gives no reason to prefer one of them, so every one has
-    # to be acceptable
-    names = [_license_words(name) for name in license_str.split(",") if name.strip()]
     known = {_license_words(name) for name in COMPATIBLE_LICENSE_NAMES}
-    return bool(names) and known.issuperset(names)
+    if _license_words(license_str) in known:
+        return True
+
+    # a value naming several licenses, whether it combines them or offers a choice, is accepted
+    # only when every one of them is. The whole value is matched first, so that a name holding a
+    # separator is not taken apart into pieces that name nothing
+    names = [
+        _license_words(name) for name in re.split(r"[,/]|\bor\b", license_str, flags=re.IGNORECASE)
+    ]
+    return known.issuperset(names)
 
 
 def _quotes_license_text(license_str: str) -> bool:
@@ -680,9 +693,10 @@ def _license_words(value: str) -> str:
 
     :param value: The license string to normalise.
     """
-    # separators are spelled inconsistently ("MPL 2.0" for "MPL-2.0"), and both a leading "The"
-    # and a trailing "License" are noise the same name is written with and without
-    words = re.findall(r"[A-Z0-9]+", value.upper())
+    # separators are spelled inconsistently ("MPL 2.0" for "MPL-2.0"), "licence" and "license"
+    # are the same word, and both a leading "The" and a trailing "License" are noise the same
+    # name is written with and without
+    words = re.findall(r"[A-Z0-9]+", value.upper().replace("LICENCE", "LICENSE"))
     if words[:1] == ["THE"]:
         del words[0]
     if words[-1:] == ["LICENSE"]:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -679,8 +679,9 @@ def _names_license(license_str: str) -> bool:
     names = [
         _license_words(name)
         for name in re.split(r"[,/]|\band\b|\bor\b", license_str, flags=re.IGNORECASE)
+        if name.strip()
     ]
-    return known.issuperset(names)
+    return bool(names) and known.issuperset(names)
 
 
 def _quotes_license_text(license_str: str) -> bool:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -102,6 +102,9 @@ LICENSE_TEXT_GRANTS = {
     " applications, and to alter it and redistribute it freely",
 }
 
+# Words that turn the grant written behind them into its opposite
+GRANT_NEGATIONS = ("NO", "NOT", "NEITHER", "NEVER")
+
 # SPDX identifiers accepted in a PEP 639 `license_expression`
 COMPATIBLE_SPDX_LICENSES = {
     "0BSD",
@@ -686,7 +689,14 @@ def _quotes_license_text(license_str: str) -> bool:
     :param license_str: The license string to read.
     """
     words = f" {_license_words(license_str)} "
-    return any(f" {_license_words(grant)} " in words for grant in LICENSE_TEXT_GRANTS)
+    for grant in LICENSE_TEXT_GRANTS:
+        before, found, _ = words.partition(f" {_license_words(grant)} ")
+        # a grant the text denies is not one the license gives
+        preceding = before.rsplit(maxsplit=1)
+        if found and (not preceding or preceding[-1] not in GRANT_NEGATIONS):
+            return True
+
+    return False
 
 
 def _license_words(value: str) -> str:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -14,32 +14,74 @@ import urllib.request
 from datetime import datetime
 from typing import Any
 
-# OSI-approved and common compatible licenses
-COMPATIBLE_LICENSES = {
-    "MIT",
-    "Apache-2.0",
+# Complete spellings of compatible licenses, as packages write them in the free-form license
+# field and as PyPI names them in its `License ::` classifiers. A value has to be one of these
+# in full: a name occurring somewhere inside it says nothing about the terms around it.
+COMPATIBLE_LICENSE_NAMES = {
+    # names of the PyPI classifiers, which are a closed vocabulary
     "Apache Software License",
-    "BSD",
-    "BSD-3-Clause",
-    "BSD-2-Clause",
-    "ISC",
+    "Boost Software License 1.0 (BSL-1.0)",
+    "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+    "CMU License (MIT-CMU)",
+    "GNU Lesser General Public License v2 (LGPLv2)",
+    "GNU Lesser General Public License v2 or later (LGPLv2+)",
+    "GNU Lesser General Public License v3 (LGPLv3)",
+    "GNU Lesser General Public License v3 or later (LGPLv3+)",
+    "GNU Library or Lesser General Public License (LGPL)",
+    "Historical Permission Notice and Disclaimer (HPND)",
+    "ISC License (ISCL)",
+    "MIT No Attribution License (MIT-0)",
+    "Mozilla Public License 2.0 (MPL 2.0)",
+    "Public Domain",
     "Python Software Foundation License",
-    "PSF",
-    "LGPL",
-    "MPL-2.0",
-    "Unlicense",
+    "The Unlicense (Unlicense)",
+    "Universal Permissive License (UPL)",
+    "Zero-Clause BSD (0BSD)",
+    "zlib/libpng License",
+    # spellings of the same licenses used in the free-form field
+    "Apache",
+    "Apache 2.0",
+    "Apache Software License 2.0",
+    "BSD",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
     "CC0",
-    # compact spellings that would not survive the boundary check as a suffix of the name above
-    "PSFL",
+    "CC0 1.0",
+    "CC0 1.0 Universal",
+    "ISC",
     "ISCL",
+    "LGPL",
     "LGPLv2",
     "LGPLv3",
+    "MIT",
+    "MPL",
+    "MPL 2.0",
+    "PSF",
+    "PSFL",
+    "The MIT License (MIT)",
+    "Unlicense",
+    "Zlib",
 }
 
-# Licenses recognised only as the whole value, because their wording also turns up in prose that
-# says the opposite ("this software is not in the public domain")
-EXACT_LICENSES = {
-    "Public Domain",
+# Opening of the grant each permissive license spells out, used to recognise packages that put
+# their whole license text in the license field. The grant is what the license actually gives,
+# so it identifies the text where the heading above it would only be a name in prose.
+LICENSE_TEXT_GRANTS = {
+    # MIT
+    "Permission is hereby granted, free of charge, to any person obtaining a copy",
+    # ISC
+    "Permission to use, copy, modify, and/or distribute this software for any purpose",
+    # BSD, 2-clause and 3-clause alike
+    "Redistribution and use in source and binary forms, with or without modification, are"
+    " permitted",
+    # Apache-2.0
+    "Licensed under the Apache License, Version 2.0",
+    # MPL-2.0
+    "This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0",
+    # Unlicense
+    "This is free and unencumbered software released into the public domain",
+    # Zlib
+    "Permission is granted to anyone to use this software for any purpose",
 }
 
 # SPDX identifiers accepted in a PEP 639 `license_expression`
@@ -184,10 +226,7 @@ def check_license_compatibility(
         return False, "No license information"
 
     license_upper = license_str.upper()
-    spdx_compatible, joins_licenses = _evaluate_spdx_expression(license_str)
-    # a value that reads as an expression joining licenses is precise enough to judge on the
-    # names in it alone, whichever field it came from
-    spdx_expression = spdx_expression or joins_licenses
+    spdx_compatible = _evaluate_spdx_expression(license_str)
 
     if spdx_compatible:
         return True, f"Compatible ({license_str})"
@@ -195,14 +234,18 @@ def check_license_compatibility(
     copyleft = _is_copyleft(license_upper)
 
     # whatever the evaluator did not accept in an expression names a license that is not on the
-    # allow list, so guessing from the wording would only weaken the check. For free-form fields
-    # the wording is all we have, but a name we do recognise there must not end up approving a
-    # copyleft or custom license next to it
-    guessable = not spdx_expression and not copyleft and "LICENSEREF" not in license_upper
-    if spdx_compatible is None and guessable:
-        for compatible in COMPATIBLE_LICENSES | EXACT_LICENSES:
-            if _names_license(license_upper, compatible):
-                return True, f"Compatible ({license_str})"
+    # allow list, so reading such a value further would only weaken the check. A free-form field
+    # is all we have to go on, but what we recognise in it must not end up approving a copyleft
+    # license standing next to it
+    if spdx_compatible is None and not copyleft:
+        # a text spelling out a grant we accept states what the license gives, so it is read as
+        # that license even where its own wording happens to read like an expression
+        if _quotes_license_text(license_str):
+            return True, f"Compatible ({license_str})"
+        # a name is only the label of terms the value does not show, so it is not read out of
+        # the prose around it, nor out of an expression PyPI has already validated
+        if not spdx_expression and _names_license(license_str):
+            return True, f"Compatible ({license_str})"
 
     if copyleft:
         return False, f"Incompatible copyleft license ({license_str})"
@@ -504,23 +547,22 @@ class _SpdxSyntaxError(Exception):
     """Raised when a string does not follow the SPDX expression grammar."""
 
 
-def _evaluate_spdx_expression(license_str: str) -> tuple[bool | None, bool]:
+def _evaluate_spdx_expression(license_str: str) -> bool | None:
     """
     Check an SPDX license expression (PEP 639) against the allow list.
 
     Returns whether the expression is compatible, which is None when it names a license that is
-    neither known-compatible nor known-problematic or when the string is not an expression at
-    all, together with whether the part that did read as one joined several licenses.
+    neither known-compatible nor known-problematic or when the string is not an expression at all.
 
     :param license_str: The license string to evaluate, e.g. "MIT OR Apache-2.0".
     """
     tokens = re.findall(r"\(|\)|[^\s()]+", license_str)
     if not tokens:
-        return None, False
+        return None
     # real expressions nest a group or two at most; refuse anything deeper rather than recursing
     # into it, and refuse outright as the fallback would match on a name nested inside
     if _max_group_depth(tokens) > MAX_SPDX_NESTING:
-        return False, True
+        return False
 
     remaining = list(tokens)
     try:
@@ -531,10 +573,7 @@ def _evaluate_spdx_expression(license_str: str) -> tuple[bool | None, bool]:
     except _SpdxSyntaxError:
         result = None
 
-    # judge the shape on the tokens that were read as an expression, so that prose merely holding
-    # the word "and" is not mistaken for one, while a malformed expression still is
-    read = tokens[: len(tokens) - len(remaining)]
-    return result, any(token.upper() in ("AND", "OR", "WITH") for token in read)
+    return result
 
 
 def _evaluate_spdx_tokens(tokens: list[str]) -> bool | None:
@@ -605,21 +644,43 @@ def _evaluate_spdx_operand(tokens: list[str]) -> bool | None:
     return True if identifier in COMPATIBLE_SPDX_LICENSES else None
 
 
-def _names_license(license_upper: str, name: str) -> bool:
+def _names_license(license_str: str) -> bool:
     """
-    Return whether an upper-cased license string names the given license.
+    Return whether a license string is, as a whole, one or more licenses we accept.
 
-    :param license_upper: The upper-cased license string to search.
-    :param name: The license name to look for, e.g. "MPL-2.0".
+    :param license_str: The license string to read, e.g. "MIT License".
     """
-    # tolerate spelling variants of the separators, so that "MPL 2.0" is read as "MPL-2.0", but
-    # match whole words only, so the name is neither assembled out of unrelated ones ("this
-    # copyright" holding an "ISC") nor read out of one that merely starts the same ("MITigation")
-    if name in EXACT_LICENSES:
-        return license_upper.strip() == name.upper()
+    # a value listing several licenses gives no reason to prefer one of them, so every one has
+    # to be acceptable
+    names = [_license_words(name) for name in license_str.split(",") if name.strip()]
+    known = {_license_words(name) for name in COMPATIBLE_LICENSE_NAMES}
+    return bool(names) and known.issuperset(names)
 
-    parts = [re.escape(part) for part in re.findall(r"[A-Z0-9]+", name.upper())]
-    return re.search(rf"\b{r'[^A-Z0-9]*'.join(parts)}(?![A-Z0-9])", license_upper) is not None
+
+def _quotes_license_text(license_str: str) -> bool:
+    """
+    Return whether a license string spells out the text of a license we accept.
+
+    :param license_str: The license string to read.
+    """
+    words = f" {_license_words(license_str)} "
+    return any(f" {_license_words(grant)} " in words for grant in LICENSE_TEXT_GRANTS)
+
+
+def _license_words(value: str) -> str:
+    """
+    Return the words of a license string as one key, so spelling variants compare equal.
+
+    :param value: The license string to normalise.
+    """
+    # separators are spelled inconsistently ("MPL 2.0" for "MPL-2.0"), and both a leading "The"
+    # and a trailing "License" are noise the same name is written with and without
+    words = re.findall(r"[A-Z0-9]+", value.upper())
+    if words[:1] == ["THE"]:
+        del words[0]
+    if words[-1:] == ["LICENSE"]:
+        del words[-1]
+    return " ".join(words)
 
 
 def _is_spdx_operator(token: str) -> bool:

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -677,7 +677,8 @@ def _names_license(license_str: str) -> bool:
     # only when every one of them is. The whole value is matched first, so that a name holding a
     # separator is not taken apart into pieces that name nothing
     names = [
-        _license_words(name) for name in re.split(r"[,/]|\bor\b", license_str, flags=re.IGNORECASE)
+        _license_words(name)
+        for name in re.split(r"[,/]|\band\b|\bor\b", license_str, flags=re.IGNORECASE)
     ]
     return known.issuperset(names)
 

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -294,6 +294,15 @@ def test_license_text_is_read_on_its_grant_only() -> None:
         (",", "Unknown/unverified license"),
         # a license we accept does not carry the one it is offered alongside
         ("MIT or Proprietary Terms", "Unknown/unverified license"),
+        # a term we cannot read is still a term, in whatever script it is written
+        ("MIT 非商用", "Unknown/unverified license"),
+        ("Apache 2.0 нельзя", "Unknown/unverified license"),
+        # a custom license names itself, whatever wording its identifier is built out of
+        (
+            "LicenseRef-Permission-is-hereby-granted-free-of-charge-to-any-person-obtaining-a"
+            "-copy-of-this-software-and-associated-documentation-files",
+            "Unknown/unverified license",
+        ),
         # groups in prose are not an expression, and no longer a name to read out of it either
         ("MIT License (a) (b) (c) (d) (e) (f) (g) and so on", "Unknown/unverified license"),
         # a value that joins licenses is read as an expression, whichever field it came from

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -131,6 +131,8 @@ def test_get_package_license_reports_spdx(info: dict[str, Any], expected: bool) 
         ),
         ("0BSD", True),
         ("MIT OR Apache-2.0", True),
+        # a group has to be closed for what follows it to be read as part of the expression
+        ("(MIT) OR (Apache-2.0)", True),
         # an alternative we do not know does not spoil one we do
         ("Frobnicate-1.0 OR MIT", True),
         ("Apache-2.0 WITH LLVM-exception", True),
@@ -186,9 +188,11 @@ def test_spdx_expressions_are_not_guessed_at(license_str: str, expected: bool) -
         # ...however the value joins them (uritemplate publishes the first)
         "BSD 3-Clause OR Apache-2.0",
         "MIT/Apache-2.0",
+        "MIT License AND Apache Software License",
         # a name holding a separator is still matched whole, before the value is split on one
         "zlib/libpng License",
         "GNU Library or Lesser General Public License (LGPL)",
+        "Historical Permission Notice and Disclaimer (HPND)",
         # a custom license alongside one we accept still leaves a usable option
         "MIT OR LicenseRef-Proprietary",
         # an exception only widens what the license allows, so the license itself decides

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -122,6 +122,13 @@ def test_get_package_license_reports_spdx(info: dict[str, Any], expected: bool) 
         ("MIT OR (Apache-2.0", False),
         ("BSD-3-Clause-No-Nuclear-License-2014", False),
         ("LicenseRef-Proprietary", False),
+        # an expression is never license prose, so a custom identifier cannot smuggle in the
+        # wording of a grant to be read as the license it belongs to
+        (
+            "LicenseRef-Permission-is-hereby-granted-free-of-charge-to-any-person-obtaining-a"
+            "-copy-of-this-software-and-associated-documentation-files",
+            False,
+        ),
         ("0BSD", True),
         ("MIT OR Apache-2.0", True),
         # an alternative we do not know does not spoil one we do
@@ -167,8 +174,21 @@ def test_spdx_expressions_are_not_guessed_at(license_str: str, expected: bool) -
         "MPL 2.0",
         "Apache 2.0 License",
         "MIT license",
+        "The MIT License",
+        "MIT Licence",
+        # a name holding a comma is matched whole, before the value is read as a list
+        "Apache License, Version 2.0",
+        # spellings the BSD family is published under (protobuf, jsonpatch)
+        "3-Clause BSD License",
+        "Modified BSD License",
         # every license of a value that lists several (pycryptodome publishes this one)
         "BSD, Public Domain",
+        # ...however the value joins them (uritemplate publishes the first)
+        "BSD 3-Clause OR Apache-2.0",
+        "MIT/Apache-2.0",
+        # a name holding a separator is still matched whole, before the value is split on one
+        "zlib/libpng License",
+        "GNU Library or Lesser General Public License (LGPL)",
         # a custom license alongside one we accept still leaves a usable option
         "MIT OR LicenseRef-Proprietary",
         # an exception only widens what the license allows, so the license itself decides
@@ -258,6 +278,8 @@ def test_compatible_licenses(license_str: str) -> None:
         ("Frobnicate-1.0 OR Frobnicate-2.0", "Unknown/unverified license"),
         # a value that is only separators names nothing
         (",", "Unknown/unverified license"),
+        # a license we accept does not carry the one it is offered alongside
+        ("MIT or Proprietary Terms", "Unknown/unverified license"),
         # groups in prose are not an expression, and no longer a name to read out of it either
         ("MIT License (a) (b) (c) (d) (e) (f) (g) and so on", "Unknown/unverified license"),
         # a value that joins licenses is read as an expression, whichever field it came from

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -51,6 +51,8 @@ def pypi_info(**overrides: Any) -> dict[str, Any]:
             pypi_info(classifiers=["Programming Language :: Python", "License :: OSI Approved"]),
             "Unknown",
         ),
+        # a classifier that is no more than the "License" segment names one no more than that does
+        (pypi_info(classifiers=["License"]), "Unknown"),
         # several classifiers: the one that fails the check decides, whatever its position
         (
             pypi_info(
@@ -159,23 +161,33 @@ def test_spdx_expressions_are_not_guessed_at(license_str: str, expected: bool) -
         "Public Domain",
         # a plain license field can hold an expression too (aiohttp publishes this one)
         "Apache-2.0 AND MIT",
-        # ...while prose that merely contains the word "and" is still matched on its wording
-        "MIT License\n\nPermission is hereby granted, free of charge, to any person obtaining a"
-        " copy of this software and associated documentation files, to deal in the Software"
-        " without restriction, including without limitation the rights to use and to permit"
-        " persons to whom the Software is furnished to do so.",
         "The MIT License (MIT)",
         "CC0 1.0 Universal",
         # spelling variants of the same licenses
         "MPL 2.0",
         "Apache 2.0 License",
+        "MIT license",
+        # every license of a value that lists several (pycryptodome publishes this one)
+        "BSD, Public Domain",
         # a custom license alongside one we accept still leaves a usable option
         "MIT OR LicenseRef-Proprietary",
         # an exception only widens what the license allows, so the license itself decides
         "Zlib WITH LLVM-exception",
         "LGPL-3.0-only WITH LGPL-3.0-linking-exception",
-        # prose is matched on its wording; the groups in it are not an expression to refuse
-        "MIT License (a) (b) (c) (d) (e) (f) (g) (h) (i) (j) (k) (l) and so on",
+        # packages that put their whole license text in the field are read on the grant it
+        # spells out, whatever heading and punctuation surround it (ya-dialogs-api, aiomusiccast)
+        "MIT License\n\n        Copyright (c) 2026 Mikhail Nevskiy\n\n        Permission is"
+        " hereby granted, free of charge, to any person obtaining a copy\n        of this"
+        ' software and associated documentation files (the "Software"), to deal\n        in the'
+        " Software without restriction.",
+        "**The MIT License (MIT)**  Copyright &copy; 2021, Tom Schneider  Permission is hereby"
+        " granted, free of charge, to any person obtaining a copy of this software and"
+        ' associated documentation files (the "Software"), to deal in the Software without'
+        " restriction.",
+        "Copyright (c) 2026\n\nPermission to use, copy, modify, and/or distribute this software"
+        " for any purpose with or without fee is hereby granted.",
+        "Redistribution and use in source and binary forms, with or without modification, are"
+        " permitted provided that the following conditions are met.",
     ],
 )
 def test_compatible_licenses(license_str: str) -> None:
@@ -216,6 +228,32 @@ def test_compatible_licenses(license_str: str) -> None:
         ("This software is not in the public domain. All rights reserved.", "Unknown/unverified"),
         ("ISC2", "Unknown/unverified license"),
         ("Internal use only, do not transmit", "Unknown/unverified license"),
+        # a name we accept does not carry the terms written around it, however it is joined to
+        # them, and an SPDX operator between prose words is not an expression to read it out of
+        ("MIT License AND Proprietary", "Unknown/unverified license"),
+        ("MIT License for non-commercial use only", "Unknown/unverified license"),
+        ("MIT plus commercial terms", "Unknown/unverified license"),
+        ("BSD, Proprietary", "Unknown/unverified license"),
+        # a license text is only recognised by the grant it spells out, not by its heading
+        ("MIT License\n\nAll rights reserved. Contact us for terms.", "Unknown/unverified"),
+        # ...and the grant has to be the one the text opens, not the tail of another word
+        (
+            "Nonpermission is hereby granted, free of charge, to any person obtaining a copy of"
+            " this software.",
+            "Unknown/unverified license",
+        ),
+        # a copyleft license the text is combined with is not excused by the grant it spells out
+        (
+            "MIT License AND GPL-3.0-only\n\nPermission is hereby granted, free of charge, to any"
+            " person obtaining a copy of this software.",
+            "Incompatible copyleft license",
+        ),
+        # neither alternative of an expression is one we know, so the expression is not either
+        ("Frobnicate-1.0 OR Frobnicate-2.0", "Unknown/unverified license"),
+        # a value that is only separators names nothing
+        (",", "Unknown/unverified license"),
+        # groups in prose are not an expression, and no longer a name to read out of it either
+        ("MIT License (a) (b) (c) (d) (e) (f) (g) and so on", "Unknown/unverified license"),
         # a value that joins licenses is read as an expression, whichever field it came from
         ("MIT AND Proprietary", "Unknown/unverified license"),
         ("MIT AND(Proprietary)", "Unknown/unverified license"),

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -282,6 +282,12 @@ def test_license_text_is_read_on_its_grant_only() -> None:
             " for non-commercial use.",
             "Unknown/unverified license",
         ),
+        # ...and neither does one that denies it outright
+        (
+            "No permission is hereby granted, free of charge, to any person obtaining a copy of"
+            " this software and associated documentation files.",
+            "Unknown/unverified license",
+        ),
         # a copyleft license the text is combined with is not excused by the grant it spells out
         (
             "MIT License AND GPL-3.0-only\n\nPermission is hereby granted, free of charge, to any"

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -213,6 +213,8 @@ def test_spdx_expressions_are_not_guessed_at(license_str: str, expected: bool) -
         " for any purpose with or without fee is hereby granted.",
         "Redistribution and use in source and binary forms, with or without modification, are"
         " permitted provided that the following conditions are met.",
+        'Licensed under the Apache License, Version 2.0 (the "License"); you may not use this'
+        " file except in compliance with the License.",
     ],
 )
 def test_compatible_licenses(license_str: str) -> None:
@@ -287,10 +289,22 @@ def test_license_text_is_read_on_its_grant_only() -> None:
             " for non-commercial use.",
             "Unknown/unverified license",
         ),
-        # ...and neither does one that denies it outright
+        # ...and neither does one that denies it outright, however the denial is worded
         (
             "No permission is hereby granted, free of charge, to any person obtaining a copy of"
             " this software and associated documentation files.",
+            "Unknown/unverified license",
+        ),
+        (
+            "No additional permission is hereby granted, free of charge, to any person obtaining"
+            " a copy of this software and associated documentation files.",
+            "Unknown/unverified license",
+        ),
+        # a grant is quoted to its last word, so a text trailing off into another license is not
+        # taken for the one it started as
+        (
+            'Licensed under the Apache License, Version 2.0 (the "License"); you may not use this'
+            " file except in compliance with the Proprietary License",
             "Unknown/unverified license",
         ),
         # a copyleft license the text is combined with is not excused by the grant it spells out

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -216,6 +216,20 @@ def test_compatible_licenses(license_str: str) -> None:
     assert compatible, status
 
 
+def test_license_text_is_read_on_its_grant_only() -> None:
+    """Test a license text is accepted on the grant it spells out, terms added to it aside."""
+    # a grant identifies the license it belongs to, but says nothing about clauses written after
+    # it, so a text adding one is still accepted. Recognising those would mean comparing against
+    # the complete text of every license, which this check does not attempt
+    restricted = (
+        "Permission is hereby granted, free of charge, to any person obtaining a copy of this"
+        ' software and associated documentation files (the "Software"), to deal in the Software'
+        " without restriction.\n\nThe Software shall be used for Good, not Evil."
+    )
+
+    assert check_license_compatibility(restricted)[0]
+
+
 @pytest.mark.parametrize(
     ("license_str", "expected_status"),
     [

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -239,13 +239,19 @@ def test_compatible_licenses(license_str: str) -> None:
         # ...and the grant has to be the one the text opens, not the tail of another word
         (
             "Nonpermission is hereby granted, free of charge, to any person obtaining a copy of"
-            " this software.",
+            " this software and associated documentation files.",
+            "Unknown/unverified license",
+        ),
+        # a text that breaks off the grant to restrict it does not spell out that grant
+        (
+            "Permission is hereby granted, free of charge, to any person obtaining a copy solely"
+            " for non-commercial use.",
             "Unknown/unverified license",
         ),
         # a copyleft license the text is combined with is not excused by the grant it spells out
         (
             "MIT License AND GPL-3.0-only\n\nPermission is hereby granted, free of charge, to any"
-            " person obtaining a copy of this software.",
+            " person obtaining a copy of this software and associated documentation files.",
             "Incompatible copyleft license",
         ),
         # neither alternative of an expression is one we know, so the expression is not either

--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -189,6 +189,7 @@ def test_spdx_expressions_are_not_guessed_at(license_str: str, expected: bool) -
         "BSD 3-Clause OR Apache-2.0",
         "MIT/Apache-2.0",
         "MIT License AND Apache Software License",
+        "MIT and/or Apache-2.0",
         # a name holding a separator is still matched whole, before the value is split on one
         "zlib/libpng License",
         "GNU Library or Lesser General Public License (LGPL)",


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5728. The dependency safety check reads a package's license from PyPI. For packages that publish a plain-text license field (or only classifiers), it searched that text for any license name it recognised — so a value like `MIT License AND Proprietary` was approved on the `MIT` inside it, whatever terms stood next to it.

Such values are now matched as a whole against known license spellings. Packages that publish their entire license text in that field are recognised by the permission the text actually grants, rather than by the name in its heading.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Match plain license values and PyPI classifier names in full against known spellings, instead of searching for a name inside them
- Recognise a package that publishes its whole license text by the permission that text grants
- Accept a value listing several licenses only when every one of them is acceptable
- Drop two guards that exact matching makes redundant
- All 110 current dependencies keep the verdict they have today

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
