### PR TITLE
Prevent track loss when merging duplicates

### DIFF
--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -16,6 +16,7 @@ from music_assistant_models.enums import (
     ProviderType,
 )
 from music_assistant_models.errors import (
+    InvalidDataError,
     MediaNotFoundError,
     MusicAssistantError,
     ProviderUnavailableError,
@@ -1142,6 +1143,16 @@ class ArtistsController(MediaControllerBase[Artist]):
         )
         await self.set_provider_mappings(db_id, provider_mappings, overwrite)
         self.logger.debug("updated %s in database: (id %s)", update.name, db_id)
+
+    async def _validate_library_item_merge(self, target: Artist, source: Artist) -> None:
+        """Validate that two artists have the same role."""
+        await super()._validate_library_item_merge(target, source)
+        if target.artist_type != source.artist_type:
+            msg = (
+                f"Cannot merge artist '{source.name}' into '{target.name}': "
+                "artists must have the same role."
+            )
+            raise InvalidDataError(msg)
 
     async def _remove_music_artist_from_library(self, db_id: int, recursive: bool) -> None:
         # recursively also remove artist albums

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -481,7 +481,12 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         return ItemMapping.from_item(db_artist)
 
     async def _update_library_item(
-        self, item_id: str | int, update: Audiobook, overwrite: bool = False
+        self,
+        item_id: str | int,
+        update: Audiobook,
+        overwrite: bool = False,
+        *,
+        set_playlog: bool = True,
     ) -> None:
         """Update existing record in the database."""
         db_id = int(item_id)  # ensure integer
@@ -535,8 +540,13 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         )
         await self.set_provider_mappings(db_id, provider_mappings, overwrite)
         self.logger.debug("updated %s in database: (id %s)", update.name, db_id)
-        await self._set_playlog(db_id, update)
+        if set_playlog:
+            await self._set_playlog(db_id, update)
         await self._set_artist_mappings(update, db_id)
+
+    async def _update_library_item_for_merge(self, item_id: int, update: Audiobook) -> None:
+        """Merge audiobook model state without applying a source resume position."""
+        await self._update_library_item(item_id, update, set_playlog=False)
 
     async def _set_playlog(self, db_id: int, media_item: Audiobook) -> None:
         """Update/set the playlog table for the given audiobook db item_id."""

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -2362,7 +2362,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             source_mappings = source_item.provider_mappings
             source_item.provider_mappings = set()
             try:
-                await self._update_library_item(target_id, source_item)
+                await self._update_library_item_for_merge(target_id, source_item)
             finally:
                 source_item.provider_mappings = source_mappings
 
@@ -2384,6 +2384,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 },
             )
             await self._merge_genre_mappings(target_id, source_id)
+            await self._merge_library_item_references(target_id, source_id)
             await self._merge_library_playlog(target_id, source_id)
             await self._merge_library_item_relations(target_id, source_id)
             await self.mass.music.database.execute_write(
@@ -2400,9 +2401,14 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         finally:
             SUPPRESS_MEDIA_ITEM_UPDATES.reset(token)
 
-        self.mass.signal_event(EventType.MEDIA_ITEM_DELETED, source_item.uri, source_item)
-        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, merged_item.uri, merged_item)
+        if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
+            self.mass.signal_event(EventType.MEDIA_ITEM_DELETED, source_item.uri, source_item)
+            self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, merged_item.uri, merged_item)
         return merged_item
+
+    async def _update_library_item_for_merge(self, item_id: int, update: ItemCls) -> None:
+        """Merge model state into an existing library item."""
+        await self._update_library_item(item_id, update)
 
     async def _merge_library_item_relations(self, target_id: int, source_id: int) -> None:
         """Transfer relations that reference the merged media item."""
@@ -2426,6 +2432,10 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         elif self.media_type == MediaType.TRACK:
             await self._move_relation_rows(DB_TABLE_ALBUM_TRACKS, "track_id", target_id, source_id)
             await self._move_relation_rows(DB_TABLE_TRACK_ARTISTS, "track_id", target_id, source_id)
+
+    async def _merge_library_item_references(self, target_id: int, source_id: int) -> None:
+        """Transfer references to the source item owned by specialized controllers."""
+        return
 
     async def _merge_genre_mappings(self, target_id: int, source_id: int) -> None:
         """Transfer genre mappings and exclusions to the target item."""
@@ -2471,6 +2481,46 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         await self.mass.music.database.delete(
             DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
             {"media_id": source_id, "media_type": self.media_type.value},
+        )
+
+    async def _merge_genre_references(self, target_id: int, source_id: int) -> None:
+        """Transfer media mappings and exclusions that point to the source genre."""
+        values = {"target_id": target_id, "source_id": source_id}
+        await self.mass.music.database.execute_write(
+            f"""
+            INSERT INTO {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}(
+                genre_id, media_id, media_type, alias, is_derived, is_manual
+            )
+            SELECT :target_id, media_id, media_type, alias, is_derived, is_manual
+            FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}
+            WHERE genre_id = :source_id
+            ON CONFLICT(genre_id, media_id, media_type) DO UPDATE SET
+                alias = CASE
+                    WHEN excluded.is_manual AND NOT is_manual
+                    THEN COALESCE(excluded.alias, alias)
+                    ELSE COALESCE(alias, excluded.alias)
+                END,
+                is_derived = is_derived OR excluded.is_derived,
+                is_manual = is_manual OR excluded.is_manual
+            """,
+            values,
+        )
+        await self.mass.music.database.execute_write(
+            f"""
+            INSERT OR IGNORE INTO {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}(
+                genre_id, media_id, media_type
+            )
+            SELECT :target_id, media_id, media_type
+            FROM {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}
+            WHERE genre_id = :source_id
+            """,
+            values,
+        )
+        await self.mass.music.database.delete(
+            DB_TABLE_GENRE_MEDIA_ITEM_MAPPING, {"genre_id": source_id}
+        )
+        await self.mass.music.database.delete(
+            DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION, {"genre_id": source_id}
         )
 
     async def _merge_library_playlog(self, target_id: int, source_id: int) -> None:

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -23,6 +23,7 @@ from music_assistant_models.enums import (
 )
 from music_assistant_models.errors import (
     InsufficientPermissions,
+    InvalidDataError,
     MediaNotFoundError,
     ProviderUnavailableError,
 )
@@ -42,12 +43,16 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.constants import (
+    DB_TABLE_ALBUM_ARTISTS,
+    DB_TABLE_ALBUM_TRACKS,
     DB_TABLE_AUDIO_ANALYSIS,
+    DB_TABLE_AUDIOBOOK_ARTISTS,
     DB_TABLE_EXTERNAL_ID_LOOKUP,
     DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
     DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
     DB_TABLE_PLAYLOG,
     DB_TABLE_PROVIDER_MAPPINGS,
+    DB_TABLE_TRACK_ARTISTS,
     MASS_LOGGER_NAME,
 )
 from music_assistant.controllers.music.helpers import search_name_match_clause
