### PR TITLE
Improve duplicate detection across music providers

### DIFF
--- a/music_assistant/controllers/metadata/constants.py
+++ b/music_assistant/controllers/metadata/constants.py
@@ -82,7 +82,7 @@ ALBUM_RECONCILIATION_TASK_ID = "metadata_album_reconciliation_v1"
 
 METADATA_LOOKUP_TASK_ID_PREFIX = "metadata_lookup"
 
-METADATA_SCAN_BATCH_SIZE = 5
+METADATA_SCAN_BATCH_SIZE = 25
 
 CONF_THUMB_CACHE_MAX_SIZE = "thumb_cache_max_size"
 

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -415,8 +415,8 @@ class MetaDataController(
             metadata={"task_domain": "metadata_thumb_cache_cleanup"},
             allow_retry=True,
         )
-        # runs every hour rather than spread across the day: it is already bounded to a
-        # handful of albums per run, so there is no shared-mirror stampede to avoid
+        # runs every hour rather than spread across the day: it is bounded to a small
+        # batch of albums per run, so there is no shared-mirror stampede to avoid
         self.mass.tasks.register_scheduled_task(
             task_id=ALBUM_RECONCILIATION_TASK_ID,
             name="Reconcile duplicate albums",

--- a/music_assistant/controllers/metadata/enrichment.py
+++ b/music_assistant/controllers/metadata/enrichment.py
@@ -236,6 +236,8 @@ class MetadataEnrichmentMixin:
                     prov_mapping.item_id, prov_mapping.provider_instance
                 )
                 album.metadata.update(prov_item.metadata)
+                # backfill identifiers (e.g. barcode) missing on a sparse library add
+                album.external_ids.update(prov_item.external_ids)
                 if album.year is None and prov_item.year:
                     album.year = prov_item.year
                 if album.album_type == AlbumType.UNKNOWN:

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -800,14 +800,15 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         self,
         external_id: str,
         external_id_type: ExternalID | None = None,
-        limit: int | None = 50,
+        *,
+        limit: int | None,
     ) -> list[ItemCls]:
         """
         Get library items for the given external identifier.
 
         :param external_id: External identifier value to look up.
         :param external_id_type: Optional identifier type.
-        :param limit: Maximum number of library items to return.
+        :param limit: Maximum number of library items to return, or None for all matches.
         """
         if external_id_type:
             lookup_values = external_id_lookup_values(external_id_type, external_id)
@@ -1576,10 +1577,19 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         if provider_mappings:
             if cur_item := await self.get_library_item_by_prov_mappings(provider_mappings):
                 return int(cur_item.item_id)
