### PR TITLE
Match album editions across providers

### DIFF
--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -52,6 +52,17 @@ if TYPE_CHECKING:
     from music_assistant.providers.musicbrainz.models import MusicBrainzBarcodeRelease
 
 
+# expected failures from a provider album-track lookup: a missing item or a transient
+# provider/transport outage. Either leaves that tracklist unavailable so the (best-effort,
+# multi-provider) match can continue rather than aborting the whole operation.
+_ALBUM_TRACK_LOOKUP_ERRORS = (
+    MediaNotFoundError,
+    RetriesExhausted,
+    TimeoutError,
+    aiohttp.ClientError,
+)
+
+
 @dataclass
 class _BaseTracksMemo:
     """Single-slot memo for a base album tracklist, shared across match candidates."""
@@ -719,8 +730,14 @@ class AlbumsController(MediaControllerBase[Album]):
             compare_tracks = await self._get_provider_album_tracks(
                 prov_album.item_id, prov_album.provider
             )
-        except MediaNotFoundError:
-            # the candidate tracklist is gone: treat it as absent and let MusicBrainz decide
+        except _ALBUM_TRACK_LOOKUP_ERRORS as err:
+            # the candidate tracklist is unavailable: treat it as absent and let MusicBrainz decide
+            self.logger.debug(
+                "Album tracks unavailable for %s on %s: %s",
+                prov_album.item_id,
+                prov_album.provider,
+                err,
+            )
             compare_tracks = []
         evidence = compare_album_evidence(
             db_album,
@@ -776,7 +793,14 @@ class AlbumsController(MediaControllerBase[Album]):
                 provider_tracks = await self._get_provider_album_tracks(
                     mapping.item_id, mapping.provider_instance
                 )
-            except MediaNotFoundError:
+            except _ALBUM_TRACK_LOOKUP_ERRORS as err:
+                # this mapping's tracklist is unavailable: try the next existing mapping
+                self.logger.debug(
+                    "Base album tracks unavailable for %s on %s: %s",
+                    mapping.item_id,
+                    mapping.provider_instance,
+                    err,
+                )
                 continue
             if album_tracks_have_positions(provider_tracks):
                 return provider_tracks

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
     from music_assistant import MusicAssistant
     from music_assistant.providers.musicbrainz import MusicbrainzProvider
-    from music_assistant.providers.musicbrainz.models import MusicBrainzRelease
+    from music_assistant.providers.musicbrainz.models import MusicBrainzBarcodeRelease
 
 
 @dataclass
@@ -763,8 +763,14 @@ class AlbumsController(MediaControllerBase[Album]):
         ):
             if not mapping.available:
                 continue
