### PR TITLE
Tidal: fix search against the new filter[query] endpoint (spec 1.10.101)

### DIFF
--- a/music_assistant/providers/tidal/_openapi_models.py
+++ b/music_assistant/providers/tidal/_openapi_models.py
@@ -39,7 +39,7 @@ class ExternalLink(TypedDict):
 
 
 class PlaylistsAttributes(TypedDict):
-    accessType: Literal["PUBLIC", "UNLISTED"]
+    accessType: Literal["PUBLIC", "UNLISTED", "PRIVATE"]
     bounded: bool
     createdAt: str
     description: NotRequired[str]

--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import urllib.parse
 from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp.client_exceptions import ClientError
@@ -62,9 +61,15 @@ class TidalMediaManager:
         if not includes:
             return results
 
-        query = urllib.parse.quote(search_query, safe="")
-        doc = await self.api.get_jsonapi(f"searchResults/{query}", include=includes)
-        data = doc.data
+        # Since spec 1.10.101 search is a collection endpoint taking the query as
+        # a filter and returning exactly one searchResults resource (with an
+        # opaque id); the old /searchResults/{query} path 400s.
+        doc = await self.api.get_jsonapi(
+            "searchResults", params={"filter[query]": search_query}, include=includes
+        )
+        if not doc.data_list:
+            return results
+        data = doc.data_list[0]
 
         # Slice the resources before parsing so we only parse up to `limit` items.
         if MediaType.TRACK in wanted:

--- a/scripts/tidal_openapi/tidal-api-oas.json
+++ b/scripts/tidal_openapi/tidal-api-oas.json
@@ -5,10 +5,10 @@
       "name" : "TIDAL Developer - Discussions",
       "url" : "https://github.com/orgs/tidal-music/discussions"
     },
-    "description" : "The TIDAL API is a [JSON:API](https://jsonapi.org/)-compliant web API exposing TIDAL's music catalogue, metadata, and user functionality. Guides, authorization documentation, and API key management live at [developer.tidal.com](https://developer.tidal.com).\n\nAll endpoints exchange `application/vnd.api+json` documents per the [JSON:API specification](https://jsonapi.org/format/): [resource objects](https://jsonapi.org/format/#document-resource-objects) with `attributes` and `relationships`, [compound documents](https://jsonapi.org/format/#document-compound-documents) via `include`, and standard [error objects](https://jsonapi.org/format/#error-objects).\n\n### Authentication and authorization\n\nEvery request requires an OAuth 2.0 access token in the `Authorization: Bearer` header. Tokens are issued at `https://auth.tidal.com/v1/oauth2/token` via the client-credentials flow (server-to-server) or the authorization-code + PKCE flow (user context; authorize at `https://login.tidal.com/authorize`). Each endpoint documents which flows it accepts, the access tier it requires, and the scopes that apply. Scopes protect private user data: fields you are not authorized to read are redacted from the response rather than causing an error, and resources you cannot access at all behave as if they do not exist. See the [authorization guide](https://developer.tidal.com/documentation/api-sdk/api-sdk-authorization) for details.\n\n### Working with responses\n\n- **Enums** — new values can be added to any enum at any time. Treat unknown values as forward-compatible, not as errors.\n- **IDs** are opaque strings. Never parse, construct, or infer meaning from them.\n- **Formats** — dates, times and durations are ISO 8601 (`2024-05-01T12:00:00Z`, `PT3M5S`); countries ISO 3166-1 alpha-2; languages BCP 47; currencies ISO 4217; colors six-digit hex.\n\n### Relationships and includes\n\n[Relationships](https://jsonapi.org/format/#document-resource-object-relationships) are returned only on request: a resource's `relationships` object contains just the relationships named in [`include`](https://jsonapi.org/format/#fetching-includes) — a relationship that was not requested is absent from the response, not empty. The full set of relationships a resource supports is documented in its schema.\n\nRequest related resources in one round trip with `?include=`, a comma-separated list of dot-separated relationship paths — e.g. `include=coverArt,artists.profileArt` on an album. A nested path automatically embeds its intermediate resources: `artists.profileArt` includes the artists as well as their profile art. Include paths are always relative to the request's root resource, also on relationship endpoints. Including a relationship never changes the primary data; the related resources are added to `included`.\n\nInclude paths are validated: a path that cannot be resolved against the resources' documented relationships is rejected with `400`. Include trees are also bounded in path depth (default 3 levels) and in the total number of distinct resources they name (default 10); individual endpoints may apply different limits. A request exceeding either limit is rejected with `400`, with the effective limit stated in the error.\n\n### Filtering, sorting, pagination\n\n- [`filter[<member>]=value`](https://jsonapi.org/format/#fetching-filtering) filters collections; each endpoint documents its available filters, and most collections require at least one.\n- [`sort=<member>`](https://jsonapi.org/format/#fetching-sorting) sorts ascending, `-<member>` descending (`sort=-addedAt`). Filter and sort members are relative to the resources being returned.\n- Parameters an endpoint cannot honor are rejected with `400`: a `filter[...]` parameter the endpoint does not document (the error lists the available filters), or `sort` on an endpoint that documents no sort values.\n- [Pagination](https://jsonapi.org/format/#fetching-pagination) is cursor-based: responses carry `links.self` and, while more pages exist, `links.next` with an opaque `page[cursor]`. Follow `next` until absent — there are no offset or total-page parameters. Collection sizes, when available, appear as `meta.total` and may be approximate.\n\n### Type qualifiers\n\nWhere a relationship can contain several resource types, a path segment may be prefixed with a concrete type to scope which type's member is accessed. A playlist's `items` are `tracks` or `videos`: `GET /playlists/{id}?include=items.tracks:albums` resolves `albums` only for the items that are tracks. Qualifiers scope member access — they never filter which resources appear in a relationship — and can be chained.\n\nThe same syntax applies to `filter` and `sort` member paths on endpoints that support it; where supported, the qualified member is listed among the endpoint's documented filters and sort values. The syntax follows JSON:API proposal [json-api#1695](https://github.com/json-api/json-api/issues/1695).\n\n### Mutations\n\n- [Partial updates](https://jsonapi.org/format/#crud-updating-resource-attributes) follow JSON:API semantics: attributes omitted from the payload are left unchanged; attributes set to `null` are cleared.\n- Every mutation accepts an [`Idempotency-Key`](https://www.ietf.org/archive/id/draft-ietf-httpapi-idempotency-key-header-07.html) header. Once the original request has completed, retrying with the same key and payload within one hour replays its response; a retry while it is still processing is rejected with `409`, and the same key with a different payload with `422`.\n- After a successful write, your own subsequent reads reflect the change; other clients may observe it with a delay.\n\n### Media resource replacements - BETA Internal only\n\nMedia resources (`tracks`, `videos`, and `albums`) can become unavailable in a country when licensing rights change. By default, TIDAL API returns the resource identifiers originally stored in a collection. This keeps ordinary reads predictable and consistent.\n\nIf a stored media resource is unavailable for the effective country, TIDAL may identify a contextually applicable alternative that is available there. Replacement is best effort, so an alternative is not always available. Replacement never changes the stored collection.\n\nTIDAL API provides two ways to work with replacements:\n\n1. **Inspect the `replacement` relationship.** A media resource can expose its applicable alternative through the `replacement` relationship. Include this relationship when a client needs both the original and replacement identifiers or wants to decide whether to use the replacement.\n\n2. **Apply replacements with `replaceMedia`.** Clients can use `replaceMedia` to substitute applicable replacements directly into selected relationship data. The parameter accepts relationship paths using the same syntax as `include`. Projection affects only the response and preserves relationship order and metadata. Each identifier includes `meta.replacement` describing whether it was `ORIGINAL`, `REPLACED`, or `NOT_REPLACED`.\n\nFor example, `GET /playlists/{id}?include=items&replaceMedia=items` applies replacements to media identifiers in the playlist's `items` relationship.\n\n### Compression\n\nResponses are gzip-compressed when the request includes `Accept-Encoding: gzip` (bodies over 2 KB).\n\n### Deprecation\n\nDeprecated endpoints, parameters, and fields are marked `deprecated` in this specification, with the replacement noted in their description. Deprecated functionality keeps working for at least six months after being marked, and is only removed once a replacement is generally available.",
+    "description" : "The TIDAL API is a [JSON:API](https://jsonapi.org/)-compliant web API exposing TIDAL's music catalogue, metadata, and user functionality. Guides, authorization documentation, and API key management live at [developer.tidal.com](https://developer.tidal.com).\n\nAll endpoints exchange `application/vnd.api+json` documents per the [JSON:API specification](https://jsonapi.org/format/): [resource objects](https://jsonapi.org/format/#document-resource-objects) with `attributes` and `relationships`, [compound documents](https://jsonapi.org/format/#document-compound-documents) via `include`, and standard [error objects](https://jsonapi.org/format/#error-objects).\n\n### Authentication and authorization\n\nEvery request requires an OAuth 2.0 access token in the `Authorization: Bearer` header. Tokens are issued at `https://auth.tidal.com/v1/oauth2/token` via the client-credentials flow (server-to-server) or the authorization-code + PKCE flow (user context; authorize at `https://login.tidal.com/authorize`). Each endpoint documents which flows it accepts, the access tier it requires, and the scopes that apply. Scopes protect private user data: fields you are not authorized to read are redacted from the response rather than causing an error, and resources you cannot access at all behave as if they do not exist. See the [authorization guide](https://developer.tidal.com/documentation/api-sdk/api-sdk-authorization) for details.\n\n### Working with responses\n\n- **Enums** — new values can be added to any enum at any time. Treat unknown values as forward-compatible, not as errors.\n- **IDs** are opaque strings. Never parse, construct, or infer meaning from them.\n- **Formats** — dates, times and durations are ISO 8601 (`2024-05-01T12:00:00Z`, `PT3M5S`); countries ISO 3166-1 alpha-2; languages BCP 47; currencies ISO 4217; colors six-digit hex.\n\n### Relationships and includes\n\n[Relationships](https://jsonapi.org/format/#document-resource-object-relationships) are returned only on request: a resource's `relationships` object contains just the relationships named in [`include`](https://jsonapi.org/format/#fetching-includes) — a relationship that was not requested is absent from the response, not empty. The full set of relationships a resource supports is documented in its schema.\n\nRequest related resources in one round trip with `?include=`, a comma-separated list of dot-separated relationship paths — e.g. `include=coverArt,artists.profileArt` on an album. A nested path automatically embeds its intermediate resources: `artists.profileArt` includes the artists as well as their profile art. Include paths are always relative to the request's root resource, also on relationship endpoints. Including a relationship never changes the primary data; the related resources are added to `included`.\n\nInclude paths are validated: a path that cannot be resolved against the resources' documented relationships is rejected with `400`. Include trees are also bounded in path depth (default 3 levels) and in the total number of distinct resources they name (default 10); individual endpoints may apply different limits. A request exceeding either limit is rejected with `400`, with the effective limit stated in the error.\n\n### Filtering, sorting, pagination\n\n- [`filter[<member>]=value`](https://jsonapi.org/format/#fetching-filtering) filters collections; each endpoint documents its available filters, and most collections require at least one.\n- [`sort=<member>`](https://jsonapi.org/format/#fetching-sorting) sorts ascending, `-<member>` descending (`sort=-addedAt`). Filter and sort members are relative to the resources being returned.\n- Parameters an endpoint cannot honor are rejected with `400`: a `filter[...]` parameter the endpoint does not document (the error lists the available filters), or `sort` on an endpoint that documents no sort values.\n- [Pagination](https://jsonapi.org/format/#fetching-pagination) is cursor-based: responses carry `links.self` and, while more pages exist, `links.next` with an opaque `page[cursor]`. Follow `next` until absent — there are no offset or total-page parameters. Collection sizes, when available, appear as `meta.total` and may be approximate.\n\n### Type qualifiers\n\nWhere a relationship can contain several resource types, a path segment may be prefixed with a concrete type to scope which type's member is accessed. A playlist's `items` are `tracks` or `videos`: `GET /playlists/{id}?include=items.tracks:albums` resolves `albums` only for the items that are tracks. Qualifiers scope member access — they never filter which resources appear in a relationship — and can be chained.\n\nThe same syntax applies to `filter` and `sort` member paths on endpoints that support it; where supported, the qualified member is listed among the endpoint's documented filters and sort values. The syntax follows JSON:API proposal [json-api#1695](https://github.com/json-api/json-api/issues/1695).\n\n### Mutations\n\n- [Partial updates](https://jsonapi.org/format/#crud-updating-resource-attributes) distinguish three wire states for nullable attributes: omission leaves the current value unchanged, an explicit `null` clears it, and a concrete value updates it.\n- Every mutation accepts an [`Idempotency-Key`](https://www.ietf.org/archive/id/draft-ietf-httpapi-idempotency-key-header-07.html) header. Once the original request has completed, retrying with the same key and payload within one hour replays its response; a retry while it is still processing is rejected with `409`, and the same key with a different payload with `422`.\n- After a successful write, your own subsequent reads reflect the change; other clients may observe it with a delay.\n\n### Media resource replacements - BETA Internal only\n\nMedia resources (`tracks`, `videos`, and `albums`) can become unavailable in a country when licensing rights change. By default, TIDAL API returns the resource identifiers originally stored in a collection. This keeps ordinary reads predictable and consistent.\n\nIf a stored media resource is unavailable for the effective country, TIDAL may identify a contextually applicable alternative that is available there. Replacement is best effort, so an alternative is not always available. Replacement never changes the stored collection.\n\nTIDAL API provides two ways to work with replacements:\n\n1. **Inspect the `replacement` relationship.** A media resource can expose its applicable alternative through the `replacement` relationship. Include this relationship when a client needs both the original and replacement identifiers or wants to decide whether to use the replacement.\n\n2. **Apply replacements with `replaceMedia`.** Clients can use `replaceMedia` to substitute applicable replacements directly into selected relationship data. The parameter accepts relationship paths using the same syntax as `include`. Projection affects only the response and preserves relationship order and metadata. Each identifier includes `meta.replacement` describing whether it was `ORIGINAL`, `REPLACED`, or `NOT_REPLACED`.\n\nFor example, `GET /playlists/{id}?include=items&replaceMedia=items` applies replacements to media identifiers in the playlist's `items` relationship.\n\n### Compression\n\nResponses are gzip-compressed when the request includes `Accept-Encoding: gzip` (bodies over 2 KB).\n\n### Deprecation\n\nDeprecated endpoints, parameters, and fields are marked `deprecated` in this specification, with the replacement noted in their description. Deprecated functionality keeps working for at least six months after being marked, and is only removed once a replacement is generally available.",
     "termsOfService" : "https://developer.tidal.com/documentation/guidelines/guidelines-developer-terms",
     "title" : "TIDAL API",
-    "version" : "1.10.79"
+    "version" : "1.10.101"
   },
   "externalDocs" : {
     "description" : "TIDAL Developer - Documentation",
@@ -242,6 +242,29 @@
       "get" : {
         "description" : "Retrieves multiple acceptedTerms by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "User id. Use `me` for the authenticated user",
+          "in" : "query",
+          "name" : "filter[owners.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "description" : "One of: DEVELOPER, UPLOAD_MARKETPLACE, MERCH_GUIDELINES (e.g. `DEVELOPER`)",
+          "in" : "query",
+          "name" : "filter[terms.termsType]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "DEVELOPER", "UPLOAD_MARKETPLACE", "MERCH_GUIDELINES" ]
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: owners, terms",
           "example" : "owners",
           "in" : "query",
@@ -255,17 +278,6 @@
             }
           }
         }, {
-          "description" : "User id. Use `me` for the authenticated user",
-          "in" : "query",
-          "name" : "filter[owners.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
           "description" : "Filter by terms.isLatestVersion",
           "in" : "query",
           "name" : "filter[terms.isLatestVersion]",
@@ -274,18 +286,6 @@
             "type" : "array",
             "items" : {
               "type" : "string"
-            }
-          }
-        }, {
-          "description" : "One of: DEVELOPER, UPLOAD_MARKETPLACE (e.g. `DEVELOPER`)",
-          "in" : "query",
-          "name" : "filter[terms.termsType]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "DEVELOPER", "UPLOAD_MARKETPLACE" ]
             }
           }
         } ],
@@ -353,7 +353,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/AcceptedTerms_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/AcceptedTerms_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -743,8 +743,8 @@
             "items" : {
               "type" : "string",
               "example" : "createdAt",
-              "enum" : [ "createdAt", "-createdAt", "title", "-title" ],
               "default" : "-createdAt",
+              "enum" : [ "createdAt", "-createdAt", "title", "-title" ],
               "x-enum-varnames" : [ "CreatedAtAsc", "CreatedAtDesc", "TitleAsc", "TitleDesc" ]
             }
           }
@@ -889,7 +889,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Albums_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Albums_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -2590,7 +2590,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Appreciations_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Appreciations_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -2931,6 +2931,17 @@
       "get" : {
         "description" : "Retrieves multiple artistClaims by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "User id. Use `me` for the authenticated user",
+          "in" : "query",
+          "name" : "filter[owners.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: acceptedArtists, owners, recommendedArtists",
           "example" : "acceptedArtists.albums",
           "in" : "query",
@@ -2941,17 +2952,6 @@
             "items" : {
               "type" : "string",
               "example" : "acceptedArtists.albums"
-            }
-          }
-        }, {
-          "description" : "User id. Use `me` for the authenticated user",
-          "in" : "query",
-          "name" : "filter[owners.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         }, {
@@ -3038,7 +3038,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/ArtistClaims_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/ArtistClaims_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -3824,7 +3824,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Artists_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Artists_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -4574,6 +4574,9 @@
           }
         },
         "responses" : {
+          "201" : {
+            "description" : "Successful response"
+          },
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
@@ -5434,6 +5437,17 @@
       "get" : {
         "description" : "Retrieves multiple artworks by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "Artwork id (e.g. `a468bee88def`)",
+          "in" : "query",
+          "name" : "filter[id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "ISO 3166-1 alpha-2 country code",
           "example" : "US",
           "in" : "query",
@@ -5453,17 +5467,6 @@
             "items" : {
               "type" : "string",
               "example" : "owners"
-            }
-          }
-        }, {
-          "description" : "Artwork id (e.g. `a468bee88def`)",
-          "in" : "query",
-          "name" : "filter[id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         } ],
@@ -5533,7 +5536,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Artworks_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Artworks_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -5749,6 +5752,17 @@
       "get" : {
         "description" : "Retrieves multiple clients by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "User id. Use `me` for the authenticated user",
+          "in" : "query",
+          "name" : "filter[owners.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: owners",
           "example" : "owners",
           "in" : "query",
@@ -5759,17 +5773,6 @@
             "items" : {
               "type" : "string",
               "example" : "owners"
-            }
-          }
-        }, {
-          "description" : "User id. Use `me` for the authenticated user",
-          "in" : "query",
-          "name" : "filter[owners.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         } ],
@@ -5837,7 +5840,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Clients_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Clients_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -6038,7 +6041,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Clients_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Clients_Update_Single_Resource_Data_Document"
                 }
               }
             },
