### PR TITLE
Match artists across providers more reliably

### DIFF
--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -926,6 +926,9 @@ class ArtistsController(MediaControllerBase[Artist]):
         Try to find match on (streaming) provider for the provided (database) artist.
 
         This is used to link objects of different providers/qualities together.
+
+        :param strict: How strictly the candidate artist itself must match; the reference
+            track/album only ever has to corroborate it, never match exactly.
         """
         self.logger.debug("Trying to match artist %s on provider %s", db_artist.name, provider.name)
         # try to get a match with some reference tracks of this artist

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -42,9 +42,8 @@ from music_assistant.constants import (
     VARIOUS_ARTISTS_NAME,
 )
 from music_assistant.helpers.compare import (
-    AlbumMatchEvidence,
     compare_album,
-    compare_album_evidence,
+    compare_album_name,
     compare_artist,
     compare_strings,
     compare_track,
@@ -970,18 +969,15 @@ class ArtistsController(MediaControllerBase[Artist]):
             search_str = f"{db_artist.name} - {ref_album.name}"
             search_result_albums = await self.mass.music.albums.search(search_str, provider.domain)
             for search_result_album in search_result_albums:
-                if not search_result_album.artists:
+                # only the album's identity matters here: a different edition is still the
+                # same record by the same artist, so the credits below decide the match
+                if not compare_album_name(search_result_album.name, ref_album.name):
                     continue
-                # an edition difference does not disprove the artist, a real conflict does
-                if (
-                    compare_album_evidence(ref_album, search_result_album, strict=False)
-                    == AlbumMatchEvidence.NO_MATCH
-                ):
-                    continue
-                if matches := await self._confirm_artist_match(
-                    db_artist, search_result_album.artists[0], strict
-                ):
-                    return matches
+                for search_album_artist in search_result_album.artists:
+                    if matches := await self._confirm_artist_match(
+                        db_artist, search_album_artist, strict
+                    ):
+                        return matches
         self.logger.debug(
             "Could not find match for Artist %s on provider %s",
             db_artist.name,

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -1059,14 +1059,16 @@ class ArtistsController(MediaControllerBase[Artist]):
         """
         if not compare_artist(db_artist, candidate, strict=strict):
             return []
