### PR TITLE
Keep player access restrictions intact when a player is replaced

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1572,7 +1572,12 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             task_id=task_id,
         )
 
-    async def unregister(self, player_id: str, permanent: bool = False) -> None:
+    async def unregister(
+        self,
+        player_id: str,
+        permanent: bool = False,
+        replacement_player_id: str | None = None,
+    ) -> None:
         """
         Unregister a player from the player controller.
 
@@ -1584,6 +1589,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         :param player_id: Player ID of the player to unregister.
         :param permanent: If True, remove the player permanently by deleting its config.
                           If False, the player config will not be removed.
+        :param replacement_player_id: Player ID that takes this player's place, only
+                                      used for a permanent removal.
         """
         player = self._players.get(player_id)
         if player is None:
@@ -1607,7 +1614,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             # and signal PLAYER_REMOVED event
             await self._cleanup_player_memberships(player_id)
             self._cleanup_protocol_links(player)
-            self.delete_player_config(player_id)
+            self.delete_player_config(player_id, replacement_player_id)
             self.logger.info("Player removed: %s", player.name)
             if player.state.type != PlayerType.PROTOCOL:
                 self.mass.signal_event(EventType.PLAYER_REMOVED, player_id)
@@ -1654,7 +1661,9 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         # We removed the player and can now clean up its config
         self.delete_player_config(player_id)
 
