### PR TITLE
Keep a player's queue when it switches role

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1520,12 +1520,13 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         async with self._register_lock:
             if (existing := self._players.get(player.player_id)) is not None:
                 # a protocol player is hidden behind its parent and owns no queue, every
-                # other player does. Reading the role change off that published reality
-                # keeps it independent of when the player's state was last recalculated,
-                # which providers cannot control (they flip the type before this call).
+                # other player does. Reading the role the player is leaving off that
+                # published reality keeps it independent of when the player's state was
+                # last recalculated, which providers cannot control (they flip the type
+                # before this call).
+                was_protocol = self.mass.player_queues.get(player.player_id) is None
                 becomes_protocol = player.type == PlayerType.PROTOCOL
-                owns_queue = self.mass.player_queues.get(player.player_id) is not None
-                role_changed = becomes_protocol == owns_queue
+                role_changed = becomes_protocol != was_protocol
                 if role_changed:
                     # release the topology of the role the player is leaving
                     self._cleanup_player_type_transition(

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1519,16 +1519,18 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         # is still setting the player up
         async with self._register_lock:
             if (existing := self._players.get(player.player_id)) is not None:
-                previous_type = existing.state.type
-                # moving in or out of the protocol role turns a player that owns a queue
-                # into one that is hidden behind a parent, or the other way around
-                role_changed = previous_type != player.type and PlayerType.PROTOCOL in (
-                    previous_type,
-                    player.type,
-                )
+                # a protocol player is hidden behind its parent and owns no queue, every
+                # other player does. Reading the role change off that published reality
+                # keeps it independent of when the player's state was last recalculated,
+                # which providers cannot control (they flip the type before this call).
+                becomes_protocol = player.type == PlayerType.PROTOCOL
+                owns_queue = self.mass.player_queues.get(player.player_id) is not None
+                role_changed = becomes_protocol == owns_queue
                 if role_changed:
-                    # release the old topology while the state still reports the old type
-                    self._cleanup_player_type_transition(existing)
+                    # release the topology of the role the player is leaving
+                    self._cleanup_player_type_transition(
+                        existing, becomes_protocol=becomes_protocol
+                    )
                 self._players[player.player_id] = player
                 if existing is not player:
                     # a fresh instance starts out with a base config only, so it needs

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1599,69 +1599,75 @@ class ProtocolLinkingMixin:
     def _cleanup_protocol_links(self, player: Player) -> None:
         """Clean up protocol links when a player is permanently removed."""
         if player.state.type == PlayerType.PROTOCOL:
-            # Protocol player being removed: remove link from parent
-            if parent_id := player.protocol_parent_id:
-                if parent_player := self.get_player(parent_id):
-                    # Use permanent=True to also remove from cached protocol IDs
-                    self._remove_protocol_link(parent_player, player.player_id, permanent=True)
-                    if (
-                        parent_player.provider.domain == "universal_player"
-                        and len(parent_player.linked_output_protocols) == 0
-                    ):
-                        # No protocols left - the universal player has nothing to play
-                        # on. Its config is deliberately kept: the player id is opaque
-                        # and cannot be recreated, so deleting it here would orphan the
-                        # entities API consumers bound to it. Only an explicit removal
-                        # by the user deletes a universal player for good.
-                        self.logger.info(
-                            "Universal player %s has no protocols left",
-                            parent_id,
-                        )
-                        self.mass.create_task(
-                            self.mass.players.unregister(parent_id, permanent=False)
-                        )
-                    else:
-                        parent_player.refresh_state()
-                else:
-                    # Parent not registered yet — still purge the cached id
-                    self._remove_protocol_id_from_cache(parent_id, player.player_id)
-        else:
-            # Native/universal player being removed: handle all linked protocol players.
-            # Collect all known protocol IDs from both active links and cached state,
-            # since disabled/inactive protocols may only exist in the cached parent data.
-            all_protocol_ids = set(self._get_known_protocol_ids(player))
-            for protocol_id in all_protocol_ids:
-                if protocol_player := self.get_player(protocol_id):
-                    # Protocol player is available: clear parent and schedule re-evaluation
-                    # so it can be matched to a new parent or a new universal player
-                    self.logger.debug(
-                        "Player %s removed - scheduling evaluation for protocol %s",
-                        player.player_id,
-                        protocol_id,
-                    )
-                    self._detach_protocol_child(protocol_player)
-                else:
-                    # Clear cached parent ID in config so protocol won't try to
-                    # restore a link to the deleted player on next restart
-                    self._clear_protocol_parent_id(protocol_id)
-                    # Protocol player is not registered yet — it may still be
-                    # mid-discovery (e.g., DLNA connecting via SSDP). Don't delete
-                    # its config as that would cause a KeyError when it finishes
-                    # registering. Stale configs are harmless and get cleaned up
-                    # naturally on subsequent restarts.
-                    self.logger.debug(
-                        "Player %s removed - protocol %s not registered, skipping cleanup",
-                        player.player_id,
-                        protocol_id,
-                    )
+            self._unlink_from_protocol_parent(player)
+            return
+        self._detach_owned_protocols(player)
 
-    def _cleanup_player_type_transition(self, existing: Player) -> None:
+    def _unlink_from_protocol_parent(self, player: Player) -> None:
+        """Release a protocol player from the parent it is attached to."""
+        if parent_id := player.protocol_parent_id:
+            if parent_player := self.get_player(parent_id):
+                # Use permanent=True to also remove from cached protocol IDs
+                self._remove_protocol_link(parent_player, player.player_id, permanent=True)
+                if (
+                    parent_player.provider.domain == "universal_player"
+                    and len(parent_player.linked_output_protocols) == 0
+                ):
+                    # No protocols left - the universal player has nothing to play
+                    # on. Its config is deliberately kept: the player id is opaque
+                    # and cannot be recreated, so deleting it here would orphan the
+                    # entities API consumers bound to it. Only an explicit removal
+                    # by the user deletes a universal player for good.
+                    self.logger.info(
+                        "Universal player %s has no protocols left",
+                        parent_id,
+                    )
+                    self.mass.create_task(self.mass.players.unregister(parent_id, permanent=False))
+                else:
+                    parent_player.refresh_state()
+            else:
+                # Parent not registered yet — still purge the cached id
+                self._remove_protocol_id_from_cache(parent_id, player.player_id)
+
+    def _detach_owned_protocols(self, player: Player) -> None:
+        """Detach the protocol players a parent owns so they can find a new parent."""
+        # collect the ids from both the active links and the cached state, since
+        # disabled/inactive protocols may only exist in the cached parent data
+        all_protocol_ids = set(self._get_known_protocol_ids(player))
+        for protocol_id in all_protocol_ids:
+            if protocol_player := self.get_player(protocol_id):
+                # Protocol player is available: clear parent and schedule re-evaluation
+                # so it can be matched to a new parent or a new universal player
+                self.logger.debug(
+                    "Player %s no longer owns protocol %s - scheduling evaluation",
+                    player.player_id,
+                    protocol_id,
+                )
+                self._detach_protocol_child(protocol_player)
+            else:
+                # Clear cached parent ID in config so protocol won't try to
+                # restore a link to its former parent on next restart
+                self._clear_protocol_parent_id(protocol_id)
+                # Protocol player is not registered yet — it may still be
+                # mid-discovery (e.g., DLNA connecting via SSDP). Don't delete
+                # its config as that would cause a KeyError when it finishes
+                # registering. Stale configs are harmless and get cleaned up
+                # naturally on subsequent restarts.
+                self.logger.debug(
+                    "Player %s no longer owns protocol %s - not registered, skipping cleanup",
+                    player.player_id,
+                    protocol_id,
+                )
+
+    def _cleanup_player_type_transition(self, existing: Player, *, becomes_protocol: bool) -> None:
         """
         Release the protocol topology a player owned before its type changed.
 
-        :param existing: The registered player instance, still reporting its previous type.
+        :param existing: The registered player instance for the changed player.
+        :param becomes_protocol: True if the player moves into the protocol role,
+            False if it leaves it.
         """
-        if existing.state.type == PlayerType.PROTOCOL:
+        if not becomes_protocol:
             # a provider may announce the new type with the live parent link already
             # dropped, so fall back to the persisted one to still reach the parent
             parent_id = existing.protocol_parent_id or self._get_cached_protocol_parent_id(
@@ -1679,7 +1685,7 @@ class ProtocolLinkingMixin:
             existing.set_protocol_parent_id(parent_id)
             # unlink at the parent and drop the persisted parent id, which would
             # otherwise heal the player's type back to protocol
-            self._cleanup_protocol_links(existing)
+            self._unlink_from_protocol_parent(existing)
             # a player leaving the protocol role has no parent, also when that parent
             # is not registered (anymore) and only the cached link could be cleaned up
             existing.set_protocol_parent_id(None)
@@ -1688,7 +1694,7 @@ class ProtocolLinkingMixin:
         # can find a new parent, then give up their ownership in its (kept) config - the
         # reverse of the removal path, which drops the ownership before the detach
         protocol_ids = set(self._get_known_protocol_ids(existing))
-        self._cleanup_protocol_links(existing)
+        self._detach_owned_protocols(existing)
         self._remove_protocol_ids_from_parent(existing, protocol_ids)
 
     def _detach_protocol_children(self, parent_id: str) -> None:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1274,6 +1274,19 @@ class TestRegisterOrUpdateTypeTransition:
         assert not self._signalled(mock_mass, EventType.PLAYER_ADDED)
         assert not self._signalled(mock_mass, EventType.PLAYER_REMOVED)
 
+    async def test_unchanged_protocol_type_leaves_queue_alone(self, mock_mass: MagicMock) -> None:
+        """Re-registering a protocol player does not hand it a queue."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = self._register(controller, provider, "player_1", PlayerType.PROTOCOL)
+
+        await controller.register_or_update(player)
+
+        mock_mass.player_queues.on_player_register.assert_not_awaited()
+        mock_mass.player_queues.on_player_remove.assert_not_called()
+        assert not self._signalled(mock_mass, EventType.PLAYER_ADDED)
+        assert not self._signalled(mock_mass, EventType.PLAYER_REMOVED)
+
     async def test_group_type_change_is_not_a_role_change(self, mock_mass: MagicMock) -> None:
         """A player that turns into a group keeps its queue (Chromecast reports both)."""
         controller = self._prepare(mock_mass)

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1116,25 +1116,42 @@ def _set_play_media_override(mock_mass: MagicMock, value: bool) -> None:
 class TestRegisterOrUpdateTypeTransition:
     """Tests for a registered player moving in or out of the protocol role."""
 
-    @staticmethod
-    def _prepare(mock_mass: MagicMock) -> PlayerController:
+    queue_ids: set[str]
+
+    def _prepare(self, mock_mass: MagicMock) -> PlayerController:
         """Build a controller with the calls a re-registration makes stubbed out."""
         mock_mass.loop = MagicMock()
         mock_mass.config.get = MagicMock(side_effect=lambda _key, default=None: default)
-        mock_mass.player_queues.on_player_register = AsyncMock()
-        mock_mass.player_queues.on_player_remove = MagicMock()
+        # the queue registry is what a re-registration reads the role change off,
+        # so it is modelled instead of mocked out
+        self.queue_ids = set()
+        mock_mass.player_queues.get = MagicMock(
+            side_effect=lambda queue_id: MagicMock() if queue_id in self.queue_ids else None
+        )
+        mock_mass.player_queues.on_player_register = AsyncMock(
+            side_effect=lambda player: self.queue_ids.add(player.player_id)
+        )
+        mock_mass.player_queues.on_player_remove = MagicMock(
+            side_effect=lambda player_id, **_kwargs: self.queue_ids.discard(player_id)
+        )
         controller = PlayerController(mock_mass)
         mock_mass.players = controller
         return controller
 
-    @staticmethod
     def _register(
-        controller: PlayerController, provider: MockProvider, player_id: str, type_: PlayerType
+        self,
+        controller: PlayerController,
+        provider: MockProvider,
+        player_id: str,
+        type_: PlayerType,
     ) -> MockPlayer:
         """Add a player to the registry with its state calculated for the given type."""
         player = MockPlayer(provider, player_id, player_id, type_)
         player.set_initialized()
         controller._players[player_id] = player
+        if type_ != PlayerType.PROTOCOL:
+            # register() gives every non-protocol player a queue
+            self.queue_ids.add(player_id)
         # MockPlayer assigns the type after Player.__init__ built the initial state,
         # so the state only reports it once it is recalculated
         player.update_state(signal_event=False)
@@ -1194,6 +1211,55 @@ class TestRegisterOrUpdateTypeTransition:
             "player_1", permanent=False
         )
         assert self._signalled(mock_mass, EventType.PLAYER_REMOVED)
+
+    async def test_leaving_protocol_role_survives_a_state_update_landing_first(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A state update between the provider's type change and this call is harmless."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        parent = self._register(controller, provider, "parent", PlayerType.PLAYER)
+        child = self._register(controller, provider, "child", PlayerType.PROTOCOL)
+        child.set_protocol_parent_id("parent")
+        parent.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="child", protocol_domain="sendspin")]
+        )
+
+        child._attr_type = PlayerType.PLAYER
+        # a debounced state update can fire while this call waits for the register lock,
+        # which makes the state report the new type before the transition is handled
+        child.update_state(signal_event=False)
+        assert child.state.type is PlayerType.PLAYER
+
+        await controller.register_or_update(child)
+
+        mock_mass.player_queues.on_player_register.assert_awaited_once_with(child)
+        assert self._signalled(mock_mass, EventType.PLAYER_ADDED)
+        assert parent.linked_output_protocols == []
+
+    async def test_entering_protocol_role_survives_a_state_update_landing_first(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """The reverse transition is handled with the state already reporting the new type."""
+        controller = self._prepare(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        parent = self._register(controller, provider, "parent", PlayerType.PLAYER)
+        child = self._register(controller, provider, "child", PlayerType.PROTOCOL)
+        child.set_protocol_parent_id("parent")
+        parent.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="child", protocol_domain="sendspin")]
+        )
+
+        parent._attr_type = PlayerType.PROTOCOL
+        parent.update_state(signal_event=False)
+        assert parent.state.type is PlayerType.PROTOCOL
+
+        await controller.register_or_update(parent)
+
+        mock_mass.player_queues.on_player_remove.assert_called_once_with("parent", permanent=False)
+        assert self._signalled(mock_mass, EventType.PLAYER_REMOVED)
+        assert parent.linked_output_protocols == []
+        assert child.protocol_parent_id is None
 
     async def test_unchanged_type_leaves_queue_alone(self, mock_mass: MagicMock) -> None:
         """Re-registering a player without a type change does not touch its queue."""


### PR DESCRIPTION
# What does this implement/fix?

Follow-up hardening on #5784. When a player switches between being a speaker output of another player and being a player of its own, the switch was detected by comparing the player's current type against the type in its last calculated state. That state is recalculated all the time (any volume change, group change or the periodic refresh), and a recalculation adopts the new type. If one landed between the provider setting the new type and announcing it, the switch was no longer visible and the player silently ended up without a queue again - the exact problem #5784 fixed.

The switch is now read off the queue the player owns instead: a speaker output never owns one, every other player always does. That is the same thing the switch has to repair, so it cannot be missed and it also heals a switch that was somehow missed earlier.

- Detect the role switch from the player's queue rather than from its last state update.
- Pass the direction of the switch into the link cleanup so it no longer depends on the state either.
- Split the protocol link cleanup into its two halves, so the caller picks the one it needs.
- Added tests covering a state update landing before the re-registration, in both directions.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
