### PR TITLE
Queueing an album over a radio no longer plays it shuffled

### DIFF
--- a/music_assistant/controllers/player_queues/README.md
+++ b/music_assistant/controllers/player_queues/README.md
@@ -110,9 +110,9 @@ analogous to how the Player Controller pairs runtime state with the wire `Player
   stay in the queue are restored to their original order rather than left shuffled behind a queue
   that now reads unshuffled. The options that only stage items for later (*add* / *next* /
   *replace next*) leave the shuffle state alone. A dynamic queue is exempt: it is an always-on
-  smart mix and forces shuffle on. That imposed shuffle is dropped again as soon as the queue stops
-  being a smart mix — *replace next* is the only staging option that can take the dynamic source
-  away, so it settles the shuffle state like the starting options do.
+  smart mix and forces shuffle on. *Replace next* is the only staging option that can take that
+  dynamic source away, so it is the one exception: it switches the imposed shuffle back off, which
+  `_enter_dynamic_mode` restores if the new media leaves the queue dynamic.
 
 ## State and Persistence
 

--- a/music_assistant/controllers/player_queues/README.md
+++ b/music_assistant/controllers/player_queues/README.md
@@ -110,7 +110,9 @@ analogous to how the Player Controller pairs runtime state with the wire `Player
   stay in the queue are restored to their original order rather than left shuffled behind a queue
   that now reads unshuffled. The options that only stage items for later (*add* / *next* /
   *replace next*) leave the shuffle state alone. A dynamic queue is exempt: it is an always-on
