### PR TITLE
Volume and mute controls no longer reappear on players that cannot use them

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1419,13 +1419,9 @@ class Player(ABC):
     @final
     def power_control(self) -> str:
         """Return the power control type."""
-        conf = self.mass.config.get_raw_player_config_value(self.player_id, CONF_POWER_CONTROL)
+        conf = self.__stored_control_conf(CONF_POWER_CONTROL, PlayerFeature.POWER)
         if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
-            # validate that NATIVE is still backed by an actual POWER feature.
-            # this handles graceful degradation for players (e.g. group players)
-            # that previously advertised POWER but no longer do.
-            if conf == PLAYER_CONTROL_NATIVE and PlayerFeature.POWER not in self.supported_features:
-                return PLAYER_CONTROL_NONE
+            # the control type is explicitly set in the config, use that
             return str(conf)
         if conf and (_control := self.mass.players.get_player_control(str(conf))):
             # the control type is explicitly set to a player control,
@@ -1440,12 +1436,7 @@ class Player(ABC):
     @final
     def volume_control(self) -> str:
         """Return the volume control type."""
-        conf = self.mass.config.get_raw_player_config_value(self.player_id, CONF_VOLUME_CONTROL)
-        if conf == PLAYER_CONTROL_NATIVE and not self.supports_feature(PlayerFeature.VOLUME_SET):
-            # NATIVE is only honored while the player still advertises the feature; dropping a
-            # stale value lets auto-select degrade to a protocol player (or to no control at all)
-            # instead of re-exposing a volume slider the provider can not drive.
-            conf = None
+        conf = self.__stored_control_conf(CONF_VOLUME_CONTROL, PlayerFeature.VOLUME_SET)
         if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
             # the control type is explicitly set in the config, use that
             return str(conf)
@@ -1471,12 +1462,7 @@ class Player(ABC):
     @final
     def mute_control(self) -> str:
         """Return the mute control type."""
-        conf = self.mass.config.get_raw_player_config_value(self.player_id, CONF_MUTE_CONTROL)
-        if conf == PLAYER_CONTROL_NATIVE and not self.supports_feature(PlayerFeature.VOLUME_MUTE):
-            # NATIVE is only honored while the player still advertises the feature; dropping a
-            # stale value lets auto-select degrade to a protocol player (or to no control at all)
-            # instead of re-exposing a mute button the provider can not drive.
-            conf = None
+        conf = self.__stored_control_conf(CONF_MUTE_CONTROL, PlayerFeature.VOLUME_MUTE)
         if conf == PLAYER_CONTROL_FAKE and self.volume_control == PLAYER_CONTROL_NONE:
             # fake mute is simulated by setting the volume to zero, so without a volume
             # control to drive there is no way to mute this player at all
@@ -2271,16 +2257,29 @@ class Player(ABC):
         return None
 
     @final
+    def __stored_control_conf(self, conf_key: str, feature: PlayerFeature) -> ConfigValueType:
+        """
+        Return the stored control selection, dropping a NATIVE the player can no longer back.
+
+        A NATIVE selection is only meaningful while the player advertises the matching feature.
+        Dropping a stale one makes the caller fall back to its auto-select logic instead of
+        re-exposing a control the provider can no longer drive - the resolved control is what
+        the final feature set is derived from, so an unchecked value would put the feature back.
+
+        :param conf_key: Config key holding the control selection.
+        :param feature: Feature a NATIVE selection requires the player to advertise.
+        """
+        conf = self.mass.config.get_raw_player_config_value(self.player_id, conf_key)
+        if conf == PLAYER_CONTROL_NATIVE and not self.supports_feature(feature):
+            return None
+        return conf
+
+    @final
     def __control_for_output(
         self, feature: PlayerFeature, conf_key: str, output_protocol_id: str
     ) -> str:
         """Resolve the control owning the given feature for one specific output."""
