### PR TITLE
Fix web players losing their queue when they switch role

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1519,6 +1519,16 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         # is still setting the player up
         async with self._register_lock:
             if (existing := self._players.get(player.player_id)) is not None:
+                previous_type = existing.state.type
+                # moving in or out of the protocol role turns a player that owns a queue
+                # into one that is hidden behind a parent, or the other way around
+                role_changed = previous_type != player.type and PlayerType.PROTOCOL in (
+                    previous_type,
+                    player.type,
+                )
+                if role_changed:
+                    # release the old topology while the player still reports its old type
+                    self._cleanup_player_type_transition(existing)
                 self._players[player.player_id] = player
                 if existing is not player:
                     # a fresh instance starts out with a base config only, so it needs
@@ -1534,6 +1544,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                 # the derived-transport edge may have been set/revoked after the
                 # initial registration (e.g. via a bridge claim)
                 self._save_underlying_player_id(player)
+                if role_changed:
+                    await self._finish_player_type_transition(player)
                 # Also schedule update when replacing existing player
                 self._schedule_update_all_players()
                 return
@@ -2344,6 +2356,26 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             player.player_id,
         )
         return True
+
+    async def _finish_player_type_transition(self, player: Player) -> None:
+        """
+        Publish a registered player that moved in or out of the protocol role.
+
+        :param player: The player, with its new type already applied to its state.
+        """
+        self._evaluate_protocol_links(player)
+        if player.state.type == PlayerType.PROTOCOL:
+            # the player is hidden behind its parent from now on and no longer owns a queue
+            self.mass.signal_event(EventType.PLAYER_REMOVED, player.player_id)
+            self.mass.player_queues.on_player_remove(player.player_id, permanent=False)
+            return
+        # the player surfaces on its own, which leaves it unusable without a queue
+        self.mass.signal_event(EventType.PLAYER_ADDED, object_id=player.player_id, data=player)
+        await self.mass.player_queues.on_player_register(player)
+        if self._registration_aborted(player):
+            # the queue restore outlived the unregister that already cleaned it up,
+            # so drop the queue we just recreated for a player that is gone
+            self.mass.player_queues.on_player_remove(player.player_id, permanent=False)
 
     async def _release_player_for_play_media(self, player: Player) -> None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1527,7 +1527,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                     player.type,
                 )
                 if role_changed:
-                    # release the old topology while the player still reports its old type
+                    # release the old topology while the state still reports the old type
                     self._cleanup_player_type_transition(existing)
                 self._players[player.player_id] = player
                 if existing is not player:

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1601,9 +1601,18 @@ class ProtocolLinkingMixin:
         :param existing: The registered player instance, still reporting its previous type.
         """
         if existing.state.type == PlayerType.PROTOCOL:
-            # the player leaves its parent: unlink it there and drop the persisted
-            # parent id, which would otherwise heal its type back to protocol
+            # a provider may announce the new type with the live parent link already
+            # dropped, so take the persisted one to still reach the parent
+            if not existing.protocol_parent_id and (
+                parent_id := self._get_cached_protocol_parent_id(existing.player_id)
+            ):
+                existing.set_protocol_parent_id(parent_id)
+            # unlink at the parent and drop the persisted parent id, which would
+            # otherwise heal the player's type back to protocol
             self._cleanup_protocol_links(existing)
+            # a player leaving the protocol role has no parent, also when that parent
+            # is not registered (anymore) and only the cached link could be cleaned up
+            existing.set_protocol_parent_id(None)
             return
         # the player becomes a child itself: detach the protocol players it owned so
         # they can find a new parent, and give up their ownership in its (kept) config

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1594,6 +1594,23 @@ class ProtocolLinkingMixin:
                         protocol_id,
                     )
 
+    def _cleanup_player_type_transition(self, existing: Player) -> None:
+        """
+        Release the protocol topology a player owned before its type changed.
+
+        :param existing: The registered player instance, still reporting its previous type.
+        """
+        if existing.state.type == PlayerType.PROTOCOL:
+            # the player leaves its parent: unlink it there and drop the persisted
+            # parent id, which would otherwise heal its type back to protocol
+            self._cleanup_protocol_links(existing)
+            return
+        # the player becomes a child itself: detach the protocol players it owned so
+        # they can find a new parent, and give up their ownership in its (kept) config
+        protocol_ids = set(self._get_known_protocol_ids(existing))
+        self._cleanup_protocol_links(existing)
+        self._remove_protocol_ids_from_parent(existing, protocol_ids)
+
     def _detach_protocol_children(self, parent_id: str) -> None:
         """
         Detach the registered protocol players of a parent player that is going away.

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1602,11 +1602,18 @@ class ProtocolLinkingMixin:
         """
         if existing.state.type == PlayerType.PROTOCOL:
             # a provider may announce the new type with the live parent link already
-            # dropped, so take the persisted one to still reach the parent
-            if not existing.protocol_parent_id and (
-                parent_id := self._get_cached_protocol_parent_id(existing.player_id)
-            ):
-                existing.set_protocol_parent_id(parent_id)
+            # dropped, so fall back to the persisted one to still reach the parent
+            parent_id = existing.protocol_parent_id or self._get_cached_protocol_parent_id(
+                existing.player_id
+            )
+            if not parent_id:
+                return
+            parent = self.get_player(parent_id)
+            if parent is not None and parent.provider.domain == "universal_player":
+                # a universal parent is replaced by the player itself once the links are
+                # re-evaluated, which carries over its config and memberships first
+                return
+            existing.set_protocol_parent_id(parent_id)
             # unlink at the parent and drop the persisted parent id, which would
             # otherwise heal the player's type back to protocol
             self._cleanup_protocol_links(existing)
@@ -1614,8 +1621,9 @@ class ProtocolLinkingMixin:
             # is not registered (anymore) and only the cached link could be cleaned up
             existing.set_protocol_parent_id(None)
             return
-        # the player becomes a child itself: detach the protocol players it owned so
-        # they can find a new parent, and give up their ownership in its (kept) config
+        # the player becomes a child itself: detach the protocol players it owned so they
+        # can find a new parent, then give up their ownership in its (kept) config - the
+        # reverse of the removal path, which drops the ownership before the detach
         protocol_ids = set(self._get_known_protocol_ids(existing))
         self._cleanup_protocol_links(existing)
         self._remove_protocol_ids_from_parent(existing, protocol_ids)

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1610,8 +1610,10 @@ class ProtocolLinkingMixin:
                 return
             parent = self.get_player(parent_id)
             if parent is not None and parent.provider.domain == "universal_player":
-                # a universal parent is replaced by the player itself once the links are
-                # re-evaluated, which carries over its config and memberships first
+                # drop only the active edge and leave the rest to the link evaluation,
+                # which replaces the wrapper with this player: a leftover edge makes it
+                # hand the player over to itself, which it refuses, abandoning the swap
+                self._remove_protocol_link(parent, existing.player_id)
                 return
             existing.set_protocol_parent_id(parent_id)
             # unlink at the parent and drop the persisted parent id, which would

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -40,7 +40,7 @@ from music_assistant_models.errors import (
     PlayerCommandFailed,
     UnsupportedFeaturedException,
 )
-from music_assistant_models.player import PlayerMedia, PlayerSource
+from music_assistant_models.player import DeviceInfo, PlayerMedia, PlayerSource
 from music_assistant_models.player_control import PlayerControl
 
 from music_assistant.constants import (
@@ -68,6 +68,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import curren
 from music_assistant.helpers.tts import TTS_QUERY_TIMEOUT_SECONDS
 from music_assistant.models.player import LinkedOutputProtocol, Player
 from music_assistant.models.player_provider import PlayerProvider
+from music_assistant.providers.universal_player.player import UniversalPlayer
 from tests.common import MockPlayer, MockProvider, create_mock_config, use_real_create_task
 
 
@@ -1289,29 +1290,41 @@ class TestRegisterOrUpdateTypeTransition:
         # a leftover parent id makes the startup repair pass heal the type back to protocol
         mock_mass.config.set.assert_any_call(parent_key, None)
 
-    async def test_universal_parent_is_left_to_the_link_evaluation(
+    async def test_universal_parent_hands_over_to_the_promoted_player(
         self, mock_mass: MagicMock
     ) -> None:
-        """A universal parent is replaced wholesale instead of being unlinked here."""
+        """A universal parent hands its config to the player that replaces it."""
         controller = self._prepare(mock_mass)
-        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        provider = MockProvider("sendspin", instance_id="sendspin", mass=mock_mass)
         universal_provider = MockProvider(
             "universal_player", instance_id="universal_player", mass=mock_mass
         )
-        parent = self._register(controller, universal_provider, "parent", PlayerType.PLAYER)
+        mock_mass.config.get_base_player_config.return_value = create_mock_config("Universal")
+        universal = UniversalPlayer(
+            cast("Any", universal_provider), "universal_1", "Universal", DeviceInfo(), ["child"]
+        )
+        universal.set_initialized()
+        controller._players["universal_1"] = universal
+        universal.update_state(signal_event=False)
         child = self._register(controller, provider, "child", PlayerType.PROTOCOL)
-        child.set_protocol_parent_id("parent")
-        parent.set_linked_output_protocols(
+        child.set_protocol_parent_id("universal_1")
+        universal.set_linked_output_protocols(
             [LinkedOutputProtocol(output_protocol_id="child", protocol_domain="sendspin")]
         )
+        migrated: list[tuple[str, str]] = []
 
-        child._attr_type = PlayerType.PLAYER
-        await controller.register_or_update(child)
+        with patch.object(
+            controller,
+            "_migrate_universal_player_config",
+            side_effect=lambda old, new: migrated.append((old, new)),
+        ):
+            child._attr_type = PlayerType.PLAYER
+            await controller.register_or_update(child)
 
-        # unlinking here would strand the universal player before its config and group
-        # memberships are carried over to the player that replaces it
-        assert parent.linked_output_protocols != []
-        assert "parent" in controller._players
+        # a leftover active link makes the wrapper refuse the handover to the player it
+        # is being replaced by, stranding the user's settings on a player on its way out
+        assert migrated == [("universal_1", "child")]
+        assert child.protocol_parent_id is None
 
     async def test_player_to_protocol_detaches_its_children(self, mock_mass: MagicMock) -> None:
         """A player that becomes a protocol child releases the protocols it owned."""

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1110,6 +1110,154 @@ def _set_play_media_override(mock_mass: MagicMock, value: bool) -> None:
     mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_side_effect)
 
 
+class TestRegisterOrUpdateTypeTransition:
+    """Tests for a registered player moving in or out of the protocol role."""
+
+    @staticmethod
+    def _prepare(mock_mass: MagicMock) -> PlayerController:
+        """Build a controller with the calls a re-registration makes stubbed out."""
+        mock_mass.loop = MagicMock()
+        mock_mass.config.get = MagicMock(side_effect=lambda _key, default=None: default)
+        mock_mass.player_queues.on_player_register = AsyncMock()
+        mock_mass.player_queues.on_player_remove = MagicMock()
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+        return controller
+
+    @staticmethod
+    def _register(
+        controller: PlayerController, provider: MockProvider, player_id: str, type_: PlayerType
+    ) -> MockPlayer:
+        """Add a player to the registry with its state calculated for the given type."""
+        player = MockPlayer(provider, player_id, player_id, type_)
+        player.set_initialized()
+        controller._players[player_id] = player
+        # MockPlayer assigns the type after Player.__init__ built the initial state,
+        # so the state only reports it once it is recalculated
+        player.update_state(signal_event=False)
+        assert player.state.type is type_
+        return player
+
+    @staticmethod
+    def _signalled(mock_mass: MagicMock, event: EventType) -> bool:
+        """Return True if the given event was signalled."""
+        return any(
+            call_args.args and call_args.args[0] == event
+            for call_args in mock_mass.signal_event.call_args_list
+        )
+
+    async def test_protocol_to_player_registers_queue(self, mock_mass: MagicMock) -> None:
+        """A protocol player that becomes a standalone player gets a queue and is announced."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = self._register(controller, provider, "player_1", PlayerType.PROTOCOL)
+
+        player._attr_type = PlayerType.PLAYER
+        await controller.register_or_update(player)
+
+        assert player.state.type is PlayerType.PLAYER
+        # without a queue the player is registered but cannot play anything
+        mock_mass.player_queues.on_player_register.assert_awaited_once_with(player)
+        assert self._signalled(mock_mass, EventType.PLAYER_ADDED)
+
+    async def test_protocol_to_player_keeps_state_pipeline_intact(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """The regular state update still runs for the tick that changes the type."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = self._register(controller, provider, "player_1", PlayerType.PROTOCOL)
+        updates: list[dict[str, tuple[Any, Any]]] = []
+        controller.subscribe_player_state_update(lambda _player, changed: updates.append(changed))
+
+        player._attr_type = PlayerType.PLAYER
+        await controller.register_or_update(player)
+
+        # the bridges and wait_for_player_update hang off this dispatch, and the changed
+        # values are consumed by it: a suppressed update is never replayed by a later one
+        assert any("type" in changed for changed in updates)
+
+    async def test_player_to_protocol_removes_queue(self, mock_mass: MagicMock) -> None:
+        """A player that becomes a protocol child loses its queue and is announced removed."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = self._register(controller, provider, "player_1", PlayerType.PLAYER)
+
+        player._attr_type = PlayerType.PROTOCOL
+        await controller.register_or_update(player)
+
+        assert player.state.type is PlayerType.PROTOCOL
+        mock_mass.player_queues.on_player_remove.assert_called_once_with(
+            "player_1", permanent=False
+        )
+        assert self._signalled(mock_mass, EventType.PLAYER_REMOVED)
+
+    async def test_unchanged_type_leaves_queue_alone(self, mock_mass: MagicMock) -> None:
+        """Re-registering a player without a type change does not touch its queue."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = self._register(controller, provider, "player_1", PlayerType.PLAYER)
+
+        await controller.register_or_update(player)
+
+        mock_mass.player_queues.on_player_register.assert_not_awaited()
+        mock_mass.player_queues.on_player_remove.assert_not_called()
+        assert not self._signalled(mock_mass, EventType.PLAYER_ADDED)
+        assert not self._signalled(mock_mass, EventType.PLAYER_REMOVED)
+
+    async def test_group_type_change_is_not_a_role_change(self, mock_mass: MagicMock) -> None:
+        """A player that turns into a group keeps its queue (Chromecast reports both)."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = self._register(controller, provider, "player_1", PlayerType.PLAYER)
+
+        player._attr_type = PlayerType.GROUP
+        await controller.register_or_update(player)
+
+        assert player.state.type is PlayerType.GROUP
+        mock_mass.player_queues.on_player_register.assert_not_awaited()
+        mock_mass.player_queues.on_player_remove.assert_not_called()
+        assert not self._signalled(mock_mass, EventType.PLAYER_ADDED)
+        assert not self._signalled(mock_mass, EventType.PLAYER_REMOVED)
+
+    async def test_protocol_to_player_unlinks_from_parent(self, mock_mass: MagicMock) -> None:
+        """A protocol player that becomes standalone is released by its parent."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        parent = self._register(controller, provider, "parent", PlayerType.PLAYER)
+        child = self._register(controller, provider, "child", PlayerType.PROTOCOL)
+        child.set_protocol_parent_id("parent")
+        parent.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="child", protocol_domain="sendspin")]
+        )
+
+        child._attr_type = PlayerType.PLAYER
+        await controller.register_or_update(child)
+
+        # a parent that keeps the link would still route audio to a player that is
+        # now standalone
+        assert parent.linked_output_protocols == []
+        assert child.protocol_parent_id is None
+
+    async def test_player_to_protocol_detaches_its_children(self, mock_mass: MagicMock) -> None:
+        """A player that becomes a protocol child releases the protocols it owned."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        parent = self._register(controller, provider, "parent", PlayerType.PLAYER)
+        child = self._register(controller, provider, "child", PlayerType.PROTOCOL)
+        child.set_protocol_parent_id("parent")
+        parent.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="child", protocol_domain="sendspin")]
+        )
+
+        parent._attr_type = PlayerType.PROTOCOL
+        await controller.register_or_update(parent)
+
+        # a protocol player cannot own protocol players of its own
+        assert parent.linked_output_protocols == []
+        assert child.protocol_parent_id is None
+
+
 class TestCmdUngroupNewBranches:
     """
     Regression tests for the post-refactor cmd_ungroup flow.

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1266,6 +1266,53 @@ class TestRegisterOrUpdateTypeTransition:
         assert parent.linked_output_protocols == []
         assert child.protocol_parent_id is None
 
+    async def test_protocol_to_player_clears_persisted_parent_link(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """The persisted parent link is dropped so a restart cannot restore the old role."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        child = self._register(controller, provider, "child", PlayerType.PROTOCOL)
+        parent_key = f"{CONF_PLAYERS}/child/values/{CONF_PROTOCOL_PARENT_ID}"
+
+        def _config_get(key: str, default: object = None) -> object:
+            if key == parent_key:
+                return "parent"
+            # the parent id is only cleared for a player that still has a config
+            return {"provider": "test"} if key == f"{CONF_PLAYERS}/child" else default
+
+        mock_mass.config.get = MagicMock(side_effect=_config_get)
+
+        child._attr_type = PlayerType.PLAYER
+        await controller.register_or_update(child)
+
+        # a leftover parent id makes the startup repair pass heal the type back to protocol
+        mock_mass.config.set.assert_any_call(parent_key, None)
+
+    async def test_universal_parent_is_left_to_the_link_evaluation(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A universal parent is replaced wholesale instead of being unlinked here."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        universal_provider = MockProvider(
+            "universal_player", instance_id="universal_player", mass=mock_mass
+        )
+        parent = self._register(controller, universal_provider, "parent", PlayerType.PLAYER)
+        child = self._register(controller, provider, "child", PlayerType.PROTOCOL)
+        child.set_protocol_parent_id("parent")
+        parent.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="child", protocol_domain="sendspin")]
+        )
+
+        child._attr_type = PlayerType.PLAYER
+        await controller.register_or_update(child)
+
+        # unlinking here would strand the universal player before its config and group
+        # memberships are carried over to the player that replaces it
+        assert parent.linked_output_protocols != []
+        assert "parent" in controller._players
+
     async def test_player_to_protocol_detaches_its_children(self, mock_mass: MagicMock) -> None:
         """A player that becomes a protocol child releases the protocols it owned."""
         controller = self._prepare(mock_mass)

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -55,7 +55,9 @@ from music_assistant.constants import (
     CONF_MIN_VOLUME,
     CONF_MUTE_CONTROL,
     CONF_OUTPUT_CODEC,
+    CONF_PLAYERS,
     CONF_POWER_CONTROL,
+    CONF_PROTOCOL_PARENT_ID,
     CONF_VOLUME_CONTROL,
     CONF_VOLUME_STEP,
 )
