### PR TITLE
Add typosquatting safety tests

### DIFF
--- a/tests/scripts/test_check_package_safety.py
+++ b/tests/scripts/test_check_package_safety.py
@@ -1,4 +1,4 @@
-"""Tests for the license checks of the package safety script."""
+"""Tests for the package safety script."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ from scripts import check_package_safety
 from scripts.check_package_safety import (
     check_license_compatibility,
     check_package,
+    check_typosquatting,
     get_package_license,
 )
 
@@ -21,6 +22,35 @@ def pypi_info(**overrides: Any) -> dict[str, Any]:
     :param overrides: Fields to set on top of the (empty) license metadata.
     """
     return {"license": None, "license_expression": None, "classifiers": [], **overrides}
+
+
+def test_typosquatting_allows_exact_popular_package() -> None:
+    """Test an exact popular package name is not reported as typosquatting."""
+    assert check_typosquatting("requests") is None
+
+
+def test_typosquatting_detects_single_character_change() -> None:
+    """Test an equal-length package name with one changed character is reported."""
+    assert (
+        check_typosquatting("requestz") == "Suspicious: Very similar to popular package 'requests'"
+    )
+
+
+@pytest.mark.parametrize(
+    ("package_name", "popular_package"),
+    [
+        ("b0t0c0re", "botocore"),
+        ("sq1a1chemy", "sqlalchemy"),
+        ("cert1f1", "certifi"),
+    ],
+)
+def test_typosquatting_detects_character_substitution(
+    package_name: str, popular_package: str
+) -> None:
+    """Test common character substitutions in popular package names are reported."""
+    assert check_typosquatting(package_name) == (
+        f"Suspicious: Character substitution of popular package '{popular_package}'"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

Adds regression coverage so changes to either typosquatting detection path cannot pass unnoticed.

- Covers single-character changes and all configured character substitutions.
- Confirms exact popular package names remain allowed.
- Broadens the test module scope description.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project’s [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.