-        conf = self.mass.config.get_raw_player_config_value(self.player_id, conf_key)
-        if conf == PLAYER_CONTROL_NATIVE and not self.supports_feature(feature):
-            # same rule as the device-wide resolvers: a stored NATIVE is only honored while
-            # the player still advertises the feature, so this output falls back to whatever
-            # actually renders its audio.
-            conf = None
+        conf = self.__stored_control_conf(conf_key, feature)
         if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
             return str(conf)
         if conf and conf not in (PLAYER_CONTROL_PROTOCOL, "auto"):

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1441,6 +1441,11 @@ class Player(ABC):
     def volume_control(self) -> str:
         """Return the volume control type."""
         conf = self.mass.config.get_raw_player_config_value(self.player_id, CONF_VOLUME_CONTROL)
+        if conf == PLAYER_CONTROL_NATIVE and not self.supports_feature(PlayerFeature.VOLUME_SET):
+            # NATIVE is only honored while the player still advertises the feature; dropping a
+            # stale value lets auto-select degrade to a protocol player (or to no control at all)
+            # instead of re-exposing a volume slider the provider can not drive.
+            conf = None
         if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
             # the control type is explicitly set in the config, use that
             return str(conf)
@@ -1467,6 +1472,11 @@ class Player(ABC):
     def mute_control(self) -> str:
         """Return the mute control type."""
         conf = self.mass.config.get_raw_player_config_value(self.player_id, CONF_MUTE_CONTROL)
+        if conf == PLAYER_CONTROL_NATIVE and not self.supports_feature(PlayerFeature.VOLUME_MUTE):
+            # NATIVE is only honored while the player still advertises the feature; dropping a
+            # stale value lets auto-select degrade to a protocol player (or to no control at all)
+            # instead of re-exposing a mute button the provider can not drive.
+            conf = None
         if conf == PLAYER_CONTROL_FAKE and self.volume_control == PLAYER_CONTROL_NONE:
             # fake mute is simulated by setting the volume to zero, so without a volume
             # control to drive there is no way to mute this player at all

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -2276,6 +2276,11 @@ class Player(ABC):
     ) -> str:
         """Resolve the control owning the given feature for one specific output."""
         conf = self.mass.config.get_raw_player_config_value(self.player_id, conf_key)
+        if conf == PLAYER_CONTROL_NATIVE and not self.supports_feature(feature):
+            # same rule as the device-wide resolvers: a stored NATIVE is only honored while
+            # the player still advertises the feature, so this output falls back to whatever
+            # actually renders its audio.
+            conf = None
         if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
             return str(conf)
         if conf and conf not in (PLAYER_CONTROL_PROTOCOL, "auto"):

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -3047,6 +3047,7 @@ class TestMuteControlGuard:
         mute_control: str,
         volume_control: str,
         controls: dict[str, PlayerControl] | None = None,
+        features: set[PlayerFeature] | None = None,
     ) -> tuple[PlayerController, MockPlayer]:
         """Build a controller with a single player using the given control config."""
         mock_mass.config.get_raw_player_config_value = MagicMock(
@@ -3057,6 +3058,8 @@ class TestMuteControlGuard:
         controller = PlayerController(mock_mass)
         provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
         player = MockPlayer(provider, "player_1", "Player 1")
+        if features is not None:
+            player._attr_supported_features = features
         controller._players = {"player_1": player}
         controller._controls = controls or {}
         mock_mass.players = controller
@@ -3092,6 +3095,8 @@ class TestMuteControlGuard:
             mock_mass,
             mute_control=PLAYER_CONTROL_NATIVE,
             volume_control=PLAYER_CONTROL_NONE,
+            # native mute is only honored while the player advertises the feature
+            features={PlayerFeature.VOLUME_MUTE},
         )
         volume_mute = AsyncMock()
         player.volume_mute = volume_mute  # type: ignore[method-assign]