@@ -368,7 +373,8 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         # drop cached artwork for the removed item
         for img in library_item.metadata.images or []:
             await self.mass.metadata.invalidate_image_cache(img.provider, img.path)
-        self.mass.signal_event(EventType.MEDIA_ITEM_DELETED, library_item.uri, library_item)
+        if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
+            self.mass.signal_event(EventType.MEDIA_ITEM_DELETED, library_item.uri, library_item)
         self.logger.debug("deleted item with id %s from database", db_id)
 
     async def library_count(self, favorite_only: bool = False) -> int:
@@ -988,6 +994,29 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         await self.add_provider_mappings(item_id, [provider_mapping])
 
     @final
+    async def merge_library_items(
+        self, target_item_id: str | int, source_item_id: str | int
+    ) -> ItemCls:
+        """
+        Merge one library item into another and return the target item.
+
+        The explicit target is the deterministic winner. Its current values stay authoritative
+        where the normal non-overwrite model update keeps them; the source is merged as the
+        incoming update. All source state is transferred before the source row is deleted.
+
+        :param target_item_id: Library ID of the item that remains after the merge.
+        :param source_item_id: Library ID of the duplicate item that is removed after transfer.
+        :raises InvalidDataError: When the IDs are identical or do not belong to this media type.
+        """
+        target_id = int(target_item_id)
+        source_id = int(source_item_id)
+        if target_id == source_id:
+            msg = "Cannot merge a library item into itself"
+            raise InvalidDataError(msg)
+        async with self._db_add_lock:
+            return await self._merge_library_items(target_id, source_id)
+
+    @final
     async def add_provider_mappings(
         self, item_id: str | int, provider_mappings: Iterable[ProviderMapping]
     ) -> None:
@@ -998,34 +1027,36 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         :param provider_mappings: The provider mappings to add.
         """
         db_id = int(item_id)  # ensure integer
-        library_item = await self.get_library_item(db_id)
-        new_mappings: set[ProviderMapping] = set()
-        for provider_mapping in provider_mappings:
-            # ignore if the mapping is already present
-            if provider_mapping not in library_item.provider_mappings:
-                new_mappings.add(provider_mapping)
-        if not new_mappings:
+        mappings = set(provider_mappings)
+        if not mappings:
             return
-        # handle special case where the user wants to merge 2 library items
-        for mapping in new_mappings:
-            if _library_item := await self.get_library_item_by_prov_id(
-                mapping.item_id, mapping.provider_instance
-            ):
-                if _library_item.item_id != library_item.item_id:
-                    # merging items
-                    self.logger.debug(
-                        "merging item id %s into item id %s based on provider mapping %s/%s",
-                        _library_item.item_id,
-                        library_item.item_id,
-                        mapping.provider_instance,
-                        mapping.item_id,
+        async with self._db_add_lock:
+            library_item = await self.get_library_item(db_id)
+            while True:
+                conflicting_item = None
+                for mapping in mappings:
+                    existing_item = await self.get_library_item_by_prov_id(
+                        mapping.item_id, mapping.provider_instance
                     )
-                    await self.remove_item_from_library(_library_item.item_id, recursive=True)
+                    if existing_item and int(existing_item.item_id) != db_id:
+                        conflicting_item = existing_item
+                        break
+                if conflicting_item is None:
                     break
-        library_item.provider_mappings.update(new_mappings)
-        self.mass.music.match_provider_instances(library_item)
-        await self.set_provider_mappings(db_id, library_item.provider_mappings)
-        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, library_item.uri, library_item)
+                self.logger.debug(
+                    "merging item id %s into item id %s based on provider mapping",
+                    conflicting_item.item_id,
+                    library_item.item_id,
+                )
+                library_item = await self._merge_library_items(db_id, int(conflicting_item.item_id))
+
+            new_mappings = mappings.difference(library_item.provider_mappings)
+            if not new_mappings:
+                return
+            library_item.provider_mappings.update(new_mappings)
+            self.mass.music.match_provider_instances(library_item)
+            await self.set_provider_mappings(db_id, library_item.provider_mappings)
+            self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, library_item.uri, library_item)
 
     @final
     async def update_provider_mapping(
@@ -2305,3 +2336,201 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 sql_query += f" ORDER BY {sort_key}"
 
         return sql_query
+
+    async def _merge_library_items(self, target_id: int, source_id: int) -> ItemCls:
+        """Merge the source library item into the target while the controller lock is held."""
+        target_item = await self.get_library_item(target_id)
+        source_item = await self.get_library_item(source_id)
+        if target_item.media_type != self.media_type or source_item.media_type != self.media_type:
+            msg = "Library items must have the controller's media type"
+            raise InvalidDataError(msg)
+        target_row = await self.mass.music.database.get_row(self.db_table, {"item_id": target_id})
+        source_row = await self.mass.music.database.get_row(self.db_table, {"item_id": source_id})
+        assert target_row is not None
+        assert source_row is not None
+        timestamps_added = tuple(
+            timestamp
+            for timestamp in (
+                int(target_row["timestamp_added"] or 0),
+                int(source_row["timestamp_added"] or 0),
+            )
+            if timestamp
+        )
+
+        token = SUPPRESS_MEDIA_ITEM_UPDATES.set(True)
+        try:
+            source_mappings = source_item.provider_mappings
+            source_item.provider_mappings = set()
+            try:
+                await self._update_library_item(target_id, source_item)
+            finally:
+                source_item.provider_mappings = source_mappings
+
+            await self.mass.music.database.update(
+                self.db_table,
+                {"item_id": target_id},
+                {
+                    "favorite": bool(target_row["favorite"]) or bool(source_row["favorite"]),
+                    "play_count": int(target_row["play_count"] or 0)
+                    + int(source_row["play_count"] or 0),
+                    "last_played": max(
+                        int(target_row["last_played"] or 0), int(source_row["last_played"] or 0)
+                    ),
+                    "timestamp_added": min(timestamps_added) if timestamps_added else 0,
+                    "timestamp_modified": max(
+                        int(target_row["timestamp_modified"] or 0),
+                        int(source_row["timestamp_modified"] or 0),
+                    ),
+                },
+            )
+            await self._merge_genre_mappings(target_id, source_id)
+            await self._merge_library_playlog(target_id, source_id)
+            await self._merge_library_item_relations(target_id, source_id)
+            await self.mass.music.database.execute_write(
+                f"UPDATE {DB_TABLE_PROVIDER_MAPPINGS} SET item_id = :target_id "
+                "WHERE media_type = :media_type AND item_id = :source_id",
+                {
+                    "target_id": target_id,
+                    "source_id": source_id,
+                    "media_type": self.media_type.value,
+                },
+            )
+            await MediaControllerBase.remove_item_from_library(self, source_id, recursive=False)
+            merged_item = await self.get_library_item(target_id)
+        finally:
+            SUPPRESS_MEDIA_ITEM_UPDATES.reset(token)
+
+        self.mass.signal_event(EventType.MEDIA_ITEM_DELETED, source_item.uri, source_item)
+        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, merged_item.uri, merged_item)
+        return merged_item
+
+    async def _merge_library_item_relations(self, target_id: int, source_id: int) -> None:
+        """Transfer relations that reference the merged media item."""
+        if self.media_type == MediaType.ALBUM:
+            await self._move_relation_rows(DB_TABLE_ALBUM_ARTISTS, "album_id", target_id, source_id)
+            await self._move_relation_rows(DB_TABLE_ALBUM_TRACKS, "album_id", target_id, source_id)
+        elif self.media_type == MediaType.ARTIST:
+            await self._move_relation_rows(
+                DB_TABLE_ALBUM_ARTISTS, "artist_id", target_id, source_id
+            )
+            await self._move_relation_rows(
+                DB_TABLE_AUDIOBOOK_ARTISTS, "artist_id", target_id, source_id
+            )
+            await self._move_relation_rows(
+                DB_TABLE_TRACK_ARTISTS, "artist_id", target_id, source_id
+            )
+        elif self.media_type == MediaType.AUDIOBOOK:
+            await self._move_relation_rows(
+                DB_TABLE_AUDIOBOOK_ARTISTS, "audiobook_id", target_id, source_id
+            )
+        elif self.media_type == MediaType.TRACK:
+            await self._move_relation_rows(DB_TABLE_ALBUM_TRACKS, "track_id", target_id, source_id)
+            await self._move_relation_rows(DB_TABLE_TRACK_ARTISTS, "track_id", target_id, source_id)
+
+    async def _merge_genre_mappings(self, target_id: int, source_id: int) -> None:
+        """Transfer genre mappings and exclusions to the target item."""
+        values = {
+            "target_id": target_id,
+            "source_id": source_id,
+            "media_type": self.media_type.value,
+        }
+        await self.mass.music.database.execute_write(
+            f"""
+            INSERT INTO {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}(
+                genre_id, media_id, media_type, alias, is_derived, is_manual
+            )
+            SELECT genre_id, :target_id, media_type, alias, is_derived, is_manual
+            FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}
+            WHERE media_id = :source_id AND media_type = :media_type
+            ON CONFLICT(genre_id, media_id, media_type) DO UPDATE SET
+                alias = CASE
+                    WHEN excluded.is_manual AND NOT is_manual
+                    THEN COALESCE(excluded.alias, alias)
+                    ELSE COALESCE(alias, excluded.alias)
+                END,
+                is_derived = is_derived OR excluded.is_derived,
+                is_manual = is_manual OR excluded.is_manual
+            """,
+            values,
+        )
+        await self.mass.music.database.execute_write(
+            f"""
+            INSERT OR IGNORE INTO {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}(
+                genre_id, media_id, media_type
+            )
+            SELECT genre_id, :target_id, media_type
+            FROM {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}
+            WHERE media_id = :source_id AND media_type = :media_type
+            """,
+            values,
+        )
+        await self.mass.music.database.delete(
+            DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+            {"media_id": source_id, "media_type": self.media_type.value},
+        )
+        await self.mass.music.database.delete(
+            DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
+            {"media_id": source_id, "media_type": self.media_type.value},
+        )
+
+    async def _merge_library_playlog(self, target_id: int, source_id: int) -> None:
+        """Transfer library-keyed playlog rows using the normal latest-entry semantics."""
+        values = {
+            "target_id": target_id,
+            "source_id": source_id,
+            "media_type": self.media_type.value,
+        }
+        await self.mass.music.database.execute_write(
+            f"""
+            INSERT INTO {DB_TABLE_PLAYLOG}(
+                item_id, provider, media_type, name, image, artists, timestamp,
+                fully_played, seconds_played, userid, queue_id, user_initiated, playback_speed
+            )
+            SELECT
+                :target_id, provider, media_type, name, image, artists, timestamp,
+                fully_played, seconds_played, userid, queue_id, user_initiated, playback_speed
+            FROM {DB_TABLE_PLAYLOG}
+            WHERE item_id = :source_id AND provider = 'library' AND media_type = :media_type
+            ON CONFLICT(item_id, provider, media_type, userid) DO UPDATE SET
+                name = CASE WHEN excluded.timestamp > timestamp THEN excluded.name ELSE name END,
+                image = CASE WHEN excluded.timestamp > timestamp THEN excluded.image ELSE image END,
+                artists = CASE WHEN excluded.timestamp > timestamp THEN excluded.artists ELSE artists END,
+                timestamp = MAX(timestamp, excluded.timestamp),
+                fully_played = CASE
+                    WHEN excluded.timestamp > timestamp THEN excluded.fully_played ELSE fully_played
+                END,
+                seconds_played = CASE
+                    WHEN excluded.timestamp > timestamp THEN excluded.seconds_played
+                    ELSE seconds_played
+                END,
+                queue_id = CASE
+                    WHEN excluded.timestamp > timestamp THEN excluded.queue_id ELSE queue_id
+                END,
+                user_initiated = user_initiated OR excluded.user_initiated,
+                playback_speed = CASE
+                    WHEN excluded.timestamp > timestamp THEN excluded.playback_speed
+                    ELSE playback_speed
+                END
+            """,
+            values,
+        )
+        await self.mass.music.database.delete(
+            DB_TABLE_PLAYLOG,
+            {
+                "item_id": source_id,
+                "provider": "library",
+                "media_type": self.media_type.value,
+            },
+        )
+
+    async def _move_relation_rows(
+        self, table: str, item_column: str, target_id: int, source_id: int
+    ) -> None:
+        """Move a relation column to the target item, retaining target duplicates."""
+        values = {"target_id": target_id, "source_id": source_id}
+        await self.mass.music.database.execute_write(
+            f"UPDATE OR IGNORE {table} SET {item_column} = :target_id "
+            f"WHERE {item_column} = :source_id",
+            values,
+        )
+        await self.mass.music.database.delete(table, {item_column: source_id})

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -2391,10 +2391,6 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                         int(target_row["last_played"] or 0), int(source_row["last_played"] or 0)
                     ),
                     "timestamp_added": min(timestamps_added) if timestamps_added else 0,
-                    "timestamp_modified": max(
-                        int(target_row["timestamp_modified"] or 0),
-                        int(source_row["timestamp_modified"] or 0),
-                    ),
                 },
             )
             await self._merge_genre_mappings(target_id, source_id)

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -2343,9 +2343,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         """Merge the source library item into the target while the controller lock is held."""
         target_item = await self.get_library_item(target_id)
         source_item = await self.get_library_item(source_id)
-        if target_item.media_type != self.media_type or source_item.media_type != self.media_type:
-            msg = "Library items must have the controller's media type"
-            raise InvalidDataError(msg)
+        await self._validate_library_item_merge(target_item, source_item)
         target_row = await self.mass.music.database.get_row(self.db_table, {"item_id": target_id})
         source_row = await self.mass.music.database.get_row(self.db_table, {"item_id": source_id})
         assert target_row is not None
@@ -2368,13 +2366,27 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             finally:
                 source_item.provider_mappings = source_mappings
 
+            await self.mass.music.database.execute_write(
+                f"""
+                UPDATE {self.db_table}
+                SET play_count = CASE item_id
+                    WHEN :target_id THEN :merged_play_count
+                    WHEN :source_id THEN 0
+                END
+                WHERE item_id IN (:target_id, :source_id)
+                """,
+                {
+                    "target_id": target_id,
+                    "source_id": source_id,
+                    "merged_play_count": int(target_row["play_count"] or 0)
+                    + int(source_row["play_count"] or 0),
+                },
+            )
             await self.mass.music.database.update(
                 self.db_table,
                 {"item_id": target_id},
                 {
                     "favorite": bool(target_row["favorite"]) or bool(source_row["favorite"]),
-                    "play_count": int(target_row["play_count"] or 0)
-                    + int(source_row["play_count"] or 0),
                     "last_played": max(
                         int(target_row["last_played"] or 0), int(source_row["last_played"] or 0)
                     ),
@@ -2413,6 +2425,12 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             self.mass.signal_event(EventType.MEDIA_ITEM_DELETED, source_item.uri, source_item)
             self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, merged_item.uri, merged_item)
         return merged_item
+
+    async def _validate_library_item_merge(self, target: ItemCls, source: ItemCls) -> None:
+        """Validate that the target and source items can be merged."""
+        if target.media_type != self.media_type or source.media_type != self.media_type:
+            msg = "Library items must have the controller's media type"
+            raise InvalidDataError(msg)
 
     async def _update_library_item_for_merge(self, item_id: int, update: ItemCls) -> None:
         """Merge model state into an existing library item."""

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -1014,7 +1014,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             msg = "Cannot merge a library item into itself"
             raise InvalidDataError(msg)
         async with self._db_add_lock:
-            return await self._merge_library_items(target_id, source_id)
+            return await self._merge_library_items_batched(target_id, source_id)
 
     @final
     async def add_provider_mappings(
@@ -1048,7 +1048,9 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                     conflicting_item.item_id,
                     library_item.item_id,
                 )
-                library_item = await self._merge_library_items(db_id, int(conflicting_item.item_id))
+                library_item = await self._merge_library_items_batched(
+                    db_id, int(conflicting_item.item_id)
+                )
 
             new_mappings = mappings.difference(library_item.provider_mappings)
             if not new_mappings:
@@ -2337,7 +2339,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
 
         return sql_query
 
-    async def _merge_library_items(self, target_id: int, source_id: int) -> ItemCls:
+    async def _merge_library_items(self, target_id: int, source_id: int) -> tuple[ItemCls, ItemCls]:
         """Merge the source library item into the target while the controller lock is held."""
         target_item = await self.get_library_item(target_id)
         source_item = await self.get_library_item(source_id)
@@ -2401,6 +2403,12 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         finally:
             SUPPRESS_MEDIA_ITEM_UPDATES.reset(token)
 
+        return source_item, merged_item
+
+    async def _merge_library_items_batched(self, target_id: int, source_id: int) -> ItemCls:
+        """Merge library items while batching the transfer's database writes."""
+        async with self.mass.music.database.deferred_commit():
+            source_item, merged_item = await self._merge_library_items(target_id, source_id)
         if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
             self.mass.signal_event(EventType.MEDIA_ITEM_DELETED, source_item.uri, source_item)
             self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, merged_item.uri, merged_item)

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -1391,6 +1391,16 @@ class GenreController(MediaControllerBase[Genre]):
         """Transfer media mappings and exclusions owned by a merged genre."""
         await self._merge_genre_references(target_id, source_id)
 
