### PR TITLE
Fix speakers showing twice when they get a native player

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1033,9 +1033,7 @@ class ProtocolLinkingMixin:
                 continue
 
             known_protocol_ids = set(self._get_known_protocol_ids(player))
-            active_protocol_ids = {
-                link.output_protocol_id for link in player.linked_output_protocols
-            }
+            refused_protocol_ids: set[str] = set()
             moved_protocol_ids: set[str] = set()
 
             # Transfer all protocol links from universal player to native player
@@ -1044,34 +1042,35 @@ class ProtocolLinkingMixin:
                     protocol_player.set_protocol_parent_id(None)
                     domain = linked.protocol_domain or protocol_player.provider.domain
                     self._add_protocol_link(native_player, protocol_player, domain)
-                    if protocol_player.protocol_parent_id == native_player.player_id:
-                        moved_protocol_ids.add(protocol_player.player_id)
-                        protocol_player.refresh_state()
-                    else:
+                    if protocol_player.protocol_parent_id != native_player.player_id:
                         # Link refused, keep the protocol owned by the universal player.
                         protocol_player.set_protocol_parent_id(player.player_id)
+                        refused_protocol_ids.add(protocol_player.player_id)
+                        continue
+                    protocol_player.refresh_state()
+                    moved_protocol_ids.add(protocol_player.player_id)
 
-            if active_protocol_ids - moved_protocol_ids:
-                # A link was refused, keep the universal player and hand over only
-                # what moved so the refused protocols are not orphaned.
-                self._migrate_protocol_ids_to_parent(native_player, moved_protocol_ids)
-                self._remove_protocol_ids_from_parent(player, moved_protocol_ids)
-                native_player.refresh_state()
-                continue
-
-            cached_only_ids = known_protocol_ids - active_protocol_ids
-            preserved_protocol_ids = moved_protocol_ids | cached_only_ids
+            # A refused link leaves the universal player in charge, so only hand over what
+            # actually moved: ownership that exists in config alone stays with it, which
+            # keeps a protocol derived from a refused one with the parent it will link to.
+            migrated_protocol_ids = (
+                moved_protocol_ids if refused_protocol_ids else known_protocol_ids
+            )
             # A device that kept its id across a type change lists itself here.
             # It must never become its own protocol, and it must also be dropped
             # from the obsolete universal player so the permanent cleanup below
             # doesn't treat it as an orphaned protocol (which would re-wrap the
             # native player in a fresh universal player).
-            preserved_protocol_ids.discard(native_player.player_id)
-            self._migrate_protocol_ids_to_parent(native_player, preserved_protocol_ids)
+            migrated_protocol_ids.discard(native_player.player_id)
+            self._migrate_protocol_ids_to_parent(native_player, migrated_protocol_ids)
             self._remove_protocol_ids_from_parent(
-                player, preserved_protocol_ids | {native_player.player_id}
+                player, migrated_protocol_ids | {native_player.player_id}
             )
             native_player.refresh_state()
+
+            if refused_protocol_ids:
+                # Registered protocols that the native player refused remain on the wrapper.
+                continue
 
             # Carry over the user's configuration and re-point group memberships
             # before the permanent removal below deletes the universal player's config

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -68,7 +68,8 @@ class UniversalPlayerProvider(PlayerProvider):
 
         Universal players are created dynamically by the PlayerController,
         not through discovery. However, we restore previously created
