### PR TITLE
Recognize version-less HLS radio streams

### DIFF
--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -331,7 +331,8 @@ async def parse_playlist_data(
     playlist_data = raw_data.decode(encoding, errors="replace")
 
     if (
-        raise_on_hls and "#EXT-X-VERSION:" in playlist_data
+        raise_on_hls
+        and ("#EXT-X-VERSION:" in playlist_data or "#EXT-X-TARGETDURATION:" in playlist_data)
     ) or "#EXT-X-STREAM-INF:" in playlist_data:
         raise IsHLSPlaylist
 

--- a/tests/controllers/streams/test_resolve_radio_stream.py
+++ b/tests/controllers/streams/test_resolve_radio_stream.py
@@ -121,18 +121,27 @@ async def test_hls_playlist_resolves_as_hls(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("url", "content_type"),
+    [
+        ("http://radio.example.com/live", "audio/x-mpegurl"),
+        ("http://radio.example.com/live.m3u8", "application/octet-stream"),
+    ],
+)
 async def test_hls_without_version_tag_still_resolves_as_hls(
     monkeypatch: pytest.MonkeyPatch,
+    url: str,
+    content_type: str,
 ) -> None:
-    """The HLS content type decides on its own, without a tag to recognise in the body."""
+    """A version-less HLS media playlist is recognised by its required tag."""
     audio = _streams_audio()
     body = b"#EXTM3U\n#EXT-X-TARGETDURATION:10\n#EXTINF:10.0,\nsegment0.aac\n"
-    response = _FakeConnCtx({"content-type": "application/vnd.apple.mpegurl"}, body)
+    response = _FakeConnCtx({"content-type": content_type}, body)
     monkeypatch.setattr(audio, "_connect_radio_stream", lambda *_args, **_kwargs: response)
 
-    result = await audio.resolve_radio_stream("http://radio.example.com/live")
+    result = await audio.resolve_radio_stream(url)
 
-    assert result == ("http://radio.example.com/live", StreamType.HLS)
+    assert result == (url, StreamType.HLS)
 
 
 @pytest.mark.asyncio

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -1000,6 +1000,13 @@ HLS_MEDIA_PLAYLIST = (
     "#EXTINF:10.0,\n"
     "http://stream.example.com/segment1.aac\n"
 )
+VERSIONLESS_HLS_MEDIA_PLAYLIST = (
+    "#EXTM3U\n"
+    "#EXT-X-TARGETDURATION:10\n"
+    '#EXT-X-KEY:METHOD=AES-128,URI="skd://test-key"\n'
+    "#EXTINF:10,\n"
+    "segment1.aac\n"
+)
 HLS_MASTER_PLAYLIST = (
     "#EXTM3U\n"
     '#EXT-X-STREAM-INF:BANDWIDTH=64000,CODECS="mp4a.40.2"\n'
@@ -1154,6 +1161,15 @@ async def test_fetch_playlist_hls_media_playlist() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fetch_playlist_versionless_hls_media_playlist() -> None:
+    """A version-less HLS media playlist is recognised by its required tag."""
+    mass = _mass_serving(VERSIONLESS_HLS_MEDIA_PLAYLIST.encode())
+
+    with pytest.raises(IsHLSPlaylist):
+        await fetch_playlist(mass, "http://example.com/station.m3u8")
+
+
+@pytest.mark.asyncio
 async def test_fetch_playlist_hls_media_playlist_allowed() -> None:
     """With raise_on_hls disabled an HLS media playlist parses like any other M3U."""
     mass = _mass_serving(HLS_MEDIA_PLAYLIST.encode())
@@ -1162,6 +1178,18 @@ async def test_fetch_playlist_hls_media_playlist_allowed() -> None:
 
     assert len(result) == 1
     assert result[0].path == "http://stream.example.com/segment1.aac"
+
+
+@pytest.mark.asyncio
+async def test_fetch_playlist_versionless_hls_media_playlist_allowed() -> None:
+    """Disabling HLS detection still exposes a version-less playlist's segment and key."""
+    mass = _mass_serving(VERSIONLESS_HLS_MEDIA_PLAYLIST.encode())
+
+    result = await fetch_playlist(mass, "http://example.com/station.m3u8", raise_on_hls=False)
+
+    assert len(result) == 1
+    assert result[0].path == "segment1.aac"
+    assert result[0].key == "skd://test-key"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

HLS media playlists may omit the optional version tag. When such a playlist used an ambiguous content type, it was treated as plain HTTP and skipped HLS-specific stream handling.

**Related issue (if applicable):**

- Follow-up to #5749

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Recognize HLS media playlists by their required target-duration tag.
- Preserve plain M3U parsing for callers that explicitly allow HLS media playlists.
- Cover ambiguous content types and `.m3u8` URLs without a version tag.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