-  smart mix and forces shuffle on.
+  smart mix and forces shuffle on. That imposed shuffle is dropped again as soon as the queue stops
+  being a smart mix — *replace next* is the only staging option that can take the dynamic source
+  away, so it settles the shuffle state like the starting options do.
 
 ## State and Persistence
 

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1835,12 +1835,19 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         :param option: The enqueue option this command resolved to.
         :param shuffle: Explicit shuffle request from the caller; None to derive it.
         """
+        queue_data = self._queue_data[queue_id]
+        queue = queue_data.queue
+        if option == QueueOption.REPLACE_NEXT and queue.is_dynamic:
+            # the one staging option that replaces the queue's sources, so the smart mix may be on
+            # its way out. Its shuffle is never the user's own (a dynamic queue's toggle is locked),
+            # so it must not outlive the source that imposed it; `_enter_dynamic_mode` forces it
+            # back on if the new media leaves the queue dynamic.
+            self._reset_shuffle(queue_id)
+            return
         if option not in (QueueOption.PLAY, QueueOption.REPLACE):
             # only the options that start playing the media right away are a new listening
             # session; staging items for later leaves the queue's shuffle state alone
             return
-        queue_data = self._queue_data[queue_id]
-        queue = queue_data.queue
         if shuffle is None:
             # Without an explicit request, shuffle only carries over when the user asked for it
             # moments ago: starting an album is otherwise expected to play it in track order,

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1838,11 +1838,12 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         queue_data = self._queue_data[queue_id]
         queue = queue_data.queue
         if option == QueueOption.REPLACE_NEXT and queue.is_dynamic:
-            # the one staging option that replaces the queue's sources, so the smart mix may be on
-            # its way out. Its shuffle is never the user's own (a dynamic queue's toggle is locked),
-            # so it must not outlive the source that imposed it; `_enter_dynamic_mode` forces it
-            # back on if the new media leaves the queue dynamic.
-            self._reset_shuffle(queue_id)
+            # The one staging option that replaces the queue's sources, so the smart mix may be on
+            # its way out - and its shuffle is never the user's own (a dynamic queue's toggle is
+            # locked), so it must not outlive the source that imposed it. Recorded directly, as in
+            # the still-dynamic case below: the state is provisional until the sources are known,
+            # and `_enter_dynamic_mode` forces shuffle back on if the queue stays dynamic.
+            queue.shuffle_enabled = False
             return
         if option not in (QueueOption.PLAY, QueueOption.REPLACE):
             # only the options that start playing the media right away are a new listening

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1842,8 +1842,11 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             # its way out - and its shuffle is never the user's own (a dynamic queue's toggle is
             # locked), so it must not outlive the source that imposed it. Recorded directly, as in
             # the still-dynamic case below: the state is provisional until the sources are known,
-            # and `_enter_dynamic_mode` forces shuffle back on if the queue stays dynamic.
+            # and `_enter_dynamic_mode` forces shuffle back on if the queue stays dynamic. The
+            # intent goes with it, or a play soon after would resurrect a shuffle the queue's own
+            # toggle now reads as off.
             queue.shuffle_enabled = False
+            queue_data.shuffle_set_at = None
             return
         if option not in (QueueOption.PLAY, QueueOption.REPLACE):
             # only the options that start playing the media right away are a new listening

--- a/tests/controllers/player_queues/test_shuffle_reset.py
+++ b/tests/controllers/player_queues/test_shuffle_reset.py
@@ -353,6 +353,10 @@ async def test_replace_next_over_a_dynamic_queue_drops_the_imposed_shuffle() -> 
     assert _queue(ctrl).smart_shuffle_active is False
     # the item playing, then the album in its own track order rather than the (reversed) shuffle
     assert _played_order(ctrl) == ["p1", *ALBUM_TRACKS]
+    # settled before the items were resolved: a shuffled queue asks the resolver to keep the items
+    # preceding a chosen track, an in-order one does not
+    resolve_call = ctrl._media_resolver._resolve_media_items.call_args
+    assert resolve_call.kwargs["keep_preceding_items"] is False
 
 
 async def test_replace_next_that_leaves_the_queue_dynamic_keeps_the_smart_mix() -> None:

--- a/tests/controllers/player_queues/test_shuffle_reset.py
+++ b/tests/controllers/player_queues/test_shuffle_reset.py
@@ -359,6 +359,28 @@ async def test_replace_next_over_a_dynamic_queue_drops_the_imposed_shuffle() -> 
     assert resolve_call.kwargs["keep_preceding_items"] is False
 
 
+async def test_replace_next_over_a_dynamic_queue_drops_the_shuffle_intent_with_it() -> None:
+    """
+    The shuffle dropped here takes its intent along, so a later play does not resurrect it.
+
+    Staging a dynamic source keeps an intent the user left on the queue moments earlier. Once
+    replace next switches the imposed shuffle off, that stamp would otherwise still be fresh enough
+    for the next play to act on - shuffling media on a queue whose toggle now reads off.
+    """
+    ctrl = _controller()
+    await ctrl.set_shuffle("q1", True)
+    await ctrl.play_media("q1", _dynamic_playlist(), QueueOption.ADD)
+    assert ctrl._queue_data["q1"].shuffle_set_at is not None
+
+    await ctrl.play_media("q1", _album(), QueueOption.REPLACE_NEXT)
+
+    assert _queue(ctrl).shuffle_enabled is False
+    assert ctrl._queue_data["q1"].shuffle_set_at is None
+    # the next media the user starts plays in order, matching what the queue's toggle now says
+    await ctrl.play_media("q1", _album(), QueueOption.REPLACE)
+    assert _played_order(ctrl) == ALBUM_TRACKS
+
+
 async def test_replace_next_that_leaves_the_queue_dynamic_keeps_the_smart_mix() -> None:
     """Staging another dynamic source keeps the queue an always-on smart mix, shuffle included."""
     ctrl = _controller(shuffle_enabled=True, smart_shuffle_active=True, is_dynamic=True)

--- a/tests/controllers/player_queues/test_shuffle_reset.py
+++ b/tests/controllers/player_queues/test_shuffle_reset.py
@@ -46,6 +46,9 @@ STAGE_OPTIONS = [QueueOption.ADD, QueueOption.NEXT, QueueOption.REPLACE_NEXT]
 # a queue as an earlier shuffle left it: the list order deliberately disagrees with the sort order
 SHUFFLED_QUEUE = [("e1", 0), ("e4", 3), ("e2", 1), ("e5", 4), ("e3", 2)]
 
+# the managed pool a dynamic queue is playing when other media is staged over it
+POOL_TRACKS = ["p1", "p2", "p3"]
+
 
 def _track(item_id: str) -> Track:
     """Build a playable Track on the 'test' provider."""
@@ -152,6 +155,16 @@ def _load_shuffled_queue(ctrl: Any) -> None:
         items.append(item)
     ctrl._queue_data["q1"].items = items
     _queue(ctrl).items = len(items)
+
+
+def _load_dynamic_pool(ctrl: Any) -> None:
+    """Fill the queue with a dynamic queue's managed pool, its first item playing."""
+    ctrl._queue_data["q1"].items = [
+        QueueItem.from_media_item("q1", _track(item_id)) for item_id in POOL_TRACKS
+    ]
+    queue = _queue(ctrl)
+    queue.items = len(POOL_TRACKS)
+    queue.current_index = 0
 
 
 @pytest.mark.parametrize("option", START_OPTIONS)
