### PR TITLE
Limit concurrent provider streams

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1032,7 +1032,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                     if isinstance(err, ProviderStreamLimitError):
                         # the requested item is playable, its provider is just at capacity:
                         # report that instead of silently advancing to another item
-                        self.logger.error(str(err))
+                        self.logger.error("%s", err)
                         await self.stop(queue_id)
                         raise
                     # Only MediaNotFoundError (item unreachable) is persistent;

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -80,6 +80,7 @@ from music_assistant.controllers.player_queues.state import PlayerQueueData
 from music_assistant.controllers.player_queues.stream_feeder import StreamFeederMixin
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.api import api_command
+from music_assistant.models.music_provider import ProviderStreamLimitError
 from music_assistant.models.player import Player, PlayerMedia
 
 if TYPE_CHECKING:
@@ -1028,6 +1029,12 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                     break
                 except (MediaNotFoundError, AudioError) as err:
                     item_name = queue_item.name if queue_item else "unknown"
+                    if isinstance(err, ProviderStreamLimitError):
+                        # the requested item is playable, its provider is just at capacity:
+                        # report that instead of silently advancing to another item
+                        self.logger.error(str(err))
+                        await self.stop(queue_id)
+                        raise
                     # Only MediaNotFoundError (item unreachable) is persistent;
                     # keep AudioError items available so a retry can resurface
                     # the same actionable error.
@@ -1350,6 +1357,9 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                 # we're all set, this is our next item
                 next_item = queue_item
                 break
+            except ProviderStreamLimitError:
+                # transient source capacity, do not burn a playable item over it
+                raise
             except MediaNotFoundError, AudioError:
                 # No stream details found, skip this QueueItem
                 self.logger.warning(

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -1004,28 +1004,61 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         """
         queue_data = self._queue_data.get(queue_item.queue_id)
         items = tuple(queue_data.items) if queue_data else ()
-        # the started item keeps its own buffer; its direct successor keeps a prewarm
-        # in flight, so a resume or seek does not cost the upcoming crossfade
-        spared_item_ids = {queue_item.queue_item_id}
+        successor: QueueItem | None = None
         for index, item in enumerate(items):
             if item.queue_item_id == queue_item.queue_item_id and index + 1 < len(items):
-                spared_item_ids.add(items[index + 1].queue_item_id)
+                successor = items[index + 1]
                 break
+        # the started item keeps its own buffer, and its direct successor keeps the prewarm
+        # for the upcoming crossfade unless the aborts below leave the provider without a slot
+        spared_item_ids = {queue_item.queue_item_id}
+        if successor is not None:
+            spared_item_ids.add(successor.queue_item_id)
         for item in items:
-            if item.queue_item_id in spared_item_ids or item.streamdetails is None:
+            if item.queue_item_id in spared_item_ids:
                 continue
-            audio_buffer = item.streamdetails.buffer
-            if audio_buffer is None or not audio_buffer.is_buffering:
-                continue
-            provider = self.mass.get_provider(item.streamdetails.provider, return_unavailable=True)
-            if not isinstance(provider, MusicProvider) or provider.max_concurrent_streams is None:
-                continue
+            await self._abort_source_buffer(item, queue_item)
+        if successor is not None:
+            await self._abort_source_buffer(successor, queue_item, only_when_saturated=True)
+
+    async def _abort_source_buffer(
+        self,
+        item: QueueItem,
+        started_item: QueueItem,
+        only_when_saturated: bool = False,
+    ) -> None:
+        """
+        Cancel one item's still-filling source so its provider stream slot is handed over.
+
+        :param item: The queue item whose source buffer should be aborted.
+        :param started_item: The queue item that is about to start playing.
+        :param only_when_saturated: Only abort while the provider has no free slot left.
+        """
+        if item.streamdetails is None:
+            return
+        audio_buffer = item.streamdetails.buffer
+        if audio_buffer is None or not audio_buffer.is_buffering:
+            return
+        provider = self.mass.get_provider(item.streamdetails.provider, return_unavailable=True)
+        if not isinstance(provider, MusicProvider) or provider.max_concurrent_streams is None:
+            return
+        if only_when_saturated:
+            if provider.has_available_stream_slot:
+                # an abort above already freed a slot, so this prewarm can stay
+                return
+            self.logger.debug(
+                "Aborting the prewarm of %s: %s has no free stream slot left for %s",
+                item.name,
+                provider.name,
+                started_item.name,
+            )
+        else:
             self.logger.debug(
                 "Aborting the source of %s to free a %s stream slot for %s",
                 item.name,
                 provider.name,
-                queue_item.name,
+                started_item.name,
             )
-            # the cancelled buffer stays attached: it marks the source as aborted for
-            # the flow stream's accounting and fails is_valid() for any later reuse
-            await audio_buffer.clear()
+        # the cancelled buffer stays attached: it marks the source as aborted for
+        # the flow stream's accounting and fails is_valid() for any later reuse
+        await audio_buffer.clear()

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -58,13 +58,13 @@ from music_assistant.controllers.player_queues.helpers import (
     is_dynamic_source,
 )
 from music_assistant.controllers.player_queues.managed_pool import gate_tracks
-from music_assistant.controllers.streams.audio_buffer import AudioBuffer
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_user,
     set_current_user,
 )
 from music_assistant.helpers.audio import get_probed_duration, store_probed_duration
 from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
+from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
     from music_assistant_models.media_items.metadata import MediaItemImage
@@ -375,6 +375,10 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                         *org_images,
                     ]
                 )
+        if is_start:
+            # a track skip should hand its source slot to the item the user is starting
+            await self._abort_superseded_source_buffers(queue_item)
+
         # Fetch streamdetails (reuses existing if buffer is still valid for the seek).
         queue_item.streamdetails = await self.mass.streams.audio.get_stream_details(
             queue_item=queue_item,
@@ -391,11 +395,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         # initialize the buffer ~30s before the current track ends instead.
         # AudioSource items are realtime/live and bypass the AudioBuffer.
         if is_start and queue_item.streamdetails.media_type != MediaType.AUDIO_SOURCE:
-            await AudioBuffer.get_buffer(
-                self.mass,
-                queue_item.streamdetails,
+            await self.mass.streams.audio.get_audio_buffer(
+                queue_item,
                 seek_position_ms=int(seek_position * 1000),
-                wait_ready=True,
                 reason="prepare",
             )
             # the first chunk is in, so the source has been probed and a duration the
@@ -993,3 +995,29 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         # Drop anything already queued/played
         queued_set = set(queue_track_items)
         return [track for track in dynamic_tracks if track not in queued_set]
+
+    async def _abort_superseded_source_buffers(self, queue_item: QueueItem) -> None:
+        """
+        Abort the still-filling source buffers of other items in the same queue.
+
+        :param queue_item: The queue item that is about to start playing.
+        """
+        queue_data = self._queue_data.get(queue_item.queue_id)
+        for item in tuple(queue_data.items) if queue_data else ():
+            if item.queue_item_id == queue_item.queue_item_id or item.streamdetails is None:
+                continue
+            audio_buffer = item.streamdetails.buffer
+            if audio_buffer is None or not audio_buffer.is_buffering:
+                continue
+            provider = self.mass.get_provider(item.streamdetails.provider, return_unavailable=True)
+            if not isinstance(provider, MusicProvider) or provider.max_concurrent_streams is None:
+                continue
+            self.logger.debug(
+                "Aborting the source of %s to free a %s stream slot for %s",
+                item.name,
+                provider.name,
+                queue_item.name,
+            )
+            await audio_buffer.clear()
+            if item.streamdetails.buffer is audio_buffer:
+                item.streamdetails.buffer = None

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -1003,8 +1003,16 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         :param queue_item: The queue item that is about to start playing.
         """
         queue_data = self._queue_data.get(queue_item.queue_id)
-        for item in tuple(queue_data.items) if queue_data else ():
-            if item.queue_item_id == queue_item.queue_item_id or item.streamdetails is None:
+        items = tuple(queue_data.items) if queue_data else ()
+        # the started item keeps its own buffer; its direct successor keeps a prewarm
+        # in flight, so a resume or seek does not cost the upcoming crossfade
+        spared_item_ids = {queue_item.queue_item_id}
+        for index, item in enumerate(items):
+            if item.queue_item_id == queue_item.queue_item_id and index + 1 < len(items):
+                spared_item_ids.add(items[index + 1].queue_item_id)
+                break
+        for item in items:
+            if item.queue_item_id in spared_item_ids or item.streamdetails is None:
                 continue
             audio_buffer = item.streamdetails.buffer
             if audio_buffer is None or not audio_buffer.is_buffering:
@@ -1018,6 +1026,6 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                 provider.name,
                 queue_item.name,
             )
+            # the cancelled buffer stays attached: it marks the source as aborted for
+            # the flow stream's accounting and fails is_valid() for any later reuse
             await audio_buffer.clear()
-            if item.streamdetails.buffer is audio_buffer:
-                item.streamdetails.buffer = None

--- a/music_assistant/controllers/player_queues/stream_feeder.py
+++ b/music_assistant/controllers/player_queues/stream_feeder.py
@@ -26,7 +26,7 @@ from music_assistant.constants import (
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.controllers.player_queues.base import _PlayerQueuesBase
-from music_assistant.controllers.streams.audio_buffer import AudioBuffer
+from music_assistant.controllers.streams.constants import STREAM_SLOT_WAIT_TIMEOUT
 
 if TYPE_CHECKING:
     from music_assistant_models.queue_item import QueueItem
@@ -73,16 +73,19 @@ class StreamFeederMixin(_PlayerQueuesBase):
                     next_item.name,
                     queue.display_name,
                 )
-                await AudioBuffer.get_buffer(
-                    self.mass,
-                    next_item.streamdetails,
+                await self.mass.streams.audio.get_audio_buffer(
+                    next_item,
                     reason="prepare_next",
-                    wait_ready=True,
+                    capacity_wait_timeout=STREAM_SLOT_WAIT_TIMEOUT,
                 )
             except (AudioError, MediaNotFoundError) as err:
                 self.logger.debug("Failed to prepare next audio buffer: %s", err)
 
-        self.mass.create_task(_do_prepare)
+        self.mass.create_task(
+            _do_prepare,
+            task_id=f"prepare_next_audio_buffer_{queue_id}",
+            abort_existing=True,
+        )
 
     def _enqueue_next_item(self, queue_id: str, next_item: QueueItem | None) -> None:
         """Enqueue the next item on the player."""

--- a/music_assistant/controllers/player_queues/stream_feeder.py
+++ b/music_assistant/controllers/player_queues/stream_feeder.py
@@ -80,6 +80,12 @@ class StreamFeederMixin(_PlayerQueuesBase):
                 )
             except (AudioError, MediaNotFoundError) as err:
                 self.logger.debug("Failed to prepare next audio buffer: %s", err)
+            except asyncio.CancelledError:
+                # a replacement prepare aborted this one: release the half-filled source
+                # so its slot is not pinned until the inactivity sweep
+                if (sd := next_item.streamdetails) and (buf := sd.buffer) and buf.is_buffering:
+                    await asyncio.shield(buf.clear())
+                raise
 
         self.mass.create_task(
             _do_prepare,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -108,7 +108,10 @@ from music_assistant.controllers.streams.constants import (
 from music_assistant.controllers.streams.ogg_handler import get_chained_ogg_stream
 from music_assistant.controllers.streams.smart_fades import SmartFadesMixer
 from music_assistant.controllers.streams.smart_fades.fades import SmartFade
-from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
+from music_assistant.controllers.streams.smart_fades.helpers import (
+    MIN_EFFECTIVE_FADE_BUFFER,
+    SMART_CROSSFADE_DURATION,
+)
 from music_assistant.helpers import ssl as ssl_util
 from music_assistant.helpers.aiohttp_client import encoded_request_url
 from music_assistant.helpers.audio import (
@@ -168,6 +171,8 @@ if TYPE_CHECKING:
 
 # Seconds of PCM yielded directly to the player before the crossfade holdback starts buffering.
 WARMUP_DURATION = 8
+# Minimum overlap used when the full incoming crossfade buffer was not prepared.
+MIN_CROSSFADE_FALLBACK_DURATION = 5
 
 # Chunk size for the realtime AudioSource path; small enough to keep ffmpeg→consumer
 # latency below ~50 ms while still amortising per-chunk overhead.
@@ -189,9 +194,8 @@ class CrossfadeData:
     """Data class to hold crossfade data."""
 
     data: bytes
-    fade_in_size: int
+    fade_in_media_duration: float
     pcm_format: AudioFormat  # Format of the 'data' bytes (current/previous track's format)
-    fade_in_pcm_format: AudioFormat  # Format for 'fade_in_size' (next track's format)
     queue_item_id: str
     # Offset for the fade_in track's elapsed time calculation, to account for crossfade duration and trim
     elapsed_time_offset: float = 0.0
@@ -1265,11 +1269,13 @@ class StreamsAudio:
         self,
         queue_item: QueueItem,
         pcm_format: AudioFormat,
-        seek_position: int = 0,
+        seek_position: float = 0,
         playback_speed: float = 1.0,
         raise_on_error: bool = True,
         normalization_override: VolumeNormalizationMode | None = None,
         session_id: str | None = None,
+        prepared_buffer: AudioBuffer | None = None,
+        exact_seek: bool = False,
     ) -> AsyncGenerator[bytes]:
         """
         Get the (PCM) audio stream for a single queue item.
@@ -1285,6 +1291,8 @@ class StreamsAudio:
             re-evaluating it from the (possibly just-updated) loudness measurement. Used by
             the crossfade path to keep a track's replayed intro and its body on the same mode.
         :param session_id: Queue session that owns processing-detail updates.
+        :param prepared_buffer: Existing buffer that must be used without opening a new source.
+        :param exact_seek: Preserve millisecond precision instead of user-seek quantization.
         """
         streamdetails = queue_item.streamdetails
         assert streamdetails
@@ -1346,9 +1354,16 @@ class StreamsAudio:
         # provider's streamdetails, which everything below must then work with.
         seek_position_ms = int(seek_position * 1000)
         try:
-            audio_buffer = await self.get_audio_buffer(
-                queue_item, seek_position_ms=seek_position_ms, reason="streaming"
-            )
+            if prepared_buffer is not None:
+                if streamdetails.buffer is not prepared_buffer or not prepared_buffer.is_valid(
+                    seek_position_ms
+                ):
+                    raise AudioError("Prepared crossfade buffer is no longer available")
+                audio_buffer = prepared_buffer
+            else:
+                audio_buffer = await self.get_audio_buffer(
+                    queue_item, seek_position_ms=seek_position_ms, reason="streaming"
+                )
         except AudioError as err:
             streamdetails.stream_error = True
             if raise_on_error:
@@ -1438,6 +1453,7 @@ class StreamsAudio:
             output_format=pcm_format,
             seek_position_ms=seek_position_ms,
             filter_params=filter_params or None,
+            exact_seek=exact_seek,
         )
 
         first_chunk_received = False
@@ -1595,7 +1611,7 @@ class StreamsAudio:
             else crossfade_buffer_duration,
         )
         # skip crossfade if buffer would be too small to be meaningful
-        if crossfade_buffer_duration < 5:
+        if crossfade_buffer_duration < MIN_CROSSFADE_FALLBACK_DURATION:
             crossfade_buffer_duration = 0
         # Ensure crossfade buffer size is aligned to frame boundaries
         # Frame size = bytes_per_sample * channels
@@ -1613,6 +1629,7 @@ class StreamsAudio:
         if crossfade_data and crossfade_data.normalization_mode == VolumeNormalizationMode.DYNAMIC:
             norm_override = VolumeNormalizationMode.DYNAMIC
 
+        exact_buffer_seek = crossfade_data is not None
         if crossfade_data:
             # reported media-time (TRIM + CF) is decoupled from the raw buffer seek below (X)
             streamdetails.seek_position = crossfade_data.elapsed_time_offset
@@ -1628,19 +1645,12 @@ class StreamsAudio:
                     yield pcm_slice
                     await asyncio.sleep(0)
                 bytes_written += len(crossfade_data.data)
-            # skip past the audio already consumed by the crossfade
-            fade_in_duration_seconds = (
-                crossfade_data.fade_in_size / crossfade_data.fade_in_pcm_format.pcm_sample_size
-            )
-            discard_seconds = int(fade_in_duration_seconds)
-            fractional_seconds = fade_in_duration_seconds - discard_seconds
-            discard_leftover = int(fractional_seconds * pcm_format.pcm_sample_size)
-            discard_leftover = (discard_leftover // frame_size) * frame_size
+            # skip past the source media already consumed by the crossfade
+            discard_position = crossfade_data.fade_in_media_duration
             crossfade_data = None
             self._crossfade_data.pop(queue.queue_id, None)
         else:
-            discard_seconds = int(streamdetails.seek_position)
-            discard_leftover = 0
+            discard_position = float(streamdetails.seek_position)
 
         # Yield the first WARMUP_DURATION worth of audio immediately so playback starts
         # right away. After that, start accumulating the crossfade holdback buffer.
@@ -1651,15 +1661,13 @@ class StreamsAudio:
         async for chunk in self.get_queue_item_stream(
             queue_item,
             pcm_format,
-            seek_position=discard_seconds,
+            seek_position=discard_position,
             playback_speed=playback_speed,
             normalization_override=norm_override,
             session_id=session_id,
+            exact_seek=exact_buffer_seek,
         ):
             total_chunks_received += 1
-            if discard_leftover:
-                chunk = chunk[discard_leftover:]  # noqa: PLW2901
-                discard_leftover = 0
 
             if warmup_bytes < warmup_size:
                 # warmup: yield directly, don't buffer
@@ -1706,7 +1714,13 @@ class StreamsAudio:
             next_queue_item = None
 
         crossfade_allowed = False
+        transition_mode = CrossfadeMode.DISABLED
+        fade_in_buffer_duration = 0.0
+        fade_in_playback_speed = 1.0
         if next_queue_item and next_queue_item.streamdetails:
+            fade_in_playback_speed = cast(
+                "float", next_queue_item.extra_attributes.get("playback_speed", 1.0)
+            )
             next_pcm = await self.select_pcm_format(
                 player=player,
                 streamdetails=next_queue_item.streamdetails,
@@ -1721,6 +1735,14 @@ class StreamsAudio:
                 sample_rate=pcm_format.sample_rate,
                 next_sample_rate=next_pcm.sample_rate,
             )
+            if crossfade_allowed:
+                transition_mode, fade_in_buffer_duration = self._select_buffered_crossfade(
+                    next_queue_item.streamdetails,
+                    crossfade_mode,
+                    standard_crossfade_duration,
+                    fade_in_playback_speed,
+                )
+                crossfade_allowed = transition_mode != CrossfadeMode.DISABLED
         if not crossfade_allowed:
             # no crossfade enabled/allowed, just yield the buffer last part
             bytes_written += len(buffer)
@@ -1729,47 +1751,53 @@ class StreamsAudio:
                 await asyncio.sleep(0)
         else:
             assert next_queue_item is not None
+            assert next_queue_item.streamdetails is not None
+            assert next_queue_item.streamdetails.buffer is not None
+            fade_in_audio_buffer = cast("AudioBuffer", next_queue_item.streamdetails.buffer)
             # the remaining buffer is the fade-out tail of the current track
             fade_out_data = bytes(buffer)
             buffer = bytearray()
+            fade_in_buffer_size = int(pcm_format.pcm_sample_size * fade_in_buffer_duration)
+            fade_in_buffer_size = (fade_in_buffer_size // frame_size) * frame_size
             # initialized before the try block — the except handler reads these
             first_part_written = 0
             second_part_buf = bytearray()
             try:
                 # wrap the next track's stream in a counting generator that caps
-                # at crossfade_buffer_size and tracks how many bytes were consumed
+                # at the resident fade-in size and tracks how many bytes were consumed
                 fade_in_bytes_consumed = 0
 
                 _next_item = next_queue_item
 
                 async def _limited_fade_in() -> AsyncGenerator[bytes]:
                     nonlocal fade_in_bytes_consumed
-                    async for chunk in self.get_queue_item_stream(
+                    fade_in_stream = self.get_queue_item_stream(
                         _next_item,
                         pcm_format,
-                        playback_speed=cast(
-                            "float", _next_item.extra_attributes.get("playback_speed", 1.0)
-                        ),
+                        playback_speed=fade_in_playback_speed,
                         session_id=session_id,
-                    ):
-                        remaining = crossfade_buffer_size - fade_in_bytes_consumed
-                        if remaining <= 0:
-                            break
-                        if len(chunk) > remaining:
-                            fade_in_bytes_consumed += remaining
-                            yield chunk[:remaining]
-                            break
-                        fade_in_bytes_consumed += len(chunk)
-                        yield chunk
+                        prepared_buffer=fade_in_audio_buffer,
+                    )
+                    async with aclosing(fade_in_stream):
+                        async for chunk in fade_in_stream:
+                            remaining = fade_in_buffer_size - fade_in_bytes_consumed
+                            if remaining <= 0:
+                                break
+                            if len(chunk) >= remaining:
+                                fade_in_bytes_consumed += remaining
+                                yield chunk[:remaining]
+                                break
+                            fade_in_bytes_consumed += len(chunk)
+                            yield chunk
 
                 smart_fade = await self.smart_fades_mixer.build(
-                    fade_in_streamdetails=cast("StreamDetails", next_queue_item.streamdetails),
+                    fade_in_streamdetails=next_queue_item.streamdetails,
                     fade_out_streamdetails=streamdetails,
                     pcm_format=pcm_format,
                     standard_crossfade_duration=standard_crossfade_duration,
-                    mode=crossfade_mode,
+                    mode=transition_mode,
                     fade_out_data=fade_out_data,
-                    fade_in_bytes_len=crossfade_buffer_size,
+                    fade_in_bytes_len=fade_in_buffer_size,
                 )
                 crossfade_timing = smart_fade.timing_info
                 # Split mix output at end-of-overlap: PRE+CF to A, POST to B's intro.
@@ -1802,17 +1830,16 @@ class StreamsAudio:
                 uncredited_tail_bytes = len(fade_out_data) - first_part_written
                 self._crossfade_data[queue_item.queue_id] = CrossfadeData(
                     data=bytes(second_part_buf),
-                    fade_in_size=fade_in_bytes_consumed,
+                    fade_in_media_duration=(fade_in_bytes_consumed / pcm_format.pcm_sample_size)
+                    * fade_in_playback_speed,
                     pcm_format=pcm_format,
-                    fade_in_pcm_format=pcm_format,
                     queue_item_id=next_queue_item.queue_item_id,
                     elapsed_time_offset=(
                         crossfade_timing.fadein_trimmed_duration
                         + crossfade_timing.crossfade_duration
-                    ),
-                    normalization_mode=cast(
-                        "StreamDetails", next_queue_item.streamdetails
-                    ).volume_normalization_mode,
+                    )
+                    * fade_in_playback_speed,
+                    normalization_mode=next_queue_item.streamdetails.volume_normalization_mode,
                 )
                 crossfade_elapsed = asyncio.get_event_loop().time() - crossfade_start_time
                 self.logger.debug(
@@ -1859,7 +1886,11 @@ class StreamsAudio:
             streamdetails.uri,
             queue_item.name,
             queue.display_name,
-            next_queue_item.name if next_queue_item else "N/A",
+            (
+                next_queue_item.name
+                if next_queue_item and queue_item.queue_id in self._crossfade_data
+                else "N/A"
+            ),
         )
 
     async def get_queue_flow_stream(
@@ -2031,7 +2062,7 @@ class StreamsAudio:
                 else crossfade_buffer_duration,
             )
             # skip crossfade if buffer would be too small to be meaningful
-            if crossfade_buffer_duration < 5:
+            if crossfade_buffer_duration < MIN_CROSSFADE_FALLBACK_DURATION:
                 crossfade_buffer_duration = 0
             # Ensure crossfade buffer size is aligned to frame boundaries
             # Frame size = bytes_per_sample * channels
@@ -2048,27 +2079,46 @@ class StreamsAudio:
             # Build eagerly so seek_position is set before PlayLogEntry is appended —
             # consumer-paced mix() would otherwise let the queue briefly report 0.
             crossfade_smart_fade: SmartFade | None = None
-            if (
-                last_fadeout_part
-                and last_streamdetails
-                and crossfade_buffer_size > 0
-                and crossfade_mode != CrossfadeMode.DISABLED
-            ):
-                crossfade_smart_fade = await self.smart_fades_mixer.build(
-                    fade_in_streamdetails=queue_track.streamdetails,
-                    fade_out_streamdetails=last_streamdetails,
-                    pcm_format=pcm_format,
-                    standard_crossfade_duration=standard_crossfade_duration,
-                    mode=crossfade_mode,
-                    fade_out_data=last_fadeout_part,
-                    fade_in_bytes_len=crossfade_buffer_size,
-                )
-                timing_info = crossfade_smart_fade.timing_info
-                queue_track.streamdetails.seek_position = (
-                    raw_seek_position
-                    + timing_info.fadein_trimmed_duration
-                    + timing_info.crossfade_duration
-                )
+            incoming_crossfade_size = crossfade_buffer_size
+            incoming_audio_buffer: AudioBuffer | None = None
+            if last_fadeout_part and last_streamdetails:
+                transition_mode = CrossfadeMode.DISABLED
+                incoming_duration = 0.0
+                if crossfade_buffer_size > 0 and crossfade_mode != CrossfadeMode.DISABLED:
+                    transition_mode, incoming_duration = self._select_buffered_crossfade(
+                        queue_track.streamdetails,
+                        crossfade_mode,
+                        standard_crossfade_duration,
+                        track_playback_speed,
+                    )
+                if transition_mode == CrossfadeMode.DISABLED:
+                    # nothing to fade into: flush the held-back tail of the previous track
+                    for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
+                        yield pcm_slice
+                        await asyncio.sleep(0)
+                    last_fadeout_part = b""
+                    last_streamdetails = None
+                    last_play_log_entry = None
+                else:
+                    assert queue_track.streamdetails.buffer is not None
+                    incoming_audio_buffer = cast("AudioBuffer", queue_track.streamdetails.buffer)
+                    incoming_crossfade_size = int(pcm_format.pcm_sample_size * incoming_duration)
+                    incoming_crossfade_size = (incoming_crossfade_size // frame_size) * frame_size
+                    crossfade_smart_fade = await self.smart_fades_mixer.build(
+                        fade_in_streamdetails=queue_track.streamdetails,
+                        fade_out_streamdetails=last_streamdetails,
+                        pcm_format=pcm_format,
+                        standard_crossfade_duration=standard_crossfade_duration,
+                        mode=transition_mode,
+                        fade_out_data=last_fadeout_part,
+                        fade_in_bytes_len=incoming_crossfade_size,
+                    )
+                    timing_info = crossfade_smart_fade.timing_info
+                    queue_track.streamdetails.seek_position = (
+                        raw_seek_position
+                        + (timing_info.fadein_trimmed_duration + timing_info.crossfade_duration)
+                        * track_playback_speed
+                    )
             # append to play log so the queue controller can work out which track is playing
             play_log_entry = PlayLogEntry(queue_track.queue_item_id)
             pq_data.flow_mode_stream_log.append(play_log_entry)
@@ -2087,6 +2137,7 @@ class StreamsAudio:
                 ),
                 raise_on_error=False,
                 session_id=flow_session_id,
+                prepared_buffer=incoming_audio_buffer,
             ):
                 # if a newer producer has taken over this queue, stop sending
                 # audio and exit cleanly before the outer-loop end-of-track
@@ -2127,7 +2178,10 @@ class StreamsAudio:
                 # smart fades enabled: accumulate chunks in crossfade buffer
                 crossfade_buffer.extend(chunk)
                 del chunk
-                if len(crossfade_buffer) < crossfade_buffer_size:
+                required_buffer_size = (
+                    incoming_crossfade_size if last_fadeout_part else crossfade_buffer_size
+                )
+                if len(crossfade_buffer) < required_buffer_size:
                     await asyncio.sleep(0)
                     continue
 
@@ -2138,8 +2192,8 @@ class StreamsAudio:
                     and crossfade_smart_fade is not None
                     and last_play_log_entry is not None
                 ):
-                    fadein_part = bytes(crossfade_buffer[:crossfade_buffer_size])
-                    remaining_bytes = bytes(crossfade_buffer[crossfade_buffer_size:])
+                    fadein_part = bytes(crossfade_buffer[:incoming_crossfade_size])
+                    remaining_bytes = bytes(crossfade_buffer[incoming_crossfade_size:])
                     try:
                         crossfade_bytes_written = 0
                         async for mix_chunk in self.smart_fades_mixer.mix(
@@ -3034,6 +3088,57 @@ class StreamsAudio:
                 ffmpeg_proc.returncode,
                 streamdetails.uri,
             )