+    async def _validate_library_item_merge(self, target: Genre, source: Genre) -> None:
+        """Validate that two genres belong to the same taxonomy."""
+        await super()._validate_library_item_merge(target, source)
+        if target.content_type != source.content_type:
+            msg = (
+                f"Cannot merge genre '{source.name}' into '{target.name}': "
+                "genres must belong to the same taxonomy (music / podcast / audiobook)."
+            )
+            raise InvalidDataError(msg)
+
     async def _bulk_scan_media_genres(self) -> None:
         """
         Bulk-scan all media items and rebuild genre mappings using CTE.

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -1387,6 +1387,10 @@ class GenreController(MediaControllerBase[Genre]):
         )
         self.logger.debug("updated %s in database: (id %s)", update.name, db_id)
 
+    async def _merge_library_item_references(self, target_id: int, source_id: int) -> None:
+        """Transfer media mappings and exclusions owned by a merged genre."""
+        await self._merge_genre_references(target_id, source_id)
+
     async def _bulk_scan_media_genres(self) -> None:
         """
         Bulk-scan all media items and rebuild genre mappings using CTE.

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -740,7 +740,12 @@ class TracksController(MediaControllerBase[Track]):
         return db_id
 
     async def _update_library_item(
-        self, item_id: str | int, update: Track, overwrite: bool = False
+        self,
+        item_id: str | int,
+        update: Track,
+        overwrite: bool = False,
+        *,
+        set_album: bool = True,
     ) -> None:
         """Update Track record in the database, merging data."""
         db_id = int(item_id)  # ensure integer
@@ -783,7 +788,7 @@ class TracksController(MediaControllerBase[Track]):
         artists = update.artists if overwrite else cur_item.artists + update.artists
         await self._set_track_artists(db_id, artists, overwrite=overwrite)
         # update/set track album
-        if update.album:
+        if update.album and set_album:
             await self._set_track_album(
                 db_id=db_id,
                 album=update.album,
@@ -792,6 +797,10 @@ class TracksController(MediaControllerBase[Track]):
                 overwrite=overwrite,
             )
         self.logger.debug("updated %s in database: (id %s)", update.name, db_id)
