### PR TITLE
Improve library matching across providers

### DIFF
--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -63,6 +63,11 @@ from music_assistant.helpers.collections import (
 )
 from music_assistant.helpers.compare import compare_media_item
 from music_assistant.helpers.database import UNSET
+from music_assistant.helpers.external_ids import (
+    external_id_lookup_values,
+    external_id_sort_key,
+    normalize_external_ids,
+)
 from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.helpers.util import guard_single_request, parse_optional_bool
 
@@ -271,8 +276,13 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 # actually add a new item in the library db
                 self.mass.music.match_provider_instances(item)
                 async with self._db_add_lock:
-                    library_id = await self._add_library_item(item)
-                    new_item = True
+                    if library_id := await self._get_library_item_by_match(item):
+                        await self._update_library_item(
+                            library_id, item, overwrite=overwrite_existing
+                        )
+                    else:
+                        library_id = await self._add_library_item(item)
+                        new_item = True
         # return final library_item
         library_item = await self.get_library_item(library_id)
         if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
@@ -784,17 +794,31 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         return None
 
     @final
-    async def get_library_item_by_external_id(
-        self, external_id: str, external_id_type: ExternalID | None = None
-    ) -> ItemCls | None:
-        """Get the library item for the given external id."""
+    async def get_library_items_by_external_id(
+        self,
+        external_id: str,
+        external_id_type: ExternalID | None = None,
+        limit: int = 50,
+    ) -> list[ItemCls]:
+        """
+        Get library items for the given external identifier.
+
+        :param external_id: External identifier value to look up.
+        :param external_id_type: Optional identifier type.
+        :param limit: Maximum number of library items to return.
+        """
+        lookup_values = (
+            external_id_lookup_values(external_id_type, external_id)
+            if external_id_type
+            else (external_id,)
+        )
         subquery_parts = [
             "media_type = :ext_id_media_type",
-            "external_id = :external_id",
+            "external_id IN :external_ids",
         ]
         query_params: dict[str, Any] = {
             "ext_id_media_type": self.media_type.value,
-            "external_id": external_id,
+            "external_ids": lookup_values,
         }
         if external_id_type:
             subquery_parts.append("external_id_type = :external_id_type")
@@ -804,23 +828,39 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             f"WHERE {' AND '.join(subquery_parts)}"
         )
         query = f"{self.db_table}.item_id IN ({subquery})"
-        for item in await self.get_library_items_by_query(
-            limit=1,
+        items = await self.get_library_items_by_query(
+            limit=limit,
             extra_query_parts=[query],
             extra_query_params=query_params,
-        ):
-            return item
-        return None
+        )
+        return sorted(items, key=lambda item: int(item.item_id))
+
+    @final
+    async def get_library_item_by_external_id(
+        self, external_id: str, external_id_type: ExternalID | None = None
+    ) -> ItemCls | None:
+        """Get the first library item for the given external id, if present."""
+        items = await self.get_library_items_by_external_id(external_id, external_id_type, limit=1)
+        return items[0] if items else None
+
+    @final
+    async def get_library_items_by_external_ids(
+        self, external_ids: set[tuple[ExternalID, str]]
+    ) -> list[ItemCls]:
+        """Get all library items matching any of the given external identifiers."""
+        result: dict[str, ItemCls] = {}
+        for external_id_type, external_id in sorted(external_ids, key=external_id_sort_key):
+            for item in await self.get_library_items_by_external_id(external_id, external_id_type):
+                result.setdefault(item.item_id, item)
+        return list(result.values())
 
     @final
     async def get_library_item_by_external_ids(
         self, external_ids: set[tuple[ExternalID, str]]
     ) -> ItemCls | None:
         """Get the library item for (one of) the given external ids."""
-        for external_id_type, external_id in external_ids:
-            if match := await self.get_library_item_by_external_id(external_id, external_id_type):
-                return match
-        return None
+        items = await self.get_library_items_by_external_ids(external_ids)
+        return items[0] if items else None
 
     @final
     async def get_library_items_by_prov_id(
@@ -1310,6 +1350,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             DB_TABLE_EXTERNAL_ID_LOOKUP,
             {"media_type": self.media_type.value, "item_id": db_id},
         )
