### PR TITLE
Only download a radio station's playlist once

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -721,7 +721,12 @@ class StreamsAudio:
                     # take the playlist from this very response: a separate request would
                     # go out with another user agent and stricter TLS than the rest of the
                     # radio paths, so a host could answer it differently
-                    playlist_data = await resp.content.read(MAX_PLAYLIST_SIZE)
+                    try:
+                        playlist_data = await resp.content.read(MAX_PLAYLIST_SIZE)
+                    except aiohttp.ClientError as err:
+                        # the endpoint answered as a playlist, so a truncated body is a bad
+                        # playlist - not a reason to fall back to streaming the URL directly
+                        raise InvalidDataError(f"Error while fetching playlist {url}") from err
                     playlist_charset = resp.charset
 
             if headers.get("icy-metaint") is not None:

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -129,12 +129,12 @@ from music_assistant.helpers.ffmpeg import (
 )
 from music_assistant.helpers.named_pipe import read_named_pipe
 from music_assistant.helpers.playlists import (
-    MAX_PLAYLIST_SIZE,
     PLAYLIST_CONTENT_TYPES,
     IsHLSPlaylist,
     PlaylistItem,
     parse_m3u,
     parse_playlist_data,
+    read_playlist_body,
 )
 from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
 from music_assistant.helpers.util import (
@@ -725,7 +725,7 @@ class StreamsAudio:
                     # go out with another user agent and stricter TLS than the rest of the
                     # radio paths, so a host could answer it differently
                     try:
-                        playlist_data = await resp.content.read(MAX_PLAYLIST_SIZE)
+                        playlist_data = await read_playlist_body(resp.content)
                     except aiohttp.ClientError as err:
                         # the endpoint answered as a playlist, so a truncated body is a bad
                         # playlist - not a reason to fall back to streaming the URL directly

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -130,6 +130,7 @@ from music_assistant.helpers.ffmpeg import (
 from music_assistant.helpers.named_pipe import read_named_pipe
 from music_assistant.helpers.playlists import (
     MAX_PLAYLIST_SIZE,
+    PLAYLIST_CONTENT_TYPES,
     IsHLSPlaylist,
     PlaylistItem,
     parse_m3u,
@@ -710,13 +711,15 @@ class StreamsAudio:
                 resp.raise_for_status()
                 if not resp.headers:
                     raise InvalidDataError("no headers found")
+                content_type = headers.get("content-type", "")
                 if (
                     url.endswith((".m3u", ".m3u8", ".pls"))
                     or ".m3u?" in url
                     or ".m3u8?" in url
                     or ".pls?" in url
-                    or "audio/x-mpegurl" in headers.get("content-type", "")
-                    or "audio/x-scpls" in headers.get("content-type", "")
+                    or any(
+                        playlist_type in content_type for playlist_type in PLAYLIST_CONTENT_TYPES
+                    )
                 ):
                     # take the playlist from this very response: a separate request would
                     # go out with another user agent and stricter TLS than the rest of the

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -128,7 +128,13 @@ from music_assistant.helpers.ffmpeg import (
     get_ffmpeg_stream,
 )
 from music_assistant.helpers.named_pipe import read_named_pipe
-from music_assistant.helpers.playlists import IsHLSPlaylist, PlaylistItem, fetch_playlist, parse_m3u
+from music_assistant.helpers.playlists import (
+    MAX_PLAYLIST_SIZE,
+    IsHLSPlaylist,
+    PlaylistItem,
+    parse_m3u,
+    parse_playlist_data,
+)
 from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
 from music_assistant.helpers.util import (
     clean_stream_title,
@@ -693,6 +699,8 @@ class StreamsAudio:
 
         stream_type = StreamType.HTTP
         timeout = ClientTimeout(total=None, connect=10, sock_read=5)
+        playlist_data: bytes | None = None
+        playlist_charset: str | None = None
 
         try:
             async with self._connect_radio_stream(
@@ -702,6 +710,19 @@ class StreamsAudio:
                 resp.raise_for_status()
                 if not resp.headers:
                     raise InvalidDataError("no headers found")
+                if (
+                    url.endswith((".m3u", ".m3u8", ".pls"))
+                    or ".m3u?" in url
+                    or ".m3u8?" in url
+                    or ".pls?" in url
+                    or "audio/x-mpegurl" in headers.get("content-type", "")
+                    or "audio/x-scpls" in headers.get("content-type", "")
+                ):
+                    # take the playlist from this very response: a separate request would
+                    # go out with another user agent and stricter TLS than the rest of the
+                    # radio paths, so a host could answer it differently
+                    playlist_data = await resp.content.read(MAX_PLAYLIST_SIZE)
+                    playlist_charset = resp.charset
 
             if headers.get("icy-metaint") is not None:
                 stream_type = StreamType.ICY
@@ -709,16 +730,9 @@ class StreamsAudio:
                 # Ogg streams (Opus/Vorbis) have in-band metadata via Vorbis comments
                 stream_type = StreamType.IN_BAND
 
-            if (
-                url.endswith((".m3u", ".m3u8", ".pls"))
-                or ".m3u?" in url
-                or ".m3u8?" in url
-                or ".pls?" in url
-                or "audio/x-mpegurl" in headers.get("content-type", "")
-                or "audio/x-scpls" in headers.get("content-type", "")
-            ):
+            if playlist_data is not None:
                 try:
-                    substreams = await fetch_playlist(mass, url)
+                    substreams = await parse_playlist_data(url, playlist_data, playlist_charset)
                     if not any(x for x in substreams if x.length):
                         for line in substreams:
                             if not line.is_url:

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -129,6 +129,7 @@ from music_assistant.helpers.ffmpeg import (
 )
 from music_assistant.helpers.named_pipe import read_named_pipe
 from music_assistant.helpers.playlists import (
+    HLS_CONTENT_TYPES,
     PLAYLIST_CONTENT_TYPES,
     IsHLSPlaylist,
     PlaylistItem,
@@ -712,7 +713,10 @@ class StreamsAudio:
                 if not resp.headers:
                     raise InvalidDataError("no headers found")
                 content_type = headers.get("content-type", "")
-                if (
+                # a server declaring HLS settles it: a media playlist is free to carry none
+                # of the tags the parser recognises an HLS playlist by
+                is_hls = any(hls_type in content_type for hls_type in HLS_CONTENT_TYPES)
+                if not is_hls and (
                     url.endswith((".m3u", ".m3u8", ".pls"))
                     or ".m3u?" in url
                     or ".m3u8?" in url
@@ -734,7 +738,9 @@ class StreamsAudio:
 
             if headers.get("icy-metaint") is not None:
                 stream_type = StreamType.ICY
-            elif headers.get("content-type", "") in ("application/ogg", "audio/ogg"):
+            elif is_hls:
+                stream_type = StreamType.HLS
+            elif content_type in ("application/ogg", "audio/ogg"):
                 # Ogg streams (Opus/Vorbis) have in-band metadata via Vorbis comments
                 stream_type = StreamType.IN_BAND
 

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -131,6 +131,7 @@ from music_assistant.helpers.named_pipe import read_named_pipe
 from music_assistant.helpers.playlists import (
     HLS_CONTENT_TYPES,
     PLAYLIST_CONTENT_TYPES,
+    PLAYLIST_READ_TIMEOUT,
     IsHLSPlaylist,
     PlaylistItem,
     parse_m3u,
@@ -712,7 +713,8 @@ class StreamsAudio:
                 resp.raise_for_status()
                 if not resp.headers:
                     raise InvalidDataError("no headers found")
-                content_type = headers.get("content-type", "")
+                # media types are case insensitive, the comparisons below are all lower case
+                content_type = headers.get("content-type", "").lower()
                 # a server declaring HLS settles it: a media playlist is free to carry none
                 # of the tags the parser recognises an HLS playlist by
                 is_hls = any(hls_type in content_type for hls_type in HLS_CONTENT_TYPES)
@@ -729,7 +731,10 @@ class StreamsAudio:
                     # go out with another user agent and stricter TLS than the rest of the
                     # radio paths, so a host could answer it differently
                     try:
-                        playlist_data = await read_playlist_body(resp.content)
+                        # the probe has no total timeout, so bound the body on its own:
+                        # a server trickling bytes would otherwise stall resolving for hours
+                        async with asyncio.timeout(PLAYLIST_READ_TIMEOUT):
+                            playlist_data = await read_playlist_body(resp.content)
                     except aiohttp.ClientError as err:
                         # the endpoint answered as a playlist, so a truncated body is a bad
                         # playlist - not a reason to fall back to streaming the URL directly

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -46,6 +46,7 @@ FIELD_SEPARATOR = "||"
 # playlists are small text files: cap the read so a stream served under a
 # playlist content-type does not pull an endless body into memory
 MAX_PLAYLIST_SIZE = 64 * 1024
+PLAYLIST_READ_TIMEOUT = 5
 
 
 class IsHLSPlaylist(InvalidDataError):
@@ -352,7 +353,9 @@ async def fetch_playlist(
     """Fetch and parse a remote M3U or PLS playlist."""
     try:
         async with mass.http_session.get(
-            encoded_request_url(url), allow_redirects=True, timeout=ClientTimeout(total=5)
+            encoded_request_url(url),
+            allow_redirects=True,
+            timeout=ClientTimeout(total=PLAYLIST_READ_TIMEOUT),
         ) as resp:
             # an error page is still a body: its markup would otherwise parse into entries
             resp.raise_for_status()

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -34,6 +34,8 @@ from music_assistant.helpers.uri import BUILTIN_URL_SCHEMES
 from music_assistant.helpers.util import detect_charset, try_parse_int
 
 if TYPE_CHECKING:
+    from aiohttp import StreamReader
+
     from music_assistant.mass import MusicAssistant
 
 
@@ -296,6 +298,23 @@ def parse_pls(pls_data: str) -> list[PlaylistItem]:
     return playlist
 
 
+async def read_playlist_body(content: StreamReader) -> bytes:
+    """
+    Read a playlist body, up to MAX_PLAYLIST_SIZE bytes.
+
+    :param content: Response body to read from.
+    """
+    # a single read returns whatever happens to be buffered, so a playlist spread over
+    # several chunks would otherwise be parsed truncated
+    raw_data = bytearray()
+    while len(raw_data) < MAX_PLAYLIST_SIZE:
+        chunk = await content.read(MAX_PLAYLIST_SIZE - len(raw_data))
+        if not chunk:
+            break
+        raw_data += chunk
+    return bytes(raw_data)
+
+
 async def parse_playlist_data(
     url: str, raw_data: bytes, charset: str | None = None, raise_on_hls: bool = True
 ) -> list[PlaylistItem]:
@@ -337,7 +356,7 @@ async def fetch_playlist(
         ) as resp:
             # an error page is still a body: its markup would otherwise parse into entries
             resp.raise_for_status()
-            raw_data = await resp.content.read(MAX_PLAYLIST_SIZE)
+            raw_data = await read_playlist_body(resp.content)
             charset = resp.charset
     except TimeoutError as err:
         msg = f"Timeout while fetching playlist {url}"

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -40,6 +40,9 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 HLS_CONTENT_TYPES = ("application/vnd.apple.mpegurl",)
 FIELD_SEPARATOR = "||"
+# playlists are small text files: cap the read so a stream served under a
+# playlist content-type does not pull an endless body into memory
+MAX_PLAYLIST_SIZE = 64 * 1024
 
 
 class IsHLSPlaylist(InvalidDataError):
@@ -292,25 +295,19 @@ def parse_pls(pls_data: str) -> list[PlaylistItem]:
     return playlist
 
 
-async def fetch_playlist(
-    mass: MusicAssistant, url: str, raise_on_hls: bool = True
+async def parse_playlist_data(
+    url: str, raw_data: bytes, charset: str | None = None, raise_on_hls: bool = True
 ) -> list[PlaylistItem]:
-    """Fetch and parse a remote M3U or PLS playlist."""
-    try:
-        async with mass.http_session.get(
-            encoded_request_url(url), allow_redirects=True, timeout=ClientTimeout(total=5)
-        ) as resp:
-            # an error page is still a body: its markup would otherwise parse into entries
-            resp.raise_for_status()
-            raw_data = await resp.content.read(64 * 1024)
-            encoding = await detect_charset(raw_data, preferred=resp.charset)
-            playlist_data = raw_data.decode(encoding, errors="replace")
-    except TimeoutError as err:
-        msg = f"Timeout while fetching playlist {url}"
-        raise InvalidDataError(msg) from err
-    except client_exceptions.ClientError as err:
-        msg = f"Error while fetching playlist {url}"
-        raise InvalidDataError(msg) from err
+    """
+    Parse the raw body of an M3U or PLS playlist into entries.
+
+    :param url: URL the body was fetched from, used to pick the playlist flavour.
+    :param raw_data: Raw (undecoded) playlist body.
+    :param charset: Charset declared by the server, if any.
+    :param raise_on_hls: Raise IsHLSPlaylist for an HLS media playlist.
+    """
+    encoding = await detect_charset(raw_data, preferred=charset)
+    playlist_data = raw_data.decode(encoding, errors="replace")
 
     if (
         raise_on_hls and "#EXT-X-VERSION:" in playlist_data
@@ -327,6 +324,28 @@ async def fetch_playlist(
         raise InvalidDataError(msg)
 
     return playlist
+
+
+async def fetch_playlist(
+    mass: MusicAssistant, url: str, raise_on_hls: bool = True
+) -> list[PlaylistItem]:
+    """Fetch and parse a remote M3U or PLS playlist."""
+    try:
+        async with mass.http_session.get(
+            encoded_request_url(url), allow_redirects=True, timeout=ClientTimeout(total=5)
+        ) as resp:
+            # an error page is still a body: its markup would otherwise parse into entries
+            resp.raise_for_status()
+            raw_data = await resp.content.read(MAX_PLAYLIST_SIZE)
+            charset = resp.charset
+    except TimeoutError as err:
+        msg = f"Timeout while fetching playlist {url}"
+        raise InvalidDataError(msg) from err
+    except client_exceptions.ClientError as err:
+        msg = f"Error while fetching playlist {url}"
+        raise InvalidDataError(msg) from err
+
+    return await parse_playlist_data(url, raw_data, charset, raise_on_hls)
 
 
 # --------------------------------------------------------------------------- #

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 HLS_CONTENT_TYPES = ("application/vnd.apple.mpegurl",)
-PLAYLIST_CONTENT_TYPES = ("audio/x-mpegurl", "audio/x-scpls", *HLS_CONTENT_TYPES)
+PLAYLIST_CONTENT_TYPES = ("audio/x-mpegurl", "audio/x-scpls")
 FIELD_SEPARATOR = "||"
 # playlists are small text files: cap the read so a stream served under a
 # playlist content-type does not pull an endless body into memory

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 HLS_CONTENT_TYPES = ("application/vnd.apple.mpegurl",)
+PLAYLIST_CONTENT_TYPES = ("audio/x-mpegurl", "audio/x-scpls", *HLS_CONTENT_TYPES)
 FIELD_SEPARATOR = "||"
 # playlists are small text files: cap the read so a stream served under a
 # playlist content-type does not pull an endless body into memory

--- a/tests/controllers/streams/test_resolve_radio_stream.py
+++ b/tests/controllers/streams/test_resolve_radio_stream.py
@@ -19,25 +19,36 @@ HLS_BODY = b"#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:10,\nsegment0.aac\n"
 class _FakeContent:
     """Minimal stand-in for aiohttp StreamReader content."""
 
-    def __init__(self, raw_data: bytes | Exception) -> None:
+    def __init__(self, raw_data: bytes | Exception, chunk_size: int | None = None) -> None:
         self._raw_data = raw_data
+        self._chunk_size = chunk_size
+        self._pos = 0
 
     async def read(self, n: int) -> bytes:
         if isinstance(self._raw_data, Exception):
             raise self._raw_data
-        return self._raw_data[:n]
+        # like the real stream, a read hands over what has arrived so far
+        available = len(self._raw_data) - self._pos
+        size = min(n, self._chunk_size, available) if self._chunk_size else min(n, available)
+        chunk = self._raw_data[self._pos : self._pos + size]
+        self._pos += size
+        return chunk
 
 
 class _FakeConnCtx:
     """Async context manager yielding a fake radio probe response."""
 
     def __init__(
-        self, headers: dict[str, str], raw_data: bytes | Exception = b"", charset: str | None = None
+        self,
+        headers: dict[str, str],
+        raw_data: bytes | Exception = b"",
+        charset: str | None = None,
+        chunk_size: int | None = None,
     ) -> None:
         self._resp = MagicMock()
         self._resp.headers = headers
         self._resp.charset = charset
-        self._resp.content = _FakeContent(raw_data)
+        self._resp.content = _FakeContent(raw_data, chunk_size)
 
     async def __aenter__(self) -> Any:
         return self._resp
@@ -67,7 +78,7 @@ async def test_playlist_is_unwrapped_from_the_probe_response(
     audio = _streams_audio()
     responses = {
         "http://radio.example.com/station.pls": _FakeConnCtx(
-            {"content-type": "audio/x-scpls"}, PLS_BODY
+            {"content-type": "audio/x-scpls"}, PLS_BODY, chunk_size=8
         ),
         "http://radio.example.com/stream": _FakeConnCtx({"icy-metaint": "16000"}),
     }

--- a/tests/controllers/streams/test_resolve_radio_stream.py
+++ b/tests/controllers/streams/test_resolve_radio_stream.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
+import aiohttp
 import pytest
 from music_assistant_models.enums import StreamType
+from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.controllers.streams.audio import StreamsAudio
 
@@ -17,10 +19,12 @@ HLS_BODY = b"#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:10,\nsegment0.aac\n"
 class _FakeContent:
     """Minimal stand-in for aiohttp StreamReader content."""
 
-    def __init__(self, raw_data: bytes) -> None:
+    def __init__(self, raw_data: bytes | Exception) -> None:
         self._raw_data = raw_data
 
     async def read(self, n: int) -> bytes:
+        if isinstance(self._raw_data, Exception):
+            raise self._raw_data
         return self._raw_data[:n]
 
 
@@ -28,7 +32,7 @@ class _FakeConnCtx:
     """Async context manager yielding a fake radio probe response."""
 
     def __init__(
-        self, headers: dict[str, str], raw_data: bytes = b"", charset: str | None = None
+        self, headers: dict[str, str], raw_data: bytes | Exception = b"", charset: str | None = None
     ) -> None:
         self._resp = MagicMock()
         self._resp.headers = headers
@@ -95,3 +99,21 @@ async def test_hls_playlist_resolves_as_hls(monkeypatch: pytest.MonkeyPatch) -> 
     result = await audio.resolve_radio_stream("http://radio.example.com/station.m3u8")
 
     assert result == ("http://radio.example.com/station.m3u8", StreamType.HLS)
+    cast("MagicMock", audio.mass).http_session.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_truncated_playlist_is_not_cached_as_a_direct_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A playlist body that dies mid-transfer fails instead of being streamed as audio."""
+    audio = _streams_audio()
+    response = _FakeConnCtx(
+        {"content-type": "audio/x-scpls"}, aiohttp.ClientPayloadError("connection closed")
+    )
+    monkeypatch.setattr(audio, "_connect_radio_stream", lambda *_args, **_kwargs: response)
+
+    with pytest.raises(InvalidDataError):
+        await audio.resolve_radio_stream("http://radio.example.com/station.pls")
+
+    cast("MagicMock", audio.mass).cache.set.assert_not_called()

--- a/tests/controllers/streams/test_resolve_radio_stream.py
+++ b/tests/controllers/streams/test_resolve_radio_stream.py
@@ -91,14 +91,14 @@ async def test_playlist_is_unwrapped_from_the_probe_response(
 
 @pytest.mark.asyncio
 async def test_hls_playlist_resolves_as_hls(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An HLS media playlist is recognised from the probe response body."""
+    """An HLS station without a telling URL is recognised by its content type."""
     audio = _streams_audio()
     response = _FakeConnCtx({"content-type": "application/vnd.apple.mpegurl"}, HLS_BODY)
     monkeypatch.setattr(audio, "_connect_radio_stream", lambda *_args, **_kwargs: response)
 
-    result = await audio.resolve_radio_stream("http://radio.example.com/station.m3u8")
+    result = await audio.resolve_radio_stream("http://radio.example.com/live")
 
-    assert result == ("http://radio.example.com/station.m3u8", StreamType.HLS)
+    assert result == ("http://radio.example.com/live", StreamType.HLS)
     cast("MagicMock", audio.mass).http_session.get.assert_not_called()
 
 

--- a/tests/controllers/streams/test_resolve_radio_stream.py
+++ b/tests/controllers/streams/test_resolve_radio_stream.py
@@ -1,0 +1,97 @@
+"""Tests for radio stream resolution on the streams controller."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import StreamType
+
+from music_assistant.controllers.streams.audio import StreamsAudio
+
+PLS_BODY = b"[playlist]\nNumberOfEntries=1\nFile1=http://radio.example.com/stream\n"
+HLS_BODY = b"#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:10,\nsegment0.aac\n"
+
+
+class _FakeContent:
+    """Minimal stand-in for aiohttp StreamReader content."""
+
+    def __init__(self, raw_data: bytes) -> None:
+        self._raw_data = raw_data
+
+    async def read(self, n: int) -> bytes:
+        return self._raw_data[:n]
+
+
+class _FakeConnCtx:
+    """Async context manager yielding a fake radio probe response."""
+
+    def __init__(
+        self, headers: dict[str, str], raw_data: bytes = b"", charset: str | None = None
+    ) -> None:
+        self._resp = MagicMock()
+        self._resp.headers = headers
+        self._resp.charset = charset
+        self._resp.content = _FakeContent(raw_data)
+
+    async def __aenter__(self) -> Any:
+        return self._resp
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+def _streams_audio() -> StreamsAudio:
+    """Build a streams audio controller with an empty resolved-radio cache."""
+    mass = MagicMock()
+    mass.cache.get = AsyncMock(return_value=None)
+    mass.cache.set = AsyncMock()
+    return StreamsAudio(mass)
+
+
+@pytest.mark.asyncio
+async def test_playlist_is_unwrapped_from_the_probe_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The playlist is read from the probe response instead of being fetched again.
+
+    A fetch of its own would go out over another session and user agent than the rest of
+    the radio paths use, which a host is free to answer differently.
+    """
+    audio = _streams_audio()
+    responses = {
+        "http://radio.example.com/station.pls": _FakeConnCtx(
+            {"content-type": "audio/x-scpls"}, PLS_BODY
+        ),
+        "http://radio.example.com/stream": _FakeConnCtx({"icy-metaint": "16000"}),
+    }
+    requested: list[str] = []
+
+    def _fake_connect(url: str, **_kwargs: Any) -> _FakeConnCtx:
+        requested.append(url)
+        return responses[url]
+
+    monkeypatch.setattr(audio, "_connect_radio_stream", _fake_connect)
+
+    result = await audio.resolve_radio_stream("http://radio.example.com/station.pls")
+
+    assert result == ("http://radio.example.com/stream", StreamType.ICY)
+    assert requested == [
+        "http://radio.example.com/station.pls",
+        "http://radio.example.com/stream",
+    ]
+    cast("MagicMock", audio.mass).http_session.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hls_playlist_resolves_as_hls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An HLS media playlist is recognised from the probe response body."""
+    audio = _streams_audio()
+    response = _FakeConnCtx({"content-type": "application/vnd.apple.mpegurl"}, HLS_BODY)
+    monkeypatch.setattr(audio, "_connect_radio_stream", lambda *_args, **_kwargs: response)
+
+    result = await audio.resolve_radio_stream("http://radio.example.com/station.m3u8")
+
+    assert result == ("http://radio.example.com/station.m3u8", StreamType.HLS)

--- a/tests/controllers/streams/test_resolve_radio_stream.py
+++ b/tests/controllers/streams/test_resolve_radio_stream.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -19,12 +20,17 @@ HLS_BODY = b"#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:10,\nsegment0.aac\n"
 class _FakeContent:
     """Minimal stand-in for aiohttp StreamReader content."""
 
-    def __init__(self, raw_data: bytes | Exception, chunk_size: int | None = None) -> None:
+    def __init__(
+        self, raw_data: bytes | Exception, chunk_size: int | None = None, delay: float = 0
+    ) -> None:
         self._raw_data = raw_data
         self._chunk_size = chunk_size
+        self._delay = delay
         self._pos = 0
 
     async def read(self, n: int) -> bytes:
+        if self._delay:
+            await asyncio.sleep(self._delay)
         if isinstance(self._raw_data, Exception):
             raise self._raw_data
         # like the real stream, a read hands over what has arrived so far
@@ -44,11 +50,12 @@ class _FakeConnCtx:
         raw_data: bytes | Exception = b"",
         charset: str | None = None,
         chunk_size: int | None = None,
+        delay: float = 0,
     ) -> None:
         self._resp = MagicMock()
         self._resp.headers = headers
         self._resp.charset = charset
-        self._resp.content = _FakeContent(raw_data, chunk_size)
+        self._resp.content = _FakeContent(raw_data, chunk_size, delay)
 
     async def __aenter__(self) -> Any:
         return self._resp
@@ -126,6 +133,37 @@ async def test_hls_without_version_tag_still_resolves_as_hls(
     result = await audio.resolve_radio_stream("http://radio.example.com/live")
 
     assert result == ("http://radio.example.com/live", StreamType.HLS)
+
+
+@pytest.mark.asyncio
+async def test_content_type_is_matched_case_insensitively(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A server shouting its media type in mixed case is understood all the same."""
+    audio = _streams_audio()
+    response = _FakeConnCtx({"content-type": "Application/Vnd.Apple.Mpegurl"}, HLS_BODY)
+    monkeypatch.setattr(audio, "_connect_radio_stream", lambda *_args, **_kwargs: response)
+
+    result = await audio.resolve_radio_stream("http://radio.example.com/live")
+
+    assert result == ("http://radio.example.com/live", StreamType.HLS)
+
+
+@pytest.mark.asyncio
+async def test_trickling_playlist_body_gives_up_instead_of_stalling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A server feeding the playlist a byte at a time cannot hold up resolving."""
+    audio = _streams_audio()
+    response = _FakeConnCtx({"content-type": "audio/x-scpls"}, PLS_BODY, chunk_size=1, delay=0.02)
+    monkeypatch.setattr(audio, "_connect_radio_stream", lambda *_args, **_kwargs: response)
+    # a byte at a time at that pace runs well past the budget
+    monkeypatch.setattr("music_assistant.controllers.streams.audio.PLAYLIST_READ_TIMEOUT", 0.05)
+
+    with pytest.raises(InvalidDataError, match="Timeout"):
+        await audio.resolve_radio_stream("http://radio.example.com/station.pls")
+
+    cast("MagicMock", audio.mass).cache.set.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/streams/test_resolve_radio_stream.py
+++ b/tests/controllers/streams/test_resolve_radio_stream.py
@@ -114,6 +114,21 @@ async def test_hls_playlist_resolves_as_hls(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 @pytest.mark.asyncio
+async def test_hls_without_version_tag_still_resolves_as_hls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The HLS content type decides on its own, without a tag to recognise in the body."""
+    audio = _streams_audio()
+    body = b"#EXTM3U\n#EXT-X-TARGETDURATION:10\n#EXTINF:10.0,\nsegment0.aac\n"
+    response = _FakeConnCtx({"content-type": "application/vnd.apple.mpegurl"}, body)
+    monkeypatch.setattr(audio, "_connect_radio_stream", lambda *_args, **_kwargs: response)
+
+    result = await audio.resolve_radio_stream("http://radio.example.com/live")
+
+    assert result == ("http://radio.example.com/live", StreamType.HLS)
+
+
+@pytest.mark.asyncio
 async def test_truncated_playlist_is_not_cached_as_a_direct_stream(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -1010,19 +1010,33 @@ HLS_MASTER_PLAYLIST = (
 class _FakeContent:
     """Stand-in for the payload stream of an aiohttp response."""
 
-    def __init__(self, raw_data: bytes) -> None:
+    def __init__(self, raw_data: bytes, chunk_size: int | None = None) -> None:
         self._raw_data = raw_data
+        # like the real stream, a read hands over what has arrived so far, not the full
+        # amount asked for
+        self._chunk_size = chunk_size or max(len(raw_data), 1)
+        self._pos = 0
 
     async def read(self, n: int = -1) -> bytes:
-        return self._raw_data if n < 0 else self._raw_data[:n]
+        available = len(self._raw_data) - self._pos
+        size = available if n < 0 else min(n, self._chunk_size, available)
+        chunk = self._raw_data[self._pos : self._pos + size]
+        self._pos += size
+        return chunk
 
 
 class _FakeResponse:
     """Stand-in for the aiohttp response of a playlist fetch."""
 
-    def __init__(self, raw_data: bytes, charset: str | None, status: int = 200) -> None:
+    def __init__(
+        self,
+        raw_data: bytes,
+        charset: str | None,
+        status: int = 200,
+        chunk_size: int | None = None,
+    ) -> None:
         self.charset = charset
-        self.content = _FakeContent(raw_data)
+        self.content = _FakeContent(raw_data, chunk_size)
         self.status = status
 
     def raise_for_status(self) -> None:
@@ -1063,16 +1077,24 @@ class _FailingRequest:
         return None
 
 
-def _mass_serving(raw_data: bytes, charset: str | None = None, status: int = 200) -> Any:
+def _mass_serving(
+    raw_data: bytes,
+    charset: str | None = None,
+    status: int = 200,
+    chunk_size: int | None = None,
+) -> Any:
     """
     Return a mock mass whose http session serves the given playlist bytes.
 
     :param raw_data: Raw response body handed to fetch_playlist.
     :param charset: Charset the server declares in its Content-Type header, if any.
     :param status: HTTP status the server answers with.
+    :param chunk_size: Largest amount a single read hands over, if the body is chunked.
     """
     mass = MagicMock()
-    mass.http_session.get = MagicMock(return_value=_FakeResponse(raw_data, charset, status))
+    mass.http_session.get = MagicMock(
+        return_value=_FakeResponse(raw_data, charset, status, chunk_size)
+    )
     return mass
 
 
@@ -1240,6 +1262,18 @@ async def test_fetch_playlist_declared_charset_is_used() -> None:
     result = await fetch_playlist(mass, "http://example.com/station.m3u")
 
     assert result[0].title == "Хит"
+
+
+@pytest.mark.asyncio
+async def test_fetch_playlist_reads_a_body_that_arrives_in_chunks() -> None:
+    """A playlist spread over several chunks is parsed whole, not just its first chunk."""
+    mass = _mass_serving(
+        b"#EXTM3U\n#EXTINF:-1,Station\nhttp://stream.example.com/aac\n", chunk_size=8
+    )
+
+    result = await fetch_playlist(mass, "http://example.com/station.m3u")
+
+    assert [x.path for x in result] == ["http://stream.example.com/aac"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

When resolving a radio station, we first open the station URL to look at its headers. If that URL turns out to be a playlist file, we then downloaded the exact same URL a second time to read it.

That second download was the odd one out: every other radio request (the header probe, the ICY stream, the plain stream, the HLS fetch) goes out over the streaming session, which identifies itself as ffmpeg and tolerates the sloppy TLS setups radio servers are known for. The playlist download instead used the regular session, with the Music Assistant user agent and strict certificate checking. A station behind a filter, or with an expired certificate, could therefore answer the first request fine and reject the second one — a confusing failure that looked like a broken playlist.

The playlist is now read from the response we already have, so there is no second request to diverge.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Radio resolving reads a station's playlist from the response it already opened, instead of downloading the URL twice.
- Splits the parsing half of `fetch_playlist` into `parse_playlist_data`, so both callers share the same parsing (and the same 64 KB read cap, now a named constant).
- A playlist whose download breaks off halfway is now reported as a broken playlist, instead of the station URL being treated as an audio stream for the next three hours.
- HLS stations that only announce themselves through their content type (no `.m3u8` in the URL) are now recognised as HLS instead of being treated as a plain stream.
- Playlists are now read to the end rather than to whatever arrived first, so a larger playlist no longer silently loses entries (this also affects playlists imported through the built-in, SomaFM and Apple Music providers).
- Adds tests covering playlist unwrapping, HLS detection, chunked downloads and the truncated-download case.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