-        # fetch the full artist so we have all metadata, and re-compare: only the full
-        # object carries the external ids and artist type that can still reject the candidate
-        prov_artist = await self.get_provider_item(
-            candidate.item_id, candidate.provider, fallback=candidate
-        )
-        if not compare_artist(db_artist, prov_artist, strict=strict):
-            return []
-        return list(prov_artist.provider_mappings)
+        # only the full artist carries the external ids and artist type that can still reject
+        # the candidate, so a credit the provider cannot resolve confirms nothing; a credit
+        # that resolves to a library item is already owned by another artist
+        with contextlib.suppress(MediaNotFoundError):
+            prov_artist = await self.get_provider_item(candidate.item_id, candidate.provider)
+            if prov_artist.provider != "library" and compare_artist(
+                db_artist, prov_artist, strict=strict
+            ):
+                return list(prov_artist.provider_mappings)
+        return []
 
     async def _add_library_item(
         self, item: Artist | ItemMapping, overwrite_existing: bool = False

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -42,7 +42,9 @@ from music_assistant.constants import (
     VARIOUS_ARTISTS_NAME,
 )
 from music_assistant.helpers.compare import (
+    AlbumMatchEvidence,
     compare_album,
+    compare_album_evidence,
     compare_artist,
     compare_strings,
     compare_track,
@@ -926,7 +928,6 @@ class ArtistsController(MediaControllerBase[Artist]):
         This is used to link objects of different providers/qualities together.
         """
         self.logger.debug("Trying to match artist %s on provider %s", db_artist.name, provider.name)
-        matches: list[ProviderMapping] = []
         # try to get a match with some reference tracks of this artist
         ref_tracks = await self.mass.music.artists.tracks(db_artist.item_id, db_artist.provider)
         if len(ref_tracks) < 10:
@@ -940,22 +941,14 @@ class ArtistsController(MediaControllerBase[Artist]):
             search_str = f"{db_artist.name} - {ref_track.name}"
             search_results = await self.mass.music.tracks.search(search_str, provider.domain)
             for search_result_item in search_results:
-                if not compare_strings(search_result_item.name, ref_track.name, strict=strict):
+                # the reference track must corroborate the candidate, not merely share its title
+                if not compare_track(ref_track, search_result_item, strict=False):
                     continue
                 # get matching artist from track
                 for search_item_artist in search_result_item.artists:
-                    if not compare_strings(search_item_artist.name, db_artist.name, strict=strict):
-                        continue
-                    # 100% track match
-                    # get full artist details so we have all metadata
-                    prov_artist = await self.get_provider_item(
-                        search_item_artist.item_id,
-                        search_item_artist.provider,
-                        fallback=search_item_artist,
-                    )
-                    # 100% match
-                    matches.extend(prov_artist.provider_mappings)
-                    if matches:
+                    if matches := await self._confirm_artist_match(
+                        db_artist, search_item_artist, strict
+                    ):
                         return matches
         # try to get a match with some reference albums of this artist
         ref_albums = await self.mass.music.artists.albums(db_artist.item_id, db_artist.provider)
@@ -976,28 +969,22 @@ class ArtistsController(MediaControllerBase[Artist]):
             for search_result_album in search_result_albums:
                 if not search_result_album.artists:
                     continue
-                if not compare_strings(search_result_album.name, ref_album.name, strict=strict):
+                # an edition difference does not disprove the artist, a real conflict does
+                if (
+                    compare_album_evidence(ref_album, search_result_album, strict=False)
+                    == AlbumMatchEvidence.NO_MATCH
+                ):
                     continue
-                # artist must match 100%
-                if not compare_artist(db_artist, search_result_album.artists[0], strict=strict):
-                    continue
-                # 100% match
-                # get full artist details so we have all metadata
-                prov_artist = await self.get_provider_item(
-                    search_result_album.artists[0].item_id,
-                    search_result_album.artists[0].provider,
-                    fallback=search_result_album.artists[0],
-                )
-                matches.extend(prov_artist.provider_mappings)
-                if matches:
+                if matches := await self._confirm_artist_match(
+                    db_artist, search_result_album.artists[0], strict
+                ):
                     return matches
-        if not matches:
-            self.logger.debug(
-                "Could not find match for Artist %s on provider %s",
-                db_artist.name,
-                provider.name,
-            )
-        return matches
+        self.logger.debug(
+            "Could not find match for Artist %s on provider %s",
+            db_artist.name,
+            provider.name,
+        )
+        return []
 
     async def match_providers(self, db_artist: Artist) -> None:
         """
@@ -1057,6 +1044,26 @@ class ArtistsController(MediaControllerBase[Artist]):
                 f"provider_filter '{provider_filter}' does not match the requested "
                 f"provider '{provider_instance_id_or_domain}'"
             )
+
+    async def _confirm_artist_match(
+        self, db_artist: Artist, candidate: Artist | ItemMapping, strict: bool
+    ) -> list[ProviderMapping]:
+        """
+        Return the provider mappings of a candidate artist that confirms as the given artist.
+
+        :param candidate: The artist as credited on a search result, which may be a simplified
+            object without external ids.
+        """
+        if not compare_artist(db_artist, candidate, strict=strict):
+            return []
+        # fetch the full artist so we have all metadata, and re-compare: only the full
+        # object carries the external ids and artist type that can still reject the candidate
+        prov_artist = await self.get_provider_item(
+            candidate.item_id, candidate.provider, fallback=candidate
+        )
+        if not compare_artist(db_artist, prov_artist, strict=strict):
+            return []
+        return list(prov_artist.provider_mappings)
 
     async def _add_library_item(
         self, item: Artist | ItemMapping, overwrite_existing: bool = False

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -210,7 +210,7 @@ def compare_album_evidence(
     if version_evidence == AlbumMatchEvidence.NO_MATCH:
         return AlbumMatchEvidence.NO_MATCH
     # compare name
-    if not _compare_album_name(base_item.name, compare_item.name):
+    if not compare_album_name(base_item.name, compare_item.name):
         return AlbumMatchEvidence.NO_MATCH
 
     ambiguous = version_evidence == AlbumMatchEvidence.INSUFFICIENT
@@ -735,6 +735,16 @@ def compare_version(base_version: str, compare_version: str) -> bool:
     return _normalize_version_tokens(base_version) == _normalize_version_tokens(compare_version)
 
 
+def compare_album_name(base_name: str, compare_name: str) -> bool:
+    """Return True if two album titles are the same identity, ignoring formatting drift."""
+    # the retail suffix carries no identity information: Apple Music appends it to
+    # EP/single titles while already setting album_type
+    return compare_strings(
+        _ALBUM_SUFFIX_PATTERN.sub("", base_name),
+        _ALBUM_SUFFIX_PATTERN.sub("", compare_name),
+    )
+
+
 def compare_explicit(base: MediaItemMetadata, compare: MediaItemMetadata) -> bool | None:
     """Compare if explicit is same in metadata."""
     if base.explicit is not None and compare.explicit is not None:
@@ -785,16 +795,6 @@ def _compare_album_version(base_version: str, compare_version: str) -> AlbumMatc
         # vs. "Deluxe 2022 Remaster"): an ambiguous packaging difference a tracklist can resolve
         return AlbumMatchEvidence.INSUFFICIENT
     return AlbumMatchEvidence.NO_MATCH
-
-
-def _compare_album_name(base_name: str, compare_name: str) -> bool:
-    """Return True if two album titles are the same identity, ignoring formatting drift."""
-    # the retail suffix carries no identity information: Apple Music appends it to
-    # EP/single titles while already setting album_type
-    return compare_strings(
-        _ALBUM_SUFFIX_PATTERN.sub("", base_name),
-        _ALBUM_SUFFIX_PATTERN.sub("", compare_name),
-    )
 
 
 def _compare_safe_strings(base: str, compare: str) -> bool:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -712,7 +712,9 @@ def compare_strings(str1: str, str2: str, strict: bool = True) -> bool:
     str1_lower = str1.lower()
     str2_lower = str2.lower()
     if strict:
-        return str1_lower == str2_lower
+        # fall back to the same normalization the (search_name) candidate lookup uses,
+        # so an item that selection surfaces is never rejected here on formatting alone
+        return str1_lower == str2_lower or _compare_safe_strings(str1, str2)
     # return early if total length mismatch
     if abs(len(str1) - len(str2)) > 4:
         return False
@@ -787,26 +789,31 @@ def _compare_album_version(base_version: str, compare_version: str) -> AlbumMatc
 
 def _compare_album_name(base_name: str, compare_name: str) -> bool:
     """Return True if two album titles are the same identity, ignoring formatting drift."""
-    base_safe = _normalize_album_name(base_name)
-    compare_safe = _normalize_album_name(compare_name)
+    # the retail suffix carries no identity information: Apple Music appends it to
+    # EP/single titles while already setting album_type
+    return compare_strings(
+        _ALBUM_SUFFIX_PATTERN.sub("", base_name),
+        _ALBUM_SUFFIX_PATTERN.sub("", compare_name),
+    )
+
+
+def _compare_safe_strings(base: str, compare: str) -> bool:
+    """Return True if two names are equal ignoring case, diacritics, punctuation and spacing."""
+    base_safe = _normalize_name(base)
+    compare_safe = _normalize_name(compare)
     if base_safe and compare_safe:
         return base_safe == compare_safe
     if base_safe or compare_safe:
         return False
-    # both titles collapse to nothing under normalization (e.g. pure punctuation):
-    # fall back to a raw comparison with all whitespace removed, so spacing drift
-    # ("( )" vs "()") still matches while unrelated titles don't; the retail suffix
-    # is stripped here as well so "... - EP" still matches "..."
-    base_raw = _ALBUM_SUFFIX_PATTERN.sub("", base_name)
-    compare_raw = _ALBUM_SUFFIX_PATTERN.sub("", compare_name)
-    return "".join(base_raw.split()).casefold() == "".join(compare_raw.split()).casefold()
+    # both names collapse to nothing under normalization (e.g. the band "!!!"): fall back
+    # to a raw comparison with all whitespace removed, so spacing drift ("( )" vs "()")
+    # still matches while unrelated symbol-only names don't
+    return "".join(base.split()).casefold() == "".join(compare.split()).casefold()
 
 
-def _normalize_album_name(name: str) -> str:
-    """Return a punctuation/diacritic/whitespace-insensitive album title for identity checks."""
-    # the retail suffix carries no identity information: Apple Music appends it to
-    # EP/single titles while already setting album_type
-    name = _ALBUM_SUFFIX_PATTERN.sub("", name)
+@lru_cache(maxsize=1024)
+def _normalize_name(name: str) -> str:
+    """Return a punctuation/diacritic/whitespace-insensitive name for identity checks."""
     return create_safe_string(name, True, True)
 
 

--- a/tests/controllers/music/test_artists_match.py
+++ b/tests/controllers/music/test_artists_match.py
@@ -1,0 +1,342 @@
+"""Tests for ArtistsController provider matching (explicit, IO-capable enrichment)."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, Mock, patch
+
+from music_assistant_models.enums import ArtistType, ExternalID, MediaType
+from music_assistant_models.media_items import (
+    Album,
+    Artist,
+    ItemMapping,
+    ProviderMapping,
+    Track,
+    UniqueList,
+)
+
+from music_assistant.controllers.music.media.artists import ArtistsController
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+MB_ARTIST_ID = "11111111-1111-1111-1111-111111111111"
+OTHER_MB_ARTIST_ID = "22222222-2222-2222-2222-222222222222"
+LIBRARY_ITEM_ID = "lib1"
+# the base library artist is linked to one existing (already-loaded) provider
+BASE_MAPPING = ProviderMapping(
+    item_id="base-prov", provider_domain="tidal", provider_instance="tidal_1"
+)
+CANDIDATE_MAPPING = ProviderMapping(
+    item_id="cand", provider_domain="spotify", provider_instance="spotify_1"
+)
+
+
+# ---------------------------------------------------------------------------
+# builders
+# ---------------------------------------------------------------------------
+
+
+def _artist_id(name: str) -> str:
+    """Return the provider item id used for an artist with the given name."""
+    return name.lower().replace(" ", "-")
+
+
+def _credit(name: str, provider: str) -> ItemMapping:
+    """Build the simplified artist credit as it appears on a media item."""
+    return ItemMapping(
+        media_type=MediaType.ARTIST,
+        item_id=_artist_id(name),
+        provider=provider,
+        name=name,
+    )
+
+
+def _library_artist(
+    *,
+    name: str = "Main Artist",
+    artist_type: ArtistType = ArtistType.SINGER,
+    external_ids: set[tuple[ExternalID, str]] | None = None,
+) -> Artist:
+    """Build the base (library) artist under match."""
+    return Artist(
+        item_id=LIBRARY_ITEM_ID,
+        provider="library",
+        name=name,
+        artist_type=artist_type,
+        external_ids=external_ids or set(),
+        provider_mappings={BASE_MAPPING},
+    )
+
+
+def _provider_artist(
+    *,
+    name: str = "Main Artist",
+    artist_type: ArtistType = ArtistType.SINGER,
+    external_ids: set[tuple[ExternalID, str]] | None = None,
+) -> Artist:
+    """Build the full provider artist returned for a credited candidate."""
+    return Artist(
+        item_id=_artist_id(name),
+        provider="spotify_1",
+        name=name,
+        artist_type=artist_type,
+        external_ids=external_ids or set(),
+        provider_mappings={CANDIDATE_MAPPING},
+    )
+
+
+def _track(
+    item_id: str,
+    provider: str,
+    *,
+    name: str = "Track One",
+    album_name: str = "Album X",
+    duration: int = 200,
+    artist_names: Sequence[str] = ("Main Artist",),
+    mappings: Sequence[ProviderMapping] | None = None,
+) -> Track:
+    """Build a track for the reference-track leg, with its artists credited by name."""
+    if mappings is None:
+        mappings = [
+            ProviderMapping(item_id=item_id, provider_domain=provider, provider_instance=provider)
+        ]
+    return Track(
+        item_id=item_id,
+        provider=provider,
+        name=name,
+        duration=duration,
+        disc_number=1,
+        track_number=1,
+        artists=UniqueList([_credit(artist_name, provider) for artist_name in artist_names]),
+        album=ItemMapping(
+            media_type=MediaType.ALBUM,
+            item_id=f"{item_id}-album",
+            provider=provider,
+            name=album_name,
+        ),
+        provider_mappings=set(mappings),
+    )
+
+
+def _album(
+    item_id: str,
+    provider: str,
+    *,
+    name: str = "Album X",
+    version: str = "",
+    artist_names: Sequence[str] = ("Main Artist",),
+    mappings: Sequence[ProviderMapping] | None = None,
+) -> Album:
+    """Build an album for the reference-album leg, with its artists credited by name."""
+    if mappings is None:
+        mappings = [
+            ProviderMapping(item_id=item_id, provider_domain=provider, provider_instance=provider)
+        ]
+    return Album(
+        item_id=item_id,
+        provider=provider,
+        name=name,
+        version=version,
+        artists=UniqueList([_credit(artist_name, provider) for artist_name in artist_names]),
+        provider_mappings=set(mappings),
+    )
+
+
+def _provider() -> Mock:
+    """Return a mock streaming MusicProvider for matching."""
+    provider = Mock()
+    provider.name = "Spotify"
+    provider.instance_id = "spotify_1"
+    provider.domain = "spotify"
+    return provider
+
+
+@dataclass
+class _Harness:
+    """A controller under test together with its mocked IO boundaries."""
+
+    ctrl: ArtistsController
+    track_search: AsyncMock
+    album_search: AsyncMock
+    get_provider_item: AsyncMock
+    provider: Mock
+
+    async def match(self, db_artist: Artist, *, strict: bool = True) -> list[ProviderMapping]:
+        """Match against the single (streaming) provider the harness owns."""
+        return await self.ctrl.match_provider(db_artist, self.provider, strict)
+
+
+@contextmanager
+def _harness(
+    *,
+    ref_tracks: Sequence[Track] = (),
+    track_results: Sequence[Track] = (),
+    ref_albums: Sequence[Album] = (),
+    album_results: Sequence[Album] = (),
+    provider_artists: Sequence[Artist] = (),
+) -> Iterator[_Harness]:
+    """
+    Yield an ArtistsController with every IO boundary mocked.
+
+    :param ref_tracks: Reference tracks of the library artist.
+    :param track_results: Track search results returned by the matched provider.
+    :param ref_albums: Reference albums of the library artist.
+    :param album_results: Album search results returned by the matched provider.
+    :param provider_artists: Full provider artists, resolved by their item id.
+    """
+    full_artists = {artist.item_id: artist for artist in provider_artists}
+
+    async def _artist_tracks(item_id: str, _provider: str) -> list[Track]:
+        return list(ref_tracks) if item_id == LIBRARY_ITEM_ID else []
+
+    async def _artist_albums(item_id: str, _provider: str) -> list[Album]:
+        return list(ref_albums) if item_id == LIBRARY_ITEM_ID else []
+
+    track_search = AsyncMock(return_value=list(track_results))
+    album_search = AsyncMock(return_value=list(album_results))
+    mass = Mock()
+    mass.music.artists.tracks = AsyncMock(side_effect=_artist_tracks)
+    mass.music.artists.albums = AsyncMock(side_effect=_artist_albums)
+    mass.music.tracks.search = track_search
+    mass.music.albums.search = album_search
+    ctrl = ArtistsController.__new__(ArtistsController)
+    ctrl.logger = logging.getLogger("test.artists.match")
+    ctrl.mass = mass
+    get_provider_item = AsyncMock(
+        side_effect=lambda item_id, _provider, **_kwargs: full_artists[item_id]
+    )
+    with patch.multiple(ctrl, get_provider_item=get_provider_item):
+        yield _Harness(ctrl, track_search, album_search, get_provider_item, _provider())
+
+
+# ---------------------------------------------------------------------------
+# reference-track leg
+# ---------------------------------------------------------------------------
+
+
+async def test_corroborating_reference_track_matches() -> None:
+    """A search result the reference track corroborates yields the candidate's mappings."""
+    with _harness(
+        ref_tracks=[_track("lib-track", "library", mappings=(BASE_MAPPING,))],
+        track_results=[_track("s1", "spotify_1")],
+        provider_artists=[_provider_artist()],
+    ) as harness:
+        matches = await harness.match(_library_artist())
+
+    assert matches == [CANDIDATE_MAPPING]
+
+
+async def test_same_title_on_another_recording_does_not_match() -> None:
+    """A result that only shares the track title is not corroboration."""
+    with _harness(
+        ref_tracks=[_track("lib-track", "library", mappings=(BASE_MAPPING,))],
+        track_results=[_track("s1", "spotify_1", album_name="Other Album", duration=260)],
+        provider_artists=[_provider_artist()],
+    ) as harness:
+        matches = await harness.match(_library_artist())
+
+    assert matches == []
+    harness.get_provider_item.assert_not_awaited()
+
+
+async def test_featuring_artist_difference_does_not_block_match() -> None:
+    """A result crediting only the main artist still corroborates a featured-artist track."""
+    with _harness(
+        ref_tracks=[
+            _track(
+                "lib-track",
+                "library",
+                artist_names=("Main Artist", "Feat Artist"),
+                mappings=(BASE_MAPPING,),
+            )
+        ],
+        track_results=[_track("s1", "spotify_1")],
+        provider_artists=[_provider_artist()],
+    ) as harness:
+        matches = await harness.match(_library_artist())
+
+    assert matches == [CANDIDATE_MAPPING]
+
+
+async def test_accent_drift_on_artist_name_matches() -> None:
+    """An accented library artist matches its unaccented spelling on the provider."""
+    with _harness(
+        ref_tracks=[
+            _track("lib-track", "library", artist_names=("Sigur Rós",), mappings=(BASE_MAPPING,))
+        ],
+        track_results=[_track("s1", "spotify_1", artist_names=("Sigur Ros",))],
+        provider_artists=[_provider_artist(name="Sigur Ros")],
+    ) as harness:
+        matches = await harness.match(_library_artist(name="Sigur Rós"))
+
+    assert matches == [CANDIDATE_MAPPING]
+
+
+# ---------------------------------------------------------------------------
+# full-artist confirmation
+# ---------------------------------------------------------------------------
+
+
+async def test_conflicting_musicbrainz_id_on_full_artist_rejects() -> None:
+    """A same-named candidate whose full artist is a different MusicBrainz artist is rejected."""
+    with _harness(
+        ref_tracks=[_track("lib-track", "library", mappings=(BASE_MAPPING,))],
+        track_results=[_track("s1", "spotify_1")],
+        provider_artists=[
+            _provider_artist(external_ids={(ExternalID.MB_ARTIST, OTHER_MB_ARTIST_ID)})
+        ],
+    ) as harness:
+        matches = await harness.match(
+            _library_artist(external_ids={(ExternalID.MB_ARTIST, MB_ARTIST_ID)})
+        )
+
+    assert matches == []
+    # the credit itself carries no external ids, so only the full artist can reject it
+    harness.get_provider_item.assert_awaited_once()
+
+
+async def test_conflicting_artist_type_on_full_artist_rejects() -> None:
+    """A same-named candidate whose full artist is a different artist type is rejected."""
+    with _harness(
+        ref_tracks=[_track("lib-track", "library", mappings=(BASE_MAPPING,))],
+        track_results=[_track("s1", "spotify_1")],
+        provider_artists=[_provider_artist(artist_type=ArtistType.SINGER)],
+    ) as harness:
+        matches = await harness.match(_library_artist(artist_type=ArtistType.AUTHOR))
+
+    assert matches == []
+    harness.get_provider_item.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# reference-album leg
+# ---------------------------------------------------------------------------
+
+
+async def test_reference_album_edition_difference_confirms_artist() -> None:
+    """An edition difference between the reference album and the result still confirms."""
+    with _harness(
+        ref_albums=[_album("lib-album", "library", mappings=(BASE_MAPPING,))],
+        album_results=[_album("s1", "spotify_1", version="Deluxe Edition")],
+        provider_artists=[_provider_artist()],
+    ) as harness:
+        matches = await harness.match(_library_artist())
+
+    assert matches == [CANDIDATE_MAPPING]
+
+
+async def test_reference_album_recording_conflict_does_not_match() -> None:
+    """A live edition of the reference album is a different record, so it cannot confirm."""
+    with _harness(
+        ref_albums=[_album("lib-album", "library", mappings=(BASE_MAPPING,))],
+        album_results=[_album("s1", "spotify_1", version="Live")],
+        provider_artists=[_provider_artist()],
+    ) as harness:
+        matches = await harness.match(_library_artist())
+
+    assert matches == []
+    harness.get_provider_item.assert_not_awaited()

--- a/tests/controllers/music/test_artists_match.py
+++ b/tests/controllers/music/test_artists_match.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock, patch
 
 from music_assistant_models.enums import ArtistType, ExternalID, MediaType
+from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -206,9 +207,13 @@ def _harness(
     ctrl = ArtistsController.__new__(ArtistsController)
     ctrl.logger = logging.getLogger("test.artists.match")
     ctrl.mass = mass
-    get_provider_item = AsyncMock(
-        side_effect=lambda item_id, _provider, **_kwargs: full_artists[item_id]
-    )
+
+    async def _full_artist(item_id: str, _provider: str, **_kwargs: object) -> Artist:
+        if item_id not in full_artists:
+            raise MediaNotFoundError(item_id)
+        return full_artists[item_id]
+
+    get_provider_item = AsyncMock(side_effect=_full_artist)
     with patch.multiple(ctrl, get_provider_item=get_provider_item):
         yield _Harness(ctrl, track_search, album_search, get_provider_item, _provider())
 
@@ -340,3 +345,34 @@ async def test_reference_album_recording_conflict_does_not_match() -> None:
 
     assert matches == []
     harness.get_provider_item.assert_not_awaited()
+
+
+async def test_unresolvable_credit_does_not_match() -> None:
+    """A credit the provider cannot resolve to a full artist confirms nothing."""
+    with _harness(
+        ref_tracks=[_track("lib-track", "library", mappings=(BASE_MAPPING,))],
+        track_results=[_track("s1", "spotify_1")],
+        provider_artists=[],
+    ) as harness:
+        matches = await harness.match(_library_artist())
+
+    assert matches == []
+
+
+async def test_credit_owned_by_another_library_artist_does_not_match() -> None:
+    """A credit that resolves to a library item belongs to another artist, so it cannot confirm."""
+    other_library_artist = Artist(
+        item_id="lib2",
+        provider="library",
+        name="Main Artist",
+        provider_mappings={BASE_MAPPING, CANDIDATE_MAPPING},
+    )
+    with _harness(
+        ref_tracks=[_track("lib-track", "library", mappings=(BASE_MAPPING,))],
+        track_results=[_track("s1", "spotify_1")],
+    ) as harness:
+        harness.get_provider_item.side_effect = None
+        harness.get_provider_item.return_value = other_library_artist
+        matches = await harness.match(_library_artist())
+
+    assert matches == []

--- a/tests/controllers/music/test_artists_match.py
+++ b/tests/controllers/music/test_artists_match.py
@@ -334,17 +334,55 @@ async def test_reference_album_edition_difference_confirms_artist() -> None:
     assert matches == [CANDIDATE_MAPPING]
 
 
-async def test_reference_album_recording_conflict_does_not_match() -> None:
-    """A live edition of the reference album is a different record, so it cannot confirm."""
+async def test_reference_album_packaging_editions_confirm_artist() -> None:
+    """Two non-overlapping packaging editions are still the same record by the same artist."""
+    with _harness(
+        ref_albums=[
+            _album("lib-album", "library", version="2009 Remaster", mappings=(BASE_MAPPING,))
+        ],
+        album_results=[_album("s1", "spotify_1", version="Deluxe Edition")],
+        provider_artists=[_provider_artist()],
+    ) as harness:
+        matches = await harness.match(_library_artist())
+
+    assert matches == [CANDIDATE_MAPPING]
+
+
+async def test_reference_album_retail_suffix_confirms_artist() -> None:
+    """An Apple-style retail suffix on the provider title does not block the match."""
     with _harness(
         ref_albums=[_album("lib-album", "library", mappings=(BASE_MAPPING,))],
-        album_results=[_album("s1", "spotify_1", version="Live")],
+        album_results=[_album("s1", "spotify_1", name="Album X - EP")],
+        provider_artists=[_provider_artist()],
+    ) as harness:
+        matches = await harness.match(_library_artist())
+
+    assert matches == [CANDIDATE_MAPPING]
+
+
+async def test_reference_album_different_title_does_not_match() -> None:
+    """A search result for another album cannot confirm the artist."""
+    with _harness(
+        ref_albums=[_album("lib-album", "library", mappings=(BASE_MAPPING,))],
+        album_results=[_album("s1", "spotify_1", name="Another Album")],
         provider_artists=[_provider_artist()],
     ) as harness:
         matches = await harness.match(_library_artist())
 
     assert matches == []
     harness.get_provider_item.assert_not_awaited()
+
+
+async def test_album_credit_beyond_the_first_confirms_artist() -> None:
+    """A collaboration album crediting the artist second still confirms it."""
+    with _harness(
+        ref_albums=[_album("lib-album", "library", mappings=(BASE_MAPPING,))],
+        album_results=[_album("s1", "spotify_1", artist_names=("Other Artist", "Main Artist"))],
+        provider_artists=[_provider_artist()],
+    ) as harness:
+        matches = await harness.match(_library_artist())
+
+    assert matches == [CANDIDATE_MAPPING]
 
 
 async def test_unresolvable_credit_does_not_match() -> None:

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -195,6 +195,32 @@ def test_compare_artist() -> None:
     assert compare.compare_artist(artist_a, artist_b) is False
 
 
+def test_compare_artist_name_normalization() -> None:
+    """An accent difference in an artist name does not block a strict match."""
+    artist_a = media_items.Artist(
+        item_id="1",
+        provider="test1",
+        name="Bj\u00f6rk",
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id="1", provider_domain="test", provider_instance="test1"
+            )
+        },
+    )
+    artist_b = media_items.Artist(
+        item_id="2",
+        provider="test2",
+        name="Bjork",
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id="2", provider_domain="test", provider_instance="test2"
+            )
+        },
+    )
+
+    assert compare.compare_artist(artist_a, artist_b) is True
+
+
 def test_compare_album() -> None:
     """Test album comparison."""
     album_a = media_items.Album(
@@ -1036,6 +1062,34 @@ def test_compare_track_missing_disc_number_assumes_disc_one() -> None:
     disc_two = _albumtrack("3", "test2", disc_number=2)
     disc_two.duration = 320
     assert compare.compare_track(untagged, disc_two) is False
+
+
+def test_compare_strings_accent_drift_matches() -> None:
+    """Diacritics do not distinguish two otherwise identical names."""
+    assert compare.compare_strings("Sigur R\u00f3s", "Sigur Ros") is True
+    assert compare.compare_strings("C\u00e9line Dion", "Celine Dion") is True
+    assert compare.compare_strings("Bj\u00f6rk", "Bjork") is True
+
+
+def test_compare_strings_punctuation_and_spacing_drift_matches() -> None:
+    """Apostrophe, punctuation and spacing drift does not distinguish two names."""
+    assert compare.compare_strings("Jane's Addiction", "Jane\u2019s Addiction") is True
+    assert compare.compare_strings("A.C. Newman", "AC Newman") is True
+    assert compare.compare_strings("All-4-One", "All4One") is True
+
+
+def test_compare_strings_symbol_only_names_stay_distinct() -> None:
+    """Names that normalize to nothing are compared raw, so only real duplicates match."""
+    assert compare.compare_strings("!!!", "...") is False
+    # spacing drift within such a name is still the same name
+    assert compare.compare_strings("( )", "()") is True
+    # a name that normalizes to nothing is never the same as one that doesn't
+    assert compare.compare_strings("!!!", "Chk Chk Chk") is False
+
+
+def test_compare_strings_normalization_does_not_leak_into_fuzzy() -> None:
+    """The non-strict path keeps its own (more lenient) verdicts."""
+    assert compare.compare_strings("!!!", "...", strict=False) is True
 
 
 def test_compare_strings_case_insensitive_fuzzy() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5783. Artists that exist on several providers often stayed unlinked. The artist matcher compared names with plain lowercase equality, while the database lookup that surfaces the candidates in the first place already ignores accents, punctuation and spacing — so "Björk" and "Bjork", or "Céline Dion" and "Celine Dion", were offered up as a candidate and then rejected again. The matcher also rolled its own name comparisons instead of using the shared compare helpers the other media types moved to, and never checked the artist it fetched from the provider before linking it.

Replayed against a real 8,000-artist library: 234 groups of artist rows turn out to be the same artist under two spellings, and 90 more artist pairs now match (no wrong merges found in any of them). Matched duplicate track pairs go from 1,851 to 1,866 on the same library.

- Compare names the same way we look them up, so accent, punctuation and spacing differences no longer block a match
- Names made purely of symbols (the band "!!!") are still compared as-is, so they can't all collapse into each other
- Match artists with the shared track/album/artist compare helpers instead of hand-written name checks
- Verify the full artist fetched from the provider before linking it
- A different edition of a reference album no longer blocks the artist match: only the album's identity counts, and the credits on it decide the artist

Comparing names this way costs more than a plain lowercase check (about 1.4µs extra per comparison that isn't an exact match), so CodSpeed flags the `compare_strings` benchmark. That is a deliberate trade: it is the comparison that was missing the matches, and even a full library resync only spends about a second more on it.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