+        external_ids = normalize_external_ids(external_ids)
         if lookup_rows := [
             {
                 "media_type": self.media_type.value,
@@ -1516,14 +1557,19 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         if provider_mappings:
             if cur_item := await self.get_library_item_by_prov_mappings(provider_mappings):
                 return int(cur_item.item_id)
-        if cur_item := await self.get_library_item_by_external_ids(item.external_ids):
-            # existing item match by external id
-            # Double check external IDs - if MBID exists, regards that as overriding
+        for cur_item in await self.get_library_items_by_external_ids(item.external_ids):
+            # External identifiers may be reused, so verify every candidate.
             if compare_media_item(item, cur_item):
                 return int(cur_item.item_id)
-        # search by (exact) name match
-        query = f"{self.db_table}.name = :name OR {self.db_table}.sort_name = :sort_name"
-        query_params = {"name": item.name, "sort_name": item.sort_name}
+        # search by normalized exact name match
+        query = (
+            f"{self.db_table}.search_name = :search_name "
+            f"OR {self.db_table}.search_sort_name = :search_sort_name"
+        )
+        query_params = {
+            "search_name": create_safe_string(item.name, True, True),
+            "search_sort_name": create_safe_string(item.sort_name or "", True, True),
+        }
         for db_item in await self.get_library_items_by_query(
             extra_query_parts=[query], extra_query_params=query_params
         ):

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -65,6 +65,7 @@ from music_assistant.helpers.compare import compare_media_item
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.external_ids import (
     external_id_lookup_values,
+    external_id_lookup_values_untyped,
     external_id_sort_key,
     normalize_external_ids,
 )
@@ -276,6 +277,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 # actually add a new item in the library db
                 self.mass.music.match_provider_instances(item)
                 async with self._db_add_lock:
+                    # Another task may have inserted the same item while this task waited.
                     if library_id := await self._get_library_item_by_match(item):
                         await self._update_library_item(
                             library_id, item, overwrite=overwrite_existing
@@ -798,7 +800,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         self,
         external_id: str,
         external_id_type: ExternalID | None = None,
-        limit: int = 50,
+        limit: int | None = 50,
     ) -> list[ItemCls]:
         """
         Get library items for the given external identifier.
@@ -807,11 +809,10 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         :param external_id_type: Optional identifier type.
         :param limit: Maximum number of library items to return.
         """
-        lookup_values = (
-            external_id_lookup_values(external_id_type, external_id)
-            if external_id_type
-            else (external_id,)
-        )
+        if external_id_type:
+            lookup_values = external_id_lookup_values(external_id_type, external_id)
+        else:
+            lookup_values = external_id_lookup_values_untyped(external_id)
         subquery_parts = [
             "media_type = :ext_id_media_type",
             "external_id IN :external_ids",
@@ -828,12 +829,28 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             f"WHERE {' AND '.join(subquery_parts)}"
         )
         query = f"{self.db_table}.item_id IN ({subquery})"
-        items = await self.get_library_items_by_query(
-            limit=limit,
+        if limit is not None:
+            limited_items = await self.get_library_items_by_query(
+                limit=limit,
+                extra_query_parts=[query],
+                extra_query_params=query_params,
+            )
+            return sorted(limited_items, key=lambda item: int(item.item_id))
+
+        all_items: list[ItemCls] = []
+        offset = 0
+        page_size = 500
+        while page := await self.get_library_items_by_query(
+            limit=page_size,
+            offset=offset,
             extra_query_parts=[query],
             extra_query_params=query_params,
-        )
-        return sorted(items, key=lambda item: int(item.item_id))
+        ):
+            all_items.extend(page)
+            if len(page) < page_size:
+                break
+            offset += page_size
+        return sorted(all_items, key=lambda item: int(item.item_id))
 
     @final
     async def get_library_item_by_external_id(
@@ -850,7 +867,9 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         """Get all library items matching any of the given external identifiers."""
         result: dict[str, ItemCls] = {}
         for external_id_type, external_id in sorted(external_ids, key=external_id_sort_key):
-            for item in await self.get_library_items_by_external_id(external_id, external_id_type):
+            for item in await self.get_library_items_by_external_id(
+                external_id, external_id_type, limit=None
+            ):
                 result.setdefault(item.item_id, item)
         return list(result.values())
 

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -656,7 +656,7 @@ class TracksController(MediaControllerBase[Track]):
                     fallback=search_result_item,
                 )
                 if compare_track(base_track, prov_track, strict=strict, track_albums=ref_albums):
-                    matches.extend(search_result_item.provider_mappings)
+                    matches.extend(prov_track.provider_mappings)
 
         if not matches:
             self.logger.debug(

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from difflib import SequenceMatcher
 
 from music_assistant_models.enums import ExternalID, MediaType
@@ -20,12 +21,27 @@ from music_assistant_models.media_items import (
     Track,
 )
 
+from music_assistant.helpers.external_ids import normalize_external_id
+
 IGNORE_VERSIONS = (
     "explicit",  # explicit is matched separately
     "music from and inspired by the motion picture",
     "original soundtrack",
     "hi-res",  # quality is handled separately
 )
+
+_VERSION_IGNORE_WORDS = {
+    "album",
+    "edition",
+    "variant",
+    "versie",
+    "version",
+    "versione",
+}
+_VERSION_WORD_ALIASES = {
+    "remastered": "remaster",
+}
+_IGNORE_VERSION_KEYS = {create_safe_string(value) for value in IGNORE_VERSIONS}
 
 
 def compare_media_item(
@@ -80,7 +96,7 @@ def compare_artist(
     if compare_item_ids(base_item, compare_item):
         return True
     # return early on (un)matched external id
-    for ext_id in (ExternalID.DISCOGS, ExternalID.MB_ARTIST, ExternalID.TADB):
+    for ext_id in (ExternalID.MB_ARTIST, ExternalID.DISCOGS, ExternalID.TADB):
         external_id_match = compare_external_ids(
             base_item.external_ids, compare_item.external_ids, ext_id
         )
@@ -107,19 +123,22 @@ def compare_album(
     if compare_item_ids(base_item, compare_item):
         return True
 
-    # return early on (un)matched external id
+    # return early on (un)matched authoritative external id
     for ext_id in (
-        ExternalID.DISCOGS,
         ExternalID.MB_ALBUM,
+        ExternalID.DISCOGS,
         ExternalID.TADB,
-        ExternalID.ASIN,
-        ExternalID.BARCODE,
     ):
         external_id_match = compare_external_ids(
             base_item.external_ids, compare_item.external_ids, ext_id
         )
         if external_id_match is not None:
             return external_id_match
+
+    secondary_external_id_match = any(
+        compare_external_ids(base_item.external_ids, compare_item.external_ids, ext_id) is True
+        for ext_id in (ExternalID.ASIN, ExternalID.BARCODE)
+    )
 
     # compare version
     if not compare_version(base_item.version, compare_item.version):
@@ -133,7 +152,12 @@ def compare_album(
     assert isinstance(base_item, Album)
     assert isinstance(compare_item, Album)
     # compare year
-    if base_item.year and compare_item.year and base_item.year != compare_item.year:
+    if (
+        base_item.year
+        and compare_item.year
+        and base_item.year != compare_item.year
+        and not secondary_external_id_match
+    ):
         return False
     # compare explicitness
     if compare_explicit(base_item.metadata, compare_item.metadata) is False:
@@ -519,28 +543,26 @@ def compare_external_ids(
     external_id_type: ExternalID,
 ) -> bool | None:
     """Compare external ids and return True if a match was found."""
-    base_ids = {x[1] for x in external_ids_base if x[0] == external_id_type}
+    base_ids = {
+        normalize_external_id(external_id_type, value)
+        for current_type, value in external_ids_base
+        if current_type == external_id_type
+    }
     if not base_ids:
         # return early if the requested external id type is not present in the base set
         return None
-    compare_ids = {x[1] for x in external_ids_compare if x[0] == external_id_type}
+    compare_ids = {
+        normalize_external_id(external_id_type, value)
+        for current_type, value in external_ids_compare
+        if current_type == external_id_type
+    }
     if not compare_ids:
         # return early if the requested external id type is not present in the compare set
         return None
-    for base_id in base_ids:
-        if base_id in compare_ids:
-            return True
-        # handle upc stored as EAN-13 barcode
-        if external_id_type == ExternalID.BARCODE and len(base_id) == 12:
-            if f"0{base_id}" in compare_ids:
-                return True
-        # handle EAN-13 stored as UPC barcode
-        if external_id_type == ExternalID.BARCODE and len(base_id) == 13:
-            if base_id[1:] in compare_ids:
-                return True
-        # return false if the identifier is unique (e.g. musicbrainz id)
-        if external_id_type.is_unique:
-            return False
+    if base_ids.intersection(compare_ids):
+        return True
+    if external_id_type.is_unique:
+        return False
     return None
 
 
@@ -585,36 +607,7 @@ def compare_strings(str1: str, str2: str, strict: bool = True) -> bool:
 
 def compare_version(base_version: str, compare_version: str) -> bool:
     """Compare version string."""
-    if not base_version and not compare_version:
-        return True
-    if not base_version and compare_version.lower() in IGNORE_VERSIONS:
-        return True
-    if not compare_version and base_version.lower() in IGNORE_VERSIONS:
-        return True
-    if not base_version and compare_version:
-        return False
-    if base_version and not compare_version:
-        return False
-
-    if " " not in base_version and " " not in compare_version:
-        return compare_strings(base_version, compare_version, False)
-
-    # do this the hard way as sometimes the version string is in the wrong order
-    base_versions = sorted(base_version.lower().split(" "))
-    compare_versions = sorted(compare_version.lower().split(" "))
-    # filter out words we can ignore (such as 'version')
-    ignore_words = [
-        *IGNORE_VERSIONS,
-        "version",
-        "edition",
-        "variant",
-        "versie",
-        "versione",
-    ]
-    base_versions = [x for x in base_versions if x not in ignore_words]
-    compare_versions = [x for x in compare_versions if x not in ignore_words]
-
-    return base_versions == compare_versions
+    return _normalize_version_tokens(base_version) == _normalize_version_tokens(compare_version)
 
 
 def compare_explicit(base: MediaItemMetadata, compare: MediaItemMetadata) -> bool | None:
@@ -624,6 +617,17 @@ def compare_explicit(base: MediaItemMetadata, compare: MediaItemMetadata) -> boo
         # only strict compare them if both have the info set
         return base.explicit == compare.explicit
     return None
+
+
+def _normalize_version_tokens(value: str) -> tuple[str, ...]:
+    """Return meaningful version tokens in stable order."""
+    if not value or create_safe_string(value) in _IGNORE_VERSION_KEYS:
+        return ()
+    tokens = (
+        _VERSION_WORD_ALIASES.get(token, token)
+        for token in re.findall(r"[^\W_]+", value.casefold())
+    )
+    return tuple(sorted(token for token in tokens if token not in _VERSION_IGNORE_WORDS))
 
 
 def _is_dynamic_radio(item: Radio | ItemMapping) -> bool:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from difflib import SequenceMatcher
+from functools import lru_cache
 
 from music_assistant_models.enums import ExternalID, MediaType
 from music_assistant_models.helpers import create_safe_string
@@ -619,6 +620,7 @@ def compare_explicit(base: MediaItemMetadata, compare: MediaItemMetadata) -> boo
     return None
 
 
+@lru_cache(maxsize=1024)
 def _normalize_version_tokens(value: str) -> tuple[str, ...]:
     """Return meaningful version tokens in stable order."""
     if not value or create_safe_string(value) in _IGNORE_VERSION_KEYS:

--- a/music_assistant/helpers/external_ids.py
+++ b/music_assistant/helpers/external_ids.py
@@ -89,6 +89,31 @@ def external_id_lookup_values(external_id_type: ExternalID, value: str) -> tuple
     return tuple(sorted(values))
 
 
+def external_id_lookup_values_untyped(value: str) -> tuple[str, ...]:
+    """
+    Return lookup values for an identifier whose type is not known.
+
+    :param value: Identifier value to look up.
+    """
+    values = {value.strip()}
+    for external_id_type in ExternalID:
+        values.update(external_id_lookup_values(external_id_type, value))
+    return tuple(sorted(values))
+
+
+def barcode_to_upc(value: str) -> str:
+    """
+    Return the shortest UPC/EAN representation of a valid barcode.
+
+    :param value: Barcode in a provider or canonical storage format.
+    """
+    normalized_value = normalize_external_id(ExternalID.BARCODE, value)
+    if not _is_valid_gtin(normalized_value):
+        return value
+    payload = normalized_value.lstrip("0")
+    return payload.zfill(12)
+
+
 def external_id_sort_key(external_id: tuple[ExternalID, str]) -> tuple[int, str, str]:
     """
     Return a deterministic preference key for an external identifier.

--- a/music_assistant/helpers/external_ids.py
+++ b/music_assistant/helpers/external_ids.py
@@ -1,0 +1,141 @@
+"""Helpers for normalizing and looking up external media identifiers."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from uuid import UUID
+
+from music_assistant_models.enums import ExternalID
+
+_GTIN_LENGTHS = (8, 12, 13, 14, 15)
+_ISRC_PATTERN = re.compile(r"^[A-Z]{2}[A-Z0-9]{3}\d{7}$")
+_MUSICBRAINZ_PREFIX = "musicbrainz_"
+
+_EXTERNAL_ID_PRIORITY = {
+    ExternalID.MB_RECORDING: 0,
+    ExternalID.MB_TRACK: 1,
+    ExternalID.MB_ALBUM: 2,
+    ExternalID.MB_ARTIST: 3,
+    ExternalID.DISCOGS: 4,
+    ExternalID.TADB: 5,
+    ExternalID.ACOUSTID: 6,
+    ExternalID.MB_RELEASEGROUP: 7,
+    ExternalID.ASIN: 20,
+    ExternalID.BARCODE: 21,
+    ExternalID.ISRC: 22,
+}
+
+
+def normalize_external_id(external_id_type: ExternalID, value: str) -> str:
+    """
+    Return the canonical representation of an external media identifier.
+
+    Invalid identifiers are returned stripped but otherwise unchanged so provider data
+    remains available for exact matching.
+
+    :param external_id_type: Type of the external identifier.
+    :param value: Identifier value supplied by a provider or file tag.
+    """
+    value = value.strip()
+    if external_id_type == ExternalID.BARCODE:
+        return _normalize_barcode(value)
+    if external_id_type == ExternalID.ISRC:
+        return _normalize_isrc(value)
+    if external_id_type.value.startswith(_MUSICBRAINZ_PREFIX):
+        return _normalize_mbid(value)
+    return value
+
+
+def normalize_external_ids(
+    external_ids: Iterable[tuple[ExternalID, str]],
+) -> set[tuple[ExternalID, str]]:
+    """
+    Return external identifiers with canonical values.
+
+    :param external_ids: External identifier type/value pairs.
+    """
+    return {
+        (external_id_type, normalize_external_id(external_id_type, value))
+        for external_id_type, value in external_ids
+        if value.strip()
+    }
+
+
+def external_id_lookup_values(external_id_type: ExternalID, value: str) -> tuple[str, ...]:
+    """
+    Return indexed lookup values compatible with current and legacy storage formats.
+
+    :param external_id_type: Type of the external identifier.
+    :param value: Identifier value to look up.
+    """
+    raw_value = value.strip()
+    normalized_value = normalize_external_id(external_id_type, raw_value)
+    values = {raw_value, normalized_value}
+
+    if external_id_type == ExternalID.BARCODE and _is_valid_gtin(normalized_value):
+        payload = normalized_value.lstrip("0")
+        for length in _GTIN_LENGTHS:
+            if len(payload) <= length:
+                values.add(payload.zfill(length))
+    elif external_id_type == ExternalID.ISRC and _ISRC_PATTERN.fullmatch(normalized_value):
+        values.add(
+            f"{normalized_value[:2]}-{normalized_value[2:5]}-"
+            f"{normalized_value[5:7]}-{normalized_value[7:]}"
+        )
+    elif external_id_type.value.startswith(_MUSICBRAINZ_PREFIX) and normalized_value != raw_value:
+        values.add(f"{{{normalized_value}}}")
+
+    return tuple(sorted(values))
+
+
+def external_id_sort_key(external_id: tuple[ExternalID, str]) -> tuple[int, str, str]:
+    """
+    Return a deterministic preference key for an external identifier.
+
+    :param external_id: External identifier type/value pair.
+    """
+    external_id_type, value = external_id
+    default_priority = 10 if external_id_type.is_unique else 30
+    return (
+        _EXTERNAL_ID_PRIORITY.get(external_id_type, default_priority),
+        external_id_type.value,
+        normalize_external_id(external_id_type, value),
+    )
+
+
+def _normalize_barcode(value: str) -> str:
+    """Return a valid UPC/EAN/GTIN as GTIN-14."""
+    compact_value = value.replace("-", "").replace(" ", "")
+    if len(compact_value) not in _GTIN_LENGTHS or not compact_value.isdigit():
+        return value
+    payload = compact_value.lstrip("0")
+    if not payload or len(payload) > 14:
+        return value
+    normalized_value = payload.zfill(14)
+    return normalized_value if _is_valid_gtin(normalized_value) else value
+
+
+def _normalize_isrc(value: str) -> str:
+    """Return a valid ISRC without separators."""
+    normalized_value = value.replace("-", "").replace(" ", "").upper()
+    return normalized_value if _ISRC_PATTERN.fullmatch(normalized_value) else value
+
+
+def _normalize_mbid(value: str) -> str:
+    """Return a MusicBrainz identifier as a lowercase UUID."""
+    try:
+        return str(UUID(value.strip("{}")))
+    except ValueError, AttributeError:
+        return value
+
+
+def _is_valid_gtin(value: str) -> bool:
+    """Return whether a value is a canonical GTIN-14 with a valid check digit."""
+    if len(value) != 14 or not value.isdigit():
+        return False
+    body = value[:-1]
+    checksum = sum(
+        int(char) * (3 if index % 2 == 0 else 1) for index, char in enumerate(reversed(body))
+    )
+    return (10 - checksum % 10) % 10 == int(value[-1])

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -682,6 +682,7 @@ def normalize_unicode(value: str | None) -> str | None:
     return unicodedata.normalize("NFC", value)
 
 
+@functools.lru_cache(maxsize=2048)
 def parse_title_and_version(
     title: str,
     track_version: str | None = None,

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -696,7 +696,8 @@ def parse_title_and_version(
     :param strip_for_search: Aggressively strip for search matching.
     :param strip_for_display: Strip superfluous suffixes for display.
     """
-    version = track_version or ""
+    version_parts = [track_version] if track_version else []
+    version_keys = {track_version.casefold()} if track_version else set()
 
     # Strip featuring, bracketed version info, and hyphen suffixes (e.g. "- Remastered 2019")
     if strip_for_search:
@@ -712,12 +713,12 @@ def parse_title_and_version(
         # Clean up dangling hyphens and extra spaces
         title = re.sub(r"\s*-\s*$", "", title)
         title = re.sub(r"\s+", " ", title).strip()
-        return title, version
+        return title, track_version or ""
 
     # Strip video/audio suffixes like "(Official Video)"
     if strip_for_display:
         title = _DISPLAY_STRIP_PATTERN.sub("", title).strip()
-        return title, version
+        return title, track_version or ""
 
     # Standard version parsing
     for parts in (
@@ -756,10 +757,14 @@ def parse_title_and_version(
             for version_str in VERSION_PARTS:
                 if version_str in clean_part:
                     # Preserve original casing (and any nested brackets) for output
-                    version = _strip_outer_markers(title_part)
+                    version_part = _strip_outer_markers(title_part)
+                    if version_part.casefold() not in version_keys:
+                        version_parts.append(version_part)
+                        version_keys.add(version_part.casefold())
                     title = title.replace(title_part, "").strip()
-                    return title, version
-    return title, version
+                    break
+    title = re.sub(r"\s{2,}", " ", title).strip()
+    return title, " ".join(version_parts)
 
 
 def _balanced_bracket_groups(text: str, open_char: str, close_char: str) -> list[str]:

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -196,7 +196,7 @@ def parse_album(
     if record_label := attributes.get("recordLabel"):
         album.metadata.label = record_label
     if upc := attributes.get("upc"):
-        album.external_ids.add((ExternalID.BARCODE, "0" + upc))
+        album.external_ids.add((ExternalID.BARCODE, upc))
     if notes := attributes.get("editorialNotes"):
         album.metadata.description = notes.get("standard") or notes.get("short")
     if content_rating := attributes.get("contentRating"):

--- a/music_assistant/providers/itunes_artwork/__init__.py
+++ b/music_assistant/providers/itunes_artwork/__init__.py
@@ -11,6 +11,7 @@ from music_assistant_models.errors import ResourceTemporarilyUnavailable
 from music_assistant_models.media_items import MediaItemImage, MediaItemMetadata, UniqueList
 
 from music_assistant.controllers.cache import use_cache
+from music_assistant.helpers.external_ids import barcode_to_upc
 from music_assistant.models.metadata_provider import MetadataProvider
 
 if TYPE_CHECKING:
@@ -89,8 +90,7 @@ class ITunesArtworkMetadataProvider(MetadataProvider):
 
         :param barcode: UPC/EAN barcode for the album.
         """
-        # iTunes expects a UPC (12 digits), strip leading zero from EAN-13 if present
-        upc = barcode.lstrip("0").zfill(12) if len(barcode) == 13 else barcode
+        upc = barcode_to_upc(barcode)
         try:
             async with self.mass.http_session.get(
                 ITUNES_LOOKUP_URL, params={"upc": upc}

--- a/tests/controllers/music/test_external_id_lookup.py
+++ b/tests/controllers/music/test_external_id_lookup.py
@@ -110,6 +110,34 @@ async def test_formatted_isrc_from_two_providers_dedupes(music: MusicController)
 
     assert library_track_1.item_id == library_track_2.item_id
     assert library_track_2.external_ids == {(ExternalID.ISRC, ISRC)}
+    untyped_match = await music.tracks.get_library_item_by_external_id("US-RC1-76-07839")
+    assert untyped_match is not None
+    assert untyped_match.item_id == library_track_1.item_id
+
+
+async def test_matching_checks_more_than_fifty_external_id_candidates(
+    music: MusicController,
+) -> None:
+    """Internal matching paginates every row sharing a non-unique identifier."""
+    for index in range(50):
+        await music.tracks.add_item_to_library(
+            create_track(
+                f"provider{index}_1",
+                f"collision_{index}",
+                name=f"Collision {index}",
+                duration=100 + index * 20,
+            )
+        )
+    expected = await music.tracks.add_item_to_library(
+        create_track("expected_1", "expected", name="Expected", duration=2000)
+    )
+
+    matched = await music.tracks.add_item_to_library(
+        create_track("incoming_1", "incoming", name="Different name", duration=2000)
+    )
+
+    assert matched.item_id == expected.item_id
+    assert await music.tracks.library_count() == 51
 
 
 async def test_non_unique_external_id_candidates_are_all_verified(

--- a/tests/controllers/music/test_external_id_lookup.py
+++ b/tests/controllers/music/test_external_id_lookup.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncGenerator
 
 import pytest
 from music_assistant_models.enums import ExternalID
+from music_assistant_models.media_items import Album, Artist, ProviderMapping, UniqueList
 
 from music_assistant.constants import DB_TABLE_EXTERNAL_ID_LOOKUP
 from music_assistant.controllers.music import MusicController
@@ -14,6 +15,7 @@ from music_assistant.mass import MusicAssistant
 from .helpers import ISRC, create_track
 
 MBID = "b1a9c0e9-d987-4042-ae91-78d6a3267d69"
+BARCODE = "0724354283857"
 
 
 @pytest.fixture
@@ -37,6 +39,57 @@ async def _get_lookup_rows(music: MusicController, item_id: int | str) -> set[tu
     }
 
 
+def _create_album(
+    provider_instance: str,
+    item_id: str,
+    name: str,
+    artist_name: str,
+    year: int,
+    barcode: str = BARCODE,
+) -> Album:
+    """
+    Create an album as received from a music provider.
+
+    :param provider_instance: Provider instance the album originates from.
+    :param item_id: Provider-native album identifier.
+    :param name: Album name.
+    :param artist_name: Album artist name.
+    :param year: Album release year.
+    :param barcode: Album barcode.
+    """
+    provider_domain = provider_instance.rsplit("_", 1)[0]
+    return Album(
+        item_id=item_id,
+        provider=provider_instance,
+        name=name,
+        year=year,
+        external_ids={(ExternalID.BARCODE, barcode)},
+        provider_mappings={
+            ProviderMapping(
+                item_id=item_id,
+                provider_domain=provider_domain,
+                provider_instance=provider_instance,
+            )
+        },
+        artists=UniqueList(
+            [
+                Artist(
+                    item_id=f"{item_id}_artist",
+                    provider=provider_instance,
+                    name=artist_name,
+                    provider_mappings={
+                        ProviderMapping(
+                            item_id=f"{item_id}_artist",
+                            provider_domain=provider_domain,
+                            provider_instance=provider_instance,
+                        )
+                    },
+                )
+            ]
+        ),
+    )
+
+
 async def test_same_isrc_from_two_providers_dedupes(music: MusicController) -> None:
     """Two providers exposing the same track with an identical ISRC merge into one item."""
     library_track_1 = await music.tracks.add_item_to_library(create_track("spotify_1", "track_abc"))
@@ -45,6 +98,54 @@ async def test_same_isrc_from_two_providers_dedupes(music: MusicController) -> N
     assert library_track_1.item_id == library_track_2.item_id
     assert len(library_track_2.provider_mappings) == 2
     assert await music.tracks.library_count() == 1
+
+
+async def test_formatted_isrc_from_two_providers_dedupes(music: MusicController) -> None:
+    """Equivalent formatted ISRC values merge into one library track."""
+    first = create_track("spotify_1", "track_abc", isrc="US-RC1-76-07839")
+    second = create_track("tidal_1", "track_xyz", isrc="usrc17607839")
+
+    library_track_1 = await music.tracks.add_item_to_library(first)
+    library_track_2 = await music.tracks.add_item_to_library(second)
+
+    assert library_track_1.item_id == library_track_2.item_id
+    assert library_track_2.external_ids == {(ExternalID.ISRC, ISRC)}
+
+
+async def test_non_unique_external_id_candidates_are_all_verified(
+    music: MusicController,
+) -> None:
+    """An unrelated barcode collision does not hide the correct album candidate."""
+    unrelated = await music.albums.add_item_to_library(
+        _create_album("apple_music_1", "unrelated", "Keeping It All Low", "XP", 2019)
+    )
+    expected = await music.albums.add_item_to_library(
+        _create_album(
+            "apple_music_1",
+            "expected",
+            "#1",
+            "Fischerspooner",
+            2001,
+            barcode="000724354283857",
+        )
+    )
+    await music.database.execute_write(
+        f"UPDATE {DB_TABLE_EXTERNAL_ID_LOOKUP} SET external_id = :external_id "
+        "WHERE media_type = 'album' AND item_id = :item_id",
+        {"external_id": "000724354283857", "item_id": int(expected.item_id)},
+    )
+
+    matched = await music.albums.add_item_to_library(
+        _create_album("qobuz_1", "qobuz_release", "#1", "Fischerspooner", 2002)
+    )
+
+    assert matched.item_id == expected.item_id
+    assert matched.item_id != unrelated.item_id
+    assert await music.albums.library_count() == 2
+    assert {mapping.provider_instance for mapping in matched.provider_mappings} == {
+        "apple_music_1",
+        "qobuz_1",
+    }
 
 
 async def test_get_library_item_by_external_id(music: MusicController) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -2,12 +2,15 @@
 
 from collections.abc import AsyncGenerator
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from music_assistant_models.media_items import ProviderMapping
 
 from music_assistant.controllers.music import MusicController
 from music_assistant.mass import MusicAssistant
+
+from .helpers import create_track
 
 
 @pytest.fixture
@@ -118,3 +121,41 @@ async def test_by_prov_id_empty_item_ids_matches_nothing(music: MusicController)
 
     assert result == []
     assert ran is False  # short-circuits before it can build an unconstrained query
+
+
+async def test_match_provider_uses_full_track_mapping(music: MusicController) -> None:
+    """Provider matching stores mapping details from the fetched track."""
+    base_track = create_track("spotify_1", "base")
+    search_track = create_track("qobuz_1", "candidate")
+    full_track = create_track("qobuz_1", "candidate")
+    full_track.provider_mappings = {
+        ProviderMapping(
+            item_id="candidate",
+            provider_domain="qobuz",
+            provider_instance="qobuz_1",
+            url="https://provider.example/full",
+        )
+    }
+    provider = MagicMock()
+    provider.name = "Qobuz"
+    provider.domain = "qobuz"
+
+    with (
+        patch.object(music.tracks, "search", AsyncMock(return_value=[search_track])),
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(return_value=full_track),
+        ),
+        patch(
+            "music_assistant.controllers.music.media.tracks.compare_media_item",
+            return_value=True,
+        ),
+        patch(
+            "music_assistant.controllers.music.media.tracks.compare_track",
+            return_value=True,
+        ),
+    ):
+        mappings = await music.tracks.match_provider(base_track, provider, ref_albums=[])
+
+    assert mappings == list(full_track.provider_mappings)

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -25,6 +25,9 @@ def test_compare_version() -> None:
     assert compare.compare_version("Karaoke", "Karaoke Version") is True
     assert compare.compare_version("Remaster", "Remaster Edition Deluxe") is False
     assert compare.compare_version("Remastered Version", "Deluxe Version") is False
+    assert compare.compare_version("2011 Remaster", "Remastered 2011") is True
+    assert compare.compare_version("", "Album Version") is True
+    assert compare.compare_version("Deluxe 2022 Remaster", "2022 Remaster") is False
 
 
 def test_compare_artist() -> None:
@@ -215,6 +218,77 @@ def test_compare_album() -> None:
     assert compare.compare_album(album_a, album_b) is False
     # partial artist match is allowed in non-strict mode
     assert compare.compare_album(album_a, album_b, False) is True
+
+
+def test_compare_album_barcode_requires_corroboration() -> None:
+    """A shared retail barcode only overrides year when album identity also agrees."""
+    artist_a = media_items.Artist(
+        item_id="1",
+        provider="test1",
+        name="Artist A",
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id="1", provider_domain="test", provider_instance="test1"
+            )
+        },
+    )
+    artist_b = media_items.Artist(
+        item_id="2",
+        provider="test2",
+        name="Artist A",
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id="2", provider_domain="test", provider_instance="test2"
+            )
+        },
+    )
+    barcode_a = (ExternalID.BARCODE, "000724354283857")
+    barcode_b = (ExternalID.BARCODE, "0724354283857")
+    album_a = media_items.Album(
+        item_id="1",
+        provider="test1",
+        name="#1",
+        year=2001,
+        artists=media_items.UniqueList([artist_a]),
+        external_ids={barcode_a},
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id="1", provider_domain="test", provider_instance="test1"
+            )
+        },
+    )
+    album_b = media_items.Album(
+        item_id="2",
+        provider="test2",
+        name="#1",
+        year=2002,
+        artists=media_items.UniqueList([artist_b]),
+        external_ids={barcode_b},
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id="2", provider_domain="test", provider_instance="test2"
+            )
+        },
+    )
+
+    assert compare.compare_album(album_a, album_b) is True
+
+    album_b.name = "Different Album"
+    assert compare.compare_album(album_a, album_b) is False
+    album_b.name = album_a.name
+    album_b.artists[0].name = "Different Artist"
+    assert compare.compare_album(album_a, album_b) is False
+
+
+def test_compare_external_ids_checks_all_unique_values() -> None:
+    """One mismatching unique identifier does not hide another matching value."""
+    base_ids = {
+        (ExternalID.MB_ALBUM, "11111111-1111-1111-1111-111111111111"),
+        (ExternalID.MB_ALBUM, "22222222-2222-2222-2222-222222222222"),
+    }
+    compare_ids = {(ExternalID.MB_ALBUM, "22222222-2222-2222-2222-222222222222")}
+
+    assert compare.compare_external_ids(base_ids, compare_ids, ExternalID.MB_ALBUM) is True
 
 
 def test_compare_track() -> None:  # noqa: PLR0915

--- a/tests/helpers/test_external_ids.py
+++ b/tests/helpers/test_external_ids.py
@@ -3,7 +3,9 @@
 from music_assistant_models.enums import ExternalID
 
 from music_assistant.helpers.external_ids import (
+    barcode_to_upc,
     external_id_lookup_values,
+    external_id_lookup_values_untyped,
     normalize_external_id,
     normalize_external_ids,
 )
@@ -33,6 +35,12 @@ def test_legacy_gtin_lookup_values() -> None:
     assert "0724354283857" in values
     assert "00724354283857" in values
     assert "000724354283857" in values
+
+
+def test_untyped_lookup_values_and_itunes_upc() -> None:
+    """Untyped lookups normalize formatted IDs and canonical GTINs convert to UPC."""
+    assert "USRC17607839" in external_id_lookup_values_untyped("US-RC1-76-07839")
+    assert barcode_to_upc("00724354283857") == "724354283857"
 
 
 def test_normalize_isrc_and_mbid() -> None:

--- a/tests/helpers/test_external_ids.py
+++ b/tests/helpers/test_external_ids.py
@@ -1,0 +1,56 @@
+"""Tests for external media identifier helpers."""
+
+from music_assistant_models.enums import ExternalID
+
+from music_assistant.helpers.external_ids import (
+    external_id_lookup_values,
+    normalize_external_id,
+    normalize_external_ids,
+)
+
+
+def test_normalize_gtin_variants() -> None:
+    """Equivalent UPC/EAN/GTIN representations normalize to GTIN-14."""
+    canonical = "00724354283857"
+
+    assert normalize_external_id(ExternalID.BARCODE, "724354283857") == canonical
+    assert normalize_external_id(ExternalID.BARCODE, "0724354283857") == canonical
+    assert normalize_external_id(ExternalID.BARCODE, canonical) == canonical
+    assert normalize_external_id(ExternalID.BARCODE, "000724354283857") == canonical
+
+
+def test_invalid_gtin_is_preserved() -> None:
+    """Invalid provider barcode data remains available for exact matching."""
+    assert normalize_external_id(ExternalID.BARCODE, "0724354283858") == "0724354283858"
+    assert normalize_external_id(ExternalID.BARCODE, "catalog-123") == "catalog-123"
+
+
+def test_legacy_gtin_lookup_values() -> None:
+    """A canonical barcode lookup includes legacy zero-padded storage forms."""
+    values = external_id_lookup_values(ExternalID.BARCODE, "0724354283857")
+
+    assert "724354283857" in values
+    assert "0724354283857" in values
+    assert "00724354283857" in values
+    assert "000724354283857" in values
+
+
+def test_normalize_isrc_and_mbid() -> None:
+    """Formatted ISRCs and MusicBrainz UUIDs use canonical representations."""
+    mbid = "B1A9C0E9-D987-4042-AE91-78D6A3267D69"
+
+    assert normalize_external_id(ExternalID.ISRC, "us-rc1-76-07839") == "USRC17607839"
+    assert normalize_external_id(ExternalID.ISRC, "invalid-isrc") == "invalid-isrc"
+    assert normalize_external_id(ExternalID.MB_RECORDING, f"{{{mbid}}}") == mbid.lower()
+
+
+def test_normalize_external_ids_deduplicates_values() -> None:
+    """Equivalent identifier forms collapse to one canonical pair."""
+    result = normalize_external_ids(
+        {
+            (ExternalID.BARCODE, "0724354283857"),
+            (ExternalID.BARCODE, "000724354283857"),
+        }
+    )
+
+    assert result == {(ExternalID.BARCODE, "00724354283857")}

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -120,6 +120,14 @@ def test_version_extract() -> None:
     assert version == "Oliver Smith Remix (Mixed)"
 
 
+def test_version_extracts_multiple_qualifiers() -> None:
+    """All recognized title qualifiers contribute to the version."""
+    title, version = util.parse_title_and_version("( ) [Deluxe] [2022 Remaster]")
+
+    assert title == "( )"
+    assert version == "Deluxe 2022 Remaster"
+
+
 def test_with_handling_in_titles() -> None:
     """Test 'with' handling - preserved in title, stripped as featuring credit."""
     # 'with you' (preserved as title word)

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -4,7 +4,7 @@ from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import ExternalID, MediaType
 from music_assistant_models.media_items import Album, ItemMapping
 
 from music_assistant.providers.apple_music.library import _TRACK_PAGE_SIZE, AppleMusicLibraryManager
@@ -94,6 +94,20 @@ def _artists_relationship(*names: str) -> dict[str, Any]:
             ]
         }
     }