@@ -320,6 +333,38 @@ async def test_playing_over_a_dynamic_queue_honours_an_explicit_play_in_order() 
     assert _queue(ctrl).smart_shuffle_active is False
     # the flag alone proves little here: the album itself has to come out in its own order
     assert _played_order(ctrl) == ALBUM_TRACKS
+
+
+async def test_replace_next_over_a_dynamic_queue_drops_the_imposed_shuffle() -> None:
+    """
+    An album staged over a dynamic queue takes its source away, so the smart mix's shuffle goes too.
+
+    Staging normally leaves the shuffle state alone, but the shuffle a dynamic queue runs on is not
+    the user's own choice - its toggle is locked - so it must not silently reorder the album that
+    replaces it. Replace next is the only staging option that replaces the queue's sources.
+    """
+    ctrl = _controller(shuffle_enabled=True, smart_shuffle_active=True, is_dynamic=True)
+    _load_dynamic_pool(ctrl)
+
+    await ctrl.play_media("q1", _album(), QueueOption.REPLACE_NEXT)
+
+    assert _queue(ctrl).is_dynamic is False
+    assert _queue(ctrl).shuffle_enabled is False
+    assert _queue(ctrl).smart_shuffle_active is False
+    # the item playing, then the album in its own track order rather than the (reversed) shuffle
+    assert _played_order(ctrl) == ["p1", *ALBUM_TRACKS]
+
+
+async def test_replace_next_that_leaves_the_queue_dynamic_keeps_the_smart_mix() -> None:
+    """Staging another dynamic source keeps the queue an always-on smart mix, shuffle included."""
+    ctrl = _controller(shuffle_enabled=True, smart_shuffle_active=True, is_dynamic=True)
+    _load_dynamic_pool(ctrl)
+
+    await ctrl.play_media("q1", _dynamic_playlist(), QueueOption.REPLACE_NEXT)
+
+    assert _queue(ctrl).is_dynamic is True
+    assert _queue(ctrl).shuffle_enabled is True
+    assert _queue(ctrl).smart_shuffle_active is True
 
 
 async def test_playing_media_on_an_ended_queue_resets_shuffle() -> None:


### PR DESCRIPTION
# What does this implement/fix?

A queue playing a radio or dynamic playlist is an always-on smart mix, so shuffle is switched on
for it and its toggle is locked. Picking an album and choosing "Play next (replace queue)" takes
that dynamic source away, but the shuffle it imposed stayed behind — so the album was queued up in
random order, and the queue was left showing a shuffle the user never switched on.

Follow-up to #5740, which fixed this for play and replace but not for this menu item.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- "Play next (replace queue)" over a radio or dynamic playlist now queues the new media in its own
  order, and the queue no longer reports a shuffle the user never set.
- Queueing another radio or dynamic playlist that way still keeps the smart mix, shuffle included.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
