### PR TITLE
Improve album edition matching

### DIFF
--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -750,16 +750,17 @@ def _compare_album_version(base_version: str, compare_version: str) -> AlbumMatc
     compare_tokens = set(_normalize_version_tokens(compare_version))
     if base_tokens == compare_tokens:
         return AlbumMatchEvidence.MATCH
+    # a recording-changing qualifier (live, karaoke, remix, ...) makes an otherwise
+    # unequal pair of editions unsafe to merge, wherever it appears in either wording,
+    # not only when it is the token that happens to differ between the two, and even
+    # when the other side omits version metadata entirely
+    if (base_tokens | compare_tokens) & _RECORDING_CONFLICT_VERSION_TOKENS:
+        return AlbumMatchEvidence.NO_MATCH
     if not base_tokens or not compare_tokens:
         # a provider commonly omits edition metadata entirely (e.g. a remaster tagged
         # without a version string), so a blank version next to a real one is
         # undecided rather than a proven conflict: let a tracklist resolve it
         return AlbumMatchEvidence.INSUFFICIENT
-    # a recording-changing qualifier (live, karaoke, remix, ...) makes an otherwise
-    # unequal pair of editions unsafe to merge, wherever it appears in either wording,
-    # not only when it is the token that happens to differ between the two
-    if (base_tokens | compare_tokens) & _RECORDING_CONFLICT_VERSION_TOKENS:
-        return AlbumMatchEvidence.NO_MATCH
     if base_tokens < compare_tokens or compare_tokens < base_tokens:
         # one version's wording is a strict subset of the other's (e.g. "2022 Remaster"
         # vs. "Deluxe 2022 Remaster"): an ambiguous packaging difference a tracklist can resolve

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from difflib import SequenceMatcher
+from enum import Enum
 from functools import lru_cache
 
 from music_assistant_models.enums import ExternalID, MediaType
@@ -43,6 +45,18 @@ _VERSION_WORD_ALIASES = {
     "remastered": "remaster",
 }
 _IGNORE_VERSION_KEYS = {create_safe_string(value) for value in IGNORE_VERSIONS}