--- a/tests/models/test_player_controls.py
+++ b/tests/models/test_player_controls.py
@@ -751,6 +751,34 @@ class TestControlForOutput:
         _link_protocols(player, [_make_protocol_link("proto_a")])
         assert player.volume_control_for_output("proto_a") == PLAYER_CONTROL_NATIVE
 
+    def test_stale_native_degrades_to_named_output(self, mock_mass: MagicMock) -> None:
+        """A stored NATIVE the player can no longer back hands the output to its own protocol."""
+        proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_SET})
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": proto_a})
+        )
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect({CONF_VOLUME_CONTROL: PLAYER_CONTROL_NATIVE})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(player, [_make_protocol_link("proto_a")])
+        assert player.volume_control_for_output("proto_a") == "proto_a"
+        # the device-wide resolver must agree, otherwise the two disagree on the same config
+        assert player.volume_control == "proto_a"
+
+    def test_stale_native_mute_degrades_to_named_output(self, mock_mass: MagicMock) -> None:
+        """The mute resolver applies the same stale-NATIVE rule as the volume one."""
+        proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_MUTE})
+        mock_mass.players.get_player = MagicMock(
+            side_effect=self._get_player_lookup({"proto_a": proto_a})
+        )
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect({CONF_MUTE_CONTROL: PLAYER_CONTROL_NATIVE})
+        )
+        player = _create_player(mock_mass)
+        _link_protocols(player, [_make_protocol_link("proto_a")])
+        assert player.mute_control_for_output("proto_a") == "proto_a"
+
     def test_explicit_config_wins(self, mock_mass: MagicMock) -> None:
         """An explicitly configured control is a device-wide statement, so it still wins."""
         proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.VOLUME_SET})

--- a/tests/models/test_player_controls.py
+++ b/tests/models/test_player_controls.py
@@ -244,8 +244,29 @@ class TestVolumeControlExplicitConfig:
         mock_mass.config.get_raw_player_config_value = MagicMock(
             side_effect=_make_config_side_effect({CONF_VOLUME_CONTROL: PLAYER_CONTROL_NATIVE})
         )
-        player = _create_player(mock_mass)
+        # NATIVE control requires the player to actually advertise VOLUME_SET —
+        # otherwise the getter drops the stale value and falls back to auto-select.
+        player = _create_player(mock_mass, features={PlayerFeature.VOLUME_SET})
         assert player.volume_control == PLAYER_CONTROL_NATIVE