-            if self.mass.get_provider(mapping.provider_instance) is None:
-                # only trust a currently-loaded exact provider instance
+            provider = self.mass.get_provider(mapping.provider_instance, return_unavailable=True)
+            if (
+                provider is None
+                or provider.instance_id != mapping.provider_instance
+                or not provider.available
+            ):
+                # only trust the exact, currently-available provider instance and never a
+                # same-domain fallback pointing at a different account/server
                 continue
             try:
                 provider_tracks = await self._get_provider_album_tracks(
@@ -796,7 +802,7 @@ class AlbumsController(MediaControllerBase[Album]):
         if musicbrainz is None:
             return AlbumMatchEvidence.INSUFFICIENT
         musicbrainz = cast("MusicbrainzProvider", musicbrainz)
-        releases_by_barcode: dict[str, list[MusicBrainzRelease]] = {}
+        releases_by_barcode: dict[str, list[MusicBrainzBarcodeRelease]] = {}
         try:
             for barcode in sorted(base_barcodes | compare_barcodes):
                 releases_by_barcode[barcode] = await musicbrainz.get_releases_by_barcode(barcode)
@@ -812,9 +818,13 @@ class AlbumsController(MediaControllerBase[Album]):
         if base_release_ids & compare_release_ids:
             # both albums carry a barcode that names the same single specific release
             return AlbumMatchEvidence.MATCH
+        if not all(releases_by_barcode[barcode] for barcode in base_barcodes | compare_barcodes):
+            # an unresolved barcode leaves the release-group sets incomplete, so a disjoint
+            # comparison could wrongly reject regional equivalents: abstain instead
+            return AlbumMatchEvidence.INSUFFICIENT
         base_group_ids = _release_group_ids(base_barcodes, releases_by_barcode)
         compare_group_ids = _release_group_ids(compare_barcodes, releases_by_barcode)
-        if base_group_ids and compare_group_ids and base_group_ids.isdisjoint(compare_group_ids):
+        if base_group_ids.isdisjoint(compare_group_ids):
             # the barcodes belong to entirely different release groups: different albums
             return AlbumMatchEvidence.NO_MATCH
         # a shared release group alone (or an ambiguous barcode) never identifies an edition
@@ -903,7 +913,7 @@ def _canonical_album_barcodes(album: Album) -> set[str]:
 
 
 def _unambiguous_release_ids(
-    barcodes: set[str], releases_by_barcode: dict[str, list[MusicBrainzRelease]]
+    barcodes: set[str], releases_by_barcode: dict[str, list[MusicBrainzBarcodeRelease]]
 ) -> set[str]:
     """Return release ids that at least one of the barcodes resolves to unambiguously."""
     release_ids: set[str] = set()
@@ -916,7 +926,7 @@ def _unambiguous_release_ids(
 
 
 def _release_group_ids(
-    barcodes: set[str], releases_by_barcode: dict[str, list[MusicBrainzRelease]]
+    barcodes: set[str], releases_by_barcode: dict[str, list[MusicBrainzBarcodeRelease]]
 ) -> set[str]:
     """Return every release-group id the barcodes resolve to."""
     return {

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -696,7 +696,7 @@ class AlbumsController(MediaControllerBase[Album]):
                 fallback=search_result_item,
             )
             evidence = await self._resolve_album_evidence(
-                db_album, prov_album, strict, base_tracks_memo
+                db_album, prov_album, provider, strict, base_tracks_memo
             )
             if evidence == AlbumMatchEvidence.MATCH:
                 matches.extend(prov_album.provider_mappings)
@@ -712,6 +712,7 @@ class AlbumsController(MediaControllerBase[Album]):
         self,
         db_album: Album,
         prov_album: Album,
+        provider: MusicProvider,
         strict: bool,
         base_tracks_memo: _BaseTracksMemo,
     ) -> AlbumMatchEvidence:
@@ -720,6 +721,10 @@ class AlbumsController(MediaControllerBase[Album]):
 
         An ambiguous album is escalated to ordered track fingerprints and, only if those
         stay inconclusive, to MusicBrainz; a mapping is accepted only on a MATCH.
+
+        :param provider: The exact provider instance the candidate album was matched on;
+            its tracklist is fetched directly so a same-domain fallback can never
+            fingerprint the candidate against a different account/server.
         """
         evidence = compare_album_evidence(db_album, prov_album, strict=strict)
         if evidence != AlbumMatchEvidence.INSUFFICIENT:
@@ -727,15 +732,13 @@ class AlbumsController(MediaControllerBase[Album]):
         # ambiguous metadata: resolve conservatively with ordered track fingerprints
         base_tracks = await self._resolve_base_album_tracks(db_album, base_tracks_memo)
         try:
-            compare_tracks = await self._get_provider_album_tracks(
-                prov_album.item_id, prov_album.provider
-            )
+            compare_tracks = await provider.get_album_tracks(prov_album.item_id)
         except _ALBUM_TRACK_LOOKUP_ERRORS as err:
             # the candidate tracklist is unavailable: treat it as absent and let MusicBrainz decide
             self.logger.debug(
                 "Album tracks unavailable for %s on %s: %s",
                 prov_album.item_id,
-                prov_album.provider,
+                provider.instance_id,
                 err,
             )
             compare_tracks = []

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
+import aiohttp
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import AlbumType, ExternalID, MediaType, ProviderFeature
 from music_assistant_models.errors import (
@@ -48,6 +49,7 @@ if TYPE_CHECKING:
 
     from music_assistant import MusicAssistant
     from music_assistant.providers.musicbrainz import MusicbrainzProvider
+    from music_assistant.providers.musicbrainz.models import MusicBrainzRelease
 
 
 @dataclass
@@ -713,9 +715,13 @@ class AlbumsController(MediaControllerBase[Album]):
             return evidence
         # ambiguous metadata: resolve conservatively with ordered track fingerprints
         base_tracks = await self._resolve_base_album_tracks(db_album, base_tracks_memo)
-        compare_tracks = await self._get_provider_album_tracks(
-            prov_album.item_id, prov_album.provider
-        )
+        try:
+            compare_tracks = await self._get_provider_album_tracks(
+                prov_album.item_id, prov_album.provider
+            )
+        except MediaNotFoundError:
+            # the candidate tracklist is gone: treat it as absent and let MusicBrainz decide
+            compare_tracks = []
         evidence = compare_album_evidence(
             db_album,
             prov_album,
@@ -739,18 +745,36 @@ class AlbumsController(MediaControllerBase[Album]):
 
     async def _load_base_album_tracks(self, db_album: Album) -> list[Track] | None:
         """
-        Return an ordered base tracklist to fingerprint against.
+        Return a complete, ordered base tracklist to fingerprint against.
 
-        Prefers the already-stored library tracks when their disc/track positions can be
-        trusted, and otherwise fetches from a single existing provider mapping.
+        Iterates the album's existing provider mappings in a deterministic order and
+        returns the first loaded provider's full tracklist whose disc/track positions can
+        be trusted. A provider-sourced tracklist is used rather than the stored library
+        tracks because those can be an incomplete subset (individually added tracks), and
+        an incomplete base would make a track-count difference look like a real conflict.
         """
-        library_tracks = await self.get_library_album_tracks(db_album.item_id)
-        if album_tracks_have_positions(library_tracks):
-            return library_tracks
-        mapping = next((m for m in db_album.provider_mappings if m.available), None)
-        if mapping is None:
-            return None
-        return await self._get_provider_album_tracks(mapping.item_id, mapping.provider_instance)
+        for mapping in sorted(
+            db_album.provider_mappings,
+            key=lambda mapping: (
+                mapping.provider_domain,
+                mapping.provider_instance,
+                mapping.item_id,
+            ),
+        ):
+            if not mapping.available:
+                continue
+            if self.mass.get_provider(mapping.provider_instance) is None:
+                # only trust a currently-loaded exact provider instance
+                continue
+            try:
+                provider_tracks = await self._get_provider_album_tracks(
+                    mapping.item_id, mapping.provider_instance
+                )
+            except MediaNotFoundError:
+                continue
+            if album_tracks_have_positions(provider_tracks):
+                return provider_tracks
+        return None
 
     async def _musicbrainz_album_evidence(
         self, base_album: Album, compare_album: Album
@@ -758,47 +782,42 @@ class AlbumsController(MediaControllerBase[Album]):
         """
         Return album match evidence from MusicBrainz release identity, or abstain.
 
-        Two barcodes resolving to the same specific MusicBrainz release are strong
-        positive evidence; barcodes belonging to entirely different release groups are
-        negative. A shared release group alone, an unresolved barcode or a lookup failure
-        abstains (INSUFFICIENT) rather than guessing.
+        A barcode that resolves unambiguously to a single specific MusicBrainz release on
+        both albums is strong positive evidence; barcodes belonging to entirely different
+        release groups are negative. A barcode resolving to several releases, a shared
+        release group alone, an unresolved barcode or a lookup failure abstains
+        (INSUFFICIENT) rather than guessing.
         """
-        base_barcode = _canonical_album_barcode(base_album)
-        compare_barcode = _canonical_album_barcode(compare_album)
-        if not base_barcode or not compare_barcode:
+        base_barcodes = _canonical_album_barcodes(base_album)
+        compare_barcodes = _canonical_album_barcodes(compare_album)
+        if not base_barcodes or not compare_barcodes:
             return AlbumMatchEvidence.INSUFFICIENT
         musicbrainz = self.mass.get_provider("musicbrainz")
         if musicbrainz is None:
             return AlbumMatchEvidence.INSUFFICIENT
         musicbrainz = cast("MusicbrainzProvider", musicbrainz)
+        releases_by_barcode: dict[str, list[MusicBrainzRelease]] = {}
         try:
-            base_releases = await musicbrainz.get_releases_by_barcode(base_barcode)
-            if not base_releases:
-                return AlbumMatchEvidence.INSUFFICIENT
-            if compare_barcode == base_barcode:
-                compare_releases = base_releases
-            else:
-                compare_releases = await musicbrainz.get_releases_by_barcode(compare_barcode)
-        except (RetriesExhausted, InvalidDataError) as err:
+            for barcode in sorted(base_barcodes | compare_barcodes):
+                releases_by_barcode[barcode] = await musicbrainz.get_releases_by_barcode(barcode)
+        except (RetriesExhausted, InvalidDataError, TimeoutError, aiohttp.ClientError) as err:
             self.logger.debug(
                 "MusicBrainz barcode lookup failed while matching album %s: %s",
                 base_album.name,
                 err,
             )
             return AlbumMatchEvidence.INSUFFICIENT
-        if not compare_releases:
-            return AlbumMatchEvidence.INSUFFICIENT
-        base_release_ids = {release.id for release in base_releases}
-        compare_release_ids = {release.id for release in compare_releases}
+        base_release_ids = _unambiguous_release_ids(base_barcodes, releases_by_barcode)
+        compare_release_ids = _unambiguous_release_ids(compare_barcodes, releases_by_barcode)
         if base_release_ids & compare_release_ids:
-            # both barcodes resolve to the same specific release: the same edition
+            # both albums carry a barcode that names the same single specific release
             return AlbumMatchEvidence.MATCH
-        base_group_ids = {release.release_group.id for release in base_releases}
-        compare_group_ids = {release.release_group.id for release in compare_releases}
+        base_group_ids = _release_group_ids(base_barcodes, releases_by_barcode)
+        compare_group_ids = _release_group_ids(compare_barcodes, releases_by_barcode)
         if base_group_ids and compare_group_ids and base_group_ids.isdisjoint(compare_group_ids):
             # the barcodes belong to entirely different release groups: different albums
             return AlbumMatchEvidence.NO_MATCH
-        # a shared release group alone never identifies a specific edition
+        # a shared release group alone (or an ambiguous barcode) never identifies an edition
         return AlbumMatchEvidence.INSUFFICIENT
 
     async def _set_album_artists(
@@ -874,9 +893,34 @@ class AlbumsController(MediaControllerBase[Album]):
         return item
 
 
-def _canonical_album_barcode(album: Album) -> str | None:
-    """Return an album's barcode in canonical UPC form, or None if it has no valid barcode."""
-    barcode = album.get_external_id(ExternalID.BARCODE)
-    if not barcode or not is_valid_barcode(barcode):
-        return None
-    return barcode_to_upc(barcode)
+def _canonical_album_barcodes(album: Album) -> set[str]:
+    """Return an album's valid barcodes in canonical UPC form."""
+    return {
+        barcode_to_upc(value)
+        for external_id_type, value in album.external_ids
+        if external_id_type == ExternalID.BARCODE and is_valid_barcode(value)
+    }
+
+
+def _unambiguous_release_ids(
+    barcodes: set[str], releases_by_barcode: dict[str, list[MusicBrainzRelease]]
+) -> set[str]:
+    """Return release ids that at least one of the barcodes resolves to unambiguously."""
+    release_ids: set[str] = set()
+    for barcode in barcodes:
+        resolved = {release.id for release in releases_by_barcode.get(barcode, [])}
+        # only a barcode that maps to exactly one specific release is trustworthy evidence
+        if len(resolved) == 1:
+            release_ids |= resolved
+    return release_ids
+
+
+def _release_group_ids(
+    barcodes: set[str], releases_by_barcode: dict[str, list[MusicBrainzRelease]]
+) -> set[str]:
+    """Return every release-group id the barcodes resolve to."""
+    return {
+        release.release_group.id
+        for barcode in barcodes
+        for release in releases_by_barcode.get(barcode, [])
+    }

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import AlbumType, ExternalID, MediaType, ProviderFeature
-from music_assistant_models.errors import InvalidDataError, MediaNotFoundError, MusicAssistantError
+from music_assistant_models.errors import (
+    InvalidDataError,
+    MediaNotFoundError,
+    MusicAssistantError,
+    RetriesExhausted,
+)
 from music_assistant_models.helpers import create_safe_string
 from music_assistant_models.media_items import (
     Album,
@@ -24,12 +30,14 @@ from music_assistant_models.media_items import (
 from music_assistant.constants import DB_TABLE_ALBUM_ARTISTS, DB_TABLE_ALBUM_TRACKS, DB_TABLE_ALBUMS
 from music_assistant.controllers.music.helpers import search_name_match_clause
 from music_assistant.helpers.compare import (
-    compare_album,
+    AlbumMatchEvidence,
+    album_tracks_have_positions,
+    compare_album_evidence,
     compare_artists,
-    compare_media_item,
     loose_compare_strings,
 )
 from music_assistant.helpers.database import UNSET
+from music_assistant.helpers.external_ids import barcode_to_upc, is_valid_barcode
 from music_assistant.helpers.json import serialize_to_json
 from music_assistant.models.music_provider import MusicProvider
 
@@ -39,6 +47,15 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from music_assistant import MusicAssistant
+    from music_assistant.providers.musicbrainz import MusicbrainzProvider
+
+
+@dataclass
+class _BaseTracksMemo:
+    """Single-slot memo for a base album tracklist, shared across match candidates."""
+
+    resolved: bool = False
+    tracks: list[Track] | None = None
 
 
 class AlbumsController(MediaControllerBase[Album]):
@@ -493,36 +510,14 @@ class AlbumsController(MediaControllerBase[Album]):
         self, db_album: Album, provider: MusicProvider, strict: bool = True
     ) -> list[ProviderMapping]:
         """
-        Try to find match on (streaming) provider for the provided (database) album.
+        Try to find a match on the given (streaming) provider for a (database) album.
 
-        This is used to link objects of different providers/qualities together.
+        Links albums of different providers/qualities together. Sparse provider search
+        results only rule out a confident non-match; a candidate that still looks
+        ambiguous is confirmed against the full provider album, its tracklist and, as a
+        last resort, MusicBrainz before its provider mapping is accepted.
         """
-        self.logger.debug("Trying to match album %s on provider %s", db_album.name, provider.name)
-        matches: list[ProviderMapping] = []
-        artist_name = db_album.artists[0].name
-        search_str = f"{artist_name} - {db_album.name}"
-        search_result = await self.search(search_str, provider.instance_id)
-        for search_result_item in search_result:
-            if not search_result_item.available:
-                continue
-            if not compare_media_item(db_album, search_result_item, strict=strict):
-                continue
-            # we must fetch the full album version, search results can be simplified objects
-            prov_album = await self.get_provider_item(
-                search_result_item.item_id,
-                search_result_item.provider,
-                fallback=search_result_item,
-            )
-            if compare_album(db_album, prov_album, strict=strict):
-                # 100% match
-                matches.extend(prov_album.provider_mappings)
-        if not matches:
-            self.logger.debug(
-                "Could not find match for Album %s on provider %s",
-                db_album.name,
-                provider.name,
-            )
-        return matches
+        return await self._match_provider(db_album, provider, strict, _BaseTracksMemo())
 
     async def match_providers(self, db_album: Album) -> None:
         """
@@ -535,6 +530,8 @@ class AlbumsController(MediaControllerBase[Album]):
         if not db_album.artists:
             return  # guard
 
+        # resolve the base tracklist at most once for the whole match operation
+        base_tracks_memo = _BaseTracksMemo()
         # try to find match on all providers
         processed_domains = set()
         for provider in self.mass.music.providers:
@@ -547,7 +544,7 @@ class AlbumsController(MediaControllerBase[Album]):
             if not provider.is_streaming_provider:
                 # matching on unique providers is pointless as they push (all) their content to MA
                 continue
-            if match := await self.match_provider(db_album, provider):
+            if match := await self._match_provider(db_album, provider, True, base_tracks_memo):
                 # 100% match, we update the db with the additional provider mapping(s)
                 await self.add_provider_mappings(db_album.item_id, match)
                 processed_domains.add(provider.domain)
@@ -657,6 +654,153 @@ class AlbumsController(MediaControllerBase[Album]):
             return await prov.get_album_tracks(item_id)
         return []
 
+    async def _match_provider(
+        self,
+        db_album: Album,
+        provider: MusicProvider,
+        strict: bool,
+        base_tracks_memo: _BaseTracksMemo,
+    ) -> list[ProviderMapping]:
+        """Search one provider and return the mappings of every confirmed album match."""
+        self.logger.debug("Trying to match album %s on provider %s", db_album.name, provider.name)
+        matches: list[ProviderMapping] = []
+        artist_name = db_album.artists[0].name
+        search_str = f"{artist_name} - {db_album.name}"
+        for search_result_item in await self.search(search_str, provider.instance_id):
+            if not search_result_item.available:
+                continue
+            # a sparse search result only rules out a confident non-match; a MATCH or an
+            # ambiguous (INSUFFICIENT) candidate is confirmed against the full album below
+            if (
+                compare_album_evidence(db_album, search_result_item, strict=strict)
+                == AlbumMatchEvidence.NO_MATCH
+            ):
+                continue
+            # search results can be simplified objects, so fetch the full provider album
+            prov_album = await self.get_provider_item(
+                search_result_item.item_id,
+                search_result_item.provider,
+                fallback=search_result_item,
+            )
+            evidence = await self._resolve_album_evidence(
+                db_album, prov_album, strict, base_tracks_memo
+            )
+            if evidence == AlbumMatchEvidence.MATCH:
+                matches.extend(prov_album.provider_mappings)
+        if not matches:
+            self.logger.debug(
+                "Could not find match for Album %s on provider %s",
+                db_album.name,
+                provider.name,
+            )
+        return matches
+
+    async def _resolve_album_evidence(
+        self,
+        db_album: Album,
+        prov_album: Album,
+        strict: bool,
+        base_tracks_memo: _BaseTracksMemo,
+    ) -> AlbumMatchEvidence:
+        """
+        Return the match evidence for a fully-fetched provider album.
+
+        An ambiguous album is escalated to ordered track fingerprints and, only if those
+        stay inconclusive, to MusicBrainz; a mapping is accepted only on a MATCH.
+        """
+        evidence = compare_album_evidence(db_album, prov_album, strict=strict)
+        if evidence != AlbumMatchEvidence.INSUFFICIENT:
+            return evidence
+        # ambiguous metadata: resolve conservatively with ordered track fingerprints
+        base_tracks = await self._resolve_base_album_tracks(db_album, base_tracks_memo)
+        compare_tracks = await self._get_provider_album_tracks(
+            prov_album.item_id, prov_album.provider
+        )
+        evidence = compare_album_evidence(
+            db_album,
+            prov_album,
+            strict=strict,
+            base_tracks=base_tracks,
+            compare_tracks=compare_tracks,
+        )
+        if evidence != AlbumMatchEvidence.INSUFFICIENT:
+            return evidence
+        # tracklists could not resolve it either: consult MusicBrainz as a last resort
+        return await self._musicbrainz_album_evidence(db_album, prov_album)
+
+    async def _resolve_base_album_tracks(
+        self, db_album: Album, base_tracks_memo: _BaseTracksMemo
+    ) -> list[Track] | None:
+        """Return the memoized base tracklist, resolving it once on first use."""
+        if not base_tracks_memo.resolved:
+            base_tracks_memo.tracks = await self._load_base_album_tracks(db_album)
+            base_tracks_memo.resolved = True
+        return base_tracks_memo.tracks
+
+    async def _load_base_album_tracks(self, db_album: Album) -> list[Track] | None:
+        """
+        Return an ordered base tracklist to fingerprint against.
+
+        Prefers the already-stored library tracks when their disc/track positions can be
+        trusted, and otherwise fetches from a single existing provider mapping.
+        """
+        library_tracks = await self.get_library_album_tracks(db_album.item_id)
+        if album_tracks_have_positions(library_tracks):
+            return library_tracks
+        mapping = next((m for m in db_album.provider_mappings if m.available), None)
+        if mapping is None:
+            return None
+        return await self._get_provider_album_tracks(mapping.item_id, mapping.provider_instance)
+
+    async def _musicbrainz_album_evidence(
+        self, base_album: Album, compare_album: Album
+    ) -> AlbumMatchEvidence:
+        """
+        Return album match evidence from MusicBrainz release identity, or abstain.
+
+        Two barcodes resolving to the same specific MusicBrainz release are strong
+        positive evidence; barcodes belonging to entirely different release groups are
+        negative. A shared release group alone, an unresolved barcode or a lookup failure
+        abstains (INSUFFICIENT) rather than guessing.
+        """
+        base_barcode = _canonical_album_barcode(base_album)
+        compare_barcode = _canonical_album_barcode(compare_album)
+        if not base_barcode or not compare_barcode:
+            return AlbumMatchEvidence.INSUFFICIENT
+        musicbrainz = self.mass.get_provider("musicbrainz")
+        if musicbrainz is None:
+            return AlbumMatchEvidence.INSUFFICIENT
+        musicbrainz = cast("MusicbrainzProvider", musicbrainz)
+        try:
+            base_releases = await musicbrainz.get_releases_by_barcode(base_barcode)
+            if not base_releases:
+                return AlbumMatchEvidence.INSUFFICIENT
+            if compare_barcode == base_barcode:
+                compare_releases = base_releases
+            else:
+                compare_releases = await musicbrainz.get_releases_by_barcode(compare_barcode)
+        except (RetriesExhausted, InvalidDataError) as err:
+            self.logger.debug(
+                "MusicBrainz barcode lookup failed while matching album %s: %s",
+                base_album.name,
+                err,
+            )
+            return AlbumMatchEvidence.INSUFFICIENT
+        if not compare_releases:
+            return AlbumMatchEvidence.INSUFFICIENT
+        base_release_ids = {release.id for release in base_releases}
+        compare_release_ids = {release.id for release in compare_releases}
+        if base_release_ids & compare_release_ids:
+            # both barcodes resolve to the same specific release: the same edition
+            return AlbumMatchEvidence.MATCH
+        base_group_ids = {release.release_group.id for release in base_releases}
+        compare_group_ids = {release.release_group.id for release in compare_releases}
+        if base_group_ids and compare_group_ids and base_group_ids.isdisjoint(compare_group_ids):
+            # the barcodes belong to entirely different release groups: different albums
+            return AlbumMatchEvidence.NO_MATCH
+        # a shared release group alone never identifies a specific edition
+        return AlbumMatchEvidence.INSUFFICIENT
+
     async def _set_album_artists(
         self,
         db_id: int,
@@ -728,3 +872,11 @@ class AlbumsController(MediaControllerBase[Album]):
         item.album_type = AlbumType(db_row["album_type"])
         item.artists = self._parse_summary_artist_mappings(db_row)
         return item
+
+
+def _canonical_album_barcode(album: Album) -> str | None:
+    """Return an album's barcode in canonical UPC form, or None if it has no valid barcode."""
+    barcode = album.get_external_id(ExternalID.BARCODE)
+    if not barcode or not is_valid_barcode(barcode):
+        return None
+    return barcode_to_upc(barcode)

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -274,6 +274,21 @@ def compare_album_track_fingerprint(
     return evidence
 
 
+def album_tracks_have_positions(tracks: Sequence[Track] | None) -> bool:
+    """
+    Return True if a tracklist has a trustworthy, unambiguous disc/track layout.
+
+    A caller choosing a base tracklist for album-track fingerprinting can use this to
+    prefer an already-available tracklist over fetching another one, only falling back
+    when the available tracklist's positions cannot be trusted.
+
+    :param tracks: Tracklist to inspect.
+    """
+    if not tracks:
+        return False
+    return bool(_track_positions(tracks))
+
+
 def compare_track(
     base_item: Track,
     compare_item: Track,

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -279,12 +279,16 @@ def album_tracks_have_positions(tracks: Sequence[Track] | None) -> bool:
     Return True if a tracklist has a trustworthy, unambiguous disc/track layout.
 
     A caller choosing a base tracklist for album-track fingerprinting can use this to
-    prefer an already-available tracklist over fetching another one, only falling back
-    when the available tracklist's positions cannot be trusted.
+    reject a tracklist whose positions cannot be trusted (a missing disc or track number,
+    or a duplicate position) and fall back to another source instead.
 
     :param tracks: Tracklist to inspect.
     """
     if not tracks:
+        return False
+    # a missing disc or track number is treated as unknown rather than silently assumed,
+    # so such a tracklist is not trusted as a shape reference
+    if any(not track.disc_number or not track.track_number for track in tracks):
         return False
     return bool(_track_positions(tracks))
 

--- a/music_assistant/helpers/external_ids.py
+++ b/music_assistant/helpers/external_ids.py
@@ -102,6 +102,19 @@ def is_valid_isrc(value: str) -> bool:
     return bool(_ISRC_PATTERN.fullmatch(normalize_external_id(ExternalID.ISRC, value)))
 
 
+def is_valid_barcode(value: str) -> bool:
+    """
+    Return whether a value is a structurally valid (canonical) barcode/GTIN.
+
+    An invalid barcode is still preserved as-is for storage/exact-match lookups, but
+    should be treated as absent by callers that rely on the barcode being a genuine
+    GTIN (e.g. a MusicBrainz release lookup).
+
+    :param value: Identifier value to validate.
+    """
+    return _is_valid_gtin(normalize_external_id(ExternalID.BARCODE, value))
+
+
 def external_id_lookup_values_untyped(value: str) -> tuple[str, ...]:
     """
     Return lookup values for an identifier whose type is not known.

--- a/music_assistant/providers/musicbrainz/models.py
+++ b/music_assistant/providers/musicbrainz/models.py
@@ -186,6 +186,28 @@ class MusicBrainzRelease(DataClassDictMixin):
 
 
 @dataclass
+class MusicBrainzBarcodeRelease(DataClassDictMixin):
+    """
+    Slim release identity from a barcode search result.
+
+    A barcode search only needs each hit's release and release-group id, so this
+    deliberately ignores the summary fields a search response carries (media without a
+    tracklist, artist credits, ...) that the full release model cannot parse.
+    """
+
+    id: str
+    release_group: MusicBrainzReleaseGroup
+
+    @classmethod
+    def from_raw(cls, data: Any) -> MusicBrainzBarcodeRelease:
+        """Instantiate object from raw api data."""
+        alt_data = replace_hyphens(data)
+        if TYPE_CHECKING:
+            alt_data = cast("dict[str, Any]", alt_data)
+        return MusicBrainzBarcodeRelease.from_dict(alt_data)
+
+
+@dataclass
 class MusicBrainzRecording(DataClassDictMixin):
     """Model for a (basic) Recording object as received from the MusicBrainz API."""
 

--- a/music_assistant/providers/musicbrainz/provider.py
+++ b/music_assistant/providers/musicbrainz/provider.py
@@ -353,7 +353,9 @@ class MusicbrainzProvider(MetadataProvider):
             if value.isdigit()
         ]
         query = " OR ".join(f"barcode:{value}" for value in barcodes)
-        result = await self._api_client.get_data("release", query=query)
+        # a barcode identifies a single physical product, so one generously-sized page
+        # returns every release carrying it (no pagination needed)
+        result = await self._api_client.get_data("release", query=query, limit="100")
         if not result or not (releases := result.get("releases")):
             return []
         parsed: list[MusicBrainzRelease] = []

--- a/music_assistant/providers/musicbrainz/provider.py
+++ b/music_assistant/providers/musicbrainz/provider.py
@@ -6,7 +6,7 @@ import re
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
-from mashumaro.exceptions import MissingField
+from mashumaro.exceptions import InvalidFieldValue, MissingField
 from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import ArtistEntityType, ConfigEntryType, ExternalID, LinkType
 from music_assistant_models.errors import InvalidDataError
@@ -30,6 +30,7 @@ from .constants import (
 )
 from .models import (
     MusicBrainzArtist,
+    MusicBrainzBarcodeRelease,
     MusicBrainzRecording,
     MusicBrainzRelation,
     MusicBrainzRelease,
@@ -336,9 +337,13 @@ class MusicbrainzProvider(MetadataProvider):
         msg = "Invalid MusicBrainz Album ID provided"
         raise InvalidDataError(msg)
 
-    async def get_releases_by_barcode(self, barcode: str) -> list[MusicBrainzRelease]:
+    async def get_releases_by_barcode(self, barcode: str) -> list[MusicBrainzBarcodeRelease]:
         """
         Get the releases MusicBrainz has on file for a barcode/UPC.
+
+        The result is complete: a truncated page or a release entry that cannot be parsed
+        raises :class:`InvalidDataError` so the caller abstains instead of mistaking a
+        partial release/group set for the whole set.
 
         :param barcode: Album barcode (UPC/EAN/GTIN), with or without separators.
         :return: Releases carrying this barcode, or an empty list if none are found.
@@ -354,15 +359,22 @@ class MusicbrainzProvider(MetadataProvider):
         ]
         query = " OR ".join(f"barcode:{value}" for value in barcodes)
         # a barcode identifies a single physical product, so one generously-sized page
-        # returns every release carrying it (no pagination needed)
+        # returns every release carrying it
         result = await self._api_client.get_data("release", query=query, limit="100")
         if not result or not (releases := result.get("releases")):
             return []
-        parsed: list[MusicBrainzRelease] = []
+        if result.get("count", len(releases)) > len(releases):
+            msg = "MusicBrainz barcode result is truncated"
+            raise InvalidDataError(msg)
+        parsed: list[MusicBrainzBarcodeRelease] = []
         for release in releases:
-            # a single malformed entry should not sink the releases we did parse
-            with suppress(MissingField):
-                parsed.append(MusicBrainzRelease.from_raw(release))
+            try:
+                parsed.append(MusicBrainzBarcodeRelease.from_raw(release))
+            except (MissingField, InvalidFieldValue) as err:
+                # dropping a malformed row would make the release/group set look complete
+                # when it is not, so the whole lookup is treated as unusable
+                msg = "MusicBrainz barcode result has an unparsable release"
+                raise InvalidDataError(msg) from err
         return parsed
 
     async def get_releasegroup_details(self, releasegroup_id: str) -> MusicBrainzReleaseGroup:

--- a/music_assistant/providers/musicbrainz/provider.py
+++ b/music_assistant/providers/musicbrainz/provider.py
@@ -16,6 +16,7 @@ from music_assistant_models.media_items.metadata import LifeSpan
 from music_assistant.constants import VARIOUS_ARTISTS_MBID
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.compare import compare_strings
+from music_assistant.helpers.external_ids import external_id_lookup_values, is_valid_barcode
 from music_assistant.helpers.util import parse_title_and_version
 from music_assistant.models.metadata_provider import MetadataProvider
 
@@ -334,6 +335,33 @@ class MusicbrainzProvider(MetadataProvider):
                 raise InvalidDataError from err
         msg = "Invalid MusicBrainz Album ID provided"
         raise InvalidDataError(msg)
+
+    async def get_releases_by_barcode(self, barcode: str) -> list[MusicBrainzRelease]:
+        """
+        Get the releases MusicBrainz has on file for a barcode/UPC.
+
+        :param barcode: Album barcode (UPC/EAN/GTIN), with or without separators.
+        :return: Releases carrying this barcode, or an empty list if none are found.
+        """
+        if not is_valid_barcode(barcode):
+            return []
+        # a UPC-12 and its zero-padded EAN-13/GTIN forms are the same physical barcode,
+        # so query every compatible form to also resolve a provider's shorter/longer notation
+        barcodes = [
+            value
+            for value in external_id_lookup_values(ExternalID.BARCODE, barcode)
+            if value.isdigit()
+        ]
+        query = " OR ".join(f"barcode:{value}" for value in barcodes)
+        result = await self._api_client.get_data("release", query=query)
+        if not result or not (releases := result.get("releases")):
+            return []
+        parsed: list[MusicBrainzRelease] = []
+        for release in releases:
+            # a single malformed entry should not sink the releases we did parse
+            with suppress(MissingField):
+                parsed.append(MusicBrainzRelease.from_raw(release))
+        return parsed
 
     async def get_releasegroup_details(self, releasegroup_id: str) -> MusicBrainzReleaseGroup:
         """Get ReleaseGroup details by providing a MusicBrainz ReleaseGroup id."""

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -20,6 +20,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.controllers.music.media.albums import AlbumsController
+from music_assistant.helpers.compare import AlbumMatchEvidence
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -149,6 +150,14 @@ def _mb(**releases_by_barcode: list[SimpleNamespace]) -> Mock:
     return musicbrainz
 
 
+def _loaded_provider(instance_id: str, *, available: bool = True) -> Mock:
+    """Return a mock provider instance for the loaded-provider registry."""
+    provider = Mock()
+    provider.instance_id = instance_id
+    provider.available = available
+    return provider
+
+
 @dataclass
 class _Harness:
     """A controller under test together with its mocked IO boundaries."""
@@ -172,6 +181,7 @@ def _harness(
     provider_album_tracks: dict[str, list[Track] | MediaNotFoundError] | None = None,
     musicbrainz: Mock | None = None,
     loaded_instances: Sequence[str] = ("tidal_1",),
+    provider_registry: dict[str, Mock] | None = None,
 ) -> Iterator[_Harness]:
     """
     Yield an AlbumsController with every IO boundary mocked.
@@ -181,14 +191,20 @@ def _harness(
     :param provider_album_tracks: Provider album tracks (or an error to raise) keyed by
         album item id; the base album's mapping ids resolve here too.
     :param musicbrainz: Optional mock MusicBrainz provider.
-    :param loaded_instances: Provider instance ids considered currently loaded.
+    :param loaded_instances: Provider instance ids considered currently loaded and available.
+    :param provider_registry: Explicit instance-id -> provider mock overrides.
     """
     album_tracks = provider_album_tracks or {}
+    registry = {instance: _loaded_provider(instance) for instance in loaded_instances}
+    registry.update(provider_registry or {})
 
-    def _get_provider(domain: str) -> object | None:
+    def _get_provider(domain: str, return_unavailable: bool = False) -> object | None:
         if domain == "musicbrainz":
             return musicbrainz
-        return object() if domain in loaded_instances else None
+        provider = registry.get(domain)
+        if provider is None:
+            return None
+        return provider if (return_unavailable or provider.available) else None
 
     mass = Mock()
     mass.get_provider = Mock(side_effect=_get_provider)
@@ -394,6 +410,32 @@ async def test_base_mapping_not_found_is_skipped() -> None:
     assert harness.album_track_calls() == ["gone", "ok", "s1"]
 
 
+async def test_base_mapping_skipped_when_exact_instance_not_loaded() -> None:
+    """A mapping whose exact instance is not loaded is skipped, never a same-domain fallback."""
+    base = _library_album(
+        version="2022 Remaster",
+        mappings=[
+            ProviderMapping(item_id="wrong", provider_domain="aaa", provider_instance="aaa_1"),
+            ProviderMapping(item_id="ok", provider_domain="bbb", provider_instance="bbb_1"),
+        ],
+    )
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    with _harness(
+        search_results=[sparse],
+        provider_items={"s1": full},
+        provider_album_tracks={"wrong": _tracklist(14), "ok": _tracklist(14), "s1": _tracklist(14)},
+        loaded_instances=("bbb_1",),
+        # aaa_1 resolves (same-domain fallback) to a different instance, so it must be skipped
+        provider_registry={"aaa_1": _loaded_provider("other_1")},
+    ) as harness:
+        matches = await harness.ctrl.match_provider(base, _provider())
+
+    assert [mapping.item_id for mapping in matches] == ["s1"]
+    # "wrong" is never fetched because its exact instance isn't the one that resolved
+    assert harness.album_track_calls() == ["ok", "s1"]
+
+
 async def test_candidate_tracklist_not_found_falls_through_to_musicbrainz() -> None:
     """A candidate tracklist that 404s is treated as absent so MusicBrainz can decide."""
     musicbrainz = _mb(**{BASE_BARCODE: [_mb_release("rel-1", "rg-1")]})
@@ -512,6 +554,49 @@ async def test_musicbrainz_skipped_without_a_configured_provider() -> None:
     """With no MusicBrainz provider configured the match simply abstains."""
     with _mb_harness(None) as (harness, base):
         assert await harness.ctrl.match_provider(base, _provider()) == []
+
+
+def _mb_evidence_ctrl(musicbrainz: Mock) -> AlbumsController:
+    """Return a bare controller wired to a mock MusicBrainz provider."""
+    mass = Mock()
+    mass.get_provider = Mock(
+        side_effect=lambda domain: musicbrainz if domain == "musicbrainz" else None
+    )
+    ctrl = AlbumsController.__new__(AlbumsController)
+    ctrl.logger = logging.getLogger("test.albums.mb")
+    ctrl.mass = mass
+    return ctrl
+
+
+async def test_musicbrainz_evidence_all_resolved_disjoint_groups_reject() -> None:
+    """Disjoint release groups are negative evidence when every barcode resolved."""
+    musicbrainz = _mb(
+        **{
+            BASE_BARCODE: [_mb_release("rel-1", "rg-1")],
+            OTHER_BARCODE: [_mb_release("rel-2", "rg-2")],
+        }
+    )
+    ctrl = _mb_evidence_ctrl(musicbrainz)
+    base = _library_album(barcodes=(BASE_BARCODE,))
+    compare = _album("s1", "spotify_1", barcodes=(OTHER_BARCODE,))
+
+    assert await ctrl._musicbrainz_album_evidence(base, compare) == AlbumMatchEvidence.NO_MATCH
+
+
+async def test_musicbrainz_evidence_unresolved_barcode_blocks_disjoint_rejection() -> None:
+    """An unresolved barcode leaves the group sets incomplete, so it cannot reject."""
+    musicbrainz = _mb(
+        **{
+            # BASE_BARCODE stays unresolved ([]); THIRD_BARCODE resolves to a distinct group
+            THIRD_BARCODE: [_mb_release("rel-1", "rg-1")],
+            OTHER_BARCODE: [_mb_release("rel-2", "rg-2")],
+        }
+    )
+    ctrl = _mb_evidence_ctrl(musicbrainz)
+    base = _library_album(barcodes=(BASE_BARCODE, THIRD_BARCODE))
+    compare = _album("s1", "spotify_1", barcodes=(OTHER_BARCODE,))
+
+    assert await ctrl._musicbrainz_album_evidence(base, compare) == AlbumMatchEvidence.INSUFFICIENT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -1,0 +1,415 @@
+"""Tests for AlbumsController provider matching (explicit, IO-capable enrichment)."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, Mock, patch
+
+from music_assistant_models.enums import ExternalID
+from music_assistant_models.media_items import (
+    Album,
+    Artist,
+    ProviderMapping,
+    Track,
+    UniqueList,
+)
+
+from music_assistant.controllers.music.media.albums import AlbumsController
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+MB_ALBUM_ID = "11111111-1111-1111-1111-111111111111"
+BASE_BARCODE = "888072439412"
+OTHER_BARCODE = "075678643224"
+
+
+# ---------------------------------------------------------------------------
+# builders
+# ---------------------------------------------------------------------------
+
+
+def _artist() -> Artist:
+    """Return the single album artist shared by every fixture album."""
+    return Artist(
+        item_id="artist",
+        provider="library",
+        name="Sigur Rós",
+        provider_mappings={
+            ProviderMapping(item_id="artist", provider_domain="test", provider_instance="library")
+        },
+    )
+
+
+def _album(
+    item_id: str = "1",
+    provider: str = "library",
+    *,
+    name: str = "( )",
+    version: str = "",
+    year: int | None = 2022,
+    external_ids: set[tuple[ExternalID, str]] | None = None,
+    barcode: str | None = None,
+) -> Album:
+    """Build an Album for match-provider tests."""
+    ext = set(external_ids or set())
+    if barcode:
+        ext.add((ExternalID.BARCODE, barcode))
+    return Album(
+        item_id=item_id,
+        provider=provider,
+        name=name,
+        version=version,
+        year=year,
+        external_ids=ext,
+        artists=UniqueList([_artist()]),
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain=provider, provider_instance=provider)
+        },
+    )
+
+
+def _track(number: int, *, isrc_prefix: str = "USRC17607", duration: int = 200) -> Track:
+    """Build one ordered album track with a distinct ISRC per position."""
+    return Track(
+        item_id=str(number),
+        provider="spotify_1",
+        name=f"Track {number}",
+        duration=duration,
+        disc_number=1,
+        track_number=number,
+        external_ids={(ExternalID.ISRC, f"{isrc_prefix}{number:03d}")},
+        provider_mappings={
+            ProviderMapping(
+                item_id=str(number), provider_domain="spotify", provider_instance="spotify_1"
+            )
+        },
+    )
+
+
+def _tracklist(count: int, *, isrc_prefix: str = "USRC17607") -> list[Track]:
+    """Build an ordered tracklist of the given length."""
+    return [_track(number, isrc_prefix=isrc_prefix) for number in range(1, count + 1)]
+
+
+def _mb_release(release_id: str, release_group_id: str) -> SimpleNamespace:
+    """Return a stand-in for a parsed MusicBrainz release."""
+    return SimpleNamespace(id=release_id, release_group=SimpleNamespace(id=release_group_id))
+
+
+def _provider() -> Mock:
+    """Return a mock streaming MusicProvider for matching."""
+    provider = Mock()
+    provider.name = "Spotify"
+    provider.instance_id = "spotify_1"
+    provider.domain = "spotify"
+    return provider
+
+
+@dataclass
+class _Harness:
+    """A controller under test together with its mocked IO boundaries."""
+
+    ctrl: AlbumsController
+    search: AsyncMock
+    get_provider_item: AsyncMock
+    get_library_album_tracks: AsyncMock
+    get_provider_album_tracks: AsyncMock
+
+
+@contextmanager
+def _harness(
+    *,
+    search_results: Sequence[Album],
+    provider_items: dict[str, Album],
+    library_tracks: list[Track] | None = None,
+    provider_album_tracks: dict[str, list[Track]] | None = None,
+    musicbrainz: Mock | None = None,
+) -> Iterator[_Harness]:
+    """
+    Yield an AlbumsController with every IO boundary mocked.
+
+    :param search_results: Sparse album search results returned to the prefilter.
+    :param provider_items: Full provider albums keyed by their item id.
+    :param library_tracks: Stored library tracks returned for the base album.
+    :param provider_album_tracks: Provider album tracks keyed by album item id.
+    :param musicbrainz: Optional mock MusicBrainz provider.
+    """
+    mass = Mock()
+    mass.get_provider = Mock(
+        side_effect=lambda domain: musicbrainz if domain == "musicbrainz" else None
+    )
+    ctrl = AlbumsController.__new__(AlbumsController)
+    ctrl.logger = logging.getLogger("test.albums.match")
+    ctrl.mass = mass
+    search = AsyncMock(return_value=list(search_results))
+    get_provider_item = AsyncMock(
+        side_effect=lambda item_id, _provider, **_kwargs: provider_items[item_id]
+    )
+    library = AsyncMock(return_value=list(library_tracks or []))
+    album_tracks = provider_album_tracks or {}
+    provider_tracks = AsyncMock(
+        side_effect=lambda item_id, _provider: list(album_tracks.get(item_id, []))
+    )
+    with patch.multiple(
+        ctrl,
+        search=search,
+        get_provider_item=get_provider_item,
+        get_library_album_tracks=library,
+        _get_provider_album_tracks=provider_tracks,
+    ):
+        yield _Harness(ctrl, search, get_provider_item, library, provider_tracks)
+
+
+# ---------------------------------------------------------------------------
+# search-result prefilter
+# ---------------------------------------------------------------------------
+
+
+async def test_clear_no_match_search_result_skips_full_fetch() -> None:
+    """A confidently non-matching search result is dropped before any full fetch."""
+    other = _album(item_id="s1", provider="spotify_1", name="Takk...")
+    with _harness(search_results=[other], provider_items={}) as harness:
+        matches = await harness.ctrl.match_provider(_album(), _provider())
+
+    assert matches == []
+    harness.get_provider_item.assert_not_awaited()
+
+
+async def test_insufficient_search_result_proceeds_to_one_full_fetch() -> None:
+    """An ambiguous search result is confirmed against exactly one full provider album."""
+    base = _album(version="", external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)})
+    sparse = _album(item_id="s1", provider="spotify_1", version="Remaster")
+    full = _album(
+        item_id="s1",
+        provider="spotify_1",
+        version="",
+        external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)},
+    )
+    with _harness(search_results=[sparse], provider_items={"s1": full}) as harness:
+        matches = await harness.ctrl.match_provider(base, _provider())
+
+    assert [mapping.item_id for mapping in matches] == ["s1"]
+    harness.get_provider_item.assert_awaited_once()
+
+
+async def test_full_item_match_uses_no_track_or_musicbrainz_calls() -> None:
+    """A full album that matches on metadata never fetches tracks or hits MusicBrainz."""
+    musicbrainz = Mock()
+    musicbrainz.get_releases_by_barcode = AsyncMock()
+    base = _album(external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)})
+    sparse = _album(item_id="s1", provider="spotify_1", version="Remaster")
+    full = _album(
+        item_id="s1", provider="spotify_1", external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)}
+    )
+    with _harness(
+        search_results=[sparse], provider_items={"s1": full}, musicbrainz=musicbrainz
+    ) as harness:
+        matches = await harness.ctrl.match_provider(base, _provider())
+
+    assert [mapping.item_id for mapping in matches] == ["s1"]
+    harness.get_library_album_tracks.assert_not_awaited()
+    harness.get_provider_album_tracks.assert_not_awaited()
+    musicbrainz.get_releases_by_barcode.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# track-fingerprint resolution
+# ---------------------------------------------------------------------------
+
+
+async def test_ambiguous_albums_resolve_via_track_fingerprints() -> None:
+    """The 14-track remaster vs deluxe-remaster case matches once tracklists agree."""
+    musicbrainz = Mock()
+    musicbrainz.get_releases_by_barcode = AsyncMock()
+    base = _album(version="2022 Remaster")
+    sparse = _album(item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster")
+    full = _album(item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster")
+    with _harness(
+        search_results=[sparse],
+        provider_items={"s1": full},
+        library_tracks=_tracklist(14),
+        provider_album_tracks={"s1": _tracklist(14)},
+        musicbrainz=musicbrainz,
+    ) as harness:
+        matches = await harness.ctrl.match_provider(base, _provider())
+
+    assert [mapping.item_id for mapping in matches] == ["s1"]
+    harness.get_library_album_tracks.assert_awaited_once()
+    harness.get_provider_album_tracks.assert_awaited_once_with("s1", "spotify_1")
+    # a decisive fingerprint match must not fall through to MusicBrainz
+    musicbrainz.get_releases_by_barcode.assert_not_awaited()
+
+
+async def test_different_track_counts_do_not_map() -> None:
+    """An 8-track album and a 14-track edition are never merged by fingerprints."""
+    base = _album(version="2022 Remaster")
+    sparse = _album(item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster")
+    full = _album(item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster")
+    with _harness(
+        search_results=[sparse],
+        provider_items={"s1": full},
+        library_tracks=_tracklist(8),
+        provider_album_tracks={"s1": _tracklist(14)},
+    ) as harness:
+        assert await harness.ctrl.match_provider(base, _provider()) == []
+
+
+async def test_conflicting_isrc_fingerprints_do_not_map() -> None:
+    """Same-length tracklists with conflicting ISRCs are a different recording."""
+    base = _album(version="2022 Remaster")
+    sparse = _album(item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster")
+    full = _album(item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster")
+    with _harness(
+        search_results=[sparse],
+        provider_items={"s1": full},
+        library_tracks=_tracklist(14, isrc_prefix="USRC17607"),
+        provider_album_tracks={"s1": _tracklist(14, isrc_prefix="USRC28718")},
+    ) as harness:
+        assert await harness.ctrl.match_provider(base, _provider()) == []
+
+
+async def test_base_tracks_fetched_once_across_candidates() -> None:
+    """The base tracklist is resolved once even when several candidates need it."""
+    base = _album(version="2022 Remaster")
+    search_results = [
+        _album(item_id=f"s{index}", provider="spotify_1", version="Deluxe 2022 Remaster")
+        for index in range(1, 4)
+    ]
+    provider_items = {
+        album.item_id: _album(
+            item_id=album.item_id, provider="spotify_1", version="Deluxe 2022 Remaster"
+        )
+        for album in search_results
+    }
+    with _harness(
+        search_results=search_results,
+        provider_items=provider_items,
+        library_tracks=_tracklist(14),
+        # every candidate stays ambiguous (no tracks to compare against)
+        provider_album_tracks={},
+    ) as harness:
+        await harness.ctrl.match_provider(base, _provider())
+
+    harness.get_library_album_tracks.assert_awaited_once()
+    assert harness.get_provider_album_tracks.await_count == len(search_results)
+
+
+# ---------------------------------------------------------------------------
+# MusicBrainz last-resort evidence
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _ambiguous_harness(
+    musicbrainz: Mock | None,
+    *,
+    base_barcode: str = BASE_BARCODE,
+    compare_barcode: str = BASE_BARCODE,
+) -> Iterator[tuple[_Harness, Album]]:
+    """Yield a harness whose only candidate is ambiguous through the fingerprint stage."""
+    base = _album(version="2022 Remaster", barcode=base_barcode)
+    sparse = _album(
+        item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster", barcode=compare_barcode
+    )
+    full = _album(
+        item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster", barcode=compare_barcode
+    )
+    with _harness(
+        search_results=[sparse],
+        provider_items={"s1": full},
+        library_tracks=_tracklist(14),
+        # no candidate tracks: the fingerprint stays inconclusive and MusicBrainz decides
+        provider_album_tracks={"s1": []},
+        musicbrainz=musicbrainz,
+    ) as harness:
+        yield harness, base
+
+
+async def test_musicbrainz_shared_release_resolves_after_fingerprint_insufficiency() -> None:
+    """A shared specific MusicBrainz release confirms the match once tracks fall short."""
+    musicbrainz = Mock()
+    musicbrainz.get_releases_by_barcode = AsyncMock(return_value=[_mb_release("rel-1", "rg-1")])
+    with _ambiguous_harness(musicbrainz) as (harness, base):
+        matches = await harness.ctrl.match_provider(base, _provider())
+
+    assert [mapping.item_id for mapping in matches] == ["s1"]
+    # the tracklist is consulted before MusicBrainz is ever asked
+    harness.get_provider_album_tracks.assert_awaited_once_with("s1", "spotify_1")
+    musicbrainz.get_releases_by_barcode.assert_awaited()
+
+
+async def test_musicbrainz_shared_release_group_alone_does_not_match() -> None:
+    """Different specific releases in one release group must not identify an edition."""
+    musicbrainz = Mock()
+
+    async def _releases(barcode: str) -> list[SimpleNamespace]:
+        if barcode == BASE_BARCODE:
+            return [_mb_release("rel-1", "rg-9")]
+        return [_mb_release("rel-2", "rg-9")]
+
+    musicbrainz.get_releases_by_barcode = AsyncMock(side_effect=_releases)
+    with _ambiguous_harness(musicbrainz, compare_barcode=OTHER_BARCODE) as (harness, base):
+        assert await harness.ctrl.match_provider(base, _provider()) == []
+
+
+async def test_musicbrainz_disjoint_release_groups_do_not_match() -> None:
+    """Barcodes in entirely different release groups are negative evidence."""
+    musicbrainz = Mock()
+
+    async def _releases(barcode: str) -> list[SimpleNamespace]:
+        if barcode == BASE_BARCODE:
+            return [_mb_release("rel-1", "rg-1")]
+        return [_mb_release("rel-2", "rg-2")]
+
+    musicbrainz.get_releases_by_barcode = AsyncMock(side_effect=_releases)
+    with _ambiguous_harness(musicbrainz, compare_barcode=OTHER_BARCODE) as (harness, base):
+        assert await harness.ctrl.match_provider(base, _provider()) == []
+
+
+async def test_musicbrainz_unresolved_barcode_abstains() -> None:
+    """A barcode MusicBrainz cannot resolve abstains instead of guessing."""
+    musicbrainz = Mock()
+    musicbrainz.get_releases_by_barcode = AsyncMock(return_value=[])
+    with _ambiguous_harness(musicbrainz) as (harness, base):
+        assert await harness.ctrl.match_provider(base, _provider()) == []
+
+
+async def test_musicbrainz_skipped_without_a_configured_provider() -> None:
+    """With no MusicBrainz provider configured the match simply abstains."""
+    with _ambiguous_harness(None) as (harness, base):
+        assert await harness.ctrl.match_provider(base, _provider()) == []
+
+
+# ---------------------------------------------------------------------------
+# bulk-sync guard
+# ---------------------------------------------------------------------------
+
+
+async def test_get_library_item_by_match_is_io_free() -> None:
+    """The DB-only sync match path must never reach a provider or MusicBrainz."""
+    mass = Mock()
+    mass.get_provider = Mock(side_effect=AssertionError("provider lookup during sync"))
+    ctrl = AlbumsController.__new__(AlbumsController)
+    ctrl.logger = logging.getLogger("test.albums.sync")
+    ctrl.mass = mass
+    ctrl.db_table = "albums"
+    item = _album(item_id="a1", provider="spotify_1", barcode=BASE_BARCODE)
+
+    with patch.multiple(
+        ctrl,
+        # every DB lookup returns nothing; a real provider/MusicBrainz call would raise
+        get_library_item_by_prov_id=AsyncMock(return_value=None),
+        get_library_item_by_prov_mappings=AsyncMock(return_value=None),
+        get_library_items_by_external_ids=AsyncMock(return_value=[]),
+        get_library_items_by_query=AsyncMock(return_value=[]),
+        search=AsyncMock(side_effect=AssertionError("search during sync")),
+        get_provider_item=AsyncMock(side_effect=AssertionError("provider fetch during sync")),
+    ):
+        assert await ctrl._get_library_item_by_match(item) is None
+
+    mass.get_provider.assert_not_called()

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock, patch
 
 from music_assistant_models.enums import ExternalID
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import MediaNotFoundError, RetriesExhausted
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -178,7 +178,7 @@ def _harness(
     *,
     search_results: Sequence[Album],
     provider_items: dict[str, Album],
-    provider_album_tracks: dict[str, list[Track] | MediaNotFoundError] | None = None,
+    provider_album_tracks: dict[str, list[Track] | Exception] | None = None,
     musicbrainz: Mock | None = None,
     loaded_instances: Sequence[str] = ("tidal_1",),
     provider_registry: dict[str, Mock] | None = None,
@@ -218,7 +218,7 @@ def _harness(
 
     async def _album_tracks(item_id: str, _provider: str) -> list[Track]:
         result = album_tracks.get(item_id, [])
-        if isinstance(result, MediaNotFoundError):
+        if isinstance(result, Exception):
             raise result
         return list(result)
 
@@ -410,6 +410,33 @@ async def test_base_mapping_not_found_is_skipped() -> None:
     assert harness.album_track_calls() == ["gone", "ok", "s1"]
 
 
+async def test_base_mapping_transient_error_is_skipped() -> None:
+    """A transient base tracklist failure skips to the next mapping."""
+    base = _library_album(
+        version="2022 Remaster",
+        mappings=[
+            ProviderMapping(item_id="flaky", provider_domain="aaa", provider_instance="aaa_1"),
+            ProviderMapping(item_id="ok", provider_domain="bbb", provider_instance="bbb_1"),
+        ],
+    )
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    with _harness(
+        search_results=[sparse],
+        provider_items={"s1": full},
+        provider_album_tracks={
+            "flaky": RetriesExhausted("flaky"),
+            "ok": _tracklist(14),
+            "s1": _tracklist(14),
+        },
+        loaded_instances=("aaa_1", "bbb_1"),
+    ) as harness:
+        matches = await harness.ctrl.match_provider(base, _provider())
+
+    assert [mapping.item_id for mapping in matches] == ["s1"]
+    assert harness.album_track_calls() == ["flaky", "ok", "s1"]
+
+
 async def test_base_mapping_skipped_when_exact_instance_not_loaded() -> None:
     """A mapping whose exact instance is not loaded is skipped, never a same-domain fallback."""
     base = _library_album(
@@ -446,6 +473,24 @@ async def test_candidate_tracklist_not_found_falls_through_to_musicbrainz() -> N
         search_results=[sparse],
         provider_items={"s1": full},
         provider_album_tracks={"base-prov": _tracklist(14), "s1": MediaNotFoundError("s1")},
+        musicbrainz=musicbrainz,
+    ) as harness:
+        matches = await harness.ctrl.match_provider(base, _provider())
+
+    assert [mapping.item_id for mapping in matches] == ["s1"]
+    musicbrainz.get_releases_by_barcode.assert_awaited()
+
+
+async def test_candidate_tracklist_transient_error_falls_through_to_musicbrainz() -> None:
+    """A transient candidate tracklist failure is treated as absent so MusicBrainz can decide."""
+    musicbrainz = _mb(**{BASE_BARCODE: [_mb_release("rel-1", "rg-1")]})
+    base = _library_album(version="2022 Remaster", barcodes=[BASE_BARCODE])
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=[BASE_BARCODE])
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=[BASE_BARCODE])
+    with _harness(
+        search_results=[sparse],
+        provider_items={"s1": full},
+        provider_album_tracks={"base-prov": _tracklist(14), "s1": TimeoutError()},
         musicbrainz=musicbrainz,
     ) as harness:
         matches = await harness.ctrl.match_provider(base, _provider())

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock, patch
 
 from music_assistant_models.enums import ExternalID
+from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -26,6 +27,11 @@ if TYPE_CHECKING:
 MB_ALBUM_ID = "11111111-1111-1111-1111-111111111111"
 BASE_BARCODE = "888072439412"
 OTHER_BARCODE = "075678643224"
+THIRD_BARCODE = "093624912514"
+# the base library album is linked to one existing (already-loaded) provider
+BASE_MAPPING = ProviderMapping(
+    item_id="base-prov", provider_domain="tidal", provider_instance="tidal_1"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -46,19 +52,23 @@ def _artist() -> Artist:
 
 
 def _album(
-    item_id: str = "1",
-    provider: str = "library",
+    item_id: str,
+    provider: str,
     *,
     name: str = "( )",
     version: str = "",
     year: int | None = 2022,
     external_ids: set[tuple[ExternalID, str]] | None = None,
-    barcode: str | None = None,
+    barcodes: Sequence[str] = (),
+    mappings: Sequence[ProviderMapping] | None = None,
 ) -> Album:
     """Build an Album for match-provider tests."""
     ext = set(external_ids or set())
-    if barcode:
-        ext.add((ExternalID.BARCODE, barcode))
+    ext.update((ExternalID.BARCODE, barcode) for barcode in barcodes)
+    if mappings is None:
+        mappings = [
+            ProviderMapping(item_id=item_id, provider_domain=provider, provider_instance=provider)
+        ]
     return Album(
         item_id=item_id,
         provider=provider,
@@ -67,20 +77,38 @@ def _album(
         year=year,
         external_ids=ext,
         artists=UniqueList([_artist()]),
-        provider_mappings={
-            ProviderMapping(item_id=item_id, provider_domain=provider, provider_instance=provider)
-        },
+        provider_mappings=set(mappings),
     )
 
 
-def _track(number: int, *, isrc_prefix: str = "USRC17607", duration: int = 200) -> Track:
+def _library_album(
+    *,
+    version: str = "",
+    external_ids: set[tuple[ExternalID, str]] | None = None,
+    barcodes: Sequence[str] = (),
+    mappings: Sequence[ProviderMapping] = (BASE_MAPPING,),
+) -> Album:
+    """Build the base (library) album under match."""
+    return _album(
+        "lib1",
+        "library",
+        version=version,
+        external_ids=external_ids,
+        barcodes=barcodes,
+        mappings=mappings,
+    )
+
+
+def _track(
+    number: int, *, isrc_prefix: str = "USRC17607", duration: int = 200, disc_number: int = 1
+) -> Track:
     """Build one ordered album track with a distinct ISRC per position."""
     return Track(
         item_id=str(number),
         provider="spotify_1",
         name=f"Track {number}",
         duration=duration,
-        disc_number=1,
+        disc_number=disc_number,
         track_number=number,
         external_ids={(ExternalID.ISRC, f"{isrc_prefix}{number:03d}")},
         provider_mappings={
@@ -91,9 +119,12 @@ def _track(number: int, *, isrc_prefix: str = "USRC17607", duration: int = 200) 
     )
 
 
-def _tracklist(count: int, *, isrc_prefix: str = "USRC17607") -> list[Track]:
+def _tracklist(count: int, *, isrc_prefix: str = "USRC17607", disc_number: int = 1) -> list[Track]:
     """Build an ordered tracklist of the given length."""
-    return [_track(number, isrc_prefix=isrc_prefix) for number in range(1, count + 1)]
+    return [
+        _track(number, isrc_prefix=isrc_prefix, disc_number=disc_number)
+        for number in range(1, count + 1)
+    ]
 
 
 def _mb_release(release_id: str, release_group_id: str) -> SimpleNamespace:
@@ -110,6 +141,14 @@ def _provider() -> Mock:
     return provider
 
 
+def _mb(**releases_by_barcode: list[SimpleNamespace]) -> Mock:
+    """Return a mock MusicBrainz provider answering barcode lookups from a mapping."""
+    lookup = {BASE_BARCODE: [], OTHER_BARCODE: [], THIRD_BARCODE: [], **releases_by_barcode}
+    musicbrainz = Mock()
+    musicbrainz.get_releases_by_barcode = AsyncMock(side_effect=lambda barcode: lookup[barcode])
+    return musicbrainz
+
+
 @dataclass
 class _Harness:
     """A controller under test together with its mocked IO boundaries."""
@@ -117,8 +156,12 @@ class _Harness:
     ctrl: AlbumsController
     search: AsyncMock
     get_provider_item: AsyncMock
-    get_library_album_tracks: AsyncMock
     get_provider_album_tracks: AsyncMock
+    get_provider: Mock
+
+    def album_track_calls(self) -> list[str]:
+        """Return the album item ids passed to each provider album-track lookup."""
+        return [call.args[0] for call in self.get_provider_album_tracks.await_args_list]
 
 
 @contextmanager
@@ -126,23 +169,29 @@ def _harness(
     *,
     search_results: Sequence[Album],
     provider_items: dict[str, Album],
-    library_tracks: list[Track] | None = None,
-    provider_album_tracks: dict[str, list[Track]] | None = None,
+    provider_album_tracks: dict[str, list[Track] | MediaNotFoundError] | None = None,
     musicbrainz: Mock | None = None,
+    loaded_instances: Sequence[str] = ("tidal_1",),
 ) -> Iterator[_Harness]:
     """
     Yield an AlbumsController with every IO boundary mocked.
 
     :param search_results: Sparse album search results returned to the prefilter.
     :param provider_items: Full provider albums keyed by their item id.
-    :param library_tracks: Stored library tracks returned for the base album.
-    :param provider_album_tracks: Provider album tracks keyed by album item id.
+    :param provider_album_tracks: Provider album tracks (or an error to raise) keyed by
+        album item id; the base album's mapping ids resolve here too.
     :param musicbrainz: Optional mock MusicBrainz provider.
+    :param loaded_instances: Provider instance ids considered currently loaded.
     """
+    album_tracks = provider_album_tracks or {}
+
+    def _get_provider(domain: str) -> object | None:
+        if domain == "musicbrainz":
+            return musicbrainz
+        return object() if domain in loaded_instances else None
+
     mass = Mock()
-    mass.get_provider = Mock(
-        side_effect=lambda domain: musicbrainz if domain == "musicbrainz" else None
-    )
+    mass.get_provider = Mock(side_effect=_get_provider)
     ctrl = AlbumsController.__new__(AlbumsController)
     ctrl.logger = logging.getLogger("test.albums.match")
     ctrl.mass = mass
@@ -150,19 +199,23 @@ def _harness(
     get_provider_item = AsyncMock(
         side_effect=lambda item_id, _provider, **_kwargs: provider_items[item_id]
     )
-    library = AsyncMock(return_value=list(library_tracks or []))
-    album_tracks = provider_album_tracks or {}
-    provider_tracks = AsyncMock(
-        side_effect=lambda item_id, _provider: list(album_tracks.get(item_id, []))
-    )
+
+    async def _album_tracks(item_id: str, _provider: str) -> list[Track]:
+        result = album_tracks.get(item_id, [])
+        if isinstance(result, MediaNotFoundError):
+            raise result
+        return list(result)
+
+    get_provider_album_tracks = AsyncMock(side_effect=_album_tracks)
     with patch.multiple(
         ctrl,
         search=search,
         get_provider_item=get_provider_item,
-        get_library_album_tracks=library,
-        _get_provider_album_tracks=provider_tracks,
+        _get_provider_album_tracks=get_provider_album_tracks,
     ):
-        yield _Harness(ctrl, search, get_provider_item, library, provider_tracks)
+        yield _Harness(
+            ctrl, search, get_provider_item, get_provider_album_tracks, mass.get_provider
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -172,9 +225,9 @@ def _harness(
 
 async def test_clear_no_match_search_result_skips_full_fetch() -> None:
     """A confidently non-matching search result is dropped before any full fetch."""
-    other = _album(item_id="s1", provider="spotify_1", name="Takk...")
+    other = _album("s1", "spotify_1", name="Takk...")
     with _harness(search_results=[other], provider_items={}) as harness:
-        matches = await harness.ctrl.match_provider(_album(), _provider())
+        matches = await harness.ctrl.match_provider(_library_album(), _provider())
 
     assert matches == []
     harness.get_provider_item.assert_not_awaited()
@@ -182,14 +235,9 @@ async def test_clear_no_match_search_result_skips_full_fetch() -> None:
 
 async def test_insufficient_search_result_proceeds_to_one_full_fetch() -> None:
     """An ambiguous search result is confirmed against exactly one full provider album."""
-    base = _album(version="", external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)})
-    sparse = _album(item_id="s1", provider="spotify_1", version="Remaster")
-    full = _album(
-        item_id="s1",
-        provider="spotify_1",
-        version="",
-        external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)},
-    )
+    base = _library_album(external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)})
+    sparse = _album("s1", "spotify_1", version="Remaster")
+    full = _album("s1", "spotify_1", external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)})
     with _harness(search_results=[sparse], provider_items={"s1": full}) as harness:
         matches = await harness.ctrl.match_provider(base, _provider())
 
@@ -199,20 +247,16 @@ async def test_insufficient_search_result_proceeds_to_one_full_fetch() -> None:
 
 async def test_full_item_match_uses_no_track_or_musicbrainz_calls() -> None:
     """A full album that matches on metadata never fetches tracks or hits MusicBrainz."""
-    musicbrainz = Mock()
-    musicbrainz.get_releases_by_barcode = AsyncMock()
-    base = _album(external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)})
-    sparse = _album(item_id="s1", provider="spotify_1", version="Remaster")
-    full = _album(
-        item_id="s1", provider="spotify_1", external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)}
-    )
+    musicbrainz = _mb()
+    base = _library_album(external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)})
+    sparse = _album("s1", "spotify_1", version="Remaster")
+    full = _album("s1", "spotify_1", external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)})
     with _harness(
         search_results=[sparse], provider_items={"s1": full}, musicbrainz=musicbrainz
     ) as harness:
         matches = await harness.ctrl.match_provider(base, _provider())
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
-    harness.get_library_album_tracks.assert_not_awaited()
     harness.get_provider_album_tracks.assert_not_awaited()
     musicbrainz.get_releases_by_barcode.assert_not_awaited()
 