-        universal players from config.
+        universal players from config. Native players that match a restored
+        universal player take it over, which removes the universal player.
         """
         async with self._lock:
             for player_conf in await self.mass.config.get_player_configs(
@@ -77,6 +78,17 @@ class UniversalPlayerProvider(PlayerProvider):
                 # Restore universal player from config
                 # The stored protocol IDs enable fast matching when protocols register
                 await self._restore_player(player_conf.player_id)
+
+        # This provider restores its players in a background task, so a native player
+        # may already have registered while none of the universal players it should
+        # replace existed yet. Re-check those now that the wrappers are back.
+        for player in self.mass.players.iter_players():
+            if player.state.type == PlayerType.GROUP:
+                continue
+            self.mass.players._check_replace_universal_player(player)
+            # Protocols that are disabled or not registered only ever reach a player's
+            # output list through cache recovery, which the registration path runs.
+            self.mass.players._recover_cached_protocol_links(player)
 
     async def create_universal_player(
         self,

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import re
 from collections.abc import Awaitable, Iterator
-from typing import Any, cast
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
@@ -27,6 +27,7 @@ from music_assistant.constants import (
     CONF_PLAYERS,
     CONF_PREFERRED_OUTPUT_PROTOCOL,
     CONF_PROTOCOL_PARENT_ID,
+    CONF_UNDERLYING_PLAYER_ID,
 )
 from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.config.migrations import migrate
@@ -6515,42 +6516,54 @@ class TestUniversalPlayerMerging:
 class TestUniversalPlayerReplacement:
     """Tests for replacing a universal player with a native player."""
 
-    async def test_replace_preserves_moved_protocols_during_parent_cleanup(
-        self, mock_mass: MagicMock
+    @pytest.mark.parametrize(
+        ("airplay_registered", "missing_protocol_id", "missing_domain", "missing_enabled"),
+        [
+            (True, "dlna_cached", "dlna", True),
+            (True, "dlna_cached", "dlna", False),
+            (False, "spb_cached", "sendspin", False),
+        ],
+    )
+    async def test_replace_migrates_missing_cached_protocol_during_parent_cleanup(
+        self,
+        mock_mass: MagicMock,
+        airplay_registered: bool,
+        missing_protocol_id: str,
+        missing_domain: str,
+        missing_enabled: bool,
     ) -> None:
-        """Moved protocol ownership must survive the removed universal cleanup."""
+        """Missing cached protocol ownership must survive replacement and cleanup."""
         controller = PlayerController(mock_mass)
         up_provider = create_mock_universal_provider(mock_mass)
 
-        config_store: dict[str, object] = {
-            "players/sonos_1": {"enabled": True},
-            "players/up_old": {"enabled": True},
-            "players/ap_live": {"enabled": True},
-            "players/dlna_cached": {
-                "enabled": True,
-                "provider": "dlna--test",
-                "player_type": "protocol",
-                "values": {"protocol_parent_id": "up_old"},
-            },
+        missing_values = {"protocol_parent_id": "up_old"}
+        if missing_domain == "sendspin":
+            missing_values[CONF_UNDERLYING_PLAYER_ID] = "ap_live"
+        config_store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "sonos_1": {"enabled": True, "values": {}},
+                "up_old": {"enabled": airplay_registered, "values": {}},
+                "ap_live": {
+                    "enabled": airplay_registered,
+                    "provider": "airplay--test",
+                    "player_type": "protocol",
+                    "values": {"protocol_parent_id": "up_old"},
+                },
+                missing_protocol_id: {
+                    "enabled": missing_enabled,
+                    "provider": f"{missing_domain}--test",
+                    "player_type": "protocol",
+                    "values": missing_values,
+                },
+            }
         }
-
-        def config_get(key: str, default: object = None) -> object:
-            return config_store.get(key, default)
-
-        def config_set(key: str, value: object) -> None:
-            config_store[key] = value
-
-        def config_remove(key: str) -> None:
-            config_store.pop(key, None)
+        _wire_nested_config(mock_mass, config_store)
 
         scheduled_tasks: list[Awaitable[object]] = []
 
         def capture_task(task: Awaitable[object], *_args: Any, **_kwargs: Any) -> None:
             scheduled_tasks.append(task)
 
-        mock_mass.config.get = MagicMock(side_effect=config_get)
-        mock_mass.config.set = MagicMock(side_effect=config_set)
-        mock_mass.config.remove = MagicMock(side_effect=config_remove)
         mock_mass.players = controller
         mock_mass.player_queues = MagicMock()
         mock_mass.call_later = MagicMock()
@@ -6562,12 +6575,11 @@ class TestUniversalPlayerReplacement:
             player_id="up_old",
             name="Old Universal",
             device_info=DeviceInfo(model="Test", manufacturer="Test"),
-            protocol_player_ids=["ap_live", "dlna_cached"],
+            protocol_player_ids=["ap_live", missing_protocol_id],
         )
         universal._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, "AA:BB:CC:DD:EE:FF")
         universal._cache.clear()
         universal.update_state(signal_event=False)
-        universal.set_initialized()
 
         native_provider = MockProvider("sonos", mass=mock_mass)
         native = MockPlayer(
@@ -6588,35 +6600,69 @@ class TestUniversalPlayerReplacement:
         )
         ap_live.set_initialized()
 
-        controller._players = {
-            "up_old": universal,
-            "sonos_1": native,
-            "ap_live": ap_live,
-        }
-
-        controller._add_protocol_link(universal, ap_live, "airplay")
+        controller._players = {"up_old": universal, "sonos_1": native}
+        if airplay_registered:
+            controller._players["ap_live"] = ap_live
+            controller._add_protocol_link(universal, ap_live, "airplay")
+        else:
+            universal.set_linked_output_protocols(
+                [
+                    LinkedOutputProtocol(
+                        output_protocol_id="ap_live",
+                        protocol_domain="airplay",
+                        priority=10,
+                    )
+                ]
+            )
+        universal.set_linked_output_protocols(
+            [
+                *universal.linked_output_protocols,
+                LinkedOutputProtocol(
+                    output_protocol_id=missing_protocol_id,
+                    protocol_domain=missing_domain,
+                    priority=20,
+                    derived_from="ap_live" if missing_domain == "sendspin" else None,
+                ),
+            ]
+        )
 
         controller._check_replace_universal_player(native)
 
-        assert ap_live.protocol_parent_id == "sonos_1"
-        linked_ids = cast("list[str]", config_store["players/sonos_1/values/linked_protocol_ids"])
-        assert set(linked_ids) == {
+        if airplay_registered:
+            assert ap_live.protocol_parent_id == "sonos_1"
+        else:
+            assert (
+                config_store[CONF_PLAYERS]["ap_live"]["values"][CONF_PROTOCOL_PARENT_ID]
+                == "sonos_1"
+            )
+        assert set(config_store[CONF_PLAYERS]["sonos_1"]["values"]["linked_protocol_ids"]) == {
             "ap_live",
-            "dlna_cached",
+            missing_protocol_id,
         }
-        assert config_store["players/dlna_cached/values/protocol_parent_id"] == "sonos_1"
+        assert (
+            config_store[CONF_PLAYERS][missing_protocol_id]["values"][CONF_PROTOCOL_PARENT_ID]
+            == "sonos_1"
+        )
         unregister_tasks = [t for t in scheduled_tasks if "unregister" in repr(t)]
         assert len(unregister_tasks) == 1
 
         await unregister_tasks[0]
 
         assert "up_old" not in controller._players
-        assert ap_live.protocol_parent_id == "sonos_1"
-        assert config_store["players/dlna_cached/values/protocol_parent_id"] == "sonos_1"
-        linked_ids = cast("list[str]", config_store["players/sonos_1/values/linked_protocol_ids"])
-        assert set(linked_ids) == {
+        if airplay_registered:
+            assert ap_live.protocol_parent_id == "sonos_1"
+        else:
+            assert (
+                config_store[CONF_PLAYERS]["ap_live"]["values"][CONF_PROTOCOL_PARENT_ID]
+                == "sonos_1"
+            )
+        assert (
+            config_store[CONF_PLAYERS][missing_protocol_id]["values"][CONF_PROTOCOL_PARENT_ID]
+            == "sonos_1"
+        )
+        assert set(config_store[CONF_PLAYERS]["sonos_1"]["values"]["linked_protocol_ids"]) == {
             "ap_live",
-            "dlna_cached",
+            missing_protocol_id,
         }
 
     def test_replace_keeps_universal_when_all_links_refused(self, mock_mass: MagicMock) -> None:
@@ -6841,6 +6887,102 @@ class TestUniversalPlayerReplacement:
         assert all(
             link.output_protocol_id != "ap_old" for link in universal.linked_output_protocols
         )
+
+    def test_replace_keeps_cached_protocols_when_a_link_is_refused(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        Keep cached-only protocol ownership on a universal player that survives.
+
+        The native player refuses the sendspin link, so the universal player stays in
+        charge. Ownership that only exists in config must not be handed over, so a
+        protocol derived from a refused one keeps pointing at the parent it will link to.
+        """
+        controller = PlayerController(mock_mass)
+        up_provider = create_mock_universal_provider(mock_mass)
+
+        config_store: dict[str, Any] = {
+            "players/cast_1": {"enabled": True},
+            "players/up_old": {"enabled": True},
+            "players/spb_old": {"enabled": True},
+            "players/spb_new": {"enabled": True},
+            "players/ap_old": {"enabled": True},
+            "players/dlna_cached": {"enabled": False},
+        }
+        mock_mass.config.get = MagicMock(side_effect=config_store.get)
+        mock_mass.config.set = MagicMock(side_effect=config_store.__setitem__)
+        mock_mass.config.remove = MagicMock(side_effect=lambda key: config_store.pop(key, None))
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.call_later = MagicMock()
+        mock_mass.loop = MagicMock()
+        mock_mass.create_task = MagicMock()
+
+        identifiers = {IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"}
+        universal = UniversalPlayer(
+            provider=up_provider,
+            player_id="up_old",
+            name="Soundbar (Universal)",
+            device_info=DeviceInfo(model="Test", manufacturer="Test"),
+            protocol_player_ids=["spb_old", "ap_old", "dlna_cached"],
+        )
+        universal._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, "AA:BB:CC:DD:EE:FF")
+        universal._cache.clear()
+        universal.update_state(signal_event=False)
+        universal.set_initialized()
+
+        native = MockPlayer(
+            MockProvider("cast", mass=mock_mass), "cast_1", "Soundbar", identifiers=identifiers
+        )
+        native.set_initialized()
+        sendspin_provider = MockProvider("sendspin", mass=mock_mass)
+        spb_old = MockPlayer(
+            sendspin_provider,
+            "spb_old",
+            "Soundbar (Sendspin)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers=identifiers,
+        )
+        spb_old.set_initialized()
+        spb_new = MockPlayer(
+            sendspin_provider,
+            "spb_new",
+            "Soundbar (Sendspin v2)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers=identifiers,
+        )
+        spb_new.set_initialized()
+        ap_old = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_old",
+            "Soundbar (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers=identifiers,
+        )
+        ap_old.set_initialized()
+
+        controller._players = {
+            "up_old": universal,
+            "cast_1": native,
+            "spb_old": spb_old,
+            "spb_new": spb_new,
+            "ap_old": ap_old,
+        }
+        controller._add_protocol_link(universal, spb_old, "sendspin")
+        controller._add_protocol_link(universal, ap_old, "airplay")
+        controller._add_protocol_link(native, spb_new, "sendspin")
+
+        controller._check_replace_universal_player(native)
+
+        # the registered airplay link moved, the refused sendspin link did not
+        assert ap_old.protocol_parent_id == "cast_1"
+        assert spb_old.protocol_parent_id == "up_old"
+        # the cached-only protocol stays with the universal player that remains in charge
+        assert "dlna_cached" in universal._protocol_player_ids
+        assert "dlna_cached" not in (
+            config_store.get("players/cast_1/values/linked_protocol_ids") or []
+        )
+        assert config_store.get("players/dlna_cached/values/protocol_parent_id") != "cast_1"
 
     @staticmethod
     def _setup_carry_over_scenario(
@@ -7174,6 +7316,109 @@ class TestUniversalPlayerReplacement:
 
         mock_mass.player_queues.stop.assert_not_awaited()
         assert "up_old" not in controller._players
+
+    async def test_provider_discovery_rechecks_registered_native_players(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A native player that registered before its wrapper was restored is promoted."""
+        controller = PlayerController(mock_mass)
+        config_store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "sonos_1": {"enabled": True, "values": {}},
+                "up_old": {"enabled": True, "provider": "universal_player", "values": {}},
+                "ap_live": {
+                    "enabled": True,
+                    "provider": "airplay--test",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "up_old"},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, config_store)
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.create_task = MagicMock()
+        mock_mass.config.get_player_configs = AsyncMock(return_value=[])
+
+        provider = create_mock_universal_provider(mock_mass)
+        identifiers = {IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"}
+        universal = _create_universal_player(
+            mock_mass, "up_old", "Old Universal", ["ap_live"], identifiers=identifiers
+        )
+        native = MockPlayer(
+            MockProvider("sonos", mass=mock_mass), "sonos_1", "Sonos", identifiers=identifiers
+        )
+        native.set_initialized()
+        ap_live = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_live",
+            "AirPlay",
+            player_type=PlayerType.PROTOCOL,
+            identifiers=identifiers,
+        )
+        ap_live.set_initialized()
+        controller._players = {
+            "up_old": universal,
+            "sonos_1": native,
+            "ap_live": ap_live,
+        }
+        controller._add_protocol_link(universal, ap_live, "airplay")
+
+        await provider.discover_players()
+
+        assert ap_live.protocol_parent_id == "sonos_1"
+        assert native.protocol_parent_id is None
+
+    async def test_provider_discovery_does_not_replace_wrapper_with_group(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A matching group player must never take over a wrapper's protocols."""
+        controller = PlayerController(mock_mass)
+        config_store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "up_old": {"enabled": True, "provider": "universal_player", "values": {}},
+                "ap_owned": {
+                    "enabled": True,
+                    "provider": "airplay--test",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "up_old"},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, config_store)
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.create_task = MagicMock()
+        mock_mass.config.get_player_configs = AsyncMock(return_value=[])
+
+        provider = create_mock_universal_provider(mock_mass)
+        identifiers = {IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"}
+        universal = _create_universal_player(
+            mock_mass, "up_old", "Old Universal", ["ap_owned"], identifiers=identifiers
+        )
+        group = MockPlayer(
+            MockProvider("sync_group", mass=mock_mass),
+            "group_1",
+            "Group",
+            player_type=PlayerType.GROUP,
+            identifiers=identifiers,
+        )
+        group.set_initialized()
+        ap_owned = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_owned",
+            "AirPlay",
+            player_type=PlayerType.PROTOCOL,
+            identifiers=identifiers,
+        )
+        ap_owned.set_initialized()
+        controller._players = {"up_old": universal, "group_1": group, "ap_owned": ap_owned}
+        controller._add_protocol_link(universal, ap_owned, "airplay")
+
+        await provider.discover_players()
+
+        assert ap_owned.protocol_parent_id == "up_old"
+        assert not group.linked_output_protocols
 
 
 class TestEndToEndDuplicateProtocol:


### PR DESCRIPTION
# What does this implement/fix?

Speakers that were previously represented by a Universal Player (wrapping their DLNA/AirPlay
protocol players) did not hand over to the real player when one appeared — for example generic
LinkPlay speakers, which got a native player in #5729. The result was two players for one
speaker, with the wrapper keeping all the outputs so the native player could not play.

The takeover checked whether every protocol link had moved, but a link whose protocol player
had not registered yet looks exactly like a link the native player refused, so the handover was
abandoned. Refusals are now recorded when they actually happen.

- Only genuinely refused protocol links keep a speaker on its Universal Player.
- Protocol ownership that moved is now saved even when part of the handover is refused.
- Native players that registered before the Universal Players were restored are re-checked.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