+
+    def test_explicit_native_degrades_when_feature_missing(self, mock_mass: MagicMock) -> None:
+        """Stale NATIVE config falls back to NONE when the player no longer advertises VOLUME_SET."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect({CONF_VOLUME_CONTROL: PLAYER_CONTROL_NATIVE})
+        )
+        player = _create_player(mock_mass)
+        assert player.volume_control == PLAYER_CONTROL_NONE
+
+    def test_explicit_native_degrades_to_protocol_player(self, mock_mass: MagicMock) -> None:
+        """Stale NATIVE config degrades to a protocol player that can drive the volume."""
+        protocol = _create_protocol_player(mock_mass, "proto_vol", {PlayerFeature.VOLUME_SET})
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect({CONF_VOLUME_CONTROL: PLAYER_CONTROL_NATIVE})
+        )
+        mock_mass.players.get_player = MagicMock(return_value=protocol)
+        player = _create_player(mock_mass)
+        _link_protocols(player, [_make_protocol_link("proto_vol")])
+        assert player.volume_control == "proto_vol"
 
     def test_explicit_none(self, mock_mass: MagicMock) -> None:
         """Volume control returns none even with native support."""
@@ -298,8 +319,29 @@ class TestMuteControlExplicitConfig:
         mock_mass.config.get_raw_player_config_value = MagicMock(
             side_effect=_make_config_side_effect({CONF_MUTE_CONTROL: PLAYER_CONTROL_NATIVE})
         )
-        player = _create_player(mock_mass)
+        # NATIVE control requires the player to actually advertise VOLUME_MUTE —
+        # otherwise the getter drops the stale value and falls back to auto-select.
+        player = _create_player(mock_mass, features={PlayerFeature.VOLUME_MUTE})
         assert player.mute_control == PLAYER_CONTROL_NATIVE
+
+    def test_explicit_native_degrades_when_feature_missing(self, mock_mass: MagicMock) -> None:
+        """Stale NATIVE config falls back to NONE when the player no longer advertises the feature."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect({CONF_MUTE_CONTROL: PLAYER_CONTROL_NATIVE})
+        )
+        player = _create_player(mock_mass)
+        assert player.mute_control == PLAYER_CONTROL_NONE
+
+    def test_explicit_native_degrades_to_protocol_player(self, mock_mass: MagicMock) -> None:
+        """Stale NATIVE config degrades to a protocol player that can drive the mute."""
+        protocol = _create_protocol_player(mock_mass, "proto_mute", {PlayerFeature.VOLUME_MUTE})
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect({CONF_MUTE_CONTROL: PLAYER_CONTROL_NATIVE})
+        )
+        mock_mass.players.get_player = MagicMock(return_value=protocol)
+        player = _create_player(mock_mass)
+        _link_protocols(player, [_make_protocol_link("proto_mute")])
+        assert player.mute_control == "proto_mute"
 
     def test_explicit_none(self, mock_mass: MagicMock) -> None:
         """Mute control returns none when explicitly configured."""

--- a/tests/models/test_player_controls.py
+++ b/tests/models/test_player_controls.py
@@ -256,6 +256,11 @@ class TestVolumeControlExplicitConfig:
         )
         player = _create_player(mock_mass)
         assert player.volume_control == PLAYER_CONTROL_NONE
+        # the resolved control is what the final feature set is derived from, so the state has
+        # to be recalculated to prove the invalid control does not put VOLUME_SET back
+        player.set_initialized()
+        player.update_state(signal_event=False)
+        assert PlayerFeature.VOLUME_SET not in player.state.supported_features
 
     def test_explicit_native_degrades_to_protocol_player(self, mock_mass: MagicMock) -> None:
         """Stale NATIVE config degrades to a protocol player that can drive the volume."""
@@ -331,6 +336,11 @@ class TestMuteControlExplicitConfig:
         )
         player = _create_player(mock_mass)
         assert player.mute_control == PLAYER_CONTROL_NONE
+        # the resolved control is what the final feature set is derived from, so the state has
+        # to be recalculated to prove the invalid control does not put VOLUME_MUTE back
+        player.set_initialized()
+        player.update_state(signal_event=False)
+        assert PlayerFeature.VOLUME_MUTE not in player.state.supported_features
 
     def test_explicit_native_degrades_to_protocol_player(self, mock_mass: MagicMock) -> None:
         """Stale NATIVE config degrades to a protocol player that can drive the mute."""


### PR DESCRIPTION
# What does this implement/fix?

A player's volume/mute control setting can hold the value `native` even after the
provider stops advertising the matching feature (for example a Sonos Connect on
fixed line-out, or any player whose capabilities change between restarts). That
stale value was returned as-is, and because the final feature set is derived back
from the resolved control, it re-added `VOLUME_SET`/`VOLUME_MUTE` and put the
volume slider and mute button back on a player that cannot act on them.

`power_control` already guarded against this; volume and mute did not.

**Related issue (if applicable):**

- n/a (spotted while reviewing #5748)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- A stored `native` volume or mute control is ignored when the player no longer
  advertises the feature, so the control falls back to auto-select instead of
  showing a slider or mute button that does nothing.
- Auto-select can then hand the volume or mute over to a linked protocol player
  where one is available, rather than dropping the control entirely.
- Tests for both the degraded and the protocol-player fallback path.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
