### PR TITLE
Keep a bridged output with the speaker connection it runs on

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1042,9 +1042,11 @@ class ProtocolLinkingMixin:
             # Transfer all protocol links from universal player to native player.
             # Derived protocols ride on another output and must stay with it, so settle
             # the bases first and let a derived protocol inherit its base's refusal.
-            for linked in sorted(
-                player.linked_output_protocols, key=lambda link: link.derived_from is not None
-            ):
+            def _is_derived(link: LinkedOutputProtocol) -> bool:
+                protocol_player = self.get_player(link.output_protocol_id)
+                return bool(protocol_player and protocol_player.underlying_player_id)
+
+            for linked in sorted(player.linked_output_protocols, key=_is_derived):
                 if protocol_player := self.get_player(linked.output_protocol_id):
                     if protocol_player.underlying_player_id in refused_protocol_ids:
                         refused_protocol_ids.add(protocol_player.player_id)

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1039,9 +1039,16 @@ class ProtocolLinkingMixin:
             refused_protocol_ids: set[str] = set()
             moved_protocol_ids: set[str] = set()
 
-            # Transfer all protocol links from universal player to native player
-            for linked in list(player.linked_output_protocols):
+            # Transfer all protocol links from universal player to native player.
+            # Derived protocols ride on another output and must stay with it, so settle
+            # the bases first and let a derived protocol inherit its base's refusal.
+            for linked in sorted(
+                player.linked_output_protocols, key=lambda link: link.derived_from is not None
+            ):
                 if protocol_player := self.get_player(linked.output_protocol_id):
+                    if protocol_player.underlying_player_id in refused_protocol_ids:
+                        refused_protocol_ids.add(protocol_player.player_id)
+                        continue
                     protocol_player.set_protocol_parent_id(None)
                     domain = linked.protocol_domain or protocol_player.provider.domain
                     self._add_protocol_link(native_player, protocol_player, domain)

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1039,21 +1039,28 @@ class ProtocolLinkingMixin:
             refused_protocol_ids: set[str] = set()
             moved_protocol_ids: set[str] = set()
 
-            # Transfer all protocol links from universal player to native player.
-            # Derived protocols ride on another output and must stay with it, so settle
-            # the bases first and let a derived protocol inherit its base's refusal.
-            def _is_derived(link: LinkedOutputProtocol) -> bool:
-                protocol_player = self.get_player(link.output_protocol_id)
-                return bool(protocol_player and protocol_player.underlying_player_id)
-
-            for linked in sorted(player.linked_output_protocols, key=_is_derived):
-                if protocol_player := self.get_player(linked.output_protocol_id):
-                    if protocol_player.underlying_player_id in refused_protocol_ids:
-                        refused_protocol_ids.add(protocol_player.player_id)
-                        continue
+            # Transfer the protocol links from the universal player to the native player.
+            # A derived protocol rides on another output, so a base and everything riding
+            # on it can only move together: refusing one of them holds back the group.
+            for group in self._group_protocol_links(player):
+                domains = {
+                    protocol_player.player_id: linked.protocol_domain
+                    or protocol_player.provider.domain
+                    for linked, protocol_player in group
+                }
+                if any(
+                    self._parent_has_active_protocol_from_domain(
+                        native_player, domain, exclude_player_id=protocol_id
+                    )
+                    for protocol_id, domain in domains.items()
+                ):
+                    refused_protocol_ids.update(domains.keys())
+                    continue
+                for _, protocol_player in group:
                     protocol_player.set_protocol_parent_id(None)
-                    domain = linked.protocol_domain or protocol_player.provider.domain
-                    self._add_protocol_link(native_player, protocol_player, domain)
+                    self._add_protocol_link(
+                        native_player, protocol_player, domains[protocol_player.player_id]
+                    )
                     if protocol_player.protocol_parent_id != native_player.player_id:
                         # Link refused, keep the protocol owned by the universal player.
                         protocol_player.set_protocol_parent_id(player.player_id)
