### PR TITLE
Fix sporadic stutter when playing live audio sources

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -531,9 +531,14 @@ class StreamsAudio:
                 audio_source = streamdetails.path
 
         # pace ffmpeg at native rate for live sources; the producer (e.g.
-        # librespot's pipe backend) may otherwise write faster than realtime
-        if streamdetails.media_type == MediaType.AUDIO_SOURCE and "-re" not in extra_input_args:
-            extra_input_args += ["-re"]
+        # librespot's pipe backend) may otherwise write faster than realtime.
+        # The initial burst grants a small bounded read-ahead so downstream
+        # jitter does not immediately underrun the player. Providers that need
+        # different pacing can pass their own -re/-readrate args to override.
+        if streamdetails.media_type == MediaType.AUDIO_SOURCE and not (
+            "-re" in extra_input_args or "-readrate" in extra_input_args
+        ):
+            extra_input_args += ["-readrate", "1", "-readrate_initial_burst", "0.5"]
 
         # handle seek support
         if seek_position and streamdetails.duration and streamdetails.allow_seek:

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -535,8 +535,10 @@ class StreamsAudio:
         # The initial burst grants a small bounded read-ahead so downstream
         # jitter does not immediately underrun the player. Providers that need
         # different pacing can pass their own -re/-readrate args to override.