@@ -224,79 +268,148 @@ async def test_full_item_match_uses_no_track_or_musicbrainz_calls() -> None:
 
 async def test_ambiguous_albums_resolve_via_track_fingerprints() -> None:
     """The 14-track remaster vs deluxe-remaster case matches once tracklists agree."""
-    musicbrainz = Mock()
-    musicbrainz.get_releases_by_barcode = AsyncMock()
-    base = _album(version="2022 Remaster")
-    sparse = _album(item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster")
-    full = _album(item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster")
+    musicbrainz = _mb()
+    base = _library_album(version="2022 Remaster")
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
     with _harness(
         search_results=[sparse],
         provider_items={"s1": full},
-        library_tracks=_tracklist(14),
-        provider_album_tracks={"s1": _tracklist(14)},
+        provider_album_tracks={"base-prov": _tracklist(14), "s1": _tracklist(14)},
         musicbrainz=musicbrainz,
     ) as harness:
         matches = await harness.ctrl.match_provider(base, _provider())
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
-    harness.get_library_album_tracks.assert_awaited_once()
-    harness.get_provider_album_tracks.assert_awaited_once_with("s1", "spotify_1")
+    # base tracklist comes from the existing provider mapping, candidate from the match target
+    assert harness.album_track_calls() == ["base-prov", "s1"]
     # a decisive fingerprint match must not fall through to MusicBrainz
     musicbrainz.get_releases_by_barcode.assert_not_awaited()
 
 
 async def test_different_track_counts_do_not_map() -> None:
-    """An 8-track album and a 14-track edition are never merged by fingerprints."""
-    base = _album(version="2022 Remaster")
-    sparse = _album(item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster")
-    full = _album(item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster")
+    """A complete 8-track album and a 14-track edition are never merged by fingerprints."""
+    base = _library_album(version="2022 Remaster")
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
     with _harness(
         search_results=[sparse],
         provider_items={"s1": full},
-        library_tracks=_tracklist(8),
-        provider_album_tracks={"s1": _tracklist(14)},
+        provider_album_tracks={"base-prov": _tracklist(8), "s1": _tracklist(14)},
     ) as harness:
         assert await harness.ctrl.match_provider(base, _provider()) == []
 
 
 async def test_conflicting_isrc_fingerprints_do_not_map() -> None:
     """Same-length tracklists with conflicting ISRCs are a different recording."""
-    base = _album(version="2022 Remaster")
-    sparse = _album(item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster")
-    full = _album(item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster")
+    base = _library_album(version="2022 Remaster")
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
     with _harness(
         search_results=[sparse],
         provider_items={"s1": full},
-        library_tracks=_tracklist(14, isrc_prefix="USRC17607"),
-        provider_album_tracks={"s1": _tracklist(14, isrc_prefix="USRC28718")},
+        provider_album_tracks={
+            "base-prov": _tracklist(14, isrc_prefix="USRC17607"),
+            "s1": _tracklist(14, isrc_prefix="USRC28718"),
+        },
     ) as harness:
         assert await harness.ctrl.match_provider(base, _provider()) == []
 
 
 async def test_base_tracks_fetched_once_across_candidates() -> None:
-    """The base tracklist is resolved once even when several candidates need it."""
-    base = _album(version="2022 Remaster")
+    """The base tracklist is fetched once even when several candidates need it."""
+    base = _library_album(version="2022 Remaster")
     search_results = [
-        _album(item_id=f"s{index}", provider="spotify_1", version="Deluxe 2022 Remaster")
-        for index in range(1, 4)
+        _album(f"s{index}", "spotify_1", version="Deluxe 2022 Remaster") for index in range(1, 4)
     ]
-    provider_items = {
-        album.item_id: _album(
-            item_id=album.item_id, provider="spotify_1", version="Deluxe 2022 Remaster"
-        )
-        for album in search_results
-    }
+    provider_items = {album.item_id: album for album in search_results}
     with _harness(
         search_results=search_results,
         provider_items=provider_items,
-        library_tracks=_tracklist(14),
         # every candidate stays ambiguous (no tracks to compare against)
-        provider_album_tracks={},
+        provider_album_tracks={"base-prov": _tracklist(14)},
     ) as harness:
         await harness.ctrl.match_provider(base, _provider())
 
-    harness.get_library_album_tracks.assert_awaited_once()
-    assert harness.get_provider_album_tracks.await_count == len(search_results)
+    # the base mapping is only fetched once, regardless of the number of candidates
+    assert harness.album_track_calls().count("base-prov") == 1
+
+
+async def test_base_tracks_use_first_trustworthy_loaded_mapping() -> None:
+    """Base resolution deterministically skips unloaded/untrustworthy mappings."""
+    base = _library_album(
+        version="2022 Remaster",
+        mappings=[
+            ProviderMapping(item_id="a", provider_domain="aaa", provider_instance="aaa_1"),
+            ProviderMapping(item_id="b", provider_domain="bbb", provider_instance="bbb_1"),
+            ProviderMapping(item_id="c", provider_domain="ccc", provider_instance="ccc_1"),
+        ],
+    )
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    with _harness(
+        search_results=[sparse],
+        provider_items={"s1": full},
+        provider_album_tracks={
+            # "a" is on an unloaded instance and must never be fetched
+            "a": _tracklist(14),
+            # "b" is loaded but its positions are untrustworthy (no disc numbers)
+            "b": _tracklist(14, disc_number=0),
+            "c": _tracklist(14),
+            "s1": _tracklist(14),
+        },
+        loaded_instances=("bbb_1", "ccc_1", "tidal_1"),
+    ) as harness:
+        matches = await harness.ctrl.match_provider(base, _provider())
+
+    assert [mapping.item_id for mapping in matches] == ["s1"]
+    # unloaded "a" skipped before any fetch; "b" fetched but rejected; "c" used
+    assert harness.album_track_calls() == ["b", "c", "s1"]
+
+
+async def test_base_mapping_not_found_is_skipped() -> None:
+    """A base mapping whose tracklist lookup 404s is skipped for the next mapping."""
+    base = _library_album(
+        version="2022 Remaster",
+        mappings=[
+            ProviderMapping(item_id="gone", provider_domain="aaa", provider_instance="aaa_1"),
+            ProviderMapping(item_id="ok", provider_domain="bbb", provider_instance="bbb_1"),
+        ],
+    )
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    with _harness(
+        search_results=[sparse],
+        provider_items={"s1": full},
+        provider_album_tracks={
+            "gone": MediaNotFoundError("gone"),
+            "ok": _tracklist(14),
+            "s1": _tracklist(14),
+        },
+        loaded_instances=("aaa_1", "bbb_1"),
+    ) as harness:
+        matches = await harness.ctrl.match_provider(base, _provider())
+
+    assert [mapping.item_id for mapping in matches] == ["s1"]
+    assert harness.album_track_calls() == ["gone", "ok", "s1"]
+
+
+async def test_candidate_tracklist_not_found_falls_through_to_musicbrainz() -> None:
+    """A candidate tracklist that 404s is treated as absent so MusicBrainz can decide."""
+    musicbrainz = _mb(**{BASE_BARCODE: [_mb_release("rel-1", "rg-1")]})
+    base = _library_album(version="2022 Remaster", barcodes=[BASE_BARCODE])
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=[BASE_BARCODE])
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=[BASE_BARCODE])
+    with _harness(
+        search_results=[sparse],
+        provider_items={"s1": full},
+        provider_album_tracks={"base-prov": _tracklist(14), "s1": MediaNotFoundError("s1")},
+        musicbrainz=musicbrainz,
+    ) as harness:
+        matches = await harness.ctrl.match_provider(base, _provider())
+
+    assert [mapping.item_id for mapping in matches] == ["s1"]
+    musicbrainz.get_releases_by_barcode.assert_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -305,83 +418,99 @@ async def test_base_tracks_fetched_once_across_candidates() -> None:
 
 
 @contextmanager
-def _ambiguous_harness(
+def _mb_harness(
     musicbrainz: Mock | None,
     *,
-    base_barcode: str = BASE_BARCODE,
-    compare_barcode: str = BASE_BARCODE,
+    base_barcodes: Sequence[str] = (BASE_BARCODE,),
+    compare_barcodes: Sequence[str] = (BASE_BARCODE,),
 ) -> Iterator[tuple[_Harness, Album]]:
-    """Yield a harness whose only candidate is ambiguous through the fingerprint stage."""
-    base = _album(version="2022 Remaster", barcode=base_barcode)
-    sparse = _album(
-        item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster", barcode=compare_barcode
-    )
-    full = _album(
-        item_id="s1", provider="spotify_1", version="Deluxe 2022 Remaster", barcode=compare_barcode
-    )
+    """Yield a harness plus base album whose only candidate is ambiguous past fingerprints."""
+    base = _library_album(version="2022 Remaster", barcodes=base_barcodes)
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=compare_barcodes)
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=compare_barcodes)
     with _harness(
         search_results=[sparse],
         provider_items={"s1": full},
-        library_tracks=_tracklist(14),
-        # no candidate tracks: the fingerprint stays inconclusive and MusicBrainz decides
-        provider_album_tracks={"s1": []},
+        # base tracklist present but candidate has none: fingerprint stays inconclusive
+        provider_album_tracks={"base-prov": _tracklist(14), "s1": []},
         musicbrainz=musicbrainz,
     ) as harness:
         yield harness, base
 
 
-async def test_musicbrainz_shared_release_resolves_after_fingerprint_insufficiency() -> None:
-    """A shared specific MusicBrainz release confirms the match once tracks fall short."""
-    musicbrainz = Mock()
-    musicbrainz.get_releases_by_barcode = AsyncMock(return_value=[_mb_release("rel-1", "rg-1")])
-    with _ambiguous_harness(musicbrainz) as (harness, base):
+async def test_musicbrainz_shared_single_release_matches() -> None:
+    """A barcode resolving to one shared specific release confirms the match."""
+    musicbrainz = _mb(**{BASE_BARCODE: [_mb_release("rel-1", "rg-1")]})
+    with _mb_harness(musicbrainz) as (harness, base):
         matches = await harness.ctrl.match_provider(base, _provider())
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
     # the tracklist is consulted before MusicBrainz is ever asked
-    harness.get_provider_album_tracks.assert_awaited_once_with("s1", "spotify_1")
+    assert harness.album_track_calls() == ["base-prov", "s1"]
     musicbrainz.get_releases_by_barcode.assert_awaited()
+
+
+async def test_musicbrainz_multiple_releases_per_barcode_abstains() -> None:
+    """A barcode resolving to several releases is ambiguous and must not match."""
+    musicbrainz = _mb(
+        **{BASE_BARCODE: [_mb_release("rel-1", "rg-1"), _mb_release("rel-2", "rg-1")]}
+    )
+    with _mb_harness(musicbrainz) as (harness, base):
+        assert await harness.ctrl.match_provider(base, _provider()) == []
+
+
+async def test_musicbrainz_multiple_barcodes_are_all_considered() -> None:
+    """Every canonical barcode on each album is used, not just the first."""
+    musicbrainz = _mb(**{THIRD_BARCODE: [_mb_release("rel-9", "rg-9")]})
+    with _mb_harness(
+        musicbrainz, base_barcodes=(BASE_BARCODE, THIRD_BARCODE), compare_barcodes=(THIRD_BARCODE,)
+    ) as (harness, base):
+        assert [
+            mapping.item_id for mapping in await harness.ctrl.match_provider(base, _provider())
+        ] == ["s1"]
 
 
 async def test_musicbrainz_shared_release_group_alone_does_not_match() -> None:
     """Different specific releases in one release group must not identify an edition."""
-    musicbrainz = Mock()
-
-    async def _releases(barcode: str) -> list[SimpleNamespace]:
-        if barcode == BASE_BARCODE:
-            return [_mb_release("rel-1", "rg-9")]
-        return [_mb_release("rel-2", "rg-9")]
-
-    musicbrainz.get_releases_by_barcode = AsyncMock(side_effect=_releases)
-    with _ambiguous_harness(musicbrainz, compare_barcode=OTHER_BARCODE) as (harness, base):
+    musicbrainz = _mb(
+        **{
+            BASE_BARCODE: [_mb_release("rel-1", "rg-9")],
+            OTHER_BARCODE: [_mb_release("rel-2", "rg-9")],
+        }
+    )
+    with _mb_harness(musicbrainz, compare_barcodes=(OTHER_BARCODE,)) as (harness, base):
         assert await harness.ctrl.match_provider(base, _provider()) == []
 
 
 async def test_musicbrainz_disjoint_release_groups_do_not_match() -> None:
     """Barcodes in entirely different release groups are negative evidence."""
-    musicbrainz = Mock()
-
-    async def _releases(barcode: str) -> list[SimpleNamespace]:
-        if barcode == BASE_BARCODE:
-            return [_mb_release("rel-1", "rg-1")]
-        return [_mb_release("rel-2", "rg-2")]
-
-    musicbrainz.get_releases_by_barcode = AsyncMock(side_effect=_releases)
-    with _ambiguous_harness(musicbrainz, compare_barcode=OTHER_BARCODE) as (harness, base):
+    musicbrainz = _mb(
+        **{
+            BASE_BARCODE: [_mb_release("rel-1", "rg-1")],
+            OTHER_BARCODE: [_mb_release("rel-2", "rg-2")],
+        }
+    )
+    with _mb_harness(musicbrainz, compare_barcodes=(OTHER_BARCODE,)) as (harness, base):
         assert await harness.ctrl.match_provider(base, _provider()) == []
 
 
 async def test_musicbrainz_unresolved_barcode_abstains() -> None:
     """A barcode MusicBrainz cannot resolve abstains instead of guessing."""
+    with _mb_harness(_mb()) as (harness, base):
+        assert await harness.ctrl.match_provider(base, _provider()) == []
+
+
+async def test_musicbrainz_transport_error_abstains() -> None:
+    """A MusicBrainz outage abstains rather than aborting the whole match."""
     musicbrainz = Mock()
-    musicbrainz.get_releases_by_barcode = AsyncMock(return_value=[])
-    with _ambiguous_harness(musicbrainz) as (harness, base):
+    musicbrainz.get_releases_by_barcode = AsyncMock(side_effect=TimeoutError())
+    with _mb_harness(musicbrainz) as (harness, base):
         assert await harness.ctrl.match_provider(base, _provider()) == []
 
 
 async def test_musicbrainz_skipped_without_a_configured_provider() -> None:
     """With no MusicBrainz provider configured the match simply abstains."""
-    with _ambiguous_harness(None) as (harness, base):
+    with _mb_harness(None) as (harness, base):
         assert await harness.ctrl.match_provider(base, _provider()) == []
 
 
@@ -398,7 +527,7 @@ async def test_get_library_item_by_match_is_io_free() -> None:
     ctrl.logger = logging.getLogger("test.albums.sync")
     ctrl.mass = mass
     ctrl.db_table = "albums"
-    item = _album(item_id="a1", provider="spotify_1", barcode=BASE_BARCODE)
+    item = _album("a1", "spotify_1", barcodes=[BASE_BARCODE])
 
     with patch.multiple(
         ctrl,
@@ -409,6 +538,7 @@ async def test_get_library_item_by_match_is_io_free() -> None:
         get_library_items_by_query=AsyncMock(return_value=[]),
         search=AsyncMock(side_effect=AssertionError("search during sync")),
         get_provider_item=AsyncMock(side_effect=AssertionError("provider fetch during sync")),
+        _get_provider_album_tracks=AsyncMock(side_effect=AssertionError("track fetch during sync")),
     ):
         assert await ctrl._get_library_item_by_match(item) is None
 

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -167,6 +167,11 @@ class _Harness:
     get_provider_item: AsyncMock
     get_provider_album_tracks: AsyncMock
     get_provider: Mock
+    provider: Mock
+
+    async def match(self, db_album: Album, *, strict: bool = True) -> list[ProviderMapping]:
+        """Match against the single (streaming) provider the harness owns."""
+        return await self.ctrl.match_provider(db_album, self.provider, strict)
 
     def album_track_calls(self) -> list[str]:
         """Return the album item ids passed to each provider album-track lookup."""
@@ -216,13 +221,17 @@ def _harness(
         side_effect=lambda item_id, _provider, **_kwargs: provider_items[item_id]
     )
 
-    async def _album_tracks(item_id: str, _provider: str) -> list[Track]:
+    async def _album_tracks(item_id: str, *_rest: object) -> list[Track]:
         result = album_tracks.get(item_id, [])
         if isinstance(result, Exception):
             raise result
         return list(result)
 
+    # a single recorder backs both the base mapping lookup (_get_provider_album_tracks)
+    # and the candidate lookup (provider.get_album_tracks), so their calls stay ordered
     get_provider_album_tracks = AsyncMock(side_effect=_album_tracks)
+    provider = _provider()
+    provider.get_album_tracks = get_provider_album_tracks
     with patch.multiple(
         ctrl,
         search=search,
@@ -230,7 +239,7 @@ def _harness(
         _get_provider_album_tracks=get_provider_album_tracks,
     ):
         yield _Harness(
-            ctrl, search, get_provider_item, get_provider_album_tracks, mass.get_provider
+            ctrl, search, get_provider_item, get_provider_album_tracks, mass.get_provider, provider
         )
 
 
@@ -243,7 +252,7 @@ async def test_clear_no_match_search_result_skips_full_fetch() -> None:
     """A confidently non-matching search result is dropped before any full fetch."""
     other = _album("s1", "spotify_1", name="Takk...")
     with _harness(search_results=[other], provider_items={}) as harness:
-        matches = await harness.ctrl.match_provider(_library_album(), _provider())
+        matches = await harness.match(_library_album())
 
     assert matches == []
     harness.get_provider_item.assert_not_awaited()
@@ -255,7 +264,7 @@ async def test_insufficient_search_result_proceeds_to_one_full_fetch() -> None:
     sparse = _album("s1", "spotify_1", version="Remaster")
     full = _album("s1", "spotify_1", external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)})
     with _harness(search_results=[sparse], provider_items={"s1": full}) as harness:
-        matches = await harness.ctrl.match_provider(base, _provider())
+        matches = await harness.match(base)
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
     harness.get_provider_item.assert_awaited_once()
@@ -270,7 +279,7 @@ async def test_full_item_match_uses_no_track_or_musicbrainz_calls() -> None:
     with _harness(
         search_results=[sparse], provider_items={"s1": full}, musicbrainz=musicbrainz
     ) as harness:
-        matches = await harness.ctrl.match_provider(base, _provider())
+        matches = await harness.match(base)
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
     harness.get_provider_album_tracks.assert_not_awaited()
@@ -294,7 +303,7 @@ async def test_ambiguous_albums_resolve_via_track_fingerprints() -> None:
         provider_album_tracks={"base-prov": _tracklist(14), "s1": _tracklist(14)},
         musicbrainz=musicbrainz,
     ) as harness:
-        matches = await harness.ctrl.match_provider(base, _provider())
+        matches = await harness.match(base)
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
     # base tracklist comes from the existing provider mapping, candidate from the match target
@@ -313,7 +322,7 @@ async def test_different_track_counts_do_not_map() -> None:
         provider_items={"s1": full},
         provider_album_tracks={"base-prov": _tracklist(8), "s1": _tracklist(14)},
     ) as harness:
-        assert await harness.ctrl.match_provider(base, _provider()) == []
+        assert await harness.match(base) == []
 
 
 async def test_conflicting_isrc_fingerprints_do_not_map() -> None:
@@ -329,7 +338,7 @@ async def test_conflicting_isrc_fingerprints_do_not_map() -> None:
             "s1": _tracklist(14, isrc_prefix="USRC28718"),
         },
     ) as harness:
-        assert await harness.ctrl.match_provider(base, _provider()) == []
+        assert await harness.match(base) == []
 
 
 async def test_base_tracks_fetched_once_across_candidates() -> None:
@@ -345,7 +354,7 @@ async def test_base_tracks_fetched_once_across_candidates() -> None:
         # every candidate stays ambiguous (no tracks to compare against)
         provider_album_tracks={"base-prov": _tracklist(14)},
     ) as harness:
-        await harness.ctrl.match_provider(base, _provider())
+        await harness.match(base)
 
     # the base mapping is only fetched once, regardless of the number of candidates
     assert harness.album_track_calls().count("base-prov") == 1
@@ -376,7 +385,7 @@ async def test_base_tracks_use_first_trustworthy_loaded_mapping() -> None:
         },
         loaded_instances=("bbb_1", "ccc_1", "tidal_1"),
     ) as harness:
-        matches = await harness.ctrl.match_provider(base, _provider())
+        matches = await harness.match(base)
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
     # unloaded "a" skipped before any fetch; "b" fetched but rejected; "c" used
@@ -404,7 +413,7 @@ async def test_base_mapping_not_found_is_skipped() -> None:
         },
         loaded_instances=("aaa_1", "bbb_1"),
     ) as harness:
-        matches = await harness.ctrl.match_provider(base, _provider())
+        matches = await harness.match(base)
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
     assert harness.album_track_calls() == ["gone", "ok", "s1"]
@@ -431,7 +440,7 @@ async def test_base_mapping_transient_error_is_skipped() -> None:
         },
         loaded_instances=("aaa_1", "bbb_1"),
     ) as harness:
-        matches = await harness.ctrl.match_provider(base, _provider())
+        matches = await harness.match(base)
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
     assert harness.album_track_calls() == ["flaky", "ok", "s1"]
@@ -456,7 +465,7 @@ async def test_base_mapping_skipped_when_exact_instance_not_loaded() -> None:
         # aaa_1 resolves (same-domain fallback) to a different instance, so it must be skipped
         provider_registry={"aaa_1": _loaded_provider("other_1")},
     ) as harness:
-        matches = await harness.ctrl.match_provider(base, _provider())
+        matches = await harness.match(base)
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
     # "wrong" is never fetched because its exact instance isn't the one that resolved