@@ -6185,7 +6188,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/CollaborationInviteRedemptions_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/CollaborationInviteRedemptions_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -6236,6 +6239,17 @@
       "get" : {
         "description" : "Retrieves multiple collaborationInvites by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "Invite code",
+          "in" : "query",
+          "name" : "filter[code]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: owners, subject",
           "example" : "subject.items",
           "in" : "query",
@@ -6246,17 +6260,6 @@
             "items" : {
               "type" : "string",
               "example" : "subject.items"
-            }
-          }
-        }, {
-          "description" : "Invite code",
-          "in" : "query",
-          "name" : "filter[code]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         }, {
@@ -6334,7 +6337,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/CollaborationInvites_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/CollaborationInvites_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -6684,6 +6687,29 @@
       "get" : {
         "description" : "Retrieves multiple comments by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "Filter by subject resource ID (e.g. `12345`)",
+          "in" : "query",
+          "name" : "filter[subject.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "description" : "Filter by subject resource type (e.g. `albums`)",
+          "in" : "query",
+          "name" : "filter[subject.type]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "albums", "tracks" ]
+            }
+          }
+        }, {
           "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
           "in" : "query",
           "name" : "page[cursor]",
@@ -6701,8 +6727,8 @@
             "items" : {
               "type" : "string",
               "example" : "createdAt",
-              "enum" : [ "createdAt", "-createdAt", "likeCount", "-likeCount", "replyCount", "-replyCount", "startTime", "-startTime" ],
               "default" : "-createdAt",
+              "enum" : [ "createdAt", "-createdAt", "likeCount", "-likeCount", "replyCount", "-replyCount", "startTime", "-startTime" ],
               "x-enum-varnames" : [ "CreatedAtAsc", "CreatedAtDesc", "LikeCountAsc", "LikeCountDesc", "ReplyCountAsc", "ReplyCountDesc", "StartTimeAsc", "StartTimeDesc" ]
             }
           }
@@ -6728,29 +6754,6 @@
             "type" : "array",
             "items" : {
               "type" : "string"
-            }
-          }
-        }, {
-          "description" : "Filter by subject resource ID (e.g. `12345`)",
-          "in" : "query",
-          "name" : "filter[subject.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
-          "description" : "Filter by subject resource type (e.g. `albums`)",
-          "in" : "query",
-          "name" : "filter[subject.type]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "albums", "tracks" ]
             }
           }
         } ],
@@ -6818,7 +6821,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Comments_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Comments_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -7292,6 +7295,17 @@
       "get" : {
         "description" : "Retrieves multiple contentClaims by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "User id. Use `me` for the authenticated user",
+          "in" : "query",
+          "name" : "filter[owners.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: claimedResource, claimingArtist, owners",
           "example" : "claimedResource",
           "in" : "query",
@@ -7302,17 +7316,6 @@
             "items" : {
               "type" : "string",
               "example" : "claimedResource"
-            }
-          }
-        }, {
-          "description" : "User id. Use `me` for the authenticated user",
-          "in" : "query",
-          "name" : "filter[owners.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         }, {
@@ -7390,7 +7393,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/ContentClaims_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/ContentClaims_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -8009,6 +8012,17 @@
       "get" : {
         "description" : "Retrieves multiple downloads by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "Download id (e.g. `VFJBQ0tTOjEyMzQ1`)",
+          "in" : "query",
+          "name" : "filter[id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: owners",
           "example" : "owners",
           "in" : "query",
@@ -8019,17 +8033,6 @@
             "items" : {
               "type" : "string",
               "example" : "owners"
-            }
-          }
-        }, {
-          "description" : "Download id (e.g. `VFJBQ0tTOjEyMzQ1`)",
-          "in" : "query",
-          "name" : "filter[id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         } ],
@@ -8235,19 +8238,6 @@
       "get" : {
         "description" : "Retrieves multiple dspSharingLinks by available filters, or without if applicable.",
         "parameters" : [ {
-          "description" : "Allows the client to customize which related resources should be returned. Available options: subject",
-          "example" : "subject",
-          "in" : "query",
-          "name" : "include",
-          "required" : false,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "example" : "subject"
-            }
-          }
-        }, {
           "description" : "The id of the subject resource",
           "in" : "query",
           "name" : "filter[subject.id]",
@@ -8268,6 +8258,19 @@
             "items" : {
               "type" : "string",
               "enum" : [ "tracks", "albums", "artists" ]
+            }
+          }
+        }, {
+          "description" : "Allows the client to customize which related resources should be returned. Available options: subject",
+          "example" : "subject",
+          "in" : "query",
+          "name" : "include",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "example" : "subject"
             }
           }
         }, {
@@ -8417,33 +8420,6 @@
       "get" : {
         "description" : "Retrieves multiple dynamicModules by available filters, or without if applicable.",
         "parameters" : [ {
-          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
-          "in" : "query",
-          "name" : "refreshSeed",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "description" : "ISO 3166-1 alpha-2 country code",
-          "example" : "US",
-          "in" : "query",
-          "name" : "countryCode",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "description" : "BCP 47 locale (e.g., en-US, nb-NO, pt-BR). Defaults to en-US if not provided or unsupported.",
-          "example" : "en-US",
-          "in" : "query",
-          "name" : "locale",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "en-US"
-          }
-        }, {
           "description" : "The type of device making the request",
           "example" : "PHONE",
           "in" : "query",
@@ -8473,6 +8449,44 @@
             "type" : "string"
           }
         }, {
+          "description" : "DynamicModules Id (e.g. `nejMcAhh5N8S3EQ4LaqysVdI0cZZ`)",
+          "in" : "query",
+          "name" : "filter[id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
+          "in" : "query",
+          "name" : "refreshSeed",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "ISO 3166-1 alpha-2 country code",
+          "example" : "US",
+          "in" : "query",
+          "name" : "countryCode",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "BCP 47 locale (e.g., en-US, nb-NO, pt-BR). Defaults to en-US if not provided or unsupported.",
+          "example" : "en-US",
+          "in" : "query",
+          "name" : "locale",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "en-US"
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: items, seedItem",
           "example" : "items",
           "in" : "query",
@@ -8483,17 +8497,6 @@
             "items" : {
               "type" : "string",
               "example" : "items"
-            }
-          }
-        }, {
-          "description" : "DynamicModules Id (e.g. `nejMcAhh5N8S3EQ4LaqysVdI0cZZ`)",
-          "in" : "query",
-          "name" : "filter[id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         }, {
@@ -8568,33 +8571,6 @@
             "type" : "string"
           }
         }, {
-          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
-          "in" : "query",
-          "name" : "refreshSeed",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "description" : "ISO 3166-1 alpha-2 country code",
-          "example" : "US",
-          "in" : "query",
-          "name" : "countryCode",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "description" : "BCP 47 locale (e.g., en-US, nb-NO, pt-BR). Defaults to en-US if not provided or unsupported.",
-          "example" : "en-US",
-          "in" : "query",
-          "name" : "locale",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "en-US"
-          }
-        }, {
           "description" : "The type of device making the request",
           "example" : "PHONE",
           "in" : "query",
@@ -8622,6 +8598,33 @@
           "required" : true,
           "schema" : {
             "type" : "string"
+          }
+        }, {
+          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
+          "in" : "query",
+          "name" : "refreshSeed",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "ISO 3166-1 alpha-2 country code",
+          "example" : "US",
+          "in" : "query",
+          "name" : "countryCode",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "BCP 47 locale (e.g., en-US, nb-NO, pt-BR). Defaults to en-US if not provided or unsupported.",
+          "example" : "en-US",
+          "in" : "query",
+          "name" : "locale",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "en-US"
           }
         }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: items, seedItem",
@@ -8708,6 +8711,35 @@
             "type" : "string"
           }
         }, {
+          "description" : "The type of device making the request",
+          "example" : "PHONE",
+          "in" : "query",
+          "name" : "deviceType",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "BROWSER", "CAR", "DESKTOP", "PHONE", "TABLET", "TV" ]
+          }
+        }, {
+          "description" : "The system type of the device making the request",
+          "example" : "IOS",
+          "in" : "query",
+          "name" : "systemType",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ANDROID", "DESKTOP", "TESLA", "IOS", "WEB" ]
+          }
+        }, {
+          "description" : "Client version number",
+          "example" : "2026.0.1",
+          "in" : "query",
+          "name" : "clientVersion",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
           "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
           "in" : "query",
           "name" : "refreshSeed",
@@ -8741,35 +8773,6 @@
           "schema" : {
             "type" : "string",
             "default" : "en-US"
-          }
-        }, {
-          "description" : "The type of device making the request",
-          "example" : "PHONE",
-          "in" : "query",
-          "name" : "deviceType",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "BROWSER", "CAR", "DESKTOP", "PHONE", "TABLET", "TV" ]
-          }
-        }, {
-          "description" : "The system type of the device making the request",
-          "example" : "IOS",
-          "in" : "query",
-          "name" : "systemType",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ANDROID", "DESKTOP", "TESLA", "IOS", "WEB" ]
-          }
-        }, {
-          "description" : "Client version number",
-          "example" : "2026.0.1",
-          "in" : "query",
-          "name" : "clientVersion",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
           }
         }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: items",
@@ -8856,33 +8859,6 @@
             "type" : "string"
           }
         }, {
-          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
-          "in" : "query",
-          "name" : "refreshSeed",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "description" : "ISO 3166-1 alpha-2 country code",
-          "example" : "US",
-          "in" : "query",
-          "name" : "countryCode",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "description" : "BCP 47 locale (e.g., en-US, nb-NO, pt-BR). Defaults to en-US if not provided or unsupported.",
-          "example" : "en-US",
-          "in" : "query",
-          "name" : "locale",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "en-US"
-          }
-        }, {
           "description" : "The type of device making the request",
           "example" : "PHONE",
           "in" : "query",
@@ -8910,6 +8886,33 @@
           "required" : true,
           "schema" : {
             "type" : "string"
+          }
+        }, {
+          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
+          "in" : "query",
+          "name" : "refreshSeed",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "ISO 3166-1 alpha-2 country code",
+          "example" : "US",
+          "in" : "query",
+          "name" : "countryCode",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "BCP 47 locale (e.g., en-US, nb-NO, pt-BR). Defaults to en-US if not provided or unsupported.",
+          "example" : "en-US",
+          "in" : "query",
+          "name" : "locale",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "en-US"
           }
         }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: seedItem",
@@ -8987,33 +8990,6 @@
       "get" : {
         "description" : "Retrieves multiple dynamicPages by available filters, or without if applicable.",
         "parameters" : [ {
-          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
-          "in" : "query",
-          "name" : "refreshSeed",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "description" : "ISO 3166-1 alpha-2 country code",
-          "example" : "US",
-          "in" : "query",
-          "name" : "countryCode",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "description" : "BCP 47 locale (e.g., en-US, nb-NO, pt-BR). Defaults to en-US if not provided or unsupported.",
-          "example" : "en-US",
-          "in" : "query",
-          "name" : "locale",
-          "required" : false,
-          "schema" : {
-            "type" : "string",
-            "default" : "en-US"
-          }
-        }, {
           "description" : "The type of device making the request",
           "example" : "PHONE",
           "in" : "query",
@@ -9043,6 +9019,44 @@
             "type" : "string"
           }
         }, {
+          "description" : "type of the page (e.g. `ARTIST`)",
+          "in" : "query",
+          "name" : "filter[pageType]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
+          "in" : "query",
+          "name" : "refreshSeed",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "ISO 3166-1 alpha-2 country code",
+          "example" : "US",
+          "in" : "query",
+          "name" : "countryCode",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "BCP 47 locale (e.g., en-US, nb-NO, pt-BR). Defaults to en-US if not provided or unsupported.",
+          "example" : "en-US",
+          "in" : "query",
+          "name" : "locale",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "en-US"
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: modules, subject",
           "example" : "modules.items",
           "in" : "query",
@@ -9053,17 +9067,6 @@
             "items" : {
               "type" : "string",
               "example" : "modules.items"
-            }
-          }
-        }, {
-          "description" : "type of the page (e.g. `ARTIST`)",
-          "in" : "query",
-          "name" : "filter[pageType]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         }, {
@@ -9149,6 +9152,35 @@
             "type" : "string"
           }
         }, {
+          "description" : "The type of device making the request",
+          "example" : "PHONE",
+          "in" : "query",
+          "name" : "deviceType",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "BROWSER", "CAR", "DESKTOP", "PHONE", "TABLET", "TV" ]
+          }
+        }, {
+          "description" : "The system type of the device making the request",
+          "example" : "IOS",
+          "in" : "query",
+          "name" : "systemType",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ANDROID", "DESKTOP", "TESLA", "IOS", "WEB" ]
+          }
+        }, {
+          "description" : "Client version number",
+          "example" : "2026.0.1",
+          "in" : "query",
+          "name" : "clientVersion",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
           "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
           "in" : "query",
           "name" : "refreshSeed",
@@ -9182,35 +9214,6 @@
           "schema" : {
             "type" : "string",
             "default" : "en-US"
-          }
-        }, {
-          "description" : "The type of device making the request",
-          "example" : "PHONE",
-          "in" : "query",
-          "name" : "deviceType",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "BROWSER", "CAR", "DESKTOP", "PHONE", "TABLET", "TV" ]
-          }
-        }, {
-          "description" : "The system type of the device making the request",
-          "example" : "IOS",
-          "in" : "query",
-          "name" : "systemType",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ANDROID", "DESKTOP", "TESLA", "IOS", "WEB" ]
-          }
-        }, {
-          "description" : "Client version number",
-          "example" : "2026.0.1",
-          "in" : "query",
-          "name" : "clientVersion",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
           }
         }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: modules",
@@ -9372,6 +9375,17 @@
       "get" : {
         "description" : "Retrieves multiple genres by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "Allows filtering by genre id(s). USER_SELECTABLE is special value used to return specific genres which users can select from (e.g. `'1,2,3' or 'USER_SELECTABLE'`)",
+          "in" : "query",
+          "name" : "filter[id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
           "in" : "query",
           "name" : "page[cursor]",
@@ -9388,17 +9402,6 @@
           "schema" : {
             "type" : "string",
             "default" : "en-US"
-          }
-        }, {
-          "description" : "Allows filtering by genre id(s). USER_SELECTABLE is special value used to return specific genres which users can select from (e.g. `'1,2,3' or 'USER_SELECTABLE'`)",
-          "in" : "query",
-          "name" : "filter[id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
           }
         } ],
         "responses" : {
@@ -9641,7 +9644,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Installations_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Installations_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -9847,6 +9850,18 @@
             "type" : "string"
           }
         }, {
+          "description" : "One of: tracks, videos, albums, playlists, userCollectionTracks (e.g. `tracks`)",
+          "in" : "query",
+          "name" : "filter[type]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "tracks", "videos", "albums", "playlists", "userCollectionTracks" ]
+            }
+          }
+        }, {
           "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
           "in" : "query",
           "name" : "page[cursor]",
@@ -9879,7 +9894,7 @@
             }
           }
         }, {
-          "description" : "One of: PENDING, STORED (e.g. `PENDING`)",
+          "description" : "One of: PENDING, STORED, FAILED (e.g. `PENDING`)",
           "in" : "query",
           "name" : "filter[state]",
           "required" : false,
@@ -9887,19 +9902,7 @@
             "type" : "array",
             "items" : {
               "type" : "string",
-              "enum" : [ "PENDING", "STORED" ]
-            }
-          }
-        }, {
-          "description" : "One of: tracks, videos, albums, playlists, userCollectionTracks (e.g. `tracks`)",
-          "in" : "query",
-          "name" : "filter[type]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "tracks", "videos", "albums", "playlists", "userCollectionTracks" ]
+              "enum" : [ "PENDING", "STORED", "FAILED" ]
             }
           }
         }, {
@@ -9982,6 +9985,9 @@
           }
         },
         "responses" : {
+          "201" : {
+            "description" : "Successful response"
+          },
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
@@ -10123,7 +10129,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Lyrics_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Lyrics_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -10577,7 +10583,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/ManualArtistClaims_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/ManualArtistClaims_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -10628,6 +10634,17 @@
       "get" : {
         "description" : "Retrieves multiple offlineTasks by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "List of offline task IDs (e.g. `a468bee88def`)",
+          "in" : "query",
+          "name" : "filter[installation.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
           "in" : "query",
           "name" : "page[cursor]",
@@ -10646,17 +10663,6 @@
             "items" : {
               "type" : "string",
               "example" : "collection"
-            }
-          }
-        }, {
-          "description" : "List of offline task IDs (e.g. `a468bee88def`)",
-          "in" : "query",
-          "name" : "filter[installation.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         }, {
@@ -11110,6 +11116,17 @@
       "get" : {
         "description" : "Retrieves multiple playQueues by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "User id. Use `me` for the authenticated user",
+          "in" : "query",
+          "name" : "filter[owners.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
           "in" : "query",
           "name" : "page[cursor]",
@@ -11128,17 +11145,6 @@
             "items" : {
               "type" : "string",
               "example" : "current"
-            }
-          }
-        }, {
-          "description" : "User id. Use `me` for the authenticated user",
-          "in" : "query",
-          "name" : "filter[owners.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         }, {
@@ -11216,7 +11222,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/PlayQueues_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/PlayQueues_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -11851,6 +11857,9 @@
           }
         },
         "responses" : {
+          "201" : {
+            "description" : "Successful response"
+          },
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
@@ -12083,8 +12092,8 @@
             "items" : {
               "type" : "string",
               "example" : "createdAt",
-              "enum" : [ "createdAt", "-createdAt", "lastModifiedAt", "-lastModifiedAt", "name", "-name" ],
               "default" : "-createdAt",
+              "enum" : [ "createdAt", "-createdAt", "lastModifiedAt", "-lastModifiedAt", "name", "-name" ],
               "x-enum-varnames" : [ "CreatedAtAsc", "CreatedAtDesc", "LastModifiedAtAsc", "LastModifiedAtDesc", "NameAsc", "NameDesc" ]
             }
           }
@@ -12108,6 +12117,17 @@
             "items" : {
               "type" : "string",
               "example" : "items"
+            }
+          }
+        }, {
+          "description" : "User id. Use `me` for the authenticated user",
+          "in" : "query",
+          "name" : "filter[collaborators.id]",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           }
         }, {
@@ -12193,15 +12213,6 @@
       "post" : {
         "description" : "Creates a new playlist.",
         "parameters" : [ {
-          "description" : "ISO 3166-1 alpha-2 country code",
-          "example" : "US",
-          "in" : "query",
-          "name" : "countryCode",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
           "$ref" : "#/components/parameters/IdempotencyKey"
         } ],
         "requestBody" : {
@@ -12218,7 +12229,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Playlists_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Playlists_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -12424,15 +12435,6 @@
             "type" : "string"
           }
         }, {
-          "description" : "ISO 3166-1 alpha-2 country code",
-          "example" : "US",
-          "in" : "query",
-          "name" : "countryCode",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
           "$ref" : "#/components/parameters/IdempotencyKey"
         } ],
         "requestBody" : {
@@ -12445,6 +12447,16 @@
           }
         },
         "responses" : {
+          "200" : {
+            "content" : {
+              "application/vnd.api+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Playlists_Update_Single_Resource_Data_Document"
+                }
+              }
+            },
+            "description" : "Successful response"
+          },
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
@@ -12630,12 +12642,14 @@
           }
         },
         "security" : [ {
+          "Client_Credentials" : [ ]
+        }, {
           "Authorization_Code_PKCE" : [ ]
         } ],
         "summary" : "Get collaboratorProfiles relationship (\"to-many\").",
         "tags" : [ "playlists" ],
         "x-path-item-properties" : {
-          "required-access-tier" : "INTERNAL"
+          "required-access-tier" : "THIRD_PARTY"
         }
       },
       "post" : {
@@ -12662,6 +12676,9 @@
           }
         },
         "responses" : {
+          "201" : {
+            "description" : "Successful response"
+          },
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
@@ -12783,12 +12800,14 @@
           }
         },
         "security" : [ {
+          "Client_Credentials" : [ ]
+        }, {
           "Authorization_Code_PKCE" : [ ]
         } ],
         "summary" : "Get collaborators relationship (\"to-many\").",
         "tags" : [ "playlists" ],
         "x-path-item-properties" : {
-          "required-access-tier" : "INTERNAL"
+          "required-access-tier" : "THIRD_PARTY"
         }
       }
     },