+
+# duration tolerances (seconds) for the album-track fingerprint comparison
+_ISRC_DURATION_TOLERANCE = 8
+_FALLBACK_DURATION_TOLERANCE = 2
+
+
+class AlbumMatchEvidence(Enum):
+    """Confidence level for an album identity comparison."""
+
+    MATCH = "match"
+    NO_MATCH = "no_match"
+    INSUFFICIENT = "insufficient"
 
 
 def compare_media_item(
@@ -120,9 +134,32 @@ def compare_album(
     strict: bool = True,
 ) -> bool | None:
     """Compare two album items and return True if they match."""
+    return compare_album_evidence(base_item, compare_item, strict) == AlbumMatchEvidence.MATCH
+
+
+def compare_album_evidence(
+    base_item: Album | ItemMapping,
+    compare_item: Album | ItemMapping,
+    strict: bool = True,
+    base_tracks: Sequence[Track] | None = None,
+    compare_tracks: Sequence[Track] | None = None,
+) -> AlbumMatchEvidence:
+    """
+    Return the match evidence for two album items.
+
+    Unlike `compare_album`, this distinguishes a confident non-match from
+    insufficient metadata (e.g. an edition difference that cannot be resolved from
+    the album's own fields), so a caller that can fetch tracklists knows when doing
+    so may still resolve the comparison. If `base_tracks`/`compare_tracks` are
+    supplied, an ordered track fingerprint comparison is used to resolve that
+    remaining ambiguity.
+
+    :param base_tracks: Ordered tracklist for base_item, if already available to the caller.
+    :param compare_tracks: Ordered tracklist for compare_item, if already available.
+    """
     # return early on exact item_id match
     if compare_item_ids(base_item, compare_item):
-        return True
+        return AlbumMatchEvidence.MATCH
 
     # return early on (un)matched authoritative external id
     for ext_id in (
@@ -134,37 +171,85 @@ def compare_album(
             base_item.external_ids, compare_item.external_ids, ext_id
         )
         if external_id_match is not None:
-            return external_id_match
+            return AlbumMatchEvidence.MATCH if external_id_match else AlbumMatchEvidence.NO_MATCH
 
+    # barcode/ASIN are shared across pressings and are non-unique corroboration only,
+    # so they are never used on their own, only to corroborate a year mismatch below
     secondary_external_id_match = any(
         compare_external_ids(base_item.external_ids, compare_item.external_ids, ext_id) is True
         for ext_id in (ExternalID.ASIN, ExternalID.BARCODE)
     )
 
-    # compare version
-    if not compare_version(base_item.version, compare_item.version):
-        return False
+    # a real edition conflict (e.g. deluxe vs. live) is decisive, an ambiguous
+    # subset/superset wording (e.g. "2022 Remaster" vs "Deluxe 2022 Remaster") is not
+    version_evidence = _compare_album_version(base_item.version, compare_item.version)
+    if version_evidence == AlbumMatchEvidence.NO_MATCH:
+        return AlbumMatchEvidence.NO_MATCH
     # compare name
     if not compare_strings(base_item.name, compare_item.name, strict=True):
-        return False
+        return AlbumMatchEvidence.NO_MATCH
+
+    ambiguous = version_evidence == AlbumMatchEvidence.INSUFFICIENT
     if not strict and (isinstance(base_item, ItemMapping) or isinstance(compare_item, ItemMapping)):
-        return True
+        if not ambiguous:
+            return AlbumMatchEvidence.MATCH
+        return compare_album_track_fingerprint(base_tracks, compare_tracks)
     # for strict matching we REQUIRE both items to be a real album object
     assert isinstance(base_item, Album)
     assert isinstance(compare_item, Album)
-    # compare year
+    # compare year: without corroboration this is provider drift, not proof either way
     if (
         base_item.year
         and compare_item.year
         and base_item.year != compare_item.year
         and not secondary_external_id_match
     ):
-        return False
+        ambiguous = True
     # compare explicitness
     if compare_explicit(base_item.metadata, compare_item.metadata) is False:
-        return False
+        return AlbumMatchEvidence.NO_MATCH
     # compare album artist(s)
-    return compare_artists(base_item.artists, compare_item.artists, not strict)
+    if not compare_artists(base_item.artists, compare_item.artists, not strict):
+        return AlbumMatchEvidence.NO_MATCH
+    if not ambiguous:
+        return AlbumMatchEvidence.MATCH
+    return compare_album_track_fingerprint(base_tracks, compare_tracks)
+
+
+def compare_album_track_fingerprint(
+    base_tracks: Sequence[Track] | None,
+    compare_tracks: Sequence[Track] | None,
+) -> AlbumMatchEvidence:
+    """
+    Compare two album tracklists position-by-position and return match evidence.
+
+    Requires an identical disc/track shape to consider two tracklists the same
+    edition. At each position, a shared (normalized) ISRC with a compatible duration
+    is preferred as identity evidence; conflicting ISRCs indicate a different
+    recording/remaster. Positions without a usable ISRC on either side fall back to
+    a normalized title/version match with a tight duration tolerance.
+
+    :param base_tracks: Ordered tracklist for the base album.
+    :param compare_tracks: Ordered tracklist for the album being compared.
+    """
+    if not base_tracks or not compare_tracks:
+        return AlbumMatchEvidence.INSUFFICIENT
+    base_positions = _track_positions(base_tracks)
+    compare_positions = _track_positions(compare_tracks)
+    if not base_positions or not compare_positions:
+        return AlbumMatchEvidence.INSUFFICIENT
+    if base_positions.keys() != compare_positions.keys():
+        # different disc/track shape (e.g. a bonus disc or missing tracks): different edition
+        return AlbumMatchEvidence.NO_MATCH
+
+    evidence = AlbumMatchEvidence.MATCH
+    for position, base_track in base_positions.items():
+        position_evidence = _compare_track_fingerprint(base_track, compare_positions[position])
+        if position_evidence == AlbumMatchEvidence.NO_MATCH:
+            return AlbumMatchEvidence.NO_MATCH
+        if position_evidence == AlbumMatchEvidence.INSUFFICIENT:
+            evidence = AlbumMatchEvidence.INSUFFICIENT
+    return evidence
 
 
 def compare_track(
@@ -635,3 +720,76 @@ def _normalize_version_tokens(value: str) -> tuple[str, ...]:
 def _is_dynamic_radio(item: Radio | ItemMapping) -> bool:
     """Return True if the item is a dynamic radio station."""
     return isinstance(item, Radio) and item.is_dynamic
+
+
+def _compare_album_version(base_version: str, compare_version: str) -> AlbumMatchEvidence:
+    """Return match evidence for an album version/edition comparison."""
+    base_tokens = set(_normalize_version_tokens(base_version))
+    compare_tokens = set(_normalize_version_tokens(compare_version))
+    if base_tokens == compare_tokens:
+        return AlbumMatchEvidence.MATCH
+    if not base_tokens or not compare_tokens:
+        # providers normally tag deluxe/live/remaster editions explicitly, so a blank
+        # version next to a real one is treated as a genuine edition conflict
+        return AlbumMatchEvidence.NO_MATCH
+    if base_tokens < compare_tokens or compare_tokens < base_tokens:
+        # one version's wording is a strict subset of the other's (e.g. "2022 Remaster"
+        # vs. "Deluxe 2022 Remaster"): could be the same or a genuinely different edition
+        return AlbumMatchEvidence.INSUFFICIENT
+    return AlbumMatchEvidence.NO_MATCH
+
+
+def _track_positions(tracks: Sequence[Track]) -> dict[tuple[int, int], Track]:
+    """Return tracks keyed by their (disc_number, track_number) position."""
+    positions: dict[tuple[int, int], Track] = {}
+    for track in tracks:
+        if not track.track_number:
+            return {}
+        key = (track.disc_number or 1, track.track_number)
+        if key in positions:
+            # duplicate position: the tracklist shape cannot be trusted
+            return {}
+        positions[key] = track
+    return positions
+
+
+def _compare_track_fingerprint(base_track: Track, compare_track: Track) -> AlbumMatchEvidence:
+    """Return match evidence for a single album-track position."""
+    base_isrcs = _normalized_external_ids(base_track.external_ids, ExternalID.ISRC)
+    compare_isrcs = _normalized_external_ids(compare_track.external_ids, ExternalID.ISRC)
+    if base_isrcs and compare_isrcs:
+        if base_isrcs.isdisjoint(compare_isrcs):
+            # both sides tagged an ISRC and they disagree: a different recording/remaster
+            return AlbumMatchEvidence.NO_MATCH
+        if _duration_close(base_track.duration, compare_track.duration, _ISRC_DURATION_TOLERANCE):
+            return AlbumMatchEvidence.MATCH
+        return AlbumMatchEvidence.INSUFFICIENT
+
+    # no usable ISRC on (at least) one side: fall back to title/version + duration
+    if not base_track.name or not compare_track.name:
+        return AlbumMatchEvidence.INSUFFICIENT
+    if not compare_strings(base_track.name, compare_track.name, strict=True):
+        return AlbumMatchEvidence.NO_MATCH
+    if not compare_version(base_track.version, compare_track.version):
+        return AlbumMatchEvidence.NO_MATCH
+    if not base_track.duration or not compare_track.duration:
+        return AlbumMatchEvidence.INSUFFICIENT
+    if _duration_close(base_track.duration, compare_track.duration, _FALLBACK_DURATION_TOLERANCE):
+        return AlbumMatchEvidence.MATCH
+    return AlbumMatchEvidence.NO_MATCH
+
+
+def _normalized_external_ids(
+    external_ids: set[tuple[ExternalID, str]], external_id_type: ExternalID
+) -> set[str]:
+    """Return the normalized values of a specific external id type."""
+    return {
+        normalize_external_id(external_id_type, value)
+        for current_type, value in external_ids
+        if current_type == external_id_type
+    }
+
+
+def _duration_close(base_duration: int, compare_duration: int, tolerance: int) -> bool:
+    """Return True if two track durations (in seconds) are within tolerance."""
+    return abs(base_duration - compare_duration) <= tolerance

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -46,6 +46,19 @@ _VERSION_WORD_ALIASES = {
 }
 _IGNORE_VERSION_KEYS = {create_safe_string(value) for value in IGNORE_VERSIONS}
 
+# version tokens that signal a fundamentally different recording (not just packaging),
+# so they must never be treated as an ambiguous/mergeable edition difference
+_RECORDING_CONFLICT_VERSION_TOKENS = {
+    "acoustic",
+    "cover",
+    "demo",
+    "instrumental",
+    "karaoke",
+    "live",
+    "remix",
+    "session",
+}
+
 # duration tolerances (seconds) for the album-track fingerprint comparison
 _ISRC_DURATION_TOLERANCE = 8
 _FALLBACK_DURATION_TOLERANCE = 2
@@ -734,8 +747,13 @@ def _compare_album_version(base_version: str, compare_version: str) -> AlbumMatc
         return AlbumMatchEvidence.NO_MATCH
     if base_tokens < compare_tokens or compare_tokens < base_tokens:
         # one version's wording is a strict subset of the other's (e.g. "2022 Remaster"
-        # vs. "Deluxe 2022 Remaster"): could be the same or a genuinely different edition
-        return AlbumMatchEvidence.INSUFFICIENT
+        # vs. "Deluxe 2022 Remaster"): ambiguous, UNLESS the extra wording itself signals
+        # a different recording (e.g. "Deluxe" vs. "Deluxe Karaoke Edition"), which is
+        # never safe to merge regardless of the subset relationship
+        extra_tokens = base_tokens ^ compare_tokens
+        if extra_tokens.isdisjoint(_RECORDING_CONFLICT_VERSION_TOKENS):
+            return AlbumMatchEvidence.INSUFFICIENT
+        return AlbumMatchEvidence.NO_MATCH
     return AlbumMatchEvidence.NO_MATCH
 
 
@@ -761,6 +779,8 @@ def _compare_track_fingerprint(base_track: Track, compare_track: Track) -> Album
         if base_isrcs.isdisjoint(compare_isrcs):
             # both sides tagged an ISRC and they disagree: a different recording/remaster
             return AlbumMatchEvidence.NO_MATCH
+        if not base_track.duration or not compare_track.duration:
+            return AlbumMatchEvidence.INSUFFICIENT
         if _duration_close(base_track.duration, compare_track.duration, _ISRC_DURATION_TOLERANCE):
             return AlbumMatchEvidence.MATCH
         return AlbumMatchEvidence.INSUFFICIENT

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -24,7 +24,7 @@ from music_assistant_models.media_items import (
     Track,
 )
 
-from music_assistant.helpers.external_ids import normalize_external_id
+from music_assistant.helpers.external_ids import is_valid_isrc, normalize_external_id
 
 IGNORE_VERSIONS = (
     "explicit",  # explicit is matched separately
@@ -35,6 +35,7 @@ IGNORE_VERSIONS = (
 
 _VERSION_IGNORE_WORDS = {
     "album",
+    "at",
     "edition",
     "variant",
     "versie",
@@ -165,7 +166,9 @@ def compare_album_evidence(
     the album's own fields), so a caller that can fetch tracklists knows when doing
     so may still resolve the comparison. If `base_tracks`/`compare_tracks` are
     supplied, an ordered track fingerprint comparison is used to resolve that
-    remaining ambiguity.
+    remaining ambiguity, and a conflicting fingerprint overrides an otherwise
+    nominally-matching album (e.g. identical title/version/year but a different
+    number of tracks).
 
     :param base_tracks: Ordered tracklist for base_item, if already available to the caller.
     :param compare_tracks: Ordered tracklist for compare_item, if already available.
@@ -199,14 +202,12 @@ def compare_album_evidence(
     if version_evidence == AlbumMatchEvidence.NO_MATCH:
         return AlbumMatchEvidence.NO_MATCH
     # compare name
-    if not compare_strings(base_item.name, compare_item.name, strict=True):
+    if not _compare_album_name(base_item.name, compare_item.name):
         return AlbumMatchEvidence.NO_MATCH
 
     ambiguous = version_evidence == AlbumMatchEvidence.INSUFFICIENT
     if not strict and (isinstance(base_item, ItemMapping) or isinstance(compare_item, ItemMapping)):
-        if not ambiguous:
-            return AlbumMatchEvidence.MATCH
-        return compare_album_track_fingerprint(base_tracks, compare_tracks)
+        return _finalize_album_evidence(ambiguous, base_tracks, compare_tracks)
     # for strict matching we REQUIRE both items to be a real album object
     assert isinstance(base_item, Album)
     assert isinstance(compare_item, Album)
@@ -224,9 +225,7 @@ def compare_album_evidence(
     # compare album artist(s)
     if not compare_artists(base_item.artists, compare_item.artists, not strict):
         return AlbumMatchEvidence.NO_MATCH
-    if not ambiguous:
-        return AlbumMatchEvidence.MATCH
-    return compare_album_track_fingerprint(base_tracks, compare_tracks)
+    return _finalize_album_evidence(ambiguous, base_tracks, compare_tracks)
 
 
 def compare_album_track_fingerprint(
@@ -237,10 +236,12 @@ def compare_album_track_fingerprint(
     Compare two album tracklists position-by-position and return match evidence.
 
     Requires an identical disc/track shape to consider two tracklists the same
-    edition. At each position, a shared (normalized) ISRC with a compatible duration
-    is preferred as identity evidence; conflicting ISRCs indicate a different
-    recording/remaster. Positions without a usable ISRC on either side fall back to
-    a normalized title/version match with a tight duration tolerance.
+    edition; a tracklist that never reports a disc number is treated as insufficient
+    (not assumed disc 1) when compared against a genuinely multi-disc tracklist. At
+    each position, a shared (normalized) ISRC with a compatible duration is preferred
+    as identity evidence; conflicting ISRCs indicate a different recording/remaster.
+    Positions without a usable ISRC on either side fall back to a normalized
+    title/version match with a tight duration tolerance.
 
     :param base_tracks: Ordered tracklist for the base album.
     :param compare_tracks: Ordered tracklist for the album being compared.
@@ -250,6 +251,14 @@ def compare_album_track_fingerprint(
     base_positions = _track_positions(base_tracks)
     compare_positions = _track_positions(compare_tracks)
     if not base_positions or not compare_positions:
+        return AlbumMatchEvidence.INSUFFICIENT
+    base_is_multi_disc = any(disc_number > 1 for disc_number, _ in base_positions)
+    compare_is_multi_disc = any(disc_number > 1 for disc_number, _ in compare_positions)
+    if (base_is_multi_disc and _has_unknown_disc_layout(compare_tracks)) or (
+        compare_is_multi_disc and _has_unknown_disc_layout(base_tracks)
+    ):
+        # one side never reports a disc number while the other is genuinely multi-disc:
+        # assuming disc 1 for the unknown side would produce a false shape conflict
         return AlbumMatchEvidence.INSUFFICIENT
     if base_positions.keys() != compare_positions.keys():
         # different disc/track shape (e.g. a bonus disc or missing tracks): different edition
@@ -742,23 +751,45 @@ def _compare_album_version(base_version: str, compare_version: str) -> AlbumMatc
     if base_tokens == compare_tokens:
         return AlbumMatchEvidence.MATCH
     if not base_tokens or not compare_tokens:
-        # providers normally tag deluxe/live/remaster editions explicitly, so a blank
-        # version next to a real one is treated as a genuine edition conflict
+        # a provider commonly omits edition metadata entirely (e.g. a remaster tagged
+        # without a version string), so a blank version next to a real one is
+        # undecided rather than a proven conflict: let a tracklist resolve it
+        return AlbumMatchEvidence.INSUFFICIENT
+    # a recording-changing qualifier (live, karaoke, remix, ...) makes an otherwise
+    # unequal pair of editions unsafe to merge, wherever it appears in either wording,
+    # not only when it is the token that happens to differ between the two
+    if (base_tokens | compare_tokens) & _RECORDING_CONFLICT_VERSION_TOKENS:
         return AlbumMatchEvidence.NO_MATCH
     if base_tokens < compare_tokens or compare_tokens < base_tokens:
         # one version's wording is a strict subset of the other's (e.g. "2022 Remaster"
-        # vs. "Deluxe 2022 Remaster"): ambiguous, UNLESS the extra wording itself signals
-        # a different recording (e.g. "Deluxe" vs. "Deluxe Karaoke Edition"), which is
-        # never safe to merge regardless of the subset relationship
-        extra_tokens = base_tokens ^ compare_tokens
-        if extra_tokens.isdisjoint(_RECORDING_CONFLICT_VERSION_TOKENS):
-            return AlbumMatchEvidence.INSUFFICIENT
-        return AlbumMatchEvidence.NO_MATCH
+        # vs. "Deluxe 2022 Remaster"): an ambiguous packaging difference a tracklist can resolve
+        return AlbumMatchEvidence.INSUFFICIENT
     return AlbumMatchEvidence.NO_MATCH
+
+
+def _compare_album_name(base_name: str, compare_name: str) -> bool:
+    """Return True if two album titles are the same identity, ignoring formatting drift."""
+    base_safe = _normalize_album_name(base_name)
+    compare_safe = _normalize_album_name(compare_name)
+    if base_safe and compare_safe:
+        return base_safe == compare_safe
+    if base_safe or compare_safe:
+        return False
+    # both titles collapse to nothing under normalization (e.g. pure punctuation):
+    # fall back to a whitespace-normalized raw comparison so unrelated titles don't match
+    return " ".join(base_name.split()).casefold() == " ".join(compare_name.split()).casefold()
+
+
+def _normalize_album_name(name: str) -> str:
+    """Return a punctuation/diacritic/whitespace-normalized album title for identity checks."""
+    return " ".join(create_safe_string(name).split())
 
 
 def _track_positions(tracks: Sequence[Track]) -> dict[tuple[int, int], Track]:
     """Return tracks keyed by their (disc_number, track_number) position."""
+    if len({bool(track.disc_number) for track in tracks}) > 1:
+        # some tracks report a disc number and others don't: the shape can't be trusted
+        return {}
     positions: dict[tuple[int, int], Track] = {}
     for track in tracks:
         if not track.track_number:
@@ -771,10 +802,15 @@ def _track_positions(tracks: Sequence[Track]) -> dict[tuple[int, int], Track]:
     return positions
 
 
+def _has_unknown_disc_layout(tracks: Sequence[Track]) -> bool:
+    """Return True if a tracklist reports no disc number at all (an assumed single disc)."""
+    return all(not track.disc_number for track in tracks)
+
+
 def _compare_track_fingerprint(base_track: Track, compare_track: Track) -> AlbumMatchEvidence:
     """Return match evidence for a single album-track position."""
-    base_isrcs = _normalized_external_ids(base_track.external_ids, ExternalID.ISRC)
-    compare_isrcs = _normalized_external_ids(compare_track.external_ids, ExternalID.ISRC)
+    base_isrcs = _track_isrcs(base_track)
+    compare_isrcs = _track_isrcs(compare_track)
     if base_isrcs and compare_isrcs:
         if base_isrcs.isdisjoint(compare_isrcs):
             # both sides tagged an ISRC and they disagree: a different recording/remaster
@@ -799,17 +835,30 @@ def _compare_track_fingerprint(base_track: Track, compare_track: Track) -> Album
     return AlbumMatchEvidence.NO_MATCH
 
 
-def _normalized_external_ids(
-    external_ids: set[tuple[ExternalID, str]], external_id_type: ExternalID
-) -> set[str]:
-    """Return the normalized values of a specific external id type."""
+def _track_isrcs(track: Track) -> set[str]:
+    """Return the structurally valid, normalized ISRCs tagged on a track."""
     return {
-        normalize_external_id(external_id_type, value)
-        for current_type, value in external_ids
-        if current_type == external_id_type
+        normalize_external_id(ExternalID.ISRC, value)
+        for current_type, value in track.external_ids
+        if current_type == ExternalID.ISRC and is_valid_isrc(value)
     }
 
 
 def _duration_close(base_duration: int, compare_duration: int, tolerance: int) -> bool:
     """Return True if two track durations (in seconds) are within tolerance."""
     return abs(base_duration - compare_duration) <= tolerance
+
+
+def _finalize_album_evidence(
+    ambiguous: bool,
+    base_tracks: Sequence[Track] | None,
+    compare_tracks: Sequence[Track] | None,
+) -> AlbumMatchEvidence:
+    """Combine an album's metadata ambiguity with an optional track fingerprint override."""
+    fingerprint_evidence = compare_album_track_fingerprint(base_tracks, compare_tracks)
+    if fingerprint_evidence == AlbumMatchEvidence.NO_MATCH:
+        # a conflicting tracklist is decisive even if the album's own metadata looked fine
+        return AlbumMatchEvidence.NO_MATCH
+    if not ambiguous:
+        return AlbumMatchEvidence.MATCH
+    return fingerprint_evidence

--- a/music_assistant/helpers/external_ids.py
+++ b/music_assistant/helpers/external_ids.py
@@ -89,6 +89,19 @@ def external_id_lookup_values(external_id_type: ExternalID, value: str) -> tuple
     return tuple(sorted(values))
 
 
+def is_valid_isrc(value: str) -> bool:
+    """
+    Return whether a value is a structurally valid (canonical) ISRC.
+
+    An invalid ISRC is still preserved as-is for storage/exact-match lookups, but
+    should be treated as absent by callers that rely on the ISRC being a genuine,
+    globally unique recording identifier (e.g. album/track fingerprint comparisons).
+
+    :param value: Identifier value to validate.
+    """
+    return bool(_ISRC_PATTERN.fullmatch(normalize_external_id(ExternalID.ISRC, value)))
+
+
 def external_id_lookup_values_untyped(value: str) -> tuple[str, ...]:
     """
     Return lookup values for an identifier whose type is not known.

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1,5 +1,6 @@
 """Tests for mediaitem compare helper functions."""
 
+import pytest
 from music_assistant_models import media_items
 from music_assistant_models.enums import ExternalID
 
@@ -499,6 +500,46 @@ def test_compare_album_evidence_blank_vs_remaster_resolves_with_fingerprint() ->
         )
         == compare.AlbumMatchEvidence.NO_MATCH
     )
+
+
+@pytest.mark.parametrize(
+    "conflict_version",
+    ["Live", "Remix", "Karaoke Edition", "Instrumental", "Acoustic Version", "Demo", "Cover"],
+)
+def test_compare_album_evidence_blank_vs_recording_conflict_is_no_match(
+    conflict_version: str,
+) -> None:
+    """
+    A blank version next to a recording-changing qualifier is a proven conflict.
+
+    Unlike a blank version next to plain packaging wording (remaster, deluxe, ...), a
+    missing version tag can never explain away a recording-altering qualifier on the
+    other side, so this must not be left for a tracklist to resolve.
+    """
+    base_item = _album(version="")
+    compare_item = _album(item_id="2", provider="test2", version=conflict_version)
+
+    assert (
+        compare.compare_album_evidence(base_item, compare_item)
+        == compare.AlbumMatchEvidence.NO_MATCH
+    )
+    assert compare.compare_album(base_item, compare_item) is False
+
+
+@pytest.mark.parametrize("packaging_version", ["Remaster", "Deluxe Edition", "Anniversary Edition"])
+def test_compare_album_evidence_blank_vs_packaging_edition_is_insufficient(
+    packaging_version: str,
+) -> None:
+    """A blank version next to plain packaging wording stays undecided, not a proven conflict."""
+    base_item = _album(version="")
+    compare_item = _album(item_id="2", provider="test2", version=packaging_version)
+
+    assert (
+        compare.compare_album_evidence(base_item, compare_item)
+        == compare.AlbumMatchEvidence.INSUFFICIENT
+    )
+    # the compatibility wrapper stays conservative and does not merge on insufficient evidence
+    assert compare.compare_album(base_item, compare_item) is False
 
 
 def test_compare_album_evidence_resolves_with_matching_fingerprint() -> None:

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -397,6 +397,18 @@ def test_compare_album_evidence_ambiguous_version_without_tracks_is_insufficient
     assert compare.compare_album(base_item, compare_item) is False
 
 
+def test_compare_album_evidence_subset_wording_with_recording_conflict_is_no_match() -> None:
+    """A subset edition wording that adds a recording-altering qualifier must not merge."""
+    base_item = _album(version="Deluxe")
+    compare_item = _album(item_id="2", provider="test2", version="Deluxe Karaoke Edition")
+
+    assert (
+        compare.compare_album_evidence(base_item, compare_item)
+        == compare.AlbumMatchEvidence.NO_MATCH
+    )
+    assert compare.compare_album(base_item, compare_item) is False
+
+
 def test_compare_album_evidence_resolves_with_matching_fingerprint() -> None:
     """Ambiguous edition wording resolves to MATCH once track fingerprints agree."""
     base_item = _album(version="2022 Remaster")
@@ -450,6 +462,17 @@ def test_compare_album_track_fingerprint_matching_isrc_and_duration() -> None:
     assert (
         compare.compare_album_track_fingerprint(base_tracks, compare_tracks)
         == compare.AlbumMatchEvidence.MATCH
+    )
+
+
+def test_compare_album_track_fingerprint_shared_isrc_without_duration_is_insufficient() -> None:
+    """A shared ISRC alone cannot confirm a match if neither side has a duration."""
+    base_tracks = [_track("1", track_number=1, isrc="USRC17607839", duration=0)]
+    compare_tracks = [_track("2", track_number=1, isrc="USRC17607839", duration=0)]
+
+    assert (
+        compare.compare_album_track_fingerprint(base_tracks, compare_tracks)
+        == compare.AlbumMatchEvidence.INSUFFICIENT
     )
 
 

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -6,6 +6,87 @@ from music_assistant_models.enums import ExternalID
 from music_assistant.helpers import compare
 
 
+def _album(
+    item_id: str = "1",
+    provider: str = "test1",
+    name: str = "Album A",
+    version: str = "",
+    year: int | None = None,
+    external_ids: set[tuple[ExternalID, str]] | None = None,
+) -> media_items.Album:
+    """Build a minimal Album for evidence comparisons."""
+    return media_items.Album(
+        item_id=item_id,
+        provider=provider,
+        name=name,
+        version=version,
+        year=year,
+        external_ids=external_ids or set(),
+        artists=media_items.UniqueList(
+            [
+                media_items.Artist(
+                    item_id="artist",
+                    provider=provider,
+                    name="Artist A",
+                    provider_mappings={
+                        media_items.ProviderMapping(
+                            item_id="artist", provider_domain="test", provider_instance=provider
+                        )
+                    },
+                )
+            ]
+        ),
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id=item_id, provider_domain="test", provider_instance=provider
+            )
+        },
+    )
+
+
+def _track(
+    item_id: str,
+    disc_number: int = 1,
+    track_number: int = 1,
+    name: str = "Track",
+    version: str = "",
+    duration: int = 200,
+    isrc: str | None = None,
+) -> media_items.Track:
+    """Build a minimal Track for album-track fingerprint comparisons."""
+    return media_items.Track(
+        item_id=item_id,
+        provider="test1",
+        name=name,
+        version=version,
+        duration=duration,
+        disc_number=disc_number,
+        track_number=track_number,
+        external_ids={(ExternalID.ISRC, isrc)} if isrc else set(),
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id=item_id, provider_domain="test", provider_instance="test1"
+            )
+        },
+    )
+
+
+def _tracklist(
+    count: int, *, isrc_prefix: str = "USRC17607", duration: int = 200
+) -> list[media_items.Track]:
+    """Build an ordered list of distinct tracks sharing a common ISRC/duration scheme."""
+    return [
+        _track(
+            item_id=str(number),
+            track_number=number,
+            name=f"Track {number}",
+            duration=duration,
+            isrc=f"{isrc_prefix}{number:03d}",
+        )
+        for number in range(1, count + 1)
+    ]
+
+
 def test_compare_version() -> None:
     """Test the version compare helper."""
     assert compare.compare_version("Remaster", "remaster") is True
@@ -278,6 +359,145 @@ def test_compare_album_barcode_requires_corroboration() -> None:
     album_b.name = album_a.name
     album_b.artists[0].name = "Different Artist"
     assert compare.compare_album(album_a, album_b) is False
+
+
+def test_compare_album_evidence_barcode_never_matches_unrelated_titles() -> None:
+    """A shared canonical barcode alone must never match unrelated title/artist data."""
+    barcode = {(ExternalID.BARCODE, "0724354283857")}
+    album_a = _album(name="Album A", external_ids=barcode)
+    album_b = _album(item_id="2", provider="test2", name="Completely Different Album", year=1999)
+    album_b.external_ids = barcode
+
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.NO_MATCH
+    assert compare.compare_album(album_a, album_b) is False
+
+
+def test_compare_album_evidence_mb_releasegroup_not_sufficient_alone() -> None:
+    """A shared MusicBrainz release-group is family evidence only, never sufficient identity."""
+    releasegroup = {(ExternalID.MB_RELEASEGROUP, "11111111-1111-1111-1111-111111111111")}
+    original = _album(name="Album A", version="", external_ids=releasegroup)
+    remaster = _album(item_id="2", provider="test2", name="Album A", version="Live")
+    remaster.external_ids = releasegroup
+
+    # a genuine edition conflict (studio vs. live) must not auto-merge on releasegroup alone
+    assert compare.compare_album_evidence(original, remaster) == compare.AlbumMatchEvidence.NO_MATCH
+    assert compare.compare_album(original, remaster) is False
+
+
+def test_compare_album_evidence_ambiguous_version_without_tracks_is_insufficient() -> None:
+    """An ambiguous subset/superset edition wording without tracklists stays undecided."""
+    base_item = _album(version="2022 Remaster")
+    compare_item = _album(item_id="2", provider="test2", version="Deluxe 2022 Remaster")
+
+    assert (
+        compare.compare_album_evidence(base_item, compare_item)
+        == compare.AlbumMatchEvidence.INSUFFICIENT
+    )
+    # the compatibility wrapper stays conservative and does not merge on insufficient evidence
+    assert compare.compare_album(base_item, compare_item) is False
+
+
+def test_compare_album_evidence_resolves_with_matching_fingerprint() -> None:
+    """Ambiguous edition wording resolves to MATCH once track fingerprints agree."""
+    base_item = _album(version="2022 Remaster")
+    compare_item = _album(item_id="2", provider="test2", version="Deluxe 2022 Remaster")
+    base_tracks = _tracklist(14)
+    compare_tracks = _tracklist(14)
+
+    assert (
+        compare.compare_album_evidence(
+            base_item, compare_item, base_tracks=base_tracks, compare_tracks=compare_tracks
+        )
+        == compare.AlbumMatchEvidence.MATCH
+    )
+
+
+def test_compare_album_evidence_resolves_with_conflicting_fingerprint() -> None:
+    """Ambiguous edition wording resolves to NO_MATCH once track fingerprints disagree."""
+    base_item = _album(version="2022 Remaster")
+    compare_item = _album(item_id="2", provider="test2", version="Deluxe 2022 Remaster")
+    base_tracks = _tracklist(14, isrc_prefix="USRC17607")
+    compare_tracks = _tracklist(14, isrc_prefix="USRC28718")
+
+    assert (
+        compare.compare_album_evidence(
+            base_item, compare_item, base_tracks=base_tracks, compare_tracks=compare_tracks
+        )
+        == compare.AlbumMatchEvidence.NO_MATCH
+    )
+
+
+def test_compare_album_evidence_ordinary_and_deluxe_track_counts_stay_distinct() -> None:
+    """An ordinary 8-track album and a 14-track edition must not be merged via fingerprints."""
+    base_item = _album(version="2022 Remaster")
+    compare_item = _album(item_id="2", provider="test2", version="Deluxe 2022 Remaster")
+    base_tracks = _tracklist(8)
+    compare_tracks = _tracklist(14)
+
+    assert (
+        compare.compare_album_evidence(
+            base_item, compare_item, base_tracks=base_tracks, compare_tracks=compare_tracks
+        )
+        == compare.AlbumMatchEvidence.NO_MATCH
+    )
+
+
+def test_compare_album_track_fingerprint_matching_isrc_and_duration() -> None:
+    """Equal ISRC, title and duration at every position is a confident match."""
+    base_tracks = _tracklist(3)
+    compare_tracks = _tracklist(3)
+
+    assert (
+        compare.compare_album_track_fingerprint(base_tracks, compare_tracks)
+        == compare.AlbumMatchEvidence.MATCH
+    )
+
+
+def test_compare_album_track_fingerprint_conflicting_isrc() -> None:
+    """Conflicting ISRCs at the same position indicate a different recording/remaster."""
+    base_tracks = [_track("1", track_number=1, isrc="USRC17607839")]
+    compare_tracks = [_track("2", track_number=1, isrc="USRC28718001")]
+
+    assert (
+        compare.compare_album_track_fingerprint(base_tracks, compare_tracks)
+        == compare.AlbumMatchEvidence.NO_MATCH
+    )
+
+
+def test_compare_album_track_fingerprint_title_duration_fallback() -> None:
+    """Without ISRCs, matching normalized title/version and a tight duration match."""
+    base_tracks = [_track("1", track_number=1, name="Track One", duration=200)]
+    compare_tracks = [_track("2", track_number=1, name="Track One", duration=201)]
+
+    assert (
+        compare.compare_album_track_fingerprint(base_tracks, compare_tracks)
+        == compare.AlbumMatchEvidence.MATCH
+    )
+    # a genuine duration conflict without ISRCs cannot be treated as the same recording
+    compare_tracks = [_track("2", track_number=1, name="Track One", duration=260)]
+    assert (
+        compare.compare_album_track_fingerprint(base_tracks, compare_tracks)
+        == compare.AlbumMatchEvidence.NO_MATCH
+    )
+
+
+def test_compare_album_track_fingerprint_sparse_tracks_are_insufficient() -> None:
+    """Tracks with no ISRC, title, or duration cannot support a confident decision."""
+    base_tracks = [_track("1", track_number=1, name="", duration=0)]
+    compare_tracks = [_track("2", track_number=1, name="", duration=0)]
+
+    assert (
+        compare.compare_album_track_fingerprint(base_tracks, compare_tracks)
+        == compare.AlbumMatchEvidence.INSUFFICIENT
+    )
+    # no tracklists supplied at all is equally undecided
+    assert (
+        compare.compare_album_track_fingerprint(None, None)
+        == compare.AlbumMatchEvidence.INSUFFICIENT
+    )
+    assert (
+        compare.compare_album_track_fingerprint([], []) == compare.AlbumMatchEvidence.INSUFFICIENT
+    )
 
 
 def test_compare_external_ids_checks_all_unique_values() -> None:

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -372,14 +372,43 @@ def test_compare_album_evidence_barcode_never_matches_unrelated_titles() -> None
     assert compare.compare_album(album_a, album_b) is False
 
 
+def test_compare_album_evidence_name_hyphen_spacing_drift_matches() -> None:
+    """Punctuation/spacing drift around a title's hyphenation does not block a match."""
+    album_a = _album(name="All Change - - EP")
+    album_b = _album(item_id="2", provider="test2", name="All Change - EP")
+
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+    assert compare.compare_album(album_a, album_b) is True
+
+
+def test_compare_album_evidence_name_accent_and_apostrophe_variants_match() -> None:
+    """Diacritic and apostrophe drift in an otherwise identical title does not block a match."""
+    album_a = _album(name="Am\u00e9lie Soundtrack")
+    album_b = _album(item_id="2", provider="test2", name="Amelie Soundtrack")
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+
+    album_a = _album(name="Guns N' Roses Live")
+    album_b = _album(item_id="2", provider="test2", name="Guns N Roses Live")
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+
+
+def test_compare_album_evidence_unrelated_punctuation_only_titles_stay_distinct() -> None:
+    """Two different titles that both normalize to nothing must not be treated as equal."""
+    album_a = _album(name="...")
+    album_b = _album(item_id="2", provider="test2", name="!!!")
+
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.NO_MATCH
+    assert compare.compare_album(album_a, album_b) is False
+
+
 def test_compare_album_evidence_mb_releasegroup_not_sufficient_alone() -> None:
     """A shared MusicBrainz release-group is family evidence only, never sufficient identity."""
     releasegroup = {(ExternalID.MB_RELEASEGROUP, "11111111-1111-1111-1111-111111111111")}
-    original = _album(name="Album A", version="", external_ids=releasegroup)
+    original = _album(name="Album A", version="Original Mix", external_ids=releasegroup)
     remaster = _album(item_id="2", provider="test2", name="Album A", version="Live")
     remaster.external_ids = releasegroup
 
-    # a genuine edition conflict (studio vs. live) must not auto-merge on releasegroup alone
+    # a genuine edition conflict (studio mix vs. live) must not auto-merge on releasegroup alone
     assert compare.compare_album_evidence(original, remaster) == compare.AlbumMatchEvidence.NO_MATCH
     assert compare.compare_album(original, remaster) is False
 
@@ -407,6 +436,69 @@ def test_compare_album_evidence_subset_wording_with_recording_conflict_is_no_mat
         == compare.AlbumMatchEvidence.NO_MATCH
     )
     assert compare.compare_album(base_item, compare_item) is False
+
+
+def test_compare_album_evidence_recording_conflict_word_anywhere_is_no_match() -> None:
+    """A recording-changing qualifier stays NO_MATCH even when it's shared, not differing."""
+    # "live" is shared by both sides here (not the token that differs), but a bare
+    # "Live" tag next to a specific "Live at <venue>" tag is still not safe to merge
+    base_item = _album(version="Live")
+    compare_item = _album(item_id="2", provider="test2", version="Live at Wembley")
+
+    assert (
+        compare.compare_album_evidence(base_item, compare_item)
+        == compare.AlbumMatchEvidence.NO_MATCH
+    )
+    assert compare.compare_album(base_item, compare_item) is False
+
+
+def test_compare_album_evidence_equivalent_location_wording_matches() -> None:
+    """Reordered wording that differs only by a harmless connector word ('at') still matches."""
+    base_item = _album(version="Live at Wembley")
+    compare_item = _album(item_id="2", provider="test2", version="Wembley Live")
+
+    assert (
+        compare.compare_album_evidence(base_item, compare_item) == compare.AlbumMatchEvidence.MATCH
+    )
+    assert compare.compare_album(base_item, compare_item) is True
+
+
+def test_compare_album_evidence_blank_vs_remaster_version_is_insufficient() -> None:
+    """A blank version next to a tagged remaster is undecided, not a proven conflict."""
+    base_item = _album(version="")
+    compare_item = _album(item_id="2", provider="test2", version="Remaster")
+
+    assert (
+        compare.compare_album_evidence(base_item, compare_item)
+        == compare.AlbumMatchEvidence.INSUFFICIENT
+    )
+    # the compatibility wrapper stays conservative and does not merge on insufficient evidence
+    assert compare.compare_album(base_item, compare_item) is False
+
+
+def test_compare_album_evidence_blank_vs_remaster_resolves_with_fingerprint() -> None:
+    """A blank-vs-remaster version gap is resolved once track fingerprints are supplied."""
+    base_item = _album(version="")
+    compare_item = _album(item_id="2", provider="test2", version="Remaster")
+    matching_tracks = _tracklist(10)
+
+    assert (
+        compare.compare_album_evidence(
+            base_item, compare_item, base_tracks=matching_tracks, compare_tracks=matching_tracks
+        )
+        == compare.AlbumMatchEvidence.MATCH
+    )
+
+    conflicting_tracks = _tracklist(10, isrc_prefix="USRC28718")
+    assert (
+        compare.compare_album_evidence(
+            base_item,
+            compare_item,
+            base_tracks=matching_tracks,
+            compare_tracks=conflicting_tracks,
+        )
+        == compare.AlbumMatchEvidence.NO_MATCH
+    )
 
 
 def test_compare_album_evidence_resolves_with_matching_fingerprint() -> None:
@@ -454,6 +546,21 @@ def test_compare_album_evidence_ordinary_and_deluxe_track_counts_stay_distinct()
     )
 
 
+def test_compare_album_evidence_fingerprint_overrides_matching_metadata() -> None:
+    """A conflicting tracklist overrides an otherwise nominally-matching album."""
+    base_item = _album(version="", year=2020)
+    compare_item = _album(item_id="2", provider="test2", version="", year=2020)
+    base_tracks = _tracklist(8)
+    compare_tracks = _tracklist(14)
+
+    assert (
+        compare.compare_album_evidence(
+            base_item, compare_item, base_tracks=base_tracks, compare_tracks=compare_tracks
+        )
+        == compare.AlbumMatchEvidence.NO_MATCH
+    )
+
+
 def test_compare_album_track_fingerprint_matching_isrc_and_duration() -> None:
     """Equal ISRC, title and duration at every position is a confident match."""
     base_tracks = _tracklist(3)
@@ -483,6 +590,30 @@ def test_compare_album_track_fingerprint_conflicting_isrc() -> None:
 
     assert (
         compare.compare_album_track_fingerprint(base_tracks, compare_tracks)
+        == compare.AlbumMatchEvidence.NO_MATCH
+    )
+
+
+def test_compare_album_track_fingerprint_invalid_isrc_falls_back_to_title_duration() -> None:
+    """A structurally invalid ISRC is ignored, not treated as identity evidence."""
+    base_tracks = [_track("1", track_number=1, name="Track One", duration=200, isrc="NOTANISRC")]
+    matching_compare_tracks = [
+        _track("2", track_number=1, name="Track One", duration=200, isrc="ALSOINVALID")
+    ]
+
+    # both sides tag an (invalid) ISRC, but neither is structurally valid, so the
+    # comparison falls back to title/duration and still finds a match
+    assert (
+        compare.compare_album_track_fingerprint(base_tracks, matching_compare_tracks)
+        == compare.AlbumMatchEvidence.MATCH
+    )
+
+    # a genuine title conflict is still caught once the invalid ISRCs are ignored
+    conflicting_compare_tracks = [
+        _track("2", track_number=1, name="Different Track", duration=200, isrc="ALSOINVALID")
+    ]
+    assert (
+        compare.compare_album_track_fingerprint(base_tracks, conflicting_compare_tracks)
         == compare.AlbumMatchEvidence.NO_MATCH
     )
 
@@ -520,6 +651,25 @@ def test_compare_album_track_fingerprint_sparse_tracks_are_insufficient() -> Non
     )
     assert (
         compare.compare_album_track_fingerprint([], []) == compare.AlbumMatchEvidence.INSUFFICIENT
+    )
+
+
+def test_compare_album_track_fingerprint_unknown_disc_layout_vs_multi_disc_is_insufficient() -> (
+    None
+):
+    """An unknown (no disc numbers reported at all) layout can't be shape-compared."""
+    # a provider that never reports disc numbers: assumed single disc by omission
+    base_tracks = [_track(str(n), disc_number=0, track_number=n) for n in range(1, 15)]
+    # the other side is a genuine 2-disc release (8 + 6 tracks)
+    compare_tracks = [_track(f"d1-{n}", disc_number=1, track_number=n) for n in range(1, 9)] + [
+        _track(f"d2-{n}", disc_number=2, track_number=n) for n in range(1, 7)
+    ]
+
+    # assuming disc 1 for the unknown side would falsely look like a shape conflict
+    # (or, worse, a false match): neither is safe, so this must stay undecided
+    assert (
+        compare.compare_album_track_fingerprint(base_tracks, compare_tracks)
+        == compare.AlbumMatchEvidence.INSUFFICIENT
     )
 
 


### PR DESCRIPTION
# What does this implement/fix?

Distinguish definite album matches from edition differences that need track details, instead of treating every uncertain comparison as a mismatch.

- Add explicit match, mismatch, and insufficient-evidence results
- Compare ordered track fingerprints when album metadata is ambiguous
- Keep existing library sync behavior conservative and IO-free

**Related issue (if applicable):**

- Builds on #5770

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.