### PR TITLE
Prevent hidden audio stream failures

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1658,10 +1658,6 @@ class StreamsAudio:
                     self.mass.player_queues.prepare_next_audio_buffer(queue_item.queue_id)
                 yield chunk
                 del chunk
-            # The FFmpeg stdin feeder swallows producer errors; re-raise even after
-            # partial audio so a failed source is not mistaken for a completed stream.
-            if audio_buffer.has_error:
-                raise AudioError("Failed to stream audio") from audio_buffer._producer_error
             finished = True
         except AudioError as err:
             streamdetails.stream_error = True

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -132,6 +132,7 @@ class FFMpeg(AsyncProcess):
         # or None if not yet parsed / not reported (e.g. live radio streams).
         self.parsed_duration: int | None = None
         self._stdin_feeder_task: asyncio.Task[None] | None = None
+        self._stdin_feeder_exception: Exception | None = None
         self._stderr_reader_task: asyncio.Task[None] | None = None
         # holds the detached abort-on-corrupt-stream task from _log_reader_task so it
         # isn't garbage collected mid-flight; not otherwise awaited
@@ -153,6 +154,11 @@ class FFMpeg(AsyncProcess):
             stderr=True,
         )
         self.logger = LOGGER
+
+    @property
+    def stdin_feeder_exception(self) -> Exception | None:
+        """Return the exception raised by the stdin feeder task, if any."""
+        return self._stdin_feeder_exception
 
     async def start(self) -> None:
         """Perform Async init of process."""
@@ -280,12 +286,19 @@ class FFMpeg(AsyncProcess):
         self.logger.log(VERBOSE_LOG_LEVEL, "Start reading audio data from source...")
         try:
             start = time.time()
-            async for chunk in self.audio_input:
+            while True:
+                try:
+                    chunk = await anext(self.audio_input)
+                except StopAsyncIteration:
+                    generator_exhausted = True
+                    break
+                except Exception as err:
+                    self._stdin_feeder_exception = err
+                    raise
                 chunk_count += 1
                 if self.closed:
                     return
                 await self.write(chunk)
-            generator_exhausted = True
         except asyncio.CancelledError:
             status = "cancelled"
             raise
