### PR TITLE
Hide the volume controls on Sonos speakers with fixed line-out

### DIFF
--- a/music_assistant/providers/sonos_s1/constants.py
+++ b/music_assistant/providers/sonos_s1/constants.py
@@ -15,12 +15,12 @@ CONF_HOUSEHOLD_ID = "household_id"
 # PAUSE is advertised unconditionally: whether a speaker can pause depends on what it has
 # loaded rather than on the model, so pause() reads that back from the speaker itself and
 # falls back to stop when it is refused.
+# The volume features are deliberately absent here: they depend on the individual speaker
+# and are added by SonosPlayer.
 PLAYER_FEATURES = (
     PlayerFeature.PLAY_MEDIA,
     PlayerFeature.PAUSE,
     PlayerFeature.SET_MEMBERS,
-    PlayerFeature.VOLUME_MUTE,
-    PlayerFeature.VOLUME_SET,
     PlayerFeature.ENQUEUE,
     PlayerFeature.GAPLESS_PLAYBACK,
     PlayerFeature.SELECT_SOURCE,

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -89,9 +89,9 @@ class SonosPlayer(Player):
 
         # Set player attributes
         self._attr_supported_features = set(PLAYER_FEATURES)
+        # a speaker playing out at a fixed level (a Connect or Port wired into an amplifier)
+        # rejects volume commands, so it is left without volume and mute control at all
         if not fixed_volume:
-            # a speaker playing out at a fixed level (a Connect or Port wired into an
-            # amplifier) refuses volume commands, so it must not offer any volume control
             self._attr_supported_features |= {PlayerFeature.VOLUME_SET, PlayerFeature.VOLUME_MUTE}
         # S1 hardware is fixed to 16-bit at 44.1/48 kHz
         self._attr_supported_sample_rates = [(44100, 16), (48000, 16)]

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -14,7 +14,13 @@ import time
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, cast
 
-from music_assistant_models.enums import IdentifierType, MediaType, PlaybackState, PlayerState
+from music_assistant_models.enums import (
+    IdentifierType,
+    MediaType,
+    PlaybackState,
+    PlayerFeature,
+    PlayerState,
+)
 from music_assistant_models.errors import PlayerCommandFailed
 from soco import SoCoException
 from soco.core import MUSIC_SRC_RADIO, SoCo
@@ -70,14 +76,23 @@ class SonosPlayer(Player):
         self,
         provider: SonosPlayerProvider,
         soco: SoCo,
+        fixed_volume: bool,
     ) -> None:
-        """Initialize SonosPlayer instance."""
+        """
+        Initialize SonosPlayer instance.
+
+        :param fixed_volume: Whether the speaker is set to fixed volume output.
+        """
         super().__init__(provider, soco.uid)
         self.soco = soco
         self.household_id: str = soco.household_id
 
         # Set player attributes
         self._attr_supported_features = set(PLAYER_FEATURES)
+        if not fixed_volume:
+            # a speaker playing out at a fixed level (a Connect or Port wired into an
+            # amplifier) refuses volume commands, so it must not offer any volume control
+            self._attr_supported_features |= {PlayerFeature.VOLUME_SET, PlayerFeature.VOLUME_MUTE}
         # S1 hardware is fixed to 16-bit at 44.1/48 kHz
         self._attr_supported_sample_rates = [(44100, 16), (48000, 16)]
         self._attr_name = soco.player_name

--- a/music_assistant/providers/sonos_s1/provider.py
+++ b/music_assistant/providers/sonos_s1/provider.py
@@ -195,7 +195,7 @@ class SonosPlayerProvider(PlayerProvider):
         if not is_visible:
             return
         try:
-            sonos_player = SonosPlayer(self, soco, fixed_volume)
+            sonos_player = SonosPlayer(self, soco, fixed_volume=fixed_volume)
 
             # Register with Music Assistant
             await sonos_player.setup()

--- a/music_assistant/providers/sonos_s1/provider.py
+++ b/music_assistant/providers/sonos_s1/provider.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any, cast
 
 from music_assistant_models.config_entries import ConfigEntry
