### PR TITLE
Add custom image upload for media items, scoped to genres

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -119,6 +119,8 @@ DSP_IRS_DIRNAME: Final[str] = "dsp_irs"
 # impulse response ids are lowercased shortuuids, so plain lowercase alphanumerics;
 # validating against this keeps a caller-supplied id from escaping the storage dir
 DSP_IR_ID_RE: Final = re.compile(r"^[a-z0-9]+$")
+# subdirectory under the storage path holding user-uploaded custom media item images
+CUSTOM_IMAGES_DIRNAME: Final[str] = "custom_images"
 CONF_OUTPUT_CHANNELS: Final[str] = "output_channels"
 CONF_FLOW_MODE: Final[str] = "flow_mode"
 CONF_FLOW_MODE_SAMPLE_RATE: Final[str] = "flow_mode_sample_rate"

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import logging
+import os
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
 from contextlib import suppress
@@ -12,6 +15,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, final, overload
 
+import aiofiles
+import shortuuid
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import (
     EventType,
@@ -23,6 +28,7 @@ from music_assistant_models.enums import (
 )
 from music_assistant_models.errors import (
     InsufficientPermissions,
+    InvalidDataError,
     MediaNotFoundError,
     ProviderUnavailableError,
 )
@@ -42,6 +48,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.constants import (
+    CUSTOM_IMAGES_DIRNAME,
     DB_TABLE_AUDIO_ANALYSIS,
     DB_TABLE_EXTERNAL_ID_LOOKUP,
     DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
@@ -58,7 +65,9 @@ from music_assistant.helpers.collections import (
 )
 from music_assistant.helpers.compare import compare_media_item
 from music_assistant.helpers.database import UNSET
+from music_assistant.helpers.images import MAX_CUSTOM_IMAGE_BYTES, validate_custom_image
 from music_assistant.helpers.json import json_loads, serialize_to_json
+from music_assistant.helpers.security import is_safe_path
 from music_assistant.helpers.util import guard_single_request, parse_optional_bool
 
 if TYPE_CHECKING:
@@ -210,7 +219,18 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             self.remove_item_from_library,
             required_scope=Scope.LIBRARY_MANAGE,
         )
+        self.mass.register_api_command(
+            f"music/{api_base}/set_image",
+            self.set_item_image,
+            required_scope=Scope.LIBRARY_MANAGE,
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/remove_image",
+            self.remove_item_image,
+            required_scope=Scope.LIBRARY_MANAGE,
+        )
         self._db_add_lock = asyncio.Lock()
+        self._custom_image_lock = asyncio.Lock()
 
     @property
     def translation_owner(self) -> str:
@@ -368,8 +388,123 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         # drop cached artwork for the removed item
         for img in library_item.metadata.images or []:
             await self.mass.metadata.invalidate_image_cache(img.provider, img.path)
+            if self._is_custom_image(img):
+                await self._delete_custom_image_file(img.path)
         self.mass.signal_event(EventType.MEDIA_ITEM_DELETED, library_item.uri, library_item)
         self.logger.debug("deleted item with id %s from database", db_id)
+
+    @final
+    async def set_item_image(
+        self,
+        item_id: str | int,
+        data: str,
+        file_hint: str | None = None,
+        image_type: ImageType = ImageType.THUMB,
+    ) -> ItemCls:
+        """
+        Set a custom image for a library item from base64 encoded image data.
+
+        Replaces any existing image(s) of the given type on the item. Only raster
+        formats (png/jpg/webp) are accepted; the format is detected from the actual
+        content.
+
+        :param item_id: The library (database) id of the item.
+        :param data: Base64 encoded image bytes, optionally as a data-URL.
+        :param file_hint: Optional original filename, only used in error messages.
+        :param image_type: The image type to set (defaults to thumb).
+        """
+        db_id = int(item_id)
+        # a data-URL prefix is allowed for convenience (that's what a browser
+        # FileReader produces); only the base64 payload after the comma is used
+        if data.startswith("data:"):
+            data = data.split(",", 1)[-1]
+        # base64 inflates by roughly 4/3, so bound the encoded input before decoding
+        # to cap memory, then confirm the decoded size against the real limit
+        if len(data) > MAX_CUSTOM_IMAGE_BYTES // 3 * 4 + 8:
+            raise InvalidDataError("Image exceeds the size limit")
+        try:
+            raw = base64.b64decode(data, validate=True)
+        except binascii.Error as err:
+            raise InvalidDataError("Image data is not valid base64") from err
+        try:
+            ext = await asyncio.to_thread(validate_custom_image, raw)
+        except InvalidDataError as err:
+            if file_hint:
+                raise InvalidDataError(f"{err.args[0]} (file: {file_hint})") from err
+            raise
+
+        async with self._custom_image_lock:
+            metadata = await self._get_raw_metadata(db_id)
+            old_images = [img for img in metadata.images or [] if img.type == image_type]
+            rel_path = await self._write_custom_image_file(raw, ext, db_id)
+            new_image = MediaItemImage(
+                type=image_type,
+                path=rel_path,
+                provider="builtin",
+                remotely_accessible=False,
+            )
+            metadata.images = UniqueList(
+                [*(img for img in metadata.images or [] if img.type != image_type), new_image]
+            )
+            try:
+                await self._persist_metadata(db_id, metadata)
+            except BaseException:
+                # drop the just-written file so a failed update leaves no orphan
+                await self._delete_custom_image_file(rel_path)
+                raise
+            for old_img in old_images:
+                await self.mass.metadata.invalidate_image_cache(old_img.provider, old_img.path)
+                if self._is_custom_image(old_img):
+                    await self._delete_custom_image_file(old_img.path)
+
+        library_item = await self.get_library_item(db_id)
+        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, library_item.uri, library_item)
+        return library_item
+
+    @final
+    async def remove_item_image(
+        self, item_id: str | int, image_type: ImageType = ImageType.THUMB
+    ) -> ItemCls:
+        """
+        Remove a previously set custom image from a library item.
+
+        Restores the item's default image of that type when one exists (such as the
+        builtin genre icons). A no-op when the item has no custom image of that type.
+
+        :param item_id: The library (database) id of the item.
+        :param image_type: The image type to remove (defaults to thumb).
+        """
+        db_id = int(item_id)
+        async with self._custom_image_lock:
+            metadata = await self._get_raw_metadata(db_id)
+            custom_images = [
+                img
+                for img in metadata.images or []
+                if img.type == image_type and self._is_custom_image(img)
+            ]
+            if not custom_images:
+                return await self.get_library_item(db_id)
+            library_item = await self.get_library_item(db_id)
+            default_images: list[MediaItemImage] = list(
+                self._get_default_images(library_item, image_type) or []
+            )
+            metadata.images = (
+                UniqueList(
+                    [
+                        *(img for img in metadata.images or [] if img.type != image_type),
+                        *default_images,
+                    ]
+                )
+                or None
+            )
+            await self._persist_metadata(db_id, metadata)
+            for old_img in custom_images:
+                await self.mass.metadata.invalidate_image_cache(old_img.provider, old_img.path)
+                await self._delete_custom_image_file(old_img.path)
+
+        library_item = await self.get_library_item(db_id)
+        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, library_item.uri, library_item)
+        return library_item
 
     async def library_count(self, favorite_only: bool = False) -> int:
         """
@@ -1949,6 +2084,73 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             {"metadata": serialize_to_json(metadata)},
         )
         return True
+
+    def _get_default_images(
+        self, item: ItemCls, image_type: ImageType
+    ) -> UniqueList[MediaItemImage] | None:
+        """
+        Return the default image(s) of the given type for this item, if any.
+
+        Override in a subclass when the media type has builtin default artwork
+        (such as the curated genre icons) that should be restored when a custom
+        image is removed.
+        """
+        return None
+
+    def _is_custom_image(self, img: MediaItemImage) -> bool:
+        """Return True when the image is a user-uploaded custom image."""
+        return img.provider == "builtin" and img.path.startswith(f"{CUSTOM_IMAGES_DIRNAME}/")
+
+    def _custom_images_dir(self) -> str:
+        """Return the directory holding user-uploaded custom images."""
+        return os.path.join(self.mass.storage_path, CUSTOM_IMAGES_DIRNAME)
+
+    async def _get_raw_metadata(self, db_id: int) -> MediaItemMetadata:
+        """
+        Return the item's metadata parsed straight from the db record.
+
+        Reading the raw column (instead of via get_library_item) avoids persisting
+        images that are only injected at read time, such as the album thumb that
+        gets merged into a track's images.
+        """
+        db_row = await self.mass.music.database.get_row(self.db_table, {"item_id": db_id})
+        if not db_row:
+            raise MediaNotFoundError(f"{self.media_type.value} with id {db_id} not found")
+        if raw_metadata := db_row["metadata"]:
+            return MediaItemMetadata.from_dict(json_loads(raw_metadata))
+        return MediaItemMetadata()
+
+    async def _write_custom_image_file(self, raw: bytes, ext: str, db_id: int) -> str:
+        """
+        Write uploaded image bytes to the custom images dir and return the relative path.
+
+        The filename is fully server-generated with a random suffix per upload, so a
+        replaced image gets a new path (and thus a new imageproxy id), which keeps
+        stale cached variants from ever being served.
+        """
+        images_dir = self._custom_images_dir()
+        await asyncio.to_thread(os.makedirs, images_dir, exist_ok=True)
+        filename = f"{self.media_type.value}.{db_id}.{shortuuid.random(8).lower()}.{ext}"
+        async with aiofiles.open(os.path.join(images_dir, filename), "wb") as outfile:
+            await outfile.write(raw)
+        return f"{CUSTOM_IMAGES_DIRNAME}/{filename}"
+
+    async def _delete_custom_image_file(self, rel_path: str) -> None:
+        """Delete a stored custom image file by its (metadata) relative path."""
+        images_dir = self._custom_images_dir()
+        filename = rel_path.removeprefix(f"{CUSTOM_IMAGES_DIRNAME}/")
+        if not is_safe_path(filename, images_dir):
+            return
+        with suppress(FileNotFoundError):
+            await asyncio.to_thread(os.remove, os.path.join(images_dir, filename))
+
+    async def _persist_metadata(self, db_id: int, metadata: MediaItemMetadata) -> None:
+        """Write the given metadata directly to the item's db record."""
+        await self.mass.music.database.update(
+            self.db_table,
+            {"item_id": db_id},
+            {"metadata": serialize_to_json(metadata)},
+        )
 
     def _sync_details_query_parts(self) -> tuple[str, str, dict[str, Any]]:
         """

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -27,6 +27,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.constants import (
+    CUSTOM_IMAGES_DIRNAME,
     DB_TABLE_ALBUM_TRACKS,
     DB_TABLE_ALBUMS,
     DB_TABLE_ARTISTS,
@@ -677,6 +678,23 @@ class GenreController(MediaControllerBase[Genre]):
         """
         if full_restore:
             self.logger.warning("Performing FULL restore - deleting all existing genres")