@@ -13041,8 +13060,8 @@
             "items" : {
               "type" : "string",
               "example" : "addedAt",
-              "enum" : [ "addedAt", "-addedAt", "albums.title", "-albums.title", "artists.name", "-artists.name", "duration", "-duration", "itemIndex", "-itemIndex", "title", "-title" ],
               "default" : "itemIndex",
+              "enum" : [ "addedAt", "-addedAt", "albums.title", "-albums.title", "artists.name", "-artists.name", "duration", "-duration", "itemIndex", "-itemIndex", "title", "-title" ],
               "x-enum-varnames" : [ "AddedAtAsc", "AddedAtDesc", "AlbumsTitleAsc", "AlbumsTitleDesc", "ArtistsNameAsc", "ArtistsNameDesc", "DurationAsc", "DurationDesc", "ItemIndexAsc", "ItemIndexDesc", "TitleAsc", "TitleDesc" ]
             }
           }
@@ -13067,6 +13086,15 @@
               "type" : "string",
               "example" : "items"
             }
+          }
+        }, {
+          "description" : "Filter playlist items by a free-text query (e.g. `halo`)",
+          "in" : "query",
+          "name" : "filter[query]",
+          "required" : false,
+          "schema" : {
+            "maxLength" : 100,
+            "type" : "string"
           }
         }, {
           "description" : "Applies context-dependent replacements to media resource identifiers in selected relationships without changing stored data. Paths are comma-separated and follow `include` syntax. Example: items",
@@ -13202,15 +13230,6 @@
             "type" : "string"
           }
         }, {
-          "description" : "ISO 3166-1 alpha-2 country code",
-          "example" : "US",
-          "in" : "query",
-          "name" : "countryCode",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
           "$ref" : "#/components/parameters/IdempotencyKey"
         } ],
         "requestBody" : {
@@ -13227,7 +13246,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Playlists_Items_Multi_Relationship_Data_Document"
+                  "$ref" : "#/components/schemas/Playlists_Items_Add_Multi_Relationship_Data_Document"
                 }
               }
             },
@@ -13617,7 +13636,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/PriceConfigurations_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/PriceConfigurations_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -13729,6 +13748,17 @@
       "get" : {
         "description" : "Retrieves multiple providerOwners by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "User id. Use `me` for the authenticated user",
+          "in" : "query",
+          "name" : "filter[owners.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: owners, provider",
           "example" : "owners",
           "in" : "query",
@@ -13739,17 +13769,6 @@
             "items" : {
               "type" : "string",
               "example" : "owners"
-            }
-          }
-        }, {
-          "description" : "User id. Use `me` for the authenticated user",
-          "in" : "query",
-          "name" : "filter[owners.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         } ],
@@ -13953,6 +13972,17 @@
       "get" : {
         "description" : "Retrieves multiple providerProductInfos by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "Content provider ID (e.g. `50`)",
+          "in" : "query",
+          "name" : "filter[provider.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "ISO 3166-1 alpha-2 country code",
           "example" : "US",
           "in" : "query",
@@ -13990,17 +14020,6 @@
           "in" : "query",
           "name" : "filter[grid]",
           "required" : false,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
-          "description" : "Content provider ID (e.g. `50`)",
-          "in" : "query",
-          "name" : "filter[provider.id]",
-          "required" : true,
           "schema" : {
             "type" : "array",
             "items" : {
@@ -14290,27 +14309,6 @@
       "get" : {
         "description" : "Retrieves multiple purchases by available filters, or without if applicable.",
         "parameters" : [ {
-          "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
-          "in" : "query",
-          "name" : "page[cursor]",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "description" : "Allows the client to customize which related resources should be returned. Available options: owners, subject",
-          "example" : "subject",
-          "in" : "query",
-          "name" : "include",
-          "required" : false,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "example" : "subject"
-            }
-          }
-        }, {
           "description" : "User id. Use `me` for the authenticated user",
           "in" : "query",
           "name" : "filter[owners.id]",
@@ -14331,6 +14329,27 @@
             "items" : {
               "type" : "string",
               "enum" : [ "albums", "tracks" ]
+            }
+          }
+        }, {
+          "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
+          "in" : "query",
+          "name" : "page[cursor]",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "Allows the client to customize which related resources should be returned. Available options: owners, subject",
+          "example" : "subject",
+          "in" : "query",
+          "name" : "include",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "example" : "subject"
             }
           }
         }, {
@@ -14556,6 +14575,29 @@
       "get" : {
         "description" : "Retrieves multiple reactions by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "Filter by subject resource ID (e.g. `12345`)",
+          "in" : "query",
+          "name" : "filter[subject.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "description" : "Filter by subject resource type (e.g. `albums`)",
+          "in" : "query",
+          "name" : "filter[subject.type]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "albums", "tracks", "artists", "videos", "playlists", "comments" ]
+            }
+          }
+        }, {
           "in" : "query",
           "name" : "stats",
           "required" : false,
@@ -14607,29 +14649,6 @@
             "type" : "array",
             "items" : {
               "type" : "string"
-            }
-          }
-        }, {
-          "description" : "Filter by subject resource ID (e.g. `12345`)",
-          "in" : "query",
-          "name" : "filter[subject.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
-          "description" : "Filter by subject resource type (e.g. `albums`)",
-          "in" : "query",
-          "name" : "filter[subject.type]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "albums", "tracks", "artists", "videos", "playlists", "comments" ]
             }
           }
         } ],
@@ -14697,7 +14716,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Reactions_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Reactions_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -14981,7 +15000,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/SavedShares_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/SavedShares_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -15094,8 +15113,8 @@
       "delete" : {
         "description" : "Deletes existing searchHistoryEntrie.",
         "parameters" : [ {
-          "description" : "Opaque identifier for a search history entry",
-          "example" : "MjcyNjg5OTAjamF5",
+          "description" : "Canonical opaque identifier for a user's exact saved history query.",
+          "example" : "24HkRueBIeyGHPttoaQetVx4SwUxlzp3da06bqbwjF1t4dNXV",
           "in" : "path",
           "name" : "id",
           "required" : true,
@@ -15147,16 +15166,16 @@
         }
       }
     },
-    "/searchResults/{id}" : {
+    "/searchResults" : {
       "get" : {
-        "description" : "Retrieves single searchResult by id.",
+        "description" : "Searches for a query and returns a collection containing exactly one search results resource.",
         "parameters" : [ {
-          "description" : "Search query string used as the resource identifier",
-          "example" : "hello",
-          "in" : "path",
-          "name" : "id",
+          "description" : "Search query (e.g. `hello`)",
+          "in" : "query",
+          "name" : "filter[query]",
           "required" : true,
           "schema" : {
+            "maxLength" : 256,
             "type" : "string"
           }
         }, {
@@ -15167,8 +15186,8 @@
           "required" : false,
           "schema" : {
             "type" : "string",
-            "enum" : [ "INCLUDE", "EXCLUDE" ],
-            "default" : "INCLUDE"
+            "default" : "INCLUDE",
+            "enum" : [ "INCLUDE", "EXCLUDE" ]
           }
         }, {
           "description" : "ISO 3166-1 alpha-2 country code",
@@ -15237,7 +15256,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/SearchResults_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/SearchResults_Multi_Resource_Data_Document"
                 }
               }
             },
@@ -15273,7 +15292,7 @@
         }, {
           "Authorization_Code_PKCE" : [ "r_usr", "search.read" ]
         } ],
-        "summary" : "Get single searchResult.",
+        "summary" : "Get search results by query.",
         "tags" : [ "searchResults" ],
         "x-path-item-properties" : {
           "required-access-tier" : "THIRD_PARTY"
@@ -15284,8 +15303,7 @@
       "get" : {
         "description" : "Retrieves albums relationship.",
         "parameters" : [ {
-          "description" : "Search query string used as the resource identifier",
-          "example" : "hello",
+          "description" : "An opaque search results identifier",
           "in" : "path",
           "name" : "id",
           "required" : true,
@@ -15300,8 +15318,8 @@
           "required" : false,
           "schema" : {
             "type" : "string",
-            "enum" : [ "INCLUDE", "EXCLUDE" ],
-            "default" : "INCLUDE"
+            "default" : "INCLUDE",
+            "enum" : [ "INCLUDE", "EXCLUDE" ]
           }
         }, {
           "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
@@ -15425,8 +15443,7 @@
       "get" : {
         "description" : "Retrieves artists relationship.",
         "parameters" : [ {
-          "description" : "Search query string used as the resource identifier",
-          "example" : "hello",
+          "description" : "An opaque search results identifier",
           "in" : "path",
           "name" : "id",
           "required" : true,
@@ -15441,8 +15458,8 @@
           "required" : false,
           "schema" : {
             "type" : "string",
-            "enum" : [ "INCLUDE", "EXCLUDE" ],
-            "default" : "INCLUDE"
+            "default" : "INCLUDE",
+            "enum" : [ "INCLUDE", "EXCLUDE" ]
           }
         }, {
           "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
@@ -15566,8 +15583,7 @@
       "get" : {
         "description" : "Retrieves playlists relationship.",
         "parameters" : [ {
-          "description" : "Search query string used as the resource identifier",
-          "example" : "hello",
+          "description" : "An opaque search results identifier",
           "in" : "path",
           "name" : "id",
           "required" : true,
@@ -15582,8 +15598,8 @@
           "required" : false,
           "schema" : {
             "type" : "string",
-            "enum" : [ "INCLUDE", "EXCLUDE" ],
-            "default" : "INCLUDE"
+            "default" : "INCLUDE",
+            "enum" : [ "INCLUDE", "EXCLUDE" ]
           }
         }, {
           "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
@@ -15707,8 +15723,7 @@
       "get" : {
         "description" : "Retrieves topHits relationship.",
         "parameters" : [ {
-          "description" : "Search query string used as the resource identifier",
-          "example" : "hello",
+          "description" : "An opaque search results identifier",
           "in" : "path",
           "name" : "id",
           "required" : true,
@@ -15723,8 +15738,8 @@
           "required" : false,
           "schema" : {
             "type" : "string",
-            "enum" : [ "INCLUDE", "EXCLUDE" ],
-            "default" : "INCLUDE"
+            "default" : "INCLUDE",
+            "enum" : [ "INCLUDE", "EXCLUDE" ]
           }
         }, {
           "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
@@ -15848,8 +15863,7 @@
       "get" : {
         "description" : "Retrieves tracks relationship.",
         "parameters" : [ {
-          "description" : "Search query string used as the resource identifier",
-          "example" : "hello",
+          "description" : "An opaque search results identifier",
           "in" : "path",
           "name" : "id",
           "required" : true,
@@ -15864,8 +15878,8 @@
           "required" : false,
           "schema" : {
             "type" : "string",
-            "enum" : [ "INCLUDE", "EXCLUDE" ],
-            "default" : "INCLUDE"
+            "default" : "INCLUDE",
+            "enum" : [ "INCLUDE", "EXCLUDE" ]
           }
         }, {
           "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
@@ -15989,8 +16003,7 @@
       "get" : {
         "description" : "Retrieves videos relationship.",
         "parameters" : [ {
-          "description" : "Search query string used as the resource identifier",
-          "example" : "hello",
+          "description" : "An opaque search results identifier",
           "in" : "path",
           "name" : "id",
           "required" : true,
@@ -16005,8 +16018,8 @@
           "required" : false,
           "schema" : {
             "type" : "string",
-            "enum" : [ "INCLUDE", "EXCLUDE" ],
-            "default" : "INCLUDE"
+            "default" : "INCLUDE",
+            "enum" : [ "INCLUDE", "EXCLUDE" ]
           }
         }, {
           "description" : "Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified",
@@ -16126,16 +16139,16 @@
         }
       }
     },
-    "/searchSuggestions/{id}" : {
+    "/searchSuggestions" : {
       "get" : {
-        "description" : "Retrieves single searchSuggestion by id.",
+        "description" : "Searches for a query and returns a collection containing exactly one search suggestions resource.",
         "parameters" : [ {
-          "description" : "Search query string used as the resource identifier",
-          "example" : "hello",
-          "in" : "path",
-          "name" : "id",
+          "description" : "Search query (e.g. `hello`)",
+          "in" : "query",
+          "name" : "filter[query]",
           "required" : true,
           "schema" : {
+            "maxLength" : 256,
             "type" : "string"
           }
         }, {
@@ -16146,8 +16159,8 @@
           "required" : false,
           "schema" : {
             "type" : "string",
-            "enum" : [ "INCLUDE", "EXCLUDE" ],
-            "default" : "INCLUDE"
+            "default" : "INCLUDE",
+            "enum" : [ "INCLUDE", "EXCLUDE" ]
           }
         }, {
           "description" : "ISO 3166-1 alpha-2 country code",
@@ -16187,7 +16200,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/SearchSuggestions_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/SearchSuggestions_Multi_Resource_Data_Document"
                 }
               }
             },
@@ -16221,9 +16234,9 @@
         "security" : [ {
           "Client_Credentials" : [ ]
         }, {
-          "Authorization_Code_PKCE" : [ ]
+          "Authorization_Code_PKCE" : [ "r_usr", "search.read" ]
         } ],
-        "summary" : "Get single searchSuggestion.",
+        "summary" : "Get search suggestions by query.",
         "tags" : [ "searchSuggestions" ],
         "x-path-item-properties" : {
           "required-access-tier" : "THIRD_PARTY"
@@ -16234,8 +16247,7 @@
       "get" : {
         "description" : "Retrieves directHits relationship.",
         "parameters" : [ {
-          "description" : "Search query string used as the resource identifier",
-          "example" : "hello",
+          "description" : "An opaque search suggestions identifier",
           "in" : "path",
           "name" : "id",
           "required" : true,
@@ -16250,8 +16262,8 @@
           "required" : false,
           "schema" : {
             "type" : "string",
-            "enum" : [ "INCLUDE", "EXCLUDE" ],
-            "default" : "INCLUDE"
+            "default" : "INCLUDE",
+            "enum" : [ "INCLUDE", "EXCLUDE" ]
           }
         }, {
           "description" : "ISO 3166-1 alpha-2 country code",
@@ -16333,7 +16345,7 @@
         "security" : [ {
           "Client_Credentials" : [ ]
         }, {
-          "Authorization_Code_PKCE" : [ ]
+          "Authorization_Code_PKCE" : [ "r_usr", "search.read" ]
         } ],
         "summary" : "Get directHits relationship (\"to-many\").",
         "tags" : [ "searchSuggestions" ],
@@ -16346,8 +16358,7 @@
       "get" : {
         "description" : "Retrieves history relationship.",
         "parameters" : [ {
-          "description" : "Search query string used as the resource identifier",
-          "example" : "hello",
+          "description" : "An opaque search suggestions identifier",
           "in" : "path",
           "name" : "id",
           "required" : true,
@@ -16362,8 +16373,8 @@
           "required" : false,
           "schema" : {
             "type" : "string",
-            "enum" : [ "INCLUDE", "EXCLUDE" ],
-            "default" : "INCLUDE"
+            "default" : "INCLUDE",
+            "enum" : [ "INCLUDE", "EXCLUDE" ]
           }
         }, {
           "description" : "ISO 3166-1 alpha-2 country code",
@@ -16433,7 +16444,7 @@
           }
         },
         "security" : [ {
-          "Authorization_Code_PKCE" : [ ]
+          "Authorization_Code_PKCE" : [ "r_usr", "search.read" ]
         } ],
         "summary" : "Get history relationship (\"to-many\").",
         "tags" : [ "searchSuggestions" ],
@@ -16446,6 +16457,17 @@
       "get" : {
         "description" : "Retrieves multiple shares by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "A share code (e.g. `xyz`)",
+          "in" : "query",
+          "name" : "filter[code]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: owners, sharedResources",
           "example" : "sharedResources",
           "in" : "query",
@@ -16456,17 +16478,6 @@
             "items" : {
               "type" : "string",
               "example" : "sharedResources"
-            }
-          }
-        }, {
-          "description" : "A share code (e.g. `xyz`)",
-          "in" : "query",
-          "name" : "filter[code]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         }, {
@@ -16546,7 +16557,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Shares_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Shares_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -16881,7 +16892,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/SquareConnections_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/SquareConnections_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -16968,6 +16979,9 @@
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
+          "403" : {
+            "$ref" : "#/components/responses/SquareConnectionsReadById403Response"
+          },
           "404" : {
             "$ref" : "#/components/responses/Default404Response"
           },
@@ -17040,6 +17054,9 @@
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
+          "403" : {
+            "$ref" : "#/components/responses/SquareConnectionsReadSingleDataRelationship403Response"
+          },
           "404" : {
             "$ref" : "#/components/responses/Default404Response"
           },
@@ -17099,7 +17116,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/SquareConnections_Single_Relationship_Data_Document"
+                  "$ref" : "#/components/schemas/SquareConnections_SelectedSite_Update_Single_Relationship_Data_Document"
                 }
               }
             },
@@ -17107,6 +17124,9 @@
           },
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
+          },
+          "403" : {
+            "$ref" : "#/components/responses/SquareConnectionsUpdateSingleDataRelationship403Response"
           },
           "404" : {
             "$ref" : "#/components/responses/Default404Response"
@@ -17194,6 +17214,9 @@
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
+          "403" : {
+            "$ref" : "#/components/responses/SquareConnectionsReadMultiDataRelationship403Response"
+          },
           "404" : {
             "$ref" : "#/components/responses/Default404Response"
           },
@@ -17230,6 +17253,17 @@
       "get" : {
         "description" : "Retrieves multiple stripeConnections by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "User id. Use `me` for the authenticated user",
+          "in" : "query",
+          "name" : "filter[owners.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: owners",
           "example" : "owners",
           "in" : "query",
@@ -17240,17 +17274,6 @@
             "items" : {
               "type" : "string",
               "example" : "owners"
-            }
-          }
-        }, {
-          "description" : "User id. Use `me` for the authenticated user",
-          "in" : "query",
-          "name" : "filter[owners.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         } ],
@@ -17327,7 +17350,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/StripeConnections_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/StripeConnections_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -17458,6 +17481,17 @@
       "get" : {
         "description" : "Retrieves multiple stripeDashboardLinks by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "User id. Use `me` for the authenticated user",
+          "in" : "query",
+          "name" : "filter[owners.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: owners",
           "example" : "owners",
           "in" : "query",
@@ -17468,17 +17502,6 @@
             "items" : {
               "type" : "string",
               "example" : "owners"
-            }
-          }
-        }, {
-          "description" : "User id. Use `me` for the authenticated user",
-          "in" : "query",
-          "name" : "filter[owners.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         } ],
@@ -17612,6 +17635,17 @@
       "get" : {
         "description" : "Retrieves multiple subscriptionPriceChangeDecisions by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "User id. Use `me` for the authenticated user",
+          "in" : "query",
+          "name" : "filter[owners.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: priceChange",
           "example" : "priceChange",
           "in" : "query",
@@ -17622,17 +17656,6 @@
             "items" : {
               "type" : "string",
               "example" : "priceChange"
-            }
-          }
-        }, {
-          "description" : "User id. Use `me` for the authenticated user",
-          "in" : "query",
-          "name" : "filter[owners.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         } ],
@@ -17700,7 +17723,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/SubscriptionPriceChangeDecisions_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/SubscriptionPriceChangeDecisions_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -17776,7 +17799,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/SubscriptionPriceChangeDecisions_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/SubscriptionPriceChangeDecisions_Update_Single_Resource_Data_Document"
                 }
               }
             },
@@ -17915,7 +17938,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/TemporaryUserTokens_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/TemporaryUserTokens_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -18118,6 +18141,18 @@
       "get" : {
         "description" : "Retrieves multiple terms by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "One of: DEVELOPER, UPLOAD_MARKETPLACE, MERCH_GUIDELINES (e.g. `DEVELOPER`)",
+          "in" : "query",
+          "name" : "filter[termsType]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "DEVELOPER", "UPLOAD_MARKETPLACE", "MERCH_GUIDELINES" ]
+            }
+          }
+        }, {
           "description" : "Filter by countryCode",
           "in" : "query",
           "name" : "filter[countryCode]",
@@ -18137,18 +18172,6 @@
             "type" : "array",
             "items" : {
               "type" : "string"
-            }
-          }
-        }, {
-          "description" : "One of: DEVELOPER, UPLOAD_MARKETPLACE (e.g. `DEVELOPER`)",
-          "in" : "query",
-          "name" : "filter[termsType]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "DEVELOPER", "UPLOAD_MARKETPLACE" ]
             }
           }
         } ],
@@ -18479,7 +18502,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/TrackSourceFiles_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/TrackSourceFiles_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -18869,8 +18892,8 @@
             "items" : {
               "type" : "string",
               "example" : "createdAt",
-              "enum" : [ "createdAt", "-createdAt", "title", "-title" ],
               "default" : "-createdAt",
+              "enum" : [ "createdAt", "-createdAt", "title", "-title" ],
               "x-enum-varnames" : [ "CreatedAtAsc", "CreatedAtDesc", "TitleAsc", "TitleDesc" ]
             }
           }
@@ -19015,7 +19038,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Tracks_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/Tracks_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -21180,7 +21203,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/UsageRules_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/UsageRules_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -21474,8 +21497,8 @@
             "items" : {
               "type" : "string",
               "example" : "addedAt",
-              "enum" : [ "addedAt", "-addedAt", "artists.name", "-artists.name", "releaseDate", "-releaseDate", "title", "-title" ],
               "default" : "-addedAt",
+              "enum" : [ "addedAt", "-addedAt", "artists.name", "-artists.name", "releaseDate", "-releaseDate", "title", "-title" ],
               "x-enum-varnames" : [ "AddedAtAsc", "AddedAtDesc", "ArtistsNameAsc", "ArtistsNameDesc", "ReleaseDateAsc", "ReleaseDateDesc", "TitleAsc", "TitleDesc" ]
             }
           }
@@ -21899,8 +21922,8 @@
             "items" : {
               "type" : "string",
               "example" : "addedAt",
-              "enum" : [ "addedAt", "-addedAt", "name", "-name" ],
               "default" : "-addedAt",
+              "enum" : [ "addedAt", "-addedAt", "name", "-name" ],
               "x-enum-varnames" : [ "AddedAtAsc", "AddedAtDesc", "NameAsc", "NameDesc" ]
             }
           }
@@ -22142,6 +22165,17 @@
       "get" : {
         "description" : "Retrieves multiple userCollectionFolders by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "Folder Id (e.g. `CBMHXUOuJZgroV2kWpeVLL1I7xdgvF6ocDEGCXov8SZq3WVhrOcOq5pjnGawKX`)",
+          "in" : "query",
+          "name" : "filter[id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: items, owners, userCollection",
           "example" : "items.items",
           "in" : "query",
@@ -22152,17 +22186,6 @@
             "items" : {
               "type" : "string",
               "example" : "items.items"
-            }
-          }
-        }, {
-          "description" : "Folder Id (e.g. `CBMHXUOuJZgroV2kWpeVLL1I7xdgvF6ocDEGCXov8SZq3WVhrOcOq5pjnGawKX`)",
-          "in" : "query",
-          "name" : "filter[id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         }, {
@@ -22240,7 +22263,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/UserCollectionFolders_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/UserCollectionFolders_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -22582,8 +22605,8 @@
             "items" : {
               "type" : "string",
               "example" : "addedAt",
-              "enum" : [ "addedAt", "-addedAt", "lastModifiedAt", "-lastModifiedAt", "name", "-name" ],
               "default" : "addedAt",
+              "enum" : [ "addedAt", "-addedAt", "lastModifiedAt", "-lastModifiedAt", "name", "-name" ],
               "x-enum-varnames" : [ "AddedAtAsc", "AddedAtDesc", "LastModifiedAtAsc", "LastModifiedAtDesc", "NameAsc", "NameDesc" ]
             }
           }
@@ -22680,6 +22703,9 @@
           }
         },
         "responses" : {
+          "201" : {
+            "description" : "Successful response"
+          },
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
@@ -23077,8 +23103,8 @@
             "items" : {
               "type" : "string",
               "example" : "addedAt",
-              "enum" : [ "addedAt", "-addedAt", "lastModifiedAt", "-lastModifiedAt", "name", "-name" ],
               "default" : "-addedAt",
+              "enum" : [ "addedAt", "-addedAt", "lastModifiedAt", "-lastModifiedAt", "name", "-name" ],
               "x-enum-varnames" : [ "AddedAtAsc", "AddedAtDesc", "LastModifiedAtAsc", "LastModifiedAtDesc", "NameAsc", "NameDesc" ]
             }
           }
@@ -23882,8 +23908,8 @@
             "items" : {
               "type" : "string",
               "example" : "addedAt",
-              "enum" : [ "addedAt", "-addedAt", "albums.title", "-albums.title", "artists.name", "-artists.name", "duration", "-duration", "title", "-title" ],
               "default" : "-addedAt",
+              "enum" : [ "addedAt", "-addedAt", "albums.title", "-albums.title", "artists.name", "-artists.name", "duration", "-duration", "title", "-title" ],
               "x-enum-varnames" : [ "AddedAtAsc", "AddedAtDesc", "AlbumsTitleAsc", "AlbumsTitleDesc", "ArtistsNameAsc", "ArtistsNameDesc", "DurationAsc", "DurationDesc", "TitleAsc", "TitleDesc" ]
             }
           }
@@ -24307,8 +24333,8 @@
             "items" : {
               "type" : "string",
               "example" : "addedAt",
-              "enum" : [ "addedAt", "-addedAt", "artists.name", "-artists.name", "duration", "-duration", "title", "-title" ],
               "default" : "-addedAt",
+              "enum" : [ "addedAt", "-addedAt", "artists.name", "-artists.name", "duration", "-duration", "title", "-title" ],
               "x-enum-varnames" : [ "AddedAtAsc", "AddedAtDesc", "ArtistsNameAsc", "ArtistsNameDesc", "DurationAsc", "DurationDesc", "TitleAsc", "TitleDesc" ]
             }
           }
@@ -24735,8 +24761,8 @@
             "items" : {
               "type" : "string",
               "example" : "albums.addedAt",
-              "enum" : [ "albums.addedAt", "-albums.addedAt", "albums.artists.name", "-albums.artists.name", "albums.releaseDate", "-albums.releaseDate", "albums.title", "-albums.title" ],
               "default" : "-albums.addedAt",
+              "enum" : [ "albums.addedAt", "-albums.addedAt", "albums.artists.name", "-albums.artists.name", "albums.releaseDate", "-albums.releaseDate", "albums.title", "-albums.title" ],
               "x-enum-varnames" : [ "AlbumsAddedAtAsc", "AlbumsAddedAtDesc", "AlbumsArtistsNameAsc", "AlbumsArtistsNameDesc", "AlbumsReleaseDateAsc", "AlbumsReleaseDateDesc", "AlbumsTitleAsc", "AlbumsTitleDesc" ]
             }
           }
@@ -24844,6 +24870,9 @@
           }
         },
         "responses" : {
+          "201" : {
+            "description" : "Successful response"
+          },
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
@@ -24981,8 +25010,8 @@
             "items" : {
               "type" : "string",
               "example" : "artists.addedAt",
-              "enum" : [ "artists.addedAt", "-artists.addedAt", "artists.name", "-artists.name" ],
               "default" : "-artists.addedAt",
+              "enum" : [ "artists.addedAt", "-artists.addedAt", "artists.name", "-artists.name" ],
               "x-enum-varnames" : [ "ArtistsAddedAtAsc", "ArtistsAddedAtDesc", "ArtistsNameAsc", "ArtistsNameDesc" ]
             }
           }