@@ -475,7 +484,7 @@ async def test_candidate_tracklist_not_found_falls_through_to_musicbrainz() -> N
         provider_album_tracks={"base-prov": _tracklist(14), "s1": MediaNotFoundError("s1")},
         musicbrainz=musicbrainz,
     ) as harness:
-        matches = await harness.ctrl.match_provider(base, _provider())
+        matches = await harness.match(base)
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
     musicbrainz.get_releases_by_barcode.assert_awaited()
@@ -493,10 +502,37 @@ async def test_candidate_tracklist_transient_error_falls_through_to_musicbrainz(
         provider_album_tracks={"base-prov": _tracklist(14), "s1": TimeoutError()},
         musicbrainz=musicbrainz,
     ) as harness:
-        matches = await harness.ctrl.match_provider(base, _provider())
+        matches = await harness.match(base)
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
     musicbrainz.get_releases_by_barcode.assert_awaited()
+
+
+async def test_candidate_tracklist_uses_matched_provider_not_same_domain_fallback() -> None:
+    """The candidate tracklist is fetched from the matched provider, never a same-domain fallback."""
+    # a second instance of the candidate's domain is registered in the loaded-provider
+    # registry; re-resolving the candidate through it would fingerprint against the wrong
+    # account and reject the correct match
+    fallback = _loaded_provider("spotify_other")
+    fallback.get_album_tracks = AsyncMock(return_value=_tracklist(14, isrc_prefix="USRC28718"))
+    base = _library_album(version="2022 Remaster")
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster")
+    with _harness(
+        search_results=[sparse],
+        provider_items={"s1": full},
+        provider_album_tracks={"base-prov": _tracklist(14)},
+        provider_registry={"spotify_1": fallback},
+    ) as harness:
+        # the matched provider itself returns the correct, agreeing tracklist
+        harness.provider.get_album_tracks = AsyncMock(return_value=_tracklist(14))
+        matches = await harness.match(base)
+
+    assert [mapping.item_id for mapping in matches] == ["s1"]
+    harness.provider.get_album_tracks.assert_awaited_once_with("s1")
+    # the same-domain fallback is never consulted and the candidate domain is never re-resolved
+    fallback.get_album_tracks.assert_not_awaited()
+    assert all(call.args[0] != "spotify_1" for call in harness.get_provider.call_args_list)
 
 
 # ---------------------------------------------------------------------------
