### PR TITLE
Refresh CUE metadata after encoding fixes

### DIFF
--- a/music_assistant/providers/filesystem_cloud/base.py
+++ b/music_assistant/providers/filesystem_cloud/base.py
@@ -314,7 +314,7 @@ class CloudFileSystemProvider(LocalFileSystemProvider):
         self,
         *,
         file_checksums: dict[str, str],
-        cue_file_checksums: dict[str, str],
+        cue_file_checksums: dict[str, set[str]],
         cur_filenames: set[str],
         items_to_process: list[tuple[FileSystemItem, str | None]],
         unchanged_cue_items: list[FileSystemItem],

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -470,12 +470,12 @@ class LocalFileSystemProvider(MusicProvider):
         for db_row in await self.mass.music.database.get_rows_from_query(query, limit=0):
             file_checksums[db_row["provider_item_id"]] = str(db_row["details"])
         # provider_mappings stores synthetic per-track ids for CUE sheets, not the
-        # CUE path, so derive a path-keyed checksum map for the scan classifier
-        cue_file_checksums: dict[str, str] = {}
+        # CUE path, so collect every track checksum per path for the scan classifier
+        cue_file_checksums: dict[str, set[str]] = {}
         for prov_item_id, checksum in file_checksums.items():
             parsed = parse_cue_track_id(prov_item_id)
             if parsed is not None:
-                cue_file_checksums[parsed[0]] = checksum
+                cue_file_checksums.setdefault(parsed[0], set()).add(checksum)
         # find all supported files in the base directory and all subfolders
         # we work bottom up, as-in we derive all info from the tracks
         cur_filenames: set[str] = set()
@@ -1078,7 +1078,7 @@ class LocalFileSystemProvider(MusicProvider):
         self,
         *,
         file_checksums: dict[str, str],
-        cue_file_checksums: dict[str, str],
+        cue_file_checksums: dict[str, set[str]],
         cur_filenames: set[str],
         items_to_process: list[tuple[FileSystemItem, str | None]],
         unchanged_cue_items: list[FileSystemItem],
@@ -1094,7 +1094,7 @@ class LocalFileSystemProvider(MusicProvider):
         ``scan_errors`` and stop the walk once it reports ``aborted``.
 
         :param file_checksums: Previously stored checksum per provider item id.
-        :param cue_file_checksums: Previously stored checksum keyed by CUE relative_path.
+        :param cue_file_checksums: Previously stored track checksums keyed by CUE relative_path.
         :param cur_filenames: Receives the ids/paths present in this scan.
         :param items_to_process: Receives changed or new items to process.
         :param unchanged_cue_items: Receives CUE sheets whose checksum matches.
@@ -1136,7 +1136,7 @@ class LocalFileSystemProvider(MusicProvider):
         item: FileSystemItem,
         *,
         file_checksums: dict[str, str],
-        cue_file_checksums: dict[str, str],
+        cue_file_checksums: dict[str, set[str]],
         cur_filenames: set[str],
         items_to_process: list[tuple[FileSystemItem, str | None]],
         unchanged_cue_items: list[FileSystemItem],
@@ -1148,7 +1148,7 @@ class LocalFileSystemProvider(MusicProvider):
 
         :param item: The file to classify.
         :param file_checksums: Previously stored checksum per provider item id.
-        :param cue_file_checksums: Previously stored checksum keyed by CUE relative_path.
+        :param cue_file_checksums: Previously stored track checksums keyed by CUE relative_path.
         :param cur_filenames: Receives the ids/paths present in this scan.
         :param items_to_process: Receives changed or new items to process.
         :param unchanged_cue_items: Receives CUE sheets whose checksum matches.
@@ -1172,11 +1172,14 @@ class LocalFileSystemProvider(MusicProvider):
         item_checksum = item.checksum
         if is_cue:
             cue_stems.add(item.absolute_path.rsplit(".", 1)[0])
-            prev_checksum = cue_file_checksums.get(item.relative_path)
             item_checksum = cue_metadata_checksum(item.checksum)
+            prev_checksums = cue_file_checksums.get(item.relative_path, set())
+            prev_checksum = min(prev_checksums, default=None)
+            checksum_matches = prev_checksums == {item_checksum}
         else:
             prev_checksum = file_checksums.get(item.relative_path)
-        if item_checksum == prev_checksum:
+            checksum_matches = item_checksum == prev_checksum
+        if checksum_matches:
             # unchanged, just record it as still present
             cur_filenames.add(item.relative_path)
             if is_cue:

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -120,6 +120,7 @@ from .constants import (
 )
 from .cue import (
     CueSheetHandler,
+    cue_metadata_checksum,
     cue_referenced_audio_stem,
     make_cue_track_id,
     parse_cue_track_id,
@@ -1168,12 +1169,14 @@ class LocalFileSystemProvider(MusicProvider):
         ):
             return
         is_cue = item.ext in CUE_EXTENSIONS and self.media_content_type == "music"