@@ -25090,6 +25119,9 @@
           }
         },
         "responses" : {
+          "201" : {
+            "description" : "Successful response"
+          },
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
@@ -25133,7 +25165,8 @@
     },
     "/userCollections/{id}/relationships/owners" : {
       "get" : {
-        "description" : "Retrieves owners relationship.",
+        "deprecated" : true,
+        "description" : "Deprecated. Use the owners relationship on the dedicated collection resources instead: userCollectionAlbums, userCollectionArtists, userCollectionTracks, userCollectionVideos, or userCollectionPlaylists.",
         "parameters" : [ {
           "description" : "User collection id",
           "example" : "123456",
@@ -25315,8 +25348,8 @@
             "items" : {
               "type" : "string",
               "example" : "playlists.addedAt",
-              "enum" : [ "playlists.addedAt", "-playlists.addedAt", "playlists.lastUpdatedAt", "-playlists.lastUpdatedAt", "playlists.name", "-playlists.name" ],
               "default" : "-playlists.addedAt",
+              "enum" : [ "playlists.addedAt", "-playlists.addedAt", "playlists.lastUpdatedAt", "-playlists.lastUpdatedAt", "playlists.name", "-playlists.name" ],
               "x-enum-varnames" : [ "PlaylistsAddedAtAsc", "PlaylistsAddedAtDesc", "PlaylistsLastUpdatedAtAsc", "PlaylistsLastUpdatedAtDesc", "PlaylistsNameAsc", "PlaylistsNameDesc" ]
             }
           }
@@ -25414,6 +25447,9 @@
           }
         },
         "responses" : {
+          "201" : {
+            "description" : "Successful response"
+          },
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
@@ -25551,8 +25587,8 @@
             "items" : {
               "type" : "string",
               "example" : "tracks.addedAt",
-              "enum" : [ "tracks.addedAt", "-tracks.addedAt", "tracks.albums.title", "-tracks.albums.title", "tracks.artists.name", "-tracks.artists.name", "tracks.duration", "-tracks.duration", "tracks.title", "-tracks.title" ],
               "default" : "-tracks.addedAt",
+              "enum" : [ "tracks.addedAt", "-tracks.addedAt", "tracks.albums.title", "-tracks.albums.title", "tracks.artists.name", "-tracks.artists.name", "tracks.duration", "-tracks.duration", "tracks.title", "-tracks.title" ],
               "x-enum-varnames" : [ "TracksAddedAtAsc", "TracksAddedAtDesc", "TracksAlbumsTitleAsc", "TracksAlbumsTitleDesc", "TracksArtistsNameAsc", "TracksArtistsNameDesc", "TracksDurationAsc", "TracksDurationDesc", "TracksTitleAsc", "TracksTitleDesc" ]
             }
           }
@@ -25660,6 +25696,9 @@
           }
         },
         "responses" : {
+          "201" : {
+            "description" : "Successful response"
+          },
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
@@ -25797,8 +25836,8 @@
             "items" : {
               "type" : "string",
               "example" : "videos.addedAt",
-              "enum" : [ "videos.addedAt", "-videos.addedAt", "videos.artists.name", "-videos.artists.name", "videos.duration", "-videos.duration", "videos.title", "-videos.title" ],
               "default" : "-videos.addedAt",
+              "enum" : [ "videos.addedAt", "-videos.addedAt", "videos.artists.name", "-videos.artists.name", "videos.duration", "-videos.duration", "videos.title", "-videos.title" ],
               "x-enum-varnames" : [ "VideosAddedAtAsc", "VideosAddedAtDesc", "VideosArtistsNameAsc", "VideosArtistsNameDesc", "VideosDurationAsc", "VideosDurationDesc", "VideosTitleAsc", "VideosTitleDesc" ]
             }
           }
@@ -25906,6 +25945,9 @@
           }
         },
         "responses" : {
+          "201" : {
+            "description" : "Successful response"
+          },
           "400" : {
             "$ref" : "#/components/responses/Default400Response"
           },
@@ -26159,7 +26201,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/UserDataExportRequests_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/UserDataExportRequests_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -27055,7 +27097,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/UserRecommendationBlocks_Artists_Multi_Relationship_Data_Document"
+                  "$ref" : "#/components/schemas/UserRecommendationBlocks_Artists_Add_Multi_Relationship_Data_Document"
                 }
               }
             },
@@ -27363,7 +27405,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/UserRecommendationBlocks_Tracks_Multi_Relationship_Data_Document"
+                  "$ref" : "#/components/schemas/UserRecommendationBlocks_Tracks_Add_Multi_Relationship_Data_Document"
                 }
               }
             },
@@ -27591,7 +27633,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/UserRecommendationBlocks_Videos_Multi_Relationship_Data_Document"
+                  "$ref" : "#/components/schemas/UserRecommendationBlocks_Videos_Add_Multi_Relationship_Data_Document"
                 }
               }
             },
@@ -28155,7 +28197,7 @@
             "content" : {
               "application/vnd.api+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/UserReports_Single_Resource_Data_Document"
+                  "$ref" : "#/components/schemas/UserReports_Create_Single_Resource_Data_Document"
                 }
               }
             },
@@ -28206,6 +28248,17 @@
       "get" : {
         "description" : "Retrieves multiple userSubscriptionPriceChanges by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "User id. Use `me` for the authenticated user",
+          "in" : "query",
+          "name" : "filter[owners.id]",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
           "description" : "Allows the client to customize which related resources should be returned. Available options: decision",
           "example" : "decision",
           "in" : "query",
@@ -28216,17 +28269,6 @@
             "items" : {
               "type" : "string",
               "example" : "decision"
-            }
-          }
-        }, {
-          "description" : "User id. Use `me` for the authenticated user",
-          "in" : "query",
-          "name" : "filter[owners.id]",
-          "required" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
             }
           }
         } ],
@@ -29656,6 +29698,46 @@
         },
         "description" : "Idempotency key reused with a different payload"
       },
+      "SquareConnectionsReadById403Response" : {
+        "content" : {
+          "application/vnd.api+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/SquareConnectionsReadById403ResponseBody"
+            }
+          }
+        },
+        "description" : "Latest terms and conditions must be accepted"
+      },
+      "SquareConnectionsReadMultiDataRelationship403Response" : {
+        "content" : {
+          "application/vnd.api+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/SquareConnectionsReadMultiDataRelationship403ResponseBody"
+            }
+          }
+        },
+        "description" : "Latest terms and conditions must be accepted"
+      },
+      "SquareConnectionsReadSingleDataRelationship403Response" : {
+        "content" : {
+          "application/vnd.api+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/SquareConnectionsReadSingleDataRelationship403ResponseBody"
+            }
+          }
+        },
+        "description" : "Latest terms and conditions must be accepted"
+      },
+      "SquareConnectionsUpdateSingleDataRelationship403Response" : {
+        "content" : {
+          "application/vnd.api+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/SquareConnectionsUpdateSingleDataRelationship403ResponseBody"
+            }
+          }
+        },
+        "description" : "Latest terms and conditions must be accepted"
+      },
       "SquareConnectionsUpdateSingleDataRelationship409Response" : {
         "content" : {
           "application/vnd.api+json" : {
@@ -29881,6 +29963,18 @@
           }
         }
       },
+      "AcceptedTerms_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/AcceptedTerms_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "AcceptedTerms_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -29959,24 +30053,9 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "AcceptedTerms_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/AcceptedTerms_Resource_Object"
           },
           "included" : {
             "$ref" : "#/components/schemas/Included"
@@ -30015,24 +30094,6 @@
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/Resource_Identifier"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "AlbumStatistics_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/AlbumStatistics_Resource_Object"
             }
           },
           "included" : {
@@ -30148,12 +30209,6 @@
             "type" : "string",
             "enum" : [ "ALBUM", "EP", "SINGLE" ]
           },
-          "barcodeId" : {
-            "maxLength" : 13,
-            "minLength" : 12,
-            "type" : "string",
-            "description" : "Barcode id (EAN-13 or UPC-A)"
-          },
           "copyright" : {
             "$ref" : "#/components/schemas/Copyright"
           },
@@ -30172,13 +30227,6 @@
           },
           "title" : {
             "type" : "string"
-          },
-          "upc" : {
-            "maxLength" : 13,
-            "minLength" : 12,
-            "type" : "string",
-            "description" : "Barcode id (EAN-13 or UPC-A). Deprecated: use 'barcodeId' instead. This field will be removed in a future version.",
-            "deprecated" : true
           },
           "version" : {
             "type" : "string"
@@ -30500,6 +30548,18 @@
           }
         }
       },
+      "Albums_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Albums_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "Albums_Items_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -30676,8 +30736,8 @@
               "$ref" : "#/components/schemas/Albums_Replacement_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -30765,8 +30825,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -30936,18 +30996,12 @@
           }
         }
       },
-      "Appreciations_Multi_Resource_Data_Document" : {
+      "Appreciations_Create_Single_Resource_Data_Document" : {
         "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/Appreciations_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
+            "$ref" : "#/components/schemas/Appreciations_Resource_Object"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -30971,21 +31025,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "Appreciations_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/Appreciations_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -31052,24 +31091,6 @@
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/Resource_Identifier"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "ArtistBiographies_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/ArtistBiographies_Resource_Object"
             }
           },
           "included" : {
@@ -31179,21 +31200,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "ArtistClaimStatuses_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/ArtistClaimStatuses_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -31358,6 +31364,18 @@
           }
         }
       },
+      "ArtistClaims_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/ArtistClaims_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "ArtistClaims_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -31452,24 +31470,6 @@
           "name" : {
             "type" : "string",
             "description" : "Name of the artist role"
-          }
-        }
-      },
-      "ArtistRoles_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/ArtistRoles_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -31679,7 +31679,13 @@
             }
           },
           "handle" : {
-            "type" : "string"
+            "oneOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "object",
+              "nullable" : true,
+              "enum" : [ null ]
+            } ]
           },
           "name" : {
             "minLength" : 1,
@@ -31786,6 +31792,18 @@
             "type" : "boolean",
             "description" : "Is the artist spotlighted?",
             "example" : true
+          }
+        }
+      },
+      "Artists_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Artists_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -32006,8 +32024,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -32319,6 +32337,18 @@
           }
         }
       },
+      "Artworks_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Artworks_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "Artworks_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -32533,6 +32563,18 @@
           }
         }
       },
+      "Clients_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Clients_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "Clients_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -32614,6 +32656,18 @@
           }
         }
       },
+      "Clients_Update_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Clients_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "CollaborationInviteRedemptionsCreateOperation_Payload" : {
         "required" : [ "data" ],
         "type" : "object",
@@ -32678,18 +32732,12 @@
           }
         }
       },
-      "CollaborationInviteRedemptions_Multi_Resource_Data_Document" : {
+      "CollaborationInviteRedemptions_Create_Single_Resource_Data_Document" : {
         "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/CollaborationInviteRedemptions_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
+            "$ref" : "#/components/schemas/CollaborationInviteRedemptions_Resource_Object"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -32713,21 +32761,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "CollaborationInviteRedemptions_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/CollaborationInviteRedemptions_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -32805,6 +32838,18 @@
           "revoked" : {
             "type" : "boolean",
             "description" : "Whether the invite has been revoked by the subject's owner"
+          }
+        }
+      },
+      "CollaborationInvites_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/CollaborationInvites_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -32886,8 +32931,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -32976,8 +33021,8 @@
               "$ref" : "#/components/schemas/CommentsCreateOperation_Payload_Data_Relationships_ParentComment_Data"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           }
         }