-from music_assistant_models.enums import ConfigEntryType, PlayerFeature
+from music_assistant_models.enums import ConfigEntryType
 from requests.exceptions import RequestException
 from soco import SoCo, events_asyncio, zonegroupstate
 from soco import config as soco_config
@@ -195,12 +195,7 @@ class SonosPlayerProvider(PlayerProvider):
         if not is_visible:
             return
         try:
-            sonos_player = SonosPlayer(self, soco)
-            if not fixed_volume:
-                sonos_player._attr_supported_features = {
-                    *sonos_player._attr_supported_features,
-                    PlayerFeature.VOLUME_SET,
-                }
+            sonos_player = SonosPlayer(self, soco, fixed_volume)
 
             # Register with Music Assistant
             await sonos_player.setup()

--- a/tests/providers/sonos_s1/test_player.py
+++ b/tests/providers/sonos_s1/test_player.py
@@ -51,7 +51,7 @@ def sonos_player() -> SonosPlayer:
     """Create a SonosPlayer with a mocked soco device and provider."""
     provider = MagicMock()
     provider.mass.streams.resolve_stream_url = AsyncMock(return_value=STREAM_URL)
-    return SonosPlayer(provider=provider, soco=_make_soco())
+    return SonosPlayer(provider=provider, soco=_make_soco(), fixed_volume=False)
 
 
 @pytest.fixture
@@ -77,7 +77,7 @@ def _make_player(mass: MusicAssistant, uid: str, name: str) -> SonosPlayer:
     provider = MagicMock()
     provider.mass = mass
     provider.topology_condition = asyncio.Condition()
-    return SonosPlayer(provider=provider, soco=_make_soco(uid, name))
+    return SonosPlayer(provider=provider, soco=_make_soco(uid, name), fixed_volume=False)
 
 
 def _poll_id(player: SonosPlayer) -> str:
@@ -128,6 +128,19 @@ async def test_play_media_builds_didl_from_stream_url(sonos_player: SonosPlayer)
 def test_pause_is_advertised_as_a_supported_feature(sonos_player: SonosPlayer) -> None:
     """Without the feature the player controller converts every pause into a stop."""
     assert PlayerFeature.PAUSE in sonos_player.supported_features
+
+
+def test_volume_is_advertised_for_a_regular_speaker(sonos_player: SonosPlayer) -> None:
+    """A speaker with its own amplifier is driven over its native volume control."""
+    assert PlayerFeature.VOLUME_SET in sonos_player.supported_features
+    assert PlayerFeature.VOLUME_MUTE in sonos_player.supported_features
+
+
+def test_volume_is_not_advertised_for_a_fixed_volume_speaker() -> None:
+    """A speaker with fixed line-out rejects volume commands, so it must not offer them."""
+    player = SonosPlayer(provider=MagicMock(), soco=_make_soco(), fixed_volume=True)
+    assert PlayerFeature.VOLUME_SET not in player.supported_features
+    assert PlayerFeature.VOLUME_MUTE not in player.supported_features
 
 
 class _RecordingSoco:
@@ -707,7 +720,7 @@ async def test_setup_reads_the_speaker_off_the_event_loop(sonos_player: SonosPla
 async def test_unsubscribe_drops_subscriptions_even_when_cancelled() -> None:
     """A cancelled unsubscribe must not leave stale entries that block resubscribing."""
     provider = MagicMock()
-    player = SonosPlayer(provider=provider, soco=_make_soco())
+    player = SonosPlayer(provider=provider, soco=_make_soco(), fixed_volume=False)
     subscription = MagicMock()
     subscription.unsubscribe = AsyncMock(side_effect=partial(asyncio.sleep, 5))
     player._subscriptions = [subscription]
@@ -734,7 +747,7 @@ async def _subscribe_with_failing_speaker(player: SonosPlayer) -> None:
 
 async def test_failed_subscribe_marks_the_speaker_offline() -> None:
     """A failed subscription must take the speaker offline and release the lock."""
-    player = SonosPlayer(provider=MagicMock(), soco=_make_soco())
+    player = SonosPlayer(provider=MagicMock(), soco=_make_soco(), fixed_volume=False)
 
     await _subscribe_with_failing_speaker(player)
 
@@ -744,7 +757,7 @@ async def test_failed_subscribe_marks_the_speaker_offline() -> None:
 
 async def test_speaker_can_resubscribe_after_a_failed_subscribe() -> None:
     """A speaker that failed to subscribe must still be able to subscribe later."""
-    player = SonosPlayer(provider=MagicMock(), soco=_make_soco())
+    player = SonosPlayer(provider=MagicMock(), soco=_make_soco(), fixed_volume=False)
     await _subscribe_with_failing_speaker(player)
 
     with patch.object(player, "_subscribe_target", AsyncMock()) as subscribe_target:
@@ -756,7 +769,7 @@ async def test_speaker_can_resubscribe_after_a_failed_subscribe() -> None:
 
 async def test_speaker_taken_offline_mid_subscribe_keeps_no_subscriptions() -> None:
     """A speaker that goes offline while subscribing must not keep the subscriptions it created."""
-    player = SonosPlayer(provider=MagicMock(), soco=_make_soco())
+    player = SonosPlayer(provider=MagicMock(), soco=_make_soco(), fixed_volume=False)
     subscribing = asyncio.Event()
     speaker_responds = asyncio.Event()
 
@@ -787,7 +800,7 @@ async def test_speaker_taken_offline_mid_subscribe_keeps_no_subscriptions() -> N
 
 async def test_speaker_going_offline_is_not_resubscribed_halfway() -> None:
     """No new subscriptions may be created while a speaker is still going offline."""
-    player = SonosPlayer(provider=MagicMock(), soco=_make_soco())
+    player = SonosPlayer(provider=MagicMock(), soco=_make_soco(), fixed_volume=False)
     unsubscribing = asyncio.Event()
     speaker_responds = asyncio.Event()
 

--- a/tests/providers/sonos_s1/test_provider.py
+++ b/tests/providers/sonos_s1/test_provider.py
@@ -230,17 +230,19 @@ async def test_invisible_speaker_is_not_interrogated() -> None:
     player_cls.assert_not_called()
 
 
-async def test_new_speaker_is_registered() -> None:
-    """A newly discovered speaker is built and set up."""
+@pytest.mark.parametrize("fixed_volume", [False, True])
+async def test_new_speaker_is_registered(fixed_volume: bool) -> None:
+    """A newly discovered speaker is built with the volume mode it was interrogated for."""
     provider, _ = _make_provider()
     soco = _make_soco()
+    soco.fixed_volume = fixed_volume
 
     with patch("music_assistant.providers.sonos_s1.provider.SonosPlayer") as player_cls:
         player_cls.return_value.setup = AsyncMock()
         await provider._setup_player(soco)
 
     soco.get_speaker_info.assert_called_once()
-    player_cls.assert_called_once_with(provider, soco)
+    player_cls.assert_called_once_with(provider, soco, fixed_volume)
     player_cls.return_value.setup.assert_awaited_once()
 
 

--- a/tests/providers/sonos_s1/test_provider.py
+++ b/tests/providers/sonos_s1/test_provider.py
@@ -242,7 +242,7 @@ async def test_new_speaker_is_registered(fixed_volume: bool) -> None:
         await provider._setup_player(soco)
 
     soco.get_speaker_info.assert_called_once()
-    player_cls.assert_called_once_with(provider, soco, fixed_volume)
+    player_cls.assert_called_once_with(provider, soco, fixed_volume=fixed_volume)
     player_cls.return_value.setup.assert_awaited_once()
 
 


### PR DESCRIPTION
# What does this implement/fix?

A Sonos Connect or Port that is set to fixed volume output (wired into an amplifier that does the volume) plays out at a fixed level and rejects any volume command. The S1 provider still offered those speakers a volume slider and a mute button, which could only fail. It also dragged along the volume of any group they were part of.

There is already a check for this in the provider, but it never did anything: the volume features were listed in the base feature set, so the "add them only when the volume is not fixed" branch had nothing left to add. Sonos S2 already handles this correctly; S1 now matches.

**Related issue (if applicable):**

- n/a (found while fixing #5736)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Speakers with fixed volume output no longer advertise volume or mute support, so they show no volume slider and no mute button, and can be given an external volume control instead.
- The feature set is now assembled in the player itself, from the fixed volume mode discovery already reads.
- Tests for both the fixed and the regular volume path.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