+
+    def _select_buffered_crossfade(
+        self,
+        streamdetails: StreamDetails,
+        crossfade_mode: CrossfadeMode,
+        standard_crossfade_duration: int,
+        playback_speed: float = 1.0,
+    ) -> tuple[CrossfadeMode, float]:
+        """
+        Select a crossfade that can be completed from resident incoming PCM.
+
+        :param streamdetails: Incoming track stream details.
+        :param crossfade_mode: Requested crossfade mode.
+        :param standard_crossfade_duration: Configured standard overlap in seconds.
+        :param playback_speed: Incoming track playback-speed multiplier.
+        :return: Effective mode and resident fade-in duration in seconds.
+        """
+        audio_buffer = getattr(streamdetails, "buffer", None)
+        if (
+            crossfade_mode == CrossfadeMode.DISABLED
+            or playback_speed <= 0
+            or audio_buffer is None
+            or audio_buffer.has_error
+            or not audio_buffer.is_valid()
+        ):
+            return CrossfadeMode.DISABLED, 0
+
+        available_seconds = audio_buffer.duration_available / playback_speed
+        if (
+            crossfade_mode == CrossfadeMode.SMART_CROSSFADE
+            and audio_buffer.ready.is_set()
+            and available_seconds >= MIN_EFFECTIVE_FADE_BUFFER
+        ):
+            return crossfade_mode, min(SMART_CROSSFADE_DURATION, available_seconds)
+        if (
+            crossfade_mode == CrossfadeMode.STANDARD_CROSSFADE
+            and standard_crossfade_duration >= MIN_CROSSFADE_FALLBACK_DURATION
+            and audio_buffer.ready.is_set()
+            and available_seconds >= standard_crossfade_duration
+        ):
+            return crossfade_mode, standard_crossfade_duration
+
+        fallback_duration = min(standard_crossfade_duration, available_seconds)
+        if fallback_duration < MIN_CROSSFADE_FALLBACK_DURATION:
+            return CrossfadeMode.DISABLED, 0
+        self.logger.debug(
+            "Using %s second standard crossfade for %s from resident audio",
+            fallback_duration,
+            streamdetails.uri,
+        )
+        return CrossfadeMode.STANDARD_CROSSFADE, fallback_duration
 
     async def _resolve_media_stream_source(
         self,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -14,7 +14,7 @@ import os
 import re
 import time
 from collections.abc import AsyncGenerator, Iterable
-from contextlib import asynccontextmanager
+from contextlib import aclosing, asynccontextmanager, nullcontext
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, cast
@@ -99,6 +99,7 @@ from music_assistant.controllers.streams.constants import (
     CACHE_CATEGORY_RESOLVED_RADIO_URL,
     CACHE_PROVIDER,
     CONF_ALLOW_CROSSFADE_SAME_ALBUM,
+    STREAM_SLOT_WAIT_TIMEOUT,
     STREAMDETAILS_INBAND_TITLE_HANDOFF_KEY,
     STREAMDETAILS_INBAND_TITLE_KEY,
 )
@@ -148,6 +149,7 @@ from music_assistant.helpers.util import (
     parse_title_and_version,
     remove_file,
 )
+from music_assistant.models.music_provider import MusicProvider, ProviderStreamLimitError
 
 if TYPE_CHECKING:
     from music_assistant_models.player_queue import PlayerQueue
@@ -155,7 +157,6 @@ if TYPE_CHECKING:
     from music_assistant_models.streamdetails import StreamDetails
 
     from music_assistant.mass import MusicAssistant
-    from music_assistant.models.music_provider import MusicProvider
     from music_assistant.models.player import Player
     from music_assistant.models.plugin import PluginProvider
 
@@ -447,6 +448,7 @@ class StreamsAudio:
         seek_position: int = 0,
         filter_params: list[str] | None = None,
         chunk_seconds: float = 1.0,
+        source_wait_timeout: float | None = STREAM_SLOT_WAIT_TIMEOUT,
     ) -> AsyncGenerator[bytes]:
         """
         Get audio stream for given media details as raw PCM.
@@ -460,215 +462,28 @@ class StreamsAudio:
             Defaults to 1 s for track-like sources; callers streaming live
             AudioSources should pass a much smaller value (e.g. 0.02) to keep
             end-to-end latency low.
+        :param source_wait_timeout: Maximum seconds to wait for a free source-stream slot
+            on the providing music provider, or None to wait without a timeout.
+        :raises ProviderStreamLimitError: If the provider has no free slot within the timeout.
         """