@@ -33107,6 +33152,18 @@
           }
         }
       },
+      "Comments_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Comments_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "Comments_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -33188,8 +33245,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -33368,12 +33425,24 @@
               "$ref" : "#/components/schemas/ContentClaims_ClaimedResource_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
             "$ref" : "#/components/schemas/Included"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
+      "ContentClaims_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/ContentClaims_Resource_Object"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -33461,8 +33530,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -33516,24 +33585,6 @@
           }
         }
       },
-      "Credits_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/Credits_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "Credits_Relationships" : {
         "properties" : {
           "artist" : {
@@ -33576,8 +33627,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -33623,11 +33674,13 @@
         "description" : "Current user's reaction"
       },
       "Default400ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "status" ],
               "type" : "object",
               "properties" : {
                 "detail" : {
@@ -33638,19 +33691,19 @@
                   "type" : "string",
                   "example" : "400"
                 }
-              },
-              "required" : [ "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "Default404ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "status" ],
               "type" : "object",
               "properties" : {
                 "detail" : {
@@ -33661,19 +33714,19 @@
                   "type" : "string",
                   "example" : "404"
                 }
-              },
-              "required" : [ "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "Default405ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "status" ],
               "type" : "object",
               "properties" : {
                 "detail" : {
@@ -33684,19 +33737,19 @@
                   "type" : "string",
                   "example" : "405"
                 }
-              },
-              "required" : [ "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "Default406ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "status" ],
               "type" : "object",
               "properties" : {
                 "detail" : {
@@ -33707,19 +33760,19 @@
                   "type" : "string",
                   "example" : "406"
                 }
-              },
-              "required" : [ "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "Default415ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "status" ],
               "type" : "object",
               "properties" : {
                 "detail" : {
@@ -33730,19 +33783,19 @@
                   "type" : "string",
                   "example" : "415"
                 }
-              },
-              "required" : [ "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "Default429ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "status" ],
               "type" : "object",
               "properties" : {
                 "detail" : {
@@ -33753,19 +33806,19 @@
                   "type" : "string",
                   "example" : "429"
                 }
-              },
-              "required" : [ "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "Default500ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "status" ],
               "type" : "object",
               "properties" : {
                 "detail" : {
@@ -33776,19 +33829,19 @@
                   "type" : "string",
                   "example" : "500"
                 }
-              },
-              "required" : [ "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "Default503ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "status" ],
               "type" : "object",
               "properties" : {
                 "detail" : {
@@ -33799,12 +33852,10 @@
                   "type" : "string",
                   "example" : "503"
                 }
-              },
-              "required" : [ "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "Download_Link" : {
         "required" : [ "href", "meta" ],
@@ -34021,24 +34072,9 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "DspSharingLinks_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/DspSharingLinks_Resource_Object"
           },
           "included" : {
             "$ref" : "#/components/schemas/Included"
@@ -34084,8 +34120,8 @@
               "$ref" : "#/components/schemas/DspSharingLinks_Subject_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -34285,8 +34321,8 @@
               "$ref" : "#/components/schemas/DynamicModules_SeedItem_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -34306,8 +34342,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -34442,24 +34478,9 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "DynamicPages_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/DynamicPages_Resource_Object"
           },
           "included" : {
             "$ref" : "#/components/schemas/Included"
@@ -34505,8 +34526,8 @@
               "$ref" : "#/components/schemas/DynamicPages_Subject_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -34730,25 +34751,14 @@
           }
         }
       },
-      "Highlight" : {
-        "type" : "object",
-        "properties" : {
-          "length" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "start" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }
-      },
       "Idempotency409ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -34764,19 +34774,19 @@
                   "type" : "string",
                   "example" : "409"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "Idempotency422ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -34792,12 +34802,10 @@
                   "type" : "string",
                   "example" : "422"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "Included" : {
         "type" : "array",
@@ -35122,6 +35130,18 @@
             "type" : "string",
             "description" : "Human-readable name for the installation",
             "example" : "My iPhone"
+          }
+        }
+      },
+      "Installations_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Installations_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -35489,6 +35509,18 @@
           }
         }
       },
+      "Lyrics_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Lyrics_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "Lyrics_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -35497,24 +35529,6 @@
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/Resource_Identifier"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "Lyrics_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/Lyrics_Resource_Object"
             }
           },
           "included" : {
@@ -35567,8 +35581,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -35630,8 +35644,8 @@
               "$ref" : "#/components/schemas/Lyrics_Track_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -35837,18 +35851,12 @@
           }
         }
       },
-      "ManualArtistClaims_Multi_Resource_Data_Document" : {
+      "ManualArtistClaims_Create_Single_Resource_Data_Document" : {
         "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/ManualArtistClaims_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
+            "$ref" : "#/components/schemas/ManualArtistClaims_Resource_Object"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -35872,21 +35880,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "ManualArtistClaims_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/ManualArtistClaims_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -35937,7 +35930,7 @@
           "state" : {
             "type" : "string",
             "description" : "New state for the offline task",
-            "enum" : [ "IN_PROGRESS", "FAILED", "COMPLETED" ]
+            "enum" : [ "PENDING", "IN_PROGRESS", "FAILED", "COMPLETED" ]
           }
         }
       },
@@ -36003,8 +35996,8 @@
               "$ref" : "#/components/schemas/OfflineTasks_Collection_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -36051,8 +36044,8 @@
               "$ref" : "#/components/schemas/OfflineTasks_Item_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -36144,8 +36137,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -36446,6 +36439,18 @@
           }
         }
       },
+      "PlayQueues_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/PlayQueues_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "PlayQueues_Current_Resource_Identifier" : {
         "required" : [ "id", "type" ],
         "type" : "object",
@@ -36494,8 +36499,8 @@
               "$ref" : "#/components/schemas/PlayQueues_Current_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -36704,8 +36709,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -36840,7 +36845,7 @@
         "properties" : {
           "accessType" : {
             "type" : "string",
-            "description" : "Access type",
+            "description" : "User-selectable playlist visibility.",
             "example" : "PUBLIC",
             "enum" : [ "PUBLIC", "UNLISTED" ]
           },
@@ -36904,6 +36909,23 @@
         "properties" : {
           "positionBefore" : {
             "type" : "string"
+          }
+        }
+      },
+      "PlaylistsItemsRelationshipAddOperation_Response_Meta_SkippedItem" : {
+        "required" : [ "id", "reason", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "reason" : {
+            "type" : "string",
+            "enum" : [ "NOT_FOUND" ]
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "tracks", "videos" ]
           }
         }
       },
@@ -37027,7 +37049,7 @@
         "properties" : {
           "accessType" : {
             "type" : "string",
-            "description" : "Access type",
+            "description" : "User-selectable playlist visibility.",
             "example" : "PUBLIC",
             "enum" : [ "PUBLIC", "UNLISTED" ]
           },
@@ -37046,8 +37068,8 @@
           "accessType" : {
             "type" : "string",
             "description" : "Access type",
-            "example" : "PUBLIC",
-            "enum" : [ "PUBLIC", "UNLISTED" ]
+            "example" : "PRIVATE",
+            "enum" : [ "PUBLIC", "UNLISTED", "PRIVATE" ]
           },
           "bounded" : {
             "type" : "boolean",
@@ -37097,6 +37119,77 @@
             "type" : "string",
             "description" : "The type of the playlist",
             "enum" : [ "EDITORIAL", "USER", "MIX", "ARTIST" ]
+          }
+        }
+      },
+      "Playlists_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Playlists_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
+      "Playlists_Items_Add_Multi_Relationship_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Playlists_Items_Add_Resource_Identifier"
+            }
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          },
+          "meta" : {
+            "$ref" : "#/components/schemas/Playlists_Items_Add_Multi_Relationship_Data_Document_Meta"
+          }
+        }
+      },
+      "Playlists_Items_Add_Multi_Relationship_Data_Document_Meta" : {
+        "required" : [ "skipped" ],
+        "type" : "object",
+        "properties" : {
+          "skipped" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PlaylistsItemsRelationshipAddOperation_Response_Meta_SkippedItem"
+            }
+          }
+        }
+      },
+      "Playlists_Items_Add_Resource_Identifier" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "meta" : {
+            "$ref" : "#/components/schemas/Playlists_Items_Add_Resource_Identifier_Meta"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "tracks", "videos" ]
+          }
+        }
+      },
+      "Playlists_Items_Add_Resource_Identifier_Meta" : {
+        "required" : [ "addedAt", "itemId" ],
+        "type" : "object",
+        "properties" : {
+          "addedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "itemId" : {
+            "type" : "string"
           }
         }
       },
@@ -37305,6 +37398,18 @@
           }
         }
       },
+      "Playlists_Update_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Playlists_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "PriceConfigurationsCreateOperation_Payload" : {
         "required" : [ "data" ],
         "type" : "object",
@@ -37395,6 +37500,18 @@
             "type" : "string",
             "description" : "Price amount with max 2 decimal places",
             "example" : "9.99"
+          }
+        }
+      },
+      "PriceConfigurations_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/PriceConfigurations_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -37539,24 +37656,9 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "ProviderOwners_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/ProviderOwners_Resource_Object"
           },
           "included" : {
             "$ref" : "#/components/schemas/Included"
@@ -37650,24 +37752,9 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "ProviderProductInfos_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/ProviderProductInfos_Resource_Object"
           },
           "included" : {
             "$ref" : "#/components/schemas/Included"
@@ -37713,8 +37800,8 @@
               "$ref" : "#/components/schemas/ProviderProductInfos_Subject_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -37733,24 +37820,6 @@
             "type" : "string",
             "description" : "Provider name",
             "example" : "Columbia/Legacy"
-          }
-        }
-      },
-      "Providers_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/Providers_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -37883,24 +37952,9 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "Purchases_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/Purchases_Resource_Object"
           },
           "included" : {
             "$ref" : "#/components/schemas/Included"
@@ -37946,8 +38000,8 @@
               "$ref" : "#/components/schemas/Purchases_Subject_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -38059,6 +38113,18 @@
           }
         }
       },
+      "Reactions_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Reactions_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "Reactions_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -38140,21 +38206,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "Reactions_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/Reactions_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -38290,18 +38341,12 @@
           }
         }
       },
-      "SavedShares_Multi_Resource_Data_Document" : {
+      "SavedShares_Create_Single_Resource_Data_Document" : {
         "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/SavedShares_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
+            "$ref" : "#/components/schemas/SavedShares_Resource_Object"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -38325,21 +38370,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "SavedShares_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/SavedShares_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -38408,52 +38438,13 @@
           }
         }
       },
-      "Scopes_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/Scopes_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "SearchHistoryEntries_Attributes" : {
-        "required" : [ "highlights", "query" ],
+        "required" : [ "query" ],
         "type" : "object",
         "properties" : {
-          "highlights" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/Highlight"
-            }
-          },
           "query" : {
             "minLength" : 1,
             "type" : "string"
-          }
-        }
-      },
-      "SearchHistoryEntries_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/SearchHistoryEntries_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -38474,21 +38465,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "SearchHistoryEntries_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/SearchHistoryEntries_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -38583,13 +38559,18 @@
         }
       },
       "SearchResults_Attributes" : {
-        "required" : [ "trackingId" ],
+        "required" : [ "query", "trackingId" ],
         "type" : "object",
         "properties" : {
           "didYouMean" : {
             "type" : "string",
             "description" : "'did you mean' prompt",
             "example" : "beatles"
+          },
+          "query" : {
+            "type" : "string",
+            "description" : "The search query represented by this resource",
+            "example" : "hello"
           },
           "trackingId" : {
             "type" : "string",
@@ -38721,21 +38702,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "SearchResults_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/SearchResults_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -38875,16 +38841,13 @@
         }
       },
       "SearchSuggestions_Attributes" : {
-        "required" : [ "trackingId" ],
+        "required" : [ "query", "trackingId" ],
         "type" : "object",
         "properties" : {
-          "history" : {
-            "type" : "array",
-            "description" : "Suggestions from search history. Deprecated — use the history relationship instead. Will be deleted shortly.",
-            "deprecated" : true,
-            "items" : {
-              "$ref" : "#/components/schemas/SearchSuggestions_History"
-            }
+          "query" : {
+            "type" : "string",
+            "description" : "The search query represented by this resource",
+            "example" : "hello"
           },
           "suggestions" : {
             "type" : "array",
@@ -38959,23 +38922,6 @@
           }
         }
       },
-      "SearchSuggestions_History" : {
-        "required" : [ "query" ],
-        "type" : "object",
-        "properties" : {
-          "highlights" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/SearchSuggestions_Highlights"
-            }
-          },
-          "query" : {
-            "minLength" : 1,
-            "type" : "string"
-          }
-        },
-        "description" : "Suggestions from search history. Deprecated — use the history relationship instead. Will be deleted shortly."
-      },
       "SearchSuggestions_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -39042,21 +38988,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "SearchSuggestions_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/SearchSuggestions_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -39154,6 +39085,18 @@
             "items" : {
               "$ref" : "#/components/schemas/External_Link"
             }
+          }
+        }
+      },
+      "Shares_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Shares_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -39295,8 +39238,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "links" : {
@@ -39342,6 +39285,90 @@
           }
         }
       },
+      "SquareConnectionsReadById403ResponseBody" : {
+        "required" : [ "errors" ],
+        "type" : "object",
+        "properties" : {
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "required" : [ "code", "status" ],
+              "type" : "object",
+              "properties" : {
+                "code" : {
+                  "type" : "string",
+                  "example" : "REQUIRED_TERMS_NOT_ACCEPTED",
+                  "enum" : [ "REQUIRED_TERMS_NOT_ACCEPTED" ]
+                },
+                "detail" : {
+                  "type" : "string",
+                  "example" : "Latest terms and conditions must be accepted"
+                },
+                "status" : {
+                  "type" : "string",
+                  "example" : "403"
+                }
+              }
+            }
+          }
+        }
+      },
+      "SquareConnectionsReadMultiDataRelationship403ResponseBody" : {
+        "required" : [ "errors" ],
+        "type" : "object",
+        "properties" : {
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "required" : [ "code", "status" ],
+              "type" : "object",
+              "properties" : {
+                "code" : {
+                  "type" : "string",
+                  "example" : "REQUIRED_TERMS_NOT_ACCEPTED",
+                  "enum" : [ "REQUIRED_TERMS_NOT_ACCEPTED" ]
+                },
+                "detail" : {
+                  "type" : "string",
+                  "example" : "Latest terms and conditions must be accepted"
+                },
+                "status" : {
+                  "type" : "string",
+                  "example" : "403"
+                }
+              }
+            }
+          }
+        }
+      },
+      "SquareConnectionsReadSingleDataRelationship403ResponseBody" : {
+        "required" : [ "errors" ],
+        "type" : "object",
+        "properties" : {
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "required" : [ "code", "status" ],
+              "type" : "object",
+              "properties" : {
+                "code" : {
+                  "type" : "string",
+                  "example" : "REQUIRED_TERMS_NOT_ACCEPTED",
+                  "enum" : [ "REQUIRED_TERMS_NOT_ACCEPTED" ]
+                },
+                "detail" : {
+                  "type" : "string",
+                  "example" : "Latest terms and conditions must be accepted"
+                },
+                "status" : {
+                  "type" : "string",
+                  "example" : "403"
+                }
+              }
+            }
+          }
+        }
+      },
       "SquareConnectionsSelectedSiteRelationshipUpdateOperation_Payload" : {
         "required" : [ "data" ],
         "type" : "object",
@@ -39351,8 +39378,8 @@
               "$ref" : "#/components/schemas/SquareConnectionsSelectedSiteRelationshipUpdateOperation_Payload_Data"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           }
         }
@@ -39371,12 +39398,42 @@
         },
         "description" : "The site to select; null clears the selection."
       },
-      "SquareConnectionsUpdateSingleDataRelationship409ResponseBody" : {
+      "SquareConnectionsUpdateSingleDataRelationship403ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
+              "type" : "object",
+              "properties" : {
+                "code" : {
+                  "type" : "string",
+                  "example" : "REQUIRED_TERMS_NOT_ACCEPTED",
+                  "enum" : [ "REQUIRED_TERMS_NOT_ACCEPTED" ]
+                },
+                "detail" : {
+                  "type" : "string",
+                  "example" : "Latest terms and conditions must be accepted"
+                },
+                "status" : {
+                  "type" : "string",
+                  "example" : "403"
+                }
+              }
+            }
+          }
+        }
+      },
+      "SquareConnectionsUpdateSingleDataRelationship409ResponseBody" : {
+        "required" : [ "errors" ],
+        "type" : "object",
+        "properties" : {
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -39392,12 +39449,10 @@
                   "type" : "string",
                   "example" : "409"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "SquareConnections_Attributes" : {
         "required" : [ "status" ],
@@ -39451,6 +39506,18 @@
           }
         }
       },
+      "SquareConnections_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/SquareConnections_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "SquareConnections_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -39459,24 +39526,6 @@
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/Resource_Identifier"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "SquareConnections_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/SquareConnections_Resource_Object"
             }
           },
           "included" : {
@@ -39520,6 +39569,37 @@
           }
         }
       },
+      "SquareConnections_SelectedSite_Update_Resource_Identifier" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "squareSites" ]
+          }
+        }
+      },
+      "SquareConnections_SelectedSite_Update_Single_Relationship_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "oneOf" : [ {
+              "$ref" : "#/components/schemas/SquareConnections_SelectedSite_Update_Resource_Identifier"
+            }, {
+              "type" : "object",
+              "nullable" : true,
+              "enum" : [ null ]
+            } ]
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "SquareConnections_Single_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -39529,8 +39609,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -39573,24 +39653,6 @@
           }
         }
       },
-      "SquareSites_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/SquareSites_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "SquareSites_Resource_Object" : {
         "required" : [ "id", "type" ],
         "type" : "object",
@@ -39608,21 +39670,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "SquareSites_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/SquareSites_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -39659,8 +39706,8 @@
             "description" : "Deprecated: use meta.integrationType instead.",
             "example" : "REDIRECT",
             "deprecated" : true,
-            "enum" : [ "REDIRECT", "EMBEDDED" ],
-            "default" : "REDIRECT"
+            "default" : "REDIRECT",
+            "enum" : [ "REDIRECT", "EMBEDDED" ]
           },
           "refreshUrl" : {
             "type" : "string",
@@ -39684,8 +39731,8 @@
             "type" : "string",
             "description" : "Integration type for Stripe onboarding",
             "example" : "REDIRECT",
-            "enum" : [ "REDIRECT", "EMBEDDED" ],
-            "default" : "REDIRECT"
+            "default" : "REDIRECT",
+            "enum" : [ "REDIRECT", "EMBEDDED" ]
           },
           "refreshUrl" : {
             "type" : "string",
@@ -39725,6 +39772,18 @@
             "type" : "string",
             "description" : "Current status of this Stripe connection",
             "enum" : [ "PENDING_REQUIREMENTS", "UNDER_REVIEW", "ACCEPTED", "REJECTED", "SUSPENDED" ]
+          }
+        }
+      },
+      "StripeConnections_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/StripeConnections_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -39791,21 +39850,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "StripeConnections_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/StripeConnections_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -39880,21 +39924,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "StripeDashboardLinks_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/StripeDashboardLinks_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -40017,6 +40046,18 @@
           }
         }
       },