@@ -1091,6 +1098,45 @@ class ProtocolLinkingMixin:
 
             # Stop playback and remove the now-obsolete universal player
             self.mass.create_task(self._stop_and_unregister(player, native_player.player_id))
+
+    def _group_protocol_links(
+        self, parent: Player
+    ) -> list[list[tuple[LinkedOutputProtocol, Player]]]:
+        """
+        Group a parent's registered protocol links with the protocols riding on them.
+
+        Each group holds one base protocol followed by the derived protocols that ride
+        on it. A protocol whose underlying player is not one of the parent's own links
+        forms a group of its own.
+
+        :param parent: The parent player whose protocol links should be grouped.
+        """
+        registered = [
+            (linked, protocol_player)
+            for linked in parent.linked_output_protocols
+            if (protocol_player := self.get_player(linked.output_protocol_id))
+        ]
+        link_ids = {protocol_player.player_id for _, protocol_player in registered}
+        riders: dict[str, list[tuple[LinkedOutputProtocol, Player]]] = {}
+        bases: list[tuple[LinkedOutputProtocol, Player]] = []
+        for linked, protocol_player in registered:
+            underlying_id = protocol_player.underlying_player_id
+            if underlying_id and underlying_id in link_ids:
+                riders.setdefault(underlying_id, []).append((linked, protocol_player))
+            else:
+                bases.append((linked, protocol_player))
+
+        groups = [
+            [(linked, protocol_player), *riders.get(protocol_player.player_id, [])]
+            for linked, protocol_player in bases
+        ]
+        # A derived protocol riding on another derived protocol has no base group here,
+        # so it moves on its own rather than being dropped from the transfer.
+        grouped_ids = {
+            protocol_player.player_id for group in groups for _, protocol_player in group
+        }
+        groups.extend([entry] for entry in registered if entry[1].player_id not in grouped_ids)
+        return groups
 
     def _migrate_universal_player_config(self, universal_id: str, native_id: str) -> None:
         """

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -10565,6 +10565,90 @@ class TestDerivedProtocolLinking:
         assert derived.protocol_parent_id == "up_aabbccddeeff"
         assert "spb_1" in universal._protocol_player_ids
 
+    def test_derived_stays_with_refused_base_on_replacement(self, mock_mass: MagicMock) -> None:
+        """
+        Keep a derived protocol with its base when the base's link is refused.
+
+        The native player absorbs the first universal player's cast protocol, so the
+        second universal player's cast protocol is refused and stays behind. The
+        sendspin bridge riding on it must stay behind too instead of moving on its own.
+        """
+        controller = PlayerController(mock_mass)
+        up_provider = create_mock_universal_provider(mock_mass)
+
+        config_store: dict[str, Any] = {
+            f"players/{player_id}": {"enabled": True}
+            for player_id in ("native", "up_a", "up_b", "cc_1", "cc_2", "spb_2")
+        }
+        mock_mass.config.get = MagicMock(side_effect=config_store.get)
+        mock_mass.config.set = MagicMock(side_effect=config_store.__setitem__)
+        mock_mass.config.remove = MagicMock(side_effect=lambda key: config_store.pop(key, None))
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.call_later = MagicMock()
+        mock_mass.loop = MagicMock()
+        mock_mass.create_task = MagicMock()
+
+        mac = "AA:BB:CC:DD:EE:FF"
+        identifiers = {IdentifierType.MAC_ADDRESS: mac}
+        universals = {}
+        for universal_id, protocol_ids in (("up_a", ["cc_1"]), ("up_b", ["cc_2", "spb_2"])):
+            universal = UniversalPlayer(
+                provider=up_provider,
+                player_id=universal_id,
+                name=f"Soundbar ({universal_id})",
+                device_info=DeviceInfo(model="Test", manufacturer="Test"),
+                protocol_player_ids=protocol_ids,
+            )
+            universal._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, mac)
+            universal._cache.clear()
+            universal.update_state(signal_event=False)
+            universal.set_initialized()
+            universals[universal_id] = universal
+
+        native = MockPlayer(
+            MockProvider("linkplay", mass=mock_mass), "native", "Soundbar", identifiers=identifiers
+        )
+        native.set_initialized()
+
+        cast_provider = MockProvider("chromecast", mass=mock_mass)
+        cast_players = {}
+        for cast_id in ("cc_1", "cc_2"):
+            cast_player = MockPlayer(
+                cast_provider,
+                cast_id,
+                f"Cast {cast_id}",
+                player_type=PlayerType.PROTOCOL,
+                identifiers=identifiers,
+            )
+            cast_player.set_initialized()
+            cast_players[cast_id] = cast_player
+
+        derived = self._make_derived_player(mock_mass, "spb_2", "cc_2")
+
+        controller._players = {
+            **universals,
+            **cast_players,
+            "native": native,
+            "spb_2": derived,
+        }
+        controller._add_protocol_link(universals["up_a"], cast_players["cc_1"], "chromecast")
+        controller._add_protocol_link(universals["up_b"], cast_players["cc_2"], "chromecast")
+        controller._add_protocol_link(universals["up_b"], derived, "sendspin")
+
+        controller._check_replace_universal_player(native)
+
+        # the second universal player keeps the refused cast protocol and its bridge
+        assert cast_players["cc_2"].protocol_parent_id == "up_b"
+        assert derived.protocol_parent_id == "up_b"
+        assert {link.output_protocol_id for link in universals["up_b"].linked_output_protocols} == {
+            "cc_2",
+            "spb_2",
+        }
+        # the native player only took over the protocol it could actually claim
+        assert {link.output_protocol_id for link in native.linked_output_protocols} == {"cc_1"}
+        assert "spb_2" not in (config_store.get("players/native/values/linked_protocol_ids") or [])
+
     def test_save_underlying_player_id_persists_and_clears(self, mock_mass: MagicMock) -> None:
         """Test the derived edge is persisted, cleared when revoked and skipped otherwise."""
         controller = PlayerController(mock_mass)

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -10657,6 +10657,90 @@ class TestDerivedProtocolLinking:
         assert {link.output_protocol_id for link in native.linked_output_protocols} == {"cc_1"}
         assert "spb_2" not in (config_store.get("players/native/values/linked_protocol_ids") or [])
 
+    def test_base_stays_with_refused_derived_on_replacement(self, mock_mass: MagicMock) -> None:
+        """
+        Keep a base protocol with its derived protocol when the derived link is refused.
+
+        The native player already serves the sendspin domain, so the universal player's
+        sendspin bridge cannot move. The cast protocol it rides on must stay behind with
+        it instead of moving on its own.
+        """
+        controller = PlayerController(mock_mass)
+        up_provider = create_mock_universal_provider(mock_mass)
+
+        config_store: dict[str, Any] = {
+            f"players/{player_id}": {"enabled": True}
+            for player_id in ("native", "up_b", "cc_2", "spb_2", "spb_native")
+        }
+        mock_mass.config.get = MagicMock(side_effect=config_store.get)
+        mock_mass.config.set = MagicMock(side_effect=config_store.__setitem__)
+        mock_mass.config.remove = MagicMock(side_effect=lambda key: config_store.pop(key, None))
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.call_later = MagicMock()
+        mock_mass.loop = MagicMock()
+        mock_mass.create_task = MagicMock()
+
+        mac = "AA:BB:CC:DD:EE:FF"
+        identifiers = {IdentifierType.MAC_ADDRESS: mac}
+        universal = UniversalPlayer(
+            provider=up_provider,
+            player_id="up_b",
+            name="Soundbar (Universal)",
+            device_info=DeviceInfo(model="Test", manufacturer="Test"),
+            protocol_player_ids=["cc_2", "spb_2"],
+        )
+        universal._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, mac)
+        universal._cache.clear()
+        universal.update_state(signal_event=False)
+        universal.set_initialized()
+
+        native = MockPlayer(
+            MockProvider("linkplay", mass=mock_mass), "native", "Soundbar", identifiers=identifiers
+        )
+        native.set_initialized()
+        cast_player = MockPlayer(
+            MockProvider("chromecast", mass=mock_mass),
+            "cc_2",
+            "Cast",
+            player_type=PlayerType.PROTOCOL,
+            identifiers=identifiers,
+        )
+        cast_player.set_initialized()
+        derived = self._make_derived_player(mock_mass, "spb_2", "cc_2")
+        sendspin_native = MockPlayer(
+            MockProvider("sendspin", mass=mock_mass),
+            "spb_native",
+            "Soundbar (Sendspin)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers=identifiers,
+        )
+        sendspin_native.set_initialized()
+
+        controller._players = {
+            "up_b": universal,
+            "native": native,
+            "cc_2": cast_player,
+            "spb_2": derived,
+            "spb_native": sendspin_native,
+        }
+        controller._add_protocol_link(universal, cast_player, "chromecast")
+        controller._add_protocol_link(universal, derived, "sendspin")
+        controller._add_protocol_link(native, sendspin_native, "sendspin")
+
+        controller._check_replace_universal_player(native)
+
+        # the bridge could not move, so the cast protocol it rides on stays with it
+        assert derived.protocol_parent_id == "up_b"
+        assert cast_player.protocol_parent_id == "up_b"
+        assert {link.output_protocol_id for link in universal.linked_output_protocols} == {
+            "cc_2",
+            "spb_2",
+        }
+        assert {link.output_protocol_id for link in native.linked_output_protocols} == {
+            "spb_native"
+        }
+
     def test_save_underlying_player_id_persists_and_clears(self, mock_mass: MagicMock) -> None:
         """Test the derived edge is persisted, cleared when revoked and skipped otherwise."""
         controller = PlayerController(mock_mass)

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -10565,13 +10565,17 @@ class TestDerivedProtocolLinking:
         assert derived.protocol_parent_id == "up_aabbccddeeff"
         assert "spb_1" in universal._protocol_player_ids
 
-    def test_derived_stays_with_refused_base_on_replacement(self, mock_mass: MagicMock) -> None:
+    @pytest.mark.parametrize("derived_first", [False, True])
+    def test_derived_stays_with_refused_base_on_replacement(
+        self, mock_mass: MagicMock, derived_first: bool
+    ) -> None:
         """
         Keep a derived protocol with its base when the base's link is refused.
 
         The native player absorbs the first universal player's cast protocol, so the
         second universal player's cast protocol is refused and stays behind. The