-    def delete_player_config(self, player_id: str) -> None:
+    def delete_player_config(
+        self, player_id: str, replacement_player_id: str | None = None
+    ) -> None:
         """
         Permanently delete a player's configuration, including its DSP and queue settings.
 
@@ -1665,6 +1674,10 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         returns as a brand new player once it is discovered again. Protocol players that
         are still registered or that already moved to another parent keep their config;
         registered ones are detached from the removed player and re-evaluated.
+
+        :param player_id: Player ID of the player to delete the configuration of.
+        :param replacement_player_id: Player ID that takes this player's place, so users
+                                      restricted to it follow the replacement.
         """
         self._detach_protocol_children(player_id)
         player_ids = [
@@ -1684,10 +1697,18 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             if self.get_player(pid) is None:
                 self.mass.player_queues.purge_saved_queue(pid)
         # a user access filter is an allow-list of player ids, so it must not be left
-        # pointing at a player whose config was just wiped
-        self.mass.create_task(
-            self.mass.webserver.auth.remove_from_user_filters(player_ids=player_ids)
-        )
+        # pointing at a player whose config was just wiped: a replaced player hands its
+        # entries over to its replacement, a removed one has them dropped
+        if replacement_player_id:
+            self.mass.create_task(
+                self.mass.webserver.auth.replace_player_in_user_filters(
+                    player_id, replacement_player_id, removed_player_ids=player_ids
+                )
+            )
+        else:
+            self.mass.create_task(
+                self.mass.webserver.auth.remove_from_user_filters(player_ids=player_ids)
+            )
 
     def scale_volume_to_device(self, player_id: str, logical_volume: int) -> int:
         """Scale logical volume (0-100) to device volume (min_volume-max_volume)."""

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -118,7 +118,10 @@ class ProtocolLinkingMixin:
         def get_player(self, player_id: str) -> Player | None: ...  # noqa: D102
 
         def unregister(  # noqa: D102
-            self, player_id: str, permanent: bool = False
+            self,
+            player_id: str,
+            permanent: bool = False,
+            replacement_player_id: str | None = None,
         ) -> Coroutine[Any, Any, None]: ...
 
     def _is_protocol_player(self, player: Player) -> bool:
@@ -885,7 +888,7 @@ class ProtocolLinkingMixin:
         self._repoint_group_memberships(remove.player_id, keep.player_id)
 
         # Stop playback and remove the obsolete player
-        self.mass.create_task(self._stop_and_unregister(remove))
+        self.mass.create_task(self._stop_and_unregister(remove, keep.player_id))
 
     def _link_protocols_to_universal(
         self, universal_player: Player, protocol_players: list[Player]
@@ -1078,7 +1081,7 @@ class ProtocolLinkingMixin:
             self._repoint_group_memberships(player.player_id, native_player.player_id)
 
             # Stop playback and remove the now-obsolete universal player
-            self.mass.create_task(self._stop_and_unregister(player))
+            self.mass.create_task(self._stop_and_unregister(player, native_player.player_id))
 
     def _migrate_universal_player_config(self, universal_id: str, native_id: str) -> None:
         """
@@ -1227,7 +1230,7 @@ class ProtocolLinkingMixin:
                         entry.value = new_members
                     other_player.refresh_state()
 
-    async def _stop_and_unregister(self, player: Player) -> None:
+    async def _stop_and_unregister(self, player: Player, replacement_player_id: str) -> None:
         """
         Stop active playback on a player and then permanently unregister it.
 
@@ -1237,11 +1240,14 @@ class ProtocolLinkingMixin:
         intentionally not transferred.
 
         :param player: The obsolete player to stop and permanently remove.
+        :param replacement_player_id: Player ID that takes the obsolete player's place.
         """
         if player.playback_state != PlaybackState.IDLE:
             with suppress(PlayerCommandFailed, PlayerUnavailableError):
                 await self.mass.player_queues.stop(player.player_id)
-        await self.unregister(player.player_id, permanent=True)
+        await self.unregister(
+            player.player_id, permanent=True, replacement_player_id=replacement_player_id
+        )
 
     def _parent_has_active_protocol_from_domain(
         self, parent: Player, domain: str, exclude_player_id: str | None = None

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1249,6 +1249,9 @@ class AuthenticationManager:
 
         if updates:
             await self.database.update("users", {"user_id": target_user.user_id}, updates)
+            self.webserver.update_active_user_filters(
+                target_user.user_id, player_filter=player_filter, provider_filter=provider_filter
+            )
             # Refresh target user to get updated filters
             refreshed_user = await self.get_user(target_user.user_id)
             if not refreshed_user:
@@ -1291,8 +1294,10 @@ class AuthenticationManager:
         ending up with access to every player.
 
         :param old_player_id: ID of the player that is replaced.
-        :param new_player_id: ID of the player that takes its place.
-        :param removed_player_ids: IDs of the players that are removed along with it.
+        :param new_player_id: ID of the player that takes its place, must not be one of
+            the removed players.
+        :param removed_player_ids: IDs of all players whose config is removed, which
+            normally includes the replaced player itself.
         """
         await self._rewrite_user_filters(
             keep_provider=None,

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1277,6 +1277,29 @@ class AuthenticationManager:
             keep_player=(lambda x: x not in player_ids) if player_ids else None,
         )
 
+    async def replace_player_in_user_filters(
+        self,
+        old_player_id: str,
+        new_player_id: str,
+        removed_player_ids: Collection[str] = (),
+    ) -> None:
+        """
+        Point the access filters of all users at the replacement of a removed player.
+
+        Call this when a player is automatically replaced by another one, so a user that
+        is restricted to the old player follows the replacement instead of silently
+        ending up with access to every player.
+
+        :param old_player_id: ID of the player that is replaced.
+        :param new_player_id: ID of the player that takes its place.
+        :param removed_player_ids: IDs of the players that are removed along with it.
+        """
+        await self._rewrite_user_filters(
+            keep_provider=None,
+            keep_player=(lambda x: x not in removed_player_ids) if removed_player_ids else None,
+            map_player=lambda x: new_player_id if x == old_player_id else x,
+        )
+
     @api_command("auth/user/update")
     async def update_user_profile(
         self,
@@ -1956,30 +1979,53 @@ class AuthenticationManager:
         self,
         keep_provider: Callable[[str], bool] | None,
         keep_player: Callable[[str], bool] | None,
+        map_player: Callable[[str], str] | None = None,
     ) -> None:
-        """Rewrite the access filters of all users, dropping the entries that are not kept."""
-        if keep_provider is None and keep_player is None:
+        """
+        Rewrite the access filters of all users.
+
+        :param keep_provider: Returns False for the provider entries that must be dropped.
+        :param keep_player: Returns False for the player entries that must be dropped.
+        :param map_player: Maps a player entry onto its replacement, applied before keep_player.
+        """
+        if keep_provider is None and keep_player is None and map_player is None:
             return
         # removing a provider wipes the config of its players one by one, so without the lock
         # those rewrites would read the same filter and each undo the other's removal
         async with self._user_filter_lock:
             for row in await self.database.get_rows("users", limit=0):
-                updates: dict[str, str] = {}
-                for column, keep_func in (
-                    ("provider_filter", keep_provider),
-                    ("player_filter", keep_player),
+                changed: dict[str, list[str]] = {}
+                for column, keep_func, map_func in (
+                    ("provider_filter", keep_provider, None),
+                    ("player_filter", keep_player, map_player),
                 ):
-                    if keep_func is None:
+                    if keep_func is None and map_func is None:
                         continue
                     current: list[str] = json_loads(row[column])
-                    remaining = [x for x in current if keep_func(x)]
+                    remaining: list[str] = []
+                    dropped: list[str] = []
+                    for entry in current:
+                        mapped = map_func(entry) if map_func else entry
+                        if keep_func and not keep_func(mapped):
+                            dropped.append(entry)
+                        elif mapped not in remaining:
+                            remaining.append(mapped)
                     if remaining == current:
                         continue
-                    updates[column] = json_dumps(remaining)
-                    dropped = ", ".join(x for x in current if x not in remaining)
-                    if remaining:
+                    changed[column] = remaining
+                    if not dropped:
                         self.logger.info(
-                            "Removed %s from the %s of user '%s'", dropped, column, row["username"]
+                            "Updated the %s of user '%s' to %s",
+                            column,
+                            row["username"],
+                            ", ".join(remaining),
+                        )
+                    elif remaining:
+                        self.logger.info(
+                            "Removed %s from the %s of user '%s'",
+                            ", ".join(dropped),
+                            column,
+                            row["username"],
                         )
                     else:
                         # An empty filter means unrestricted. A user whose entries are all gone is
@@ -1988,12 +2034,23 @@ class AuthenticationManager:
                         self.logger.warning(
                             "Removed the last entries (%s) from the %s of user '%s'. This user is "
                             "no longer restricted, adjust the access settings if needed.",
-                            dropped,
+                            ", ".join(dropped),
                             column,
                             row["username"],
                         )
-                if updates:
-                    await self.database.update("users", {"user_id": row["user_id"]}, updates)
+                if changed:
+                    await self.database.update(
+                        "users",
+                        {"user_id": row["user_id"]},
+                        {column: json_dumps(value) for column, value in changed.items()},
+                    )
+                    # a session holds its own copy of the User object, so the live ones have to
+                    # follow or they keep applying the filter that was just rewritten
+                    self.webserver.update_active_user_filters(
+                        row["user_id"],
+                        player_filter=changed.get("player_filter"),
+                        provider_filter=changed.get("provider_filter"),
+                    )
 
     async def _migrate_playlog_to_first_user(self, user_id: str) -> None:
         """

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1248,10 +1248,15 @@ class AuthenticationManager:
             updates["provider_filter"] = json_dumps(provider_filter)
 
         if updates:
-            await self.database.update("users", {"user_id": target_user.user_id}, updates)
-            self.webserver.update_active_user_filters(
-                target_user.user_id, player_filter=player_filter, provider_filter=provider_filter
-            )
+            # the lock the automatic rewrites take as well, so a player or provider that is
+            # being removed cannot overwrite the filters an admin just saved
+            async with self._user_filter_lock:
+                await self.database.update("users", {"user_id": target_user.user_id}, updates)
+                self.webserver.update_active_user_filters(
+                    target_user.user_id,
+                    player_filter=player_filter,
+                    provider_filter=provider_filter,
+                )
             # Refresh target user to get updated filters
             refreshed_user = await self.get_user(target_user.user_id)
             if not refreshed_user:

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -431,6 +431,33 @@ class WebserverController(CoreController):
                 )
                 client._cancel()
 
+    def update_active_user_filters(
+        self,
+        user_id: str,
+        player_filter: list[str] | None = None,
+        provider_filter: list[str] | None = None,
+    ) -> None:
+        """
+        Apply updated access filters to the live sessions of a user.
+
+        Call this after the filters of a user were changed in the database, so the
+        change takes effect right away instead of only on the next connection.
+
+        :param user_id: ID of the user whose sessions must be updated.
+        :param player_filter: The new player filter, or None to leave it untouched.
+        :param provider_filter: The new provider filter, or None to leave it untouched.
+        """
+        for client in list(self.clients):
+            user = client._authenticated_user
+            if user is None or user.user_id != user_id:
+                continue
+            # updated in place: the connection's context holds this very object
+            if player_filter is not None:
+                user.player_filter[:] = player_filter
+            if provider_filter is not None:
+                user.provider_filter[:] = provider_filter
+            self.logger.debug("Updated the access filters of a live session of %s", user.username)
+
     def set_sendspin_player_for_token(self, token: str, player_id: str) -> None:
         """
         Set the sendspin player_id on the websocket clients holding the given token.

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -383,7 +383,9 @@ class UniversalPlayerProvider(PlayerProvider):
                 )
                 self.mass.players._migrate_universal_player_config(player_id, default_parent)
                 self.mass.players._repoint_group_memberships(player_id, default_parent)
-                self.mass.players.delete_player_config(player_id)
+                self.mass.players.delete_player_config(
+                    player_id, replacement_player_id=default_parent
+                )
             return
 
         stored_protocol_ids = valid_protocol_ids

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -5226,6 +5226,34 @@ class TestUnregisterTeardown:
         assert player.unloaded
 
 
+class TestDeletePlayerConfigUserFilters:
+    """Test how a deleted player config is reflected in the user access filters."""
+
+    def test_removal_drops_the_player_from_the_filters(self, mock_mass: MagicMock) -> None:
+        """A removed player is dropped from the access filter of every user."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+
+        controller.delete_player_config("sonos_1")
+
+        mock_mass.webserver.auth.remove_from_user_filters.assert_called_once_with(
+            player_ids=["sonos_1"]
+        )
+        mock_mass.webserver.auth.replace_player_in_user_filters.assert_not_called()
+
+    def test_replacement_hands_the_filters_to_the_new_player(self, mock_mass: MagicMock) -> None:
+        """A replaced player hands its access filter entries over to its replacement."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+
+        controller.delete_player_config("up_old", replacement_player_id="sonos_1")
+
+        mock_mass.webserver.auth.replace_player_in_user_filters.assert_called_once_with(
+            "up_old", "sonos_1", removed_player_ids=["up_old"]
+        )
+        mock_mass.webserver.auth.remove_from_user_filters.assert_not_called()
+
+
 class TestConfigChangeRestartsPlayback:
     """Test that a changed player setting which needs a reload restarts playback."""
 

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -261,6 +261,7 @@ def mock_mass() -> Iterator[MagicMock]:
     mass.get_providers = MagicMock(return_value=[])
     # awaited by the tests that replay the tasks scheduled during a config wipe
     mass.webserver.auth.remove_from_user_filters = AsyncMock()
+    mass.webserver.auth.replace_player_in_user_filters = AsyncMock()
     yield mass
     for call in mass.create_task.call_args_list:
         if call.args and inspect.iscoroutine(coro := call.args[0]):
@@ -6492,6 +6493,27 @@ class TestUniversalPlayerMerging:
         assert call_order == ["stop", "unregister"]
         mock_mass.player_queues.stop.assert_awaited_once_with("up_remove")
 
+    async def test_merge_hands_the_user_filters_to_the_keeper(self, mock_mass: MagicMock) -> None:
+        """The absorbed wrapper hands its access filter entries to the keeper."""
+        config_store: dict[str, Any] = {
+            "players/up_keep": {"enabled": True},
+            "players/up_remove": {"enabled": True},
+            "players/ap_keep": {"enabled": True},
+            "players/dlna_live": {"enabled": True},
+        }
+        controller, keep, scheduled_tasks = self._setup_merge_scenario(mock_mass, config_store)
+
+        with patch.object(controller, "_save_universal_player_data"):
+            controller._check_merge_universal_players(keep)
+
+        task = next(t for t in scheduled_tasks if "unregister" in repr(t))
+        with patch.object(controller, "unregister", new=AsyncMock()) as mock_unregister:
+            await task
+
+        mock_unregister.assert_awaited_once_with(
+            "up_remove", permanent=True, replacement_player_id="up_keep"
+        )
+
     async def test_merge_idle_loser_not_stopped(self, mock_mass: MagicMock) -> None:
         """An idle losing wrapper is removed without a stop command."""
         config_store: dict[str, Any] = {
@@ -7292,6 +7314,34 @@ class TestUniversalPlayerReplacement:
 
         assert call_order == ["stop", "unregister"]
         mock_mass.player_queues.stop.assert_awaited_once_with("up_old")
+
+    async def test_replace_hands_the_user_filters_to_the_native_player(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """The replaced wrapper hands its access filter entries to the native player."""
+        config_store: dict[str, Any] = {
+            "players/cast_1": {"enabled": True},
+            "players/up_old": {
+                "enabled": True,
+                "name": "Soundbar (Universal)",
+                "default_name": "Soundbar (Universal)",
+                "values": {"linked_protocol_ids": ["ap_live"]},
+            },
+            "players/ap_live": {"enabled": True},
+        }
+        controller, native, scheduled_tasks = self._setup_carry_over_scenario(
+            mock_mass, config_store
+        )
+
+        controller._check_replace_universal_player(native)
+
+        task = next(t for t in scheduled_tasks if "unregister" in repr(t))
+        with patch.object(controller, "unregister", new=AsyncMock()) as mock_unregister:
+            await task
+
+        mock_unregister.assert_awaited_once_with(
+            "up_old", permanent=True, replacement_player_id="cast_1"
+        )
 
     async def test_replace_idle_universal_not_stopped(self, mock_mass: MagicMock) -> None:
         """An idle universal player is removed without a stop command."""
@@ -9546,7 +9596,9 @@ class TestUniversalPlayerRestoreOrphanCleanup:
         mock_mass.players._repoint_group_memberships.assert_called_once_with(
             universal_id, native_parent_id
         )
-        mock_mass.players.delete_player_config.assert_called_once_with(universal_id)
+        mock_mass.players.delete_player_config.assert_called_once_with(
+            universal_id, replacement_player_id=native_parent_id
+        )
 
         # Each protocol's parent_id is restored to the disabled native parent
         parent_restorations = {
@@ -9635,7 +9687,9 @@ class TestUniversalPlayerRestoreOrphanCleanup:
             universal_id, shell_id
         )
         mock_mass.players._repoint_group_memberships.assert_called_once_with(universal_id, shell_id)
-        mock_mass.players.delete_player_config.assert_called_once_with(universal_id)
+        mock_mass.players.delete_player_config.assert_called_once_with(
+            universal_id, replacement_player_id=shell_id
+        )
 
     @pytest.mark.asyncio
     async def test_protocols_reparented_to_their_own_native_claimer(
@@ -9712,7 +9766,9 @@ class TestUniversalPlayerRestoreOrphanCleanup:
         mock_mass.players._repoint_group_memberships.assert_called_once_with(
             universal_id, "native_a"
         )
-        mock_mass.players.delete_player_config.assert_called_once_with(universal_id)
+        mock_mass.players.delete_player_config.assert_called_once_with(
+            universal_id, replacement_player_id="native_a"
+        )
 
     @pytest.mark.asyncio
     async def test_restore_native_claims_carries_config_and_deletes_wrapper(

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta
 from sqlite3 import IntegrityError
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from music_assistant_models.auth import AuthProviderType, Scope, User, UserRole
@@ -2491,6 +2492,99 @@ async def test_remove_from_user_filters_in_parallel(auth_manager: Authentication
     )
 
     assert await _get_filters(auth_manager, user.user_id) == ([], [])
+
+
+async def test_replace_player_in_user_filters(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that a replaced player is swapped for its replacement in the access filters.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    only_wrapper = await auth_manager.create_user(username="onlywrapper", player_filter=["up_old"])
+    both = await auth_manager.create_user(
+        username="both", player_filter=["up_old", "sonos_1", "kitchen"]
+    )
+    unrestricted = await auth_manager.create_user(username="unrestricted")
+
+    await auth_manager.replace_player_in_user_filters(
+        "up_old", "sonos_1", removed_player_ids=["up_old"]
+    )
+
+    # a user restricted to the replaced player must follow it instead of losing the restriction
+    assert (await _get_filters(auth_manager, only_wrapper.user_id))[1] == ["sonos_1"]
+    # a user that already had access to both must not end up with the replacement twice
+    assert (await _get_filters(auth_manager, both.user_id))[1] == ["sonos_1", "kitchen"]
+    assert await _get_filters(auth_manager, unrestricted.user_id) == ([], [])
+
+
+async def test_replace_player_in_user_filters_drops_removed_players(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Test that players removed along with the replaced one are still dropped.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(
+        username="restricted", player_filter=["up_old", "up_old_airplay", "kitchen"]
+    )
+
+    await auth_manager.replace_player_in_user_filters(
+        "up_old", "sonos_1", removed_player_ids=["up_old", "up_old_airplay"]
+    )
+
+    assert (await _get_filters(auth_manager, user.user_id))[1] == ["sonos_1", "kitchen"]
+
+
+async def test_user_filter_removal_updates_live_sessions(
+    auth_manager: AuthenticationManager, mass_minimal: MusicAssistant
+) -> None:
+    """
+    Test that a filter removal is applied to the sessions that are already connected.
+
+    :param auth_manager: AuthenticationManager instance.
+    :param mass_minimal: Minimal MusicAssistant instance.
+    """
+    user = await auth_manager.create_user(
+        username="restricted",
+        provider_filter=["spotify--old", "jellyfin--live"],
+        player_filter=["player_gone", "player_live"],
+    )
+    bystander = await auth_manager.create_user(username="bystander", player_filter=["player_other"])
+    session = MagicMock(_authenticated_user=await auth_manager.get_user(user.user_id))
+    bystander_session = MagicMock(
+        _authenticated_user=await auth_manager.get_user(bystander.user_id)
+    )
+    mass_minimal.webserver.clients.update({session, bystander_session})
+
+    await auth_manager.remove_from_user_filters(
+        provider_instance_ids=["spotify--old"], player_ids=["player_gone"]
+    )
+
+    assert session._authenticated_user.provider_filter == ["jellyfin--live"]
+    assert session._authenticated_user.player_filter == ["player_live"]
+    # a session of another user must keep its own filters
+    assert bystander_session._authenticated_user.player_filter == ["player_other"]
+
+
+async def test_replace_player_in_user_filters_updates_live_sessions(
+    auth_manager: AuthenticationManager, mass_minimal: MusicAssistant
+) -> None:
+    """
+    Test that a replacement is applied to the sessions that are already connected.
+
+    :param auth_manager: AuthenticationManager instance.
+    :param mass_minimal: Minimal MusicAssistant instance.
+    """
+    user = await auth_manager.create_user(username="onlywrapper", player_filter=["up_old"])
+    session = MagicMock(_authenticated_user=await auth_manager.get_user(user.user_id))
+    mass_minimal.webserver.clients.add(session)
+
+    await auth_manager.replace_player_in_user_filters(
+        "up_old", "sonos_1", removed_player_ids=["up_old"]
+    )
+
+    assert session._authenticated_user.player_filter == ["sonos_1"]
 
 
 async def test_prune_stale_user_filters(auth_manager: AuthenticationManager) -> None:

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -2494,6 +2494,26 @@ async def test_remove_from_user_filters_in_parallel(auth_manager: Authentication
     assert await _get_filters(auth_manager, user.user_id) == ([], [])
 
 
+async def test_update_user_filters_updates_live_sessions(
+    auth_manager: AuthenticationManager, mass_minimal: MusicAssistant
+) -> None:
+    """
+    Test that an admin restricting a user takes effect on their connected sessions.
+
+    :param auth_manager: AuthenticationManager instance.
+    :param mass_minimal: Minimal MusicAssistant instance.
+    """
+    user = await auth_manager.create_user(username="unrestricted")
+    session = MagicMock(_authenticated_user=await auth_manager.get_user(user.user_id))
+    mass_minimal.webserver.clients.add(session)
+
+    await auth_manager.update_user_filters(user, ["kitchen"], None)
+
+    assert session._authenticated_user.player_filter == ["kitchen"]
+    # a filter that was not part of the update must be left alone
+    assert session._authenticated_user.provider_filter == []
+
+
 async def test_replace_player_in_user_filters(auth_manager: AuthenticationManager) -> None:
     """
     Test that a replaced player is swapped for its replacement in the access filters.


### PR DESCRIPTION
# What does this implement/fix?

When Music Assistant automatically replaces a Universal Player wrapper with the native player for the same device, the wrapper's id was simply dropped from the per-user player access filters. Since an empty filter means "no restriction", a user who was restricted to just that one speaker silently ended up with access to *every* player. The filter now follows the replacement instead.

A second problem: filter changes were only written to the database, never to the sessions that are already connected. After a plain player removal the database says "unrestricted" while the open session still holds the id of a player that no longer exists, so that session loses access to all players (and stops receiving player/queue updates) until the user reconnects.

- A replaced player now hands its access filter entries over to its replacement, instead of the restriction being lifted.
- Filter changes are applied to already connected sessions right away, so a removal or replacement no longer requires a reconnect.
- Players that are removed along with the replaced one are still dropped from the filters, and the replacement is never listed twice.
- An admin changing a user's access in the settings now takes effect immediately as well, instead of only after that user reconnects.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