-        if streamdetails.media_type == MediaType.AUDIO_SOURCE and not (
-            "-re" in extra_input_args or "-readrate" in extra_input_args
+        if (
+            streamdetails.media_type == MediaType.AUDIO_SOURCE
+            and "-re" not in extra_input_args
+            and "-readrate" not in extra_input_args
         ):
             extra_input_args += ["-readrate", "1", "-readrate_initial_burst", "0.5"]
 
@@ -1399,7 +1401,7 @@ class StreamsAudio:
         directly — no ffmpeg in the data path.
 
         Slow path: when formats differ, ffmpeg resamples/recodes the stream
-        (with ``-re`` for rate pacing) via ``get_media_stream``.
+        (with ``-readrate`` pacing) via ``get_media_stream``.
 
         :param queue_item: The AudioSource queue item to stream.
         :param pcm_format: Output PCM format the consumer wants.

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -371,6 +371,7 @@ def build_concat_filelist(paths: list[str]) -> str:
 async def realtime_pcm_pacer(
     inner: AsyncGenerator[bytes],
     pcm_format: AudioFormat,
+    initial_burst_s: float = 0.5,
 ) -> AsyncGenerator[bytes]:
     """
     Pace a PCM byte stream at the format's native rate.
@@ -381,6 +382,10 @@ async def realtime_pcm_pacer(
 
     :param inner: Source generator yielding raw PCM bytes.
     :param pcm_format: PCM format the inner generator emits.
+    :param initial_burst_s: Bounded head start (in seconds of audio) passed
+        through unpaced, so downstream jitter does not immediately underrun.
+        Mirrors ffmpeg's ``-readrate_initial_burst``; producers that cannot
+        deliver faster than realtime simply never use the allowance.
     """
     bytes_per_second = pcm_format.sample_rate * pcm_format.channels * (pcm_format.bit_depth // 8)
     if bytes_per_second <= 0 or not pcm_format.content_type.is_pcm():
@@ -394,7 +399,7 @@ async def realtime_pcm_pacer(
     async for chunk in inner:
         yield chunk
         total_bytes += len(chunk)
-        expected_elapsed = total_bytes / bytes_per_second
+        expected_elapsed = total_bytes / bytes_per_second - initial_burst_s
         actual_elapsed = loop.time() - start_time
         if actual_elapsed < expected_elapsed:
             await asyncio.sleep(expected_elapsed - actual_elapsed)

--- a/music_assistant/providers/spotify_connect/ARCHITECTURE.md
+++ b/music_assistant/providers/spotify_connect/ARCHITECTURE.md
@@ -23,7 +23,7 @@ its local HTTP + WebSocket API. Music Assistant needs **no** Spotify Web API cre
         │   GoLibrespotClient over its local HTTP + WS API:
         │   REST control (resume/pause/seek/volume) + /events (state, metadata)
         ▼
-   get_audio_stream  (CUSTOM stream: source-paced, ends on pause)
+   get_audio_stream  (CUSTOM stream: backpressured, ends on pause)
         │
         ▼
    MA streams controller  (ffmpeg resample, per player)
@@ -59,9 +59,11 @@ go-librespot ──s16le PCM──▶ stdout ──▶ get_audio_stream ──�
 - **`StreamType.CUSTOM`**: `get_audio_stream` reads the daemon's stdout and yields PCM. The
   subprocess pipe always has a reader, so go-librespot's non-blocking pipe open never fails,
   and we control the byte stream (pacing it, and ending it cleanly on pause).
-- **Source pacing**: go-librespot's pipe backend is not realtime-paced, so `get_audio_stream`
-  paces the read at the native rate. This back-pressures the daemon to ~realtime, keeping it
-  only a fraction of a second ahead so transport commands land quickly.
+- **Pacing**: the streams controller's realtime pacer (ffmpeg `-readrate` with a small
+  initial burst) is the single pacing authority. go-librespot's pipe backend is not
+  realtime-paced, but backpressure through the stdout pipe keeps the daemon only a
+  fraction of a second ahead, so transport commands land quickly, while the burst
+  headroom absorbs scheduling jitter that would otherwise underrun the player.
 - **Pause → clean EOF**: go-librespot keeps the pipe open while paused (it just stops writing),
   so `get_audio_stream` detects the gap and **ends the stream** — the player leaves the playing
   state (track preserved) and the next `playing` event re-streams. Resume works from both the

--- a/music_assistant/providers/spotify_connect/ARCHITECTURE.md
+++ b/music_assistant/providers/spotify_connect/ARCHITECTURE.md
@@ -58,7 +58,7 @@ go-librespot ──s16le PCM──▶ stdout ──▶ get_audio_stream ──�
 
 - **`StreamType.CUSTOM`**: `get_audio_stream` reads the daemon's stdout and yields PCM. The
   subprocess pipe always has a reader, so go-librespot's non-blocking pipe open never fails,
-  and we control the byte stream (pacing it, and ending it cleanly on pause).
+  and we control the byte stream (ending it cleanly on pause).
 - **Pacing**: the streams controller's realtime pacer (ffmpeg `-readrate` with a small
   initial burst) is the single pacing authority. go-librespot's pipe backend is not
   realtime-paced, but backpressure through the stdout pipe keeps the daemon only a

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -266,8 +266,8 @@ class SpotifyConnectProvider(PluginProvider):
         # pauses so the player leaves the playing state. decoded_audio_format tells
         # the core the PCM is s16le while audio_format keeps the Ogg/Vorbis source
         # codec for display; MA resamples to each player's format as needed.
-        # `-fflags nobuffer` keeps ffmpeg from buffering ahead on the resample path
-        # (we back-pressure the daemon to realtime in get_audio_stream).
+        # `-fflags nobuffer` keeps ffmpeg's own input buffering low so the
+        # controller's realtime pacer owns the (small, bounded) read-ahead.
         # expiration=0: never reuse a cached streamdetails so the active-device
         # check above re-runs on every play attempt.
         return StreamDetails(
@@ -290,12 +290,6 @@ class SpotifyConnectProvider(PluginProvider):
         """
         Yield raw PCM from the go-librespot daemon's stdout for the live AudioSource.
 
-        We rate-pace the read at the source's native rate so go-librespot (whose
-        pipe backend is not realtime-paced) is back-pressured to ~realtime and
-        stays only a fraction of a second ahead. Without this, on the ffmpeg
-        resample path (when the player's PCM format differs from ours) nothing
-        throttles the daemon — it races seconds ahead and pause/skip lag badly.
-
         When playback pauses the daemon stops writing PCM; we then end the stream
         (clean EOF) so the consuming player leaves the playing state. The next
         ``playing`` event re-triggers playback. ``seek_position`` is ignored —
@@ -306,11 +300,13 @@ class SpotifyConnectProvider(PluginProvider):
         proc = self._proc
         if proc is None:
             raise AudioError("Spotify Connect daemon is not running")
-        fmt = self._decoded_audio_format
-        bytes_per_second = fmt.sample_rate * fmt.channels * (fmt.bit_depth // 8)
-        loop = self.mass.loop
-        start = loop.time()
-        streamed = 0
+        # No pacing here: the streams controller's realtime pacer (ffmpeg readrate
+        # with a small initial burst) is the single pacing authority for live
+        # sources. Backpressure through the stdout pipe bounds how far the daemon
+        # (whose pipe backend is not realtime-paced) runs ahead, while the burst
+        # headroom absorbs scheduling jitter that would otherwise underrun the
+        # player. Pacing a second time here would pin the feed to exactly realtime
+        # and starve that headroom.
         while True:
             try:
                 chunk = await asyncio.wait_for(
@@ -326,11 +322,6 @@ class SpotifyConnectProvider(PluginProvider):
             if not chunk:
                 return  # daemon stdout closed (process exited / restarting)
             yield chunk
-            # pace at native rate → back-pressure the daemon to ~realtime
-            streamed += len(chunk)
-            ahead = streamed / bytes_per_second - (loop.time() - start)
-            if ahead > 0:
-                await asyncio.sleep(ahead)
 
     async def on_source_selected(
         self,

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -205,7 +205,7 @@ def _multi_part_streamdetails() -> StreamDetails:
     )
 
 
-def _flac_streamdetails() -> StreamDetails:
+def _flac_streamdetails(extra_input_args: list[str] | None = None) -> StreamDetails:
     return _make_streamdetails(
         audio_format=AudioFormat(
             content_type=ContentType.FLAC,
@@ -213,7 +213,8 @@ def _flac_streamdetails() -> StreamDetails:
             sample_rate=44100,
             bit_depth=16,
             channels=2,
-        )
+        ),
+        extra_input_args=extra_input_args,
     )
 
 
@@ -468,16 +469,7 @@ async def test_get_media_stream_respects_provider_pacing_args(
     provider_pacing_args: list[str],
 ) -> None:
     """Provider-supplied -re/-readrate args suppress the automatic AudioSource pacing."""
-    streamdetails = _make_streamdetails(
-        audio_format=AudioFormat(
-            content_type=ContentType.FLAC,
-            codec_type=ContentType.FLAC,
-            sample_rate=44100,
-            bit_depth=16,
-            channels=2,
-        ),
-        extra_input_args=list(provider_pacing_args),
-    )
+    streamdetails = _flac_streamdetails(extra_input_args=list(provider_pacing_args))
     audio = _make_audio_controller()
     await _drain(audio.get_media_stream(streamdetails, _make_pcm_format()))
 

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -103,6 +103,7 @@ def _make_streamdetails(
     *,
     audio_format: AudioFormat,
     decoded_audio_format: AudioFormat | None = None,
+    extra_input_args: list[str] | None = None,
 ) -> StreamDetails:
     return StreamDetails(
         provider="test_provider",
@@ -112,6 +113,7 @@ def _make_streamdetails(
         media_type=MediaType.AUDIO_SOURCE,
         stream_type=StreamType.NAMED_PIPE,
         path="/tmp/fake-fifo",  # noqa: S108
+        extra_input_args=extra_input_args or [],
     )
 
 
@@ -436,3 +438,48 @@ async def test_get_media_stream_keeps_caller_extra_input_args_intact(
 
     assert patch_ffmpeg.last_instance.extra_input_args == [*_PROVIDER_INPUT_ARGS, "-ss", "600"]
     assert streamdetails.extra_input_args == [*_PROVIDER_INPUT_ARGS]
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_adds_realtime_pacing_for_audio_source(
+    patch_ffmpeg: type[_FakeFFMpeg],
+) -> None:
+    """A live AudioSource gets realtime pacing with a small initial burst of headroom."""
+    audio = _make_audio_controller()
+    await _drain(audio.get_media_stream(_flac_streamdetails(), _make_pcm_format()))
+
+    assert patch_ffmpeg.last_instance is not None
+    assert patch_ffmpeg.last_instance.extra_input_args == [
+        "-readrate",
+        "1",
+        "-readrate_initial_burst",
+        "0.5",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider_pacing_args",
+    [["-readrate", "1.0", "-readrate_initial_burst", "2"], ["-re"]],
+    ids=["readrate", "re"],
+)
+async def test_get_media_stream_respects_provider_pacing_args(
+    patch_ffmpeg: type[_FakeFFMpeg],
+    provider_pacing_args: list[str],
+) -> None:
+    """Provider-supplied -re/-readrate args suppress the automatic AudioSource pacing."""
+    streamdetails = _make_streamdetails(
+        audio_format=AudioFormat(
+            content_type=ContentType.FLAC,
+            codec_type=ContentType.FLAC,
+            sample_rate=44100,
+            bit_depth=16,
+            channels=2,
+        ),
+        extra_input_args=list(provider_pacing_args),
+    )
+    audio = _make_audio_controller()
+    await _drain(audio.get_media_stream(streamdetails, _make_pcm_format()))
+
+    assert patch_ffmpeg.last_instance is not None
+    assert patch_ffmpeg.last_instance.extra_input_args == provider_pacing_args

--- a/tests/helpers/test_audio.py
+++ b/tests/helpers/test_audio.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import AsyncGenerator
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
@@ -12,6 +15,7 @@ from music_assistant.helpers.audio import (
     build_concat_filelist,
     calculate_content_length,
     parse_loudnorm,
+    realtime_pcm_pacer,
     resolve_output_player_ids,
 )
 from music_assistant.helpers.ffmpeg import DEFAULT_MP3_BIT_RATE
@@ -118,3 +122,30 @@ def test_parse_loudnorm_reads_a_report_from_further_down_the_filter_chain() -> N
     """The marker carries the filter's position, which is not zero behind another filter."""
     chained = FFMPEG_LOUDNORM_OUTPUT.replace(b"[Parsed_loudnorm_0 @", b"[Parsed_loudnorm_1 @")
     assert parse_loudnorm(chained) == -17.86
+
+
+@pytest.mark.asyncio
+async def test_realtime_pcm_pacer_grants_bounded_initial_burst() -> None:
+    """The pacer lets a bounded head start through unpaced, then enforces realtime."""
+    # tiny format keeps the test fast: 16000 B/s, so 1s of audio is 16000 bytes
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=1,
+    )
+
+    async def _instant_producer() -> AsyncGenerator[bytes]:
+        for _ in range(10):
+            yield b"\x00" * 1600  # 0.1s of audio per chunk, produced instantly
+
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    async for _ in realtime_pcm_pacer(_instant_producer(), pcm_format):
+        pass
+    elapsed = loop.time() - start
+
+    # 1.0s of audio with a 0.5s burst allowance should take ~0.5s: clearly less
+    # than realtime (burst granted) but still paced (not instant). Bounds are
+    # deliberately wide to stay robust on loaded CI runners.
+    assert 0.3 < elapsed < 0.9


### PR DESCRIPTION
# What does this implement/fix?

Users reported sporadic audio stutter (buffer underruns) when playing a live audio source (Spotify Connect, line-in, etc.). The audio chain for live sources was paced at exactly realtime in multiple places at once, leaving zero buffer headroom anywhere in the chain — any tiny scheduling hiccup went straight to the player as an audible dropout.

- Give live audio sources a small, bounded (0.5s) read-ahead in the streams controller so short hiccups are absorbed instead of heard
- Skip the automatic pacing when a provider supplies its own `-re`/`-readrate` input args
- Remove Spotify Connect's second realtime pacing loop, which starved that headroom; backpressure still keeps the daemon close to realtime so transport commands stay responsive
- Add tests covering the pacing input args

**Related issue (if applicable):**

- related issue n/a (user reports)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
