### PR TITLE
Radio shuffle resets after queue transfer

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1795,10 +1795,13 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             queue_data.transitioning = value
 
     def _clear(self, queue_id: str, skip_stop: bool = False) -> None:
-        """Drop the queue's items and playback position, leaving its settings untouched."""
+        """Drop the queue's items and playback position, leaving user settings untouched."""
         queue = self._queue_data[queue_id].queue
         self.mass.streams.audio_processing.clear(queue_id)
         self.store_sources(queue, [])
+        if queue.is_dynamic:
+            # Dynamic sources impose shuffle, so clearing the source clears that shuffle too.
+            queue.shuffle_enabled = False
         queue.is_dynamic = False
         # dropping the dynamic source changes what smart shuffle resolves to, so the derived
         # flag has to follow or clients keep showing a smart mix on a plain queue

--- a/tests/controllers/player_queues/test_transfer_queue.py
+++ b/tests/controllers/player_queues/test_transfer_queue.py
@@ -89,6 +89,7 @@ def _shuffle_controller(
     source_shuffle_enabled: bool,
     source_shuffle_set_at: float | None,
     target_shuffle_set_at: float | None,
+    source_is_dynamic: bool = False,
 ) -> MagicMock:
     """
     Build a controller stand-in whose two queues carry real state records.
@@ -99,6 +100,7 @@ def _shuffle_controller(
     :param source_shuffle_enabled: Whether shuffle is on for the queue being handed over.
     :param source_shuffle_set_at: When the user last switched shuffle on for the source queue.
     :param target_shuffle_set_at: When the user last switched shuffle on for the target queue.
+    :param source_is_dynamic: Whether the source queue is managed by a dynamic source.
     """
     source_queue = PlayerQueue(
         queue_id="src",
@@ -107,6 +109,8 @@ def _shuffle_controller(
         available=True,
         items=0,
         shuffle_enabled=source_shuffle_enabled,
+        smart_shuffle_active=source_is_dynamic,
+        is_dynamic=source_is_dynamic,
     )
     target_queue = PlayerQueue(
         queue_id="tgt", active=True, display_name="Tgt", available=True, items=0
@@ -123,7 +127,7 @@ def _shuffle_controller(
     fake.resume = AsyncMock()
     fake._clear = MagicMock()
     fake.update_items = MagicMock()
-    fake.is_smart_shuffle_active = MagicMock(return_value=False)
+    fake.is_smart_shuffle_active = MagicMock(side_effect=lambda queue: queue.is_dynamic)
     target_player = MagicMock()
     target_player.state.synced_to = None
     target_player.state.active_group = None
@@ -171,3 +175,26 @@ async def test_transfer_queue_carries_the_source_shuffle_intent() -> None:
     # the gesture is good for one play and it followed the queue, so it must not be left behind
     # to shuffle whatever gets started on the player it was moved off
     assert fake._queue_data["src"].shuffle_set_at is None
+
+
+async def test_transfer_queue_drops_dynamic_shuffle_from_source() -> None:
+    """The shuffle imposed by a dynamic source follows it to the target queue."""
+    fake = _shuffle_controller(
+        source_shuffle_enabled=True,
+        source_shuffle_set_at=None,
+        target_shuffle_set_at=None,
+        source_is_dynamic=True,
+    )
+    fake._clear.side_effect = lambda queue_id, skip_stop=False: PlayerQueuesController._clear(
+        cast("PlayerQueuesController", fake), queue_id, skip_stop
+    )
+
+    await PlayerQueuesController.transfer_queue(
+        cast("PlayerQueuesController", fake), "src", "tgt", auto_play=False
+    )
+
+    assert fake.get("tgt").is_dynamic is True
+    assert fake.get("tgt").shuffle_enabled is True
+    assert fake.get("src").is_dynamic is False
+    assert fake.get("src").shuffle_enabled is False
+    assert fake.get("src").smart_shuffle_active is False


### PR DESCRIPTION
# What does this implement/fix?

Transferring a radio or dynamic playlist left its imposed shuffle switched on for the source player after the queue moved away. That empty queue could then shuffle media added later.

**Related issue (if applicable):**

- Follow-up to #5747

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Reset shuffle when clearing a queue whose dynamic source imposed it.
- Preserve the transferred radio queue's shuffle on its new player.
- Add regression coverage for both source and target queue state.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
