### PR TITLE
Prevent flaky parallel test failures

### DIFF
--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -1,9 +1,10 @@
 """Tests for protocol player linking and universal player creation."""
 
 import asyncio
+import inspect
 import logging
 import re
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Iterator
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
@@ -234,7 +235,7 @@ class SessionBoundMockPlayer(MockPlayer):
 
 
 @pytest.fixture
-def mock_mass() -> MagicMock:
+def mock_mass() -> Iterator[MagicMock]:
     """Create a mock MusicAssistant instance."""
     mass = MagicMock()
     mass.closing = False
@@ -259,7 +260,10 @@ def mock_mass() -> MagicMock:
     mass.get_providers = MagicMock(return_value=[])
     # awaited by the tests that replay the tasks scheduled during a config wipe
     mass.webserver.auth.remove_from_user_filters = AsyncMock()
-    return mass
+    yield mass
+    for call in mass.create_task.call_args_list:
+        if call.args and inspect.iscoroutine(coro := call.args[0]):
+            coro.close()
 
 
 class TestIdentifiersMatch:
@@ -7167,9 +7171,6 @@ class TestUniversalPlayerReplacement:
         controller._check_replace_universal_player(native)
         task = next(t for t in scheduled_tasks if "unregister" in repr(t))
         await task
-        for scheduled_task in scheduled_tasks:
-            if scheduled_task is not task:
-                await scheduled_task
 
         mock_mass.player_queues.stop.assert_not_awaited()
         assert "up_old" not in controller._players

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -6870,6 +6870,7 @@ class TestUniversalPlayerReplacement:
         mock_mass.config.remove = MagicMock(side_effect=config_remove)
         mock_mass.players = controller
         mock_mass.player_queues = MagicMock()
+        mock_mass.player_queues.get.return_value = None
         mock_mass.call_later = MagicMock()
         mock_mass.loop = MagicMock()
         mock_mass.create_task = MagicMock(side_effect=capture_task)
@@ -7166,6 +7167,9 @@ class TestUniversalPlayerReplacement:
         controller._check_replace_universal_player(native)
         task = next(t for t in scheduled_tasks if "unregister" in repr(t))
         await task
+        for scheduled_task in scheduled_tasks:
+            if scheduled_task is not task:
+                await scheduled_task
 
         mock_mass.player_queues.stop.assert_not_awaited()
         assert "up_old" not in controller._players

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -581,8 +581,9 @@ async def test_seekable_buffer_backpressure() -> None:
     # use fill() so there's an active producer task (eviction only happens
     # when the producer is running and needs space)
     buf.fill(_make_source(max_size + 5), source_name="test")
-    async with buf._data_available:
-        await buf._data_available.wait_for(lambda: buf.size_seconds == max_size)
+    async with asyncio.timeout(5):
+        async with buf._data_available:
+            await buf._data_available.wait_for(lambda: buf.size_seconds == max_size)
 
     assert buf.size_seconds == max_size
 

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -581,7 +581,8 @@ async def test_seekable_buffer_backpressure() -> None:
     # use fill() so there's an active producer task (eviction only happens
     # when the producer is running and needs space)
     buf.fill(_make_source(max_size + 5), source_name="test")
-    await asyncio.sleep(0.1)
+    async with buf._data_available:
+        await buf._data_available.wait_for(lambda: buf.size_seconds == max_size)
 
     assert buf.size_seconds == max_size
 


### PR DESCRIPTION
# What does this implement/fix?

Parallel test runs could intermittently fail because one test relied on a fixed delay and another left captured cleanup coroutines unawaited.

- Wait for the audio buffer to reach capacity through its condition.
- Consume player replacement cleanup work so coroutine warnings cannot surface during later tests.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.