+      "SubscriptionPriceChangeDecisions_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/SubscriptionPriceChangeDecisions_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "SubscriptionPriceChangeDecisions_Multi_Resource_Data_Document" : {
         "required" : [ "data", "links" ],
         "type" : "object",
@@ -40074,8 +40115,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -40086,15 +40127,12 @@
           }
         }
       },
-      "SubscriptionPriceChangeDecisions_Single_Resource_Data_Document" : {
+      "SubscriptionPriceChangeDecisions_Update_Single_Resource_Data_Document" : {
         "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
             "$ref" : "#/components/schemas/SubscriptionPriceChangeDecisions_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -40123,6 +40161,18 @@
       "TemporaryUserTokens_Attributes" : {
         "type" : "object"
       },
+      "TemporaryUserTokens_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/TemporaryUserTokens_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "TemporaryUserTokens_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -40131,24 +40181,6 @@
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/Resource_Identifier"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "TemporaryUserTokens_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TemporaryUserTokens_Resource_Object"
             }
           },
           "included" : {
@@ -40220,7 +40252,7 @@
           },
           "termsType" : {
             "type" : "string",
-            "enum" : [ "DEVELOPER", "UPLOAD_MARKETPLACE" ]
+            "enum" : [ "DEVELOPER", "UPLOAD_MARKETPLACE", "MERCH_GUIDELINES" ]
           }
         }
       },
@@ -40313,11 +40345,13 @@
         } ]
       },
       "TrackFilesReadById403ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -40333,19 +40367,19 @@
                   "type" : "string",
                   "example" : "403"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "TrackFilesReadById404ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -40361,12 +40395,10 @@
                   "type" : "string",
                   "example" : "404"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "TrackFiles_Attributes" : {
         "type" : "object",
@@ -40390,24 +40422,6 @@
           "url" : {
             "type" : "string",
             "description" : "File URL"
-          }
-        }
-      },
-      "TrackFiles_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TrackFiles_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -40463,11 +40477,13 @@
         }
       },
       "TrackManifestsReadById403ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -40483,19 +40499,19 @@
                   "type" : "string",
                   "example" : "403"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "TrackManifestsReadById404ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -40511,12 +40527,10 @@
                   "type" : "string",
                   "example" : "404"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "TrackManifests_Attributes" : {
         "type" : "object",
@@ -40556,24 +40570,6 @@
           "uri" : {
             "type" : "string",
             "description" : "Manifest URI"
-          }
-        }
-      },
-      "TrackManifests_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TrackManifests_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -40710,6 +40706,18 @@
           }
         }
       },
+      "TrackSourceFiles_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/TrackSourceFiles_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "TrackSourceFiles_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -40718,24 +40726,6 @@
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/Resource_Identifier"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "TrackSourceFiles_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TrackSourceFiles_Resource_Object"
             }
           },
           "included" : {
@@ -40815,24 +40805,6 @@
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/Resource_Identifier"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "TrackStatistics_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TrackStatistics_Resource_Object"
             }
           },
           "included" : {
@@ -41064,24 +41036,6 @@
             "type" : "string",
             "description" : "Status of the metadata detection job",
             "enum" : [ "PENDING", "PROCESSING", "ERROR", "OK" ]
-          }
-        }
-      },
-      "TracksMetadataStatus_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/TracksMetadataStatus_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -41381,6 +41335,18 @@
           }
         }
       },
+      "Tracks_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/Tracks_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "Tracks_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -41511,8 +41477,8 @@
               "$ref" : "#/components/schemas/Tracks_Replacement_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -41600,8 +41566,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -41812,18 +41778,12 @@
           }
         }
       },
-      "UsageRules_Multi_Resource_Data_Document" : {
+      "UsageRules_Create_Single_Resource_Data_Document" : {
         "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UsageRules_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
+            "$ref" : "#/components/schemas/UsageRules_Resource_Object"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -41879,11 +41839,13 @@
         }
       },
       "UserCollectionAlbumsAddMultiDataRelationshipWithResponse409ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -41899,12 +41861,10 @@
                   "type" : "string",
                   "example" : "409"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "UserCollectionAlbumsItemsRelationshipAddOperation_Payload" : {
         "required" : [ "data" ],
@@ -42006,17 +41966,14 @@
         }
       },
       "UserCollectionAlbums_Items_Add_Multi_Relationship_Data_Document" : {
-        "required" : [ "links" ],
+        "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/UserCollectionAlbums_Items_Resource_Identifier"
+              "$ref" : "#/components/schemas/UserCollectionAlbums_Items_Add_Resource_Identifier"
             }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -42035,6 +41992,32 @@
             "items" : {
               "$ref" : "#/components/schemas/UserCollectionAlbumsItemsRelationshipAddOperation_Response_Meta_SkippedItem"
             }
+          }
+        }
+      },
+      "UserCollectionAlbums_Items_Add_Resource_Identifier" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "meta" : {
+            "$ref" : "#/components/schemas/UserCollectionAlbums_Items_Add_Resource_Identifier_Meta"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "albums" ]
+          }
+        }
+      },
+      "UserCollectionAlbums_Items_Add_Resource_Identifier_Meta" : {
+        "required" : [ "addedAt" ],
+        "type" : "object",
+        "properties" : {
+          "addedAt" : {
+            "type" : "string",
+            "format" : "date-time"
           }
         }
       },
@@ -42106,24 +42089,6 @@
           }
         }
       },
-      "UserCollectionAlbums_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserCollectionAlbums_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "UserCollectionAlbums_Relationships" : {
         "properties" : {
           "items" : {
@@ -42173,11 +42138,13 @@
         }
       },
       "UserCollectionArtistsAddMultiDataRelationshipWithResponse409ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -42193,12 +42160,10 @@
                   "type" : "string",
                   "example" : "409"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "UserCollectionArtistsItemsRelationshipAddOperation_Payload" : {
         "required" : [ "data" ],
@@ -42300,17 +42265,14 @@
         }
       },
       "UserCollectionArtists_Items_Add_Multi_Relationship_Data_Document" : {
-        "required" : [ "links" ],
+        "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/UserCollectionArtists_Items_Resource_Identifier"
+              "$ref" : "#/components/schemas/UserCollectionArtists_Items_Add_Resource_Identifier"
             }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -42329,6 +42291,32 @@
             "items" : {
               "$ref" : "#/components/schemas/UserCollectionArtistsItemsRelationshipAddOperation_Response_Meta_SkippedItem"
             }
+          }
+        }
+      },
+      "UserCollectionArtists_Items_Add_Resource_Identifier" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "meta" : {
+            "$ref" : "#/components/schemas/UserCollectionArtists_Items_Add_Resource_Identifier_Meta"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "artists" ]
+          }
+        }
+      },
+      "UserCollectionArtists_Items_Add_Resource_Identifier_Meta" : {
+        "required" : [ "addedAt" ],
+        "type" : "object",
+        "properties" : {
+          "addedAt" : {
+            "type" : "string",
+            "format" : "date-time"
           }
         }
       },
@@ -42387,24 +42375,6 @@
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/Resource_Identifier"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "UserCollectionArtists_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserCollectionArtists_Resource_Object"
             }
           },
           "included" : {
@@ -42516,11 +42486,13 @@
         }
       },
       "UserCollectionFoldersDeleteResource400ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -42536,12 +42508,10 @@
                   "type" : "string",
                   "example" : "400"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "UserCollectionFoldersItemsRelationshipAddOperation_Payload" : {
         "type" : "object",
@@ -42646,6 +42616,18 @@
           "numberOfItems" : {
             "type" : "integer",
             "format" : "int32"
+          }
+        }
+      },
+      "UserCollectionFolders_Create_Single_Resource_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/UserCollectionFolders_Resource_Object"
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -42777,8 +42759,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -42805,11 +42787,13 @@
         }
       },
       "UserCollectionPlaylistsAddMultiDataRelationshipWithResponse409ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -42825,12 +42809,10 @@
                   "type" : "string",
                   "example" : "409"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "UserCollectionPlaylistsItemsRelationshipAddOperation_Payload" : {
         "required" : [ "data" ],
@@ -42932,17 +42914,14 @@
         }
       },
       "UserCollectionPlaylists_Items_Add_Multi_Relationship_Data_Document" : {
-        "required" : [ "links" ],
+        "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/UserCollectionPlaylists_Items_Resource_Identifier"
+              "$ref" : "#/components/schemas/UserCollectionPlaylists_Items_Add_Resource_Identifier"
             }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -42961,6 +42940,32 @@
             "items" : {
               "$ref" : "#/components/schemas/UserCollectionPlaylistsItemsRelationshipAddOperation_Response_Meta_SkippedItem"
             }
+          }
+        }
+      },
+      "UserCollectionPlaylists_Items_Add_Resource_Identifier" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "meta" : {
+            "$ref" : "#/components/schemas/UserCollectionPlaylists_Items_Add_Resource_Identifier_Meta"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "playlists" ]
+          }
+        }
+      },
+      "UserCollectionPlaylists_Items_Add_Resource_Identifier_Meta" : {
+        "required" : [ "addedAt" ],
+        "type" : "object",
+        "properties" : {
+          "addedAt" : {
+            "type" : "string",
+            "format" : "date-time"
           }
         }
       },
@@ -43029,24 +43034,6 @@
           }
         }
       },
-      "UserCollectionPlaylists_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserCollectionPlaylists_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "UserCollectionPlaylists_Relationships" : {
         "properties" : {
           "items" : {
@@ -43096,11 +43083,13 @@
         }
       },
       "UserCollectionSaveForLatersAddMultiDataRelationshipWithResponse409ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -43116,12 +43105,10 @@
                   "type" : "string",
                   "example" : "409"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "UserCollectionSaveForLatersItemsRelationshipAddOperation_Payload" : {
         "required" : [ "data" ],
@@ -43211,17 +43198,14 @@
         }
       },
       "UserCollectionSaveForLaters_Items_Add_Multi_Relationship_Data_Document" : {
-        "required" : [ "links" ],
+        "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/UserCollectionSaveForLaters_Items_Resource_Identifier"
+              "$ref" : "#/components/schemas/UserCollectionSaveForLaters_Items_Add_Resource_Identifier"
             }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -43240,6 +43224,32 @@
             "items" : {
               "$ref" : "#/components/schemas/UserCollectionSaveForLatersItemsRelationshipAddOperation_Response_Meta_SkippedItem"
             }
+          }
+        }
+      },
+      "UserCollectionSaveForLaters_Items_Add_Resource_Identifier" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "meta" : {
+            "$ref" : "#/components/schemas/UserCollectionSaveForLaters_Items_Add_Resource_Identifier_Meta"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "tracks", "albums", "artists", "playlists", "videos" ]
+          }
+        }
+      },
+      "UserCollectionSaveForLaters_Items_Add_Resource_Identifier_Meta" : {
+        "required" : [ "addedAt" ],
+        "type" : "object",
+        "properties" : {
+          "addedAt" : {
+            "type" : "string",
+            "format" : "date-time"
           }
         }
       },
@@ -43311,24 +43321,6 @@
           }
         }
       },
-      "UserCollectionSaveForLaters_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserCollectionSaveForLaters_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "UserCollectionSaveForLaters_Relationships" : {
         "properties" : {
           "items" : {
@@ -43378,11 +43370,13 @@
         }
       },
       "UserCollectionTracksAddMultiDataRelationshipWithResponse409ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -43398,12 +43392,10 @@
                   "type" : "string",
                   "example" : "409"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "UserCollectionTracksItemsRelationshipAddOperation_Payload" : {
         "required" : [ "data" ],
@@ -43505,17 +43497,14 @@
         }
       },
       "UserCollectionTracks_Items_Add_Multi_Relationship_Data_Document" : {
-        "required" : [ "links" ],
+        "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/UserCollectionTracks_Items_Resource_Identifier"
+              "$ref" : "#/components/schemas/UserCollectionTracks_Items_Add_Resource_Identifier"
             }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -43534,6 +43523,32 @@
             "items" : {
               "$ref" : "#/components/schemas/UserCollectionTracksItemsRelationshipAddOperation_Response_Meta_SkippedItem"
             }
+          }
+        }
+      },
+      "UserCollectionTracks_Items_Add_Resource_Identifier" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "meta" : {
+            "$ref" : "#/components/schemas/UserCollectionTracks_Items_Add_Resource_Identifier_Meta"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "tracks" ]
+          }
+        }
+      },
+      "UserCollectionTracks_Items_Add_Resource_Identifier_Meta" : {
+        "required" : [ "addedAt" ],
+        "type" : "object",
+        "properties" : {
+          "addedAt" : {
+            "type" : "string",
+            "format" : "date-time"
           }
         }
       },
@@ -43605,24 +43620,6 @@
           }
         }
       },
-      "UserCollectionTracks_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserCollectionTracks_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "UserCollectionTracks_Relationships" : {
         "properties" : {
           "items" : {
@@ -43672,11 +43669,13 @@
         }
       },
       "UserCollectionVideosAddMultiDataRelationshipWithResponse409ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -43692,12 +43691,10 @@
                   "type" : "string",
                   "example" : "409"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "UserCollectionVideosItemsRelationshipAddOperation_Payload" : {
         "required" : [ "data" ],
@@ -43799,17 +43796,14 @@
         }
       },
       "UserCollectionVideos_Items_Add_Multi_Relationship_Data_Document" : {
-        "required" : [ "links" ],
+        "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/UserCollectionVideos_Items_Resource_Identifier"
+              "$ref" : "#/components/schemas/UserCollectionVideos_Items_Add_Resource_Identifier"
             }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -43828,6 +43822,32 @@
             "items" : {
               "$ref" : "#/components/schemas/UserCollectionVideosItemsRelationshipAddOperation_Response_Meta_SkippedItem"
             }
+          }
+        }
+      },
+      "UserCollectionVideos_Items_Add_Resource_Identifier" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "meta" : {
+            "$ref" : "#/components/schemas/UserCollectionVideos_Items_Add_Resource_Identifier_Meta"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "videos" ]
+          }
+        }
+      },
+      "UserCollectionVideos_Items_Add_Resource_Identifier_Meta" : {
+        "required" : [ "addedAt" ],
+        "type" : "object",
+        "properties" : {
+          "addedAt" : {
+            "type" : "string",
+            "format" : "date-time"
           }
         }
       },
@@ -43899,24 +43919,6 @@
           }
         }
       },
-      "UserCollectionVideos_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserCollectionVideos_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "UserCollectionVideos_Relationships" : {
         "properties" : {
           "items" : {
@@ -43966,11 +43968,13 @@
         }
       },
       "UserCollectionsAddMultiDataRelationship409ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -43986,12 +43990,10 @@
                   "type" : "string",
                   "example" : "409"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "UserCollectionsAlbumsRelationshipAddOperation_Payload" : {
         "required" : [ "data" ],
@@ -44417,24 +44419,6 @@
           }
         }
       },
-      "UserCollections_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserCollections_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "UserCollections_Playlists_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -44663,24 +44647,6 @@
           }
         }
       },
-      "UserDailyMixes_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserDailyMixes_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "UserDailyMixes_Relationships" : {
         "properties" : {
           "items" : {
@@ -44769,18 +44735,12 @@
           }
         }
       },
-      "UserDataExportRequests_Multi_Resource_Data_Document" : {
+      "UserDataExportRequests_Create_Single_Resource_Data_Document" : {
         "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserDataExportRequests_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
+            "$ref" : "#/components/schemas/UserDataExportRequests_Resource_Object"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -44807,21 +44767,6 @@
           }
         }
       },
-      "UserDataExportRequests_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/UserDataExportRequests_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "UserDiscoveryMixes_Attributes" : {
         "type" : "object"
       },
@@ -44833,24 +44778,6 @@
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/Resource_Identifier"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "UserDiscoveryMixes_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserDiscoveryMixes_Resource_Object"
             }
           },
           "included" : {
@@ -44927,24 +44854,6 @@
           }
         }
       },
-      "UserNewReleaseMixes_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserNewReleaseMixes_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "UserNewReleaseMixes_Relationships" : {
         "properties" : {
           "items" : {
@@ -45011,24 +44920,6 @@
           }
         }
       },
-      "UserOfflineMixes_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserOfflineMixes_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "UserOfflineMixes_Relationships" : {
         "properties" : {
           "items" : {
@@ -45075,11 +44966,13 @@
         }
       },
       "UserRecommendationBlocksAddMultiDataRelationshipWithResponse409ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -45095,12 +44988,10 @@
                   "type" : "string",
                   "example" : "409"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "UserRecommendationBlocksArtistsRelationshipAddOperation_Payload" : {
         "required" : [ "data" ],
@@ -45264,6 +45155,34 @@
           }
         }
       },
+      "UserRecommendationBlocks_Artists_Add_Multi_Relationship_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/UserRecommendationBlocks_Artists_Add_Resource_Identifier"
+            }
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
+      "UserRecommendationBlocks_Artists_Add_Resource_Identifier" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "artists" ]
+          }
+        }
+      },
       "UserRecommendationBlocks_Artists_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -45333,24 +45252,6 @@
           }
         }
       },
-      "UserRecommendationBlocks_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserRecommendationBlocks_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "UserRecommendationBlocks_Relationships" : {
         "properties" : {
           "artists" : {
@@ -45405,6 +45306,34 @@
           }
         }
       },
+      "UserRecommendationBlocks_Tracks_Add_Multi_Relationship_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/UserRecommendationBlocks_Tracks_Add_Resource_Identifier"
+            }
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
+      "UserRecommendationBlocks_Tracks_Add_Resource_Identifier" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "tracks" ]
+          }
+        }
+      },
       "UserRecommendationBlocks_Tracks_Multi_Relationship_Data_Document" : {
         "required" : [ "links" ],
         "type" : "object",
@@ -45453,6 +45382,34 @@
           },
           "replacement" : {
             "$ref" : "#/components/schemas/Replacement_Provenance"
+          }
+        }
+      },
+      "UserRecommendationBlocks_Videos_Add_Multi_Relationship_Data_Document" : {
+        "required" : [ "data", "links" ],
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/UserRecommendationBlocks_Videos_Add_Resource_Identifier"
+            }
+          },
+          "links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
+      "UserRecommendationBlocks_Videos_Add_Resource_Identifier" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "videos" ]
           }
         }
       },
@@ -45518,24 +45475,6 @@
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/Resource_Identifier"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "UserRecommendations_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserRecommendations_Resource_Object"
             }
           },
           "included" : {
@@ -45689,18 +45628,12 @@
           }
         }
       },
-      "UserReports_Multi_Resource_Data_Document" : {
+      "UserReports_Create_Single_Resource_Data_Document" : {
         "required" : [ "data", "links" ],
         "type" : "object",
         "properties" : {
           "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/UserReports_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
+            "$ref" : "#/components/schemas/UserReports_Resource_Object"
           },
           "links" : {
             "$ref" : "#/components/schemas/Links"
@@ -45724,21 +45657,6 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
-          }
-        }
-      },
-      "UserReports_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/UserReports_Resource_Object"
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -45825,24 +45743,9 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "UserSubscriptionPriceChanges_Single_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "$ref" : "#/components/schemas/UserSubscriptionPriceChanges_Resource_Object"
           },
           "included" : {
             "$ref" : "#/components/schemas/Included"
@@ -45899,24 +45802,6 @@
           }
         }
       },