-        mass = self.mass
-        logger = self.logger.getChild("media_stream")
-        logger.log(VERBOSE_LOG_LEVEL, "Starting media stream for %s", streamdetails.uri)
-        # copy: the args below are appended per call, while the StreamDetails is cached on
-        # the queue item and reused across calls (retry, seek, background analysis)
-        extra_input_args = list(streamdetails.extra_input_args or [])
-        # the branches below zero out seek_position where the seek is delegated to the
-        # source itself, so keep the requested position for the duration writeback
-        requested_seek_position = seek_position
-
-        # work out audio source for these streamdetails
-        audio_source: str | AsyncGenerator[bytes]
-        stream_type = streamdetails.stream_type
-        if stream_type == StreamType.CUSTOM:
-            # MusicProvider and PluginProvider both expose get_audio_stream with the same shape
-            provider = mass.get_provider(streamdetails.provider)
-            if provider is None:
-                raise ProviderUnavailableError(
-                    f"Provider {streamdetails.provider} for stream is no longer available"
-                )
-            provider = cast("MusicProvider | PluginProvider", provider)
-            audio_source = provider.get_audio_stream(
-                streamdetails, seek_position=seek_position if streamdetails.can_seek else 0
-            )
-            seek_position = 0 if streamdetails.can_seek else seek_position
-        elif stream_type == StreamType.ICY:
-            assert streamdetails.path is not None
-            assert isinstance(streamdetails.path, (str, list))
-            audio_source = self.get_reconnecting_icy_radio_stream(streamdetails.path, streamdetails)
-            seek_position = 0
-        elif stream_type == StreamType.SHOUTCAST:
-            assert isinstance(streamdetails.path, str)
-            audio_source = self.get_shoutcast_stream(streamdetails.path, streamdetails)
-            seek_position = 0
-        elif stream_type == StreamType.IN_BAND:
-            assert isinstance(streamdetails.path, str)  # for type checking
-
-            # For IN_BAND (OGG/Opus) radio streams, use chained OGG handler.
-            # This handles the chained OGG format by stitching logical bitstreams together
-            # so FFmpeg sees a single continuous stream. Metadata is extracted in-band.
-            audio_source = get_chained_ogg_stream(
-                mass,
-                streamdetails.path,
-                metadata_callback=partial(self._handle_inband_metadata, streamdetails),
-            )
-            seek_position = 0  # seeking not possible on radio streams
-        elif stream_type == StreamType.HLS:
-            assert isinstance(streamdetails.path, str)  # for type checking
-            substream = await self.get_hls_substream(streamdetails.path)
-            audio_source = substream.path
-            if streamdetails.media_type == MediaType.RADIO:
-                # HLS streams (especially the BBC) struggle when they're played directly
-                # with ffmpeg, where they just stop after some minutes,
-                # so we tell ffmpeg to loop around in this case.
-                extra_input_args += ["-stream_loop", "-1", "-re"]
-        else:
-            # all other stream types (HTTP, FILE, etc)
-            if stream_type == StreamType.ENCRYPTED_HTTP:
-                assert streamdetails.decryption_key is not None  # for type checking
-                extra_input_args += ["-decryption_key", streamdetails.decryption_key]
-            if isinstance(streamdetails.path, list):
-                # multi part stream
-                audio_source = self.get_multi_file_stream(streamdetails, seek_position)
-                seek_position = 0  # handled by get_multi_file_stream
-            else:
-                # regular single file/url stream
-                assert isinstance(streamdetails.path, str)  # for type checking
-                audio_source = streamdetails.path
-
-        # pace ffmpeg at native rate for live sources; the producer (e.g.
-        # librespot's pipe backend) may otherwise write faster than realtime.
-        # The initial burst grants a small bounded read-ahead so downstream
-        # jitter does not immediately underrun the player. Providers that need
-        # different pacing can pass their own -re/-readrate args to override.
-        if (
-            streamdetails.media_type == MediaType.AUDIO_SOURCE
-            and "-re" not in extra_input_args
-            and "-readrate" not in extra_input_args
-        ):
-            extra_input_args += ["-readrate", "1", "-readrate_initial_burst", "0.5"]
-
-        # handle seek support
-        if seek_position and streamdetails.duration and streamdetails.allow_seek:
-            extra_input_args += ["-ss", str(int(seek_position))]
-
-        bytes_sent = 0
-        finished = False
-        cancelled = False
-        first_chunk_received = False
-        ffmpeg_loglevel = "debug" if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL) else "info"
-        # When a provider hands us already-decoded audio (e.g. Spotify Connect /
-        # AirPlay receivers piping PCM after their own decode), audio_format is
-        # the original source format meant for display while decoded_audio_format
-        # is what ffmpeg actually needs to read off the wire.
-        ffmpeg_input_format = streamdetails.decoded_audio_format or streamdetails.audio_format
-        ffmpeg_proc = FFMpeg(
-            audio_input=audio_source,
-            input_format=ffmpeg_input_format,
-            output_format=pcm_format,
-            filter_params=filter_params,
-            extra_input_args=extra_input_args,
-            collect_log_history=True,
-            loglevel=ffmpeg_loglevel,
+        media_stream = self._get_media_stream(
+            streamdetails,
+            pcm_format,
+            seek_position,
+            filter_params,
+            chunk_seconds,
         )
-
-        try:
-            await ffmpeg_proc.start()
-            assert ffmpeg_proc.proc is not None  # for type checking
-            if logger.isEnabledFor(VERBOSE_LOG_LEVEL):
-                logger.log(
-                    VERBOSE_LOG_LEVEL,
-                    "Started media stream for %s - using streamtype: %s "
-                    "- pcm format: %s - ffmpeg PID: %s",
-                    streamdetails.uri,
-                    streamdetails.stream_type,
-                    pcm_format.content_type.value,
-                    ffmpeg_proc.proc.pid,
-                )
-            else:
-                logger.debug(
-                    "Started media stream for %s - using streamtype: %s",
-                    streamdetails.uri,
-                    streamdetails.stream_type,
-                )
-            stream_start = mass.loop.time()
-            chunk_size = calculate_content_length(pcm_format, chunk_seconds)
-            chunk_iter = ffmpeg_proc.iter_chunked(chunk_size)
-            while True:
-                # Time the read, not the yield: catches a stalled source, ignores backpressure.
-                read_timeout = (
-                    STREAM_START_TIMEOUT if not first_chunk_received else STREAM_STALL_TIMEOUT
-                )
-                try:
-                    async with asyncio.timeout(read_timeout):
-                        chunk = await anext(chunk_iter)
-                except StopAsyncIteration:
-                    break
-                except TimeoutError as err:
-                    raise AudioError(f"Source stalled: no audio for {read_timeout}s") from err
-                if not first_chunk_received:
-                    # At this point ffmpeg has started and should now know the codec used
-                    # for encoding the audio.
-                    # Note: ffmpeg_proc.input_format is the same object as
-                    # ffmpeg_input_format, so sample_rate / bit_depth / bit_rate
-                    # parsed from the ffmpeg log already live on streamdetails too.
-                    first_chunk_received = True
-                    # Skip the codec_type writeback when the provider declared a
-                    # decoded format: audio_format already holds the authoritative
-                    # source codec and the probed value would just be the
-                    # post-decode wire format (e.g. PCM for Spotify Connect).
-                    if streamdetails.decoded_audio_format is None:
-                        streamdetails.audio_format.codec_type = ffmpeg_proc.input_format.codec_type
-                    # Some providers omit (or report 0 for) the item duration; ffmpeg can
-                    # usually probe it from the source. Only apply when missing so we
-                    # don't clobber an accurate provider value with a rounded one.
-                    if ffmpeg_proc.parsed_duration is not None and not streamdetails.duration:
-                        streamdetails.duration = ffmpeg_proc.parsed_duration
-                    logger.debug(
-                        "First chunk received after %.2f seconds (codec detected: %s)",
-                        mass.loop.time() - stream_start,
-                        ffmpeg_proc.input_format.codec_type,
-                    )
+        # resolve the exact owning instance (even when flagged unavailable) so the
+        # slot is charged to the account that issued the streamdetails
+        provider = self.mass.get_provider(streamdetails.provider, return_unavailable=True)
+        stream_slot = (
+            provider.acquire_stream_slot(source_wait_timeout)
+            if isinstance(provider, MusicProvider)
+            else nullcontext()
+        )
+        async with stream_slot, aclosing(media_stream):
+            async for chunk in media_stream:
                 yield chunk
-                bytes_sent += len(chunk)
-
-            # end of audio/track reached
-            logger.debug("End of media stream reached for %s", streamdetails.uri)
-            # wait until stderr also completed reading
-            await ffmpeg_proc.wait_with_timeout(5)
-            logger.log(
-                VERBOSE_LOG_LEVEL,
-                "FFmpeg process ended with return code %s for %s",
-                ffmpeg_proc.returncode,
-                streamdetails.uri,
-            )
-            if ffmpeg_proc.returncode not in (0, None):
-                log_trail = "\n".join(list(ffmpeg_proc.log_history)[-5:])
-                raise AudioError(f"FFMpeg exited with code {ffmpeg_proc.returncode}: {log_trail}")
-            if bytes_sent == 0:
-                # edge case: no audio data was received at all
-                raise AudioError("No audio was received")
-            finished = True
-        except (Exception, GeneratorExit, asyncio.CancelledError) as err:
-            if isinstance(err, asyncio.CancelledError | GeneratorExit):
-                # we were cancelled, just raise
-                cancelled = True
-                raise
-            # dump the last 10 lines of the log in case of an unclean exit
-            logger.warning("\n".join(list(ffmpeg_proc.log_history)[-10:]))
-            raise AudioError(f"Error while streaming: {err}") from err
-        finally:
-            # always ensure close is called which also handles all cleanup
-            await ffmpeg_proc.close()
-            # determine how many seconds we've received
-            # for pcm output we can calculate this easily
-            seconds_received = bytes_sent / pcm_format.pcm_sample_size if bytes_sent else 0
-            # store accurate duration, but only for a playthrough from the very start:
-            # a seeked stream yields the remaining audio, not the item's full length
-            if finished and not requested_seek_position and seconds_received:
-                streamdetails.duration = int(seconds_received)
-
-            logger.log(
-                VERBOSE_LOG_LEVEL,
-                "stream %s (with code %s) for %s",
-                "cancelled" if cancelled else "finished" if finished else "aborted",
-                ffmpeg_proc.returncode,
-                streamdetails.uri,
-            )
 
     async def resolve_radio_stream(self, url: str) -> tuple[str, StreamType]:
         """
@@ -2835,6 +2650,253 @@ class StreamsAudio:
             "Failed to parse radio URL %s: %s - attempting direct stream", validate_url, str(err)
         )
         return await self._cache_radio_result(url, fallback_stream_type, resolved_url=validate_url)
+
+    async def _get_media_stream(
+        self,
+        streamdetails: StreamDetails,
+        pcm_format: AudioFormat,
+        seek_position: int,
+        filter_params: list[str] | None,
+        chunk_seconds: float,
+    ) -> AsyncGenerator[bytes]:
+        """
+        Stream one provider source as raw PCM.
+
+        :param streamdetails: Details of the stream to fetch.
+        :param pcm_format: Target PCM format the consumer expects.
+        :param seek_position: Requested seek offset in seconds.
+        :param filter_params: Optional ffmpeg filter expressions.
+        :param chunk_seconds: Size of each yielded chunk in seconds of audio.
+        """
+        mass = self.mass
+        logger = self.logger.getChild("media_stream")
+        logger.log(VERBOSE_LOG_LEVEL, "Starting media stream for %s", streamdetails.uri)
+        # copy: the args below are appended per call, while the StreamDetails is cached on
+        # the queue item and reused across calls (retry, seek, background analysis)
+        extra_input_args = list(streamdetails.extra_input_args or [])
+        # the resolver below zeroes out seek_position where the seek is delegated to the
+        # source itself, so keep the requested position for the duration writeback
+        requested_seek_position = seek_position
+
+        # work out audio source for these streamdetails
+        audio_source, seek_position, extra_input_args = await self._resolve_media_stream_source(
+            streamdetails, seek_position, extra_input_args
+        )
+
+        # pace ffmpeg at native rate for live sources; the producer (e.g.
+        # librespot's pipe backend) may otherwise write faster than realtime.
+        # The initial burst grants a small bounded read-ahead so downstream
+        # jitter does not immediately underrun the player. Providers that need
+        # different pacing can pass their own -re/-readrate args to override.
+        if (
+            streamdetails.media_type == MediaType.AUDIO_SOURCE
+            and "-re" not in extra_input_args
+            and "-readrate" not in extra_input_args
+        ):
+            extra_input_args += ["-readrate", "1", "-readrate_initial_burst", "0.5"]
+
+        # handle seek support
+        if seek_position and streamdetails.duration and streamdetails.allow_seek:
+            extra_input_args += ["-ss", str(int(seek_position))]
+
+        bytes_sent = 0
+        finished = False
+        cancelled = False
+        first_chunk_received = False
+        ffmpeg_loglevel = "debug" if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL) else "info"
+        # When a provider hands us already-decoded audio (e.g. Spotify Connect /
+        # AirPlay receivers piping PCM after their own decode), audio_format is
+        # the original source format meant for display while decoded_audio_format
+        # is what ffmpeg actually needs to read off the wire.
+        ffmpeg_input_format = streamdetails.decoded_audio_format or streamdetails.audio_format
+        ffmpeg_proc = FFMpeg(
+            audio_input=audio_source,
+            input_format=ffmpeg_input_format,
+            output_format=pcm_format,
+            filter_params=filter_params,
+            extra_input_args=extra_input_args,
+            collect_log_history=True,
+            loglevel=ffmpeg_loglevel,
+        )
+
+        try:
+            await ffmpeg_proc.start()
+            assert ffmpeg_proc.proc is not None  # for type checking
+            if logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+                logger.log(
+                    VERBOSE_LOG_LEVEL,
+                    "Started media stream for %s - using streamtype: %s "
+                    "- pcm format: %s - ffmpeg PID: %s",
+                    streamdetails.uri,
+                    streamdetails.stream_type,
+                    pcm_format.content_type.value,
+                    ffmpeg_proc.proc.pid,
+                )
+            else:
+                logger.debug(
+                    "Started media stream for %s - using streamtype: %s",
+                    streamdetails.uri,
+                    streamdetails.stream_type,
+                )
+            stream_start = mass.loop.time()
+            chunk_size = calculate_content_length(pcm_format, chunk_seconds)
+            chunk_iter = ffmpeg_proc.iter_chunked(chunk_size)
+            while True:
+                # Time the read, not the yield: catches a stalled source, ignores backpressure.
+                read_timeout = (
+                    STREAM_START_TIMEOUT if not first_chunk_received else STREAM_STALL_TIMEOUT
+                )
+                try:
+                    async with asyncio.timeout(read_timeout):
+                        chunk = await anext(chunk_iter)
+                except StopAsyncIteration:
+                    break
+                except TimeoutError as err:
+                    raise AudioError(f"Source stalled: no audio for {read_timeout}s") from err
+                if not first_chunk_received:
+                    # At this point ffmpeg has started and should now know the codec used
+                    # for encoding the audio.
+                    # Note: ffmpeg_proc.input_format is the same object as
+                    # ffmpeg_input_format, so sample_rate / bit_depth / bit_rate
+                    # parsed from the ffmpeg log already live on streamdetails too.
+                    first_chunk_received = True
+                    # Skip the codec_type writeback when the provider declared a
+                    # decoded format: audio_format already holds the authoritative
+                    # source codec and the probed value would just be the
+                    # post-decode wire format (e.g. PCM for Spotify Connect).
+                    if streamdetails.decoded_audio_format is None:
+                        streamdetails.audio_format.codec_type = ffmpeg_proc.input_format.codec_type
+                    # Some providers omit (or report 0 for) the item duration; ffmpeg can
+                    # usually probe it from the source. Only apply when missing so we
+                    # don't clobber an accurate provider value with a rounded one.
+                    if ffmpeg_proc.parsed_duration is not None and not streamdetails.duration:
+                        streamdetails.duration = ffmpeg_proc.parsed_duration
+                    logger.debug(
+                        "First chunk received after %.2f seconds (codec detected: %s)",
+                        mass.loop.time() - stream_start,
+                        ffmpeg_proc.input_format.codec_type,
+                    )
+                yield chunk
+                bytes_sent += len(chunk)
+
+            # end of audio/track reached
+            logger.debug("End of media stream reached for %s", streamdetails.uri)
+            # wait until stderr also completed reading
+            await ffmpeg_proc.wait_with_timeout(5)
+            logger.log(
+                VERBOSE_LOG_LEVEL,
+                "FFmpeg process ended with return code %s for %s",
+                ffmpeg_proc.returncode,
+                streamdetails.uri,
+            )
+            # a nested source raises through the stdin feeder, where ffmpeg's own exit
+            # would otherwise flatten it into a generic AudioError
+            if isinstance(ffmpeg_proc.stdin_feeder_exception, ProviderStreamLimitError):
+                raise ffmpeg_proc.stdin_feeder_exception
+            if ffmpeg_proc.returncode not in (0, None):
+                log_trail = "\n".join(list(ffmpeg_proc.log_history)[-5:])
+                raise AudioError(f"FFMpeg exited with code {ffmpeg_proc.returncode}: {log_trail}")
+            if bytes_sent == 0:
+                # edge case: no audio data was received at all
+                raise AudioError("No audio was received")
+            finished = True
+        except (Exception, GeneratorExit, asyncio.CancelledError) as err:
+            if isinstance(err, asyncio.CancelledError | GeneratorExit):
+                # we were cancelled, just raise
+                cancelled = True
+                raise
+            if isinstance(ffmpeg_proc.stdin_feeder_exception, ProviderStreamLimitError):
+                raise ffmpeg_proc.stdin_feeder_exception
+            # dump the last 10 lines of the log in case of an unclean exit
+            logger.warning("\n".join(list(ffmpeg_proc.log_history)[-10:]))
+            raise AudioError(f"Error while streaming: {err}") from err
+        finally:
+            # always ensure close is called which also handles all cleanup
+            await ffmpeg_proc.close()
+            # determine how many seconds we've received
+            # for pcm output we can calculate this easily
+            seconds_received = bytes_sent / pcm_format.pcm_sample_size if bytes_sent else 0
+            # store accurate duration, but only for a playthrough from the very start:
+            # a seeked stream yields the remaining audio, not the item's full length
+            if finished and not requested_seek_position and seconds_received:
+                streamdetails.duration = int(seconds_received)
+
+            logger.log(
+                VERBOSE_LOG_LEVEL,
+                "stream %s (with code %s) for %s",
+                "cancelled" if cancelled else "finished" if finished else "aborted",
+                ffmpeg_proc.returncode,
+                streamdetails.uri,
+            )
+
+    async def _resolve_media_stream_source(
+        self,
+        streamdetails: StreamDetails,
+        seek_position: int,
+        extra_input_args: list[str],
+    ) -> tuple[str | AsyncGenerator[bytes], int, list[str]]:
+        """
+        Resolve the input consumed by ffmpeg for the given stream details.
+
+        :param streamdetails: Details of the stream to fetch.
+        :param seek_position: Requested seek offset in seconds.
+        :param extra_input_args: Provider-supplied ffmpeg input arguments.
+        :return: The ffmpeg input, the remaining seek offset and the ffmpeg input arguments.
+        """
+        stream_type = streamdetails.stream_type
+        if stream_type == StreamType.CUSTOM:
+            # MusicProvider and PluginProvider both expose get_audio_stream with the same shape
+            provider = self.mass.get_provider(streamdetails.provider)
+            if provider is None:
+                raise ProviderUnavailableError(
+                    f"Provider {streamdetails.provider} for stream is no longer available"
+                )
+            provider = cast("MusicProvider | PluginProvider", provider)
+            audio_source = provider.get_audio_stream(
+                streamdetails, seek_position=seek_position if streamdetails.can_seek else 0
+            )
+            return audio_source, 0 if streamdetails.can_seek else seek_position, extra_input_args
+        if stream_type == StreamType.ICY:
+            assert streamdetails.path is not None
+            assert isinstance(streamdetails.path, (str, list))
+            audio_source = self.get_reconnecting_icy_radio_stream(streamdetails.path, streamdetails)
+            return audio_source, 0, extra_input_args
+        if stream_type == StreamType.SHOUTCAST:
+            assert isinstance(streamdetails.path, str)
+            return self.get_shoutcast_stream(streamdetails.path, streamdetails), 0, extra_input_args
+        if stream_type == StreamType.IN_BAND:
+            assert isinstance(streamdetails.path, str)  # for type checking
+
+            # For IN_BAND (OGG/Opus) radio streams, use chained OGG handler.
+            # This handles the chained OGG format by stitching logical bitstreams together
+            # so FFmpeg sees a single continuous stream. Metadata is extracted in-band.
+            audio_source = get_chained_ogg_stream(
+                self.mass,
+                streamdetails.path,
+                metadata_callback=partial(self._handle_inband_metadata, streamdetails),
+            )
+            # seeking not possible on radio streams
+            return audio_source, 0, extra_input_args
+        if stream_type == StreamType.HLS:
+            assert isinstance(streamdetails.path, str)  # for type checking
+            substream = await self.get_hls_substream(streamdetails.path)
+            if streamdetails.media_type == MediaType.RADIO:
+                # HLS streams (especially the BBC) struggle when they're played directly
+                # with ffmpeg, where they just stop after some minutes,
+                # so we tell ffmpeg to loop around in this case.
+                extra_input_args += ["-stream_loop", "-1", "-re"]
+            return substream.path, seek_position, extra_input_args
+
+        # all other stream types (HTTP, FILE, etc)
+        if stream_type == StreamType.ENCRYPTED_HTTP:
+            assert streamdetails.decryption_key is not None  # for type checking
+            extra_input_args += ["-decryption_key", streamdetails.decryption_key]
+        if isinstance(streamdetails.path, list):
+            # multi part stream, which handles the seek itself
+            return self.get_multi_file_stream(streamdetails, seek_position), 0, extra_input_args
+        # regular single file/url stream
+        assert isinstance(streamdetails.path, str)  # for type checking
+        return streamdetails.path, seek_position, extra_input_args
 
     async def _iter_audio_source_pcm(
         self,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1377,6 +1377,10 @@ class StreamsAudio:
             return
         streamdetails = queue_item.streamdetails
         assert streamdetails  # for type checking
+        if normalization_override is not None:
+            # a capacity reselection hands back freshly resolved details, so the
+            # crossfade's intro/body normalization pin must be re-applied to them
+            streamdetails.volume_normalization_mode = normalization_override
 
         # handle volume normalization
         gain_correct: float | None = None
@@ -1867,6 +1871,9 @@ class StreamsAudio:
                 del fade_out_data
         # make sure the buffer gets cleaned up
         del buffer
+        # a capacity reselection inside the stream replaces the queue item's details,
+        # so rebind before the writebacks land on an orphaned object
+        streamdetails = queue_item.streamdetails or streamdetails
         # update duration details based on the actual pcm data we sent
         # this also accounts for crossfade and silence stripping
         seconds_streamed = bytes_written / pcm_format.pcm_sample_size
@@ -2325,18 +2332,23 @@ class StreamsAudio:
             # this also accounts for crossfade and silence stripping
             seconds_streamed = bytes_written / pcm_sample_size
             queue_track.streamdetails.seconds_streamed = seconds_streamed
-            # the held-back crossfade tail still counts as this track's media-time
-            tail_seconds = len(last_fadeout_part) / pcm_sample_size
-            # streamdetails.duration is in media-time; seconds_streamed is stream-time
-            # (post-atempo), so we scale by the track's playback_speed to recover media-time.
-            queue_track.streamdetails.duration = int(
-                queue_track.streamdetails.seek_position
-                + (seconds_streamed + tail_seconds) * track_playback_speed
-            )
-            # propagate accurate duration to queue_item so UI displays it
-            queue_track.duration = queue_track.streamdetails.duration
             play_log_entry.seconds_streamed = seconds_streamed
-            play_log_entry.duration = queue_track.streamdetails.duration
+            # an externally aborted source ends in a clean EOF mid-track, so the
+            # streamed length must not be written back as the item's duration
+            source_buffer = queue_track.streamdetails.buffer
+            source_aborted = source_buffer is not None and source_buffer.cancelled
+            if not source_aborted:
+                # the held-back crossfade tail still counts as this track's media-time
+                tail_seconds = len(last_fadeout_part) / pcm_sample_size
+                # streamdetails.duration is in media-time; seconds_streamed is stream-time
+                # (post-atempo), so we scale by the track's playback_speed to recover media-time.
+                queue_track.streamdetails.duration = int(
+                    queue_track.streamdetails.seek_position
+                    + (seconds_streamed + tail_seconds) * track_playback_speed
+                )
+                # propagate accurate duration to queue_item so UI displays it
+                queue_track.duration = queue_track.streamdetails.duration
+                play_log_entry.duration = queue_track.streamdetails.duration
             if last_play_log_entry is play_log_entry and last_fadeout_part:
                 # Pre-count the full crossfade tail so the queue index calculation
                 # doesn't undercount while waiting for the next track's crossfade mix.
@@ -2729,7 +2741,14 @@ class StreamsAudio:
         reason: str,
         capacity_wait_timeout: float,
     ) -> AudioBuffer:
-        """Create or reuse a ready AudioBuffer within one queue-item preparation lock."""
+        """
+        Create or reuse a ready AudioBuffer within one queue-item preparation lock.
+
+        :param queue_item: Queue item whose source should be buffered.
+        :param seek_position_ms: Position in milliseconds to start from.
+        :param reason: Caller context for logging.
+        :param capacity_wait_timeout: Total seconds to spend waiting for source capacity.
+        """
         loop = asyncio.get_running_loop()
         # the playback intent lives on the details we start from; keep it across a reselection
         initial_streamdetails = queue_item.streamdetails
@@ -2757,10 +2776,10 @@ class StreamsAudio:
         busy_instances: set[str] = set()
         final_pass = False
         last_capacity_error: ProviderStreamLimitError | None = None
+        last_failed_streamdetails: StreamDetails | None = None
         while True:
-            if (
-                queue_item.streamdetails is None
-                or queue_item.streamdetails.provider in busy_instances
+            if queue_item.streamdetails is None or (
+                queue_item.streamdetails.provider in busy_instances and not final_pass
             ):
                 try:
                     queue_item.streamdetails = await self.get_stream_details(
@@ -2773,8 +2792,18 @@ class StreamsAudio:
                 except (AudioError, MediaNotFoundError) as err:
                     if last_capacity_error is None:
                         raise
-                    # capacity was the root cause, so surface the typed (actionable) error
-                    raise last_capacity_error from err
+                    if final_pass:
+                        # capacity was the root cause, surface the typed (actionable) error
+                        raise last_capacity_error from err
+                    # no usable alternative mapping: restore the capacity-blocked details
+                    # and spend the remaining budget blocking on that provider's slot
+                    final_pass = True
+                    continue
+                finally:
+                    if queue_item.streamdetails is None:
+                        # never leave the queue item without streamdetails on any exit,
+                        # including a cancellation or a non-audio provider failure
+                        queue_item.streamdetails = last_failed_streamdetails
             streamdetails = queue_item.streamdetails
             assert streamdetails is not None  # for type checking
             provider = self.mass.get_provider(streamdetails.provider, return_unavailable=True)
@@ -2801,6 +2830,7 @@ class StreamsAudio:
                 )
             except ProviderStreamLimitError as err:
                 last_capacity_error = err
+                last_failed_streamdetails = streamdetails
                 busy_instances.add(err.provider_instance)
                 if final_pass or loop.time() >= deadline:
                     raise
@@ -3105,7 +3135,7 @@ class StreamsAudio:
         :param playback_speed: Incoming track playback-speed multiplier.
         :return: Effective mode and resident fade-in duration in seconds.
         """
-        audio_buffer = getattr(streamdetails, "buffer", None)
+        audio_buffer = streamdetails.buffer
         if (
             crossfade_mode == CrossfadeMode.DISABLED
             or playback_speed <= 0

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1878,15 +1878,19 @@ class StreamsAudio:
         # this also accounts for crossfade and silence stripping
         seconds_streamed = bytes_written / pcm_format.pcm_sample_size
         streamdetails.seconds_streamed = seconds_streamed
-        uncredited_tail_seconds = uncredited_tail_bytes / pcm_format.pcm_sample_size
-        # streamdetails.duration is in media-time; seconds_streamed is stream-time
-        # (post-atempo), so we scale by playback_speed to recover media-time.
-        streamdetails.duration = int(
-            streamdetails.seek_position
-            + (seconds_streamed + uncredited_tail_seconds) * playback_speed
-        )
-        # propagate accurate duration to queue_item so UI displays it
-        queue_item.duration = streamdetails.duration
+        # an externally aborted source ends in a clean EOF mid-track, so the
+        # streamed length must not be written back as the item's duration
+        source_buffer = streamdetails.buffer
+        if source_buffer is None or not source_buffer.cancelled:
+            uncredited_tail_seconds = uncredited_tail_bytes / pcm_format.pcm_sample_size
+            # streamdetails.duration is in media-time; seconds_streamed is stream-time
+            # (post-atempo), so we scale by playback_speed to recover media-time.
+            streamdetails.duration = int(
+                streamdetails.seek_position
+                + (seconds_streamed + uncredited_tail_seconds) * playback_speed
+            )
+            # propagate accurate duration to queue_item so UI displays it
+            queue_item.duration = streamdetails.duration
         self.logger.debug(
             "Finished Streaming queue track: %s (%s) on queue %s "
             "- crossfade data prepared for next track: %s",

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2810,21 +2810,15 @@ class StreamsAudio:
                         queue_item.streamdetails = last_failed_streamdetails
             streamdetails = queue_item.streamdetails
             assert streamdetails is not None  # for type checking
-            provider = self.mass.get_provider(streamdetails.provider, return_unavailable=True)
             remaining = max(deadline - loop.time(), 0)
             alternatives_left = bool(
                 all_candidate_instances - busy_instances - {streamdetails.provider}
             )
-            provider_busy = (
-                isinstance(provider, MusicProvider) and not provider.has_available_stream_slot
-            )
-            # probe (0s) whenever a reselection can still follow: either a candidate is
-            # untried, or a final pass can still return to the best one. Blocking here would
-            # spend the budget on whichever source came last instead of the preferred one.
+            # probe (0s) whenever a reselection can still follow: a free slot is still
+            # acquired instantly, while a busy one fails fast instead of spending the
+            # whole budget on this candidate. Block only on the last resort.
             source_wait = (
-                0.0
-                if (provider_busy and not final_pass and (alternatives_left or busy_instances))
-                else remaining
+                0.0 if (not final_pass and (alternatives_left or busy_instances)) else remaining
             )
             try:
                 return await AudioBuffer.get_buffer(

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2814,10 +2814,13 @@ class StreamsAudio:
             provider_busy = (
                 isinstance(provider, MusicProvider) and not provider.has_available_stream_slot
             )
-            # probe (0s) while other candidates remain untried, so a saturated provider is
-            # swapped out instead of waited on; otherwise block for the remaining budget
+            # probe (0s) whenever a reselection can still follow: either a candidate is
+            # untried, or a final pass can still return to the best one. Blocking here would
+            # spend the budget on whichever source came last instead of the preferred one.
             source_wait = (
-                0.0 if (provider_busy and alternatives_left and not final_pass) else remaining
+                0.0
+                if (provider_busy and not final_pass and (alternatives_left or busy_instances))
+                else remaining
             )
             try:
                 return await AudioBuffer.get_buffer(
@@ -2839,6 +2842,13 @@ class StreamsAudio:
                     busy_instances.clear()
                     final_pass = True
                 queue_item.streamdetails = None
+            except AudioError:
+                if last_capacity_error is None or final_pass:
+                    raise
+                # a broken alternate must not turn a transient capacity miss into a hard
+                # failure: restore the blocked details and spend the rest of the budget there
+                queue_item.streamdetails = last_failed_streamdetails
+                final_pass = True
 
     def _get_streamdetail_candidates(
         self,
@@ -3186,9 +3196,11 @@ class StreamsAudio:
         """
         stream_type = streamdetails.stream_type
         if stream_type == StreamType.CUSTOM:
-            # MusicProvider and PluginProvider both expose get_audio_stream with the same shape
-            provider = self.mass.get_provider(streamdetails.provider)
-            if provider is None:
+            # MusicProvider and PluginProvider both expose get_audio_stream with the same shape.
+            # Pin the exact instance: a domain fallback would stream from a sibling account
+            # while the source-stream slot is charged to the instance that issued the details.
+            provider = self.mass.get_provider(streamdetails.provider, return_unavailable=True)
+            if provider is None or not provider.available:
                 raise ProviderUnavailableError(
                     f"Provider {streamdetails.provider} for stream is no longer available"
                 )
@@ -3262,8 +3274,9 @@ class StreamsAudio:
     def _open_audio_source_generator(self, streamdetails: StreamDetails) -> AsyncGenerator[bytes]:
         """Open the raw PCM generator for an AudioSource (CUSTOM or NAMED_PIPE)."""
         if streamdetails.stream_type == StreamType.CUSTOM:
-            provider = self.mass.get_provider(streamdetails.provider)
-            if provider is None:
+            # pin the exact instance, see _resolve_media_stream_source
+            provider = self.mass.get_provider(streamdetails.provider, return_unavailable=True)
+            if provider is None or not provider.available:
                 raise ProviderUnavailableError(
                     f"Provider {streamdetails.provider} for stream is no longer available"
                 )

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlparse
+from weakref import WeakValueDictionary
 
 import aiofiles
 import aiofiles.os
@@ -99,6 +100,7 @@ from music_assistant.controllers.streams.constants import (
     CACHE_CATEGORY_RESOLVED_RADIO_URL,
     CACHE_PROVIDER,
     CONF_ALLOW_CROSSFADE_SAME_ALBUM,
+    STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT,
     STREAM_SLOT_WAIT_TIMEOUT,
     STREAMDETAILS_INBAND_TITLE_HANDOFF_KEY,
     STREAMDETAILS_INBAND_TITLE_KEY,
@@ -152,6 +154,7 @@ from music_assistant.helpers.util import (
 from music_assistant.models.music_provider import MusicProvider, ProviderStreamLimitError
 
 if TYPE_CHECKING:
+    from music_assistant_models.media_items import ProviderMapping
     from music_assistant_models.player_queue import PlayerQueue
     from music_assistant_models.queue_item import QueueItem
     from music_assistant_models.streamdetails import StreamDetails
@@ -159,6 +162,7 @@ if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
     from music_assistant.models.player import Player
     from music_assistant.models.plugin import PluginProvider
+    from music_assistant.models.provider import Provider
 
 # ruff: noqa: PLR0915
 
@@ -242,6 +246,11 @@ class StreamsAudio:
         self.logger = logging.getLogger(f"{MASS_LOGGER_NAME}.streams.audio")
         self._crossfade_data: dict[str, CrossfadeData] = {}
         self._smart_fades_mixer: SmartFadesMixer | None = None
+        # serializes buffer preparation per queue item, so concurrent callers share
+        # the single source (and the single capacity reselection) instead of racing
+        self._audio_buffer_locks: WeakValueDictionary[tuple[str, str], asyncio.Lock] = (
+            WeakValueDictionary()
+        )
 
     def setup(self) -> None:
         """Set up the audio sub-controller (called after all core controllers are created)."""
@@ -261,15 +270,23 @@ class StreamsAudio:
         seek_position: int = 0,
         fade_in: bool = False,
         prefer_album_loudness: bool = False,
+        excluded_provider_instances: set[str] | None = None,
     ) -> StreamDetails:
         """
         Get streamdetails for the given QueueItem.
 
         This is called just-in-time when a PlayerQueue wants a MediaItem to be played.
         Do not try to request streamdetails too much in advance as this is expiring data.
+
+        :param queue_item: Queue item to resolve.
+        :param seek_position: Requested playback position in seconds.
+        :param fade_in: Whether playback should fade in.
+        :param prefer_album_loudness: Whether album loudness should be preferred.
+        :param excluded_provider_instances: Provider instances to skip during this selection.
         """
         mass = self.mass
         streamdetails: StreamDetails | None = None
+        excluded_provider_instances = excluded_provider_instances or set()
         time_start = time.time()
         self.logger.debug("Getting streamdetails for %s", queue_item.uri)
 
@@ -280,15 +297,20 @@ class StreamsAudio:
                 f"Unable to retrieve streamdetails for {queue_item.name} ({queue_item.uri})"
             )
 
-        if queue_item.streamdetails and (
-            # reuse if the buffer can serve this seek position (fast seek path)
-            (
-                queue_item.streamdetails.buffer
-                and queue_item.streamdetails.buffer.is_valid(int(seek_position * 1000))
+        if (
+            queue_item.streamdetails
+            # cached details of an excluded instance are exactly what we select away from
+            and queue_item.streamdetails.provider not in excluded_provider_instances
+            and (
+                # reuse if the buffer can serve this seek position (fast seek path)
+                (
+                    queue_item.streamdetails.buffer
+                    and queue_item.streamdetails.buffer.is_valid(int(seek_position * 1000))
+                )
+                # or reuse if streamdetails hasn't expired yet (new buffer will be created)
+                or (queue_item.streamdetails.created_at + queue_item.streamdetails.expiration)
+                > time.time()
             )
-            # or reuse if streamdetails hasn't expired yet (new buffer will be created)
-            or (queue_item.streamdetails.created_at + queue_item.streamdetails.expiration)
-            > time.time()
         ):
             streamdetails = queue_item.streamdetails
         else:
@@ -306,61 +328,14 @@ class StreamsAudio:
             ):
                 # handle steering into user preferred providerinstance
                 preferred_providers = playback_user.provider_filter
-            else:
-                preferred_providers = [x.provider_instance for x in media_item.provider_mappings]
-            # Remember the last AudioError so we can re-raise its (actionable)
-            # message instead of the generic MediaNotFoundError below.
-            last_audio_error: AudioError | None = None
-            attempted: set[tuple[str, str]] = set()
-            for allow_other_provider in (False, True):
-                if streamdetails:
-                    break
-                # sort by quality and check item's availability
-                for prov_media in sorted(
-                    media_item.provider_mappings, key=lambda x: x.quality or 0, reverse=True
-                ):
-                    if not prov_media.available:
-                        self.logger.debug(f"Skipping unavailable {prov_media}")
-                        continue
-                    if (
-                        not allow_other_provider
-                        and prov_media.provider_instance not in preferred_providers
-                    ):
-                        continue
-                    # the second pass is there to widen to providers the steering held back,
-                    # not to give a mapping a second chance: without a user provider filter
-                    # the first pass already tried them all, so re-attempting one just buys
-                    # the same failure at the cost of another provider round-trip
-                    attempt = (prov_media.provider_instance, prov_media.item_id)
-                    if attempt in attempted:
-                        continue
-                    # guard that provider is available
-                    provider = mass.get_provider(prov_media.provider_instance)
-                    if not provider:
-                        self.logger.debug(f"Skipping {prov_media} - provider not available")
-                        continue  # provider not available ?
-                    attempted.add(attempt)
-                    # get streamdetails from provider; music and plugin providers
-                    # share this signature, so either type can own the item.
-                    try:
-                        BYPASS_THROTTLER.set(True)
-                        stream_prov = cast("MusicProvider | PluginProvider", provider)
-                        streamdetails = await stream_prov.get_stream_details(
-                            prov_media.item_id, media_item.media_type
-                        )
-                    except AudioError as err:
-                        last_audio_error = err
-                        self.logger.warning(str(err))
-                    except MusicAssistantError as err:
-                        self.logger.warning(str(err))
-                    else:
-                        break
-                    finally:
-                        BYPASS_THROTTLER.set(False)
+            candidates = self._get_streamdetail_candidates(
+                media_item.provider_mappings,
+                preferred_providers,
+                excluded_provider_instances,
+            )
+            streamdetails = await self._request_streamdetails(candidates, media_item.media_type)
 
             if not streamdetails:
-                if last_audio_error is not None:
-                    raise last_audio_error
                 msg = f"Unable to retrieve streamdetails for {queue_item.name} ({queue_item.uri})"
                 raise MediaNotFoundError(msg)
 
@@ -440,6 +415,34 @@ class StreamsAudio:
             int((time.time() - time_start) * 1000),
         )
         return streamdetails
+
+    async def get_audio_buffer(
+        self,
+        queue_item: QueueItem,
+        seek_position_ms: int = 0,
+        reason: str = "",
+        capacity_wait_timeout: float = STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT,
+    ) -> AudioBuffer:
+        """
+        Return a ready AudioBuffer for the given queue item.
+
+        Compatible provider mappings are reselected while the owning provider has no free
+        source-stream slot. Other AudioErrors propagate as on a direct buffer request.
+
+        :param queue_item: Queue item whose source should be buffered.
+        :param seek_position_ms: Position in milliseconds to start from.
+        :param reason: Caller context for logging (e.g. 'prepare_next', 'streaming').
+        :param capacity_wait_timeout: Total seconds to spend waiting for source capacity.
+        :raises ProviderStreamLimitError: If no source slot becomes available within the budget.
+        """
+        lock_key = (queue_item.queue_id, queue_item.queue_item_id)
+        if (buffer_lock := self._audio_buffer_locks.get(lock_key)) is None:
+            buffer_lock = asyncio.Lock()
+            self._audio_buffer_locks[lock_key] = buffer_lock
+        async with buffer_lock:
+            return await self._get_audio_buffer(
+                queue_item, seek_position_ms, reason, capacity_wait_timeout
+            )
 
     async def get_media_stream(
         self,
@@ -1233,7 +1236,7 @@ class StreamsAudio:
         except AudioError as err:
             streamdetails.stream_error = True
             # revoke availability when the stream never produced any audio
-            if bytes_received == 0:
+            if bytes_received == 0 and not isinstance(err, ProviderStreamLimitError):
                 queue_item.available = False
             if raise_on_error:
                 raise
@@ -1338,6 +1341,28 @@ class StreamsAudio:
                     streamdetails,
                 )
 
+        # get or create the AudioBuffer (stores raw decoded PCM). This runs before the
+        # filters are built because a source-capacity reselection can hand back another
+        # provider's streamdetails, which everything below must then work with.
+        seek_position_ms = int(seek_position * 1000)
+        try:
+            audio_buffer = await self.get_audio_buffer(
+                queue_item, seek_position_ms=seek_position_ms, reason="streaming"
+            )
+        except AudioError as err:
+            streamdetails.stream_error = True
+            if raise_on_error:
+                raise
+            logger.error(
+                "AudioError while preparing queue item %s (%s): %s",
+                queue_item.name,
+                streamdetails.uri,
+                err,
+            )
+            return
+        streamdetails = queue_item.streamdetails
+        assert streamdetails  # for type checking
+
         # handle volume normalization
         gain_correct: float | None = None
         if streamdetails.volume_normalization_mode == VolumeNormalizationMode.DYNAMIC:
@@ -1392,14 +1417,6 @@ class StreamsAudio:
             playback_speed,
         )
 
-        # get or create the AudioBuffer (stores raw decoded PCM)
-        seek_position_ms = int(seek_position * 1000)
-        audio_buffer = await AudioBuffer.get_buffer(
-            mass=self.mass,
-            streamdetails=streamdetails,
-            seek_position_ms=seek_position_ms,
-            reason="streaming",
-        )
         if (
             streamdetails.queue_id
             and (queue_data := self.mass.player_queues.queue_data_or_none(streamdetails.queue_id))
@@ -1463,7 +1480,7 @@ class StreamsAudio:
         except AudioError as err:
             streamdetails.stream_error = True
             # revoke availability when the stream never produced any audio
-            if bytes_received == 0:
+            if bytes_received == 0 and not isinstance(err, ProviderStreamLimitError):
                 queue_item.available = False
             if raise_on_error:
                 raise
@@ -2650,6 +2667,195 @@ class StreamsAudio:
             "Failed to parse radio URL %s: %s - attempting direct stream", validate_url, str(err)
         )
         return await self._cache_radio_result(url, fallback_stream_type, resolved_url=validate_url)
+
+    async def _get_audio_buffer(
+        self,
+        queue_item: QueueItem,
+        seek_position_ms: int,
+        reason: str,
+        capacity_wait_timeout: float,
+    ) -> AudioBuffer:
+        """Create or reuse a ready AudioBuffer within one queue-item preparation lock."""
+        loop = asyncio.get_running_loop()
+        # the playback intent lives on the details we start from; keep it across a reselection
+        initial_streamdetails = queue_item.streamdetails
+        seek_position = (
+            int(initial_streamdetails.seek_position)
+            if initial_streamdetails
+            else seek_position_ms // 1000
+        )
+        fade_in = bool(initial_streamdetails and initial_streamdetails.fade_in)
+        prefer_album_loudness = bool(
+            initial_streamdetails and initial_streamdetails.prefer_album_loudness
+        )
+        all_candidate_instances = {
+            provider.instance_id
+            for mapping in (
+                queue_item.media_item.provider_mappings if queue_item.media_item else ()
+            )
+            if mapping.available
+            for provider in self._get_mapping_providers(mapping)
+        }
+        if initial_streamdetails is not None:
+            all_candidate_instances.add(initial_streamdetails.provider)
+
+        deadline = loop.time() + capacity_wait_timeout
+        busy_instances: set[str] = set()
+        final_pass = False
+        last_capacity_error: ProviderStreamLimitError | None = None
+        while True:
+            if (
+                queue_item.streamdetails is None
+                or queue_item.streamdetails.provider in busy_instances
+            ):
+                try:
+                    queue_item.streamdetails = await self.get_stream_details(
+                        queue_item,
+                        seek_position=seek_position,
+                        fade_in=fade_in,
+                        prefer_album_loudness=prefer_album_loudness,
+                        excluded_provider_instances=busy_instances,
+                    )
+                except (AudioError, MediaNotFoundError) as err:
+                    if last_capacity_error is None:
+                        raise
+                    # capacity was the root cause, so surface the typed (actionable) error
+                    raise last_capacity_error from err
+            streamdetails = queue_item.streamdetails
+            assert streamdetails is not None  # for type checking
+            provider = self.mass.get_provider(streamdetails.provider, return_unavailable=True)
+            remaining = max(deadline - loop.time(), 0)
+            alternatives_left = bool(
+                all_candidate_instances - busy_instances - {streamdetails.provider}
+            )
+            provider_busy = (
+                isinstance(provider, MusicProvider) and not provider.has_available_stream_slot
+            )
+            # probe (0s) while other candidates remain untried, so a saturated provider is
+            # swapped out instead of waited on; otherwise block for the remaining budget
+            source_wait = (
+                0.0 if (provider_busy and alternatives_left and not final_pass) else remaining
+            )
+            try:
+                return await AudioBuffer.get_buffer(
+                    mass=self.mass,
+                    streamdetails=streamdetails,
+                    seek_position_ms=seek_position_ms,
+                    wait_ready=True,
+                    reason=reason,
+                    source_wait_timeout=source_wait,
+                )
+            except ProviderStreamLimitError as err:
+                last_capacity_error = err
+                busy_instances.add(err.provider_instance)
+                if final_pass or loop.time() >= deadline:
+                    raise
+                if all_candidate_instances.issubset(busy_instances):
+                    # every candidate is saturated: one last blocking wait on the best one
+                    busy_instances.clear()
+                    final_pass = True
+                queue_item.streamdetails = None
+
+    def _get_streamdetail_candidates(
+        self,
+        provider_mappings: Iterable[ProviderMapping],
+        preferred_providers: list[str],
+        excluded_provider_instances: set[str],
+    ) -> list[tuple[ProviderMapping, Provider]]:
+        """
+        Return mapping candidates in steering, quality, and instance-fallback order.
+
+        :param provider_mappings: Mappings attached to the media item.
+        :param preferred_providers: Provider instances tried before widening to the rest.
+        :param excluded_provider_instances: Provider instances unavailable to this attempt.
+        :return: Ordered provider mapping candidates.
+        """
+        ordered_mappings = sorted(
+            provider_mappings, key=lambda mapping: mapping.quality or 0, reverse=True
+        )
+        preferred_candidates: list[tuple[ProviderMapping, Provider]] = []
+        fallback_candidates: list[tuple[ProviderMapping, Provider]] = []
+        seen_candidates: set[tuple[str, str]] = set()
+        for mapping in ordered_mappings:
+            if not mapping.available:
+                self.logger.debug("Skipping unavailable %s", mapping)
+                continue
+            for provider in self._get_mapping_providers(mapping):
+                candidate_id = (provider.instance_id, mapping.item_id)
+                if (
+                    candidate_id in seen_candidates
+                    or provider.instance_id in excluded_provider_instances
+                ):
+                    continue
+                seen_candidates.add(candidate_id)
+                candidate = (mapping, provider)
+                if provider.instance_id in preferred_providers:
+                    preferred_candidates.append(candidate)
+                else:
+                    fallback_candidates.append(candidate)
+        return [*preferred_candidates, *fallback_candidates]
+
+    def _get_mapping_providers(self, mapping: ProviderMapping) -> list[Provider]:
+        """
+        Return the mapped provider followed by compatible instances of its streaming catalog.
+
+        :param mapping: Provider mapping whose item ID will be requested.
+        :return: Loaded provider instances that can resolve the mapping.
+        """
+        providers: list[Provider] = []
+        if (
+            primary_provider := self.mass.get_provider(
+                mapping.provider_instance, return_unavailable=True
+            )
+        ) and primary_provider.available:
+            providers.append(primary_provider)
+        # another account of the same streaming catalog serves the same item ID,
+        # so it can stand in when the mapped instance can not
+        for provider in self.mass.providers:
+            if (
+                not isinstance(provider, MusicProvider)
+                or not provider.available
+                or not provider.is_streaming_provider
+                or provider.domain != mapping.provider_domain
+                or provider in providers
+            ):
+                continue
+            providers.append(provider)
+        if not providers:
+            self.logger.debug("Skipping %s - provider not available", mapping)
+        return providers
+
+    async def _request_streamdetails(
+        self,
+        candidates: Iterable[tuple[ProviderMapping, Provider]],
+        media_type: MediaType,
+    ) -> StreamDetails | None:
+        """
+        Request stream details from ordered provider mapping candidates.
+
+        :param candidates: Candidates in mapping and compatible-instance order.
+        :param media_type: Media type requested from each provider.
+        :return: The first resolved stream details, or None when every candidate failed.
+        :raises AudioError: The last (actionable) audio error when no candidate resolved.
+        """
+        last_audio_error: AudioError | None = None
+        for mapping, provider in candidates:
+            # music and plugin providers share this signature, so either type can own the item
+            token = BYPASS_THROTTLER.set(True)
+            try:
+                stream_prov = cast("MusicProvider | PluginProvider", provider)
+                return await stream_prov.get_stream_details(mapping.item_id, media_type)
+            except AudioError as err:
+                # remember the last one so its (actionable) message can be re-raised
+                last_audio_error = err
+                self.logger.warning("%s", err)
+            except MusicAssistantError as err:
+                self.logger.warning("%s", err)
+            finally:
+                BYPASS_THROTTLER.reset(token)
+        if last_audio_error is not None:
+            raise last_audio_error
+        return None
 
     async def _get_media_stream(
         self,

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -1143,15 +1143,20 @@ class AudioAnalysisController:
 
         audio_source = self.mass.streams.audio.get_media_stream(streamdetails, pcm_format)
         next_allowed = time.monotonic()
-        async for chunk in audio_source:
-            if session_key not in self._active_sessions:
-                # all providers evicted — bail early
-                break
-            now = time.monotonic()
-            if now < next_allowed:
-                await asyncio.sleep(next_allowed - now)
-            await self._distribute_chunk(session_key, chunk, max_interval=CHUNK_HANG_GUARD_SECONDS)
-            next_allowed = time.monotonic() + BACKGROUND_PACE_INTERVAL_SECONDS_FLOOR
+        # aclosing guarantees the source (and any provider stream slot it holds)
+        # is released promptly when the loop breaks out early
+        async with contextlib.aclosing(audio_source):
+            async for chunk in audio_source:
+                if session_key not in self._active_sessions:
+                    # all providers evicted — bail early
+                    break
+                now = time.monotonic()
+                if now < next_allowed:
+                    await asyncio.sleep(next_allowed - now)
+                await self._distribute_chunk(
+                    session_key, chunk, max_interval=CHUNK_HANG_GUARD_SECONDS
+                )
+                next_allowed = time.monotonic() + BACKGROUND_PACE_INTERVAL_SECONDS_FLOOR
         if session_key in self._active_sessions:
             self._finalize_providers(session_key)
 

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -143,6 +143,11 @@ class AudioBuffer:
         return len(self._chunks)
 
     @property
+    def duration_available(self) -> float:
+        """Return the exact duration of resident PCM audio in seconds."""
+        return sum(len(chunk) for chunk in self._chunks) / self.pcm_format.pcm_sample_size
+
+    @property
     def is_buffering(self) -> bool:
         """Return whether the upstream source producer is still active."""
         return self._producer_task is not None and not self._producer_task.done()
@@ -187,14 +192,18 @@ class AudioBuffer:
         chunks_ahead = seek_chunk - total_chunks
         return chunks_ahead <= SEEK_WAIT_THRESHOLD
 
-    async def get_raw_stream(self, seek_position_ms: int = 0) -> AsyncGenerator[bytes]:
+    async def get_raw_stream(
+        self, seek_position_ms: int = 0, exact_seek: bool = False
+    ) -> AsyncGenerator[bytes]:
         """
         Get raw (unprocessed) PCM audio from the buffer.
 
         :param seek_position_ms: Starting position in milliseconds.
+        :param exact_seek: Preserve millisecond precision instead of quantizing to 100 ms.
         """
-        # align to 100ms steps to avoid rounding issues
-        seek_position_ms = (seek_position_ms // 100) * 100
+        if not exact_seek:
+            # align regular user seeks to 100ms steps to avoid rounding issues
+            seek_position_ms = (seek_position_ms // 100) * 100
         chunk_number = seek_position_ms // 1000
         # handle fractional seek: trim leading samples from the first chunk
         fractional_ms = seek_position_ms % 1000
@@ -249,6 +258,7 @@ class AudioBuffer:
         output_format: AudioFormat,
         seek_position_ms: int = 0,
         filter_params: list[str] | None = None,
+        exact_seek: bool = False,
     ) -> AsyncGenerator[bytes]:
         """
         Get processed audio from the buffer.
@@ -259,16 +269,21 @@ class AudioBuffer:
         :param output_format: The desired output PCM format.
         :param seek_position_ms: Starting position in milliseconds.
         :param filter_params: FFmpeg filter parameters to apply.
+        :param exact_seek: Preserve millisecond precision for the input buffer position.
         """
         needs_ffmpeg = bool(filter_params) or self.pcm_format != output_format
 
         if not needs_ffmpeg:
-            async for chunk in self.get_raw_stream(seek_position_ms=seek_position_ms):
+            async for chunk in self.get_raw_stream(
+                seek_position_ms=seek_position_ms, exact_seek=exact_seek
+            ):
                 yield chunk
             return
 
         async for chunk in get_ffmpeg_stream(
-            audio_input=self.get_raw_stream(seek_position_ms=seek_position_ms),
+            audio_input=self.get_raw_stream(
+                seek_position_ms=seek_position_ms, exact_seek=exact_seek
+            ),
             input_format=self.pcm_format,
             output_format=output_format,
             filter_params=filter_params,

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -38,6 +38,7 @@ from music_assistant.controllers.streams.constants import (
     BufferSize,
 )
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
+from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
     from music_assistant_models.streamdetails import StreamDetails
@@ -429,8 +430,15 @@ class AudioBuffer:
                     existing_buffer._discarded_chunks,
                 )
                 streamdetails.buffer = None
-                if time.time() - existing_buffer._last_access_time > 30:
-                    # no recent consumer activity - safe to fully clear
+                # a still-filling producer holds one of the provider's source-stream
+                # slots; the replacement buffer needs that slot, so stop it now
+                provider = mass.get_provider(streamdetails.provider, return_unavailable=True)
+                must_release_slot = (
+                    existing_buffer.is_buffering
+                    and isinstance(provider, MusicProvider)
+                    and provider.max_concurrent_streams is not None
+                )
+                if must_release_slot or time.time() - existing_buffer._last_access_time > 30:
                     await asyncio.shield(existing_buffer.clear())
                 # else: an active consumer is still reading via its local reference;
                 # the inactivity monitor will clean up after it finishes

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -430,13 +430,15 @@ class AudioBuffer:
                     existing_buffer._discarded_chunks,
                 )
                 streamdetails.buffer = None
-                # a still-filling producer holds one of the provider's source-stream
-                # slots; the replacement buffer needs that slot, so stop it now
+                # a still-filling producer holds one of the provider's source-stream slots.
+                # The replacement needs a slot, so take this one back only when the provider
+                # has none free - otherwise a superseded consumer keeps draining its audio.
                 provider = mass.get_provider(streamdetails.provider, return_unavailable=True)
                 must_release_slot = (
                     existing_buffer.is_buffering
                     and isinstance(provider, MusicProvider)
                     and provider.max_concurrent_streams is not None
+                    and not provider.has_available_stream_slot
                 )
                 if must_release_slot or time.time() - existing_buffer._last_access_time > 30:
                     await asyncio.shield(existing_buffer.clear())

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -16,7 +16,7 @@ import time
 from collections import deque
 from collections.abc import AsyncGenerator, Callable
 from contextlib import aclosing, suppress
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from music_assistant_models.enums import (
     ContentType,
@@ -33,6 +33,7 @@ from music_assistant.controllers.streams.constants import (
     CONF_BUFFER_SIZE_DEFAULT,
     RADIO_BUFFER_SIZE,
     SEEK_WAIT_THRESHOLD,
+    STREAM_SLOT_WAIT_TIMEOUT,
     BufferMode,
     BufferSize,
 )
@@ -47,6 +48,10 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.audio_buffer")
 
 # Callback signature for cancel observers: invoked when the buffer is cancelled/cleared.
 CancelCallback = Callable[[], None]
+
+# Maximum seconds to wait for the first playable audio, on top of any time the producer
+# is allowed to spend waiting for a provider source-stream slot.
+BUFFER_READY_TIMEOUT: Final[int] = 15
 
 
 class AudioBufferEOF(Exception):
@@ -106,6 +111,7 @@ class AudioBuffer:
         self._background_tasks: set[asyncio.Task[None]] = set()
         self.ready = asyncio.Event()
         self._cancel_callbacks: list[CancelCallback] = []
+        self._ready_wait_lock = asyncio.Lock()
 
     # -- Properties --
 
@@ -135,6 +141,11 @@ class AudioBuffer:
     def seconds_available(self) -> int:
         """Return number of seconds of audio currently available."""
         return len(self._chunks)
+
+    @property
+    def is_buffering(self) -> bool:
+        """Return whether the upstream source producer is still active."""
+        return self._producer_task is not None and not self._producer_task.done()
 
     @property
     def first_buffered_chunk(self) -> int:
@@ -356,6 +367,7 @@ class AudioBuffer:
         seek_position_ms: int = 0,
         wait_ready: bool = False,
         reason: str = "",
+        source_wait_timeout: float | None = STREAM_SLOT_WAIT_TIMEOUT,
     ) -> AudioBuffer:
         """
         Get or create an AudioBuffer for the given streamdetails.
@@ -368,8 +380,16 @@ class AudioBuffer:
         :param seek_position_ms: Position in milliseconds to start from.
         :param wait_ready: If True, wait for the first chunk before returning.
         :param reason: Caller context for logging (e.g. 'prepare', 'streaming').
+        :param source_wait_timeout: Maximum seconds the producer may wait for a free
+            source-stream slot on the providing music provider, or None to wait
+            without a timeout.
+        :raises AudioError: If the buffer does not become ready, wrapping the typed
+            producer error (e.g. ProviderStreamLimitError) when there is one.
         """
         log_prefix = f"get_buffer[{reason}]" if reason else "get_buffer"
+        # the producer may spend its source wait before the first byte arrives,
+        # so the readiness budget covers that wait on top of the audio itself
+        ready_timeout = BUFFER_READY_TIMEOUT + (source_wait_timeout or 0)
         # determine buffer size from config
         buffer_size = BufferSize(
             mass.config.get_raw_core_config_value(
@@ -408,6 +428,8 @@ class AudioBuffer:
                     seek_position_ms,
                     existing_buffer._discarded_chunks,
                 )
+                if wait_ready:
+                    await existing_buffer._wait_until_ready(streamdetails, ready_timeout)
                 return existing_buffer
 
         # convert ms to seconds for get_media_stream (FFmpeg works in seconds)
@@ -478,23 +500,60 @@ class AudioBuffer:
 
         # start filling from the media stream (seek in seconds for FFmpeg)
         audio_source = mass.streams.audio.get_media_stream(
-            streamdetails, pcm_format, seek_position=buffer_seek_seconds, filter_params=None
+            streamdetails,
+            pcm_format,
+            seek_position=buffer_seek_seconds,
+            filter_params=None,
+            source_wait_timeout=source_wait_timeout,
         )
         audio_buffer.fill(audio_source, source_name=streamdetails.uri)
 
         if wait_ready:
-            try:
-                await asyncio.wait_for(audio_buffer.ready.wait(), timeout=15)
-            except TimeoutError:
-                raise AudioError("Timeout waiting for audio data") from audio_buffer._producer_error
-            # ready was signaled but check if it was due to a producer error
-            # (ready is also set by _notify_on_producer_error)
-            if audio_buffer.has_error:
-                raise AudioError("Failed to stream audio") from audio_buffer._producer_error
+            await audio_buffer._wait_until_ready(streamdetails, ready_timeout)
 
         return audio_buffer
 
     # -- Private methods --
+
+    async def _wait_until_ready(self, streamdetails: StreamDetails, ready_timeout: float) -> None:
+        """
+        Wait until this buffer can serve playback or raise its producer failure.
+
+        :param streamdetails: Stream details currently referencing this buffer.
+        :param ready_timeout: Maximum seconds to wait for enough buffered audio.
+        """
+        async with self._ready_wait_lock:
+            if not self.ready.is_set():
+                try:
+                    await asyncio.wait_for(self.ready.wait(), timeout=ready_timeout)
+                except TimeoutError as err:
+                    producer_error = await self._clear_failed_buffer(streamdetails)
+                    if isinstance(producer_error, AudioError):
+                        raise producer_error from err
+                    raise AudioError("Timeout waiting for audio data") from (producer_error or err)
+            # ready was signaled but check if it was due to a producer error
+            # (ready is also set by _notify_on_producer_error)
+            if not self.has_error:
+                return
+            producer_error = await self._clear_failed_buffer(streamdetails)
+            # surface a typed producer failure (e.g. a source capacity limit) as-is,
+            # so callers can act on it instead of on a generic wrapper
+            if isinstance(producer_error, AudioError):
+                raise producer_error
+            raise AudioError("Failed to stream audio") from producer_error
+
+    async def _clear_failed_buffer(self, streamdetails: StreamDetails) -> Exception | None:
+        """
+        Detach and clear this buffer after preparation failed.
+
+        :param streamdetails: Stream details currently referencing this buffer.
+        :return: The producer error recorded before the buffer was cleared.
+        """
+        producer_error = self._producer_error
+        if streamdetails.buffer is self:
+            streamdetails.buffer = None
+        await asyncio.shield(self.clear())
+        return producer_error
 
     async def _put(self, chunk: bytes) -> None:
         """

--- a/music_assistant/controllers/streams/constants.py
+++ b/music_assistant/controllers/streams/constants.py
@@ -90,6 +90,9 @@ CONF_BUFFER_SIZE_DEFAULT: Final[str] = _get_default_buffer_size()
 CONF_ALLOW_CROSSFADE_SAME_ALBUM: Final[str] = "allow_crossfade_same_album"
 CONF_SMART_FADES_LOG_LEVEL: Final[str] = "smart_fades_log_level"
 
+# Maximum wait for a provider source-stream slot before a speculative attempt gives up.
+STREAM_SLOT_WAIT_TIMEOUT: Final[float] = 5.0
+
 # Maximum seconds we wait for the buffer to catch up on a forward seek.
 # Beyond this, the stream is re-fetched at the seek position.
 SEEK_WAIT_THRESHOLD: Final[int] = 20

--- a/music_assistant/controllers/streams/constants.py
+++ b/music_assistant/controllers/streams/constants.py
@@ -94,7 +94,6 @@ CONF_SMART_FADES_LOG_LEVEL: Final[str] = "smart_fades_log_level"
 STREAM_SLOT_WAIT_TIMEOUT: Final[float] = 5.0
 
 # Total capacity budget when an actual playback start retries/reselects provider mappings.
-# Matches the buffer readiness wait, so a start never blocks longer than the audio it waits for.
 STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT: Final[float] = 15.0
 
 # Maximum seconds we wait for the buffer to catch up on a forward seek.

--- a/music_assistant/controllers/streams/constants.py
+++ b/music_assistant/controllers/streams/constants.py
@@ -93,6 +93,10 @@ CONF_SMART_FADES_LOG_LEVEL: Final[str] = "smart_fades_log_level"
 # Maximum wait for a provider source-stream slot before a speculative attempt gives up.
 STREAM_SLOT_WAIT_TIMEOUT: Final[float] = 5.0
 
+# Total capacity budget when an actual playback start retries/reselects provider mappings.
+# Matches the buffer readiness wait, so a start never blocks longer than the audio it waits for.
+STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT: Final[float] = 15.0
+
 # Maximum seconds we wait for the buffer to catch up on a forward seek.
 # Beyond this, the stream is re-fetched at the seek position.
 SEEK_WAIT_THRESHOLD: Final[int] = 20

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -116,7 +116,7 @@ from music_assistant.helpers.util import (
 )
 from music_assistant.helpers.webserver import Webserver, redact_sensitive_headers
 from music_assistant.models.core_controller import CoreController
-from music_assistant.models.music_provider import MusicProvider
+from music_assistant.models.music_provider import MusicProvider, ProviderStreamLimitError
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.universal_group.constants import UGP_PREFIX
 from music_assistant.providers.universal_group.player import UniversalGroupPlayer
@@ -743,7 +743,9 @@ class StreamsController(CoreController):
                     self.logger.error(
                         "Failed to get streamdetails for QueueItem %s: %s", queue_item_id, e
                     )
-                    queue_item.available = False
+                    # a source capacity miss is transient, the item itself is fine
+                    if not isinstance(e, ProviderStreamLimitError):
+                        queue_item.available = False
                     raise web.HTTPNotFound(
                         reason=f"No streamdetails for Queue item: {queue_item_id}"
                     )

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
+from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import TYPE_CHECKING, Final, cast
 
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.enums import ArtistType, MediaType, ProviderFeature
 from music_assistant_models.errors import (
+    AudioError,
     InvalidDataError,
     MediaNotFoundError,
     MusicAssistantError,
@@ -49,6 +51,8 @@ from .provider import Provider
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
+    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.provider import ProviderManifest
     from music_assistant_models.streamdetails import StreamDetails
 
     from music_assistant.controllers.music.media.base import (
@@ -56,8 +60,31 @@ if TYPE_CHECKING:
         LibraryItemSyncDetails,
         TrackSyncDetails,
     )
+    from music_assistant.mass import MusicAssistant
 
 CACHE_CATEGORY_PREV_LIBRARY_IDS: Final[int] = 1
+DEFAULT_MAX_CONCURRENT_STREAMS: Final[int] = 5
+
+
+class ProviderStreamLimitError(AudioError):
+    """Raised when a music provider has no source-stream slot available."""
+
+    def __init__(self, provider: MusicProvider, wait_timeout: float | None) -> None:
+        """
+        Initialize the provider stream limit error.
+
+        :param provider: Provider instance whose source-stream limit was reached.
+        :param wait_timeout: Seconds spent waiting for a slot, or None for an unbounded wait.
+        """
+        limit = provider.max_concurrent_streams
+        assert limit is not None
+        wait_text = f" after waiting {wait_timeout:g} seconds" if wait_timeout is not None else ""
+        super().__init__(
+            f"{provider.name} has reached its limit of {limit} "
+            f"concurrent source streams{wait_text}."
+        )
+        self.provider_instance = provider.instance_id
+        self.limit = limit
 
 
 class MusicProvider(Provider):
@@ -66,6 +93,67 @@ class MusicProvider(Provider):
 
     Music Provider implementations should inherit from this base model.
     """
+
+    def __init__(
+        self,
+        mass: MusicAssistant,
+        manifest: ProviderManifest,
+        config: ProviderConfig,
+        supported_features: set[ProviderFeature] | None = None,
+    ) -> None:
+        """Initialize MusicProvider."""
+        super().__init__(mass, manifest, config, supported_features)
+        max_concurrent_streams = self.max_concurrent_streams
+        if max_concurrent_streams is not None and max_concurrent_streams < 1:
+            raise ValueError("max_concurrent_streams must be at least 1 or None")
+        self._stream_semaphore = (
+            asyncio.BoundedSemaphore(max_concurrent_streams)
+            if max_concurrent_streams is not None
+            else None
+        )
+
+    @property
+    def max_concurrent_streams(self) -> int | None:
+        """
+        Return the number of source streams Music Assistant may run against this provider.
+
+        None means no limit is imposed, which is the correct answer for local and
+        self-hosted sources. Streaming providers get a conservative default of five;
+        override with a lower, evidence-backed value where the service enforces one.
+        Plugin providers (exclusive audio sources) manage their own session exclusivity
+        and are not covered by this limit.
+        """
+        return DEFAULT_MAX_CONCURRENT_STREAMS if self.is_streaming_provider else None
+
+    @property
+    def has_available_stream_slot(self) -> bool:
+        """Return whether a source stream can start without waiting."""
+        return self._stream_semaphore is None or not self._stream_semaphore.locked()
+
+    @asynccontextmanager
+    async def acquire_stream_slot(self, wait_timeout: float | None) -> AsyncGenerator[None]:
+        """
+        Acquire one source-stream slot for the duration of the context.
+
+        :param wait_timeout: Maximum seconds to wait, or None to wait without a timeout.
+        :raises ProviderStreamLimitError: If no slot becomes available before the timeout.
+        """
+        semaphore = self._stream_semaphore
+        if semaphore is None:
+            yield
+            return
+        try:
+            if wait_timeout is None:
+                await semaphore.acquire()
+            else:
+                async with asyncio.timeout(wait_timeout):
+                    await semaphore.acquire()
+        except TimeoutError as err:
+            raise ProviderStreamLimitError(self, wait_timeout) from err
+        try:
+            yield
+        finally:
+            semaphore.release()
 
     @property
     def is_streaming_provider(self) -> bool:

--- a/music_assistant/providers/abc_radio_network/provider.py
+++ b/music_assistant/providers/abc_radio_network/provider.py
@@ -35,6 +35,11 @@ if TYPE_CHECKING:
 class ABCRadioProvider(MusicProvider):
     """ABC Radio Music Provider for Music Assistant."""
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_radio(self, prov_radio_id: str) -> Radio:
         """Get full radio details by id."""
         if prov_radio_id not in ABC_RADIO_STATIONS:

--- a/music_assistant/providers/apple_music/provider.py
+++ b/music_assistant/providers/apple_music/provider.py
@@ -68,6 +68,11 @@ class AppleMusicProvider(RecommendationPayloadMixin, MusicProvider):
         self.recommendation_manager = AppleMusicRecommendationManager(self)
         self.streaming_manager = AppleMusicStreamingManager(self)
 
+    @property
+    def max_concurrent_streams(self) -> int:
+        """Apple Music accounts allow a single active playback session."""
+        return 1
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """
         Return Config entries to configure this provider.

--- a/music_assistant/providers/ard_audiothek/__init__.py
+++ b/music_assistant/providers/ard_audiothek/__init__.py
@@ -139,6 +139,11 @@ def _create_aiohttptransport(headers: dict[str, str] | None = None) -> AIOHTTPTr
 class ARDAudiothek(MusicProvider):
     """ARD Audiothek Music provider."""
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """
         Return the configuration (options) entries for the ARD Audiothek provider.

--- a/music_assistant/providers/bbc_sounds/__init__.py
+++ b/music_assistant/providers/bbc_sounds/__init__.py
@@ -90,6 +90,11 @@ class BBCSoundsProvider(RecommendationPayloadMixin, MusicProvider):
     menu: Menu | None = None
     logged_in: bool = False
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
         return (

--- a/music_assistant/providers/internet_archive/provider.py
+++ b/music_assistant/providers/internet_archive/provider.py
@@ -71,6 +71,11 @@ class InternetArchiveProvider(MusicProvider):
         self.client = InternetArchiveClient(mass)
         self.streaming = InternetArchiveStreaming(self)
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
         return ()

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -101,6 +101,11 @@ class ITunesPodcastsProvider(MusicProvider):
 
     throttler: ThrottlerManager
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
         country_codes = await asyncio.to_thread(get_country_codes)

--- a/music_assistant/providers/mammamiradio/__init__.py
+++ b/music_assistant/providers/mammamiradio/__init__.py
@@ -294,6 +294,11 @@ class MammamiradioProvider(MusicProvider):
     _audio_format_dict: dict[str, Any] | None
     _stream_path: str
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         raw = self.get_setup_value(CONF_MAMMAMIRADIO_URL)

--- a/music_assistant/providers/nts/__init__.py
+++ b/music_assistant/providers/nts/__init__.py
@@ -91,6 +91,11 @@ class NTSProvider(MusicProvider):
     _mixtapes: dict[str, str]
     _unknown_channels: set[str]
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
         return ()

--- a/music_assistant/providers/orf_radiothek/__init__.py
+++ b/music_assistant/providers/orf_radiothek/__init__.py
@@ -135,6 +135,11 @@ class RadiothekProvider(MusicProvider):
         self.catchup_proto = "progressive"
         self.catchup_stations = ""
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return provider configuration entries."""
         return (

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -110,6 +110,11 @@ class PandoraProvider(MusicProvider):
     _socks_proxy: bool = False
     _high_quality_available: bool = False
 
+    @property
+    def max_concurrent_streams(self) -> int:
+        """Pandora enforces single-device streaming (stream violation on concurrent use)."""
+        return 1
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
         return (

--- a/music_assistant/providers/phishin/provider.py
+++ b/music_assistant/providers/phishin/provider.py
@@ -52,6 +52,11 @@ if TYPE_CHECKING:
 class PhishInProvider(MusicProvider):
     """Phish.in music provider."""
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
         return ()

--- a/music_assistant/providers/podcast_index/provider.py
+++ b/music_assistant/providers/podcast_index/provider.py
@@ -46,6 +46,11 @@ class PodcastIndexProvider(MusicProvider):
     api_key: str = ""
     api_secret: str = ""
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
         return (

--- a/music_assistant/providers/radiobrowser/__init__.py
+++ b/music_assistant/providers/radiobrowser/__init__.py
@@ -54,6 +54,11 @@ async def setup(
 class RadioBrowserProvider(MusicProvider):
     """Provider implementation for RadioBrowser."""
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
         return ()

--- a/music_assistant/providers/radioparadise/provider.py
+++ b/music_assistant/providers/radioparadise/provider.py
@@ -46,6 +46,11 @@ if TYPE_CHECKING:
 class RadioParadiseProvider(MusicProvider):
     """Radio Paradise Music Provider for Music Assistant."""
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
         # we (currently) do not have any config entries to set up

--- a/music_assistant/providers/rain_mood/__init__.py
+++ b/music_assistant/providers/rain_mood/__init__.py
@@ -46,6 +46,11 @@ async def setup(
 class RainyMoodProvider(MusicProvider):
     """Music provider serving a looping rain ambience from rainymood.com."""
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider (none needed)."""
         return ()

--- a/music_assistant/providers/somafm/__init__.py
+++ b/music_assistant/providers/somafm/__init__.py
@@ -59,6 +59,11 @@ async def setup(
 class SomaFMProvider(MusicProvider):
     """Provider implementation for SomaFM Radio."""
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
         return (

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -179,6 +179,11 @@ class SpotifyProvider(MusicProvider):
             )
 
     @property
+    def max_concurrent_streams(self) -> int:
+        """Spotify accounts tolerate two concurrent sessions (main + librespot)."""
+        return 2
+
+    @property
     def audiobooks_supported(self) -> bool:
         """Check if audiobooks are supported for this user/region."""
         return self._audiobooks_supported

--- a/music_assistant/providers/sverigesradio/__init__.py
+++ b/music_assistant/providers/sverigesradio/__init__.py
@@ -59,6 +59,11 @@ async def setup(
 class SverigesRadio(MusicProvider):
     """Sveriges Radio music provider."""
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider (none required)."""
         return ()

--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -67,6 +67,11 @@ class TuneInProvider(MusicProvider):
     _throttler: Throttler
     _browse_url_map: dict[str, str]
 
+    @property
+    def max_concurrent_streams(self) -> None:
+        """Allow unlimited concurrent upstream source streams."""
+        return None
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
         return ()

--- a/music_assistant/providers/yandex_ynison/protocols.py
+++ b/music_assistant/providers/yandex_ynison/protocols.py
@@ -10,6 +10,8 @@ from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from contextlib import AbstractAsyncContextManager
+
     from music_assistant_models.enums import MediaType
     from music_assistant_models.streamdetails import StreamDetails
 
@@ -22,12 +24,26 @@ class YandexMusicProviderLike(Protocol):
     Only the subset of methods/properties used by the Ynison plugin.
     """
 
+    @property
+    def instance_id(self) -> str:
+        """Return the exact linked provider instance ID."""
+        ...
+
+    @property
+    def available(self) -> bool:
+        """Return whether the linked provider instance is available."""
+        ...
+
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Resolve stream details for a track."""
         ...
 
     def get_audio_stream(self, stream_details: StreamDetails) -> AsyncGenerator[bytes]:
         """Return async generator of raw audio bytes."""
+        ...
+
+    def acquire_stream_slot(self, wait_timeout: float | None) -> AbstractAsyncContextManager[None]:
+        """Acquire one upstream source-stream slot."""
         ...
 
     async def get_rotor_station_tracks(

--- a/music_assistant/providers/yandex_ynison/provider.py
+++ b/music_assistant/providers/yandex_ynison/provider.py
@@ -7,7 +7,7 @@ import hashlib
 import random
 import time
 from collections.abc import AsyncGenerator, Callable
-from contextlib import suppress
+from contextlib import aclosing, suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
@@ -24,6 +24,7 @@ from music_assistant_models.enums import (
     StreamType,
 )
 from music_assistant_models.errors import (
+    InvalidDataError,
     LoginFailed,
     MediaNotFoundError,
     PlayerCommandFailed,
@@ -34,6 +35,7 @@ from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 from ya_passport_auth import SecretStr
 from ya_passport_auth.ma import BorrowedCredentialSource
 
+from music_assistant.controllers.streams.constants import STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
 from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER, ThrottlerManager
 from music_assistant.models.plugin import PluginProvider
@@ -122,6 +124,10 @@ _MUSIC_TOKEN_CACHE_MAX = 4
 # Used defensively to reject stale/tampered values without raising.
 _VALID_SAMPLE_RATES: frozenset[str] = frozenset({"44100", "48000", "96000"})
 _VALID_BIT_DEPTHS: frozenset[str] = frozenset({"16", "24"})
+
+
+class _StreamOwnerMismatchError(InvalidDataError):
+    """Raised when linked-provider stream details belong to another instance."""
 
 
 @dataclass(frozen=True)
@@ -534,21 +540,27 @@ class YandexYnisonProvider(PluginProvider):
                 last_progress_sync = time.monotonic()
 
                 track_fmt = make_pcm_format(session_params)
-                async for chunk in self._stream_track(
+                track_stream = self._stream_track(
                     track_id, seek_ms=seek_ms, session_params=session_params
-                ):
-                    yield chunk
-                    bytes_yielded += len(chunk)
-                    now_mono = time.monotonic()
-                    if now_mono - last_progress_sync >= _PROGRESS_SYNC_INTERVAL:
-                        last_progress_sync = now_mono
-                        await self._sync_progress(seek_ms, bytes_yielded, player_id, session_fmt)
-                    if (
-                        self._track_changed_event.is_set()
-                        or self._stream_stop_event.is_set()
-                        or (had_claim and self._session_lost(player_id, captured_session_id))
-                    ):
-                        break
+                )
+                # aclosing: breaking out below must finalize the generator right away,
+                # otherwise the linked provider's stream slot stays charged until GC.
+                async with aclosing(track_stream):
+                    async for chunk in track_stream:
+                        yield chunk
+                        bytes_yielded += len(chunk)
+                        now_mono = time.monotonic()
+                        if now_mono - last_progress_sync >= _PROGRESS_SYNC_INTERVAL:
+                            last_progress_sync = now_mono
+                            await self._sync_progress(
+                                seek_ms, bytes_yielded, player_id, session_fmt
+                            )
+                        if (
+                            self._track_changed_event.is_set()
+                            or self._stream_stop_event.is_set()
+                            or (had_claim and self._session_lost(player_id, captured_session_id))
+                        ):
+                            break
 
                 # Align to PCM frame boundary — prevents misalignment in MA's
                 # downstream ffmpeg when a track stream is interrupted mid-chunk.
@@ -733,13 +745,21 @@ class YandexYnisonProvider(PluginProvider):
         ``get_audio_stream()`` session.  Falls back to the current
         ``_normalized_params`` when called outside a session.
         """
+        provider = self._yandex_provider
+        if provider is None:
+            self.logger.warning(
+                "Linked Yandex Music provider unavailable — stopping track %s",
+                track_id,
+            )
+            self._stream_stop_event.set()
+            return
         # In-flight stream fetch outranks unrelated 429 cooldowns:
         # dropping a stream the user is actively trying to play is
         # worse than risking another captcha. Prefetch deliberately
         # stays throttled (see `_prefetch_format_for_track`).
         bypass_token = BYPASS_THROTTLER.set(True)
         try:
-            stream_details = await self._get_stream_details_with_retry(track_id)
+            stream_details = await self._get_stream_details_with_retry(track_id, provider=provider)
         except Exception:
             self.logger.exception("Failed to get stream details for track %s", track_id)
             self._stream_stop_event.set()
@@ -747,20 +767,22 @@ class YandexYnisonProvider(PluginProvider):
         finally:
             BYPASS_THROTTLER.reset(bypass_token)
 
-        # Re-capture the provider after the above await: _yandex_provider may
-        # have flipped to None while we were fetching stream details.  Using
-        # the attribute directly below would race with
-        # _check_yandex_provider_match.
-        provider = self._yandex_provider
-        if provider is None:
+        if not self._linked_provider_is_current(provider):
             self.logger.warning(
-                "Linked Yandex Music provider unloaded mid-stream — stopping track %s",
+                "Linked Yandex Music provider changed mid-stream — stopping track %s",
                 track_id,
             )
             self._stream_stop_event.set()
             return
 
         await self._update_metadata_from_stream(stream_details, seek_ms)
+        if not self._linked_provider_is_current(provider):
+            self.logger.warning(
+                "Linked Yandex Music provider changed while preparing track %s",
+                track_id,
+            )
+            self._stream_stop_event.set()
+            return
 
         # No -re here: MA's realtime pacer is the single pacing authority for
         # AudioSources. Pacing the decode a second time would pin it to realtime
@@ -785,18 +807,38 @@ class YandexYnisonProvider(PluginProvider):
             stream_details.audio_format,
             seek_ms,
         )
-        async for chunk in get_ffmpeg_stream(
-            audio_input=provider.get_audio_stream(stream_details),
-            input_format=stream_details.audio_format,
-            output_format=out_fmt,
-            extra_input_args=extra_input_args,
-        ):
-            yield chunk
+        async with provider.acquire_stream_slot(STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT):
+            if not self._linked_provider_is_current(provider):
+                self.logger.warning(
+                    "Linked Yandex Music provider changed before starting track %s",
+                    track_id,
+                )
+                self._stream_stop_event.set()
+                return
+            raw_stream = provider.get_audio_stream(stream_details)
+            ffmpeg_stream = get_ffmpeg_stream(
+                audio_input=raw_stream,
+                input_format=stream_details.audio_format,
+                output_format=out_fmt,
+                extra_input_args=extra_input_args,
+            )
+            async with aclosing(raw_stream), aclosing(ffmpeg_stream):
+                async for chunk in ffmpeg_stream:
+                    if not self._linked_provider_is_current(provider):
+                        self.logger.warning(
+                            "Linked Yandex Music provider changed while streaming track %s",
+                            track_id,
+                        )
+                        self._stream_stop_event.set()
+                        break
+                    yield chunk
 
     async def _get_stream_details_with_retry(
         self,
         track_id: str,
         media_type: MediaType = MediaType.TRACK,
+        *,
+        provider: YandexMusicProviderLike | None = None,
     ) -> StreamDetails:
         """Fetch stream details with caching, throttling, and retry."""
         # Capture the linked yandex_music provider into a local ref at entry.
@@ -805,21 +847,30 @@ class YandexYnisonProvider(PluginProvider):
         # runs as a background task on provider-loaded/unloaded events).
         # Dereferencing the attribute after an await would raise
         # AttributeError and hard-stop the audio generator.
-        provider = self._yandex_provider
+        provider = provider or self._yandex_provider
         if provider is None:
             raise LoginFailed(
                 "Linked Yandex Music provider is not loaded — cannot fetch stream details"
             )
 
-        cache_key = f"ynison_sd_{track_id}"
+        cache_key = self._stream_details_cache_key(provider.instance_id, track_id)
         cached = await self.mass.cache.get(
             cache_key,
             provider=self.instance_id,
             base_class=StreamDetails,
         )
         if cached is not None:
-            self.logger.debug("Stream details cache hit for %s", track_id)
-            return cast("StreamDetails", cached)
+            cached_streamdetails = cast("StreamDetails", cached)
+            if cached_streamdetails.provider == provider.instance_id:
+                self.logger.debug("Stream details cache hit for %s", track_id)
+                return cached_streamdetails
+            await self.mass.cache.delete(cache_key, provider=self.instance_id)
+            self.logger.warning(
+                "Discarded stream details for %s owned by %s instead of %s",
+                track_id,
+                cached_streamdetails.provider,
+                provider.instance_id,
+            )
 
         backoff = _API_INITIAL_BACKOFF
         last_err: Exception | None = None
@@ -829,6 +880,11 @@ class YandexYnisonProvider(PluginProvider):
                     self.logger.debug("get_stream_details throttled %.1fs", delay)
             try:
                 sd = await provider.get_stream_details(track_id, media_type)
+                if sd.provider != provider.instance_id:
+                    raise _StreamOwnerMismatchError(
+                        f"Stream details for {track_id} belong to {sd.provider}, "
+                        f"expected {provider.instance_id}"
+                    )
                 # StreamDetails.data has serialize="omit", so to_dict()
                 # strips it. Manually include it so cached entries keep
                 # the URL / decryption key needed by get_audio_stream().
@@ -848,6 +904,8 @@ class YandexYnisonProvider(PluginProvider):
                 return sd
             except asyncio.CancelledError:
                 raise
+            except _StreamOwnerMismatchError:
+                raise
             except Exception as err:
                 last_err = err
                 if attempt < _API_MAX_RETRIES - 1:
@@ -864,11 +922,32 @@ class YandexYnisonProvider(PluginProvider):
         msg = f"get_stream_details failed after {_API_MAX_RETRIES} attempts for {track_id}"
         raise RuntimeError(msg) from last_err
 
-    async def _invalidate_stream_cache(self, track_id: str) -> None:
-        """Evict cached stream details for a track so the next fetch is fresh."""
-        cache_key = f"ynison_sd_{track_id}"
+    async def _invalidate_stream_cache(
+        self, track_id: str, provider_instance_id: str | None = None
+    ) -> None:
+        """
+        Evict cached stream details for a track so the next fetch is fresh.
+
+        :param track_id: Track whose cached stream details should be dropped.
+        :param provider_instance_id: Linked provider instance that owns the entry,
+            defaulting to the currently linked one.
+        """
+        if provider_instance_id is None:
+            if self._yandex_provider is None:
+                return
+            provider_instance_id = self._yandex_provider.instance_id
+        cache_key = self._stream_details_cache_key(provider_instance_id, track_id)
         await self.mass.cache.delete(cache_key, provider=self.instance_id)
         self.logger.debug("Invalidated stream cache for %s", track_id)
+
+    @staticmethod
+    def _stream_details_cache_key(provider_instance_id: str, track_id: str) -> str:
+        """Return the cache key for one linked provider instance and track."""
+        return f"ynison_sd_{provider_instance_id}_{track_id}"
+
+    def _linked_provider_is_current(self, provider: YandexMusicProviderLike) -> bool:
+        """Return whether the captured linked provider still owns streaming."""
+        return self._yandex_provider is provider and provider.available
 
     # ------------------------------------------------------------------
     # Token handling

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -175,6 +175,11 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
     _cookie: str
     _yt_dlp_module = None
 
+    @property
+    def max_concurrent_streams(self) -> int:
+        """YouTube Music serves one stream per account session."""
+        return 1
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
         return (CONF_ENTRY_UNOFFICIAL_PROVIDER,)

--- a/tests/controllers/player_queues/test_play_index_elapsed.py
+++ b/tests/controllers/player_queues/test_play_index_elapsed.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import time
 from unittest.mock import AsyncMock, MagicMock, Mock
 
+import pytest
 from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 
 from music_assistant.controllers.player_queues import PlayerQueuesController
 from music_assistant.controllers.player_queues.state import PlayerQueueData
+from music_assistant.models.music_provider import MusicProvider, ProviderStreamLimitError
 
 QUEUE_ID = "q1"
 STALE_ELAPSED = 43_217.7
@@ -117,3 +119,26 @@ async def test_play_index_retry_fallback_discards_failed_items_seek_position() -
     assert queue.current_item.queue_item_id == "fallback"
     assert queue.elapsed_time == 0
     assert all(elapsed == 0 for item_id, elapsed in signals if item_id == "fallback"), signals
+
+
+async def test_play_index_stops_and_reports_a_source_capacity_failure() -> None:
+    """Exhausted source capacity stops the queue instead of skipping to another item."""
+    ctrl, _queue, _signals = _controller_with_stale_queue()
+    queue_item = ctrl._queue_data[QUEUE_ID].items[1]
+    provider = MagicMock(spec=MusicProvider)
+    provider.max_concurrent_streams = 1
+    provider.name = "Limited"
+    provider.instance_id = "limited--1"
+    ctrl._load_item = AsyncMock(  # type: ignore[method-assign]
+        side_effect=ProviderStreamLimitError(provider, 15)
+    )
+    # another item is available, so a skip would otherwise be attempted
+    ctrl._get_next_index = Mock(return_value=0)  # type: ignore[method-assign]
+    ctrl.stop = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(ProviderStreamLimitError):
+        await ctrl.play_index(QUEUE_ID, 1)
+
+    assert queue_item.available
+    assert ctrl._load_item.await_count == 1
+    ctrl.stop.assert_awaited_once_with(QUEUE_ID)

--- a/tests/controllers/player_queues/test_queue_loader_buffers.py
+++ b/tests/controllers/player_queues/test_queue_loader_buffers.py
@@ -67,17 +67,37 @@ def _controller(*queues: tuple[str, list[QueueItem]]) -> PlayerQueuesController:
 
 
 async def test_starting_an_item_aborts_the_other_filling_sources_of_its_queue() -> None:
-    """A still-filling source of another item in the same queue hands its slot over."""
+    """A still-filling source of a preceding item in the same queue hands its slot over."""
     target = _item(QUEUE_ID, "target", LIMITED)
     filling = _item(QUEUE_ID, "filling", LIMITED)
     ctrl = _controller((QUEUE_ID, [filling, target]))
 
     await ctrl._abort_superseded_source_buffers(target)
 
+    # the aborted buffer stays attached so the flow stream can see the abort
     assert filling.streamdetails is not None
-    assert filling.streamdetails.buffer is None
+    assert filling.streamdetails.buffer is not None
+    filling.streamdetails.buffer.clear.assert_awaited_once()
     assert target.streamdetails is not None
     assert target.streamdetails.buffer is not None
+    assert target.streamdetails.buffer.clear.await_count == 0
+
+
+async def test_the_started_items_successor_keeps_its_prewarm() -> None:
+    """A resume or seek must not cost the crossfade prewarm of the upcoming track."""
+    target = _item(QUEUE_ID, "target", LIMITED)
+    upcoming = _item(QUEUE_ID, "upcoming", LIMITED)
+    stale = _item(QUEUE_ID, "stale", LIMITED)
+    ctrl = _controller((QUEUE_ID, [target, upcoming, stale]))
+
+    await ctrl._abort_superseded_source_buffers(target)
+
+    assert upcoming.streamdetails is not None
+    assert upcoming.streamdetails.buffer is not None
+    assert upcoming.streamdetails.buffer.clear.await_count == 0
+    assert stale.streamdetails is not None
+    assert stale.streamdetails.buffer is not None
+    stale.streamdetails.buffer.clear.assert_awaited_once()
 
 
 async def test_completed_and_unlimited_sources_are_left_alone() -> None:

--- a/tests/controllers/player_queues/test_queue_loader_buffers.py
+++ b/tests/controllers/player_queues/test_queue_loader_buffers.py
@@ -1,0 +1,108 @@
+"""Tests that starting an item releases the source slots its own queue no longer needs."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.queue_item import QueueItem
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+from music_assistant.controllers.streams.audio_buffer import AudioBuffer
+from music_assistant.models.music_provider import MusicProvider
+
+QUEUE_ID = "q1"
+LIMITED = "limited--1"
+UNLIMITED = "local--1"
+
+
+def _item(queue_id: str, item_id: str, provider: str | None, buffering: bool = True) -> QueueItem:
+    """
+    Build a queue item, optionally with a buffer attached to its stream details.
+
+    :param queue_id: The queue the item belongs to.
+    :param item_id: The queue item id.
+    :param provider: Provider instance owning the source, or None for an item without details.
+    :param buffering: Whether the attached buffer is still filling from its source.
+    """
+    queue_item = QueueItem(queue_id=queue_id, queue_item_id=item_id, name=item_id, duration=180)
+    if provider is None:
+        return queue_item
+    audio_buffer = MagicMock(spec=AudioBuffer)
+    audio_buffer.is_buffering = buffering
+    audio_buffer.clear = AsyncMock()
+    queue_item.streamdetails = StreamDetails(
+        provider=provider,
+        item_id=item_id,
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        media_type=MediaType.TRACK,
+        stream_type=StreamType.HTTP,
+        path=f"http://test.invalid/{item_id}.mp3",
+    )
+    queue_item.streamdetails.buffer = audio_buffer
+    return queue_item
+
+
+def _controller(*queues: tuple[str, list[QueueItem]]) -> PlayerQueuesController:
+    """Build a bare controller holding the given queues and their items."""
+    ctrl = PlayerQueuesController.__new__(PlayerQueuesController)
+    ctrl.logger = MagicMock()
+    ctrl._queue_data = {
+        queue_id: PlayerQueueData(queue=MagicMock(), items=items, session_id=queue_id)
+        for queue_id, items in queues
+    }
+    limited = MagicMock(spec=MusicProvider)
+    limited.name = "Limited"
+    limited.max_concurrent_streams = 2
+    unlimited = MagicMock(spec=MusicProvider)
+    unlimited.name = "Local"
+    unlimited.max_concurrent_streams = None
+    providers = {LIMITED: limited, UNLIMITED: unlimited}
+    ctrl.mass = MagicMock()
+    ctrl.mass.get_provider.side_effect = lambda instance, **_kwargs: providers.get(instance)
+    return ctrl
+
+
+async def test_starting_an_item_aborts_the_other_filling_sources_of_its_queue() -> None:
+    """A still-filling source of another item in the same queue hands its slot over."""
+    target = _item(QUEUE_ID, "target", LIMITED)
+    filling = _item(QUEUE_ID, "filling", LIMITED)
+    ctrl = _controller((QUEUE_ID, [filling, target]))
+
+    await ctrl._abort_superseded_source_buffers(target)
+
+    assert filling.streamdetails is not None
+    assert filling.streamdetails.buffer is None
+    assert target.streamdetails is not None
+    assert target.streamdetails.buffer is not None
+
+
+async def test_completed_and_unlimited_sources_are_left_alone() -> None:
+    """Only a source that still holds a capped provider slot is worth aborting."""
+    target = _item(QUEUE_ID, "target", LIMITED)
+    completed = _item(QUEUE_ID, "completed", LIMITED, buffering=False)
+    unlimited = _item(QUEUE_ID, "unlimited", UNLIMITED)
+    ctrl = _controller((QUEUE_ID, [completed, unlimited, target]))
+
+    await ctrl._abort_superseded_source_buffers(target)
+
+    for item in (completed, unlimited):
+        assert item.streamdetails is not None
+        assert item.streamdetails.buffer is not None
+        assert item.streamdetails.buffer.clear.await_count == 0
+
+
+async def test_other_queues_keep_their_sources() -> None:
+    """Playback on one queue never takes a source away from another queue."""
+    target = _item(QUEUE_ID, "target", LIMITED)
+    other = _item("q2", "other", LIMITED)
+    ctrl = _controller((QUEUE_ID, [target]), ("q2", [other]))
+
+    await ctrl._abort_superseded_source_buffers(target)
+
+    assert other.streamdetails is not None
+    assert other.streamdetails.buffer is not None
+    assert other.streamdetails.buffer.clear.await_count == 0

--- a/tests/controllers/player_queues/test_queue_loader_buffers.py
+++ b/tests/controllers/player_queues/test_queue_loader_buffers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 from music_assistant_models.enums import ContentType, MediaType, StreamType
@@ -57,13 +58,21 @@ def _controller(*queues: tuple[str, list[QueueItem]]) -> PlayerQueuesController:
     limited = MagicMock(spec=MusicProvider)
     limited.name = "Limited"
     limited.max_concurrent_streams = 2
+    # pinned rather than left to MagicMock truthiness: this decides whether a prewarm survives
+    limited.has_available_stream_slot = True
     unlimited = MagicMock(spec=MusicProvider)
     unlimited.name = "Local"
     unlimited.max_concurrent_streams = None
+    unlimited.has_available_stream_slot = True
     providers = {LIMITED: limited, UNLIMITED: unlimited}
     ctrl.mass = MagicMock()
     ctrl.mass.get_provider.side_effect = lambda instance, **_kwargs: providers.get(instance)
     return ctrl
+
+
+def _limited_double(ctrl: PlayerQueuesController) -> MagicMock:
+    """Return the slot-limited provider double the controller resolves LIMITED to."""
+    return cast("MagicMock", ctrl.mass.get_provider(LIMITED))
 
 
 async def test_starting_an_item_aborts_the_other_filling_sources_of_its_queue() -> None:
@@ -98,6 +107,48 @@ async def test_the_started_items_successor_keeps_its_prewarm() -> None:
     assert stale.streamdetails is not None
     assert stale.streamdetails.buffer is not None
     stale.streamdetails.buffer.clear.assert_awaited_once()
+
+
+async def test_a_saturated_provider_takes_back_the_successors_prewarm() -> None:
+    """A prewarm may not sit on the last slot the item being started needs."""
+    target = _item(QUEUE_ID, "target", LIMITED)
+    upcoming = _item(QUEUE_ID, "upcoming", LIMITED)
+    ctrl = _controller((QUEUE_ID, [target, upcoming]))
+    _limited_double(ctrl).has_available_stream_slot = False
+
+    await ctrl._abort_superseded_source_buffers(target)
+
+    assert upcoming.streamdetails is not None
+    assert upcoming.streamdetails.buffer is not None
+    upcoming.streamdetails.buffer.clear.assert_awaited_once()
+    assert target.streamdetails is not None
+    assert target.streamdetails.buffer is not None
+    assert target.streamdetails.buffer.clear.await_count == 0
+
+
+async def test_freeing_a_slot_first_lets_the_successor_keep_its_prewarm() -> None:
+    """The prewarm is only given up when aborting the stale sources did not free a slot."""
+    stale = _item(QUEUE_ID, "stale", LIMITED)
+    target = _item(QUEUE_ID, "target", LIMITED)
+    upcoming = _item(QUEUE_ID, "upcoming", LIMITED)
+    ctrl = _controller((QUEUE_ID, [stale, target, upcoming]))
+    provider = _limited_double(ctrl)
+    provider.has_available_stream_slot = False
+
+    async def _release_slot() -> None:
+        provider.has_available_stream_slot = True
+
+    assert stale.streamdetails is not None
+    assert stale.streamdetails.buffer is not None
+    stale.streamdetails.buffer.clear.side_effect = _release_slot
+
+    await ctrl._abort_superseded_source_buffers(target)
+
+    # the successor is only re-checked after the stale aborts, so it survives
+    stale.streamdetails.buffer.clear.assert_awaited_once()
+    assert upcoming.streamdetails is not None
+    assert upcoming.streamdetails.buffer is not None
+    assert upcoming.streamdetails.buffer.clear.await_count == 0
 
 
 async def test_completed_and_unlimited_sources_are_left_alone() -> None:

--- a/tests/controllers/player_queues/test_stream_feeder.py
+++ b/tests/controllers/player_queues/test_stream_feeder.py
@@ -6,15 +6,18 @@ import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import PlaybackState
+from music_assistant_models.enums import MediaType, PlaybackState
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 
 from music_assistant.controllers.player_queues import PlayerQueuesController
 from music_assistant.controllers.player_queues.state import PlayerQueueData
+from music_assistant.controllers.streams.constants import STREAM_SLOT_WAIT_TIMEOUT
+from music_assistant.models.music_provider import MusicProvider, ProviderStreamLimitError
 
 
 @pytest.mark.parametrize(
@@ -106,3 +109,64 @@ def _make_queue_item(queue_id: str, item_id: str) -> QueueItem:
         name=item_id,
         duration=60,
     )
+
+
+def _controller_with_next_item() -> tuple[PlayerQueuesController, SimpleNamespace, MagicMock]:
+    """Build a bare controller whose queue has an unprepared next item."""
+    controller = PlayerQueuesController.__new__(PlayerQueuesController)
+    controller.logger = MagicMock()
+    next_item = SimpleNamespace(
+        queue_item_id="next",
+        media_type=MediaType.TRACK,
+        streamdetails=SimpleNamespace(buffer=None),
+        name="Next",
+        available=True,
+    )
+    queue = SimpleNamespace(
+        current_item=SimpleNamespace(queue_item_id="current"),
+        next_item=next_item,
+        display_name="Queue",
+    )
+    controller.get = MagicMock(return_value=queue)  # type: ignore[method-assign]
+    controller._queue_data = {
+        "queue-1": cast("Any", SimpleNamespace(queue=queue, session_id="session-1"))
+    }
+    mass = MagicMock()
+    controller.mass = mass
+    return controller, next_item, mass
+
+
+async def test_prepare_next_uses_the_speculative_capacity_budget() -> None:
+    """Warming the next track never waits longer for capacity than a speculative attempt may."""
+    controller, next_item, mass = _controller_with_next_item()
+    mass.streams.audio.get_audio_buffer = AsyncMock()
+
+    controller.prepare_next_audio_buffer("queue-1")
+    await mass.create_task.call_args.args[0]()
+
+    mass.streams.audio.get_audio_buffer.assert_awaited_once_with(
+        next_item,
+        reason="prepare_next",
+        capacity_wait_timeout=STREAM_SLOT_WAIT_TIMEOUT,
+    )
+    assert mass.create_task.call_args.kwargs == {
+        "task_id": "prepare_next_audio_buffer_queue-1",
+        "abort_existing": True,
+    }
+
+
+async def test_prepare_next_gives_up_softly_on_a_capacity_failure() -> None:
+    """A speculative source-capacity miss leaves the next item playable."""
+    controller, next_item, mass = _controller_with_next_item()
+    provider = MagicMock(spec=MusicProvider)
+    provider.max_concurrent_streams = 1
+    provider.name = "Limited"
+    provider.instance_id = "limited--1"
+    mass.streams.audio.get_audio_buffer = AsyncMock(
+        side_effect=ProviderStreamLimitError(provider, STREAM_SLOT_WAIT_TIMEOUT)
+    )
+
+    controller.prepare_next_audio_buffer("queue-1")
+    await mass.create_task.call_args.args[0]()
+
+    assert next_item.available

--- a/tests/controllers/player_queues/test_stream_feeder.py
+++ b/tests/controllers/player_queues/test_stream_feeder.py
@@ -155,6 +155,39 @@ async def test_prepare_next_uses_the_speculative_capacity_budget() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    ("is_buffering", "expect_cleared"),
+    [(True, True), (False, False)],
+    ids=["still_filling", "completed"],
+)
+async def test_an_aborted_prepare_releases_its_half_filled_source(
+    is_buffering: bool, expect_cleared: bool
+) -> None:
+    """Aborting a prewarm must free its slot instead of pinning it until the inactivity sweep."""
+    controller, next_item, mass = _controller_with_next_item()
+    buffer = MagicMock()
+    buffer.is_buffering = is_buffering
+    buffer.clear = AsyncMock()
+    started = asyncio.Event()
+
+    async def _hang(*_args: object, **_kwargs: object) -> None:
+        # the producer is already running and owns a source slot at this point
+        next_item.streamdetails.buffer = buffer
+        started.set()
+        await asyncio.Event().wait()
+
+    mass.streams.audio.get_audio_buffer = _hang
+
+    controller.prepare_next_audio_buffer("queue-1")
+    prepare_task = asyncio.create_task(mass.create_task.call_args.args[0]())
+    await started.wait()
+    prepare_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await prepare_task
+
+    assert buffer.clear.await_count == (1 if expect_cleared else 0)
+
+
 async def test_prepare_next_gives_up_softly_on_a_capacity_failure() -> None:
     """A speculative source-capacity miss leaves the next item playable."""
     controller, next_item, mass = _controller_with_next_item()

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -866,7 +866,7 @@ async def test_audio_source_next_item_is_not_prebuffered(mass_minimal: MusicAssi
 async def test_real_buffer_producer_error_reaches_queue_item_stream(
     mass_minimal: MusicAssistant,
 ) -> None:
-    """A real AudioBuffer producer error is surfaced after buffered audio is yielded."""
+    """A real AudioBuffer producer error is surfaced instead of a truncated stream."""
 
     async def _failing_source() -> AsyncGenerator[bytes]:
         yield ONE_SECOND_CHUNK
@@ -893,7 +893,9 @@ async def test_real_buffer_producer_error_reaches_queue_item_stream(
     ):
         chunks.append(chunk)
 
-    assert chunks == [ONE_SECOND_CHUNK]
+    # the stream waits for the buffer to become playable, so a producer failure is
+    # reported before any audio is served rather than truncating it mid-stream
+    assert chunks == []
     assert streamdetails.stream_error is True
     assert queue_item.available
 

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -115,6 +115,7 @@ def test_init_defaults() -> None:
     assert buf.max_size_seconds == BUFFER_SIZE_MAP[BufferSize.BALANCED]
     assert buf.size_seconds == 0
     assert buf.seconds_available == 0
+    assert buf.duration_available == 0
     assert not buf.cancelled
     assert not buf.has_error
     assert not buf.ready.is_set()
@@ -133,6 +134,16 @@ def test_init_rolling_mode() -> None:
 
 
 # -- Put and get --
+
+
+async def test_duration_available_uses_exact_resident_byte_count() -> None:
+    """A partial EOF chunk contributes its exact PCM duration."""
+    audio_buffer = AudioBuffer(TEST_PCM_FORMAT)
+    await audio_buffer._put(ONE_SECOND_CHUNK)
+    await audio_buffer._put(ONE_SECOND_CHUNK[: len(ONE_SECOND_CHUNK) // 2])
+
+    assert audio_buffer.seconds_available == 2
+    assert audio_buffer.duration_available == 1.5
 
 
 @pytest.mark.asyncio
@@ -458,6 +469,23 @@ async def test_seek_in_raw_stream() -> None:
     assert len(chunks) == 5
     # first chunk should be chunk #5
     assert chunks[0] == _make_chunk(5)
+
+
+async def test_exact_raw_seek_preserves_millisecond_position() -> None:
+    """Crossfade continuation does not round its media-time resume backward."""
+    audio_buffer = AudioBuffer(TEST_PCM_FORMAT)
+    await audio_buffer._put(ONE_SECOND_CHUNK)
+    await audio_buffer._set_eof()
+
+    regular_stream = audio_buffer.get_raw_stream(seek_position_ms=250)
+    exact_stream = audio_buffer.get_raw_stream(seek_position_ms=250, exact_seek=True)
+    regular_chunk = await anext(regular_stream)
+    exact_chunk = await anext(exact_stream)
+    await regular_stream.aclose()
+    await exact_stream.aclose()
+
+    assert len(regular_chunk) == int(len(ONE_SECOND_CHUNK) * 0.8)
+    assert len(exact_chunk) == int(len(ONE_SECOND_CHUNK) * 0.75)
 
 
 # -- Analysis reader (read_chunk_for_analysis) --

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -31,6 +31,7 @@ from music_assistant.controllers.streams.constants import (
     BufferSize,
 )
 from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
 
 # Standard test PCM format: 44100Hz, 16-bit, stereo
 TEST_PCM_FORMAT = AudioFormat(
@@ -372,6 +373,53 @@ async def test_get_buffer_sound_effect_uses_default_ready_threshold_without_cros
     assert scheduled_tasks == []
     start_analysis.assert_not_called()
     await buffer.clear()
+
+
+@pytest.mark.parametrize(
+    ("max_concurrent_streams", "expect_released"),
+    [(1, True), (None, False)],
+    ids=["slot_limited", "unlimited"],
+)
+@pytest.mark.asyncio
+async def test_get_buffer_releases_a_slot_limited_producer_before_replacing_it(
+    max_concurrent_streams: int | None, expect_released: bool
+) -> None:
+    """A replacement buffer needs the source slot the superseded producer still holds."""
+    mass, _start_analysis, _scheduled_tasks = _make_mass_for_get_buffer()
+    provider = MagicMock(spec=MusicProvider)
+    provider.max_concurrent_streams = max_concurrent_streams
+    mass.get_provider.return_value = provider
+    streamdetails = _make_stream_details(MediaType.TRACK, duration=600, allow_seek=True)
+    blocked = asyncio.Event()
+
+    async def _never_ending_source() -> AsyncGenerator[bytes]:
+        yield _make_chunk(0)
+        await blocked.wait()
+
+    stale_buffer = AudioBuffer(TEST_PCM_FORMAT)
+    stale_buffer.fill(_never_ending_source())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    streamdetails.buffer = stale_buffer
+    # the producer is still charging a source slot and the consumer is active right now
+    assert stale_buffer.is_buffering
+    assert time.time() - stale_buffer._last_access_time < 30
+
+    # a forward seek far past the buffered window can not be served by this buffer
+    assert not stale_buffer.is_valid((SEEK_WAIT_THRESHOLD + 60) * 1000)
+    replacement = await AudioBuffer.get_buffer(
+        mass,
+        streamdetails,
+        seek_position_ms=(SEEK_WAIT_THRESHOLD + 60) * 1000,
+        reason="test",
+    )
+
+    assert replacement is not stale_buffer
+    assert stale_buffer.cancelled is expect_released
+    assert stale_buffer.is_buffering is not expect_released
+    blocked.set()
+    await stale_buffer.clear()
+    await replacement.clear()
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -376,18 +376,19 @@ async def test_get_buffer_sound_effect_uses_default_ready_threshold_without_cros
 
 
 @pytest.mark.parametrize(
-    ("max_concurrent_streams", "expect_released"),
-    [(1, True), (None, False)],
-    ids=["slot_limited", "unlimited"],
+    ("max_concurrent_streams", "has_free_slot", "expect_released"),
+    [(1, False, True), (1, True, False), (None, True, False)],
+    ids=["slot_limited_saturated", "slot_limited_with_free_slot", "unlimited"],
 )
 @pytest.mark.asyncio
 async def test_get_buffer_releases_a_slot_limited_producer_before_replacing_it(
-    max_concurrent_streams: int | None, expect_released: bool
+    max_concurrent_streams: int | None, has_free_slot: bool, expect_released: bool
 ) -> None:
-    """A replacement buffer needs the source slot the superseded producer still holds."""
+    """The superseded producer only gives up its slot when the provider has none to spare."""
     mass, _start_analysis, _scheduled_tasks = _make_mass_for_get_buffer()
     provider = MagicMock(spec=MusicProvider)
     provider.max_concurrent_streams = max_concurrent_streams
+    provider.has_available_stream_slot = has_free_slot
     mass.get_provider.return_value = provider
     streamdetails = _make_stream_details(MediaType.TRACK, duration=600, allow_seek=True)
     blocked = asyncio.Event()
@@ -401,7 +402,8 @@ async def test_get_buffer_releases_a_slot_limited_producer_before_replacing_it(
     await asyncio.sleep(0)
     await asyncio.sleep(0)
     streamdetails.buffer = stale_buffer
-    # the producer is still charging a source slot and the consumer is active right now
+    # the producer is still charging a source slot and the consumer is active right now,
+    # so the 30s inactivity heuristic must not be what decides this
     assert stale_buffer.is_buffering
     assert time.time() - stale_buffer._last_access_time < 30
 

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -1007,6 +1007,7 @@ async def test_flow_zero_audio_skip_restores_seek_position(
         seek_position=0,
         seconds_streamed=0,
         duration=120,
+        buffer=None,
     )
     first_item = SimpleNamespace(
         queue_id="queue-1",
@@ -1100,6 +1101,82 @@ async def test_flow_zero_audio_skip_restores_seek_position(
     build.assert_awaited_once()
     assert eager_seek_positions == [32]
     assert skipped_streamdetails.seek_position == raw_seek_position
+
+
+@pytest.mark.parametrize(
+    ("source_cancelled", "expected_duration"),
+    [(True, 300), (False, 3)],
+    ids=["aborted_source", "clean_source"],
+)
+@pytest.mark.asyncio
+async def test_flow_does_not_write_back_a_duration_for_an_aborted_source(
+    monkeypatch: pytest.MonkeyPatch, source_cancelled: bool, expected_duration: int
+) -> None:
+    """An externally cancelled buffer ends in a clean EOF that must not shorten the item."""
+    mass = MagicMock()
+    pcm_format = _format(ContentType.PCM_S16LE, 8000, 16)
+    streamdetails = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=SimpleNamespace(cancelled=source_cancelled),
+        fade_in=False,
+        stream_error=False,
+        uri="test://track",
+        seek_position=0,
+        seconds_streamed=0,
+        duration=300,
+    )
+    queue_track = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-1",
+        name="track",
+        media_type=MediaType.TRACK,
+        media_item=None,
+        streamdetails=streamdetails,
+        duration=300,
+        extra_attributes={},
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        flow_mode=False,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
+    queue_data = SimpleNamespace(session_id="session-1", flow_mode_stream_log=[])
+    mass.player_queues.queue_data.return_value = queue_data
+    mass.player_queues.load_next_queue_item = AsyncMock(side_effect=QueueEmpty)
+    mass.player_queues.get.return_value = queue
+    mass.streams.get_crossfade_mode.return_value = CrossfadeMode.DISABLED
+    mass.config.get_raw_core_config_value.return_value = 8
+    mass.streams.audio_processing.update_item_context = MagicMock()
+    mass.player_queues.queue_buffer_completed = MagicMock()
+    player = MagicMock()
+    player.config.get_value.return_value = "fixed_48000"
+    player.get_supported_sample_rates.return_value = []
+    mass.players.get_player.return_value = player
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+
+    async def _item_stream(*_args: object, **_kwargs: object) -> AsyncGenerator[bytes]:
+        # a cancelled buffer stops yielding without an error, exactly like a real EOF
+        for _ in range(3):
+            yield bytes(pcm_format.pcm_sample_size)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", queue_track), pcm_format, session_id="session-1"
+    )
+
+    chunks = [chunk async for chunk in stream]
+
+    assert len(chunks) == 3
+    assert streamdetails.duration == expected_duration
+    assert queue_track.duration == expected_duration
+    # the honest streamed amount is always recorded, only the duration is protected
+    assert streamdetails.seconds_streamed == 3
+    entry = queue_data.flow_mode_stream_log[0]
+    assert entry.seconds_streamed == 3
+    assert entry.duration == (None if source_cancelled else 3)
 
 
 def _manager_context(

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -1020,6 +1020,12 @@ async def test_flow_zero_audio_skip_restores_seek_position(
     raw_seek_position = 12
     skipped_streamdetails = SimpleNamespace(
         audio_format=pcm_format,
+        buffer=SimpleNamespace(
+            has_error=False,
+            is_valid=lambda *_args: True,
+            duration_available=16,
+            ready=SimpleNamespace(is_set=lambda: True),
+        ),
         fade_in=False,
         stream_error=False,
         uri="test://skipped",
@@ -1034,7 +1040,7 @@ async def test_flow_zero_audio_skip_restores_seek_position(
         media_type=MediaType.TRACK,
         media_item=None,
         streamdetails=skipped_streamdetails,
-        extra_attributes={},
+        extra_attributes={"playback_speed": 2.0},
     )
     queue = SimpleNamespace(
         queue_id="queue-1",
@@ -1067,6 +1073,7 @@ async def test_flow_zero_audio_skip_restores_seek_position(
         )
     )
     monkeypatch.setattr(audio.smart_fades_mixer, "build", build)
+    eager_seek_positions: list[float] = []
 
     async def _item_stream(
         queue_item: SimpleNamespace,
@@ -1076,6 +1083,8 @@ async def test_flow_zero_audio_skip_restores_seek_position(
         if queue_item is first_item:
             yield bytes(pcm_format.pcm_sample_size * 8)
             yield bytes(pcm_format.pcm_sample_size)
+        else:
+            eager_seek_positions.append(queue_item.streamdetails.seek_position)
 
     monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
     stream = audio.get_queue_flow_stream(
@@ -1089,6 +1098,7 @@ async def test_flow_zero_audio_skip_restores_seek_position(
         pass
 
     build.assert_awaited_once()
+    assert eager_seek_positions == [32]
     assert skipped_streamdetails.seek_position == raw_seek_position
 
 

--- a/tests/controllers/streams/test_crossfade_capacity.py
+++ b/tests/controllers/streams/test_crossfade_capacity.py
@@ -128,6 +128,7 @@ async def test_unprepared_next_track_flushes_outgoing_tail_without_opening_sourc
         seek_position=0,
         seconds_streamed=0,
         uri="test://current",
+        buffer=None,
     )
     next_details = SimpleNamespace(
         audio_format=pcm_format,
@@ -215,6 +216,7 @@ async def test_partial_crossfade_resumes_at_consumed_media_time(
         seek_position=0,
         seconds_streamed=0,
         uri="test://current",
+        buffer=None,
     )
     next_details = SimpleNamespace(
         audio_format=pcm_format,

--- a/tests/controllers/streams/test_crossfade_capacity.py
+++ b/tests/controllers/streams/test_crossfade_capacity.py
@@ -1,0 +1,324 @@
+"""Tests for crossfade degradation when incoming source capacity is unavailable."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import ContentType, CrossfadeMode, MediaType, StreamType
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.controllers.streams.audio import (
+    MIN_CROSSFADE_FALLBACK_DURATION,
+    StreamsAudio,
+)
+from music_assistant.controllers.streams.audio_buffer import AudioBuffer
+from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
+
+
+def _streamdetails(audio_buffer: AudioBuffer | None) -> StreamDetails:
+    """Build incoming track details with an optional prepared buffer."""
+    streamdetails = StreamDetails(
+        provider="test--1",
+        item_id="track-1",
+        audio_format=AudioFormat(content_type=ContentType.FLAC),
+        media_type=MediaType.TRACK,
+        stream_type=StreamType.HTTP,
+        path="http://test.invalid/track.flac",
+        duration=180,
+    )
+    streamdetails.buffer = audio_buffer
+    return streamdetails
+
+
+def _buffer(duration_available: float, ready: bool) -> AudioBuffer:
+    """Build a valid buffer with the requested resident duration."""
+    audio_buffer = MagicMock(spec=AudioBuffer)
+    audio_buffer.has_error = False
+    audio_buffer.is_valid.return_value = True
+    audio_buffer.duration_available = duration_available
+    audio_buffer.ready = MagicMock()
+    audio_buffer.ready.is_set.return_value = ready
+    return audio_buffer
+
+
+def test_ready_incoming_buffer_keeps_smart_crossfade() -> None:
+    """A fully resident incoming buffer keeps the requested Smart Fade."""
+    audio = StreamsAudio(MagicMock())
+
+    mode, duration = audio._select_buffered_crossfade(
+        _streamdetails(_buffer(SMART_CROSSFADE_DURATION, ready=True)),
+        CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+
+    assert mode == CrossfadeMode.SMART_CROSSFADE
+    assert duration == SMART_CROSSFADE_DURATION
+
+
+def test_partial_incoming_buffer_degrades_to_short_standard_crossfade() -> None:
+    """Five resident seconds are crossfaded without waiting for more source PCM."""
+    audio = StreamsAudio(MagicMock())
+    available_seconds = MIN_CROSSFADE_FALLBACK_DURATION + 2
+
+    mode, duration = audio._select_buffered_crossfade(
+        _streamdetails(_buffer(available_seconds, ready=False)),
+        CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+
+    assert mode == CrossfadeMode.STANDARD_CROSSFADE
+    assert duration == available_seconds
+
+
+def test_crossfade_resident_duration_accounts_for_playback_speed() -> None:
+    """Fast playback cannot claim more post-filter overlap than resident PCM can produce."""
+    audio = StreamsAudio(MagicMock())
+
+    mode, duration = audio._select_buffered_crossfade(
+        _streamdetails(_buffer(8, ready=False)),
+        CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+        playback_speed=2.0,
+    )
+
+    assert mode == CrossfadeMode.DISABLED
+    assert duration == 0
+
+
+@pytest.mark.parametrize(
+    "audio_buffer",
+    [
+        None,
+        _buffer(MIN_CROSSFADE_FALLBACK_DURATION - 0.5, ready=False),
+    ],
+)
+def test_unprepared_incoming_buffer_disables_crossfade(
+    audio_buffer: AudioBuffer | None,
+) -> None:
+    """An unusable incoming buffer falls back to gapless/no-crossfade playback."""
+    audio = StreamsAudio(MagicMock())
+
+    mode, duration = audio._select_buffered_crossfade(
+        _streamdetails(audio_buffer),
+        CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+
+    assert mode == CrossfadeMode.DISABLED
+    assert duration == 0
+
+
+async def test_unprepared_next_track_flushes_outgoing_tail_without_opening_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing incoming PCM emits the complete outgoing track without a blocking fade fetch."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=2,
+    )
+    current_details = SimpleNamespace(
+        duration=16,
+        seek_position=0,
+        seconds_streamed=0,
+        uri="test://current",
+    )
+    next_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=None,
+        duration=16,
+        seek_position=0,
+        uri="test://next",
+    )
+    current_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="current",
+        name="Current",
+        streamdetails=current_details,
+        extra_attributes={},
+    )
+    next_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="next",
+        name="Next",
+        streamdetails=next_details,
+        extra_attributes={},
+        available=True,
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        index_in_buffer=0,
+    )
+    player = SimpleNamespace(player_id="player-1", name="Player")
+    mass = MagicMock()
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.load_next_queue_item = AsyncMock(return_value=next_item)
+    mass.player_queues.index_by_id.return_value = 1
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+    audio.select_pcm_format = AsyncMock(return_value=pcm_format)  # type: ignore[method-assign]
+    audio.crossfade_allowed = MagicMock(return_value=True)  # type: ignore[method-assign]
+    build = AsyncMock()
+    monkeypatch.setattr(audio.smart_fades_mixer, "build", build)
+
+    async def _current_stream(
+        queue_item: object,
+        *_args: object,
+        **_kwargs: object,
+    ) -> AsyncGenerator[bytes]:
+        if queue_item is not current_item:
+            pytest.fail("The incoming source was opened during crossfade fallback")
+        yield bytes(pcm_format.pcm_sample_size * 8)
+        yield bytes(pcm_format.pcm_sample_size * 8)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _current_stream)
+    stream = audio.get_queue_item_stream_with_smartfade(
+        cast("Any", player),
+        cast("Any", current_item),
+        pcm_format,
+        crossfade_mode=CrossfadeMode.STANDARD_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+
+    output = b"".join([chunk async for chunk in stream])
+
+    assert len(output) == pcm_format.pcm_sample_size * 16
+    assert next_item.available
+    build.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("playback_speed", "resident_media_duration"),
+    [(0.5, 2.5), (2.0, 10.0)],
+)
+async def test_partial_crossfade_resumes_at_consumed_media_time(
+    monkeypatch: pytest.MonkeyPatch,
+    playback_speed: float,
+    resident_media_duration: float,
+) -> None:
+    """Crossfade output bytes resume the raw source at the matching media-time position."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=2,
+    )
+    current_details = SimpleNamespace(
+        duration=16,
+        seek_position=0,
+        seconds_streamed=0,
+        uri="test://current",
+    )
+    next_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=_buffer(resident_media_duration, ready=False),
+        duration=16,
+        seek_position=0,
+        uri="test://next",
+        volume_normalization_mode=None,
+    )
+    current_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="current",
+        name="Current",
+        streamdetails=current_details,
+        extra_attributes={},
+    )
+    next_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="next",
+        name="Next",
+        streamdetails=next_details,
+        extra_attributes={"playback_speed": playback_speed},
+        available=True,
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        index_in_buffer=0,
+    )
+    player = SimpleNamespace(player_id="player-1", name="Player")
+    mass = MagicMock()
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.load_next_queue_item = AsyncMock(return_value=next_item)
+    mass.player_queues.index_by_id.return_value = 1
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+    audio.select_pcm_format = AsyncMock(return_value=pcm_format)  # type: ignore[method-assign]
+    audio.crossfade_allowed = MagicMock(return_value=True)  # type: ignore[method-assign]
+    smart_fade = SimpleNamespace(
+        timing_info=SimpleNamespace(
+            pre_crossfade_duration=3,
+            crossfade_duration=5,
+            fadein_trimmed_duration=0,
+        )
+    )
+    monkeypatch.setattr(
+        audio.smart_fades_mixer,
+        "build",
+        AsyncMock(return_value=smart_fade),
+    )
+
+    async def _mix(
+        _smart_fade: object,
+        *,
+        fade_in_part: AsyncGenerator[bytes],
+        **_kwargs: object,
+    ) -> AsyncGenerator[bytes]:
+        async for chunk in fade_in_part:
+            yield chunk
+
+    monkeypatch.setattr(audio.smart_fades_mixer, "mix", _mix)
+    requested_beyond_resident = False
+    seek_positions: list[float | None] = []
+
+    async def _item_stream(
+        queue_item: object,
+        *_args: object,
+        **kwargs: object,
+    ) -> AsyncGenerator[bytes]:
+        nonlocal requested_beyond_resident
+        if queue_item is current_item:
+            yield bytes(pcm_format.pcm_sample_size * 8)
+            yield bytes(pcm_format.pcm_sample_size * 8)
+            return
+        seek_positions.append(cast("float | None", kwargs.get("seek_position")))
+        yield bytes(pcm_format.pcm_sample_size * MIN_CROSSFADE_FALLBACK_DURATION)
+        requested_beyond_resident = True
+        pytest.fail("Crossfade requested audio beyond the resident buffer")
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
+    stream = audio.get_queue_item_stream_with_smartfade(
+        cast("Any", player),
+        cast("Any", current_item),
+        pcm_format,
+        crossfade_mode=CrossfadeMode.STANDARD_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+
+    _ = [chunk async for chunk in stream]
+
+    assert not requested_beyond_resident
+    crossfade_data = audio._crossfade_data["queue-1"]
+    assert crossfade_data.fade_in_media_duration == resident_media_duration
+    assert crossfade_data.elapsed_time_offset == 5 * playback_speed
+
+    next_stream = audio.get_queue_item_stream_with_smartfade(
+        cast("Any", player),
+        cast("Any", next_item),
+        pcm_format,
+        crossfade_mode=CrossfadeMode.STANDARD_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+    await anext(next_stream)
+    await next_stream.aclose()
+
+    assert seek_positions == [None, resident_media_duration]
+    assert next_details.seek_position == 5 * playback_speed

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -4,17 +4,21 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
+from contextlib import suppress
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
-from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.enums import ContentType, MediaType, ProviderType, StreamType
 from music_assistant_models.errors import AudioError
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import MultiPartPath, StreamDetails
 
 import music_assistant.controllers.streams.audio as audio_mod
 from music_assistant.controllers.streams.audio import StreamsAudio
+from music_assistant.controllers.streams.audio_buffer import AudioBuffer
+from music_assistant.models.music_provider import MusicProvider, ProviderStreamLimitError
 
 # input args a provider may attach to its StreamDetails (podcastfeed does exactly this).
 # Kept as a tuple so the tests below can never assert against a mutated expectation.
@@ -45,6 +49,7 @@ class _FakeFFMpeg:
         self.returncode: int | None = 0
         self.log_history: list[str] = []
         self.proc = MagicMock(pid=1234)
+        self.stdin_feeder_exception: Exception | None = None
         type(self).last_instance = self
 
     async def start(self) -> None:
@@ -185,6 +190,75 @@ class _TwoMinuteFFMpeg(_FakeFFMpeg):
     async def iter_chunked(self, _chunk_size: int) -> AsyncGenerator[bytes]:
         for _ in range(self.seconds_emitted):
             yield b"\x00" * _PCM_SAMPLE_SIZE
+
+
+class _FailingStartFFMpeg(_FakeFFMpeg):
+    """FFMpeg double that fails while opening its source."""
+
+    async def start(self) -> None:
+        """Fail source startup."""
+        raise RuntimeError("source failed")
+
+
+class _FeederErrorFFMpeg(_FakeFFMpeg):
+    """FFMpeg double whose input feeder failed before producing PCM."""
+
+    error: Exception
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.stdin_feeder_exception = self.error
+
+    async def iter_chunked(self, _chunk_size: int) -> AsyncGenerator[bytes]:
+        """Yield no PCM after the feeder failure."""
+        if _chunk_size < 0:
+            yield b""
+
+
+class _LimitedProvider(MusicProvider):
+    """Music provider with one source-stream slot."""
+
+    @property
+    def max_concurrent_streams(self) -> int:
+        """Return one source-stream slot."""
+        return 1
+
+    def get_audio_stream(
+        self, _streamdetails: StreamDetails, seek_position: int = 0
+    ) -> AsyncGenerator[bytes]:
+        """Yield a custom source chunk."""
+        del seek_position
+
+        async def _source() -> AsyncGenerator[bytes]:
+            yield b"source"
+
+        return _source()
+
+
+def _limited_provider() -> _LimitedProvider:
+    """Build a one-slot music provider."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.type = ProviderType.MUSIC
+    manifest.domain = "limited"
+    manifest.name = "Limited"
+    config = MagicMock()
+    config.name = "Limited"
+    config.instance_id = "limited--1"
+    config.get_value.return_value = "GLOBAL"
+    return _LimitedProvider(mass, manifest, config)
+
+
+def _provider_http_streamdetails(provider: MusicProvider) -> StreamDetails:
+    """Build HTTP stream details owned by the given provider."""
+    return StreamDetails(
+        provider=provider.instance_id,
+        item_id="track-1",
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        media_type=MediaType.TRACK,
+        stream_type=StreamType.HTTP,
+        path="http://test.invalid/track.mp3",
+    )
 
 
 def _multi_part_streamdetails() -> StreamDetails:
@@ -439,6 +513,183 @@ async def test_get_media_stream_keeps_caller_extra_input_args_intact(
 
     assert patch_ffmpeg.last_instance.extra_input_args == [*_PROVIDER_INPUT_ARGS, "-ss", "600"]
     assert streamdetails.extra_input_args == [*_PROVIDER_INPUT_ARGS]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream_type", [StreamType.HTTP, StreamType.CUSTOM])
+@pytest.mark.usefixtures("patch_ffmpeg")
+async def test_music_provider_slot_covers_http_and_custom_until_eof(
+    stream_type: StreamType,
+) -> None:
+    """HTTP and CUSTOM sources hold one provider slot until their source reaches EOF."""
+    provider = _limited_provider()
+    audio = _make_audio_controller()
+    cast("MagicMock", audio.mass).get_provider.return_value = provider
+    streamdetails = StreamDetails(
+        provider=provider.instance_id,
+        item_id="track-1",
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        media_type=MediaType.TRACK,
+        stream_type=stream_type,
+        path="http://test.invalid/track.mp3" if stream_type == StreamType.HTTP else None,
+    )
+    stream = audio.get_media_stream(streamdetails, _make_pcm_format())
+
+    await anext(stream)
+    assert not provider.has_available_stream_slot
+    await _drain(stream)
+
+    cast("MagicMock", audio.mass).get_provider.assert_any_call(
+        provider.instance_id, return_unavailable=True
+    )
+    assert provider.has_available_stream_slot
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("patch_ffmpeg")
+async def test_music_provider_slot_is_acquired_before_hls_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HLS playlist resolution runs inside the provider source lease."""
+    provider = _limited_provider()
+    audio = _make_audio_controller()
+    cast("MagicMock", audio.mass).get_provider.return_value = provider
+
+    async def _get_hls_substream(_url: str) -> SimpleNamespace:
+        assert not provider.has_available_stream_slot
+        return SimpleNamespace(path="http://test.invalid/media.m3u8")
+
+    monkeypatch.setattr(audio, "get_hls_substream", _get_hls_substream)
+    streamdetails = StreamDetails(
+        provider=provider.instance_id,
+        item_id="track-1",
+        audio_format=AudioFormat(content_type=ContentType.AAC),
+        media_type=MediaType.TRACK,
+        stream_type=StreamType.HLS,
+        path="http://test.invalid/master.m3u8",
+    )
+
+    await _drain(audio.get_media_stream(streamdetails, _make_pcm_format()))
+
+    assert provider.has_available_stream_slot
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("patch_ffmpeg")
+async def test_music_provider_without_free_slot_reports_stream_limit() -> None:
+    """A second source on a one-slot provider fails with a typed capacity error."""
+    provider = _limited_provider()
+    audio = _make_audio_controller()
+    cast("MagicMock", audio.mass).get_provider.return_value = provider
+    streamdetails = _provider_http_streamdetails(provider)
+    active_stream = audio.get_media_stream(streamdetails, _make_pcm_format())
+    await anext(active_stream)
+
+    with pytest.raises(ProviderStreamLimitError):
+        await _drain(
+            audio.get_media_stream(streamdetails, _make_pcm_format(), source_wait_timeout=0)
+        )
+
+    await active_stream.aclose()
+    assert provider.has_available_stream_slot
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("patch_ffmpeg")
+async def test_non_music_provider_source_takes_no_slot() -> None:
+    """Sources owned by a plugin provider stream without any capacity handling."""
+    plugin_provider = MagicMock()
+    audio = _make_audio_controller()
+    cast("MagicMock", audio.mass).get_provider.return_value = plugin_provider
+
+    await _drain(
+        audio.get_media_stream(
+            _provider_http_streamdetails(_limited_provider()), _make_pcm_format()
+        )
+    )
+
+    plugin_provider.acquire_stream_slot.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_music_provider_slot_releases_on_source_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A source startup error releases the provider slot."""
+    monkeypatch.setattr(audio_mod, "FFMpeg", _FailingStartFFMpeg)
+    provider = _limited_provider()
+    audio = _make_audio_controller()
+    cast("MagicMock", audio.mass).get_provider.return_value = provider
+
+    with pytest.raises(AudioError):
+        await _drain(
+            audio.get_media_stream(_provider_http_streamdetails(provider), _make_pcm_format())
+        )
+
+    assert provider.has_available_stream_slot
+
+
+@pytest.mark.asyncio
+async def test_music_provider_slot_releases_on_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling a stalled source closes the provider lease."""
+    monkeypatch.setattr(audio_mod, "FFMpeg", _StallingFFMpeg)
+    provider = _limited_provider()
+    audio = _make_audio_controller()
+    cast("MagicMock", audio.mass).get_provider.return_value = provider
+    stream = audio.get_media_stream(_provider_http_streamdetails(provider), _make_pcm_format())
+    read_task = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0)
+    assert not provider.has_available_stream_slot
+
+    read_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await read_task
+
+    assert provider.has_available_stream_slot
+
+
+@pytest.mark.asyncio
+async def test_audio_buffer_clear_closes_provider_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AudioBuffer cancellation closes the source generator and releases its provider slot."""
+    monkeypatch.setattr(audio_mod, "FFMpeg", _StallingFFMpeg)
+    provider = _limited_provider()
+    audio = _make_audio_controller()
+    cast("MagicMock", audio.mass).get_provider.return_value = provider
+    audio_buffer = AudioBuffer(_make_pcm_format())
+    audio_buffer.fill(
+        audio.get_media_stream(_provider_http_streamdetails(provider), _make_pcm_format()),
+        source_name="limited",
+    )
+    await asyncio.sleep(0)
+    assert not provider.has_available_stream_slot
+
+    await audio_buffer.clear()
+
+    assert provider.has_available_stream_slot
+
+
+@pytest.mark.asyncio
+async def test_provider_capacity_error_from_ffmpeg_feeder_remains_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A capacity error raised by a nested source survives the ffmpeg stage."""
+    provider = _limited_provider()
+    _FeederErrorFFMpeg.error = ProviderStreamLimitError(provider, 5)
+    monkeypatch.setattr(audio_mod, "FFMpeg", _FeederErrorFFMpeg)
+    audio = _make_audio_controller()
+    cast("MagicMock", audio.mass).get_provider.return_value = MagicMock()
+
+    with pytest.raises(ProviderStreamLimitError):
+        await _drain(
+            audio.get_media_stream(
+                _provider_http_streamdetails(provider),
+                _make_pcm_format(),
+            )
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from music_assistant_models.enums import ContentType, MediaType, ProviderType, StreamType
-from music_assistant_models.errors import AudioError
+from music_assistant_models.errors import AudioError, ProviderUnavailableError
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import MultiPartPath, StreamDetails
 
@@ -246,7 +246,10 @@ def _limited_provider() -> _LimitedProvider:
     config.name = "Limited"
     config.instance_id = "limited--1"
     config.get_value.return_value = "GLOBAL"
-    return _LimitedProvider(mass, manifest, config)
+    provider = _LimitedProvider(mass, manifest, config)
+    # a provider that can serve a stream is a loaded one
+    provider.available = True
+    return provider
 
 
 def _provider_http_streamdetails(provider: MusicProvider) -> StreamDetails:
@@ -592,6 +595,62 @@ async def test_music_provider_without_free_slot_reports_stream_limit() -> None:
 
     await active_stream.aclose()
     assert provider.has_available_stream_slot
+
+
+def _unavailable_owner_with_sibling() -> tuple[_LimitedProvider, MagicMock, MagicMock]:
+    """Return an unavailable owner, a same-domain sibling, and a real get_provider double."""
+    owner = _limited_provider()
+    owner.available = False
+    sibling = MagicMock()
+    sibling.instance_id = "limited--2"
+
+    def _get_provider(_instance: str, return_unavailable: bool = False, **_kwargs: Any) -> Any:
+        # mirrors mass.get_provider: an unavailable streaming instance falls back to its domain
+        return owner if return_unavailable else sibling
+
+    lookup = MagicMock(side_effect=_get_provider)
+    return owner, sibling, lookup
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("patch_ffmpeg")
+async def test_custom_source_never_streams_from_a_sibling_of_the_charged_instance() -> None:
+    """The slot is charged to the instance that issued the details, so it must serve them too."""
+    owner, sibling, lookup = _unavailable_owner_with_sibling()
+    audio = _make_audio_controller()
+    cast("MagicMock", audio.mass).get_provider = lookup
+    streamdetails = StreamDetails(
+        provider=owner.instance_id,
+        item_id="track-1",
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        media_type=MediaType.TRACK,
+        stream_type=StreamType.CUSTOM,
+    )
+
+    with pytest.raises(ProviderUnavailableError):
+        await _drain(audio.get_media_stream(streamdetails, _make_pcm_format()))
+
+    sibling.get_audio_stream.assert_not_called()
+    assert owner.has_available_stream_slot
+
+
+def test_audio_source_generator_never_opens_a_sibling_of_the_charged_instance() -> None:
+    """The AudioSource entry point pins the same instance as the regular source path."""
+    owner, sibling, lookup = _unavailable_owner_with_sibling()
+    audio = _make_audio_controller()
+    cast("MagicMock", audio.mass).get_provider = lookup
+    streamdetails = StreamDetails(
+        provider=owner.instance_id,
+        item_id="source-1",
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        media_type=MediaType.AUDIO_SOURCE,
+        stream_type=StreamType.CUSTOM,
+    )
+
+    with pytest.raises(ProviderUnavailableError):
+        audio._open_audio_source_generator(streamdetails)
+
+    sibling.get_audio_stream.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/streams/test_normalization_override.py
+++ b/tests/controllers/streams/test_normalization_override.py
@@ -64,7 +64,9 @@ def audio(monkeypatch: pytest.MonkeyPatch) -> tuple[StreamsAudio, dict[str, list
             output_format: AudioFormat,
             seek_position_ms: int = 0,
             filter_params: list[str] | None = None,
+            exact_seek: bool = False,
         ) -> AsyncGenerator[bytes]:
+            del output_format, seek_position_ms, exact_seek
             captured["filter_params"] = filter_params or []
             empty: tuple[bytes, ...] = ()
             for chunk in empty:

--- a/tests/controllers/streams/test_stream_capacity.py
+++ b/tests/controllers/streams/test_stream_capacity.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.errors import MediaNotFoundError, ProviderUnavailableError
 from music_assistant_models.media_items import AudioFormat, ProviderMapping, SoundEffect
 from music_assistant_models.queue_item import QueueItem
 from music_assistant_models.streamdetails import StreamDetails
@@ -232,6 +233,71 @@ async def test_capacity_reselection_is_shared_by_concurrent_waiters(
     assert results[1] is fallback_buffer
     assert queue_item.streamdetails is fallback_details
     assert audio.get_stream_details.await_count == 1
+
+
+async def test_a_failed_reselection_spends_the_budget_on_the_blocked_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unplayable alternative falls back to waiting out the budget on the busy source."""
+    queue_item = _queue_item(
+        _mapping(BUSY_INSTANCE, ContentType.FLAC),
+        _mapping(FALLBACK_INSTANCE),
+    )
+    busy_details = _streamdetails(BUSY_INSTANCE)
+    queue_item.streamdetails = busy_details
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        FALLBACK_INSTANCE: _music_provider(FALLBACK_INSTANCE, has_slot=True),
+    }
+    audio = StreamsAudio(_mass(providers))
+    # the alternative mapping exists but can not be resolved (e.g. region locked)
+    audio.get_stream_details = AsyncMock(side_effect=MediaNotFoundError("not here"))  # type: ignore[method-assign]
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    get_buffer = AsyncMock(side_effect=[_limit_error(BUSY_INSTANCE), expected_buffer])
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    # the capacity budget is spent on the blocked provider instead of being abandoned
+    assert result is expected_buffer
+    assert get_buffer.await_count == 2
+    assert get_buffer.await_args_list[0].kwargs["source_wait_timeout"] == 0
+    assert get_buffer.await_args_list[1].kwargs["source_wait_timeout"] > 0
+    assert get_buffer.await_args_list[1].kwargs["streamdetails"] is busy_details
+    assert queue_item.streamdetails is busy_details
+
+
+@pytest.mark.parametrize(
+    "reselection_error",
+    [ProviderUnavailableError("gone"), asyncio.CancelledError()],
+    ids=["provider_unavailable", "cancelled"],
+)
+async def test_streamdetails_survive_an_unexpected_reselection_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    reselection_error: BaseException,
+) -> None:
+    """No exit path may leave the queue item without stream details."""
+    queue_item = _queue_item(
+        _mapping(BUSY_INSTANCE, ContentType.FLAC),
+        _mapping(FALLBACK_INSTANCE),
+    )
+    busy_details = _streamdetails(BUSY_INSTANCE)
+    queue_item.streamdetails = busy_details
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        FALLBACK_INSTANCE: _music_provider(FALLBACK_INSTANCE, has_slot=True),
+    }
+    audio = StreamsAudio(_mass(providers))
+    audio.get_stream_details = AsyncMock(side_effect=reselection_error)  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        AudioBuffer, "get_buffer", AsyncMock(side_effect=_limit_error(BUSY_INSTANCE))
+    )
+
+    with pytest.raises(type(reselection_error)):
+        await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    # a None here crashes the flow stream's end-of-track bookkeeping
+    assert queue_item.streamdetails is busy_details
 
 
 async def test_flow_mode_skips_the_item_on_capacity_exhaustion() -> None:

--- a/tests/controllers/streams/test_stream_capacity.py
+++ b/tests/controllers/streams/test_stream_capacity.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import ContentType, MediaType, StreamType
-from music_assistant_models.errors import MediaNotFoundError, ProviderUnavailableError
+from music_assistant_models.errors import (
+    AudioError,
+    MediaNotFoundError,
+    ProviderUnavailableError,
+)
 from music_assistant_models.media_items import AudioFormat, ProviderMapping, SoundEffect
 from music_assistant_models.queue_item import QueueItem
 from music_assistant_models.streamdetails import StreamDetails
@@ -172,13 +176,14 @@ async def test_all_candidates_busy_ends_in_one_blocking_pass_on_the_best_one(
 
     assert result is expected_buffer
     assert get_buffer.await_count == 3
-    # probe the first while an alternative is left, then wait out the budget on each
+    # every saturated candidate is only probed, so the budget survives for the final pass
     waits = [call.kwargs["source_wait_timeout"] for call in get_buffer.await_args_list]
     assert waits[0] == 0
-    assert waits[1] > 0
+    assert waits[1] == 0
     assert waits[2] > 0
-    # the final pass returns to the highest quality mapping instead of the last one tried
-    assert get_buffer.await_args_list[2].kwargs["streamdetails"].provider == BUSY_INSTANCE
+    # the single blocking wait is spent on the highest quality mapping, not the last tried
+    probed = [call.kwargs["streamdetails"].provider for call in get_buffer.await_args_list]
+    assert probed == [BUSY_INSTANCE, FALLBACK_INSTANCE, BUSY_INSTANCE]
 
 
 async def test_exhausted_budget_raises_typed_error_and_keeps_the_item_playable(
@@ -264,6 +269,76 @@ async def test_a_failed_reselection_spends_the_budget_on_the_blocked_provider(
     assert get_buffer.await_args_list[0].kwargs["source_wait_timeout"] == 0
     assert get_buffer.await_args_list[1].kwargs["source_wait_timeout"] > 0
     assert get_buffer.await_args_list[1].kwargs["streamdetails"] is busy_details
+    assert queue_item.streamdetails is busy_details
+
+
+async def test_a_broken_alternate_falls_back_to_the_capacity_blocked_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing alternate source must not turn a transient capacity miss into a hard failure."""
+    queue_item = _queue_item(
+        _mapping(BUSY_INSTANCE, ContentType.FLAC),
+        _mapping(FALLBACK_INSTANCE),
+    )
+    busy_details = _streamdetails(BUSY_INSTANCE)
+    queue_item.streamdetails = busy_details
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        FALLBACK_INSTANCE: _music_provider(FALLBACK_INSTANCE, has_slot=True),
+    }
+    audio = StreamsAudio(_mass(providers))
+    audio.get_stream_details = AsyncMock(return_value=_streamdetails(FALLBACK_INSTANCE))  # type: ignore[method-assign]
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    get_buffer = AsyncMock(
+        side_effect=[
+            _limit_error(BUSY_INSTANCE),
+            AudioError("alternate source is broken"),
+            expected_buffer,
+        ]
+    )
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    assert result is expected_buffer
+    assert get_buffer.await_count == 3
+    # the budget is returned to the blocked source instead of surfacing the alternate's error
+    assert get_buffer.await_args_list[2].kwargs["streamdetails"] is busy_details
+    assert get_buffer.await_args_list[2].kwargs["source_wait_timeout"] > 0
+    assert queue_item.streamdetails is busy_details
+
+
+async def test_the_final_pass_surfaces_the_blocked_sources_own_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once the budget is spent on the preferred source, its real failure is the answer."""
+    queue_item = _queue_item(
+        _mapping(BUSY_INSTANCE, ContentType.FLAC),
+        _mapping(FALLBACK_INSTANCE),
+    )
+    busy_details = _streamdetails(BUSY_INSTANCE)
+    queue_item.streamdetails = busy_details
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        FALLBACK_INSTANCE: _music_provider(FALLBACK_INSTANCE, has_slot=True),
+    }
+    audio = StreamsAudio(_mass(providers))
+    audio.get_stream_details = AsyncMock(return_value=_streamdetails(FALLBACK_INSTANCE))  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        AudioBuffer,
+        "get_buffer",
+        AsyncMock(
+            side_effect=[
+                _limit_error(BUSY_INSTANCE),
+                AudioError("alternate source is broken"),
+                AudioError("preferred source is broken"),
+            ]
+        ),
+    )
+
+    with pytest.raises(AudioError, match="preferred source is broken"):
+        await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
     assert queue_item.streamdetails is busy_details
 
 

--- a/tests/controllers/streams/test_stream_capacity.py
+++ b/tests/controllers/streams/test_stream_capacity.py
@@ -142,9 +142,10 @@ async def test_falls_back_to_a_compatible_instance_of_the_same_mapping(
     assert result is expected_buffer
     assert queue_item.streamdetails is not None
     assert queue_item.streamdetails.provider == FALLBACK_INSTANCE
-    # a saturated provider with alternatives left is probed, not waited on
+    # every candidate is probed (0s) while a reselection can still follow; a slot
+    # snapshot is never trusted, so a free fallback still acquires instantly
     assert get_buffer.await_args_list[0].kwargs["source_wait_timeout"] == 0
-    assert get_buffer.await_args_list[1].kwargs["source_wait_timeout"] > 0
+    assert get_buffer.await_args_list[1].kwargs["source_wait_timeout"] == 0
     fallback.get_stream_details.assert_awaited_once_with(ITEM_ID, MediaType.SOUND_EFFECT)
 
 

--- a/tests/controllers/streams/test_stream_capacity.py
+++ b/tests/controllers/streams/test_stream_capacity.py
@@ -1,0 +1,261 @@
+"""Tests for the capacity-aware source selection behind ``get_audio_buffer``."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.media_items import AudioFormat, ProviderMapping, SoundEffect
+from music_assistant_models.queue_item import QueueItem
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.controllers.streams.audio import StreamsAudio
+from music_assistant.controllers.streams.audio_buffer import AudioBuffer
+from music_assistant.models.music_provider import MusicProvider, ProviderStreamLimitError
+
+BUSY_INSTANCE = "service--busy"
+FALLBACK_INSTANCE = "service--fallback"
+ITEM_ID = "item-1"
+
+
+def _mapping(instance: str, quality: ContentType = ContentType.MP3) -> ProviderMapping:
+    """Build a streamable provider mapping."""
+    return ProviderMapping(
+        item_id=ITEM_ID,
+        provider_domain=instance.split("--", maxsplit=1)[0],
+        provider_instance=instance,
+        audio_format=AudioFormat(content_type=quality),
+    )
+
+
+def _streamdetails(instance: str) -> StreamDetails:
+    """Build HTTP stream details for one provider instance."""
+    return StreamDetails(
+        provider=instance,
+        item_id=ITEM_ID,
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        media_type=MediaType.SOUND_EFFECT,
+        stream_type=StreamType.HTTP,
+        path="http://test.invalid/item.mp3",
+        duration=30,
+    )
+
+
+def _queue_item(*mappings: ProviderMapping) -> QueueItem:
+    """Build a queue item with the given provider mappings."""
+    media_item = SoundEffect(
+        item_id=ITEM_ID,
+        provider=mappings[0].provider_instance,
+        name="Effect",
+        provider_mappings=set(mappings),
+    )
+    return QueueItem(
+        queue_id="queue-1",
+        queue_item_id="queue-item-1",
+        name="Effect",
+        duration=30,
+        media_item=media_item,
+    )
+
+
+def _limit_error(instance: str) -> ProviderStreamLimitError:
+    """Build a typed source-capacity error for a provider instance."""
+    provider = MagicMock(spec=MusicProvider)
+    provider.max_concurrent_streams = 1
+    provider.name = "Limited"
+    provider.instance_id = instance
+    return ProviderStreamLimitError(provider, 0)
+
+
+def _music_provider(instance: str, has_slot: bool) -> MagicMock:
+    """Build a loaded streaming provider instance that resolves its own stream details."""
+    provider = MagicMock(spec=MusicProvider)
+    provider.instance_id = instance
+    provider.domain = instance.split("--", maxsplit=1)[0]
+    provider.available = True
+    provider.is_streaming_provider = True
+    provider.has_available_stream_slot = has_slot
+    provider.get_stream_details = AsyncMock(return_value=_streamdetails(instance))
+    return provider
+
+
+def _mass(providers: dict[str, MagicMock] | None = None) -> MagicMock:
+    """Build a mass double that resolves the given provider instances."""
+    mass = MagicMock()
+    if providers is None:
+        mass.get_provider.return_value = MagicMock()
+    else:
+        mass.providers = list(providers.values())
+        mass.get_provider.side_effect = lambda instance, **_kwargs: providers.get(instance)
+    mass.player_queues.queue_data_or_none.return_value = None
+    mass.streams.get_config_value.return_value = -17
+    return mass
+
+
+async def test_reselects_another_mapping_after_a_capacity_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A source that has no free slot is replaced with another compatible mapping."""
+    queue_item = _queue_item(
+        _mapping(BUSY_INSTANCE, ContentType.FLAC),
+        _mapping(FALLBACK_INSTANCE),
+    )
+    queue_item.streamdetails = _streamdetails(BUSY_INSTANCE)
+    audio = StreamsAudio(_mass())
+    fallback_details = _streamdetails(FALLBACK_INSTANCE)
+    audio.get_stream_details = AsyncMock(return_value=fallback_details)  # type: ignore[method-assign]
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    get_buffer = AsyncMock(side_effect=[_limit_error(BUSY_INSTANCE), expected_buffer])
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    assert result is expected_buffer
+    assert queue_item.streamdetails is fallback_details
+    assert audio.get_stream_details.await_args is not None
+    assert audio.get_stream_details.await_args.kwargs["excluded_provider_instances"] == {
+        BUSY_INSTANCE
+    }
+
+
+async def test_falls_back_to_a_compatible_instance_of_the_same_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One mapping is retried on another loaded instance of its streaming catalog."""
+    queue_item = _queue_item(_mapping(BUSY_INSTANCE, ContentType.FLAC))
+    primary = _music_provider(BUSY_INSTANCE, has_slot=False)
+    fallback = _music_provider(FALLBACK_INSTANCE, has_slot=True)
+    audio = StreamsAudio(_mass({BUSY_INSTANCE: primary, FALLBACK_INSTANCE: fallback}))
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    get_buffer = AsyncMock(side_effect=[_limit_error(BUSY_INSTANCE), expected_buffer])
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    assert result is expected_buffer
+    assert queue_item.streamdetails is not None
+    assert queue_item.streamdetails.provider == FALLBACK_INSTANCE
+    # a saturated provider with alternatives left is probed, not waited on
+    assert get_buffer.await_args_list[0].kwargs["source_wait_timeout"] == 0
+    assert get_buffer.await_args_list[1].kwargs["source_wait_timeout"] > 0
+    fallback.get_stream_details.assert_awaited_once_with(ITEM_ID, MediaType.SOUND_EFFECT)
+
+
+async def test_all_candidates_busy_ends_in_one_blocking_pass_on_the_best_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With every candidate saturated, the budget is spent waiting on the preferred mapping."""
+    queue_item = _queue_item(
+        _mapping(BUSY_INSTANCE, ContentType.FLAC),
+        _mapping(FALLBACK_INSTANCE),
+    )
+    queue_item.streamdetails = _streamdetails(BUSY_INSTANCE)
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        FALLBACK_INSTANCE: _music_provider(FALLBACK_INSTANCE, has_slot=False),
+    }
+    audio = StreamsAudio(_mass(providers))
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    get_buffer = AsyncMock(
+        side_effect=[
+            _limit_error(BUSY_INSTANCE),
+            _limit_error(FALLBACK_INSTANCE),
+            expected_buffer,
+        ]
+    )
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    assert result is expected_buffer
+    assert get_buffer.await_count == 3
+    # probe the first while an alternative is left, then wait out the budget on each
+    waits = [call.kwargs["source_wait_timeout"] for call in get_buffer.await_args_list]
+    assert waits[0] == 0
+    assert waits[1] > 0
+    assert waits[2] > 0
+    # the final pass returns to the highest quality mapping instead of the last one tried
+    assert get_buffer.await_args_list[2].kwargs["streamdetails"].provider == BUSY_INSTANCE
+
+
+async def test_exhausted_budget_raises_typed_error_and_keeps_the_item_playable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A spent capacity budget surfaces the typed error without revoking availability."""
+    queue_item = _queue_item(_mapping(BUSY_INSTANCE, ContentType.FLAC))
+    original_details = _streamdetails(BUSY_INSTANCE)
+    queue_item.streamdetails = original_details
+    audio = StreamsAudio(_mass())
+    get_buffer = AsyncMock(side_effect=_limit_error(BUSY_INSTANCE))
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    with pytest.raises(ProviderStreamLimitError):
+        await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=0)
+
+    assert queue_item.available
+    assert queue_item.streamdetails is original_details
+    assert get_buffer.await_count == 1
+
+
+async def test_capacity_reselection_is_shared_by_concurrent_waiters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Speculative and playback waiters on one item share the single replacement source."""
+    queue_item = _queue_item(
+        _mapping(BUSY_INSTANCE, ContentType.FLAC),
+        _mapping(FALLBACK_INSTANCE),
+    )
+    busy_details = _streamdetails(BUSY_INSTANCE)
+    queue_item.streamdetails = busy_details
+    audio = StreamsAudio(_mass())
+    fallback_details = _streamdetails(FALLBACK_INSTANCE)
+    audio.get_stream_details = AsyncMock(return_value=fallback_details)  # type: ignore[method-assign]
+    fallback_buffer = MagicMock(spec=AudioBuffer)
+
+    async def _get_buffer(**kwargs: object) -> MagicMock:
+        # yield control so both waiters would race without the per-item lock
+        await asyncio.sleep(0)
+        if kwargs["streamdetails"] is busy_details:
+            raise _limit_error(BUSY_INSTANCE)
+        return fallback_buffer
+
+    monkeypatch.setattr(AudioBuffer, "get_buffer", _get_buffer)
+
+    results = await asyncio.gather(
+        audio.get_audio_buffer(queue_item, reason="prepare_next", capacity_wait_timeout=1),
+        audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1),
+    )
+
+    assert results[0] is fallback_buffer
+    assert results[1] is fallback_buffer
+    assert queue_item.streamdetails is fallback_details
+    assert audio.get_stream_details.await_count == 1
+
+
+async def test_flow_mode_skips_the_item_on_capacity_exhaustion() -> None:
+    """Flow mode drops an item it can not open a source for, leaving it playable."""
+    queue_item = _queue_item(_mapping(BUSY_INSTANCE, ContentType.FLAC))
+    streamdetails = _streamdetails(BUSY_INSTANCE)
+    streamdetails.loudness = -10.0  # skip the audio-analysis hydration call
+    queue_item.streamdetails = streamdetails
+    audio = StreamsAudio(_mass())
+    audio.get_audio_buffer = AsyncMock(  # type: ignore[method-assign]
+        side_effect=_limit_error(BUSY_INSTANCE)
+    )
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=2,
+    )
+
+    chunks = [
+        chunk
+        async for chunk in audio.get_queue_item_stream(queue_item, pcm_format, raise_on_error=False)
+    ]
+
+    assert chunks == []
+    assert queue_item.available
+    assert streamdetails.stream_error is True

--- a/tests/controllers/streams/test_streamdetails_provider_attempts.py
+++ b/tests/controllers/streams/test_streamdetails_provider_attempts.py
@@ -1,18 +1,19 @@
 """
 Tests that resolving streamdetails asks each provider mapping at most once.
 
-``get_stream_details`` walks the provider mappings twice: the first pass is limited to the
-providers the user's provider filter steers to, the second widens to the rest. Without a
-provider filter every mapping counts as preferred, so both passes cover the same set and a
-mapping that failed would be asked again -- doubling the cost of every failure, which for a
-just-in-time renderer like AI Radio means a second full text-to-speech render.
+``get_stream_details`` builds its candidates once: mappings in quality order, the instances
+that can serve each mapping within it, and the providers the user's filter steers to ahead of
+the rest. Every (instance, item id) pair appears at most once, so a mapping that failed is not
+asked again -- which for a just-in-time renderer like AI Radio would mean a second full
+text-to-speech render.
 
-The mappings below are given distinct qualities wherever order matters, so the pass the
-loop reaches them in is fixed rather than left to the iteration order of a set.
+The mappings below are given distinct qualities wherever order matters, so the order the
+candidates are reached in is fixed rather than left to the iteration order of a set.
 """
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -23,6 +24,7 @@ from music_assistant_models.queue_item import QueueItem
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.controllers.streams.audio import StreamsAudio
+from music_assistant.models.music_provider import MusicProvider
 
 INSTANCE = "ai_radio--abc"
 OTHER_INSTANCE = "tidal--xyz"
@@ -89,7 +91,15 @@ def _audio(
         (which makes every mapping on the item count as preferred).
     """
     mass = MagicMock()
-    mass.get_provider.side_effect = lambda instance: providers.get(instance)
+    for instance_id, provider in providers.items():
+        if isinstance(provider, MusicProvider):
+            provider.instance_id = instance_id
+            provider.domain = instance_id.split("--", maxsplit=1)[0]
+            provider.available = True
+            provider.is_streaming_provider = True
+    mass.get_provider.side_effect = lambda instance, **_kwargs: providers.get(instance)
+    # no other loaded instances to widen a mapping to
+    mass.providers = []
     mass.player_queues.queue_data_or_none.return_value = (
         MagicMock(userid="user1") if provider_filter else None
     )
@@ -174,3 +184,146 @@ async def test_two_mappings_on_one_provider_are_both_attempted() -> None:
 
     assert streamdetails.item_id == "good"
     assert calls == ["bad", "good"]
+
+
+def _music_provider(instance: str, has_slot: bool = True) -> MagicMock:
+    """
+    Build a streaming music provider test double.
+
+    :param instance: The instance id the provider is registered under.
+    :param has_slot: Whether the provider has a free source-stream slot.
+    """
+    provider = MagicMock(spec=MusicProvider)
+    provider.has_available_stream_slot = has_slot
+    provider.get_stream_details = AsyncMock(
+        return_value=_streamdetails(ITEM_ID, MediaType.SOUND_EFFECT, instance)
+    )
+    return provider
+
+
+async def test_mapping_quality_order_is_preserved_when_first_provider_is_busy() -> None:
+    """Capacity does not reorder a higher-quality mapping behind a lower-quality one."""
+    busy_instance = "tidal--busy"
+    available_instance = "tidal--available"
+    busy = _music_provider(busy_instance, has_slot=False)
+    available = _music_provider(available_instance)
+    audio = _audio({busy_instance: busy, available_instance: available})
+
+    streamdetails = await audio.get_stream_details(
+        queue_item=_queue_item(
+            _mapping(busy_instance, content_type=ContentType.FLAC),
+            _mapping(available_instance),
+        )
+    )
+
+    assert streamdetails.provider == busy_instance
+    busy.get_stream_details.assert_awaited_once()
+    available.get_stream_details.assert_not_awaited()
+
+
+async def test_busy_instance_preserves_playback_user_steering_order() -> None:
+    """A busy steered instance stays first; capacity is handled while acquiring the source."""
+    busy_instance = "tidal--preferred"
+    available_instance = "tidal--fallback"
+    busy = _music_provider(busy_instance, has_slot=False)
+    available = _music_provider(available_instance)
+    audio = _audio(
+        {busy_instance: busy, available_instance: available},
+        provider_filter=[busy_instance],
+    )
+
+    streamdetails = await audio.get_stream_details(
+        queue_item=_queue_item(
+            _mapping(busy_instance, content_type=ContentType.FLAC),
+            _mapping(available_instance),
+        )
+    )
+
+    assert streamdetails.provider == busy_instance
+    busy.get_stream_details.assert_awaited_once()
+    available.get_stream_details.assert_not_awaited()
+
+
+async def test_excluded_instance_is_skipped_including_its_cached_details() -> None:
+    """An excluded instance is passed over, and its unexpired details are not reused."""
+    excluded_instance = "tidal--busy"
+    available_instance = "tidal--available"
+    excluded = _music_provider(excluded_instance)
+    available = _music_provider(available_instance)
+    queue_item = _queue_item(
+        _mapping(excluded_instance, content_type=ContentType.FLAC),
+        _mapping(available_instance),
+    )
+    queue_item.streamdetails = _streamdetails(ITEM_ID, MediaType.SOUND_EFFECT, excluded_instance)
+    audio = _audio({excluded_instance: excluded, available_instance: available})
+
+    streamdetails = await audio.get_stream_details(
+        queue_item=queue_item,
+        excluded_provider_instances={excluded_instance},
+    )
+
+    assert streamdetails.provider == available_instance
+    excluded.get_stream_details.assert_not_awaited()
+
+
+async def test_mapping_falls_back_to_compatible_streaming_provider_instance() -> None:
+    """The same mapping item ID is retried on another loaded instance of its streaming domain."""
+    primary_instance = "tidal--primary"
+    fallback_instance = "tidal--fallback"
+    primary = _music_provider(primary_instance)
+    fallback = _music_provider(fallback_instance)
+    audio = _audio({primary_instance: primary, fallback_instance: fallback})
+    cast("MagicMock", audio.mass).providers = [primary, fallback]
+
+    streamdetails = await audio.get_stream_details(
+        queue_item=_queue_item(_mapping(primary_instance)),
+        excluded_provider_instances={primary_instance},
+    )
+
+    assert streamdetails.provider == fallback_instance
+    primary.get_stream_details.assert_not_awaited()
+    fallback.get_stream_details.assert_awaited_once_with(ITEM_ID, MediaType.SOUND_EFFECT)
+
+
+async def test_playback_user_steers_compatible_instance_within_mapping() -> None:
+    """Playback-user steering picks its compatible instance without changing mapping order."""
+    primary_instance = "tidal--primary"
+    preferred_instance = "tidal--preferred"
+    primary = _music_provider(primary_instance)
+    preferred = _music_provider(preferred_instance)
+    audio = _audio(
+        {primary_instance: primary, preferred_instance: preferred},
+        provider_filter=[preferred_instance],
+    )
+    cast("MagicMock", audio.mass).providers = [primary, preferred]
+
+    streamdetails = await audio.get_stream_details(
+        queue_item=_queue_item(_mapping(primary_instance))
+    )
+
+    assert streamdetails.provider == preferred_instance
+    preferred.get_stream_details.assert_awaited_once_with(ITEM_ID, MediaType.SOUND_EFFECT)
+    primary.get_stream_details.assert_not_awaited()
+
+
+async def test_playback_user_steering_precedes_cross_domain_quality() -> None:
+    """A lower-quality steered mapping is tried before widening to a higher-quality one."""
+    high_quality_instance = "tidal--high"
+    preferred_instance = "spotify--preferred"
+    high_quality = _music_provider(high_quality_instance)
+    preferred = _music_provider(preferred_instance)
+    audio = _audio(
+        {high_quality_instance: high_quality, preferred_instance: preferred},
+        provider_filter=[preferred_instance],
+    )
+
+    streamdetails = await audio.get_stream_details(
+        queue_item=_queue_item(
+            _mapping(high_quality_instance, content_type=ContentType.FLAC),
+            _mapping(preferred_instance),
+        )
+    )
+
+    assert streamdetails.provider == preferred_instance
+    preferred.get_stream_details.assert_awaited_once()
+    high_quality.get_stream_details.assert_not_awaited()

--- a/tests/models/test_music_provider.py
+++ b/tests/models/test_music_provider.py
@@ -1,0 +1,118 @@
+"""Tests for MusicProvider source-stream capacity."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import ProviderType
+
+from music_assistant.models.music_provider import (
+    DEFAULT_MAX_CONCURRENT_STREAMS,
+    MusicProvider,
+    ProviderStreamLimitError,
+)
+
+
+class _StreamingProvider(MusicProvider):
+    """Streaming provider using the default source limit."""
+
+
+class _NonStreamingProvider(MusicProvider):
+    """Non-streaming provider with no source limit."""
+
+    @property
+    def is_streaming_provider(self) -> bool:
+        """Return False for this local provider."""
+        return False
+
+
+class _SingleStreamProvider(MusicProvider):
+    """Streaming provider with one source slot."""
+
+    @property
+    def max_concurrent_streams(self) -> int:
+        """Return one source slot."""
+        return 1
+
+
+def _make_provider[ProviderT: MusicProvider](provider_cls: type[ProviderT]) -> ProviderT:
+    """Construct a minimal MusicProvider instance."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.type = ProviderType.MUSIC
+    manifest.domain = "test_provider"
+    manifest.name = "Test Provider"
+    config = MagicMock()
+    config.name = "Test Provider"
+    config.instance_id = "test_provider--1"
+    config.get_value.return_value = "GLOBAL"
+    return provider_cls(mass, manifest, config)
+
+
+def test_streaming_provider_has_conservative_default() -> None:
+    """Unknown streaming providers default to five concurrent sources."""
+    provider = _make_provider(_StreamingProvider)
+
+    assert provider.max_concurrent_streams == DEFAULT_MAX_CONCURRENT_STREAMS == 5
+
+
+def test_non_streaming_provider_is_unlimited() -> None:
+    """Non-streaming providers do not allocate a source limiter."""
+    provider = _make_provider(_NonStreamingProvider)
+
+    assert provider.max_concurrent_streams is None
+    assert provider.has_available_stream_slot
+
+
+async def test_stream_slot_is_scoped_per_provider_instance() -> None:
+    """One busy provider instance does not consume another instance's slot."""
+    first = _make_provider(_SingleStreamProvider)
+    second = _make_provider(_SingleStreamProvider)
+    cast("MagicMock", second.config).instance_id = "test_provider--2"
+
+    async with first.acquire_stream_slot(0.1):
+        assert not first.has_available_stream_slot
+        assert second.has_available_stream_slot
+        with pytest.raises(ProviderStreamLimitError):
+            async with first.acquire_stream_slot(0):
+                pytest.fail("A second source slot was unexpectedly acquired")
+
+    assert first.has_available_stream_slot
+
+
+async def test_stream_slot_is_granted_once_released() -> None:
+    """A waiter within its timeout is served as soon as the active source releases."""
+    provider = _make_provider(_SingleStreamProvider)
+    acquired = asyncio.Event()
+
+    async def _wait_for_slot() -> None:
+        async with provider.acquire_stream_slot(5):
+            acquired.set()
+
+    async with provider.acquire_stream_slot(5):
+        waiter = asyncio.create_task(_wait_for_slot())
+        await asyncio.sleep(0)
+        assert not acquired.is_set()
+
+    await waiter
+
+    assert acquired.is_set()
+    assert provider.has_available_stream_slot
+
+
+async def test_cancelled_stream_slot_wait_does_not_consume_capacity() -> None:
+    """Cancelling a waiter leaves the active source as the only leased slot."""
+    provider = _make_provider(_SingleStreamProvider)
+
+    async with provider.acquire_stream_slot(0.1):
+        waiter = asyncio.create_task(provider.acquire_stream_slot(None).__aenter__())
+        await asyncio.sleep(0)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        assert not provider.has_available_stream_slot
+
+    assert provider.has_available_stream_slot

--- a/tests/providers/stream_limits/__init__.py
+++ b/tests/providers/stream_limits/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for music-provider stream limits."""

--- a/tests/providers/stream_limits/test_stream_limits.py
+++ b/tests/providers/stream_limits/test_stream_limits.py
@@ -1,0 +1,83 @@
+"""Tests for music-provider source-stream limit declarations."""
+
+from __future__ import annotations
+
+import pytest
+
+from music_assistant.models.music_provider import MusicProvider
+from music_assistant.providers._demo_music_provider import MyDemoMusicprovider
+from music_assistant.providers.abc_radio_network.provider import ABCRadioProvider
+from music_assistant.providers.apple_music.provider import AppleMusicProvider
+from music_assistant.providers.ard_audiothek import ARDAudiothek
+from music_assistant.providers.bbc_sounds import BBCSoundsProvider
+from music_assistant.providers.filesystem_local import LocalFileSystemProvider
+from music_assistant.providers.internet_archive.provider import InternetArchiveProvider
+from music_assistant.providers.itunes_podcasts import ITunesPodcastsProvider
+from music_assistant.providers.mammamiradio import MammamiradioProvider
+from music_assistant.providers.nts import NTSProvider
+from music_assistant.providers.orf_radiothek import RadiothekProvider
+from music_assistant.providers.pandora.provider import PandoraProvider
+from music_assistant.providers.phishin.provider import PhishInProvider
+from music_assistant.providers.podcast_index.provider import PodcastIndexProvider
+from music_assistant.providers.qobuz import QobuzProvider
+from music_assistant.providers.radiobrowser import RadioBrowserProvider
+from music_assistant.providers.radioparadise.provider import RadioParadiseProvider
+from music_assistant.providers.rain_mood import RainyMoodProvider
+from music_assistant.providers.somafm import SomaFMProvider
+from music_assistant.providers.spotify.provider import SpotifyProvider
+from music_assistant.providers.sverigesradio import SverigesRadio
+from music_assistant.providers.tunein import TuneInProvider
+from music_assistant.providers.ytmusic import YoutubeMusicProvider
+
+
+def _limit(provider_cls: type[MusicProvider]) -> int | None:
+    """Read a stateless provider limit without initializing external clients."""
+    provider = provider_cls.__new__(provider_cls)
+    return provider.max_concurrent_streams
+
+
+@pytest.mark.parametrize(
+    ("provider_cls", "expected"),
+    [
+        (MyDemoMusicprovider, 5),
+        (QobuzProvider, 5),
+        (LocalFileSystemProvider, None),
+        (SpotifyProvider, 2),
+        (YoutubeMusicProvider, 1),
+        (AppleMusicProvider, 1),
+        (PandoraProvider, 1),
+    ],
+)
+def test_provider_stream_limit_defaults_and_overrides(
+    provider_cls: type[MusicProvider], expected: int | None
+) -> None:
+    """Providers inherit or override the source limit for their source category."""
+    assert _limit(provider_cls) == expected
+
+
+@pytest.mark.parametrize(
+    "provider_cls",
+    [
+        ABCRadioProvider,
+        ARDAudiothek,
+        BBCSoundsProvider,
+        InternetArchiveProvider,
+        ITunesPodcastsProvider,
+        MammamiradioProvider,
+        NTSProvider,
+        RadiothekProvider,
+        PhishInProvider,
+        PodcastIndexProvider,
+        RadioBrowserProvider,
+        RadioParadiseProvider,
+        RainyMoodProvider,
+        SomaFMProvider,
+        SverigesRadio,
+        TuneInProvider,
+    ],
+)
+def test_public_direct_providers_are_unlimited(
+    provider_cls: type[MusicProvider],
+) -> None:
+    """Audited public/direct providers do not consume the default guarded pool."""
+    assert _limit(provider_cls) is None

--- a/tests/providers/yandex_ynison/test_provider.py
+++ b/tests/providers/yandex_ynison/test_provider.py
@@ -16,16 +16,20 @@ from music_assistant_models.enums import (
     ProviderType,
 )
 from music_assistant_models.errors import (
+    InvalidDataError,
     LoginFailed,
     PlayerCommandFailed,
     ResourceTemporarilyUnavailable,
     UnsupportedFeaturedException,
 )
 from music_assistant_models.media_items import AudioFormat, AudioSource
+from music_assistant_models.streamdetails import StreamDetails
 from ya_passport_auth import SecretStr
 from ya_passport_auth.ma import BorrowedCredentialSource, list_yandex_music_instances
 
+from music_assistant.controllers.streams.constants import STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT
 from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER, ThrottlerManager
+from music_assistant.models.music_provider import MusicProvider, ProviderStreamLimitError
 from music_assistant.providers.yandex_ynison.constants import (
     CONF_ALLOW_PLAYER_SWITCH,
     CONF_DEVICE_ID,
@@ -76,6 +80,18 @@ def _arm_play_media_recorder(provider: YandexYnisonProvider) -> list[tuple[str, 
 def _stub_attr(obj: object, name: str, value: Any) -> None:
     """Setattr that bypasses mypy method-assign and ruff B010."""
     setattr(obj, name, value)
+
+
+def _set_stream_owner(
+    provider: MagicMock,
+    *streamdetails: MagicMock,
+    instance_id: str = "yandex_music--test",
+) -> None:
+    """Assign one exact available Yandex Music owner to stream-details test doubles."""
+    provider.instance_id = instance_id
+    provider.available = True
+    for details in streamdetails:
+        details.provider = instance_id
 
 
 def _make_mock_config(values: dict[str, Any] | None = None) -> MagicMock:
@@ -1026,6 +1042,7 @@ class TestPCMNormalization:
         sd.expiration = 600
         sd.duration = 200
         sd.audio_format = MagicMock()
+        _set_stream_owner(mock_yandex, sd)
         mock_yandex.get_stream_details = AsyncMock(return_value=sd)
 
         async def _fake_audio_stream(_details: object) -> Any:
@@ -1052,6 +1069,7 @@ class TestPCMNormalization:
 
         assert collected == [b"pcm-normalized"]
         mock_ffmpeg.assert_called_once()
+        mock_yandex.acquire_stream_slot.assert_called_once_with(STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT)
         call_kwargs = mock_ffmpeg.call_args
         # Default (no YM provider linked) → lossy profile
         assert call_kwargs.kwargs["output_format"] == provider._normalized_format
@@ -1063,6 +1081,55 @@ class TestPCMNormalization:
         assert "-re" not in args
         assert "-ss" not in args
 
+    async def test_stream_track_preserves_linked_provider_capacity_error(self) -> None:
+        """A linked-provider slot timeout remains typed before the inner ffmpeg starts."""
+        provider = _make_provider()
+        streamdetails = MagicMock()
+        streamdetails.audio_format = AudioFormat(
+            content_type=ContentType.MP3,
+            sample_rate=44100,
+            bit_depth=16,
+            channels=2,
+        )
+        linked_provider = MagicMock(spec=MusicProvider)
+        linked_provider.max_concurrent_streams = 1
+        linked_provider.name = "Yandex Music"
+        linked_provider.instance_id = "yandex_music--1"
+        linked_provider.available = True
+        streamdetails.provider = linked_provider.instance_id
+        capacity_error = ProviderStreamLimitError(
+            linked_provider, STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT
+        )
+
+        class _UnavailableSlot:
+            async def __aenter__(self) -> None:
+                raise capacity_error
+
+            async def __aexit__(self, *_args: object) -> None:
+                return None
+
+        linked_provider.acquire_stream_slot.return_value = _UnavailableSlot()
+
+        async def _raw_stream(_details: object) -> Any:
+            yield b"raw"
+
+        linked_provider.get_audio_stream = _raw_stream
+        provider._yandex_provider = linked_provider
+        _stub_attr(
+            provider,
+            "_get_stream_details_with_retry",
+            AsyncMock(return_value=streamdetails),
+        )
+        _stub_attr(provider, "_update_metadata_from_stream", AsyncMock())
+
+        with pytest.raises(ProviderStreamLimitError):
+            async for _ in provider._stream_track("track:123"):
+                pass
+
+        linked_provider.acquire_stream_slot.assert_called_once_with(
+            STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT
+        )
+
     async def test_stream_track_seek_adds_ss_arg(self) -> None:
         """With seek > 0, _stream_track adds -ss to ffmpeg args."""
         provider = _make_provider()
@@ -1073,6 +1140,7 @@ class TestPCMNormalization:
         sd.expiration = 600
         sd.duration = 200
         sd.audio_format = MagicMock()
+        _set_stream_owner(mock_yandex, sd)
         mock_yandex.get_stream_details = AsyncMock(return_value=sd)
 
         async def _fake_audio_stream(_details: object) -> Any:
@@ -1125,6 +1193,7 @@ class TestPCMNormalization:
         sd.expiration = 600
         sd.duration = 200
         sd.audio_format = MagicMock()
+        _set_stream_owner(mock_yandex, sd)
         mock_yandex.get_stream_details = AsyncMock(return_value=sd)
 
         async def _fake_audio_stream(_details: object) -> Any:
@@ -1319,6 +1388,7 @@ class TestPCMNormalization:
         sd.audio_format = MagicMock()
         sd.to_dict.return_value = {"track_id": "t1"}
         sd.data = {"url": "https://cdn.example.com/audio.mp3"}
+        _set_stream_owner(mock_yandex, sd)
 
         async def fetch_and_null(_track_id: str, _media_type: Any = None) -> Any:
             # Simulate the background unload task firing while we awaited.
@@ -1335,6 +1405,63 @@ class TestPCMNormalization:
         assert collected == []
         assert provider._stream_stop_event.is_set()
 
+    async def test_stream_track_provider_switch_does_not_mix_owners(self) -> None:
+        """Details from the old owner are not handed to a newly linked provider instance."""
+        provider = _make_provider()
+        owner_a = MagicMock()
+        owner_b = MagicMock()
+        streamdetails = MagicMock()
+        streamdetails.expiration = 60
+        streamdetails.audio_format = MagicMock()
+        streamdetails.to_dict.return_value = {}
+        streamdetails.data = None
+        _set_stream_owner(owner_a, streamdetails, instance_id="yandex_music--a")
+        _set_stream_owner(owner_b, instance_id="yandex_music--b")
+
+        async def _fetch_and_switch(_track_id: str, _media_type: Any) -> MagicMock:
+            provider._yandex_provider = owner_b
+            return streamdetails
+
+        owner_a.get_stream_details = AsyncMock(side_effect=_fetch_and_switch)
+        owner_a.get_audio_stream = MagicMock()
+        owner_b.get_audio_stream = MagicMock()
+        provider._yandex_provider = owner_a
+
+        output = [chunk async for chunk in provider._stream_track("track:1")]
+
+        assert output == []
+        assert provider._stream_stop_event.is_set()
+        owner_a.get_audio_stream.assert_not_called()
+        owner_b.get_audio_stream.assert_not_called()
+
+    async def test_stream_track_provider_switch_during_metadata_aborts(self) -> None:
+        """A linked-owner switch during metadata preparation cannot start the old source."""
+        provider = _make_provider()
+        owner_a = MagicMock()
+        owner_b = MagicMock()
+        streamdetails = MagicMock()
+        streamdetails.audio_format = MagicMock()
+        _set_stream_owner(owner_a, streamdetails, instance_id="yandex_music--a")
+        _set_stream_owner(owner_b, instance_id="yandex_music--b")
+        owner_a.get_audio_stream = MagicMock()
+        provider._yandex_provider = owner_a
+        _stub_attr(
+            provider,
+            "_get_stream_details_with_retry",
+            AsyncMock(return_value=streamdetails),
+        )
+
+        async def _switch_owner(*_args: object) -> None:
+            provider._yandex_provider = owner_b
+
+        _stub_attr(provider, "_update_metadata_from_stream", AsyncMock(side_effect=_switch_owner))
+
+        output = [chunk async for chunk in provider._stream_track("track:1")]
+
+        assert output == []
+        assert provider._stream_stop_event.is_set()
+        owner_a.get_audio_stream.assert_not_called()
+
 
 def _make_ym_provider_stub(
     instance_id: str = "ym-inst",
@@ -1347,6 +1474,7 @@ def _make_ym_provider_stub(
     ym_config.get_value.side_effect = values.get
     ym = MagicMock()
     ym.instance_id = instance_id
+    ym.available = True
     ym.domain = "yandex_music"
     ym.type = ProviderType.MUSIC
     ym.config = ym_config
@@ -2239,14 +2367,24 @@ class TestGetStreamDetailsWithRetry:
         sd.expiration = 600
         sd.to_dict.return_value = {"track_id": "t1"}
         sd.data = {"url": "https://cdn.example.com/audio.mp3", "decryption_key": "abc"}
+        _set_stream_owner(mock_yp, sd)
         mock_yp.get_stream_details = AsyncMock(return_value=sd)
         provider._yandex_provider = mock_yp
 
         result = await provider._get_stream_details_with_retry("t1")
         assert result is sd
         mock_yp.get_stream_details.assert_awaited_once()
+        provider.mass.cache.get.assert_awaited_once_with(  # type: ignore[attr-defined]
+            "ynison_sd_yandex_music--test_t1",
+            provider=provider.instance_id,
+            base_class=StreamDetails,
+        )
         # Verify cache.set was called with data field preserved
         provider.mass.cache.set.assert_awaited_once()  # type: ignore[attr-defined]
+        assert (
+            provider.mass.cache.set.call_args.args[0]  # type: ignore[attr-defined]
+            == "ynison_sd_yandex_music--test_t1"
+        )
         cached_value = provider.mass.cache.set.call_args[0][1]  # type: ignore[attr-defined]
         assert cached_value["data"] == sd.data
 
@@ -2257,12 +2395,52 @@ class TestGetStreamDetailsWithRetry:
         cached_sd.expiration = 600
         provider.mass.cache.get = AsyncMock(return_value=cached_sd)  # type: ignore[method-assign]
         mock_yp = MagicMock()
+        _set_stream_owner(mock_yp, cached_sd)
         mock_yp.get_stream_details = AsyncMock()
         provider._yandex_provider = mock_yp
 
         result = await provider._get_stream_details_with_retry("t1")
         assert result is cached_sd
         mock_yp.get_stream_details.assert_not_awaited()
+
+    async def test_cache_owner_mismatch_is_discarded(self) -> None:
+        """Cached details from another linked instance are never leased or streamed."""
+        provider = _make_provider()
+        cached_sd = MagicMock()
+        cached_sd.provider = "yandex_music--other"
+        provider.mass.cache.get = AsyncMock(return_value=cached_sd)  # type: ignore[method-assign]
+        fresh_sd = MagicMock()
+        fresh_sd.expiration = 60
+        fresh_sd.to_dict.return_value = {}
+        fresh_sd.data = None
+        mock_yp = MagicMock()
+        _set_stream_owner(mock_yp, fresh_sd)
+        mock_yp.get_stream_details = AsyncMock(return_value=fresh_sd)
+        provider._yandex_provider = mock_yp
+
+        result = await provider._get_stream_details_with_retry("t1")
+
+        assert result is fresh_sd
+        provider.mass.cache.delete.assert_awaited_once_with(  # type: ignore[attr-defined]
+            "ynison_sd_yandex_music--test_t1",
+            provider=provider.instance_id,
+        )
+        mock_yp.get_stream_details.assert_awaited_once()
+
+    async def test_fresh_owner_mismatch_is_not_retried(self) -> None:
+        """A deterministic provider-owner violation remains actionable and immediate."""
+        provider = _make_provider()
+        streamdetails = MagicMock()
+        streamdetails.provider = "yandex_music--other"
+        mock_yp = MagicMock()
+        _set_stream_owner(mock_yp)
+        mock_yp.get_stream_details = AsyncMock(return_value=streamdetails)
+        provider._yandex_provider = mock_yp
+
+        with pytest.raises(InvalidDataError, match="expected yandex_music--test"):
+            await provider._get_stream_details_with_retry("t1")
+
+        mock_yp.get_stream_details.assert_awaited_once()
 
     async def test_retries_on_failure(self) -> None:
         """Retries on transient error, succeeds on second attempt."""
@@ -2271,6 +2449,7 @@ class TestGetStreamDetailsWithRetry:
         sd = MagicMock()
         sd.expiration = 600
         sd.to_dict.return_value = {"track_id": "t1"}
+        _set_stream_owner(mock_yp, sd)
         mock_yp.get_stream_details = AsyncMock(side_effect=[RuntimeError("transient"), sd])
         provider._yandex_provider = mock_yp
 
@@ -2285,6 +2464,7 @@ class TestGetStreamDetailsWithRetry:
         """Raises RuntimeError after all retries exhausted."""
         provider = _make_provider()
         mock_yp = MagicMock()
+        _set_stream_owner(mock_yp)
         mock_yp.get_stream_details = AsyncMock(side_effect=RuntimeError("always fails"))
         provider._yandex_provider = mock_yp
 
@@ -2302,6 +2482,7 @@ class TestGetStreamDetailsWithRetry:
         """CancelledError propagates immediately, no retry."""
         provider = _make_provider()
         mock_yp = MagicMock()
+        _set_stream_owner(mock_yp)
         mock_yp.get_stream_details = AsyncMock(side_effect=asyncio.CancelledError())
         provider._yandex_provider = mock_yp
 
@@ -2581,10 +2762,12 @@ class TestInvalidateStreamCache:
         provider.mass.cache = MagicMock()
         provider.mass.cache.delete = AsyncMock()
 
-        await provider._invalidate_stream_cache("track:42")
+        await provider._invalidate_stream_cache(
+            "track:42", provider_instance_id="yandex_music--test"
+        )
 
         provider.mass.cache.delete.assert_called_once_with(
-            "ynison_sd_track:42",
+            "ynison_sd_yandex_music--test_track:42",
             provider=provider.instance_id,
         )
 
@@ -2907,6 +3090,7 @@ class TestPrefetchFlowsThroughToStreamDetails:
         assert default_rate != 96_000  # sanity: ensure we'll see a change
 
         mock_yandex = MagicMock()
+        _set_stream_owner(mock_yandex)
 
         async def _fake_get_stream_details(_track_id: str, _media_type: MediaType) -> Any:
             sd = MagicMock()
@@ -2920,6 +3104,7 @@ class TestPrefetchFlowsThroughToStreamDetails:
                 channels=2,
             )
             sd.to_dict = MagicMock(return_value={})
+            sd.provider = mock_yandex.instance_id
             return sd
 
         mock_yandex.get_stream_details = AsyncMock(side_effect=_fake_get_stream_details)
@@ -3149,6 +3334,90 @@ class TestNaturalEndDifferentiation:
     # belt-and-braces; intentionally untested.
 
 
+class _TrackingSlot:
+    """Stream-slot double that records acquire/release ordering."""
+
+    def __init__(self, events: list[str], index: int) -> None:
+        self._events = events
+        self._index = index
+
+    async def __aenter__(self) -> None:
+        self._events.append(f"acquired-{self._index}")
+
+    async def __aexit__(self, *_args: object) -> None:
+        self._events.append(f"released-{self._index}")
+
+
+class TestLinkedSlotRelease:
+    """The linked provider's stream slot is released as soon as a track stops streaming."""
+
+    @staticmethod
+    def _build() -> YandexYnisonProvider:
+        provider = _make_provider()
+        provider._yandex_provider = MagicMock()
+        provider._in_use_by_queue = "player1"
+        provider._active_session_id = "session-1"
+        ynison = MagicMock()
+        ynison.connected = True
+        ynison.state.is_paused = False
+        ynison.state.current_track_id = "track42"
+        provider._ynison = ynison
+        return provider
+
+    async def test_consumer_close_releases_slot(self) -> None:
+        """Closing the audio stream mid-track finalizes the generator holding the slot."""
+        provider = self._build()
+        events: list[str] = []
+
+        async def _endless_stream(
+            _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
+        ) -> Any:
+            del seek_ms, session_params  # signature-compat with _stream_track
+            async with _TrackingSlot(events, 1):
+                while True:
+                    yield b"\x00\x00\x00\x00"
+
+        _stub_attr(provider, "_stream_track", _endless_stream)
+
+        gen = provider.get_audio_stream(MagicMock(), seek_position=0)
+        assert await anext(gen) == b"\x00\x00\x00\x00"
+        assert events == ["acquired-1"]
+
+        await gen.aclose()
+
+        assert events == ["acquired-1", "released-1"]
+
+    async def test_track_change_releases_slot_before_next_track(self) -> None:
+        """A track change never leaves the previous track's slot charged."""
+        provider = self._build()
+        events: list[str] = []
+        invocations = 0
+
+        async def _two_pass_stream(
+            _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
+        ) -> Any:
+            del seek_ms, session_params  # signature-compat with _stream_track
+            nonlocal invocations
+            invocations += 1
+            index = invocations
+            async with _TrackingSlot(events, index):
+                while True:
+                    yield b"\x00\x00\x00\x00"
+                    if index == 1:
+                        provider._track_changed_event.set()
+                    else:
+                        provider._stream_stop_event.set()
+
+        _stub_attr(provider, "_stream_track", _two_pass_stream)
+
+        gen = provider.get_audio_stream(MagicMock(), seek_position=0)
+        with suppress(StopAsyncIteration):
+            async for _ in gen:
+                pass
+
+        assert events == ["acquired-1", "released-1", "acquired-2", "released-2"]
+
+
 class TestBypassThrottlerScope:
     """`BYPASS_THROTTLER` is set inside `_stream_track`, NOT inside prefetch."""
 
@@ -3157,6 +3426,7 @@ class TestBypassThrottlerScope:
         provider = _make_provider()
         observed: list[bool] = []
         mock_yandex = MagicMock()
+        _set_stream_owner(mock_yandex)
 
         async def _fake_get_stream_details(_track_id: str, _media_type: Any) -> Any:
             observed.append(BYPASS_THROTTLER.get())
@@ -3164,6 +3434,7 @@ class TestBypassThrottlerScope:
             sd.expiration = 0
             sd.duration = 1
             sd.audio_format = MagicMock()
+            sd.provider = mock_yandex.instance_id
             return sd
 
         mock_yandex.get_stream_details = AsyncMock(side_effect=_fake_get_stream_details)
@@ -3203,6 +3474,7 @@ class TestBypassThrottlerScope:
         provider = _make_provider()
         observed: list[bool] = []
         mock_yandex = MagicMock()
+        _set_stream_owner(mock_yandex)
 
         async def _fake_get_stream_details(_track_id: str, _media_type: Any) -> Any:
             observed.append(BYPASS_THROTTLER.get())
@@ -3211,6 +3483,7 @@ class TestBypassThrottlerScope:
             sd.audio_format = MagicMock()
             sd.audio_format.sample_rate = 44100
             sd.audio_format.bit_depth = 16
+            sd.provider = mock_yandex.instance_id
             return sd
 
         mock_yandex.get_stream_details = AsyncMock(side_effect=_fake_get_stream_details)


### PR DESCRIPTION
# What does this implement/fix?

Music providers could end up with many upstream source streams open at once (playback, buffering ahead, preparing the next track), which can exceed what a provider or account allows.

- Providers now declare how many concurrent source streams Music Assistant may open: evidence-backed limits for Spotify (2) and Apple Music / YouTube Music / Pandora (1), a conservative default of 5 for other streaming catalogs, and no limit for local and public radio/podcast sources.
- A slot is only held while the upstream source is actually being read (buffering) — never for audible playback out of an already filled buffer.
- When a provider has no free slot, playback automatically retries compatible provider mappings (including other configured instances of the same provider) within a bounded budget, preserving quality order and user provider steering.
- A track skip hands the previous item's source slot to the item being started.
- Speculative next-track preparation gives up softly after a few seconds; a capacity miss never marks an item unplayable, and flow mode skips the track instead of ending the stream.
- Crossfades degrade safely when the next track could not be prebuffered: smart fade when its audio is ready, a short standard fade from whatever audio is resident, otherwise no fade — and the next track then resumes at exactly the position the fade consumed.
- Yandex Ynison playback now counts against the linked Yandex Music account.

Behavior note: a source that fails before any audio was ready now reports its error right away instead of first playing a few seconds of partial audio.

<details>
<summary>Provider limit audit</summary>

| Limit | Providers |
| --- | --- |
| 1 | `apple_music`, `pandora`, `ytmusic` |
| 2 | `spotify` |
| 5 (default) | all other streaming catalogs (e.g. `tidal`, `qobuz`, `deezer`, `soundcloud`, `audible`, `siriusxm`, ...) — lowered later where evidence shows a stricter service limit |
| Unlimited | local/self-hosted sources (`filesystem_*`, `plex`, `jellyfin`, `emby`, `opensubsonic`, ...) and public radio/podcast directories (`radiobrowser`, `tunein`, `somafm`, `radioparadise`, `podcast_index`, `itunes_podcasts`, and similar) |

</details>

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