+
+    async def _update_library_item_for_merge(self, item_id: int, update: Track) -> None:
+        """Merge track model state without replacing existing album relations."""
+        await self._update_library_item(item_id, update, set_album=False)
 
     async def _set_track_album(
         self,

--- a/tests/controllers/music/test_library_item_merge.py
+++ b/tests/controllers/music/test_library_item_merge.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from music_assistant_models.enums import AlbumType, ExternalID, MediaType
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError, MusicAssistantError
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -26,6 +26,7 @@ from music_assistant.constants import (
     DB_TABLE_PLAYLOG,
     DB_TABLE_PROVIDER_MAPPINGS,
     DB_TABLE_TRACK_ARTISTS,
+    DB_TABLE_TRACKS,
 )
 from music_assistant.controllers.music.media.base import (
     SUPPRESS_MEDIA_ITEM_UPDATES,
@@ -532,6 +533,100 @@ async def test_merge_honors_outer_event_suppression(mass: MusicAssistant) -> Non
     finally:
         SUPPRESS_MEDIA_ITEM_UPDATES.reset(token)
     signal_event.assert_not_called()
+
+
+async def test_genre_merge_rejects_different_taxonomies(mass: MusicAssistant) -> None:
+    """A genre merge cannot cross music and podcast taxonomies."""
+    target = await mass.music.genres.add_item_to_library(
+        Genre(
+            item_id="0",
+            provider="library",
+            name="Podcast Genre",
+            content_type=MediaType.PODCAST,
+            provider_mappings=set(),
+        )
+    )
+    source = await mass.music.genres.add_item_to_library(
+        Genre(item_id="0", provider="library", name="Music Genre", provider_mappings=set())
+    )
+
+    with pytest.raises(InvalidDataError, match="same taxonomy"):
+        await mass.music.genres.merge_library_items(target.item_id, source.item_id)
+
+    assert await mass.music.genres.get_library_item(target.item_id)
+    assert await mass.music.genres.get_library_item(source.item_id)
+
+
+async def test_merge_retry_does_not_double_play_count(mass: MusicAssistant) -> None:
+    """A retry after a later transfer failure preserves the merged play count."""
+    artist = await _add_artist(mass, "Artist", "target_instance", "target-artist")
+    target_album = await _add_album(
+        mass,
+        "Target Album",
+        "target_instance",
+        "target-album",
+        artist,
+        "target-barcode",
+    )
+    source_album = await _add_album(
+        mass,
+        "Source Album",
+        "source_instance",
+        "source-album",
+        artist,
+        "source-barcode",
+    )
+    target = await _add_track(
+        mass,
+        "Target Track",
+        "target_instance",
+        "target-track",
+        artist,
+        target_album,
+    )
+    source = await _add_track(
+        mass,
+        "Source Track",
+        "source_instance",
+        "source-track",
+        artist,
+        source_album,
+    )
+    await mass.music.database.update(
+        DB_TABLE_TRACKS, {"item_id": int(target.item_id)}, {"play_count": 2}
+    )
+    await mass.music.database.update(
+        DB_TABLE_TRACKS, {"item_id": int(source.item_id)}, {"play_count": 3}
+    )
+
+    with (
+        patch.object(
+            mass.music.tracks,
+            "_merge_genre_mappings",
+            AsyncMock(side_effect=MusicAssistantError("merge failure")),
+        ),
+        pytest.raises(MusicAssistantError, match="merge failure"),
+    ):
+        await mass.music.tracks.merge_library_items(target.item_id, source.item_id)
+
+    target_row = await mass.music.database.get_row(
+        DB_TABLE_TRACKS, {"item_id": int(target.item_id)}
+    )
+    source_row = await mass.music.database.get_row(
+        DB_TABLE_TRACKS, {"item_id": int(source.item_id)}
+    )
+    assert target_row is not None
+    assert source_row is not None
+    assert target_row["play_count"] == 5
+    assert source_row["play_count"] == 0
+
+    await mass.music.tracks.merge_library_items(target.item_id, source.item_id)
+
+    merged_row = await mass.music.database.get_row(
+        DB_TABLE_TRACKS, {"item_id": int(target.item_id)}
+    )
+    assert merged_row is not None
+    assert merged_row["play_count"] == 5
 
 
 async def _assert_album_merge_result(

--- a/tests/controllers/music/test_library_item_merge.py
+++ b/tests/controllers/music/test_library_item_merge.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from music_assistant_models.enums import AlbumType, ExternalID, MediaType
+from music_assistant_models.enums import AlbumType, ArtistType, ExternalID, MediaType
 from music_assistant_models.errors import InvalidDataError, MediaNotFoundError, MusicAssistantError
 from music_assistant_models.media_items import (
     Album,
@@ -555,6 +555,34 @@ async def test_genre_merge_rejects_different_taxonomies(mass: MusicAssistant) ->
 
     assert await mass.music.genres.get_library_item(target.item_id)
     assert await mass.music.genres.get_library_item(source.item_id)
+
+
+async def test_artist_merge_rejects_different_roles(mass: MusicAssistant) -> None:
+    """An artist merge cannot cross music and spoken-word roles."""
+    target = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Singer",
+            artist_type=ArtistType.SINGER,
+            provider_mappings={_mapping("target_instance", "target-artist")},
+        )
+    )
+    source = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Author",
+            artist_type=ArtistType.AUTHOR,
+            provider_mappings={_mapping("source_instance", "source-artist")},
+        )
+    )
+
+    with pytest.raises(InvalidDataError, match="same role"):
+        await mass.music.artists.merge_library_items(target.item_id, source.item_id)
+
+    assert await mass.music.artists.get_library_item(target.item_id)
+    assert await mass.music.artists.get_library_item(source.item_id)
 
 
 async def test_merge_retry_does_not_double_play_count(mass: MusicAssistant) -> None:

--- a/tests/controllers/music/test_library_item_merge.py
+++ b/tests/controllers/music/test_library_item_merge.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from music_assistant_models.enums import AlbumType, ExternalID, MediaType
@@ -10,6 +10,7 @@ from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import (
     Album,
     Artist,
+    Audiobook,
     Genre,
     ProviderMapping,
     Track,
@@ -26,7 +27,10 @@ from music_assistant.constants import (
     DB_TABLE_PROVIDER_MAPPINGS,
     DB_TABLE_TRACK_ARTISTS,
 )
-from music_assistant.controllers.music.media.base import MediaControllerBase
+from music_assistant.controllers.music.media.base import (
+    SUPPRESS_MEDIA_ITEM_UPDATES,
+    MediaControllerBase,
+)
 from music_assistant.mass import MusicAssistant
 
 
@@ -337,6 +341,15 @@ async def test_track_merge_preserves_album_and_artist_relations(mass: MusicAssis
         source_artist,
         source_album,
     )
+    await mass.music.database.insert(
+        DB_TABLE_ALBUM_TRACKS,
+        {
+            "track_id": int(target.item_id),
+            "album_id": int(source_album.item_id),
+            "disc_number": 7,
+            "track_number": 8,
+        },
+    )
 
     await mass.music.tracks.merge_library_items(target.item_id, source.item_id)
 
@@ -356,8 +369,169 @@ async def test_track_merge_preserves_album_and_artist_relations(mass: MusicAssis
             DB_TABLE_TRACK_ARTISTS, {"track_id": int(target.item_id)}
         )
     } == {int(target_artist.item_id), int(source_artist.item_id)}