+            # the table wipe below would orphan any user-uploaded custom images,
+            # so delete their files (and cached variants) first
+            rows = await self.mass.music.database.get_rows_from_query(
+                f"SELECT metadata FROM {DB_TABLE_GENRES} "
+                f"WHERE metadata LIKE '%{CUSTOM_IMAGES_DIRNAME}/%'",
+                limit=0,
+            )
+            for row in rows:
+                metadata = json.loads(row["metadata"]) if row["metadata"] else {}
+                for img in metadata.get("images") or []:
+                    img_path = img.get("path") or ""
+                    if not img_path.startswith(f"{CUSTOM_IMAGES_DIRNAME}/"):
+                        continue
+                    await self.mass.metadata.invalidate_image_cache(
+                        img.get("provider") or "builtin", img_path
+                    )
+                    await self._delete_custom_image_file(img_path)
             await self.mass.music.database.delete(DB_TABLE_GENRE_MEDIA_ITEM_MAPPING)
             await self.mass.music.database.delete(DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION)
             await self.mass.music.database.delete(
@@ -1222,6 +1240,16 @@ class GenreController(MediaControllerBase[Genre]):
             ),
             "last_scan_mapped": self._last_scan_mapped,
         }
+
+    def _get_default_images(
+        self, item: Genre, image_type: ImageType
+    ) -> UniqueList[MediaItemImage] | None:
+        """Return the builtin genre icon (if any) as the default thumb image."""
+        if image_type != ImageType.THUMB:
+            return None
+        if metadata := self._get_genre_icon_metadata(item.translation_key, item.content_type):
+            return metadata.images
+        return None
 
     @staticmethod
     def _get_genre_icon_metadata(
@@ -1846,8 +1874,14 @@ class GenreController(MediaControllerBase[Genre]):
                     await self._ensure_aliases(genre_id, all_aliases)
                     if icon_metadata is not None:
                         current_md = json.loads(rows[0]["metadata"]) if rows[0]["metadata"] else {}
+                        current_images = current_md.get("images") or []
+                        # never clobber a user-uploaded custom image with the builtin icon
+                        has_custom_image = any(
+                            (img.get("path") or "").startswith(f"{CUSTOM_IMAGES_DIRNAME}/")
+                            for img in current_images
+                        )
                         fresh_images = icon_metadata.to_dict().get("images")
-                        if current_md.get("images") != fresh_images:
+                        if not has_custom_image and current_md.get("images") != fresh_images:
                             current_md["images"] = fresh_images
                             await self.mass.music.database.update(
                                 DB_TABLE_GENRES,

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -25,6 +25,7 @@ import aiofiles.os
 from aiohttp.client_exceptions import ClientError
 from music_assistant_models.enums import ProviderIconVariant
 from music_assistant_models.errors import (
+    InvalidDataError,
     MediaNotFoundError,
     MusicAssistantError,
     ProviderUnavailableError,
@@ -87,6 +88,12 @@ _MAX_IMAGEPROXY_RECURSION_DEPTH = 5
 _PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 _JPEG_MAGIC = b"\xff\xd8\xff"
 
+# User-uploaded custom media item images: size cap plus overrides for Pillow
+# format names whose canonical file extension differs from format.lower()
+# (MPO is the multi-picture jpeg variant many phone cameras produce).
+MAX_CUSTOM_IMAGE_BYTES = 10 * 1024 * 1024
+_CUSTOM_IMAGE_FORMAT_EXTENSIONS: dict[str, str] = {"JPEG": "jpg", "MPO": "jpg"}
+
 
 def is_svg_data(data: bytes) -> bool:
     """Return True when the given bytes appear to be an SVG image."""
@@ -114,6 +121,32 @@ def detect_image_content_format(data: bytes) -> str | None:
     if is_svg_data(data):
         return "svg"
     return None
+
+
+def validate_custom_image(data: bytes) -> str:
+    """
+    Validate user-uploaded image bytes and return the canonical file extension.
+
+    Any raster format Pillow can decode is accepted (which guarantees the
+    imageproxy can thumbnail it later); SVG is rejected. The format is detected
+    from the actual content, never from a client-supplied hint. This is blocking
+    CPU work, so call it from an executor thread.
+
+    :param data: Raw image bytes to validate.
+    """
+    if len(data) > MAX_CUSTOM_IMAGE_BYTES:
+        raise InvalidDataError("Image exceeds the size limit")
+    if is_svg_data(data):
+        raise InvalidDataError("SVG images are not supported for custom images")
+    try:
+        with Image.open(BytesIO(data)) as img:
+            image_format = img.format
+            img.verify()
+    except (UnidentifiedImageError, Image.DecompressionBombError, OSError, ValueError) as err:
+        raise InvalidDataError("Uploaded data is not a valid image") from err
+    if not image_format:
+        raise InvalidDataError("Uploaded data is not a valid image")
+    return _CUSTOM_IMAGE_FORMAT_EXTENSIONS.get(image_format, image_format.lower())
 
 
 def create_thumb_hash(provider: str, path_or_url: str) -> str:

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -43,6 +43,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.constants import (
+    CUSTOM_IMAGES_DIRNAME,
     GENRE_ICONS_DIR_NAME,
     MASS_LOGO,
     PLAYLIST_MEDIA_TYPES,
@@ -754,6 +755,15 @@ class BuiltinProvider(MusicProvider):
             if not is_safe_path(icon_name, str(icons_base)):
                 raise FileNotFoundError(f"Invalid genre icon reference: {path}")
             return str(icons_base.joinpath(icon_name))
+        if path.startswith(f"{CUSTOM_IMAGES_DIRNAME}/"):
+            file_name = path[len(CUSTOM_IMAGES_DIRNAME) + 1 :]
+            images_base = os.path.join(self.mass.storage_path, CUSTOM_IMAGES_DIRNAME)
+            if not is_safe_path(file_name, images_base):
+                raise FileNotFoundError(f"Invalid custom image reference: {path}")
+            # return raw bytes (instead of the local path) so the format is not
+            # restricted by the extension allowlist of the local file handling
+            async with aiofiles.open(os.path.join(images_base, file_name), "rb") as imgfile:
+                return cast("bytes", await imgfile.read())
         return path
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:

--- a/tests/controllers/music/test_custom_item_images.py
+++ b/tests/controllers/music/test_custom_item_images.py
@@ -1,0 +1,196 @@
+"""Tests for the generic custom item image commands on the media controller base."""
+
+from __future__ import annotations
+
+import base64
+import json
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import ImageType
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
+from music_assistant_models.media_items import (
+    MediaItemImage,
+    MediaItemMetadata,
+    ProviderMapping,
+    Track,
+)
+from music_assistant_models.unique_list import UniqueList
+from PIL import Image
+
+from music_assistant.constants import CUSTOM_IMAGES_DIRNAME
+from music_assistant.controllers.music.media.tracks import TracksController
+from music_assistant.helpers.json import serialize_to_json
+
+
+def _png_base64() -> str:
+    """Return a minimal valid PNG as base64 string."""
+    buf = BytesIO()
+    Image.new("RGB", (4, 4), "red").save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def _image(
+    path: str, image_type: ImageType = ImageType.THUMB, provider: str = "builtin"
+) -> MediaItemImage:
+    """Build a MediaItemImage for the given path."""
+    return MediaItemImage(type=image_type, path=path, provider=provider, remotely_accessible=False)
+
+
+def _track(images: list[MediaItemImage]) -> Track:
+    """Build a minimal library Track carrying the given images."""
+    return Track(
+        item_id="1",
+        provider="library",
+        name="Test Track",
+        provider_mappings={
+            ProviderMapping(item_id="1", provider_domain="test", provider_instance="test--1")
+        },
+        metadata=MediaItemMetadata(images=UniqueList(images) or None),
+    )
+
+
+def _controller(tmp_path: Path, images: list[MediaItemImage]) -> tuple[TracksController, MagicMock]:
+    """Build a TracksController with mocked mass whose db item carries the given images."""
+    mass = MagicMock()
+    mass.storage_path = str(tmp_path)
+    mass.music.database = AsyncMock()
+    mass.music.database.deferred_commit = MagicMock()
+    metadata = MediaItemMetadata(images=UniqueList(images) or None)
+    mass.music.database.get_row = AsyncMock(return_value={"metadata": serialize_to_json(metadata)})
+    mass.metadata.invalidate_image_cache = AsyncMock()
+    mass.get_provider.return_value = None
+    controller = TracksController(mass)
+    controller.get_library_item = AsyncMock(return_value=_track(images))  # type: ignore[method-assign]
+    return controller, mass
+
+
+def _stored_images(mass: MagicMock) -> list[dict[str, str]]:
+    """Return the images list from the metadata persisted to the db."""
+    update_call = mass.music.database.update.await_args
+    metadata = json.loads(update_call.args[2]["metadata"])
+    return metadata.get("images") or []
+
+
+async def test_set_image_stores_file_and_updates_metadata(tmp_path: Path) -> None:
+    """A valid upload lands on disk and replaces the thumb in the stored metadata."""
+    controller, mass = _controller(tmp_path, [_image("Artist/cover.jpg", provider="test--1")])
+    await controller.set_item_image("1", _png_base64())
+    images = _stored_images(mass)
+    assert len(images) == 1
+    assert images[0]["path"].startswith(f"{CUSTOM_IMAGES_DIRNAME}/track.1.")
+    assert images[0]["path"].endswith(".png")
+    assert images[0]["provider"] == "builtin"
+    stored_file = tmp_path / images[0]["path"]
+    assert stored_file.is_file()
+    # the replaced thumb got its cached variants invalidated
+    mass.metadata.invalidate_image_cache.assert_awaited_once_with("test--1", "Artist/cover.jpg")
+
+
+async def test_set_image_keeps_other_image_types(tmp_path: Path) -> None:
+    """Only images of the uploaded type are replaced; other types are untouched."""
+    fanart = _image("Artist/fanart.jpg", image_type=ImageType.FANART, provider="test--1")
+    controller, mass = _controller(tmp_path, [fanart])
+    await controller.set_item_image("1", _png_base64())
+    images = _stored_images(mass)
+    assert len(images) == 2
+    paths_by_type = {img["type"]: img["path"] for img in images}
+    assert paths_by_type["fanart"] == "Artist/fanart.jpg"
+    assert paths_by_type["thumb"].startswith(f"{CUSTOM_IMAGES_DIRNAME}/")
+
+
+async def test_set_image_replaces_previous_custom_image(tmp_path: Path) -> None:
+    """Replacing a custom image deletes the previous file from disk."""
+    images_dir = tmp_path / CUSTOM_IMAGES_DIRNAME
+    images_dir.mkdir()
+    old_file = images_dir / "track.1.oldsuffix.png"
+    old_file.write_bytes(b"old")
+    controller, mass = _controller(
+        tmp_path, [_image(f"{CUSTOM_IMAGES_DIRNAME}/track.1.oldsuffix.png")]
+    )
+    await controller.set_item_image("1", _png_base64())
+    assert not old_file.exists()
+    mass.metadata.invalidate_image_cache.assert_awaited_once_with(
+        "builtin", f"{CUSTOM_IMAGES_DIRNAME}/track.1.oldsuffix.png"
+    )
+    new_files = list(images_dir.iterdir())
+    assert len(new_files) == 1
+    assert new_files[0].name.startswith("track.1.")
+
+
+async def test_set_image_accepts_data_url(tmp_path: Path) -> None:
+    """A browser-style data-URL prefix is stripped before decoding."""
+    controller, mass = _controller(tmp_path, [])
+    await controller.set_item_image("1", f"data:image/png;base64,{_png_base64()}")
+    assert _stored_images(mass)[0]["path"].startswith(f"{CUSTOM_IMAGES_DIRNAME}/")
+
+
+async def test_set_image_invalid_base64_rejected(tmp_path: Path) -> None:
+    """Garbage base64 raises InvalidDataError and leaves no file behind."""
+    controller, _mass = _controller(tmp_path, [])
+    with pytest.raises(InvalidDataError):
+        await controller.set_item_image("1", "not-valid-base64!!!")
+    assert not (tmp_path / CUSTOM_IMAGES_DIRNAME).exists()
+
+
+async def test_set_image_oversized_rejected(tmp_path: Path) -> None:
+    """An upload above the size limit is rejected before decoding."""
+    controller, _mass = _controller(tmp_path, [])
+    oversized = "A" * (10 * 1024 * 1024 * 4 // 3 + 100)
+    with pytest.raises(InvalidDataError):
+        await controller.set_item_image("1", oversized)
+    assert not (tmp_path / CUSTOM_IMAGES_DIRNAME).exists()
+
+
+async def test_set_image_unsupported_format_rejected(tmp_path: Path) -> None:
+    """A non-raster upload (svg) is rejected and leaves no file behind."""
+    controller, _mass = _controller(tmp_path, [])
+    svg = base64.b64encode(b"<svg xmlns='http://www.w3.org/2000/svg'/>").decode()
+    with pytest.raises(InvalidDataError):
+        await controller.set_item_image("1", svg)
+    assert not (tmp_path / CUSTOM_IMAGES_DIRNAME).exists()
+
+
+async def test_set_image_unknown_item(tmp_path: Path) -> None:
+    """An unknown item id raises MediaNotFoundError and leaves no file behind."""
+    controller, mass = _controller(tmp_path, [])
+    mass.music.database.get_row = AsyncMock(return_value=None)
+    with pytest.raises(MediaNotFoundError):
+        await controller.set_item_image("42", _png_base64())
+    assert not (tmp_path / CUSTOM_IMAGES_DIRNAME).exists()
+
+
+async def test_remove_image_without_custom_image_is_noop(tmp_path: Path) -> None:
+    """Removing when no custom image exists changes nothing."""
+    controller, mass = _controller(tmp_path, [_image("Artist/cover.jpg", provider="test--1")])
+    await controller.remove_item_image("1")
+    mass.music.database.update.assert_not_awaited()
+    mass.metadata.invalidate_image_cache.assert_not_awaited()
+
+
+async def test_remove_image_deletes_file(tmp_path: Path) -> None:
+    """Removing a custom image deletes its file and drops it from metadata."""
+    images_dir = tmp_path / CUSTOM_IMAGES_DIRNAME
+    images_dir.mkdir()
+    custom_file = images_dir / "track.1.somesuffix.png"
+    custom_file.write_bytes(b"img")
+    custom_img = _image(f"{CUSTOM_IMAGES_DIRNAME}/track.1.somesuffix.png")
+    controller, mass = _controller(tmp_path, [custom_img])
+    await controller.remove_item_image("1")
+    assert not custom_file.exists()
+    assert _stored_images(mass) == []
+    mass.metadata.invalidate_image_cache.assert_awaited_once_with("builtin", custom_img.path)
+
+
+async def test_hard_delete_removes_custom_image_file(tmp_path: Path) -> None:
+    """Deleting a library item cleans up its custom image file."""
+    images_dir = tmp_path / CUSTOM_IMAGES_DIRNAME
+    images_dir.mkdir()
+    custom_file = images_dir / "track.1.somesuffix.png"
+    custom_file.write_bytes(b"img")
+    custom_img = _image(f"{CUSTOM_IMAGES_DIRNAME}/track.1.somesuffix.png")
+    controller, _mass = _controller(tmp_path, [custom_img])
+    await controller.remove_item_from_library("1", recursive=False)
+    assert not custom_file.exists()

--- a/tests/controllers/music/test_genres.py
+++ b/tests/controllers/music/test_genres.py
@@ -8,7 +8,9 @@ temporary directory.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
+from io import BytesIO
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
@@ -27,8 +29,10 @@ from music_assistant_models.media_items import (
     Track,
 )
 from music_assistant_models.unique_list import UniqueList
+from PIL import Image as PILImage
 
 from music_assistant.constants import (
+    CUSTOM_IMAGES_DIRNAME,
     DB_TABLE_ALBUM_TRACKS,
     DB_TABLE_ALBUMS,
     DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
@@ -2876,3 +2880,102 @@ class TestGenreIconMetadata:
             "music_assistant.controllers.music.media.genres.RESOURCES_DIR", tmp_path
         )
         assert GenreController._get_genre_icon_metadata("nope", MediaType.PODCAST) is None
+
+
+# ===================================================================
+# Custom genre images (user uploaded)
+# ===================================================================
+
+
+def _png_base64() -> str:
+    """Return a minimal valid PNG as base64 string."""
+    buf = BytesIO()
+    PILImage.new("RGB", (4, 4), "red").save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+async def _default_genre_id(mass: MusicAssistant, translation_key: str) -> int:
+    """Return the library id of a seeded default (music) genre by translation key."""
+    row = await mass.music.database.get_row(DB_TABLE_GENRES, {"translation_key": translation_key})
+    assert row is not None
+    return int(row["item_id"])
+
+
+class TestCustomGenreImages:
+    """Tests for setting/removing user-uploaded custom genre images."""
+
+    async def test_set_custom_image_on_default_genre(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """A custom image overrides the builtin icon and lands on disk."""
+        genre_id = await _default_genre_id(mass, "blues")
+        updated = await genre_ctrl.set_item_image(genre_id, _png_base64())
+        assert updated.image is not None
+        assert updated.image.path.startswith(f"{CUSTOM_IMAGES_DIRNAME}/genre.{genre_id}.")
+        assert updated.image.path.endswith(".png")
+        assert updated.image.provider == "builtin"
+        assert (Path(mass.storage_path) / updated.image.path).is_file()
+
+    async def test_remove_restores_builtin_icon(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """Removing the custom image brings the builtin icon back and deletes the file."""
+        genre_id = await _default_genre_id(mass, "jazz")
+        updated = await genre_ctrl.set_item_image(genre_id, _png_base64())
+        assert updated.image is not None
+        custom_path = updated.image.path
+        restored = await genre_ctrl.remove_item_image(genre_id)
+        assert restored.image is not None
+        assert restored.image.path == "genres/jazz.svg"
+        assert not (Path(mass.storage_path) / custom_path).exists()
+
+    async def test_user_genre_set_then_remove_ends_imageless(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """A user-created genre has no default icon to restore."""
+        genre = await genre_ctrl.add_item_to_library(_make_genre("My Very Own Genre"))
+        updated = await genre_ctrl.set_item_image(genre.item_id, _png_base64())
+        assert updated.image is not None
+        custom_path = updated.image.path
+        removed = await genre_ctrl.remove_item_image(genre.item_id)
+        assert removed.image is None
+        assert not (Path(mass.storage_path) / custom_path).exists()
+
+    async def test_partial_restore_keeps_custom_icon(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """restore_default_genres (partial) never clobbers a custom image."""
+        genre_id = await _default_genre_id(mass, "rock")
+        updated = await genre_ctrl.set_item_image(genre_id, _png_base64())
+        assert updated.image is not None
+        custom_path = updated.image.path
+        await genre_ctrl.restore_default_genres(full_restore=False)
+        after = await genre_ctrl.get_library_item(genre_id)
+        assert after.image is not None
+        assert after.image.path == custom_path
+
+    async def test_full_restore_deletes_custom_image_file(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """A full restore wipes the genres and cleans up their custom image files."""
+        genre_id = await _default_genre_id(mass, "soul")
+        updated = await genre_ctrl.set_item_image(genre_id, _png_base64())
+        assert updated.image is not None
+        custom_file = Path(mass.storage_path) / updated.image.path
+        assert custom_file.is_file()
+        await genre_ctrl.restore_default_genres(full_restore=True)
+        assert not custom_file.exists()
+
+    async def test_soft_delete_keeps_custom_image(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """A soft-deleted genre keeps its custom image and gets it back on re-add."""
+        genre = await genre_ctrl.add_item_to_library(_make_genre("Comeback Genre"))
+        updated = await genre_ctrl.set_item_image(genre.item_id, _png_base64())
+        assert updated.image is not None
+        custom_path = updated.image.path
+        await genre_ctrl.remove_item_from_library(genre.item_id)
+        assert (Path(mass.storage_path) / custom_path).is_file()
+        restored = await genre_ctrl.add_item_to_library(_make_genre("Comeback Genre"))
+        assert restored.image is not None
+        assert restored.image.path == custom_path

--- a/tests/helpers/test_images.py
+++ b/tests/helpers/test_images.py
@@ -18,13 +18,14 @@ from aiohttp import ClientSession, web
 from aiohttp.client_exceptions import ClientError
 from aiohttp.test_utils import TestServer
 from music_assistant_models.enums import ImageType, ProviderIconVariant
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import MediaItemImage
 from PIL import Image
 
 from music_assistant.helpers import images
 from music_assistant.helpers.images import (
     _SOURCE_CACHE_TTL,
+    MAX_CUSTOM_IMAGE_BYTES,
     create_thumb_hash,
     detect_provider_icons,
     get_image_data,
@@ -32,6 +33,7 @@ from music_assistant.helpers.images import (
     get_image_thumb_path,
     invalidate_cached_image,
     load_provider_icon,
+    validate_custom_image,
 )
 from music_assistant.models.metadata_provider import MetadataProvider
 from music_assistant.models.music_provider import MusicProvider
@@ -715,3 +717,43 @@ async def test_detect_provider_icons_png_and_variants(tmp_path: Path) -> None:
 async def test_detect_provider_icons_none(tmp_path: Path) -> None:
     """Test detecting icons in an empty directory returns empty dict."""
     assert await detect_provider_icons(str(tmp_path)) == {}
+
+
+def _raster_bytes(image_format: str) -> bytes:
+    """Return a minimal valid raster image in the given Pillow format."""
+    buf = BytesIO()
+    Image.new("RGB", (4, 4), "blue").save(buf, format=image_format)
+    return buf.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("image_format", "expected_ext"),
+    [("PNG", "png"), ("JPEG", "jpg"), ("WEBP", "webp"), ("GIF", "gif"), ("BMP", "bmp")],
+)
+def test_validate_custom_image_accepts_raster(image_format: str, expected_ext: str) -> None:
+    """Any Pillow-decodable raster format validates and maps to its canonical extension."""
+    assert validate_custom_image(_raster_bytes(image_format)) == expected_ext
+
+
+def test_validate_custom_image_rejects_svg() -> None:
+    """SVG uploads are rejected with a clear error."""
+    with pytest.raises(InvalidDataError, match="SVG"):
+        validate_custom_image(b"<svg xmlns='http://www.w3.org/2000/svg'></svg>")
+
+
+def test_validate_custom_image_rejects_garbage() -> None:
+    """Random bytes are not a valid image."""
+    with pytest.raises(InvalidDataError, match="not a valid image"):
+        validate_custom_image(b"certainly not an image")
+
+
+def test_validate_custom_image_rejects_oversized() -> None:
+    """Uploads over the byte limit are rejected before decoding."""
+    with pytest.raises(InvalidDataError, match="size limit"):
+        validate_custom_image(b"x" * (MAX_CUSTOM_IMAGE_BYTES + 1))
+
+
+def test_validate_custom_image_rejects_truncated() -> None:
+    """A truncated raster file fails validation."""
+    with pytest.raises(InvalidDataError):
+        validate_custom_image(_raster_bytes("PNG")[:20])

--- a/tests/providers/builtin/test_resolve_image.py
+++ b/tests/providers/builtin/test_resolve_image.py
@@ -1,0 +1,46 @@
+"""Tests for the builtin provider's resolve_image path handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from music_assistant.constants import CUSTOM_IMAGES_DIRNAME
+from music_assistant.providers.builtin import BuiltinProvider
+
+
+def _provider(tmp_path: Path) -> BuiltinProvider:
+    """Build a BuiltinProvider stub with resolve_image bound and a tmp storage path."""
+    provider = MagicMock()
+    provider.mass.storage_path = str(tmp_path)
+    provider.resolve_image = BuiltinProvider.resolve_image.__get__(provider, BuiltinProvider)
+    return provider
+
+
+async def test_resolve_custom_image_returns_bytes(tmp_path: Path) -> None:
+    """A stored custom image resolves to its raw file bytes."""
+    images_dir = tmp_path / CUSTOM_IMAGES_DIRNAME
+    images_dir.mkdir()
+    (images_dir / "genre.1.abcd1234.webp").write_bytes(b"webp-bytes")
+    provider = _provider(tmp_path)
+    result = await provider.resolve_image(f"{CUSTOM_IMAGES_DIRNAME}/genre.1.abcd1234.webp")
+    assert result == b"webp-bytes"
+
+
+async def test_resolve_custom_image_blocks_traversal(tmp_path: Path) -> None:
+    """A traversal attempt outside the custom images dir is rejected."""
+    images_dir = tmp_path / CUSTOM_IMAGES_DIRNAME
+    images_dir.mkdir()
+    (tmp_path / "secret.txt").write_text("secret")
+    provider = _provider(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        await provider.resolve_image(f"{CUSTOM_IMAGES_DIRNAME}/../secret.txt")
+
+
+async def test_resolve_missing_custom_image_raises(tmp_path: Path) -> None:
+    """A dangling custom image reference raises FileNotFoundError."""
+    provider = _provider(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        await provider.resolve_image(f"{CUSTOM_IMAGES_DIRNAME}/genre.1.gone.png")


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Adds `music/<type>s/set_image` and `remove_image` API commands generically on the media controller base, so any media type can get user-uploaded custom artwork. Wired up for genres first: overrides the builtin icon, or adds one to genres that have none. Images are base64-uploaded, validated as a decodable raster (SVG rejected), and stored under `storage_path/custom_images/`. Removing restores the default icon where one exists.

Frontend PR: https://github.com/music-assistant/frontend/pull/2539

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