+        item_checksum = item.checksum
         if is_cue:
             cue_stems.add(item.absolute_path.rsplit(".", 1)[0])
             prev_checksum = cue_file_checksums.get(item.relative_path)
+            item_checksum = cue_metadata_checksum(item.checksum)
         else:
             prev_checksum = file_checksums.get(item.relative_path)
-        if item.checksum == prev_checksum:
+        if item_checksum == prev_checksum:
             # unchanged, just record it as still present
             cur_filenames.add(item.relative_path)
             if is_cue:

--- a/music_assistant/providers/filesystem_local/cue.py
+++ b/music_assistant/providers/filesystem_local/cue.py
@@ -52,6 +52,9 @@ if TYPE_CHECKING:
 
 CUE_TRACK_ID_DELIMITER = "::track"
 
+# Bump when CUE decoding or parsing changes so cached and library metadata are refreshed.
+_CUE_METADATA_VERSION = 1
+
 
 @dataclass(frozen=True, slots=True)
 class _TrackBuildContext:
@@ -64,6 +67,15 @@ class _TrackBuildContext:
     track_genres: set[str] | None  # fallback genres from the audio file
     album: Album | None
     album_performers: tuple[str, ...]  # sheet-level PERFORMER values, fallback for track artists
+
+
+def cue_metadata_checksum(file_checksum: str | None) -> str:
+    """
+    Return the checksum for metadata derived from a CUE sheet.
+
+    :param file_checksum: The checksum of the source CUE file.
+    """
+    return f"{_CUE_METADATA_VERSION}:{file_checksum}"
 
 
 def make_cue_track_id(cue_relative_path: str, track_number: int) -> str:
@@ -139,11 +151,12 @@ class CueSheetHandler:
         """
         # cached by (path, checksum) so unchanged CUE files skip the file read
         provider = self.provider
+        metadata_checksum = cue_metadata_checksum(cue_item.checksum)
         cached = await provider.mass.cache.get(
             key=cue_item.relative_path,
             provider=provider.instance_id,
             category=CACHE_CATEGORY_CUE_SHEETS,
-            checksum=cue_item.checksum,
+            checksum=metadata_checksum,
             default=None,
         )
         if cached is not None:
@@ -155,7 +168,7 @@ class CueSheetHandler:
             data=asdict(sheet),
             provider=provider.instance_id,
             category=CACHE_CATEGORY_CUE_SHEETS,
-            checksum=cue_item.checksum,
+            checksum=metadata_checksum,
             expiration=3600 * 24 * 365,
         )
         return sheet
@@ -479,7 +492,7 @@ class CueSheetHandler:
                     provider_domain=provider.domain,
                     provider_instance=provider.instance_id,
                     audio_format=ctx.audio_format,
-                    details=cue_item.checksum,
+                    details=cue_metadata_checksum(cue_item.checksum),
                     in_library=True,
                 )
             },

--- a/music_assistant/providers/webdav/provider.py
+++ b/music_assistant/providers/webdav/provider.py
@@ -302,7 +302,7 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
         self,
         *,
         file_checksums: dict[str, str],
-        cue_file_checksums: dict[str, str],
+        cue_file_checksums: dict[str, set[str]],
         cur_filenames: set[str],
         items_to_process: list[tuple[FileSystemItem, str | None]],
         unchanged_cue_items: list[FileSystemItem],

--- a/tests/providers/filesystem/test_cue_integration.py
+++ b/tests/providers/filesystem/test_cue_integration.py
@@ -848,7 +848,7 @@ class TestClassifyScanItemCue:
         provider: LocalFileSystemProvider,
         item: FileSystemItem,
         *,
-        cue_file_checksums: dict[str, str] | None = None,
+        cue_file_checksums: dict[str, set[str]] | None = None,
     ) -> tuple[
         list[tuple[FileSystemItem, str | None]],
         list[FileSystemItem],
@@ -878,7 +878,7 @@ class TestClassifyScanItemCue:
         items, unchanged, cur, stems = self._classify(
             provider,
             cue_item,
-            cue_file_checksums={"album.cue": cue_metadata_checksum("checksum-v1")},
+            cue_file_checksums={"album.cue": {cue_metadata_checksum("checksum-v1")}},
         )
         assert items == []
         assert unchanged == [cue_item]
@@ -892,7 +892,7 @@ class TestClassifyScanItemCue:
         items, unchanged, _, _ = self._classify(
             provider,
             cue_item,
-            cue_file_checksums={"album.cue": cue_metadata_checksum("checksum-v1")},
+            cue_file_checksums={"album.cue": {cue_metadata_checksum("checksum-v1")}},
         )
         assert items == [(cue_item, cue_metadata_checksum("checksum-v1"))]
         assert unchanged == []
@@ -904,9 +904,25 @@ class TestClassifyScanItemCue:
         items, unchanged, _, _ = self._classify(
             provider,
             cue_item,
-            cue_file_checksums={"album.cue": "checksum-v1"},
+            cue_file_checksums={"album.cue": {"checksum-v1"}},
         )
         assert items == [(cue_item, "checksum-v1")]
+        assert unchanged == []
+
+    def test_mixed_checksums_force_metadata_refresh(self) -> None:
+        """A partially refreshed CUE is reprocessed until every track is current."""
+        provider = _make_provider()
+        cue_item = self._cue_item("checksum-v1")
+        previous_checksums = {
+            "checksum-v1",
+            cue_metadata_checksum("checksum-v1"),
+        }
+        items, unchanged, _, _ = self._classify(
+            provider,
+            cue_item,
+            cue_file_checksums={"album.cue": previous_checksums},
+        )
+        assert items == [(cue_item, min(previous_checksums))]
         assert unchanged == []
 
     def test_new_cue_has_no_prior_checksum(self) -> None:

--- a/tests/providers/filesystem/test_cue_integration.py
+++ b/tests/providers/filesystem/test_cue_integration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -17,6 +18,7 @@ from music_assistant.providers.filesystem_local import LocalFileSystemProvider
 from music_assistant.providers.filesystem_local.cue import (
     CUE_TRACK_ID_DELIMITER,
     CueSheetHandler,
+    cue_metadata_checksum,
     make_cue_track_id,
     parse_cue_track_id,
 )
@@ -230,6 +232,28 @@ class TestReadCueFile:
         assert content == cue
 
 
+class TestLoadCueSheet:
+    """Tests for parsed CUE sheet caching."""
+
+    @pytest.mark.asyncio
+    async def test_versions_cache_entries(self, tmp_path: Path) -> None:
+        """Parsed metadata uses a checksum that changes with CUE handling."""
+        cue_item = _make_cue_item(tmp_path, SAMPLE_CUE)
+        provider = _make_provider(base_path=str(tmp_path))
+        cache_get = cast("AsyncMock", provider.mass.cache.get)
+        cache_set = cast("AsyncMock", provider.mass.cache.set)
+
+        await provider._cue.load_cue_sheet(cue_item)
+
+        expected_checksum = cue_metadata_checksum(cue_item.checksum)
+        get_call = cache_get.await_args
+        set_call = cache_set.await_args
+        assert get_call is not None
+        assert set_call is not None
+        assert get_call.kwargs["checksum"] == expected_checksum
+        assert set_call.kwargs["checksum"] == expected_checksum
+
+
 class TestFindCueAudioFile:
     """Tests for audio file resolution from a CUE sheet."""
 
@@ -368,6 +392,8 @@ class TestParseCueTracks:
         assert len(set(ids)) == 3
         for track, num in zip(tracks, [1, 2, 3], strict=True):
             assert track.item_id == make_cue_track_id(cue_item.relative_path, num)
+            mapping = next(iter(track.provider_mappings))
+            assert mapping.details == cue_metadata_checksum(cue_item.checksum)
         # ISRC from CUE propagates to each track
         for track in tracks:
             isrcs = [v for k, v in track.external_ids if k == ExternalID.ISRC]
@@ -852,7 +878,7 @@ class TestClassifyScanItemCue:
         items, unchanged, cur, stems = self._classify(
             provider,
             cue_item,
-            cue_file_checksums={"album.cue": "checksum-v1"},
+            cue_file_checksums={"album.cue": cue_metadata_checksum("checksum-v1")},
         )
         assert items == []
         assert unchanged == [cue_item]
@@ -863,6 +889,18 @@ class TestClassifyScanItemCue:
         """Changed checksum: prior value is forwarded so downstream overwrite=True."""
         provider = _make_provider()
         cue_item = self._cue_item("checksum-v2")
+        items, unchanged, _, _ = self._classify(
+            provider,
+            cue_item,
+            cue_file_checksums={"album.cue": cue_metadata_checksum("checksum-v1")},
+        )
+        assert items == [(cue_item, cue_metadata_checksum("checksum-v1"))]
+        assert unchanged == []
+
+    def test_legacy_checksum_forces_metadata_refresh(self) -> None:
+        """An unversioned mapping is reprocessed even when the file is unchanged."""
+        provider = _make_provider()
+        cue_item = self._cue_item("checksum-v1")
         items, unchanged, _, _ = self._classify(
             provider,
             cue_item,


### PR DESCRIPTION
# What does this implement/fix?

CUE metadata imported with broken character encoding remained corrupted after upgrading because unchanged files reused cached parsed data.

- Version CUE-derived metadata checksums so parser changes invalidate stale cache entries.
- Refresh existing CUE library items once, then return to incremental sync.
- Cover cache invalidation and upgrade behavior.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6093

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch where applicable.