-      "Users_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/Users_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
       "Users_Resource_Object" : {
         "required" : [ "id", "type" ],
         "type" : "object",
@@ -45953,11 +45838,13 @@
         }
       },
       "VideoManifestsReadById403ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -45973,19 +45860,19 @@
                   "type" : "string",
                   "example" : "403"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "VideoManifestsReadById404ResponseBody" : {
+        "required" : [ "errors" ],
         "type" : "object",
         "properties" : {
           "errors" : {
             "type" : "array",
             "items" : {
+              "required" : [ "code", "status" ],
               "type" : "object",
               "properties" : {
                 "code" : {
@@ -46001,12 +45888,10 @@
                   "type" : "string",
                   "example" : "404"
                 }
-              },
-              "required" : [ "code", "status" ]
+              }
             }
           }
-        },
-        "required" : [ "errors" ]
+        }
       },
       "VideoManifests_Attributes" : {
         "type" : "object",
@@ -46026,24 +45911,6 @@
             "type" : "string",
             "description" : "Video presentation",
             "enum" : [ "FULL", "PREVIEW" ]
-          }
-        }
-      },
-      "VideoManifests_Multi_Resource_Data_Document" : {
-        "required" : [ "data", "links" ],
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/VideoManifests_Resource_Object"
-            }
-          },
-          "included" : {
-            "$ref" : "#/components/schemas/Included"
-          },
-          "links" : {
-            "$ref" : "#/components/schemas/Links"
           }
         }
       },
@@ -46293,8 +46160,8 @@
               "$ref" : "#/components/schemas/Videos_Replacement_Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {
@@ -46382,8 +46249,8 @@
               "$ref" : "#/components/schemas/Resource_Identifier"
             }, {
               "type" : "object",
-              "enum" : [ null ],
-              "nullable" : true
+              "nullable" : true,
+              "enum" : [ null ]
             } ]
           },
           "included" : {

--- a/tests/providers/tidal/fixtures/v2/search.json
+++ b/tests/providers/tidal/fixtures/v2/search.json
@@ -1,377 +1,379 @@
 {
-  "data": {
-    "id": "lukas%20graham",
-    "type": "searchResults",
-    "attributes": {
-      "trackingId": "c93d7f4d-49b0-4b3c-83fa-2daf3d94e73d"
-    },
-    "relationships": {
-      "albums": {
-        "data": [
-          {
-            "id": "58756127",
-            "type": "albums"
-          },
-          {
-            "id": "96969306",
-            "type": "albums"
-          },
-          {
-            "id": "271190385",
-            "type": "albums"
-          },
-          {
-            "id": "104340961",
-            "type": "albums"
-          },
-          {
-            "id": "524818809",
-            "type": "albums"
-          },
-          {
-            "id": "121563483",
-            "type": "albums"
-          },
-          {
-            "id": "242744823",
-            "type": "albums"
-          },
-          {
-            "id": "118421110",
-            "type": "albums"
-          },
-          {
-            "id": "254074183",
-            "type": "albums"
-          },
-          {
-            "id": "429400346",
-            "type": "albums"
-          },
-          {
-            "id": "270125433",
-            "type": "albums"
-          },
-          {
-            "id": "16562158",
-            "type": "albums"
-          },
-          {
-            "id": "197218765",
-            "type": "albums"
-          },
-          {
-            "id": "187840424",
-            "type": "albums"
-          },
-          {
-            "id": "151974458",
-            "type": "albums"
-          },
-          {
-            "id": "216347341",
-            "type": "albums"
-          },
-          {
-            "id": "17574778",
-            "type": "albums"
-          },
-          {
-            "id": "140268720",
-            "type": "albums"
-          },
-          {
-            "id": "105537508",
-            "type": "albums"
-          },
-          {
-            "id": "516643645",
-            "type": "albums"
-          }
-        ],
-        "links": {
-          "self": "/searchResults/lukas%20graham/relationships/albums?countryCode=AT",
-          "next": "/searchResults/lukas%20graham/relationships/albums?countryCode=AT&page%5Bcursor%5D=3nI1Esi",
-          "meta": {
-            "nextCursor": "3nI1Esi"
-          }
-        }
+  "data": [
+    {
+      "id": "LE1YpuD9BXaIdBg2FXagVdVlu6FCtNg7CnL",
+      "type": "searchResults",
+      "attributes": {
+        "trackingId": "c93d7f4d-49b0-4b3c-83fa-2daf3d94e73d"
       },
-      "artists": {
-        "data": [
-          {
-            "id": "4184211",
-            "type": "artists"
-          },
-          {
-            "id": "4394210",
-            "type": "artists"
-          },
-          {
-            "id": "4826351",
-            "type": "artists"
-          },
-          {
-            "id": "8155176",
-            "type": "artists"
-          },
-          {
-            "id": "4927349",
-            "type": "artists"
-          },
-          {
-            "id": "8583514",
-            "type": "artists"
-          },
-          {
-            "id": "4804285",
-            "type": "artists"
-          },
-          {
-            "id": "3995478",
-            "type": "artists"
-          },
-          {
-            "id": "8812",
-            "type": "artists"
-          },
-          {
-            "id": "9916090",
-            "type": "artists"
-          },
-          {
-            "id": "4816276",
-            "type": "artists"
-          },
-          {
-            "id": "9212055",
-            "type": "artists"
-          },
-          {
-            "id": "17476",
-            "type": "artists"
-          },
-          {
-            "id": "4021356",
-            "type": "artists"
-          },
-          {
-            "id": "4835141",
-            "type": "artists"
-          },
-          {
-            "id": "3887405",
-            "type": "artists"
-          },
-          {
-            "id": "9309054",
-            "type": "artists"
-          },
-          {
-            "id": "43949368",
-            "type": "artists"
-          },
-          {
-            "id": "78144738",
-            "type": "artists"
-          },
-          {
-            "id": "77395432",
-            "type": "artists"
+      "relationships": {
+        "albums": {
+          "data": [
+            {
+              "id": "58756127",
+              "type": "albums"
+            },
+            {
+              "id": "96969306",
+              "type": "albums"
+            },
+            {
+              "id": "271190385",
+              "type": "albums"
+            },
+            {
+              "id": "104340961",
+              "type": "albums"
+            },
+            {
+              "id": "524818809",
+              "type": "albums"
+            },
+            {
+              "id": "121563483",
+              "type": "albums"
+            },
+            {
+              "id": "242744823",
+              "type": "albums"
+            },
+            {
+              "id": "118421110",
+              "type": "albums"
+            },
+            {
+              "id": "254074183",
+              "type": "albums"
+            },
+            {
+              "id": "429400346",
+              "type": "albums"
+            },
+            {
+              "id": "270125433",
+              "type": "albums"
+            },
+            {
+              "id": "16562158",
+              "type": "albums"
+            },
+            {
+              "id": "197218765",
+              "type": "albums"
+            },
+            {
+              "id": "187840424",
+              "type": "albums"
+            },
+            {
+              "id": "151974458",
+              "type": "albums"
+            },
+            {
+              "id": "216347341",
+              "type": "albums"
+            },
+            {
+              "id": "17574778",
+              "type": "albums"
+            },
+            {
+              "id": "140268720",
+              "type": "albums"
+            },
+            {
+              "id": "105537508",
+              "type": "albums"
+            },
+            {
+              "id": "516643645",
+              "type": "albums"
+            }
+          ],
+          "links": {
+            "self": "/searchResults/lukas%20graham/relationships/albums?countryCode=AT",
+            "next": "/searchResults/lukas%20graham/relationships/albums?countryCode=AT&page%5Bcursor%5D=3nI1Esi",
+            "meta": {
+              "nextCursor": "3nI1Esi"
+            }
           }
-        ],
-        "links": {
-          "self": "/searchResults/lukas%20graham/relationships/artists?countryCode=AT",
-          "next": "/searchResults/lukas%20graham/relationships/artists?countryCode=AT&page%5Bcursor%5D=3nI1Esi",
-          "meta": {
-            "nextCursor": "3nI1Esi"
+        },
+        "artists": {
+          "data": [
+            {
+              "id": "4184211",
+              "type": "artists"
+            },
+            {
+              "id": "4394210",
+              "type": "artists"
+            },
+            {
+              "id": "4826351",
+              "type": "artists"
+            },
+            {
+              "id": "8155176",
+              "type": "artists"
+            },
+            {
+              "id": "4927349",
+              "type": "artists"
+            },
+            {
+              "id": "8583514",
+              "type": "artists"
+            },
+            {
+              "id": "4804285",
+              "type": "artists"
+            },
+            {
+              "id": "3995478",
+              "type": "artists"
+            },
+            {
+              "id": "8812",
+              "type": "artists"
+            },
+            {
+              "id": "9916090",
+              "type": "artists"
+            },
+            {
+              "id": "4816276",
+              "type": "artists"
+            },
+            {
+              "id": "9212055",
+              "type": "artists"
+            },
+            {
+              "id": "17476",
+              "type": "artists"
+            },
+            {
+              "id": "4021356",
+              "type": "artists"
+            },
+            {
+              "id": "4835141",
+              "type": "artists"
+            },
+            {
+              "id": "3887405",
+              "type": "artists"
+            },
+            {
+              "id": "9309054",
+              "type": "artists"
+            },
+            {
+              "id": "43949368",
+              "type": "artists"
+            },
+            {
+              "id": "78144738",
+              "type": "artists"
+            },
+            {
+              "id": "77395432",
+              "type": "artists"
+            }
+          ],
+          "links": {
+            "self": "/searchResults/lukas%20graham/relationships/artists?countryCode=AT",
+            "next": "/searchResults/lukas%20graham/relationships/artists?countryCode=AT&page%5Bcursor%5D=3nI1Esi",
+            "meta": {
+              "nextCursor": "3nI1Esi"
+            }
           }
-        }
-      },
-      "playlists": {
-        "data": [
-          {
-            "id": "67dc80a4-563f-4046-abd7-99945a6ae866",
-            "type": "playlists"
-          },
-          {
-            "id": "0fa30617-662a-42fc-ad16-fb699f3636b7",
-            "type": "playlists"
-          },
-          {
-            "id": "f3ed269b-b53d-4515-8c83-e2c4e697d93b",
-            "type": "playlists"
-          },
-          {
-            "id": "1b5bf92a-6edb-4839-a56c-0877643c4aba",
-            "type": "playlists"
-          },
-          {
-            "id": "69cf3625-b4c9-4f39-8076-fa7d3cd7784c",
-            "type": "playlists"
-          },
-          {
-            "id": "55905c86-7fb0-49ae-a574-43d14c61053f",
-            "type": "playlists"
-          },
-          {
-            "id": "acaf9642-4257-4857-950a-fbe2187e1fa3",
-            "type": "playlists"
-          },
-          {
-            "id": "3a10b48f-abd8-4577-ad25-0e6c44eebd11",
-            "type": "playlists"
-          },
-          {
-            "id": "11f23764-7e5d-4a86-af62-ff7fd202c113",
-            "type": "playlists"
-          },
-          {
-            "id": "c7e1ac7f-7689-4d99-8a3a-392f6c2a984e",
-            "type": "playlists"
-          },
-          {
-            "id": "46288e2b-ad6d-4387-a9b7-c9557418c2de",
-            "type": "playlists"
-          },
-          {
-            "id": "be10e8d9-cb8c-451d-9232-154676bb2456",
-            "type": "playlists"
-          },
-          {
-            "id": "34dbff57-88b8-4fb5-b09a-e4a79c107ffb",
-            "type": "playlists"
-          },
-          {
-            "id": "14c63d93-6f57-4540-9f95-a3bee7a8f66b",
-            "type": "playlists"
-          },
-          {
-            "id": "a2fd217b-3992-44a4-afc7-0a49360104a9",
-            "type": "playlists"
-          },
-          {
-            "id": "dc417540-3605-47a3-a054-600119de0c69",
-            "type": "playlists"
-          },
-          {
-            "id": "238482f9-60ff-44a3-b1ea-369eeddbebf6",
-            "type": "playlists"
-          },
-          {
-            "id": "3a98bd93-3b70-47ab-adfa-6735802bcc75",
-            "type": "playlists"
-          },
-          {
-            "id": "bc7e69ca-4609-4bc1-8c73-1396a1fc12c2",
-            "type": "playlists"
-          },
-          {
-            "id": "f0b21ffe-88af-41c4-bba1-0f1524a315c0",
-            "type": "playlists"
+        },
+        "playlists": {
+          "data": [
+            {
+              "id": "67dc80a4-563f-4046-abd7-99945a6ae866",
+              "type": "playlists"
+            },
+            {
+              "id": "0fa30617-662a-42fc-ad16-fb699f3636b7",
+              "type": "playlists"
+            },
+            {
+              "id": "f3ed269b-b53d-4515-8c83-e2c4e697d93b",
+              "type": "playlists"
+            },
+            {
+              "id": "1b5bf92a-6edb-4839-a56c-0877643c4aba",
+              "type": "playlists"
+            },
+            {
+              "id": "69cf3625-b4c9-4f39-8076-fa7d3cd7784c",
+              "type": "playlists"
+            },
+            {
+              "id": "55905c86-7fb0-49ae-a574-43d14c61053f",
+              "type": "playlists"
+            },
+            {
+              "id": "acaf9642-4257-4857-950a-fbe2187e1fa3",
+              "type": "playlists"
+            },
+            {
+              "id": "3a10b48f-abd8-4577-ad25-0e6c44eebd11",
+              "type": "playlists"
+            },
+            {
+              "id": "11f23764-7e5d-4a86-af62-ff7fd202c113",
+              "type": "playlists"
+            },
+            {
+              "id": "c7e1ac7f-7689-4d99-8a3a-392f6c2a984e",
+              "type": "playlists"
+            },
+            {
+              "id": "46288e2b-ad6d-4387-a9b7-c9557418c2de",
+              "type": "playlists"
+            },
+            {
+              "id": "be10e8d9-cb8c-451d-9232-154676bb2456",
+              "type": "playlists"
+            },
+            {
+              "id": "34dbff57-88b8-4fb5-b09a-e4a79c107ffb",
+              "type": "playlists"
+            },
+            {
+              "id": "14c63d93-6f57-4540-9f95-a3bee7a8f66b",
+              "type": "playlists"
+            },
+            {
+              "id": "a2fd217b-3992-44a4-afc7-0a49360104a9",
+              "type": "playlists"
+            },
+            {
+              "id": "dc417540-3605-47a3-a054-600119de0c69",
+              "type": "playlists"
+            },
+            {
+              "id": "238482f9-60ff-44a3-b1ea-369eeddbebf6",
+              "type": "playlists"
+            },
+            {
+              "id": "3a98bd93-3b70-47ab-adfa-6735802bcc75",
+              "type": "playlists"
+            },
+            {
+              "id": "bc7e69ca-4609-4bc1-8c73-1396a1fc12c2",
+              "type": "playlists"
+            },
+            {
+              "id": "f0b21ffe-88af-41c4-bba1-0f1524a315c0",
+              "type": "playlists"
+            }
+          ],
+          "links": {
+            "self": "/searchResults/lukas%20graham/relationships/playlists?countryCode=AT",
+            "next": "/searchResults/lukas%20graham/relationships/playlists?countryCode=AT&page%5Bcursor%5D=3nI1Esi",
+            "meta": {
+              "nextCursor": "3nI1Esi"
+            }
           }
-        ],
-        "links": {
-          "self": "/searchResults/lukas%20graham/relationships/playlists?countryCode=AT",
-          "next": "/searchResults/lukas%20graham/relationships/playlists?countryCode=AT&page%5Bcursor%5D=3nI1Esi",
-          "meta": {
-            "nextCursor": "3nI1Esi"
-          }
-        }
-      },
-      "tracks": {
-        "data": [
-          {
-            "id": "58756128",
-            "type": "tracks"
-          },
-          {
-            "id": "96969310",
-            "type": "tracks"
-          },
-          {
-            "id": "58756130",
-            "type": "tracks"
-          },
-          {
-            "id": "121563484",
-            "type": "tracks"
-          },
-          {
-            "id": "104340964",
-            "type": "tracks"
-          },
-          {
-            "id": "242744824",
-            "type": "tracks"
-          },
-          {
-            "id": "16562159",
-            "type": "tracks"
-          },
-          {
-            "id": "183310109",
-            "type": "tracks"
-          },
-          {
-            "id": "118421111",
-            "type": "tracks"
-          },
-          {
-            "id": "151974459",
-            "type": "tracks"
-          },
-          {
-            "id": "79492732",
-            "type": "tracks"
-          },
-          {
-            "id": "58756132",
-            "type": "tracks"
-          },
-          {
-            "id": "197218768",
-            "type": "tracks"
-          },
-          {
-            "id": "58756137",
-            "type": "tracks"
-          },
-          {
-            "id": "359762509",
-            "type": "tracks"
-          },
-          {
-            "id": "270125434",
-            "type": "tracks"
-          },
-          {
-            "id": "187840426",
-            "type": "tracks"
-          },
-          {
-            "id": "96969308",
-            "type": "tracks"
-          },
-          {
-            "id": "96969307",
-            "type": "tracks"
-          },
-          {
-            "id": "58756131",
-            "type": "tracks"
-          }
-        ],
-        "links": {
-          "self": "/searchResults/lukas%20graham/relationships/tracks?countryCode=AT",
-          "next": "/searchResults/lukas%20graham/relationships/tracks?countryCode=AT&page%5Bcursor%5D=3nI1Esi",
-          "meta": {
-            "nextCursor": "3nI1Esi"
+        },
+        "tracks": {
+          "data": [
+            {
+              "id": "58756128",
+              "type": "tracks"
+            },
+            {
+              "id": "96969310",
+              "type": "tracks"
+            },
+            {
+              "id": "58756130",
+              "type": "tracks"
+            },
+            {
+              "id": "121563484",
+              "type": "tracks"
+            },
+            {
+              "id": "104340964",
+              "type": "tracks"
+            },
+            {
+              "id": "242744824",
+              "type": "tracks"
+            },
+            {
+              "id": "16562159",
+              "type": "tracks"
+            },
+            {
+              "id": "183310109",
+              "type": "tracks"
+            },
+            {
+              "id": "118421111",
+              "type": "tracks"
+            },
+            {
+              "id": "151974459",
+              "type": "tracks"
+            },
+            {
+              "id": "79492732",
+              "type": "tracks"
+            },
+            {
+              "id": "58756132",
+              "type": "tracks"
+            },
+            {
+              "id": "197218768",
+              "type": "tracks"
+            },
+            {
+              "id": "58756137",
+              "type": "tracks"
+            },
+            {
+              "id": "359762509",
+              "type": "tracks"
+            },
+            {
+              "id": "270125434",
+              "type": "tracks"
+            },
+            {
+              "id": "187840426",
+              "type": "tracks"
+            },
+            {
+              "id": "96969308",
+              "type": "tracks"
+            },
+            {
+              "id": "96969307",
+              "type": "tracks"
+            },
+            {
+              "id": "58756131",
+              "type": "tracks"
+            }
+          ],
+          "links": {
+            "self": "/searchResults/lukas%20graham/relationships/tracks?countryCode=AT",
+            "next": "/searchResults/lukas%20graham/relationships/tracks?countryCode=AT&page%5Bcursor%5D=3nI1Esi",
+            "meta": {
+              "nextCursor": "3nI1Esi"
+            }
           }
         }
       }
     }
-  },
+  ],
   "links": {
     "self": "/searchResults/lukas%20graham?include=albums.coverArt%2Cartists.profileArt%2Cplaylists.coverArt%2Ctracks.albums.coverArt%2Ctracks.artists&countryCode=AT"
   },
@@ -389,7 +391,7 @@
         "ai": false,
         "releaseDate": "2012-03-26",
         "copyright": {
-          "text": "© 2012 Copenhagen Records / Universal Music"
+          "text": "\u00a9 2012 Copenhagen Records / Universal Music"
         },
         "popularity": 0.28222558579746027,
         "accessType": "PUBLIC",
@@ -438,7 +440,7 @@
         "ai": false,
         "releaseDate": "2018-09-07",
         "copyright": {
-          "text": "© 2019 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2019 Universal Music (Denmark) A/S"
         },
         "popularity": 0.3406352400779724,
         "accessType": "PUBLIC",
@@ -489,7 +491,7 @@
         "ai": false,
         "releaseDate": "2019-09-27",
         "copyright": {
-          "text": "© 2019 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2019 Universal Music (Denmark) A/S"
         },
         "popularity": 0.2251062561289688,
         "accessType": "PUBLIC",
@@ -538,7 +540,7 @@
         "ai": false,
         "releaseDate": "2019-11-08",
         "copyright": {
-          "text": "© 2019 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2019 Universal Music (Denmark) A/S"
         },
         "popularity": 0.2651028850675421,
         "accessType": "PUBLIC",
@@ -588,7 +590,7 @@
         "ai": false,
         "releaseDate": "2020-05-01",
         "copyright": {
-          "text": "© 2020 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2020 Universal Music (Denmark) A/S"
         },
         "popularity": 0.36036545038223267,
         "accessType": "PUBLIC",
@@ -637,7 +639,7 @@
         "ai": false,
         "releaseDate": "2020-08-20",
         "copyright": {
-          "text": "© 2020 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2020 Universal Music (Denmark) A/S"
         },
         "popularity": 0.15355200198589303,
         "accessType": "PUBLIC",
@@ -687,7 +689,7 @@
         "ai": false,
         "releaseDate": "2011-10-17",
         "copyright": {
-          "text": "© 2012 Copenhagen Records / Universal Music"
+          "text": "\u00a9 2012 Copenhagen Records / Universal Music"
         },
         "popularity": 0.22785941478408922,
         "accessType": "PUBLIC",
@@ -736,7 +738,7 @@
         "ai": false,
         "releaseDate": "2012-02-13",
         "copyright": {
-          "text": "© 2012 Copenhagen Records / Universal Music"
+          "text": "\u00a9 2012 Copenhagen Records / Universal Music"
         },
         "popularity": 0.19949200687605953,
         "accessType": "PUBLIC",
@@ -785,7 +787,7 @@
         "ai": false,
         "releaseDate": "2021-05-14",
         "copyright": {
-          "text": "© 2021 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2021 Universal Music (Denmark) A/S"
         },
         "popularity": 0.15674805818705734,
         "accessType": "PUBLIC",
@@ -835,7 +837,7 @@
         "ai": false,
         "releaseDate": "2021-05-14",
         "copyright": {
-          "text": "© 2021 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2021 Universal Music (Denmark) A/S"
         },
         "popularity": 0.1944491907265111,
         "accessType": "PUBLIC",
@@ -885,7 +887,7 @@
         "ai": false,
         "releaseDate": "2021-09-17",
         "copyright": {
-          "text": "© 2021 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2021 Universal Music (Denmark) A/S"
         },
         "popularity": 0.15884875030410214,
         "accessType": "PUBLIC",
@@ -936,7 +938,7 @@
         "ai": false,
         "releaseDate": "2022-02-18",
         "copyright": {
-          "text": "© 2022 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2022 Universal Music (Denmark) A/S"
         },
         "popularity": 0.19219816221894997,
         "accessType": "PUBLIC",
@@ -986,7 +988,7 @@
         "ai": false,
         "releaseDate": "2022-08-19",
         "copyright": {
-          "text": "© 2022 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2022 Universal Music (Denmark) A/S"
         },
         "popularity": 0.18676196311960816,
         "accessType": "PUBLIC",
@@ -1037,7 +1039,7 @@
         "ai": false,
         "releaseDate": "2022-10-21",
         "copyright": {
-          "text": "© 2022 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2022 Universal Music (Denmark) A/S"
         },
         "popularity": 0.17295020859346277,
         "accessType": "PUBLIC",
@@ -1087,7 +1089,7 @@
         "ai": false,
         "releaseDate": "2023-01-13",
         "copyright": {
-          "text": "© 2023 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2023 Universal Music (Denmark) A/S"
         },
         "popularity": 0.43128702044487,
         "accessType": "PUBLIC",
@@ -1137,7 +1139,7 @@
         "ai": false,
         "releaseDate": "2023-01-20",
         "copyright": {
-          "text": "© 2023 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2023 Universal Music (Denmark) A/S"
         },
         "popularity": 0.35705821313900377,
         "accessType": "PUBLIC",
@@ -1187,7 +1189,7 @@
         "ai": false,
         "releaseDate": "2024-05-03",
         "copyright": {
-          "text": "© 2024 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2024 Universal Music (Denmark) A/S"
         },
         "popularity": 0.07578221628095376,
         "accessType": "PUBLIC",
@@ -1237,7 +1239,7 @@
         "ai": false,
         "releaseDate": "2025-04-18",
         "copyright": {
-          "text": "© 2025 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2025 Universal Music (Denmark) A/S"
         },
         "popularity": 0.20406164776917143,
         "accessType": "PUBLIC",
@@ -1287,7 +1289,7 @@
         "ai": false,
         "releaseDate": "2026-04-24",
         "copyright": {
-          "text": "© 2026 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2026 Universal Music (Denmark) A/S"
         },
         "popularity": 0.11736994202118811,
         "accessType": "PUBLIC",
@@ -1338,7 +1340,7 @@
         "ai": false,
         "releaseDate": "2026-05-22",
         "copyright": {
-          "text": "© 2026 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2026 Universal Music (Denmark) A/S"
         },
         "popularity": 0.16214905881518296,
         "accessType": "PUBLIC",
@@ -1388,7 +1390,7 @@
         "ai": false,
         "releaseDate": "2015-05-29",
         "copyright": {
-          "text": "© 2016 Then We Take The World / Copenhagen Records / Universal Music"
+          "text": "\u00a9 2016 Then We Take The World / Copenhagen Records / Universal Music"
         },
         "popularity": 0.7480961442649546,
         "accessType": "PUBLIC",
@@ -1439,7 +1441,7 @@
         "ai": false,
         "releaseDate": "2017-09-22",
         "copyright": {
-          "text": "© 2017 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2017 Universal Music (Denmark) A/S"
         },
         "popularity": 0.0527633318074913,
         "accessType": "PUBLIC",
@@ -1488,7 +1490,7 @@
         "ai": false,
         "releaseDate": "2018-10-26",
         "copyright": {
-          "text": "© 2018 Universal Music (Denmark) A/S"
+          "text": "\u00a9 2018 Universal Music (Denmark) A/S"
         },
         "popularity": 0.5127724778932936,
         "accessType": "PUBLIC",
@@ -1892,7 +1894,7 @@
       "id": "4816276",
       "type": "artists",
       "attributes": {
-        "name": "MØ",
+        "name": "M\u00d8",
         "popularity": 0.7571531844655853,
         "externalLinks": [
           {
@@ -6082,8 +6084,8 @@
       "id": "55905c86-7fb0-49ae-a574-43d14c61053f",
       "type": "playlists",
       "attributes": {
-        "name": "Størst er kærligheden",
-        "description": "På Valentinsdag skal kærligheden fejres lidt ekstra, uanset om man er nyforelsket eller har levet sammen i mange år. Vi kan ikke hjælpe til med blomster eller chokoladeæske, men vi kan definitivt give dig musikken til en romantisk stund med din udkårne. Her findes sange om kærlighedens mange sider, fra Lukas Grahams \"Love Someone\" om kærlighedens helende kraft over Marvin Gayes opfordring i den stilfuldt sexede ”Let’s Get It On” til Sades indfølte hymne til sammenhold.",
+        "name": "St\u00f8rst er k\u00e6rligheden",
+        "description": "P\u00e5 Valentinsdag skal k\u00e6rligheden fejres lidt ekstra, uanset om man er nyforelsket eller har levet sammen i mange \u00e5r. Vi kan ikke hj\u00e6lpe til med blomster eller chokolade\u00e6ske, men vi kan definitivt give dig musikken til en romantisk stund med din udk\u00e5rne. Her findes sange om k\u00e6rlighedens mange sider, fra Lukas Grahams \"Love Someone\" om k\u00e6rlighedens helende kraft over Marvin Gayes opfordring i den stilfuldt sexede \u201dLet\u2019s Get It On\u201d til Sades indf\u00f8lte hymne til sammenhold.",
         "bounded": true,
         "duration": "PT3H55M56S",
         "numberOfItems": 62,
@@ -6138,7 +6140,7 @@
       "type": "playlists",
       "attributes": {
         "name": "Lukas Graham Essentials",
-        "description": "Lukas Graham tog først Danmark med storm og siden hele verden. Her får du nogle af gruppens bedste numre. Fra de tidlige funkhits til deres, store internationale pophits.\nCover: Lukas Graham / Photo: Press",
+        "description": "Lukas Graham tog f\u00f8rst Danmark med storm og siden hele verden. Her f\u00e5r du nogle af gruppens bedste numre. Fra de tidlige funkhits til deres, store internationale pophits.\nCover: Lukas Graham / Photo: Press",
         "bounded": true,
         "duration": "PT1H7M37S",
         "numberOfItems": 20,
@@ -6413,7 +6415,7 @@
       "type": "playlists",
       "attributes": {
         "name": "Valentinstag ",
-        "description": "Schmachtet, neckt euch, küsst und liebt euch! Was gibt es Schöneres als die Liebe? Wir können euch zwar nicht mit Blumen oder Pralinen versorgen, dafür aber mit einer wunderschönen Playlist für das perfekte Candlelight-Dinner mit euren Liebsten. (Foto: Unsplash)",
+        "description": "Schmachtet, neckt euch, k\u00fcsst und liebt euch! Was gibt es Sch\u00f6neres als die Liebe? Wir k\u00f6nnen euch zwar nicht mit Blumen oder Pralinen versorgen, daf\u00fcr aber mit einer wundersch\u00f6nen Playlist f\u00fcr das perfekte Candlelight-Dinner mit euren Liebsten. (Foto: Unsplash)",
         "bounded": true,
         "duration": "PT4H12M10S",
         "numberOfItems": 69,
@@ -6633,7 +6635,7 @@
       "type": "playlists",
       "attributes": {
         "name": "Tobias Rahim Essentials",
-        "description": "Tobias Rahim kan skrue et hit sammen. Og han har sin helt egen måde at gøre det på, hvor Rahim finder ind til en helt særlig vibe, der både rummer poesi, politisk bevidsthed, attitude og sårbarhed. Og så kan han også lave musik til dansegulvet og en solskinsdag. Her får du nogle af hans bedste numre.\nFoto: Presse",
+        "description": "Tobias Rahim kan skrue et hit sammen. Og han har sin helt egen m\u00e5de at g\u00f8re det p\u00e5, hvor Rahim finder ind til en helt s\u00e6rlig vibe, der b\u00e5de rummer poesi, politisk bevidsthed, attitude og s\u00e5rbarhed. Og s\u00e5 kan han ogs\u00e5 lave musik til dansegulvet og en solskinsdag. Her f\u00e5r du nogle af hans bedste numre.\nFoto: Presse",
         "bounded": true,
         "duration": "PT1H4M38S",
         "numberOfItems": 20,
@@ -6692,7 +6694,7 @@
         "isrc": "DKUM71200883",
         "duration": "PT3M26S",
         "copyright": {
-          "text": "℗ 2012 Copenhagen Records / Universal Music"
+          "text": "\u2117 2012 Copenhagen Records / Universal Music"
         },
         "explicit": false,
         "ai": false,
@@ -6754,7 +6756,7 @@
         "isrc": "USWB11902022",
         "duration": "PT3M",
         "copyright": {
-          "text": "a Copenhagen Records / Then We Take The World release; ℗ 2019 Universal Music (Denmark) A/S"
+          "text": "a Copenhagen Records / Then We Take The World release; \u2117 2019 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -6816,7 +6818,7 @@
         "isrc": "USWB11902814",
         "duration": "PT4M1S",
         "copyright": {
-          "text": "a Copenhagen Records / Then We Take The World release; ℗ 2019 Universal Music (Denmark) A/S"
+          "text": "a Copenhagen Records / Then We Take The World release; \u2117 2019 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -6879,7 +6881,7 @@
         "isrc": "USWB12002076",
         "duration": "PT2M52S",
         "copyright": {
-          "text": "℗ 2020 Universal Music (Denmark) A/S"
+          "text": "\u2117 2020 Universal Music (Denmark) A/S"
         },
         "explicit": true,
         "ai": false,
@@ -6946,7 +6948,7 @@
         "isrc": "DKBV71106701",
         "duration": "PT3M28S",
         "copyright": {
-          "text": "℗ 2011 Copenhagen Records"
+          "text": "\u2117 2011 Copenhagen Records"
         },
         "explicit": false,
         "ai": false,
@@ -7008,7 +7010,7 @@
         "isrc": "USWB12100981",
         "duration": "PT3M46S",
         "copyright": {
-          "text": "℗ 2021 Universal Music (Denmark) A/S"
+          "text": "\u2117 2021 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7071,7 +7073,7 @@
         "isrc": "USWB12101751",
         "duration": "PT3M46S",
         "copyright": {
-          "text": "℗ 2021 Universal Music (Denmark) A/S"
+          "text": "\u2117 2021 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7138,7 +7140,7 @@
         "isrc": "USWB12103083",
         "duration": "PT3M21S",
         "copyright": {
-          "text": "℗ 2021 Universal Music (Denmark) A/S"
+          "text": "\u2117 2021 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7201,7 +7203,7 @@
         "isrc": "USWB12201688",
         "duration": "PT2M56S",
         "copyright": {
-          "text": "℗ 2022 Universal Music (Denmark) A/S"
+          "text": "\u2117 2022 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7268,7 +7270,7 @@
         "isrc": "USWB12207016",
         "duration": "PT3M16S",
         "copyright": {
-          "text": "℗ 2023 Universal Music (Denmark) A/S"
+          "text": "\u2117 2023 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7335,7 +7337,7 @@
         "isrc": "DKUM72400183",
         "duration": "PT2M29S",
         "copyright": {
-          "text": "℗ 2024 Universal Music (Denmark) A/S"
+          "text": "\u2117 2024 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7398,7 +7400,7 @@
         "isrc": "USWB11506516",
         "duration": "PT3M57S",
         "copyright": {
-          "text": "℗ 2015 Universal Music A/S"
+          "text": "\u2117 2015 Universal Music A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7460,7 +7462,7 @@
         "isrc": "DKUM71400126",
         "duration": "PT3M27S",
         "copyright": {
-          "text": "℗ 2014 Universal Music (Denmark) A/S"
+          "text": "\u2117 2014 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7522,7 +7524,7 @@
         "isrc": "USWB11506519",
         "duration": "PT3M39S",
         "copyright": {
-          "text": "℗ 2015 Universal Music (Denmark) A/S"
+          "text": "\u2117 2015 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7584,7 +7586,7 @@
         "isrc": "USWB11514268",
         "duration": "PT3M23S",
         "copyright": {
-          "text": "℗ 2015 Then We Take The World / Copenhagen Records"
+          "text": "\u2117 2015 Then We Take The World / Copenhagen Records"
         },
         "explicit": false,
         "ai": false,
@@ -7646,7 +7648,7 @@
         "isrc": "USWB11506526",
         "duration": "PT3M23S",
         "copyright": {
-          "text": "℗ 2015 Universal Music (Denmark) A/S"
+          "text": "\u2117 2015 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7708,7 +7710,7 @@
         "isrc": "USWB11701563",
         "duration": "PT3M4S",
         "copyright": {
-          "text": "A Copenhagen Records / Then We Take The World release; ℗ 2017 Universal Music (Denmark) A/S"
+          "text": "A Copenhagen Records / Then We Take The World release; \u2117 2017 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7774,7 +7776,7 @@
         "isrc": "USWB11801972",
         "duration": "PT3M13S",
         "copyright": {
-          "text": "a Copenhagen Records / Then We Take The World release; ℗ 2018 Universal Music (Denmark) A/S"
+          "text": "a Copenhagen Records / Then We Take The World release; \u2117 2018 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7836,7 +7838,7 @@
         "isrc": "USWB11801973",
         "duration": "PT3M11S",
         "copyright": {
-          "text": "a Copenhagen Records / Then We Take The World release; ℗ 2018 Universal Music (Denmark) A/S"
+          "text": "a Copenhagen Records / Then We Take The World release; \u2117 2018 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,
@@ -7898,7 +7900,7 @@
         "isrc": "USWB11801903",
         "duration": "PT3M25S",
         "copyright": {
-          "text": "a Copenhagen Records / Then We Take The World release; ℗ 2018 Universal Music (Denmark) A/S"
+          "text": "a Copenhagen Records / Then We Take The World release; \u2117 2018 Universal Music (Denmark) A/S"
         },
         "explicit": false,
         "ai": false,

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -46,7 +46,8 @@ async def test_search(media_manager: TidalMediaManager, provider_mock: Mock) -> 
     assert first_playlist.is_editable is False
 
     provider_mock.api.get_jsonapi.assert_called_with(
-        "searchResults/lukas%20graham",
+        "searchResults",
+        params={"filter[query]": "lukas graham"},
         include=[
             "tracks.artists",
             "tracks.albums.coverArt",
@@ -57,17 +58,17 @@ async def test_search(media_manager: TidalMediaManager, provider_mock: Mock) -> 
     )
 
 
-async def test_search_single_type_and_query_encoding(
+async def test_search_single_type_passes_query_verbatim(
     media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
-    """Test search requests only the includes for the wanted types and encodes the query."""
+    """Test search requests only the includes for the wanted types, query as a filter."""
     provider_mock.api.get_jsonapi.return_value = _load_doc("search.json")
 
     results = await media_manager.search("AC/DC", [MediaType.ARTIST])
 
     assert results.tracks == []
     provider_mock.api.get_jsonapi.assert_called_with(
-        "searchResults/AC%2FDC", include=["artists.profileArt"]
+        "searchResults", params={"filter[query]": "AC/DC"}, include=["artists.profileArt"]
     )
 
 

--- a/tests/providers/tidal/test_media_extended.py
+++ b/tests/providers/tidal/test_media_extended.py
@@ -199,9 +199,9 @@ async def test_mix_modules_found_regardless_of_row_order(
 
 
 async def test_search_empty_results(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
-    """Test search with empty results."""
+    """Test search with a result resource carrying no hits."""
     provider_mock.api.get_jsonapi.return_value = JsonApiDocument(
-        {"data": {"id": "query", "type": "searchResults", "relationships": {}}}
+        {"data": [{"id": "opaque123", "type": "searchResults", "relationships": {}}]}
     )
 
     results = await media_manager.search("query", [MediaType.ARTIST])
@@ -209,4 +209,15 @@ async def test_search_empty_results(media_manager: TidalMediaManager, provider_m
     assert len(results.artists) == 0
     assert len(results.albums) == 0
     assert len(results.tracks) == 0
+
+
+async def test_search_empty_collection(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test search returns empty results when the collection carries no resource."""
+    provider_mock.api.get_jsonapi.return_value = JsonApiDocument({"data": []})
+
+    results = await media_manager.search("query", [MediaType.ARTIST])
+
+    assert len(results.artists) == 0
     assert len(results.playlists) == 0


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

FIx tidal search after the contract was changed upstream

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