+
+
+def test_parse_album_preserves_provider_upc() -> None:
+    """Apple UPC values are not padded before shared identifier normalization."""
+    provider = _create_provider_mock()
+    album_obj = _make_album_obj(
+        {"artistName": "Test Artist", "upc": "00724354283857"},
+        _artists_relationship("Test Artist"),
+    )
+
+    result = parse_album(provider, album_obj)
+
+    assert isinstance(result, Album)
+    assert (ExternalID.BARCODE, "00724354283857") in result.external_ids
 
 
 def test_parse_album_compilation_uses_album_level_artist_name() -> None:

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -1228,3 +1228,43 @@ async def test_provider_sync_suppresses_per_item_events() -> None:
     assert SUPPRESS_MEDIA_ITEM_UPDATES.get() is False
     await ctrl.add_item_to_library(create_mock_album(provider="spotify"))
     assert events == [EventType.MUSIC_SYNC_COMPLETED, EventType.MEDIA_ITEM_ADDED]
+
+
+async def test_concurrent_add_rechecks_match_inside_lock() -> None:
+    """Concurrent adds create one row and update it with the second provider item."""
+    library_item = create_mock_album(provider="library")
+    library_item.uri = "library://album/1"
+    ctrl, _mass = _create_event_capture_controller(library_item, [])
+    both_initial_checks_complete = asyncio.Event()
+    initial_checks = 0
+    library_id: int | None = None
+
+    async def get_match(_item: Mock) -> int | None:
+        nonlocal initial_checks
+        if library_id is not None:
+            return library_id
+        initial_checks += 1
+        if initial_checks <= 2:
+            if initial_checks == 2:
+                both_initial_checks_complete.set()
+            await both_initial_checks_complete.wait()
+            return None
+        return library_id
+
+    async def add_item(_item: Mock) -> int:
+        nonlocal library_id
+        library_id = 1
+        return library_id
+
+    ctrl._get_library_item_by_match.side_effect = get_match
+    ctrl._add_library_item.side_effect = add_item
+
+    results = await asyncio.gather(
+        ctrl.add_item_to_library(create_mock_album(provider="spotify")),
+        ctrl.add_item_to_library(create_mock_album(provider="qobuz")),
+    )
+
+    assert len(results) == 2
+    assert all(result is library_item for result in results)
+    ctrl._add_library_item.assert_awaited_once()
+    ctrl._update_library_item.assert_awaited_once()


### PR DESCRIPTION
# What does this implement/fix?

Prevent duplicate library entries when providers format identifiers, release years, or version metadata differently.

- Normalize and safely corroborate external identifiers without trusting reused barcodes alone
- Preserve composite edition details such as deluxe remasters
- Recheck concurrent additions and keep full provider mapping details

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.