### PR TITLE
Prevent skipped tracks from resuming too far ahead

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2417,6 +2417,8 @@ class StreamsAudio:
                 )
                 queue_track.streamdetails.stream_error = True
                 play_log_entry.seconds_streamed = 0
+                if last_fadeout_part:
+                    queue_track.streamdetails.seek_position = raw_seek_position
                 continue
             if last_fadeout_part:
                 # edge case: we did not get enough data to make the crossfade

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -992,6 +992,106 @@ async def test_flow_source_error_skips_item_without_completing_it() -> None:
     assert entry.seconds_streamed > 0
 
 
+@pytest.mark.asyncio
+async def test_flow_zero_audio_skip_restores_seek_position(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A zero-audio item keeps its original seek position when its crossfade is skipped."""
+    mass = MagicMock()
+    pcm_format = _format(ContentType.PCM_S16LE, 8000, 16)
+    first_streamdetails = SimpleNamespace(
+        audio_format=pcm_format,
+        fade_in=False,
+        stream_error=False,
+        uri="test://first",
+        seek_position=0,
+        seconds_streamed=0,
+        duration=120,
+    )
+    first_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-1",
+        name="first",
+        media_type=MediaType.TRACK,
+        media_item=None,
+        streamdetails=first_streamdetails,
+        extra_attributes={},
+    )
+    raw_seek_position = 12
+    skipped_streamdetails = SimpleNamespace(
+        audio_format=pcm_format,
+        fade_in=False,
+        stream_error=False,
+        uri="test://skipped",
+        seek_position=raw_seek_position,
+        seconds_streamed=0,
+        duration=120,
+    )
+    skipped_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-2",
+        name="skipped",
+        media_type=MediaType.TRACK,
+        media_item=None,
+        streamdetails=skipped_streamdetails,
+        extra_attributes={},
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        flow_mode=False,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
+    queue_data = SimpleNamespace(session_id="session-1", flow_mode_stream_log=[])
+    mass.player_queues.queue_data.return_value = queue_data
+    mass.player_queues.load_next_queue_item = AsyncMock(side_effect=[skipped_item, QueueEmpty])
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.get_next_item.return_value = skipped_item
+    mass.streams.get_crossfade_mode.return_value = CrossfadeMode.STANDARD_CROSSFADE
+    mass.config.get_raw_core_config_value.return_value = 8
+    mass.streams.audio_processing.update_item_context = MagicMock()
+    mass.player_queues.queue_buffer_completed = MagicMock()
+    player = MagicMock()
+    player.config.get_value.return_value = "fixed_48000"
+    player.get_supported_sample_rates.return_value = []
+    mass.players.get_player.return_value = player
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+    build = AsyncMock(
+        return_value=SimpleNamespace(
+            timing_info=SimpleNamespace(
+                fadein_trimmed_duration=2,
+                crossfade_duration=8,
+            )
+        )
+    )
+    monkeypatch.setattr(audio.smart_fades_mixer, "build", build)
+
+    async def _item_stream(
+        queue_item: SimpleNamespace,
+        *_args: object,
+        **_kwargs: object,
+    ) -> AsyncGenerator[bytes]:
+        if queue_item is first_item:
+            yield bytes(pcm_format.pcm_sample_size * 8)
+            yield bytes(pcm_format.pcm_sample_size)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue),
+        cast("Any", first_item),
+        pcm_format,
+        session_id="session-1",
+    )
+
+    async for _ in stream:
+        pass
+
+    build.assert_awaited_once()
+    assert skipped_streamdetails.seek_position == raw_seek_position
+
+
 def _manager_context(
     *,
     alters_audio: bool = False,


### PR DESCRIPTION
# What does this implement/fix?

Tracks that produce no audio after a crossfade was prepared could keep an inflated seek position and resume several seconds too far ahead on retry.

- Restore the original seek position when a zero-audio track is skipped.
- Add regression coverage for the crossfade retry path.

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