@@ -1236,6 +1238,31 @@ class TestRegisterOrUpdateTypeTransition:
 
         # a parent that keeps the link would still route audio to a player that is
         # now standalone
+        assert parent.linked_output_protocols == []
+        assert child.protocol_parent_id is None
+
+    async def test_protocol_to_player_unlinks_parent_cleared_ahead(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """The parent is released even when the provider already dropped the live link."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        parent = self._register(controller, provider, "parent", PlayerType.PLAYER)
+        child = self._register(controller, provider, "child", PlayerType.PROTOCOL)
+        parent.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="child", protocol_domain="sendspin")]
+        )
+        # Sendspin clears protocol_parent_id before it announces the new type, so only
+        # the persisted link is left to find the parent by
+        cached_key = f"{CONF_PLAYERS}/child/values/{CONF_PROTOCOL_PARENT_ID}"
+        mock_mass.config.get = MagicMock(
+            side_effect=lambda key, default=None: "parent" if key == cached_key else default
+        )
+        assert child.protocol_parent_id is None
+
+        child._attr_type = PlayerType.PLAYER
+        await controller.register_or_update(child)
+
         assert parent.linked_output_protocols == []
         assert child.protocol_parent_id is None
 


### PR DESCRIPTION
# What does this implement/fix?

Some players (Sendspin web players in particular) can switch between being a
speaker output that belongs to another player and being a player of their own.
When that switch happened, the player was only swapped in place: it never got a
queue and clients were never told it appeared or disappeared. The result was a
player that showed up but could not play anything until Music Assistant was
restarted, or a leftover queue for a player that is now hidden behind its parent.

- A player that becomes a normal player now gets its queue and is announced as added.
- A player that becomes a speaker output of another player has its queue removed and is announced as removed.
- The speaker links from the role the player just left are released, so it no longer stays attached to (or keeps owning) outputs it should not.
- Its regular state update is untouched, so queues, bridges and grouping keep seeing the change.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
