### PR TITLE
Explain why a player becoming a speaker output is not stopped first

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2389,7 +2389,11 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         """
         self._evaluate_protocol_links(player)
         if player.state.type == PlayerType.PROTOCOL:
-            # the player is hidden behind its parent from now on and no longer owns a queue
+            # the player is hidden behind its parent from now on and no longer owns a queue.
+            # only the queue is dropped, never the playback: the player either just became a
+            # (hidden) bridge client with nothing playing on it, or is already serving its
+            # parent, where a stop would cut that parent's stream short. A protocol player
+            # has no active group of its own either, so there is nothing to detach here.
             self.mass.signal_event(EventType.PLAYER_REMOVED, player.player_id)
             self.mass.player_queues.on_player_remove(player.player_id, permanent=False)
             return


### PR DESCRIPTION
# What does this implement/fix?

When a player switches to being a speaker output of another player, its queue is simply dropped — it is not stopped first and it is not detached from any group. Next to the paths that remove a player for good, that reads like an oversight.

It is not. The player is either a bridge client that was just claimed, with nothing playing on it, or one that is already playing as its parent's output — where stopping it would cut the parent's stream short. Added a comment saying so, so the next reader does not have to work it out again.

Comment only, no behaviour change.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