@@ -529,7 +565,7 @@ async def test_musicbrainz_shared_single_release_matches() -> None:
     """A barcode resolving to one shared specific release confirms the match."""
     musicbrainz = _mb(**{BASE_BARCODE: [_mb_release("rel-1", "rg-1")]})
     with _mb_harness(musicbrainz) as (harness, base):
-        matches = await harness.ctrl.match_provider(base, _provider())
+        matches = await harness.match(base)
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
     # the tracklist is consulted before MusicBrainz is ever asked
@@ -543,7 +579,7 @@ async def test_musicbrainz_multiple_releases_per_barcode_abstains() -> None:
         **{BASE_BARCODE: [_mb_release("rel-1", "rg-1"), _mb_release("rel-2", "rg-1")]}
     )
     with _mb_harness(musicbrainz) as (harness, base):
-        assert await harness.ctrl.match_provider(base, _provider()) == []
+        assert await harness.match(base) == []
 
 
 async def test_musicbrainz_multiple_barcodes_are_all_considered() -> None:
@@ -552,9 +588,7 @@ async def test_musicbrainz_multiple_barcodes_are_all_considered() -> None:
     with _mb_harness(
         musicbrainz, base_barcodes=(BASE_BARCODE, THIRD_BARCODE), compare_barcodes=(THIRD_BARCODE,)
     ) as (harness, base):