+    source_album_track = await mass.music.database.get_row(
+        DB_TABLE_ALBUM_TRACKS,
+        {"track_id": int(target.item_id), "album_id": int(source_album.item_id)},
+    )
+    assert source_album_track is not None
+    assert source_album_track["disc_number"] == 7
+    assert source_album_track["track_number"] == 8
     with pytest.raises(MediaNotFoundError):
         await mass.music.tracks.merge_library_items(target.item_id, source.item_id)
+
+
+async def test_audiobook_merge_keeps_per_user_resume_state(mass: MusicAssistant) -> None:
+    """An audiobook merge leaves resume transfer to the library playlog merge."""
+    target = await mass.music.audiobooks.add_item_to_library(
+        Audiobook(
+            item_id="0",
+            provider="library",
+            name="Target Book",
+            duration=3600,
+            provider_mappings={_mapping("target_instance", "target-book")},
+        )
+    )
+    source = await mass.music.audiobooks.add_item_to_library(
+        Audiobook(
+            item_id="0",
+            provider="library",
+            name="Source Book",
+            duration=3600,
+            provider_mappings={_mapping("source_instance", "source-book")},
+        )
+    )
+    await _add_playlog(
+        mass,
+        target.item_id,
+        "library",
+        MediaType.AUDIOBOOK,
+        timestamp=20,
+        seconds_played=20,
+        user_initiated=False,
+    )
+    await _add_playlog(
+        mass,
+        source.item_id,
+        "library",
+        MediaType.AUDIOBOOK,
+        timestamp=30,
+        seconds_played=30,
+        user_initiated=True,
+    )
+
+    with patch.object(
+        mass.music.audiobooks,
+        "_set_playlog",
+        wraps=mass.music.audiobooks._set_playlog,
+    ) as set_playlog:
+        await mass.music.audiobooks.merge_library_items(target.item_id, source.item_id)
+
+    assert isinstance(set_playlog, AsyncMock)
+    set_playlog.assert_not_awaited()
+    playlog = await mass.music.database.get_row(
+        DB_TABLE_PLAYLOG,
+        {
+            "item_id": target.item_id,
+            "provider": "library",
+            "media_type": MediaType.AUDIOBOOK.value,
+            "userid": "test-user",
+        },
+    )
+    assert playlog is not None
+    assert playlog["timestamp"] == 30
+    assert playlog["seconds_played"] == 30
+    assert playlog["user_initiated"] == 1
+
+
+async def test_genre_merge_transfers_genre_references(mass: MusicAssistant) -> None:
+    """A genre merge reassigns every media mapping and exclusion to the target genre."""
+    target = await mass.music.genres.add_item_to_library(
+        Genre(item_id="0", provider="library", name="Target Genre", provider_mappings=set())
+    )
+    source = await mass.music.genres.add_item_to_library(
+        Genre(item_id="0", provider="library", name="Source Genre", provider_mappings=set())
+    )
+    await mass.music.database.insert(
+        DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+        {
+            "genre_id": int(target.item_id),
+            "media_id": 1,
+            "media_type": MediaType.TRACK.value,
+            "alias": "target",
+            "is_derived": True,
+            "is_manual": False,
+        },
+    )
+    await mass.music.database.insert(
+        DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+        {
+            "genre_id": int(source.item_id),
+            "media_id": 1,
+            "media_type": MediaType.TRACK.value,
+            "alias": "source",
+            "is_derived": False,
+            "is_manual": True,
+        },
+    )
+    await mass.music.database.insert(
+        DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
+        {
+            "genre_id": int(source.item_id),
+            "media_id": 2,
+            "media_type": MediaType.TRACK.value,
+        },
+    )
+
+    await mass.music.genres.merge_library_items(target.item_id, source.item_id)
+
+    genre_mapping = await mass.music.database.get_row(
+        DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+        {
+            "genre_id": int(target.item_id),
+            "media_id": 1,
+            "media_type": MediaType.TRACK.value,
+        },
+    )
+    assert genre_mapping is not None
+    assert dict(genre_mapping) == {
+        "genre_id": int(target.item_id),
+        "media_id": 1,
+        "media_type": MediaType.TRACK.value,
+        "alias": "source",
+        "is_derived": 1,
+        "is_manual": 1,
+    }
+    assert await mass.music.database.get_row(
+        DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
+        {
+            "genre_id": int(target.item_id),
+            "media_id": 2,
+            "media_type": MediaType.TRACK.value,
+        },
+    )
+    assert not await mass.music.database.get_rows(
+        DB_TABLE_GENRE_MEDIA_ITEM_MAPPING, {"genre_id": int(source.item_id)}
+    )
+    assert not await mass.music.database.get_rows(
+        DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION, {"genre_id": int(source.item_id)}
+    )
+
+
+async def test_merge_honors_outer_event_suppression(mass: MusicAssistant) -> None:
+    """A merge inside a suppressed update scope does not emit item events."""
+    target = await mass.music.genres.add_item_to_library(
+        Genre(item_id="0", provider="library", name="Target Genre", provider_mappings=set())
+    )
+    source = await mass.music.genres.add_item_to_library(
+        Genre(item_id="0", provider="library", name="Source Genre", provider_mappings=set())
+    )
+    token = SUPPRESS_MEDIA_ITEM_UPDATES.set(True)
+    try:
+        with patch.object(mass, "signal_event") as signal_event:
+            await mass.music.genres.merge_library_items(target.item_id, source.item_id)
+    finally:
+        SUPPRESS_MEDIA_ITEM_UPDATES.reset(token)
+    signal_event.assert_not_called()
 
 
 async def _assert_album_merge_result(

--- a/tests/controllers/music/test_library_item_merge.py
+++ b/tests/controllers/music/test_library_item_merge.py
@@ -1,0 +1,452 @@
+"""Integration tests for non-destructive library item merges."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from music_assistant_models.enums import AlbumType, ExternalID, MediaType
+from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.media_items import (
+    Album,
+    Artist,
+    Genre,
+    ProviderMapping,
+    Track,
+    UniqueList,
+)
+
+from music_assistant.constants import (
+    DB_TABLE_ALBUM_ARTISTS,
+    DB_TABLE_ALBUM_TRACKS,
+    DB_TABLE_ALBUMS,
+    DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
+    DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+    DB_TABLE_PLAYLOG,
+    DB_TABLE_PROVIDER_MAPPINGS,
+    DB_TABLE_TRACK_ARTISTS,
+)
+from music_assistant.controllers.music.media.base import MediaControllerBase
+from music_assistant.mass import MusicAssistant
+
+
+def _mapping(provider_instance: str, item_id: str) -> ProviderMapping:
+    """Create a provider mapping for a library fixture item."""
+    return ProviderMapping(
+        item_id=item_id,
+        provider_domain=provider_instance.removesuffix("_instance"),
+        provider_instance=provider_instance,
+        in_library=True,
+    )
+
+
+async def _add_artist(
+    mass: MusicAssistant, name: str, provider_instance: str, provider_item_id: str
+) -> Artist:
+    """Create and store a fixture artist."""
+    return await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name=name,
+            provider_mappings={_mapping(provider_instance, provider_item_id)},
+        )
+    )
+
+
+async def _add_album(
+    mass: MusicAssistant,
+    name: str,
+    provider_instance: str,
+    provider_item_id: str,
+    artist: Artist,
+    external_id: str,
+) -> Album:
+    """Create and store a fixture album."""
+    return await mass.music.albums.add_item_to_library(
+        Album(
+            item_id="0",
+            provider="library",
+            name=name,
+            album_type=AlbumType.ALBUM,
+            provider_mappings={_mapping(provider_instance, provider_item_id)},
+            external_ids={(ExternalID.BARCODE, external_id)},
+            artists=UniqueList([artist]),
+        )
+    )
+
+
+async def _add_track(
+    mass: MusicAssistant,
+    name: str,
+    provider_instance: str,
+    provider_item_id: str,
+    artist: Artist,
+    album: Album,
+) -> Track:
+    """Create and store a fixture track."""
+    return await mass.music.tracks.add_item_to_library(
+        Track(
+            item_id="0",
+            provider="library",
+            name=name,
+            provider_mappings={_mapping(provider_instance, provider_item_id)},
+            artists=UniqueList([artist]),
+            album=album,
+            disc_number=1,
+            track_number=1,
+        )
+    )
+
+
+async def _add_playlog(
+    mass: MusicAssistant,
+    item_id: str | int,
+    provider: str,
+    media_type: MediaType,
+    *,
+    timestamp: int,
+    seconds_played: int,
+    user_initiated: bool,
+) -> None:
+    """Insert a playlog row for merge coverage."""
+    await mass.music.database.insert(
+        DB_TABLE_PLAYLOG,
+        {
+            "item_id": item_id,
+            "provider": provider,
+            "media_type": media_type.value,
+            "name": "Merge test",
+            "timestamp": timestamp,
+            "seconds_played": seconds_played,
+            "userid": "test-user",
+            "user_initiated": user_initiated,
+        },
+    )
+
+
+async def test_mapping_conflict_merges_albums_without_deleting_tracks(
+    mass: MusicAssistant,
+) -> None:
+    """A mapping conflict merges albums without recursively deleting their tracks."""
+    target_artist = await _add_artist(mass, "Target Artist", "target_instance", "target-artist")
+    source_artist = await _add_artist(mass, "Source Artist", "source_instance", "source-artist")
+    target = await _add_album(
+        mass,
+        "Target Album",
+        "target_instance",
+        "target-album",
+        target_artist,
+        "target-barcode",
+    )
+    source = await _add_album(
+        mass,
+        "Source Album",
+        "source_instance",
+        "source-album",
+        source_artist,
+        "source-barcode",
+    )
+    shared_track = await _add_track(
+        mass,
+        "Shared Track",
+        "shared_instance",
+        "shared-track",
+        target_artist,
+        target,
+    )
+    source_track = await _add_track(
+        mass,
+        "Source Track",
+        "source-track_instance",
+        "source-track",
+        source_artist,
+        source,
+    )
+    await mass.music.database.insert(
+        DB_TABLE_ALBUM_TRACKS,
+        {
+            "track_id": int(shared_track.item_id),
+            "album_id": int(source.item_id),
+            "disc_number": 1,
+            "track_number": 1,
+        },
+    )
+    await mass.music.database.update(
+        DB_TABLE_ALBUMS,
+        {"item_id": int(target.item_id)},
+        {
+            "favorite": False,
+            "play_count": 2,
+            "last_played": 20,
+            "timestamp_added": 20,
+            "timestamp_modified": 20,
+        },
+    )
+    await mass.music.database.update(
+        DB_TABLE_ALBUMS,
+        {"item_id": int(source.item_id)},
+        {
+            "favorite": True,
+            "play_count": 3,
+            "last_played": 30,
+            "timestamp_added": 10,
+            "timestamp_modified": 30,
+        },
+    )
+    genre = await mass.music.genres.add_item_to_library(
+        Genre(item_id="0", provider="library", name="Merge Genre", provider_mappings=set())
+    )
+    await mass.music.database.insert(
+        DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+        {
+            "genre_id": int(genre.item_id),
+            "media_id": int(target.item_id),
+            "media_type": MediaType.ALBUM.value,
+            "alias": "target",
+            "is_derived": True,
+            "is_manual": False,
+        },
+    )
+    await mass.music.database.insert(
+        DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+        {
+            "genre_id": int(genre.item_id),
+            "media_id": int(source.item_id),
+            "media_type": MediaType.ALBUM.value,
+            "alias": "source",
+            "is_derived": False,
+            "is_manual": True,
+        },
+    )
+    await mass.music.database.insert(
+        DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
+        {
+            "genre_id": int(genre.item_id),
+            "media_id": int(source.item_id),
+            "media_type": MediaType.ALBUM.value,
+        },
+    )
+    await _add_playlog(
+        mass,
+        target.item_id,
+        "library",
+        MediaType.ALBUM,
+        timestamp=20,
+        seconds_played=20,
+        user_initiated=False,
+    )
+    await _add_playlog(
+        mass,
+        source.item_id,
+        "library",
+        MediaType.ALBUM,
+        timestamp=30,
+        seconds_played=30,
+        user_initiated=True,
+    )
+    await _add_playlog(
+        mass,
+        "source-album",
+        "source_instance",
+        MediaType.ALBUM,
+        timestamp=30,
+        seconds_played=30,
+        user_initiated=True,
+    )
+
+    original_remove = MediaControllerBase.remove_item_from_library
+
+    async def assert_transferred_before_delete(
+        controller: MediaControllerBase[Album], item_id: str | int, recursive: bool = True
+    ) -> None:
+        if int(item_id) == int(source.item_id):
+            assert await mass.music.database.get_row(
+                DB_TABLE_PROVIDER_MAPPINGS,
+                {
+                    "media_type": MediaType.ALBUM.value,
+                    "item_id": int(target.item_id),
+                    "provider_instance": "source_instance",
+                    "provider_item_id": "source-album",
+                },
+            )
+            assert await mass.music.database.get_row(
+                DB_TABLE_ALBUM_TRACKS,
+                {"track_id": int(source_track.item_id), "album_id": int(target.item_id)},
+            )
+        await original_remove(controller, item_id, recursive)
+
+    with (
+        patch.object(
+            MediaControllerBase, "remove_item_from_library", assert_transferred_before_delete
+        ),
+        patch.object(
+            mass.music.albums,
+            "update_item_in_library",
+            wraps=mass.music.albums.update_item_in_library,
+        ) as update_item,
+    ):
+        await mass.music.albums.add_provider_mappings(target.item_id, source.provider_mappings)
+    update_item.assert_not_awaited()
+
+    await _assert_album_merge_result(
+        mass,
+        target,
+        source,
+        shared_track,
+        source_track,
+        target_artist,
+        source_artist,
+        genre,
+    )
+
+
+async def test_track_merge_preserves_album_and_artist_relations(mass: MusicAssistant) -> None:
+    """A track merge transfers all album and artist relations without deleting albums."""
+    target_artist = await _add_artist(mass, "Target Artist", "target_instance", "target-artist")
+    source_artist = await _add_artist(mass, "Source Artist", "source_instance", "source-artist")
+    target_album = await _add_album(
+        mass,
+        "Target Album",
+        "target_instance",
+        "target-album",
+        target_artist,
+        "target-barcode",
+    )
+    source_album = await _add_album(
+        mass,
+        "Source Album",
+        "source_instance",
+        "source-album",
+        source_artist,
+        "source-barcode",
+    )
+    target = await _add_track(
+        mass,
+        "Target Track",
+        "target_instance",
+        "target-track",
+        target_artist,
+        target_album,
+    )
+    source = await _add_track(
+        mass,
+        "Source Track",
+        "source_instance",
+        "source-track",
+        source_artist,
+        source_album,
+    )
+
+    await mass.music.tracks.merge_library_items(target.item_id, source.item_id)
+
+    with pytest.raises(MediaNotFoundError):
+        await mass.music.tracks.get_library_item(source.item_id)
+    assert await mass.music.albums.get_library_item(target_album.item_id)
+    assert await mass.music.albums.get_library_item(source_album.item_id)
+    assert {
+        int(row["album_id"])
+        for row in await mass.music.database.get_rows(
+            DB_TABLE_ALBUM_TRACKS, {"track_id": int(target.item_id)}
+        )
+    } == {int(target_album.item_id), int(source_album.item_id)}
+    assert {
+        int(row["artist_id"])
+        for row in await mass.music.database.get_rows(
+            DB_TABLE_TRACK_ARTISTS, {"track_id": int(target.item_id)}
+        )
+    } == {int(target_artist.item_id), int(source_artist.item_id)}
+    with pytest.raises(MediaNotFoundError):
+        await mass.music.tracks.merge_library_items(target.item_id, source.item_id)
+
+
+async def _assert_album_merge_result(
+    mass: MusicAssistant,
+    target: Album,
+    source: Album,
+    shared_track: Track,
+    source_track: Track,
+    target_artist: Artist,
+    source_artist: Artist,
+    genre: Genre,
+) -> None:
+    """Assert that an album merge preserved the source state on the target."""
+    with pytest.raises(MediaNotFoundError):
+        await mass.music.albums.get_library_item(source.item_id)
+    assert await mass.music.tracks.get_library_item(shared_track.item_id)
+    assert await mass.music.tracks.get_library_item(source_track.item_id)
+    merged = await mass.music.albums.get_library_item(target.item_id)
+    assert merged.favorite is True
+    merged_row = await mass.music.database.get_row(
+        DB_TABLE_ALBUMS, {"item_id": int(target.item_id)}
+    )
+    assert merged_row is not None
+    assert merged_row["play_count"] == 5
+    assert merged_row["last_played"] == 30
+    assert merged_row["timestamp_added"] == 10
+    assert {(kind, value) for kind, value in merged.external_ids} == {
+        (ExternalID.BARCODE, "target-barcode"),
+        (ExternalID.BARCODE, "source-barcode"),
+    }
+    assert {
+        int(row["track_id"])
+        for row in await mass.music.database.get_rows(
+            DB_TABLE_ALBUM_TRACKS, {"album_id": int(target.item_id)}
+        )
+    } == {int(shared_track.item_id), int(source_track.item_id)}
+    assert not await mass.music.database.get_rows(
+        DB_TABLE_ALBUM_TRACKS, {"album_id": int(source.item_id)}
+    )
+    assert {
+        int(row["artist_id"])
+        for row in await mass.music.database.get_rows(
+            DB_TABLE_ALBUM_ARTISTS, {"album_id": int(target.item_id)}
+        )
+    } == {int(target_artist.item_id), int(source_artist.item_id)}
+    genre_mapping = await mass.music.database.get_row(
+        DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+        {
+            "genre_id": int(genre.item_id),
+            "media_id": int(target.item_id),
+            "media_type": MediaType.ALBUM.value,
+        },
+    )
+    assert genre_mapping is not None
+    assert dict(genre_mapping) == {
+        "genre_id": int(genre.item_id),
+        "media_id": int(target.item_id),
+        "media_type": MediaType.ALBUM.value,
+        "alias": "source",
+        "is_derived": 1,
+        "is_manual": 1,
+    }
+    assert await mass.music.database.get_row(
+        DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
+        {
+            "genre_id": int(genre.item_id),
+            "media_id": int(target.item_id),
+            "media_type": MediaType.ALBUM.value,
+        },
+    )
+    playlog = await mass.music.database.get_row(
+        DB_TABLE_PLAYLOG,
+        {
+            "item_id": target.item_id,
+            "provider": "library",
+            "media_type": MediaType.ALBUM.value,
+            "userid": "test-user",
+        },
+    )
+    assert playlog is not None
+    assert playlog["timestamp"] == 30
+    assert playlog["seconds_played"] == 30
+    assert playlog["user_initiated"] == 1
+    assert await mass.music.database.get_row(
+        DB_TABLE_PLAYLOG,
+        {
+            "item_id": "source-album",
+            "provider": "source_instance",
+            "media_type": MediaType.ALBUM.value,
+            "userid": "test-user",
+        },
+    )


### PR DESCRIPTION
# What does this implement/fix?

Normal matched adds extend the existing library row in place. This change only consolidates two rows that already exist when a provider mapping exposes the duplicate: the explicit target row is never recreated, and the redundant source row is deleted only after its state and relations have transferred.

- Preserve mappings, IDs, library history, genre links, and item state on the existing target
- Keep album and track associations intact while deduplicating relations

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.