@@ -416,11 +429,13 @@ async def get_ffmpeg_stream(
         # the OS process has actually exited, leaving returncode as None if checked directly
         with suppress(TimeoutError):
             await ffmpeg_proc.wait_with_timeout(5)
-        if ffmpeg_proc.returncode not in (None, 0) or ffmpeg_proc.concat_error:
-            # unclean exit of ffmpeg - raise error with log tail
-            log_lines = -20 if ffmpeg_proc.concat_error else -5
-            log_tail = "\n" + "\n".join(list(ffmpeg_proc.log_history)[log_lines:])
-            raise AudioError(log_tail)
+    if ffmpeg_proc.returncode not in (None, 0) or ffmpeg_proc.concat_error:
+        # unclean exit of ffmpeg - raise error with log tail
+        log_lines = -20 if ffmpeg_proc.concat_error else -5
+        log_tail = "\n" + "\n".join(list(ffmpeg_proc.log_history)[log_lines:])
+        raise AudioError(log_tail)
+    if feeder_exception := ffmpeg_proc.stdin_feeder_exception:
+        raise AudioError("Error while feeding audio to FFmpeg") from feeder_exception
 
 
 async def get_ffmpeg_overlay_stream(
@@ -462,10 +477,12 @@ async def get_ffmpeg_overlay_stream(
         # the OS process has actually exited, leaving returncode as None if checked directly
         with suppress(TimeoutError):
             await ffmpeg_proc.wait_with_timeout(5)
-        if ffmpeg_proc.returncode not in (None, 0):
-            # unclean exit of ffmpeg - raise error with log tail
-            log_tail = "\n" + "\n".join(list(ffmpeg_proc.log_history)[-5:])
-            raise AudioError(log_tail)
+    if ffmpeg_proc.returncode not in (None, 0):
+        # unclean exit of ffmpeg - raise error with log tail
+        log_tail = "\n" + "\n".join(list(ffmpeg_proc.log_history)[-5:])
+        raise AudioError(log_tail)
+    if feeder_exception := ffmpeg_proc.stdin_feeder_exception:
+        raise AudioError("Error while feeding audio to FFmpeg") from feeder_exception
 
 
 def get_ffmpeg_resample_filter(

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -861,44 +861,6 @@ async def test_audio_source_next_item_is_not_prebuffered(mass_minimal: MusicAssi
 
 
 @pytest.mark.asyncio
-async def test_swallowed_producer_error_after_partial_audio(
-    mass_minimal: MusicAssistant,
-) -> None:
-    """A producer error swallowed by the FFmpeg feeder fails the stream even after partial audio."""
-
-    class _FailingAfterPartialBuffer(_FakeAudioBuffer):
-        has_error = True
-        _producer_error = RuntimeError("source failed")
-
-        async def get_stream(self, **_kwargs: Any) -> AsyncGenerator[bytes]:
-            async for chunk in _make_source(2):
-                yield chunk
-
-    streamdetails = _make_stream_details(MediaType.TRACK, duration=90, allow_seek=True)
-    streamdetails.loudness = -10.0  # skip the audio-analysis hydration call
-    queue_item = QueueItem(
-        queue_id="player_a",
-        queue_item_id="current",
-        name="Current",
-        duration=90,
-        streamdetails=streamdetails,
-    )
-    controller = StreamsAudio(mass_minimal)
-
-    bytes_received = 0
-    with patch.object(audio_mod, "AudioBuffer", _FailingAfterPartialBuffer):
-        async for chunk in controller.get_queue_item_stream(
-            queue_item, TEST_PCM_FORMAT, raise_on_error=False
-        ):
-            bytes_received += len(chunk)
-
-    assert bytes_received > 0
-    assert streamdetails.stream_error is True
-    # partial audio was produced, so the item is not marked unavailable
-    assert queue_item.available
-
-
-@pytest.mark.asyncio
 async def test_real_buffer_producer_error_reaches_queue_item_stream(
     mass_minimal: MusicAssistant,
 ) -> None:

--- a/tests/helpers/test_ffmpeg.py
+++ b/tests/helpers/test_ffmpeg.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 from music_assistant_models.enums import ContentType
+from music_assistant_models.errors import AudioError
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.helpers.dsp import ComplexFilter, ComplexFilterInput
@@ -23,6 +24,7 @@ from music_assistant.helpers.ffmpeg import (
     _get_overlay_volume_filter,
     get_ffmpeg_args,
     get_ffmpeg_overlay_stream,
+    get_ffmpeg_stream,
     parse_ffmpeg_duration,
     parse_ffmpeg_stream_info,
 )
@@ -523,6 +525,87 @@ async def _silence(seconds: int) -> AsyncGenerator[bytes]:
 
 async def _collect_chunks(stream: AsyncGenerator[bytes]) -> list[bytes]:
     return [chunk async for chunk in stream]
+
+
+@pytest.mark.parametrize("source_error", [RuntimeError("source failed"), BrokenPipeError()])
+async def test_ffmpeg_stream_surfaces_stdin_feeder_error(source_error: Exception) -> None:
+    """An input generator failure is surfaced after FFmpeg emits its buffered output."""
+
+    async def failing_input() -> AsyncGenerator[bytes]:
+        yield b"\x00" * _BYTES_PER_SECOND
+        raise source_error
+
+    with pytest.raises(AudioError, match="Error while feeding audio to FFmpeg") as err:
+        await _collect_chunks(
+            get_ffmpeg_stream(
+                audio_input=failing_input(),
+                input_format=AudioFormat(
+                    content_type=ContentType.PCM_S16LE,
+                    sample_rate=44100,
+                    bit_depth=16,
+                    channels=2,
+                ),
+                output_format=_PCM_FORMAT,
+            )
+        )
+
+    assert err.value.__cause__ is source_error
+
+
+async def test_ffmpeg_stream_ignores_cancelled_stdin_feeder() -> None:
+    """A cancelled input generator ends the FFmpeg stream without an error."""
+
+    async def cancelled_input() -> AsyncGenerator[bytes]:
+        yield b"\x00" * _BYTES_PER_SECOND
+        raise asyncio.CancelledError
+
+    chunks = await _collect_chunks(
+        get_ffmpeg_stream(
+            audio_input=cancelled_input(),
+            input_format=AudioFormat(
+                content_type=ContentType.PCM_S16LE,
+                sample_rate=44100,
+                bit_depth=16,
+                channels=2,
+            ),
+            output_format=_PCM_FORMAT,
+        )
+    )
+
+    assert b"".join(chunks) == b"\x00" * _BYTES_PER_SECOND
+
+
+async def test_ffmpeg_stream_ignores_early_stdin_close() -> None:
+    """FFmpeg ending its input early does not report a source failure."""
+    chunks = await _collect_chunks(
+        get_ffmpeg_stream(
+            audio_input=_silence(30),
+            input_format=_PCM_FORMAT,
+            output_format=_PCM_FORMAT,
+            extra_input_args=["-t", "0.1"],
+        )
+    )
+
+    assert chunks
+
+
+async def test_overlay_stream_surfaces_stdin_feeder_error(overlay_file: Path) -> None:
+    """A failure in the main input is surfaced after the mixed output is emitted."""
+
+    async def failing_input() -> AsyncGenerator[bytes]:
+        yield b"\x00" * _BYTES_PER_SECOND
+        raise RuntimeError("source failed")
+
+    with pytest.raises(AudioError, match="Error while feeding audio to FFmpeg") as err:
+        await _collect_chunks(
+            get_ffmpeg_overlay_stream(
+                audio_input=failing_input(),
+                overlay_input=str(overlay_file),
+                pcm_format=_PCM_FORMAT,
+            )
+        )
+
+    assert isinstance(err.value.__cause__, RuntimeError)
 
 
 def _samples(pcm: bytes, channel: int | None = None) -> Sequence[int]:


### PR DESCRIPTION
# What does this implement/fix?

FFmpeg could treat an audio source failure as a clean end of stream, causing truncated playback to look complete.

- Surface audio source failures after buffered output is delivered.
- Preserve cancellation, input duration limits, and overlay fallback behavior.
- Remove the queue-only workaround and add shared FFmpeg regression coverage.

**Related issue (if applicable):**

- Follow-up to #5725

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