-        sendspin bridge riding on it must stay behind too instead of moving on its own.
+        sendspin bridge riding on it must stay behind too instead of moving on its own,
+        whichever order the two links are listed in.
         """
         controller = PlayerController(mock_mass)
         up_provider = create_mock_universal_provider(mock_mass)
@@ -10633,8 +10637,12 @@ class TestDerivedProtocolLinking:
             "spb_2": derived,
         }
         controller._add_protocol_link(universals["up_a"], cast_players["cc_1"], "chromecast")
-        controller._add_protocol_link(universals["up_b"], cast_players["cc_2"], "chromecast")
-        controller._add_protocol_link(universals["up_b"], derived, "sendspin")
+        if derived_first:
+            controller._add_protocol_link(universals["up_b"], derived, "sendspin")
+            controller._add_protocol_link(universals["up_b"], cast_players["cc_2"], "chromecast")
+        else:
+            controller._add_protocol_link(universals["up_b"], cast_players["cc_2"], "chromecast")
+            controller._add_protocol_link(universals["up_b"], derived, "sendspin")
 
         controller._check_replace_universal_player(native)
 


### PR DESCRIPTION
# What does this implement/fix?

Some speakers expose more than one connection of the same kind (for example two Chromecast endpoints on one device). When such a speaker gets a native player, the native player takes the connections over one by one, and a connection it cannot claim stays with the wrapper it came from.

A bridged output that runs on top of one of those connections (like a Sendspin bridge riding on a Chromecast player) did not follow that rule. It could move to the native player while the connection it runs on stayed behind, or stay behind while its connection moved. Either way the bridge and the connection it depends on ended up owned by different players, and that wrong owner was written to the config.

A connection and the bridges riding on it are now moved as one group: if any of them cannot be claimed, the whole group stays where it is.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