-        for cur_item in await self.get_library_items_by_external_ids(item.external_ids):
-            # External identifiers may be reused, so verify every candidate.
-            if compare_media_item(item, cur_item):
-                return int(cur_item.item_id)
+        # fetch candidates per external id (best identifier first) and stop at the
+        # first verified match; external identifiers may be reused, so verify
+        # every candidate before accepting it
+        seen_item_ids: set[str] = set()
+        for external_id_type, external_id in sorted(item.external_ids, key=external_id_sort_key):
+            for cur_item in await self.get_library_items_by_external_id(
+                external_id, external_id_type, limit=None
+            ):
+                if cur_item.item_id in seen_item_ids:
+                    continue
+                seen_item_ids.add(cur_item.item_id)
+                if compare_media_item(item, cur_item):
+                    return int(cur_item.item_id)
         # search by normalized exact name match
         query = (
             f"{self.db_table}.search_name = :search_name "

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -216,7 +216,8 @@ def compare_album_evidence(
     ambiguous = version_evidence == AlbumMatchEvidence.INSUFFICIENT
     if ambiguous and secondary_external_id_match:
         # a shared barcode/ASIN identifies the same retail product, which resolves an
-        # ambiguous edition wording; a conflicting tracklist fingerprint still overrides
+        # ambiguous edition wording; when the caller supplies tracklists, a conflicting
+        # fingerprint still overrides
         ambiguous = False
     if not strict and (isinstance(base_item, ItemMapping) or isinstance(compare_item, ItemMapping)):
         return _finalize_album_evidence(ambiguous, base_tracks, compare_tracks)

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -794,8 +794,11 @@ def _compare_album_name(base_name: str, compare_name: str) -> bool:
         return False
     # both titles collapse to nothing under normalization (e.g. pure punctuation):
     # fall back to a raw comparison with all whitespace removed, so spacing drift
-    # ("( )" vs "()") still matches while unrelated titles don't
-    return "".join(base_name.split()).casefold() == "".join(compare_name.split()).casefold()
+    # ("( )" vs "()") still matches while unrelated titles don't; the retail suffix
+    # is stripped here as well so "... - EP" still matches "..."
+    base_raw = _ALBUM_SUFFIX_PATTERN.sub("", base_name)
+    compare_raw = _ALBUM_SUFFIX_PATTERN.sub("", compare_name)
+    return "".join(base_raw.split()).casefold() == "".join(compare_raw.split()).casefold()
 
 
 def _normalize_album_name(name: str) -> str:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -45,7 +45,11 @@ _VERSION_IGNORE_WORDS = {
 _VERSION_WORD_ALIASES = {
     "remastered": "remaster",
 }
-_IGNORE_VERSION_KEYS = {create_safe_string(value) for value in IGNORE_VERSIONS}
+# phrases stripped from a version before tokenizing: they may contain punctuation
+# ("hi-res") that the tokenizer would otherwise split into meaningful-looking tokens
+_IGNORE_VERSION_PATTERNS = tuple(
+    re.compile(rf"\b{re.escape(phrase)}\b", re.IGNORECASE) for phrase in IGNORE_VERSIONS
+)
 
 # version tokens that signal a fundamentally different recording (not just packaging),
 # so they must never be treated as an ambiguous/mergeable edition difference
@@ -60,7 +64,11 @@ _RECORDING_CONFLICT_VERSION_TOKENS = {
     "session",
 }
 
-# duration tolerances (seconds) for the album-track fingerprint comparison
+# trailing " - EP" / " - Single" retail suffix (any dash style), as appended by Apple Music
+_ALBUM_SUFFIX_PATTERN = re.compile(r"\s+[-\u2013\u2014]\s+(?:EP|Single)\s*$", re.IGNORECASE)
+
+# duration tolerances (seconds) for track comparisons: an external-id corroborated
+# match allows more duration drift than a bare title/version fallback
 _ISRC_DURATION_TOLERANCE = 8
 _FALLBACK_DURATION_TOLERANCE = 2
 
@@ -190,7 +198,7 @@ def compare_album_evidence(
             return AlbumMatchEvidence.MATCH if external_id_match else AlbumMatchEvidence.NO_MATCH
 
     # barcode/ASIN are shared across pressings and are non-unique corroboration only,
-    # so they are never used on their own, only to corroborate a year mismatch below
+    # so they are never used on their own, only to resolve a year or edition ambiguity below
     secondary_external_id_match = any(
         compare_external_ids(base_item.external_ids, compare_item.external_ids, ext_id) is True
         for ext_id in (ExternalID.ASIN, ExternalID.BARCODE)
@@ -206,6 +214,10 @@ def compare_album_evidence(
         return AlbumMatchEvidence.NO_MATCH
 
     ambiguous = version_evidence == AlbumMatchEvidence.INSUFFICIENT
+    if ambiguous and secondary_external_id_match:
+        # a shared barcode/ASIN identifies the same retail product, which resolves an
+        # ambiguous edition wording; a conflicting tracklist fingerprint still overrides
+        ambiguous = False
     if not strict and (isinstance(base_item, ItemMapping) or isinstance(compare_item, ItemMapping)):
         return _finalize_album_evidence(ambiguous, base_tracks, compare_tracks)
     # for strict matching we REQUIRE both items to be a real album object
@@ -338,7 +350,7 @@ def compare_track(
         if external_id_match is True:
             # we got a 'soft-match' on a secondary external id (like ISRC)
             # but we do a double check on duration
-            if abs(base_item.duration - compare_item.duration) <= 8:
+            if abs(base_item.duration - compare_item.duration) <= _ISRC_DURATION_TOLERANCE:
                 return True
 
     # compare name
@@ -359,15 +371,14 @@ def compare_track(
         return False
 
     # exact albumtrack match = 100% match
+    # a missing disc number means unknown: assume disc 1 (local files often omit the tag)
     if (
         base_item.album
         and compare_item.album
         and compare_album(base_item.album, compare_item.album, False)
-        and base_item.disc_number
-        and compare_item.disc_number
         and base_item.track_number
         and compare_item.track_number
-        and base_item.disc_number == compare_item.disc_number
+        and (base_item.disc_number or 1) == (compare_item.disc_number or 1)
         and base_item.track_number == compare_item.track_number
     ):
         return True
@@ -600,22 +611,6 @@ def compare_artists(
     return len(base_items) == len(compare_items) == matches
 
 
-def compare_albums(
-    base_items: list[Album | ItemMapping],
-    compare_items: list[Album | ItemMapping],
-    any_match: bool = True,
-) -> bool:
-    """Compare two lists of albums and return True if a match was found."""
-    matches = 0
-    for base_item in base_items:
-        for compare_item in compare_items:
-            if compare_album(base_item, compare_item):
-                if any_match:
-                    return True
-                matches += 1
-    return len(base_items) == matches
-
-
 def compare_item_ids(
     base_item: MediaItem | ItemMapping, compare_item: MediaItem | ItemMapping
 ) -> bool:
@@ -706,7 +701,7 @@ def loose_compare_strings(base: str, alt: str) -> bool:
     alt_comp = create_safe_string(alt)
     if base_comp in alt_comp:
         return True
-    return base_comp in alt_comp
+    return alt_comp in base_comp
 
 
 def compare_strings(str1: str, str2: str, strict: bool = True) -> bool:
@@ -748,14 +743,16 @@ def compare_explicit(base: MediaItemMetadata, compare: MediaItemMetadata) -> boo
 
 @lru_cache(maxsize=1024)
 def _normalize_version_tokens(value: str) -> tuple[str, ...]:
-    """Return meaningful version tokens in stable order."""
-    if not value or create_safe_string(value) in _IGNORE_VERSION_KEYS:
+    """Return meaningful, deduplicated version tokens in stable order."""
+    if not value:
         return ()
+    stripped_value = value.casefold()
+    for pattern in _IGNORE_VERSION_PATTERNS:
+        stripped_value = pattern.sub(" ", stripped_value)
     tokens = (
-        _VERSION_WORD_ALIASES.get(token, token)
-        for token in re.findall(r"[^\W_]+", value.casefold())
+        _VERSION_WORD_ALIASES.get(token, token) for token in re.findall(r"[^\W_]+", stripped_value)
     )
-    return tuple(sorted(token for token in tokens if token not in _VERSION_IGNORE_WORDS))
+    return tuple(sorted({token for token in tokens if token not in _VERSION_IGNORE_WORDS}))
 
 
 def _is_dynamic_radio(item: Radio | ItemMapping) -> bool:
@@ -796,13 +793,17 @@ def _compare_album_name(base_name: str, compare_name: str) -> bool:
     if base_safe or compare_safe:
         return False
     # both titles collapse to nothing under normalization (e.g. pure punctuation):
-    # fall back to a whitespace-normalized raw comparison so unrelated titles don't match
-    return " ".join(base_name.split()).casefold() == " ".join(compare_name.split()).casefold()
+    # fall back to a raw comparison with all whitespace removed, so spacing drift
+    # ("( )" vs "()") still matches while unrelated titles don't
+    return "".join(base_name.split()).casefold() == "".join(compare_name.split()).casefold()
 
 
 def _normalize_album_name(name: str) -> str:
-    """Return a punctuation/diacritic/whitespace-normalized album title for identity checks."""
-    return " ".join(create_safe_string(name).split())
+    """Return a punctuation/diacritic/whitespace-insensitive album title for identity checks."""
+    # the retail suffix carries no identity information: Apple Music appends it to
+    # EP/single titles while already setting album_type
+    name = _ALBUM_SUFFIX_PATTERN.sub("", name)
+    return create_safe_string(name, True, True)
 
 
 def _track_positions(tracks: Sequence[Track]) -> dict[tuple[int, int], Track]:

--- a/music_assistant/helpers/external_ids.py
+++ b/music_assistant/helpers/external_ids.py
@@ -83,7 +83,7 @@ def external_id_lookup_values(external_id_type: ExternalID, value: str) -> tuple
             f"{normalized_value[:2]}-{normalized_value[2:5]}-"
             f"{normalized_value[5:7]}-{normalized_value[7:]}"
         )
-    elif external_id_type.value.startswith(_MUSICBRAINZ_PREFIX) and normalized_value != raw_value:
+    elif external_id_type.value.startswith(_MUSICBRAINZ_PREFIX):
         values.add(f"{{{normalized_value}}}")
 
     return tuple(sorted(values))
@@ -164,7 +164,13 @@ def _normalize_barcode(value: str) -> str:
     if not payload or len(payload) > 14:
         return value
     normalized_value = payload.zfill(14)
-    return normalized_value if _is_valid_gtin(normalized_value) else value
+    if _is_valid_gtin(normalized_value):
+        return normalized_value
+    if len(compact_value) == 13:
+        # Qobuz delivers part of its catalogue as a GTIN-14 with the final check digit
+        # chopped off: recover the full value by appending the recomputed check digit
+        return compact_value + _gtin_check_digit(compact_value)
+    return value
 
 
 def _normalize_isrc(value: str) -> str:
@@ -185,8 +191,12 @@ def _is_valid_gtin(value: str) -> bool:
     """Return whether a value is a canonical GTIN-14 with a valid check digit."""
     if len(value) != 14 or not value.isdigit():
         return False
-    body = value[:-1]
+    return value[-1] == _gtin_check_digit(value[:-1])
+
+
+def _gtin_check_digit(body: str) -> str:
+    """Return the GTIN check digit for a numeric identifier body."""
     checksum = sum(
         int(char) * (3 if index % 2 == 0 else 1) for index, char in enumerate(reversed(body))
     )
-    return (10 - checksum % 10) % 10 == int(value[-1])
+    return str((10 - checksum % 10) % 10)

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -722,12 +722,17 @@ def parse_title_and_version(
         return title, track_version or ""
 
     # Standard version parsing
-    for parts in (
-        _balanced_bracket_groups(title, "(", ")"),
-        _balanced_bracket_groups(title, "[", "]"),
-        re.findall(r" - .*", title),
+    # each pass extracts from the current title so removals from
+    # earlier passes are taken into account
+    for extract_parts in (
+        lambda t: _balanced_bracket_groups(t, "(", ")"),
+        lambda t: _balanced_bracket_groups(t, "[", "]"),
+        lambda t: re.findall(r" - .*", t),
     ):
-        for title_part in parts:
+        for title_part in extract_parts(title):
+            # skip parts already consumed by an earlier removal in this pass
+            if title_part not in title:
+                continue
             # Extract the content without brackets/dashes for checking
             clean_part = title_part.translate(str.maketrans("", "", "()[]-")).strip().lower()
 

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -58,6 +58,7 @@ from music_assistant.controllers.tasks.context import (
     update_current_task_progress_text,
 )
 from music_assistant.helpers.compare import compare_strings
+from music_assistant.helpers.external_ids import normalize_external_id
 from music_assistant.helpers.playlists import (
     ImageInfo,
     IsHLSPlaylist,
@@ -896,11 +897,15 @@ class BuiltinProvider(MusicProvider):
         # exact ID matches (cross-provider definitive match)
         if isrc:
             candidate_isrc = candidate.get_external_id(ExternalID.ISRC)
-            if candidate_isrc and candidate_isrc.upper() == isrc.upper():
+            if candidate_isrc and normalize_external_id(
+                ExternalID.ISRC, candidate_isrc
+            ) == normalize_external_id(ExternalID.ISRC, isrc):
                 return 10
         if mbid:
             candidate_mbid = candidate.get_external_id(ExternalID.MB_RECORDING)
-            if candidate_mbid and candidate_mbid.lower() == mbid.lower():
+            if candidate_mbid and normalize_external_id(
+                ExternalID.MB_RECORDING, candidate_mbid
+            ) == normalize_external_id(ExternalID.MB_RECORDING, mbid):
                 return 10
 
         # media type gate

--- a/music_assistant/providers/musicbrainz/provider.py
+++ b/music_assistant/providers/musicbrainz/provider.py
@@ -16,7 +16,12 @@ from music_assistant_models.media_items.metadata import LifeSpan
 from music_assistant.constants import VARIOUS_ARTISTS_MBID
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.compare import compare_strings
-from music_assistant.helpers.external_ids import external_id_lookup_values, is_valid_barcode
+from music_assistant.helpers.external_ids import (
+    external_id_lookup_values,
+    is_valid_barcode,
+    is_valid_isrc,
+    normalize_external_id,
+)
 from music_assistant.helpers.util import parse_title_and_version
 from music_assistant.models.metadata_provider import MetadataProvider
 
@@ -294,9 +299,9 @@ class MusicbrainzProvider(MetadataProvider):
         :param isrc: ISRC of the recording, with or without separators.
         :return: Recordings tagged with this ISRC, or empty list if not found.
         """
-        safe_isrc = isrc.replace("-", "").strip()
-        if not safe_isrc.isalnum():
+        if not is_valid_isrc(isrc):
             return []
+        safe_isrc = normalize_external_id(ExternalID.ISRC, isrc)
         # the isrc resource rejects inc= parameters and already carries the release dates
         result = await self._api_client.get_data(f"isrc/{safe_isrc}")
         if not result or not (recordings := result.get("recordings")):

--- a/music_assistant/providers/spotify/parsers.py
+++ b/music_assistant/providers/spotify/parsers.py
@@ -107,7 +107,7 @@ def parse_album(album_obj: dict[str, Any], provider: SpotifyProvider) -> Album:
         },
     )
     if "external_ids" in album_obj and album_obj["external_ids"].get("upc"):
-        album.external_ids.add((ExternalID.BARCODE, "0" + album_obj["external_ids"]["upc"]))
+        album.external_ids.add((ExternalID.BARCODE, album_obj["external_ids"]["upc"]))
     if "external_ids" in album_obj and album_obj["external_ids"].get("ean"):
         album.external_ids.add((ExternalID.BARCODE, album_obj["external_ids"]["ean"]))
 

--- a/tests/controllers/metadata/test_enrichment.py
+++ b/tests/controllers/metadata/test_enrichment.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import aiohttp
 import pytest
 from music_assistant_models.enums import ExternalID, ProviderFeature
-from music_assistant_models.media_items import Album, Artist, Track
+from music_assistant_models.media_items import Album, Artist, ProviderMapping, Track
 from music_assistant_models.media_items.metadata import MediaItemMetadata
 
 from music_assistant.controllers.metadata.constants import CONF_ENABLE_ONLINE_METADATA
@@ -60,6 +60,44 @@ async def test_album_enrichment_survives_provider_error() -> None:
     good.get_album_metadata.assert_awaited_once()  # loop continued past the failing provider
     enrichment.logger.warning.assert_called_once()
     enrichment.mass.music.albums.update_item_in_library.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_album_enrichment_backfills_external_ids() -> None:
+    """External ids fetched from the provider item (e.g. a barcode) reach the album."""
+    enrichment = MetadataEnrichmentMixin()
+    enrichment.logger = MagicMock()
+    enrichment.mass = MagicMock()
+    enrichment.config = MagicMock()
+    enrichment.config.get_value = _online_metadata_only
+    enrichment.providers = []  # type: ignore[misc]
+    enrichment.mass.music.albums.update_item_in_library = AsyncMock()
+
+    prov_item = Album(
+        item_id="prov1",
+        provider="spotify_1",
+        name="Test Album",
+        provider_mappings=set(),
+        external_ids={(ExternalID.BARCODE, "0602577915181")},
+        metadata=MediaItemMetadata(),
+    )
+    enrichment.mass.music.albums.get_provider_item = AsyncMock(return_value=prov_item)
+
+    album = Album(
+        item_id="1",
+        provider="library",
+        name="Test Album",
+        provider_mappings={
+            ProviderMapping(
+                item_id="prov1", provider_domain="spotify", provider_instance="spotify_1"
+            )
+        },
+        metadata=MediaItemMetadata(),
+    )
+
+    await enrichment._update_album_metadata(album, force_refresh=True)
+
+    assert (ExternalID.BARCODE, "0602577915181") in album.external_ids
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -670,6 +670,28 @@ def _mb_evidence_ctrl(musicbrainz: Mock) -> AlbumsController:
     return ctrl
 
 
+async def test_musicbrainz_evidence_shared_single_release_matches() -> None:
+    """A shared barcode resolving to exactly one specific release is positive evidence."""
+    musicbrainz = _mb(**{BASE_BARCODE: [_mb_release("rel-1", "rg-1")]})
+    ctrl = _mb_evidence_ctrl(musicbrainz)
+    base = _library_album(barcodes=(BASE_BARCODE,))
+    compare = _album("s1", "spotify_1", barcodes=(BASE_BARCODE,))
+
+    assert await ctrl._musicbrainz_album_evidence(base, compare) == AlbumMatchEvidence.MATCH
+
+
+async def test_musicbrainz_evidence_ambiguous_barcode_is_not_release_identity() -> None:
+    """A shared barcode resolving to several releases never identifies a specific release."""
+    musicbrainz = _mb(
+        **{BASE_BARCODE: [_mb_release("rel-1", "rg-1"), _mb_release("rel-2", "rg-1")]}
+    )
+    ctrl = _mb_evidence_ctrl(musicbrainz)
+    base = _library_album(barcodes=(BASE_BARCODE,))
+    compare = _album("s1", "spotify_1", barcodes=(BASE_BARCODE,))
+
+    assert await ctrl._musicbrainz_album_evidence(base, compare) == AlbumMatchEvidence.INSUFFICIENT
+
+
 async def test_musicbrainz_evidence_all_resolved_disjoint_groups_reject() -> None:
     """Disjoint release groups are negative evidence when every barcode resolved."""
     musicbrainz = _mb(

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -474,10 +474,15 @@ async def test_base_mapping_skipped_when_exact_instance_not_loaded() -> None:
 
 async def test_candidate_tracklist_not_found_falls_through_to_musicbrainz() -> None:
     """A candidate tracklist that 404s is treated as absent so MusicBrainz can decide."""
-    musicbrainz = _mb(**{BASE_BARCODE: [_mb_release("rel-1", "rg-1")]})
+    musicbrainz = _mb(
+        **{
+            BASE_BARCODE: [_mb_release("rel-1", "rg-1")],
+            OTHER_BARCODE: [_mb_release("rel-2", "rg-2")],
+        }
+    )
     base = _library_album(version="2022 Remaster", barcodes=[BASE_BARCODE])
-    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=[BASE_BARCODE])
-    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=[BASE_BARCODE])
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=[OTHER_BARCODE])
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=[OTHER_BARCODE])
     with _harness(
         search_results=[sparse],
         provider_items={"s1": full},
@@ -486,16 +491,23 @@ async def test_candidate_tracklist_not_found_falls_through_to_musicbrainz() -> N
     ) as harness:
         matches = await harness.match(base)
 
-    assert [mapping.item_id for mapping in matches] == ["s1"]
+    # MusicBrainz was consulted despite the tracklist failure and its verdict
+    # (disjoint release groups) was applied
+    assert matches == []
     musicbrainz.get_releases_by_barcode.assert_awaited()
 
 
 async def test_candidate_tracklist_transient_error_falls_through_to_musicbrainz() -> None:
     """A transient candidate tracklist failure is treated as absent so MusicBrainz can decide."""
-    musicbrainz = _mb(**{BASE_BARCODE: [_mb_release("rel-1", "rg-1")]})
+    musicbrainz = _mb(
+        **{
+            BASE_BARCODE: [_mb_release("rel-1", "rg-1")],
+            OTHER_BARCODE: [_mb_release("rel-2", "rg-2")],
+        }
+    )
     base = _library_album(version="2022 Remaster", barcodes=[BASE_BARCODE])
-    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=[BASE_BARCODE])
-    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=[BASE_BARCODE])
+    sparse = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=[OTHER_BARCODE])
+    full = _album("s1", "spotify_1", version="Deluxe 2022 Remaster", barcodes=[OTHER_BARCODE])
     with _harness(
         search_results=[sparse],
         provider_items={"s1": full},
@@ -504,7 +516,9 @@ async def test_candidate_tracklist_transient_error_falls_through_to_musicbrainz(
     ) as harness:
         matches = await harness.match(base)
 
-    assert [mapping.item_id for mapping in matches] == ["s1"]
+    # MusicBrainz was consulted despite the tracklist failure and its verdict
+    # (disjoint release groups) was applied
+    assert matches == []
     musicbrainz.get_releases_by_barcode.assert_awaited()
 
 
@@ -545,7 +559,7 @@ def _mb_harness(
     musicbrainz: Mock | None,
     *,
     base_barcodes: Sequence[str] = (BASE_BARCODE,),
-    compare_barcodes: Sequence[str] = (BASE_BARCODE,),
+    compare_barcodes: Sequence[str] = (OTHER_BARCODE,),
 ) -> Iterator[tuple[_Harness, Album]]:
     """Yield a harness plus base album whose only candidate is ambiguous past fingerprints."""
     base = _library_album(version="2022 Remaster", barcodes=base_barcodes)
@@ -561,22 +575,23 @@ def _mb_harness(
         yield harness, base
 
 
-async def test_musicbrainz_shared_single_release_matches() -> None:
-    """A barcode resolving to one shared specific release confirms the match."""
-    musicbrainz = _mb(**{BASE_BARCODE: [_mb_release("rel-1", "rg-1")]})
-    with _mb_harness(musicbrainz) as (harness, base):
+async def test_shared_barcode_resolves_ambiguity_without_musicbrainz() -> None:
+    """A shared barcode resolves an ambiguous edition wording without any lookups."""
+    musicbrainz = _mb()
+    with _mb_harness(musicbrainz, compare_barcodes=(BASE_BARCODE,)) as (harness, base):
         matches = await harness.match(base)
 
     assert [mapping.item_id for mapping in matches] == ["s1"]
-    # the tracklist is consulted before MusicBrainz is ever asked
-    assert harness.album_track_calls() == ["base-prov", "s1"]
-    musicbrainz.get_releases_by_barcode.assert_awaited()
+    musicbrainz.get_releases_by_barcode.assert_not_awaited()
 
 
 async def test_musicbrainz_multiple_releases_per_barcode_abstains() -> None:
     """A barcode resolving to several releases is ambiguous and must not match."""
     musicbrainz = _mb(
-        **{BASE_BARCODE: [_mb_release("rel-1", "rg-1"), _mb_release("rel-2", "rg-1")]}
+        **{
+            BASE_BARCODE: [_mb_release("rel-1", "rg-1"), _mb_release("rel-2", "rg-1")],
+            OTHER_BARCODE: [_mb_release("rel-3", "rg-1")],
+        }
     )
     with _mb_harness(musicbrainz) as (harness, base):
         assert await harness.match(base) == []
@@ -584,11 +599,19 @@ async def test_musicbrainz_multiple_releases_per_barcode_abstains() -> None:
 
 async def test_musicbrainz_multiple_barcodes_are_all_considered() -> None:
     """Every canonical barcode on each album is used, not just the first."""
-    musicbrainz = _mb(**{THIRD_BARCODE: [_mb_release("rel-9", "rg-9")]})
+    musicbrainz = _mb(
+        **{
+            BASE_BARCODE: [_mb_release("rel-1", "rg-1")],
+            THIRD_BARCODE: [_mb_release("rel-9", "rg-9")],
+            OTHER_BARCODE: [_mb_release("rel-2", "rg-9")],
+        }
+    )
     with _mb_harness(
-        musicbrainz, base_barcodes=(BASE_BARCODE, THIRD_BARCODE), compare_barcodes=(THIRD_BARCODE,)
+        musicbrainz, base_barcodes=(BASE_BARCODE, THIRD_BARCODE), compare_barcodes=(OTHER_BARCODE,)
     ) as (harness, base):
-        assert [mapping.item_id for mapping in await harness.match(base)] == ["s1"]
+        assert await harness.match(base) == []
+    queried = {call.args[0] for call in musicbrainz.get_releases_by_barcode.await_args_list}
+    assert queried == {BASE_BARCODE, OTHER_BARCODE, THIRD_BARCODE}
 
 
 async def test_musicbrainz_shared_release_group_alone_does_not_match() -> None:
@@ -698,7 +721,7 @@ async def test_get_library_item_by_match_is_io_free() -> None:
         # every DB lookup returns nothing; a real provider/MusicBrainz call would raise
         get_library_item_by_prov_id=AsyncMock(return_value=None),
         get_library_item_by_prov_mappings=AsyncMock(return_value=None),
-        get_library_items_by_external_ids=AsyncMock(return_value=[]),
+        get_library_items_by_external_id=AsyncMock(return_value=[]),
         get_library_items_by_query=AsyncMock(return_value=[]),
         search=AsyncMock(side_effect=AssertionError("search during sync")),
         get_provider_item=AsyncMock(side_effect=AssertionError("provider fetch during sync")),

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -435,6 +435,11 @@ def test_compare_album_evidence_punctuation_only_title_whitespace_drift_matches(
     album_b = _album(item_id="2", provider="test2", name="()")
     assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
 
+    # the retail suffix is also ignored when the remaining title is punctuation-only
+    album_a = _album(name="... - EP")
+    album_b = _album(item_id="2", provider="test2", name="...")
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+
     # different punctuation-only titles are still different albums
     album_a = _album(name="\u00f7")
     album_b = _album(item_id="2", provider="test2", name="=")

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -112,6 +112,21 @@ def test_compare_version() -> None:
     assert compare.compare_version("Deluxe 2022 Remaster", "2022 Remaster") is False
 
 
+def test_compare_version_deduplicates_repeated_tokens() -> None:
+    """Repeated wording inside one version string does not block a match."""
+    assert (
+        compare.compare_version("Deluxe [2022 Remaster] 2022 Remaster", "Deluxe 2022 Remaster")
+        is True
+    )
+
+
+def test_compare_version_ignores_hi_res_wording() -> None:
+    """Quality-only wording (hi-res) is ignored wherever it appears in a version."""
+    assert compare.compare_version("Remastered", "Remastered Hi-Res Version") is True
+    assert compare.compare_version("Hi-Res Version", "") is True
+    assert compare.compare_version("Hi-Res", "Remastered") is False
+
+
 def test_compare_artist() -> None:
     """Test artist comparison."""
     artist_a = media_items.Artist(
@@ -393,6 +408,39 @@ def test_compare_album_evidence_name_accent_and_apostrophe_variants_match() -> N
     assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
 
 
+def test_compare_album_evidence_name_hyphenation_vs_spacing_matches() -> None:
+    """A hyphenated title matches its spaced or joined spelling across providers."""
+    album_a = _album(name="Trans-Europe Express")
+    album_b = _album(item_id="2", provider="test2", name="Trans Europe Express")
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+
+    album_a = _album(name="Hell - On")
+    album_b = _album(item_id="2", provider="test2", name="Hell-On")
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+
+
+def test_compare_album_evidence_name_retail_suffix_stripped() -> None:
+    """An Apple-style ' - EP'/' - Single' retail suffix does not block a match."""
+    for suffix in (" - EP", " - Single", " \u2013 EP"):
+        album_a = _album(name=f"Album A{suffix}")
+        album_b = _album(item_id="2", provider="test2", name="Album A")
+        assert (
+            compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+        ), suffix
+
+
+def test_compare_album_evidence_punctuation_only_title_whitespace_drift_matches() -> None:
+    """Whitespace drift within a punctuation-only title does not block a match."""
+    album_a = _album(name="( )")
+    album_b = _album(item_id="2", provider="test2", name="()")
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+
+    # different punctuation-only titles are still different albums
+    album_a = _album(name="\u00f7")
+    album_b = _album(item_id="2", provider="test2", name="=")
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.NO_MATCH
+
+
 def test_compare_album_evidence_unrelated_punctuation_only_titles_stay_distinct() -> None:
     """Two different titles that both normalize to nothing must not be treated as equal."""
     album_a = _album(name="...")
@@ -425,6 +473,39 @@ def test_compare_album_evidence_ambiguous_version_without_tracks_is_insufficient
     )
     # the compatibility wrapper stays conservative and does not merge on insufficient evidence
     assert compare.compare_album(base_item, compare_item) is False
+
+
+def test_compare_album_evidence_barcode_resolves_edition_ambiguity() -> None:
+    """A shared retail barcode resolves ambiguous edition wording into a match."""
+    barcode = {(ExternalID.BARCODE, "0724354283857")}
+    base_item = _album(version="2022 Remaster", external_ids=barcode)
+    compare_item = _album(item_id="2", provider="test2", version="Deluxe 2022 Remaster")
+    compare_item.external_ids = barcode
+
+    assert (
+        compare.compare_album_evidence(base_item, compare_item) == compare.AlbumMatchEvidence.MATCH
+    )
+
+    # the same corroboration applies when comparing against a minimized ItemMapping
+    mapping = media_items.ItemMapping(
+        item_id="3",
+        provider="test3",
+        name="Album A",
+        version="Deluxe 2022 Remaster",
+        external_ids=barcode,
+    )
+    assert (
+        compare.compare_album_evidence(base_item, mapping, strict=False)
+        == compare.AlbumMatchEvidence.MATCH
+    )
+
+    # a conflicting tracklist fingerprint still overrides the barcode corroboration
+    assert (
+        compare.compare_album_evidence(
+            base_item, compare_item, base_tracks=_tracklist(8), compare_tracks=_tracklist(14)
+        )
+        == compare.AlbumMatchEvidence.NO_MATCH
+    )
 
 
 def test_compare_album_evidence_subset_wording_with_recording_conflict_is_no_match() -> None:
@@ -739,6 +820,14 @@ def test_compare_external_ids_checks_all_unique_values() -> None:
     assert compare.compare_external_ids(base_ids, compare_ids, ExternalID.MB_ALBUM) is True
 
 
+def test_compare_external_ids_truncated_barcode_matches_full_value() -> None:
+    """A truncated 13-digit GTIN-14 (Qobuz) matches another provider's full barcode."""
+    base_ids = {(ExternalID.BARCODE, "0060252758365")}
+    compare_ids = {(ExternalID.BARCODE, "00602527583655")}
+
+    assert compare.compare_external_ids(base_ids, compare_ids, ExternalID.BARCODE) is True
+
+
 def test_compare_track() -> None:  # noqa: PLR0915
     """Test track comparison."""
     track_a = media_items.Track(
@@ -910,11 +999,51 @@ def test_compare_track() -> None:  # noqa: PLR0915
     assert compare.compare_track(track_a, track_b) is True
 
 
+def test_compare_track_missing_disc_number_assumes_disc_one() -> None:
+    """A track without a disc number tag still makes the exact albumtrack match on disc 1."""
+
+    def _albumtrack(item_id: str, provider: str, disc_number: int) -> media_items.Track:
+        return media_items.Track(
+            item_id=item_id,
+            provider=provider,
+            name="Track A",
+            duration=300,
+            disc_number=disc_number,
+            track_number=5,
+            artists=media_items.UniqueList(
+                [media_items.ItemMapping(item_id="1", provider=provider, name="Artist A")]
+            ),
+            album=media_items.ItemMapping(item_id="1", provider=provider, name="Album A"),
+            provider_mappings={
+                media_items.ProviderMapping(
+                    item_id=item_id, provider_domain=provider, provider_instance=provider
+                )
+            },
+        )
+
+    untagged = _albumtrack("1", "test1", disc_number=0)
+    disc_one = _albumtrack("2", "test2", disc_number=1)
+    # durations differ beyond every fallback tolerance: only the albumtrack path can match
+    disc_one.duration = 320
+    assert compare.compare_track(untagged, disc_one) is True
+
+    # an unknown disc number only ever assumes disc 1, never a higher disc
+    disc_two = _albumtrack("3", "test2", disc_number=2)
+    disc_two.duration = 320
+    assert compare.compare_track(untagged, disc_two) is False
+
+
 def test_compare_strings_case_insensitive_fuzzy() -> None:
     """Test that non-strict fuzzy matching is fully case-insensitive."""
     # These differ slightly ("Feat." vs "FT.") so create_safe_string won't match,
     # falling through to SequenceMatcher which must compare both strings lowered.
     assert compare.compare_strings("Track Feat. John", "TRACK FT. JOHN", strict=False) is True
+
+
+def test_loose_compare_strings_containment_both_directions() -> None:
+    """Partial containment matches regardless of which side has the extra wording."""
+    assert compare.loose_compare_strings("Some Track", "Some Track (Acoustic)") is True
+    assert compare.loose_compare_strings("Some Track (Acoustic)", "Some Track") is True
 
 
 def test_compare_radio() -> None:

--- a/tests/helpers/test_external_ids.py
+++ b/tests/helpers/test_external_ids.py
@@ -24,8 +24,15 @@ def test_normalize_gtin_variants() -> None:
 
 def test_invalid_gtin_is_preserved() -> None:
     """Invalid provider barcode data remains available for exact matching."""
-    assert normalize_external_id(ExternalID.BARCODE, "0724354283858") == "0724354283858"
+    assert normalize_external_id(ExternalID.BARCODE, "602445790392") == "602445790392"
     assert normalize_external_id(ExternalID.BARCODE, "catalog-123") == "catalog-123"
+
+
+def test_truncated_gtin14_recovers_check_digit() -> None:
+    """A GTIN-14 with its check digit chopped off (Qobuz) recovers the full value."""
+    assert normalize_external_id(ExternalID.BARCODE, "0060252758365") == "00602527583655"
+    # a structurally valid EAN-13 keeps taking the regular normalization path
+    assert normalize_external_id(ExternalID.BARCODE, "0724354283857") == "00724354283857"
 
 
 def test_legacy_gtin_lookup_values() -> None:
@@ -51,6 +58,15 @@ def test_normalize_isrc_and_mbid() -> None:
     assert normalize_external_id(ExternalID.ISRC, "us-rc1-76-07839") == "USRC17607839"
     assert normalize_external_id(ExternalID.ISRC, "invalid-isrc") == "invalid-isrc"
     assert normalize_external_id(ExternalID.MB_RECORDING, f"{{{mbid}}}") == mbid.lower()
+
+
+def test_mbid_lookup_values_include_braced_form() -> None:
+    """A canonical MBID lookup also covers the legacy braced storage form."""
+    mbid = "b1a9c0e9-d987-4042-ae91-78d6a3267d69"
+    values = external_id_lookup_values(ExternalID.MB_RECORDING, mbid)
+
+    assert mbid in values
+    assert f"{{{mbid}}}" in values
 
 
 def test_normalize_external_ids_deduplicates_values() -> None:

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -128,6 +128,29 @@ def test_version_extracts_multiple_qualifiers() -> None:
     assert version == "Deluxe 2022 Remaster"
 
 
+@pytest.mark.parametrize(
+    ("test_str", "expected"),
+    [
+        ("Barcelona (Special Edition - Deluxe)", ("Barcelona", "Special Edition - Deluxe")),
+        (
+            "All of Me (Tiësto's Birthday Treatment Remix - Radio Edit)",
+            ("All of Me", "Tiësto's Birthday Treatment Remix - Radio Edit"),
+        ),
+        (
+            "Crime Of The Century (2014 - HD Remaster)",
+            ("Crime Of The Century", "2014 - HD Remaster"),
+        ),
+        ("Song (Live) - Remastered 2011", ("Song", "Live Remastered 2011")),
+        ("Song (Remastered) (Remastered)", ("Song", "Remastered")),
+        ("Allejoppa - Extended [Extended]", ("Allejoppa", "Extended")),
+        ("Song - Single (Deluxe)", ("Song", "Deluxe Single")),
+    ],
+)
+def test_version_extract_sequential_passes(test_str: str, expected: tuple[str, str]) -> None:
+    """Later parsing passes see the title as reduced by earlier passes."""
+    assert util.parse_title_and_version(test_str) == expected
+
+
 def test_with_handling_in_titles() -> None:
     """Test 'with' handling - preserved in title, stripped as featuring credit."""
     # 'with you' (preserved as title word)


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5770/#5771/#5776: duplicate albums and tracks still appeared because several matching rules were stricter than the metadata providers actually deliver. Replayed against a real multi-provider library (Apple Music + Qobuz + local files), these fixes take matched duplicate track pairs from 8 to ~1,760 of 2,187 and nearly double the matched album pairs.

- Fix the title/version parser appending stale text from already-consumed bracket groups (corrupted versions like `Deluxe Deluxe)`)
- Deduplicate version tokens and honour ignore-phrases (e.g. `Hi-Res`) inside larger version strings again
- Treat a missing disc number as disc 1 so local files without a disc tag can match their streaming counterparts
- Let a shared barcode also resolve an ambiguous edition wording, not just a release-year difference
- Normalize album titles the same way as the search index and ignore trailing ` - EP` / ` - Single` suffixes when comparing
- Recover Qobuz barcodes that are delivered with a truncated check digit
- Backfill missing barcodes when enriching sparse albums and process 25 albums per metadata scan run (was 5) so duplicate repair drains faster
- Stop the external-id candidate scan at the first verified match (faster syncs)
- Small cleanups: drop the legacy `0` UPC prefix in the Spotify parser, use the shared ISRC/MBID normalization in the MusicBrainz and M3U import paths

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