-        assert [
-            mapping.item_id for mapping in await harness.ctrl.match_provider(base, _provider())
-        ] == ["s1"]
+        assert [mapping.item_id for mapping in await harness.match(base)] == ["s1"]
 
 
 async def test_musicbrainz_shared_release_group_alone_does_not_match() -> None:
@@ -566,7 +600,7 @@ async def test_musicbrainz_shared_release_group_alone_does_not_match() -> None:
         }
     )
     with _mb_harness(musicbrainz, compare_barcodes=(OTHER_BARCODE,)) as (harness, base):
-        assert await harness.ctrl.match_provider(base, _provider()) == []
+        assert await harness.match(base) == []
 
 
 async def test_musicbrainz_disjoint_release_groups_do_not_match() -> None:
@@ -578,13 +612,13 @@ async def test_musicbrainz_disjoint_release_groups_do_not_match() -> None:
         }
     )
     with _mb_harness(musicbrainz, compare_barcodes=(OTHER_BARCODE,)) as (harness, base):
-        assert await harness.ctrl.match_provider(base, _provider()) == []
+        assert await harness.match(base) == []
 
 
 async def test_musicbrainz_unresolved_barcode_abstains() -> None:
     """A barcode MusicBrainz cannot resolve abstains instead of guessing."""
     with _mb_harness(_mb()) as (harness, base):
-        assert await harness.ctrl.match_provider(base, _provider()) == []
+        assert await harness.match(base) == []
 
 
 async def test_musicbrainz_transport_error_abstains() -> None:
@@ -592,13 +626,13 @@ async def test_musicbrainz_transport_error_abstains() -> None:
     musicbrainz = Mock()
     musicbrainz.get_releases_by_barcode = AsyncMock(side_effect=TimeoutError())
     with _mb_harness(musicbrainz) as (harness, base):
-        assert await harness.ctrl.match_provider(base, _provider()) == []
+        assert await harness.match(base) == []
 
 
 async def test_musicbrainz_skipped_without_a_configured_provider() -> None:
     """With no MusicBrainz provider configured the match simply abstains."""
     with _mb_harness(None) as (harness, base):
-        assert await harness.ctrl.match_provider(base, _provider()) == []
+        assert await harness.match(base) == []
 
 
 def _mb_evidence_ctrl(musicbrainz: Mock) -> AlbumsController:

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -714,6 +714,18 @@ def test_compare_album_track_fingerprint_unknown_disc_layout_vs_multi_disc_is_in
     )
 
 
+def test_album_tracks_have_positions() -> None:
+    """A trustworthy disc/track layout is recognized, an ambiguous one is not."""
+    assert compare.album_tracks_have_positions(_tracklist(10)) is True
+    assert compare.album_tracks_have_positions(None) is False
+    assert compare.album_tracks_have_positions([]) is False
+    # a missing track number makes the layout untrustworthy
+    assert compare.album_tracks_have_positions([_track("1", track_number=0)]) is False
+    # a duplicate position cannot be trusted either
+    duplicate = [_track("1", track_number=1), _track("2", track_number=1)]
+    assert compare.album_tracks_have_positions(duplicate) is False
+
+
 def test_compare_external_ids_checks_all_unique_values() -> None:
     """One mismatching unique identifier does not hide another matching value."""
     base_ids = {

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -721,6 +721,8 @@ def test_album_tracks_have_positions() -> None:
     assert compare.album_tracks_have_positions([]) is False
     # a missing track number makes the layout untrustworthy
     assert compare.album_tracks_have_positions([_track("1", track_number=0)]) is False
+    # a missing disc number is treated as unknown, not silently assumed to be disc 1
+    assert compare.album_tracks_have_positions([_track("1", disc_number=0)]) is False
     # a duplicate position cannot be trusted either
     duplicate = [_track("1", track_number=1), _track("2", track_number=1)]
     assert compare.album_tracks_have_positions(duplicate) is False

--- a/tests/helpers/test_external_ids.py
+++ b/tests/helpers/test_external_ids.py
@@ -6,6 +6,7 @@ from music_assistant.helpers.external_ids import (
     barcode_to_upc,
     external_id_lookup_values,
     external_id_lookup_values_untyped,
+    is_valid_barcode,
     normalize_external_id,
     normalize_external_ids,
 )
@@ -62,3 +63,14 @@ def test_normalize_external_ids_deduplicates_values() -> None:
     )
 
     assert result == {(ExternalID.BARCODE, "00724354283857")}
+
+
+def test_is_valid_barcode() -> None:
+    """A structurally valid GTIN is recognized regardless of UPC/EAN notation."""
+    assert is_valid_barcode("888072439412") is True
+    assert is_valid_barcode("0888072439412") is True
+    assert is_valid_barcode("00888072439412") is True
+    # bad check digit, wrong length or non-numeric data is not a usable barcode
+    assert is_valid_barcode("602445790392") is False
+    assert is_valid_barcode("12345") is False
+    assert is_valid_barcode("catalog-123") is False

--- a/tests/providers/musicbrainz/test_provider.py
+++ b/tests/providers/musicbrainz/test_provider.py
@@ -685,6 +685,7 @@ async def test_releases_by_barcode_queries_every_compatible_form() -> None:
     call = get_data.await_args
     assert call is not None
     assert call.args == ("release",)
+    assert call.kwargs["limit"] == "100"
     query = call.kwargs["query"]
     assert "barcode:888072439412" in query
     assert "barcode:0888072439412" in query

--- a/tests/providers/musicbrainz/test_provider.py
+++ b/tests/providers/musicbrainz/test_provider.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from music_assistant_models.errors import RateLimited
+import pytest
+from music_assistant_models.errors import InvalidDataError, RateLimited
 
 from music_assistant.constants import VARIOUS_ARTISTS_MBID
 from music_assistant.providers.musicbrainz.provider import MusicbrainzProvider
@@ -645,7 +646,12 @@ async def test_release_year_by_track_name_escapes_lucene_specials() -> None:
 
 
 def _barcode_release(release_id: str, release_group_id: str, barcode: str) -> dict[str, Any]:
-    """Return one release stub as returned by a barcode search."""
+    """
+    Return one release stub as a barcode search actually returns it.
+
+    Includes the summary ``media`` object (format/track-count, no tracklist) that the
+    full release model cannot parse, so the slim search model is exercised realistically.
+    """
     return {
         "id": release_id,
         "status-id": "status-id",
@@ -654,12 +660,14 @@ def _barcode_release(release_id: str, release_group_id: str, barcode: str) -> di
         "status": "Official",
         "barcode": barcode,
         "artist-credit": [_credit("Sigur Rós", "artist-1")],
-        "release-group": {"id": release_group_id, "title": "( )"},
+        "release-group": {"id": release_group_id, "title": "( )", "primary-type": "Album"},
+        "media": [{"format": "CD", "disc-count": 1, "track-count": 14}],
+        "track-count": 14,
     }
 
 
 async def test_releases_by_barcode_parses_releases() -> None:
-    """Return every release MusicBrainz has on file for a barcode."""
+    """Return every release MusicBrainz has on file for a barcode (summary media and all)."""
     response = {
         "count": 2,
         "releases": [
@@ -706,8 +714,8 @@ async def test_releases_by_barcode_is_empty_when_not_found() -> None:
     assert await provider.get_releases_by_barcode("888072439412") == []
 
 
-async def test_releases_by_barcode_skips_a_malformed_entry() -> None:
-    """A single malformed release does not sink the ones that parse."""
+async def test_releases_by_barcode_abstains_on_malformed_entry() -> None:
+    """One unparsable release makes the whole lookup abstain rather than look complete."""
     response = {
         "releases": [
             {"id": "broken"},
@@ -716,6 +724,17 @@ async def test_releases_by_barcode_skips_a_malformed_entry() -> None:
     }
     provider, _ = _provider(response)
 
-    releases = await provider.get_releases_by_barcode("888072439412")
+    with pytest.raises(InvalidDataError):
+        await provider.get_releases_by_barcode("888072439412")
 
-    assert [release.id for release in releases] == ["rel-2"]
+
+async def test_releases_by_barcode_abstains_on_truncated_result() -> None:
+    """A truncated page abstains rather than treating a partial set as complete."""
+    response = {
+        "count": 5,
+        "releases": [_barcode_release("rel-1", "rg-1", "0888072439412")],
+    }
+    provider, _ = _provider(response)
+
+    with pytest.raises(InvalidDataError):
+        await provider.get_releases_by_barcode("888072439412")

--- a/tests/providers/musicbrainz/test_provider.py
+++ b/tests/providers/musicbrainz/test_provider.py
@@ -637,3 +637,84 @@ async def test_release_year_by_track_name_escapes_lucene_specials() -> None:
         query='"T.N.T. \\(live\\!\\)" AND artist:"AC\\/DC"',
         limit="100",
     )
+
+
+# ---------------------------------------------------------------------------
+# get_releases_by_barcode
+# ---------------------------------------------------------------------------
+
+
+def _barcode_release(release_id: str, release_group_id: str, barcode: str) -> dict[str, Any]:
+    """Return one release stub as returned by a barcode search."""
+    return {
+        "id": release_id,
+        "status-id": "status-id",
+        "count": 1,
+        "title": "( )",
+        "status": "Official",
+        "barcode": barcode,
+        "artist-credit": [_credit("Sigur Rós", "artist-1")],
+        "release-group": {"id": release_group_id, "title": "( )"},
+    }
+
+
+async def test_releases_by_barcode_parses_releases() -> None:
+    """Return every release MusicBrainz has on file for a barcode."""
+    response = {
+        "count": 2,
+        "releases": [
+            _barcode_release("rel-1", "rg-1", "0888072439412"),
+            _barcode_release("rel-2", "rg-1", "0888072439412"),
+        ],
+    }
+    provider, _ = _provider(response)
+
+    releases = await provider.get_releases_by_barcode("888072439412")
+
+    assert [release.id for release in releases] == ["rel-1", "rel-2"]
+    assert {release.release_group.id for release in releases} == {"rg-1"}
+
+
+async def test_releases_by_barcode_queries_every_compatible_form() -> None:
+    """Query the UPC-12 and its zero-padded EAN-13/GTIN forms in a single request."""
+    provider, get_data = _provider({"releases": []})
+
+    await provider.get_releases_by_barcode("888072439412")
+
+    get_data.assert_awaited_once()
+    call = get_data.await_args
+    assert call is not None
+    assert call.args == ("release",)
+    query = call.kwargs["query"]
+    assert "barcode:888072439412" in query
+    assert "barcode:0888072439412" in query
+
+
+async def test_releases_by_barcode_skips_an_invalid_barcode() -> None:
+    """A structurally invalid barcode is treated as absent, without any request."""
+    provider, get_data = _provider({"releases": []})
+
+    assert await provider.get_releases_by_barcode("not-a-barcode") == []
+    get_data.assert_not_awaited()
+
+
+async def test_releases_by_barcode_is_empty_when_not_found() -> None:
+    """An unknown barcode yields an empty list rather than an error."""
+    provider, _ = _provider(None)
+
+    assert await provider.get_releases_by_barcode("888072439412") == []
+
+
+async def test_releases_by_barcode_skips_a_malformed_entry() -> None:
+    """A single malformed release does not sink the ones that parse."""
+    response = {
+        "releases": [
+            {"id": "broken"},
+            _barcode_release("rel-2", "rg-2", "0888072439412"),
+        ]
+    }
+    provider, _ = _provider(response)
+
+    releases = await provider.get_releases_by_barcode("888072439412")
+
+    assert [release.id for release in releases] == ["rel-2"]


### PR DESCRIPTION
# What does this implement/fix?

Confirm uncertain album matches with full provider details, ordered track fingerprints, and last-resort MusicBrainz release evidence before linking editions.

- Fetch full albums only for plausible explicit-match candidates
- Reuse bounded tracklist lookups to distinguish remasters and deluxe editions
- Keep bulk library sync database-only and conservative

**Related issue (if applicable):**

- Builds on #5771

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.