### PR TITLE
Repair duplicate tracks that are already in the library

### DIFF
--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -48,7 +48,14 @@ MUSIC_SYNC_COMPLETION_CHECK_TASK_ID: Final[str] = "music_sync_completion_check"
 TRACK_RECONCILIATION_TASK_ID: Final[str] = "music_track_reconciliation"
 
 # number of duplicate track candidate pairs examined per reconciliation run
-TRACK_RECONCILIATION_BATCH_SIZE: Final[int] = 25
+TRACK_RECONCILIATION_BATCH_SIZE: Final[int] = 100
+
+# where the duplicate track walk left off, stored so a restart resumes instead of starting
+# over: the pair last examined as [item_id, item_id], or an empty list once the walk has
+# reached the end of the library
+CONF_TRACK_RECONCILIATION_CURSOR: Final[str] = "track_reconciliation_cursor"
+# whether a sync has added content that the walk still owes another pass
+CONF_TRACK_RECONCILIATION_RESCAN_DUE: Final[str] = "track_reconciliation_rescan_due"
 # max difference in seconds between two track durations to still consider them the same
 # recording; matches the widest duration window compare_track is willing to accept
 TRACK_RECONCILIATION_MAX_DURATION_DELTA: Final[int] = 8

--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -45,3 +45,10 @@ RECOMMENDATIONS_ROWS_TIMEOUT: Final[int] = 5
 DATABASE_CLEANUP_TASK_ID: Final[str] = "music_database_cleanup"
 PROVIDER_MAPPING_CORRECTION_TASK_ID: Final[str] = "music_provider_mapping_correction"
 MUSIC_SYNC_COMPLETION_CHECK_TASK_ID: Final[str] = "music_sync_completion_check"
+TRACK_RECONCILIATION_TASK_ID: Final[str] = "music_track_reconciliation"
+
+# number of duplicate track candidate pairs examined per reconciliation run
+TRACK_RECONCILIATION_BATCH_SIZE: Final[int] = 25
+# max difference in seconds between two track durations to still consider them the same
+# recording; matches the widest duration window compare_track is willing to accept
+TRACK_RECONCILIATION_MAX_DURATION_DELTA: Final[int] = 8

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -188,6 +188,18 @@ WHERE (t1.item_id > :cursor_item_id_1
 ORDER BY t1.item_id, t2.item_id
 """
 
+# Returns the edition of every equally titled album the two tracks both appear on, so the
+# candidate pair can be held to agreeing on the edition and not just on the album title.
+_SHARED_ALBUM_EDITIONS_QUERY = f"""
+SELECT al1.version AS version_1, al2.version AS version_2
+FROM {DB_TABLE_ALBUM_TRACKS} at1
+JOIN {DB_TABLE_ALBUMS} al1 ON al1.item_id = at1.album_id
+JOIN {DB_TABLE_ALBUM_TRACKS} at2 ON at2.track_id = :item_id_2
+JOIN {DB_TABLE_ALBUMS} al2
+  ON al2.item_id = at2.album_id AND al2.search_name = al1.search_name
+WHERE at1.track_id = :item_id_1
+"""
+
 
 class MusicController(MusicDatabaseSetupMixin, CoreController):
     """Several helpers around the musicproviders."""
@@ -2755,6 +2767,22 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 )
         update_current_task_progress(100, f"Merged {merged} duplicate track(s)")
 
+    async def _albums_agree_on_edition(self, item_id_1: int, item_id_2: int) -> bool:
+        """
+        Check that two tracks share an album whose edition matches as well as its title.
+
+        :param item_id_1: Library ID of the first track.
+        :param item_id_2: Library ID of the second track.
+        """
+        # the candidate query can only compare album titles, and an edition is held apart
+        # from the title: without this an original and its remaster or deluxe edition look
+        # like the same album whenever neither track carries a version of its own
+        rows = await self.database.get_rows_from_query(
+            _SHARED_ALBUM_EDITIONS_QUERY,
+            {"item_id_1": item_id_1, "item_id_2": item_id_2},
+        )
+        return any(compare_version(row["version_1"], row["version_2"]) for row in rows)
+
     async def _merge_duplicate_track_pair(self, item_id_1: int, item_id_2: int) -> bool:
         """
         Merge two candidate rows if they are confirmed to be the same track.
@@ -2771,6 +2799,8 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         # explicitly: without it a remaster, remix or radio edit of equal length would be
         # accepted as the original.
         if not compare_version(track_1.version, track_2.version):
+            return False
+        if not await self._albums_agree_on_edition(item_id_1, item_id_2):
             return False
         if not compare_track(track_1, track_2, strict=False):
             return False

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -2753,6 +2753,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             update_current_task_progress_text("No duplicate tracks found")
             return
         merged = 0
+        retry_due = False
         examined = cursor
         try:
             for index, row in enumerate(rows, 1):
@@ -2768,6 +2769,8 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                     # an earlier merge in this batch already absorbed one of the two rows
                     pass
                 except MusicAssistantError as err:
+                    # a pair that failed on something transient deserves another look
+                    retry_due = True
                     report_current_task_failure(str(err))
                     self.logger.warning(
                         "Error while reconciling duplicate tracks %s and %s: %s",
@@ -2790,7 +2793,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             # it a duplicate of a row this walk has already passed, so ask for another pass
             self._set_track_reconciliation_state(
                 None if walked_to_end else examined,
-                self._track_reconciliation_rescan_due or merged > 0,
+                self._track_reconciliation_rescan_due or merged > 0 or retry_due,
             )
         update_current_task_progress(100, f"Merged {merged} duplicate track(s)")
 

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -2752,37 +2752,46 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             self._set_track_reconciliation_state(None, self._track_reconciliation_rescan_due)
             update_current_task_progress_text("No duplicate tracks found")
             return
-        # resume after the exact pair examined last, so candidates this run refused can never
-        # starve the ones behind them, not even a further pair of the same track that the batch
-        # boundary cut off; a short batch means the walk has reached the end of the library
-        self._set_track_reconciliation_state(
-            (int(rows[-1]["item_id_1"]), int(rows[-1]["item_id_2"]))
-            if len(rows) == TRACK_RECONCILIATION_BATCH_SIZE
-            else None,
-            self._track_reconciliation_rescan_due,
-        )
         merged = 0
-        for index, row in enumerate(rows, 1):
-            update_current_task_progress_from_index(
-                index, len(rows), f"Checking duplicate track {index}/{len(rows)}"
-            )
-            try:
-                if await self._merge_duplicate_track_pair(
-                    int(row["item_id_1"]), int(row["item_id_2"])
-                ):
-                    merged += 1
-            except MediaNotFoundError:
-                # an earlier merge in this batch already absorbed one of the two rows
-                continue
-            except MusicAssistantError as err:
-                report_current_task_failure(str(err))
-                self.logger.warning(
-                    "Error while reconciling duplicate tracks %s and %s: %s",
-                    row["item_id_1"],
-                    row["item_id_2"],
-                    str(err),
-                    exc_info=err if self.logger.isEnabledFor(logging.DEBUG) else None,
+        examined = cursor
+        try:
+            for index, row in enumerate(rows, 1):
+                update_current_task_progress_from_index(
+                    index, len(rows), f"Checking duplicate track {index}/{len(rows)}"
                 )
+                try:
+                    if await self._merge_duplicate_track_pair(
+                        int(row["item_id_1"]), int(row["item_id_2"])
+                    ):
+                        merged += 1
+                except MediaNotFoundError:
+                    # an earlier merge in this batch already absorbed one of the two rows
+                    pass
+                except MusicAssistantError as err:
+                    report_current_task_failure(str(err))
+                    self.logger.warning(
+                        "Error while reconciling duplicate tracks %s and %s: %s",
+                        row["item_id_1"],
+                        row["item_id_2"],
+                        str(err),
+                        exc_info=err if self.logger.isEnabledFor(logging.DEBUG) else None,
+                    )
+                examined = (int(row["item_id_1"]), int(row["item_id_2"]))
+        finally:
+            # resume after the pair examined last, so candidates this run refused can never
+            # starve the ones behind them, not even a further pair of the same track that the
+            # batch boundary cut off. Recording it even when the run is cut short keeps the
+            # pairs it did not reach for the next run rather than skipping past them.
+            walked_to_end = len(rows) < TRACK_RECONCILIATION_BATCH_SIZE and examined == (
+                int(rows[-1]["item_id_1"]),
+                int(rows[-1]["item_id_2"]),
+            )
+            # a merge moves album and artist relations onto the surviving row, which can make
+            # it a duplicate of a row this walk has already passed, so ask for another pass
+            self._set_track_reconciliation_state(
+                None if walked_to_end else examined,
+                self._track_reconciliation_rescan_due or merged > 0,
+            )
         update_current_task_progress(100, f"Merged {merged} duplicate track(s)")
 
     def _restore_track_reconciliation_state(self) -> None:

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -55,8 +55,12 @@ from music_assistant_models.media_items.media_item import MediaCollection
 
 from music_assistant.constants import (
     CONF_ENTRY_LIBRARY_SYNC_BACK,
+    DB_TABLE_ALBUM_TRACKS,
+    DB_TABLE_ALBUMS,
     DB_TABLE_PLAYLOG,
     DB_TABLE_PROVIDER_MAPPINGS,
+    DB_TABLE_TRACK_ARTISTS,
+    DB_TABLE_TRACKS,
     PROVIDERS_WITH_SHAREABLE_URLS,
 )
 from music_assistant.controllers.music.constants import (
@@ -72,6 +76,9 @@ from music_assistant.controllers.music.constants import (
     SEARCH_CACHE_EXPIRATION_STREAMING_PROVIDER,
     SEARCH_PROVIDER_HARD_TIMEOUT,
     SEARCH_PROVIDER_SOFT_TIMEOUT,
+    TRACK_RECONCILIATION_BATCH_SIZE,
+    TRACK_RECONCILIATION_MAX_DURATION_DELTA,
+    TRACK_RECONCILIATION_TASK_ID,
 )
 from music_assistant.controllers.music.database import (
     PLAYLOG_CONFLICT_KEYS,
@@ -91,10 +98,16 @@ from music_assistant.controllers.music.recency import RecencyEngine
 from music_assistant.controllers.music.recommendations.controller import (
     RecommendationsController,
 )
+from music_assistant.controllers.tasks.context import (
+    report_current_task_failure,
+    update_current_task_progress,
+    update_current_task_progress_from_index,
+    update_current_task_progress_text,
+)
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.collections import get_collection_item_media_type_from_item_id
-from music_assistant.helpers.compare import compare_strings, compare_version
+from music_assistant.helpers.compare import compare_strings, compare_track, compare_version
 from music_assistant.helpers.database import UNSET, DatabaseConnection
 from music_assistant.helpers.datetime import (
     from_utc_timestamp,
@@ -129,6 +142,45 @@ class RecentPlayedTrack(NamedTuple):
     artists: list[ItemMapping]
 
 
+# Selects pairs of library track rows that are likely the same recording held twice,
+# once per music provider. Both rows must carry the same normalized title, share a track
+# artist and sit within a few seconds of each other. The album term is the decisive one:
+# both rows must appear on an album with the same normalized title at the same position,
+# so the merge always rests on two providers agreeing on where the track belongs rather
+# than on title and duration alone. Rows that already share a provider are skipped, as a
+# provider listing the same recording twice is a separate (and far riskier) case.
+_DUPLICATE_TRACK_CANDIDATES_QUERY = f"""
+SELECT t1.item_id AS item_id_1, t2.item_id AS item_id_2
+FROM {DB_TABLE_TRACKS} t1
+JOIN {DB_TABLE_TRACKS} t2
+  ON t2.search_name = t1.search_name
+ AND t2.item_id > t1.item_id
+ AND abs(t2.duration - t1.duration) <= :max_duration_delta
+WHERE t1.item_id > :cursor
+  AND EXISTS (
+    SELECT 1 FROM {DB_TABLE_TRACK_ARTISTS} ta1
+    JOIN {DB_TABLE_TRACK_ARTISTS} ta2
+      ON ta2.artist_id = ta1.artist_id AND ta2.track_id = t2.item_id
+    WHERE ta1.track_id = t1.item_id)
+  AND EXISTS (
+    SELECT 1 FROM {DB_TABLE_ALBUM_TRACKS} at1
+    JOIN {DB_TABLE_ALBUMS} al1 ON al1.item_id = at1.album_id
+    JOIN {DB_TABLE_ALBUM_TRACKS} at2 ON at2.track_id = t2.item_id
+    JOIN {DB_TABLE_ALBUMS} al2
+      ON al2.item_id = at2.album_id AND al2.search_name = al1.search_name
+    WHERE at1.track_id = t1.item_id
+      AND coalesce(at1.disc_number, 1) = coalesce(at2.disc_number, 1)
+      AND at1.track_number = at2.track_number)
+  AND NOT EXISTS (
+    SELECT 1 FROM {DB_TABLE_PROVIDER_MAPPINGS} pm1
+    JOIN {DB_TABLE_PROVIDER_MAPPINGS} pm2
+      ON pm2.provider_domain = pm1.provider_domain
+     AND pm2.media_type = 'track' AND pm2.item_id = t2.item_id
+    WHERE pm1.media_type = 'track' AND pm1.item_id = t1.item_id)
+ORDER BY t1.item_id
+"""
+
+
 class MusicController(MusicDatabaseSetupMixin, CoreController):
     """Several helpers around the musicproviders."""
 
@@ -151,6 +203,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         self.recency = RecencyEngine(self.mass)
         self._database: DatabaseConnection | None = None
         self._sync_lock = asyncio.Lock()
+        self._track_reconciliation_cursor = 0
         self.manifest.name = "Music controller"
         self.manifest.description = (
             "Music Assistant's core controller which manages all music from all providers."
@@ -202,6 +255,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         """Handle logic after all core controllers have been set up."""
         self._register_database_cleanup_task()
         self._register_provider_mapping_correction_task()
+        self._register_track_reconciliation_task()
         self.genres.register_scheduled_scan_task()
 
     async def close(self) -> None:
@@ -2618,6 +2672,98 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             },
             allow_retry=True,
         )
+
+    def _register_track_reconciliation_task(self) -> BackgroundTask:
+        """Register the recurring duplicate track reconciliation background task."""
+        # runs every hour rather than spread across the day: it is bounded to a small
+        # batch of candidates per run and never leaves the local database
+        return self.mass.tasks.register_scheduled_task(
+            task_id=TRACK_RECONCILIATION_TASK_ID,
+            name="Reconcile duplicate tracks",
+            handler=self._reconcile_duplicate_tracks,
+            schedule=TaskSchedule.hourly(),
+            translation_key="reconcile_duplicate_tracks",
+            translation_owner=self.translation_owner,
+            metadata={
+                "task_domain": "music_track_reconciliation",
+            },
+            allow_retry=True,
+        )
+
+    async def _reconcile_duplicate_tracks(self) -> None:
+        """Merge a small batch of library tracks that are held twice across providers."""
+        update_current_task_progress_text("Searching for duplicate tracks")
+        rows = await self.database.get_rows_from_query(
+            _DUPLICATE_TRACK_CANDIDATES_QUERY,
+            {
+                "max_duration_delta": TRACK_RECONCILIATION_MAX_DURATION_DELTA,
+                "cursor": self._track_reconciliation_cursor,
+            },
+            limit=TRACK_RECONCILIATION_BATCH_SIZE,
+        )
+        if not rows:
+            # start over on the next run so tracks added (or renamed) since the last
+            # full pass are examined too
+            self._track_reconciliation_cursor = 0
+            update_current_task_progress_text("No duplicate tracks found")
+            return
+        # resume after the last examined row so candidates this run refused can never
+        # starve the ones behind them; a partial batch means the table has been drained
+        self._track_reconciliation_cursor = (
+            int(rows[-1]["item_id_1"]) if len(rows) == TRACK_RECONCILIATION_BATCH_SIZE else 0
+        )
+        merged = 0
+        for index, row in enumerate(rows, 1):
+            update_current_task_progress_from_index(
+                index, len(rows), f"Checking duplicate track {index}/{len(rows)}"
+            )
+            try:
+                if await self._merge_duplicate_track_pair(
+                    int(row["item_id_1"]), int(row["item_id_2"])
+                ):
+                    merged += 1
+            except MediaNotFoundError:
+                # an earlier merge in this batch already absorbed one of the two rows
+                continue
+            except MusicAssistantError as err:
+                report_current_task_failure(str(err))
+                self.logger.warning(
+                    "Error while reconciling duplicate tracks %s and %s: %s",
+                    row["item_id_1"],
+                    row["item_id_2"],
+                    str(err),
+                    exc_info=err if self.logger.isEnabledFor(logging.DEBUG) else None,
+                )
+        update_current_task_progress(100, f"Merged {merged} duplicate track(s)")
+
+    async def _merge_duplicate_track_pair(self, item_id_1: int, item_id_2: int) -> bool:
+        """Merge two candidate rows if they are confirmed to be the same track."""
+        track_1 = await self.tracks.get_library_item(item_id_1)
+        track_2 = await self.tracks.get_library_item(item_id_2)
+        # the candidate query already established that both rows sit on the same album at
+        # the same position, which is the album agreement strict mode looks for, so the
+        # remaining check is run in non-strict mode. Its version check is reinstated here
+        # explicitly: without it a remaster, remix or radio edit of equal length would be
+        # accepted as the original.
+        if not compare_version(track_1.version, track_2.version):
+            return False
+        if not compare_track(track_1, track_2, strict=False):
+            return False
+        # keep the row that carries the most provider mappings so the fewest mappings and
+        # relations have to move; equal counts keep the oldest row, which the query orders first
+        target, source = (
+            (track_1, track_2)
+            if len(track_1.provider_mappings) >= len(track_2.provider_mappings)
+            else (track_2, track_1)
+        )
+        self.logger.debug(
+            "Merging duplicate track %s (id %s) into id %s",
+            target.name,
+            source.item_id,
+            target.item_id,
+        )
+        await self.tracks.merge_library_items(target.item_id, source.item_id)
+        return True
 
     def _queue_database_cleanup_task(self) -> BackgroundTask:
         """Queue the post-sync database cleanup as a managed background task."""

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -2645,6 +2645,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         if self.active_sync_tasks:
             return
         self.mass.signal_event(EventType.MUSIC_SYNC_COMPLETED)
+        # freshly synced content is the only source of new duplicates, so let the
+        # reconciliation pass walk the library again from the start
+        self._track_reconciliation_cursor = (0, 0)
         self._queue_database_cleanup_task()
 
     def _register_database_cleanup_task(self) -> BackgroundTask:
@@ -2717,18 +2720,16 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             limit=TRACK_RECONCILIATION_BATCH_SIZE,
         )
         if not rows:
-            # start over on the next run so tracks added (or renamed) since the last
-            # full pass are examined too
-            self._track_reconciliation_cursor = (0, 0)
             update_current_task_progress_text("No duplicate tracks found")
             return
         # resume after the exact pair examined last, so candidates this run refused can never
         # starve the ones behind them, not even a further pair of the same track that the batch
-        # boundary cut off; a partial batch means the table has been drained
+        # boundary cut off. The cursor is deliberately left where the library ends: walking off
+        # the end costs nothing, while starting over would rescan the whole table every hour.
+        # A completed sync rewinds it, as that is when new duplicates can appear.
         self._track_reconciliation_cursor = (
-            (int(rows[-1]["item_id_1"]), int(rows[-1]["item_id_2"]))
-            if len(rows) == TRACK_RECONCILIATION_BATCH_SIZE
-            else (0, 0)
+            int(rows[-1]["item_id_1"]),
+            int(rows[-1]["item_id_2"]),
         )
         merged = 0
         for index, row in enumerate(rows, 1):

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -173,8 +173,10 @@ WHERE (t1.item_id > :cursor_item_id_1
       ON al2.item_id = at2.album_id AND al2.search_name = al1.search_name
     WHERE at1.track_id = t1.item_id
       AND al1.search_name != ''
-      -- a disc number of 0 means the provider did not report one: assume disc 1,
-      -- matching how compare_track reads it for local files without a disc tag
+      -- an unreported position is stored as 0, so two of those agree on nothing;
+      -- a missing disc number does read as disc 1, the way compare_track takes it
+      -- for local files that carry no disc tag
+      AND at1.track_number > 0
       AND coalesce(nullif(at1.disc_number, 0), 1) = coalesce(nullif(at2.disc_number, 0), 1)
       AND at1.track_number = at2.track_number)
   AND NOT EXISTS (

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -145,10 +145,12 @@ class RecentPlayedTrack(NamedTuple):
 # Selects pairs of library track rows that are likely the same recording held twice,
 # once per music provider. Both rows must carry the same normalized title, share a track
 # artist and sit within a few seconds of each other. The album term is the decisive one:
-# both rows must appear on an album with the same normalized title at the same position,
+# both rows must appear at the same position on an album with the same normalized title,
 # so the merge always rests on two providers agreeing on where the track belongs rather
-# than on title and duration alone. Rows that already share a provider are skipped, as a
-# provider listing the same recording twice is a separate (and far riskier) case.
+# than on title and duration alone. Titles that normalize to nothing (symbol-only album
+# names) are excluded there, as they would match every other such album. Rows that already
+# share a provider are skipped, as a provider listing the same recording twice is a
+# separate (and far riskier) case.
 _DUPLICATE_TRACK_CANDIDATES_QUERY = f"""
 SELECT t1.item_id AS item_id_1, t2.item_id AS item_id_2
 FROM {DB_TABLE_TRACKS} t1
@@ -170,7 +172,10 @@ WHERE (t1.item_id > :cursor_item_id_1
     JOIN {DB_TABLE_ALBUMS} al2
       ON al2.item_id = at2.album_id AND al2.search_name = al1.search_name
     WHERE at1.track_id = t1.item_id
-      AND coalesce(at1.disc_number, 1) = coalesce(at2.disc_number, 1)
+      AND al1.search_name != ''
+      -- a disc number of 0 means the provider did not report one: assume disc 1,
+      -- matching how compare_track reads it for local files without a disc tag
+      AND coalesce(nullif(at1.disc_number, 0), 1) = coalesce(nullif(at2.disc_number, 0), 1)
       AND at1.track_number = at2.track_number)
   AND NOT EXISTS (
     SELECT 1 FROM {DB_TABLE_PROVIDER_MAPPINGS} pm1
@@ -2693,6 +2698,11 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
 
     async def _reconcile_duplicate_tracks(self) -> None:
         """Merge a small batch of library tracks that are held twice across providers."""
+        if self.active_sync_tasks:
+            # a sync is still filling in albums and mappings, so hold off rather than
+            # judge duplicates against a half-populated library
+            update_current_task_progress_text("Waiting for music sync completion")
+            return
         update_current_task_progress_text("Searching for duplicate tracks")
         cursor_item_id_1, cursor_item_id_2 = self._track_reconciliation_cursor
         rows = await self.database.get_rows_from_query(
@@ -2743,11 +2753,17 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         update_current_task_progress(100, f"Merged {merged} duplicate track(s)")
 
     async def _merge_duplicate_track_pair(self, item_id_1: int, item_id_2: int) -> bool:
-        """Merge two candidate rows if they are confirmed to be the same track."""
+        """
+        Merge two candidate rows if they are confirmed to be the same track.
+
+        :param item_id_1: Library ID of the lower-numbered candidate row.
+        :param item_id_2: Library ID of the higher-numbered candidate row.
+        :return: True when the rows were merged, False when they were left alone.
+        """
         track_1 = await self.tracks.get_library_item(item_id_1)
         track_2 = await self.tracks.get_library_item(item_id_2)
-        # the candidate query already established that both rows sit on the same album at
-        # the same position, which is the album agreement strict mode looks for, so the
+        # the candidate query already established that both rows sit at the same position on
+        # an equally titled album, which is the album agreement strict mode looks for, so the
         # remaining check is run in non-strict mode. Its version check is reinstated here
         # explicitly: without it a remaster, remix or radio edit of equal length would be
         # accepted as the original.

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -188,8 +188,10 @@ WHERE (t1.item_id > :cursor_item_id_1
 ORDER BY t1.item_id, t2.item_id
 """
 
-# Returns the edition of every equally titled album the two tracks both appear on, so the
-# candidate pair can be held to agreeing on the edition and not just on the album title.
+# Returns the edition of every album appearance that made the two tracks a candidate, so the
+# pair can be held to agreeing on the edition and not just on the album title. The album terms
+# mirror the candidate query exactly: an appearance the pair does not share a position on says
+# nothing about the edition of the one it does.
 _SHARED_ALBUM_EDITIONS_QUERY = f"""
 SELECT al1.version AS version_1, al2.version AS version_2
 FROM {DB_TABLE_ALBUM_TRACKS} at1
@@ -198,6 +200,10 @@ JOIN {DB_TABLE_ALBUM_TRACKS} at2 ON at2.track_id = :item_id_2
 JOIN {DB_TABLE_ALBUMS} al2
   ON al2.item_id = at2.album_id AND al2.search_name = al1.search_name
 WHERE at1.track_id = :item_id_1
+  AND al1.search_name != ''
+  AND at1.track_number > 0
+  AND coalesce(nullif(at1.disc_number, 0), 1) = coalesce(nullif(at2.disc_number, 0), 1)
+  AND at1.track_number = at2.track_number
 """
 
 
@@ -223,7 +229,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         self.recency = RecencyEngine(self.mass)
         self._database: DatabaseConnection | None = None
         self._sync_lock = asyncio.Lock()
-        self._track_reconciliation_cursor: tuple[int, int] = (0, 0)
+        self._track_reconciliation_cursor: tuple[int, int] | None = (0, 0)
         self._track_reconciliation_rescan_due = False
         self.manifest.name = "Music controller"
         self.manifest.description = (
@@ -2722,31 +2728,34 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             # judge duplicates against a half-populated library
             update_current_task_progress_text("Waiting for music sync completion")
             return
+        self._start_next_pass_if_due()
+        if (cursor := self._track_reconciliation_cursor) is None:
+            # the library has been walked end to end and nothing has been synced since,
+            # so there is nothing to look for: skip the query rather than scan for a miss
+            update_current_task_progress_text("No duplicate tracks found")
+            return
         update_current_task_progress_text("Searching for duplicate tracks")
-        cursor_item_id_1, cursor_item_id_2 = self._track_reconciliation_cursor
         rows = await self.database.get_rows_from_query(
             _DUPLICATE_TRACK_CANDIDATES_QUERY,
             {
                 "max_duration_delta": TRACK_RECONCILIATION_MAX_DURATION_DELTA,
-                "cursor_item_id_1": cursor_item_id_1,
-                "cursor_item_id_2": cursor_item_id_2,
+                "cursor_item_id_1": cursor[0],
+                "cursor_item_id_2": cursor[1],
             },
             limit=TRACK_RECONCILIATION_BATCH_SIZE,
         )
         if not rows:
-            self._start_next_pass_if_due()
+            self._track_reconciliation_cursor = None
             update_current_task_progress_text("No duplicate tracks found")
             return
         # resume after the exact pair examined last, so candidates this run refused can never
         # starve the ones behind them, not even a further pair of the same track that the batch
-        # boundary cut off. The cursor is deliberately left where the library ends: walking off
-        # the end costs nothing, while starting over would rescan the whole table every hour.
+        # boundary cut off; a short batch means the walk has reached the end of the library
         self._track_reconciliation_cursor = (
-            int(rows[-1]["item_id_1"]),
-            int(rows[-1]["item_id_2"]),
+            (int(rows[-1]["item_id_1"]), int(rows[-1]["item_id_2"]))
+            if len(rows) == TRACK_RECONCILIATION_BATCH_SIZE
+            else None
         )
-        if len(rows) < TRACK_RECONCILIATION_BATCH_SIZE:
-            self._start_next_pass_if_due()
         merged = 0
         for index, row in enumerate(rows, 1):
             update_current_task_progress_from_index(
@@ -2772,8 +2781,12 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         update_current_task_progress(100, f"Merged {merged} duplicate track(s)")
 
     def _start_next_pass_if_due(self) -> None:
-        """Rewind the duplicate track walk if a sync has added content since it started."""
+        """Rewind the duplicate track walk if a sync has added content and the walk is done."""
+        # rewinding a walk still in progress would keep re-examining the same first
+        # candidates, so a pending rescan waits for the current one to reach the end
         if not self._track_reconciliation_rescan_due:
+            return
+        if self._track_reconciliation_cursor is not None:
             return
         self._track_reconciliation_cursor = (0, 0)
         self._track_reconciliation_rescan_due = False

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -67,6 +67,8 @@ from music_assistant.controllers.music.constants import (
     CACHE_CATEGORY_SEARCH_RESULTS,
     CONF_DELETED_PROVIDERS,
     CONF_RESET_DB,
+    CONF_TRACK_RECONCILIATION_CURSOR,
+    CONF_TRACK_RECONCILIATION_RESCAN_DUE,
     DATABASE_CLEANUP_TASK_ID,
     DB_SCHEMA_VERSION,
     MUSIC_SYNC_COMPLETION_CHECK_TASK_ID,
@@ -212,6 +214,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
 
     domain: str = "music"
     config: CoreConfig
+    # where the duplicate track walk stands; restored from config on startup
+    _track_reconciliation_cursor: tuple[int, int] | None = (0, 0)
+    _track_reconciliation_rescan_due: bool = False
 
     def __init__(self, mass: MusicAssistant) -> None:
         """Initialize class."""
@@ -229,8 +234,6 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         self.recency = RecencyEngine(self.mass)
         self._database: DatabaseConnection | None = None
         self._sync_lock = asyncio.Lock()
-        self._track_reconciliation_cursor: tuple[int, int] | None = (0, 0)
-        self._track_reconciliation_rescan_due = False
         self.manifest.name = "Music controller"
         self.manifest.description = (
             "Music Assistant's core controller which manages all music from all providers."
@@ -282,6 +285,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         """Handle logic after all core controllers have been set up."""
         self._register_database_cleanup_task()
         self._register_provider_mapping_correction_task()
+        self._restore_track_reconciliation_state()
         self._register_track_reconciliation_task()
         self.genres.register_scheduled_scan_task()
 
@@ -2667,7 +2671,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         # freshly synced content is the only source of new duplicates, so the reconciliation
         # pass owes the library another walk; it starts once the current one reaches the end,
         # since rewinding right now would keep re-examining the same prefix forever
-        self._track_reconciliation_rescan_due = True
+        self._set_track_reconciliation_state(self._track_reconciliation_cursor, True)
         self._queue_database_cleanup_task()
 
     def _register_database_cleanup_task(self) -> BackgroundTask:
@@ -2745,16 +2749,17 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             limit=TRACK_RECONCILIATION_BATCH_SIZE,
         )
         if not rows:
-            self._track_reconciliation_cursor = None
+            self._set_track_reconciliation_state(None, self._track_reconciliation_rescan_due)
             update_current_task_progress_text("No duplicate tracks found")
             return
         # resume after the exact pair examined last, so candidates this run refused can never
         # starve the ones behind them, not even a further pair of the same track that the batch
         # boundary cut off; a short batch means the walk has reached the end of the library
-        self._track_reconciliation_cursor = (
+        self._set_track_reconciliation_state(
             (int(rows[-1]["item_id_1"]), int(rows[-1]["item_id_2"]))
             if len(rows) == TRACK_RECONCILIATION_BATCH_SIZE
-            else None
+            else None,
+            self._track_reconciliation_rescan_due,
         )
         merged = 0
         for index, row in enumerate(rows, 1):
@@ -2780,6 +2785,38 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 )
         update_current_task_progress(100, f"Merged {merged} duplicate track(s)")
 
+    def _restore_track_reconciliation_state(self) -> None:
+        """Pick the duplicate track walk back up where the previous run left it."""
+        cursor = self.mass.config.get_raw_core_config_value(
+            self.domain, CONF_TRACK_RECONCILIATION_CURSOR, [0, 0]
+        )
+        self._track_reconciliation_cursor = (
+            (int(cursor[0]), int(cursor[1])) if len(cursor) == 2 else None
+        )
+        self._track_reconciliation_rescan_due = bool(
+            self.mass.config.get_raw_core_config_value(
+                self.domain, CONF_TRACK_RECONCILIATION_RESCAN_DUE, False
+            )
+        )
+
+    def _set_track_reconciliation_state(
+        self, cursor: tuple[int, int] | None, rescan_due: bool
+    ) -> None:
+        """
+        Record how far the duplicate track walk has come, surviving a restart.
+
+        :param cursor: The pair examined last, or None once the walk reached the end.
+        :param rescan_due: Whether a completed sync still owes the library another pass.
+        """
+        self._track_reconciliation_cursor = cursor
+        self._track_reconciliation_rescan_due = rescan_due
+        self.mass.config.set_raw_core_config_value(
+            self.domain, CONF_TRACK_RECONCILIATION_CURSOR, list(cursor) if cursor else []
+        )
+        self.mass.config.set_raw_core_config_value(
+            self.domain, CONF_TRACK_RECONCILIATION_RESCAN_DUE, rescan_due
+        )
+
     def _start_next_pass_if_due(self) -> None:
         """Rewind the duplicate track walk if a sync has added content and the walk is done."""
         # rewinding a walk still in progress would keep re-examining the same first
@@ -2788,8 +2825,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             return
         if self._track_reconciliation_cursor is not None:
             return
-        self._track_reconciliation_cursor = (0, 0)
-        self._track_reconciliation_rescan_due = False
+        self._set_track_reconciliation_state((0, 0), False)
 
     async def _albums_agree_on_edition(self, item_id_1: int, item_id_2: int) -> bool:
         """

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -224,6 +224,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         self._database: DatabaseConnection | None = None
         self._sync_lock = asyncio.Lock()
         self._track_reconciliation_cursor: tuple[int, int] = (0, 0)
+        self._track_reconciliation_rescan_due = False
         self.manifest.name = "Music controller"
         self.manifest.description = (
             "Music Assistant's core controller which manages all music from all providers."
@@ -2657,9 +2658,10 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         if self.active_sync_tasks:
             return
         self.mass.signal_event(EventType.MUSIC_SYNC_COMPLETED)
-        # freshly synced content is the only source of new duplicates, so let the
-        # reconciliation pass walk the library again from the start
-        self._track_reconciliation_cursor = (0, 0)
+        # freshly synced content is the only source of new duplicates, so the reconciliation
+        # pass owes the library another walk; it starts once the current one reaches the end,
+        # since rewinding right now would keep re-examining the same prefix forever
+        self._track_reconciliation_rescan_due = True
         self._queue_database_cleanup_task()
 
     def _register_database_cleanup_task(self) -> BackgroundTask:
@@ -2732,17 +2734,19 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             limit=TRACK_RECONCILIATION_BATCH_SIZE,
         )
         if not rows:
+            self._start_next_pass_if_due()
             update_current_task_progress_text("No duplicate tracks found")
             return
         # resume after the exact pair examined last, so candidates this run refused can never
         # starve the ones behind them, not even a further pair of the same track that the batch
         # boundary cut off. The cursor is deliberately left where the library ends: walking off
         # the end costs nothing, while starting over would rescan the whole table every hour.
-        # A completed sync rewinds it, as that is when new duplicates can appear.
         self._track_reconciliation_cursor = (
             int(rows[-1]["item_id_1"]),
             int(rows[-1]["item_id_2"]),
         )
+        if len(rows) < TRACK_RECONCILIATION_BATCH_SIZE:
+            self._start_next_pass_if_due()
         merged = 0
         for index, row in enumerate(rows, 1):
             update_current_task_progress_from_index(
@@ -2766,6 +2770,13 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                     exc_info=err if self.logger.isEnabledFor(logging.DEBUG) else None,
                 )
         update_current_task_progress(100, f"Merged {merged} duplicate track(s)")
+
+    def _start_next_pass_if_due(self) -> None:
+        """Rewind the duplicate track walk if a sync has added content since it started."""
+        if not self._track_reconciliation_rescan_due:
+            return
+        self._track_reconciliation_cursor = (0, 0)
+        self._track_reconciliation_rescan_due = False
 
     async def _albums_agree_on_edition(self, item_id_1: int, item_id_2: int) -> bool:
         """

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -156,7 +156,8 @@ JOIN {DB_TABLE_TRACKS} t2
   ON t2.search_name = t1.search_name
  AND t2.item_id > t1.item_id
  AND abs(t2.duration - t1.duration) <= :max_duration_delta
-WHERE t1.item_id > :cursor
+WHERE (t1.item_id > :cursor_item_id_1
+       OR (t1.item_id = :cursor_item_id_1 AND t2.item_id > :cursor_item_id_2))
   AND EXISTS (
     SELECT 1 FROM {DB_TABLE_TRACK_ARTISTS} ta1
     JOIN {DB_TABLE_TRACK_ARTISTS} ta2
@@ -177,7 +178,7 @@ WHERE t1.item_id > :cursor
       ON pm2.provider_domain = pm1.provider_domain
      AND pm2.media_type = 'track' AND pm2.item_id = t2.item_id
     WHERE pm1.media_type = 'track' AND pm1.item_id = t1.item_id)
-ORDER BY t1.item_id
+ORDER BY t1.item_id, t2.item_id
 """
 
 
@@ -203,7 +204,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         self.recency = RecencyEngine(self.mass)
         self._database: DatabaseConnection | None = None
         self._sync_lock = asyncio.Lock()
-        self._track_reconciliation_cursor = 0
+        self._track_reconciliation_cursor: tuple[int, int] = (0, 0)
         self.manifest.name = "Music controller"
         self.manifest.description = (
             "Music Assistant's core controller which manages all music from all providers."
@@ -2693,24 +2694,29 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
     async def _reconcile_duplicate_tracks(self) -> None:
         """Merge a small batch of library tracks that are held twice across providers."""
         update_current_task_progress_text("Searching for duplicate tracks")
+        cursor_item_id_1, cursor_item_id_2 = self._track_reconciliation_cursor
         rows = await self.database.get_rows_from_query(
             _DUPLICATE_TRACK_CANDIDATES_QUERY,
             {
                 "max_duration_delta": TRACK_RECONCILIATION_MAX_DURATION_DELTA,
-                "cursor": self._track_reconciliation_cursor,
+                "cursor_item_id_1": cursor_item_id_1,
+                "cursor_item_id_2": cursor_item_id_2,
             },
             limit=TRACK_RECONCILIATION_BATCH_SIZE,
         )
         if not rows:
             # start over on the next run so tracks added (or renamed) since the last
             # full pass are examined too
-            self._track_reconciliation_cursor = 0
+            self._track_reconciliation_cursor = (0, 0)
             update_current_task_progress_text("No duplicate tracks found")
             return
-        # resume after the last examined row so candidates this run refused can never
-        # starve the ones behind them; a partial batch means the table has been drained
+        # resume after the exact pair examined last, so candidates this run refused can never
+        # starve the ones behind them, not even a further pair of the same track that the batch
+        # boundary cut off; a partial batch means the table has been drained
         self._track_reconciliation_cursor = (
-            int(rows[-1]["item_id_1"]) if len(rows) == TRACK_RECONCILIATION_BATCH_SIZE else 0
+            (int(rows[-1]["item_id_1"]), int(rows[-1]["item_id_2"]))
+            if len(rows) == TRACK_RECONCILIATION_BATCH_SIZE
+            else (0, 0)
         )
         merged = 0
         for index, row in enumerate(rows, 1):

--- a/music_assistant/controllers/music/strings.json
+++ b/music_assistant/controllers/music/strings.json
@@ -28,6 +28,7 @@
     "add_playlist_tracks": "Add items to playlist {0}",
     "remove_playlist_tracks": "Remove items from playlist {0}",
     "import_playlist_matching": "Import playlist {0}",
-    "import_radios": "Import {0} radio stations"
+    "import_radios": "Import {0} radio stations",
+    "reconcile_duplicate_tracks": "Reconcile duplicate tracks"
   }
 }

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -661,6 +661,7 @@
   "core.music.background_task.database_cleanup": "Database cleanup",
   "core.music.background_task.import_playlist_matching": "Import playlist {0}",
   "core.music.background_task.import_radios": "Import {0} radio stations",
+  "core.music.background_task.reconcile_duplicate_tracks": "Reconcile duplicate tracks",
   "core.music.background_task.remove_playlist_tracks": "Remove items from playlist {0}",
   "core.music.background_task.scan_genre_mappings": "Scan genre mappings",
   "core.music.background_task.sync_provider_albums": "Sync Albums for {0}",

--- a/tests/controllers/music/test_library_item_merge.py
+++ b/tests/controllers/music/test_library_item_merge.py
@@ -532,7 +532,13 @@ async def test_merge_honors_outer_event_suppression(mass: MusicAssistant) -> Non
             await mass.music.genres.merge_library_items(target.item_id, source.item_id)
     finally:
         SUPPRESS_MEDIA_ITEM_UPDATES.reset(token)
-    signal_event.assert_not_called()
+    # unrelated background chatter (a debounced TASKS_UPDATED) can land in the same window,
+    # so assert on the media item events this test is actually about
+    assert [
+        call.args[0]
+        for call in signal_event.call_args_list
+        if call.args and str(call.args[0].value).startswith("media_item")
+    ] == []
 
 
 async def test_genre_merge_rejects_different_taxonomies(mass: MusicAssistant) -> None:

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -106,29 +106,24 @@ async def _add_track(
     )
 
 
-async def _rename_to_duplicate(mass: MusicAssistant, track: Track) -> None:
+async def _make_titles_look_alike(mass: MusicAssistant, track: Track, title: str) -> None:
     """
-    Rewrite a track row's title to the shared duplicate title.
+    Give a track row its final title plus the shared normalized title.
 
-    Fixture tracks are inserted under unique names so that insert-time matching keeps them
-    as separate rows; this reproduces the end state of a library where matching failed.
+    Fixture tracks are inserted under unique titles so that insert-time matching keeps them
+    as separate rows; equalizing search_name afterwards reproduces the end state of a library
+    where that matching failed.
     """
+    normalized = create_safe_string(_DUPLICATE_NAME, True, True)
     await mass.music.database.update(
         DB_TABLE_TRACKS,
         {"item_id": int(track.item_id)},
         {
-            "name": _DUPLICATE_NAME,
-            "sort_name": _DUPLICATE_NAME.lower(),
-            "search_name": create_safe_string(_DUPLICATE_NAME, True, True),
-            "search_sort_name": create_safe_string(_DUPLICATE_NAME, True, True),
+            "name": title,
+            "sort_name": title.lower(),
+            "search_name": normalized,
+            "search_sort_name": normalized,
         },
-    )
-
-
-async def _set_track_title(mass: MusicAssistant, track: Track, name: str) -> None:
-    """Give a track row a raw title, leaving its normalized title untouched."""
-    await mass.music.database.update(
-        DB_TABLE_TRACKS, {"item_id": int(track.item_id)}, {"name": name}
     )
 
 
@@ -142,6 +137,8 @@ async def _build_duplicate_pair(
     second_album_name: str = "Shared Album",
     first_explicit: bool | None = None,
     second_explicit: bool | None = None,
+    first_title: str = _DUPLICATE_NAME,
+    second_title: str = _DUPLICATE_NAME,
 ) -> tuple[Track, Track]:
     """Create two same-titled library tracks that differ only as the parameters say."""
     artist_1 = await _add_artist(mass, "spotify_instance")
@@ -161,8 +158,8 @@ async def _build_duplicate_pair(
         track_number=second_track_number,
         explicit=second_explicit,
     )
-    await _rename_to_duplicate(mass, track_1)
-    await _rename_to_duplicate(mass, track_2)
+    await _make_titles_look_alike(mass, track_1, first_title)
+    await _make_titles_look_alike(mass, track_2, second_title)
     return track_1, track_2
 
 
@@ -221,12 +218,53 @@ async def test_merges_despite_disagreement_on_the_explicit_flag(mass: MusicAssis
         await mass.music.tracks.get_library_item(track_2.item_id)
 
 
+async def test_keeps_an_album_edition_apart_from_the_original(mass: MusicAssistant) -> None:
+    """An edition lives on the album, not the track, so equal track titles are not enough."""
+    track_1, track_2 = await _build_duplicate_pair(mass)
+    album_id = (
+        await mass.music.database.get_rows(
+            DB_TABLE_ALBUM_TRACKS, {"track_id": int(track_2.item_id)}
+        )
+    )[0]["album_id"]
+    await mass.music.database.update(
+        DB_TABLE_ALBUMS, {"item_id": album_id}, {"version": "2014 Remaster"}
+    )
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_merges_across_an_ignorable_album_edition(mass: MusicAssistant) -> None:
+    """A quality label like Hi-Res is not a different edition, so it must not block a merge."""
+    track_1, track_2 = await _build_duplicate_pair(mass)
+    album_id = (
+        await mass.music.database.get_rows(
+            DB_TABLE_ALBUM_TRACKS, {"track_id": int(track_2.item_id)}
+        )
+    )[0]["album_id"]
+    await mass.music.database.update(
+        DB_TABLE_ALBUMS, {"item_id": album_id}, {"version": "Hi-Res Version"}
+    )
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    surviving = await mass.music.tracks.get_library_item(track_1.item_id)
+    assert {mapping.provider_domain for mapping in surviving.provider_mappings} == {
+        "spotify",
+        "qobuz",
+    }
+    with pytest.raises(MediaNotFoundError):
+        await mass.music.tracks.get_library_item(track_2.item_id)
+
+
 async def test_keeps_differently_titled_tracks_apart(mass: MusicAssistant) -> None:
     """Titles that only look alike once normalized still have to survive the full compare."""
-    track_1, track_2 = await _build_duplicate_pair(mass)
-    # both normalize to the same search_name, so the candidate query pairs them up
-    await _set_track_title(mass, track_1, "Song, One")
-    await _set_track_title(mass, track_2, "Song One!")
+    # both titles normalize to the same search_name, so the candidate query pairs them up
+    track_1, track_2 = await _build_duplicate_pair(
+        mass, first_title="Song, One", second_title="Song One!"
+    )
 
     await mass.music._reconcile_duplicate_tracks()
 

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -449,23 +449,35 @@ async def test_no_candidate_pair_is_starved() -> None:
     assert seen == set(pairs)
 
 
-async def test_partial_batch_restarts_the_cursor() -> None:
-    """A partial batch means the table is drained, so the next run starts over."""
+async def test_drained_library_parks_the_cursor_at_the_end() -> None:
+    """Reaching the end leaves the cursor there, so later runs cost next to nothing."""
     ctrl = _bare_controller([{"item_id_1": 7, "item_id_2": 9}])
     ctrl._track_reconciliation_cursor = (5, 6)
 
     with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(return_value=True)):
         await ctrl._reconcile_duplicate_tracks()
 
-    assert ctrl._track_reconciliation_cursor == (0, 0)
+    assert ctrl._track_reconciliation_cursor == (7, 9)
 
 
-async def test_empty_batch_restarts_the_cursor() -> None:
-    """With no candidates left the cursor rewinds so later additions are examined."""
+async def test_empty_batch_leaves_the_cursor_alone() -> None:
+    """With nothing left to examine the cursor stays put rather than rescanning."""
     ctrl = _bare_controller([])
     ctrl._track_reconciliation_cursor = (500, 900)
 
     await ctrl._reconcile_duplicate_tracks()
+
+    assert ctrl._track_reconciliation_cursor == (500, 900)
+
+
+async def test_completed_sync_rewinds_the_cursor() -> None:
+    """New content arrives through a sync, so that is when the library is walked again."""
+    ctrl = _bare_controller([])
+    ctrl._track_reconciliation_cursor = (500, 900)
+    ctrl.mass = Mock(tasks=Mock(get_tasks_by_metadata=Mock(return_value=[])))
+
+    with patch.object(ctrl, "_queue_database_cleanup_task", Mock()):
+        ctrl._handle_sync_completion_check()
 
     assert ctrl._track_reconciliation_cursor == (0, 0)
 

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -5,18 +5,24 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from music_assistant_models.enums import AlbumType, ExternalID
+from music_assistant_models.enums import AlbumType, ExternalID, TaskStatus
 from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
 from music_assistant_models.helpers import create_safe_string
 from music_assistant_models.media_items import (
     Album,
     Artist,
+    MediaItemMetadata,
     ProviderMapping,
     Track,
     UniqueList,
 )
 
-from music_assistant.constants import DB_TABLE_TRACKS
+from music_assistant.constants import (
+    DB_TABLE_ALBUM_TRACKS,
+    DB_TABLE_ALBUMS,
+    DB_TABLE_TRACK_ARTISTS,
+    DB_TABLE_TRACKS,
+)
 from music_assistant.controllers.music.constants import TRACK_RECONCILIATION_BATCH_SIZE
 from music_assistant.controllers.music.controller import MusicController
 from music_assistant.mass import MusicAssistant
@@ -75,6 +81,7 @@ async def _add_track(
     duration: int = 200,
     version: str = "",
     track_number: int = 1,
+    explicit: bool | None = None,
 ) -> Track:
     """Create a fixture track under a unique name, so it is stored as its own row."""
     return await mass.music.tracks.add_item_to_library(
@@ -84,6 +91,7 @@ async def _add_track(
             name=name,
             version=version,
             duration=duration,
+            metadata=MediaItemMetadata(explicit=explicit),
             provider_mappings={
                 _mapping(
                     provider_instance,
@@ -117,6 +125,13 @@ async def _rename_to_duplicate(mass: MusicAssistant, track: Track) -> None:
     )
 
 
+async def _set_track_title(mass: MusicAssistant, track: Track, name: str) -> None:
+    """Give a track row a raw title, leaving its normalized title untouched."""
+    await mass.music.database.update(
+        DB_TABLE_TRACKS, {"item_id": int(track.item_id)}, {"name": name}
+    )
+
+
 async def _build_duplicate_pair(
     mass: MusicAssistant,
     *,
@@ -125,11 +140,15 @@ async def _build_duplicate_pair(
     second_version: str = "",
     second_track_number: int = 1,
     second_album_name: str = "Shared Album",
+    first_explicit: bool | None = None,
+    second_explicit: bool | None = None,
 ) -> tuple[Track, Track]:
     """Create two same-titled library tracks that differ only as the parameters say."""
     artist_1 = await _add_artist(mass, "spotify_instance")
     album_1 = await _add_album(mass, "spotify_instance", artist_1)
-    track_1 = await _add_track(mass, "spotify_instance", artist_1, album_1, name="First Title")
+    track_1 = await _add_track(
+        mass, "spotify_instance", artist_1, album_1, name="First Title", explicit=first_explicit
+    )
     album_2 = await _add_album(mass, second_provider, artist_1, name=second_album_name)
     track_2 = await _add_track(
         mass,
@@ -140,6 +159,7 @@ async def _build_duplicate_pair(
         duration=second_duration,
         version=second_version,
         track_number=second_track_number,
+        explicit=second_explicit,
     )
     await _rename_to_duplicate(mass, track_1)
     await _rename_to_duplicate(mass, track_2)
@@ -152,6 +172,7 @@ def _bare_controller(candidate_rows: list[dict[str, int]]) -> MusicController:
     ctrl._track_reconciliation_cursor = (0, 0)
     ctrl.logger = Mock()
     ctrl._database = Mock(get_rows_from_query=AsyncMock(return_value=candidate_rows))
+    ctrl.mass = Mock(tasks=Mock(get_tasks_by_metadata=Mock(return_value=[])))
     return ctrl
 
 
@@ -178,6 +199,92 @@ async def test_merges_cross_provider_duplicate_tracks(mass: MusicAssistant) -> N
 async def test_keeps_different_versions_apart(mass: MusicAssistant) -> None:
     """A remaster is never merged into the original recording."""
     track_1, track_2 = await _build_duplicate_pair(mass, second_version="Remastered 2011")
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_merges_despite_disagreement_on_the_explicit_flag(mass: MusicAssistant) -> None:
+    """Providers routinely disagree on the explicit flag; that alone must not block a merge."""
+    track_1, track_2 = await _build_duplicate_pair(mass, first_explicit=False, second_explicit=True)
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    surviving = await mass.music.tracks.get_library_item(track_1.item_id)
+    assert {mapping.provider_domain for mapping in surviving.provider_mappings} == {
+        "spotify",
+        "qobuz",
+    }
+    with pytest.raises(MediaNotFoundError):
+        await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_keeps_differently_titled_tracks_apart(mass: MusicAssistant) -> None:
+    """Titles that only look alike once normalized still have to survive the full compare."""
+    track_1, track_2 = await _build_duplicate_pair(mass)
+    # both normalize to the same search_name, so the candidate query pairs them up
+    await _set_track_title(mass, track_1, "Song, One")
+    await _set_track_title(mass, track_2, "Song One!")
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_keeps_tracks_with_different_artists_apart(mass: MusicAssistant) -> None:
+    """A shared title and album slot is not enough when the track artists differ."""
+    track_1, track_2 = await _build_duplicate_pair(mass)
+    other_artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Different Artist",
+            provider_mappings={_mapping("qobuz_instance", "qobuz-other-artist")},
+        )
+    )
+    await mass.music.database.delete(DB_TABLE_TRACK_ARTISTS, {"track_id": int(track_2.item_id)})
+    await mass.music.database.insert(
+        DB_TABLE_TRACK_ARTISTS,
+        {"track_id": int(track_2.item_id), "artist_id": int(other_artist.item_id)},
+    )
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_treats_an_unreported_disc_number_as_disc_one(mass: MusicAssistant) -> None:
+    """A provider that reports no disc number still matches a track tagged as disc 1."""
+    track_1, track_2 = await _build_duplicate_pair(mass)
+    await mass.music.database.update(
+        DB_TABLE_ALBUM_TRACKS, {"track_id": int(track_2.item_id)}, {"disc_number": 0}
+    )
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    surviving = await mass.music.tracks.get_library_item(track_1.item_id)
+    assert {mapping.provider_domain for mapping in surviving.provider_mappings} == {
+        "spotify",
+        "qobuz",
+    }
+
+
+async def test_ignores_albums_whose_title_normalizes_to_nothing(mass: MusicAssistant) -> None:
+    """Symbol-only album titles are not treated as agreement, they match everything."""
+    track_1, track_2 = await _build_duplicate_pair(mass, second_album_name="+")
+    for track in (track_1, track_2):
+        album_id = (
+            await mass.music.database.get_rows(
+                DB_TABLE_ALBUM_TRACKS, {"track_id": int(track.item_id)}
+            )
+        )[0]["album_id"]
+        await mass.music.database.update(
+            DB_TABLE_ALBUMS, {"item_id": album_id}, {"name": "÷", "search_name": ""}
+        )
 
     await mass.music._reconcile_duplicate_tracks()
 
@@ -281,6 +388,21 @@ async def test_full_batch_resumes_within_the_same_track() -> None:
 
     # resuming at (10, ...) rather than past track 10 keeps its remaining pairs reachable
     assert ctrl._track_reconciliation_cursor == (10, 19 + TRACK_RECONCILIATION_BATCH_SIZE)
+
+
+async def test_defers_while_a_library_sync_is_running() -> None:
+    """Duplicates are judged against a settled library, never a half-synced one."""
+    ctrl = _bare_controller([{"item_id_1": 1, "item_id_2": 2}])
+    candidate_query = AsyncMock(return_value=[{"item_id_1": 1, "item_id_2": 2}])
+    ctrl._database = Mock(get_rows_from_query=candidate_query)
+    running = Mock(status=TaskStatus.RUNNING)
+    ctrl.mass = Mock(tasks=Mock(get_tasks_by_metadata=Mock(return_value=[running])))
+
+    with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock()) as merge:
+        await ctrl._reconcile_duplicate_tracks()
+
+    assert not merge.called
+    assert not candidate_query.called
 
 
 async def test_no_candidate_pair_is_starved() -> None:

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -273,6 +273,20 @@ async def test_treats_an_unreported_disc_number_as_disc_one(mass: MusicAssistant
     }
 
 
+async def test_ignores_tracks_with_an_unreported_album_position(mass: MusicAssistant) -> None:
+    """Two unknown track numbers agree on nothing, so they are no evidence of a duplicate."""
+    track_1, track_2 = await _build_duplicate_pair(mass)
+    for track in (track_1, track_2):
+        await mass.music.database.update(
+            DB_TABLE_ALBUM_TRACKS, {"track_id": int(track.item_id)}, {"track_number": 0}
+        )
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
 async def test_ignores_albums_whose_title_normalizes_to_nothing(mass: MusicAssistant) -> None:
     """Symbol-only album titles are not treated as agreement, they match everything."""
     track_1, track_2 = await _build_duplicate_pair(mass, second_album_name="+")

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -665,6 +665,23 @@ async def test_a_merge_asks_for_another_pass() -> None:
     assert ctrl._track_reconciliation_rescan_due
 
 
+async def test_a_failed_pair_asks_for_another_pass() -> None:
+    """A pair that failed on something transient is looked at again rather than dropped."""
+    ctrl = _bare_controller([{"item_id_1": 1, "item_id_2": 2}])
+
+    with (
+        patch.object(
+            ctrl,
+            "_merge_duplicate_track_pair",
+            AsyncMock(side_effect=MusicAssistantError("transient")),
+        ),
+        patch(_REPORT_FAILURE),
+    ):
+        await ctrl._reconcile_duplicate_tracks()
+
+    assert ctrl._track_reconciliation_rescan_due
+
+
 async def test_a_run_without_merges_asks_for_nothing() -> None:
     """A walk that changed nothing has no reason to start over."""
     ctrl = _bare_controller([{"item_id_1": 1, "item_id_2": 2}])

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -624,6 +624,57 @@ async def test_the_next_pass_starts_once_the_walk_reaches_the_end() -> None:
     assert not ctrl._track_reconciliation_rescan_due
 
 
+def _persisting_mass(stored: dict[str, object]) -> Mock:
+    """Build a mass stand-in whose raw core config survives being read back."""
+    return Mock(
+        tasks=Mock(get_tasks_by_metadata=Mock(return_value=[])),
+        config=Mock(
+            set_raw_core_config_value=lambda _domain, key, value: stored.__setitem__(key, value),
+            get_raw_core_config_value=lambda _domain, key, default=None: stored.get(key, default),
+        ),
+    )
+
+
+async def test_the_walk_resumes_after_a_restart() -> None:
+    """Progress is kept across restarts, so a long run of refusals is only crossed once."""
+    stored: dict[str, object] = {}
+    ctrl = _bare_controller([])
+    ctrl.mass = _persisting_mass(stored)
+    ctrl._set_track_reconciliation_state((42, 99), True)
+
+    restarted = _bare_controller([])
+    restarted.mass = _persisting_mass(stored)
+    restarted._restore_track_reconciliation_state()
+
+    assert restarted._track_reconciliation_cursor == (42, 99)
+    assert restarted._track_reconciliation_rescan_due
+
+
+async def test_a_finished_walk_stays_finished_after_a_restart() -> None:
+    """A library with nothing left to do does not start scanning again on every boot."""
+    stored: dict[str, object] = {}
+    ctrl = _bare_controller([])
+    ctrl.mass = _persisting_mass(stored)
+    ctrl._set_track_reconciliation_state(None, False)
+
+    restarted = _bare_controller([])
+    restarted.mass = _persisting_mass(stored)
+    restarted._restore_track_reconciliation_state()
+
+    assert restarted._track_reconciliation_cursor is None
+
+
+async def test_a_first_run_starts_at_the_beginning() -> None:
+    """With nothing stored yet the walk starts at the top of the library."""
+    ctrl = _bare_controller([])
+    ctrl.mass = _persisting_mass({})
+
+    ctrl._restore_track_reconciliation_state()
+
+    assert ctrl._track_reconciliation_cursor == (0, 0)
+    assert not ctrl._track_reconciliation_rescan_due
+
+
 async def test_no_candidate_survives_a_sync_driven_rewind() -> None:
     """Repeated syncs must not keep a later candidate permanently out of reach."""
     pairs = [(index, 900 + index) for index in range(1, TRACK_RECONCILIATION_BATCH_SIZE * 3)]

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -1,0 +1,327 @@
+"""Tests for the hourly duplicate track reconciliation maintenance task."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from music_assistant_models.enums import AlbumType, ExternalID
+from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
+from music_assistant_models.helpers import create_safe_string
+from music_assistant_models.media_items import (
+    Album,
+    Artist,
+    ProviderMapping,
+    Track,
+    UniqueList,
+)
+
+from music_assistant.constants import DB_TABLE_TRACKS
+from music_assistant.controllers.music.constants import TRACK_RECONCILIATION_BATCH_SIZE
+from music_assistant.controllers.music.controller import MusicController
+from music_assistant.mass import MusicAssistant
+
+_DUPLICATE_NAME = "Shared Track Title"
+_REPORT_FAILURE = "music_assistant.controllers.music.controller.report_current_task_failure"
+
+
+def _mapping(provider_instance: str, item_id: str) -> ProviderMapping:
+    """Create a provider mapping for a library fixture item."""
+    return ProviderMapping(
+        item_id=item_id,
+        provider_domain=provider_instance.removesuffix("_instance"),
+        provider_instance=provider_instance,
+        in_library=True,
+    )
+
+
+async def _add_artist(mass: MusicAssistant, provider_instance: str) -> Artist:
+    """Create the shared fixture artist for a provider."""
+    return await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Shared Artist",
+            provider_mappings={_mapping(provider_instance, f"{provider_instance}-artist")},
+        )
+    )
+
+
+async def _add_album(
+    mass: MusicAssistant, provider_instance: str, artist: Artist, name: str = "Shared Album"
+) -> Album:
+    """Create a fixture album for a provider."""
+    slug = create_safe_string(name, True, True)
+    return await mass.music.albums.add_item_to_library(
+        Album(
+            item_id="0",
+            provider="library",
+            name=name,
+            album_type=AlbumType.ALBUM,
+            provider_mappings={_mapping(provider_instance, f"{provider_instance}-album-{slug}")},
+            external_ids={(ExternalID.BARCODE, f"{provider_instance}-barcode-{slug}")},
+            artists=UniqueList([artist]),
+        )
+    )
+
+
+async def _add_track(
+    mass: MusicAssistant,
+    provider_instance: str,
+    artist: Artist,
+    album: Album,
+    *,
+    name: str,
+    duration: int = 200,
+    version: str = "",
+    track_number: int = 1,
+) -> Track:
+    """Create a fixture track under a unique name, so it is stored as its own row."""
+    return await mass.music.tracks.add_item_to_library(
+        Track(
+            item_id="0",
+            provider="library",
+            name=name,
+            version=version,
+            duration=duration,
+            provider_mappings={
+                _mapping(
+                    provider_instance,
+                    f"{provider_instance}-track-{create_safe_string(name, True, True)}",
+                )
+            },
+            artists=UniqueList([artist]),
+            album=album,
+            disc_number=1,
+            track_number=track_number,
+        )
+    )
+
+
+async def _rename_to_duplicate(mass: MusicAssistant, track: Track) -> None:
+    """
+    Rewrite a track row's title to the shared duplicate title.
+
+    Fixture tracks are inserted under unique names so that insert-time matching keeps them
+    as separate rows; this reproduces the end state of a library where matching failed.
+    """
+    await mass.music.database.update(
+        DB_TABLE_TRACKS,
+        {"item_id": int(track.item_id)},
+        {
+            "name": _DUPLICATE_NAME,
+            "sort_name": _DUPLICATE_NAME.lower(),
+            "search_name": create_safe_string(_DUPLICATE_NAME, True, True),
+            "search_sort_name": create_safe_string(_DUPLICATE_NAME, True, True),
+        },
+    )
+
+
+async def _build_duplicate_pair(
+    mass: MusicAssistant,
+    *,
+    second_provider: str = "qobuz_instance",
+    second_duration: int = 200,
+    second_version: str = "",
+    second_track_number: int = 1,
+    second_album_name: str = "Shared Album",
+) -> tuple[Track, Track]:
+    """Create two same-titled library tracks that differ only as the parameters say."""
+    artist_1 = await _add_artist(mass, "spotify_instance")
+    album_1 = await _add_album(mass, "spotify_instance", artist_1)
+    track_1 = await _add_track(mass, "spotify_instance", artist_1, album_1, name="First Title")
+    album_2 = await _add_album(mass, second_provider, artist_1, name=second_album_name)
+    track_2 = await _add_track(
+        mass,
+        second_provider,
+        artist_1,
+        album_2,
+        name="Second Title",
+        duration=second_duration,
+        version=second_version,
+        track_number=second_track_number,
+    )
+    await _rename_to_duplicate(mass, track_1)
+    await _rename_to_duplicate(mass, track_2)
+    return track_1, track_2
+
+
+def _bare_controller(candidate_rows: list[dict[str, int]]) -> MusicController:
+    """Create a bare MusicController whose candidate query returns the given rows."""
+    ctrl = MusicController.__new__(MusicController)
+    ctrl._track_reconciliation_cursor = 0
+    ctrl.logger = Mock()
+    ctrl._database = Mock(get_rows_from_query=AsyncMock(return_value=candidate_rows))
+    return ctrl
+
+
+# --------------------------------------------------------------------------- #
+#  candidate selection and merging (against a real library database)           #
+# --------------------------------------------------------------------------- #
+
+
+async def test_merges_cross_provider_duplicate_tracks(mass: MusicAssistant) -> None:
+    """Two same-titled tracks on the same album position are merged into one row."""
+    track_1, track_2 = await _build_duplicate_pair(mass)
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    surviving = await mass.music.tracks.get_library_item(track_1.item_id)
+    assert {mapping.provider_domain for mapping in surviving.provider_mappings} == {
+        "spotify",
+        "qobuz",
+    }
+    with pytest.raises(MediaNotFoundError):
+        await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_keeps_different_versions_apart(mass: MusicAssistant) -> None:
+    """A remaster is never merged into the original recording."""
+    track_1, track_2 = await _build_duplicate_pair(mass, second_version="Remastered 2011")
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_ignores_tracks_from_the_same_provider(mass: MusicAssistant) -> None:
+    """Two rows of the same provider are left alone, however alike they look."""
+    track_1, track_2 = await _build_duplicate_pair(mass, second_provider="spotify_instance")
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_requires_agreement_on_the_album(mass: MusicAssistant) -> None:
+    """Tracks that sit on differently titled albums are not treated as duplicates."""
+    track_1, track_2 = await _build_duplicate_pair(mass, second_album_name="Greatest Hits")
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_requires_agreement_on_the_album_position(mass: MusicAssistant) -> None:
+    """Tracks at a different position on the same album are not treated as duplicates."""
+    track_1, track_2 = await _build_duplicate_pair(mass, second_track_number=4)
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_ignores_tracks_with_a_large_duration_difference(mass: MusicAssistant) -> None:
+    """A duration difference beyond the tolerance rules out a duplicate."""
+    track_1, track_2 = await _build_duplicate_pair(mass, second_duration=260)
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_keeps_the_row_with_the_most_provider_mappings(mass: MusicAssistant) -> None:
+    """The richest row survives the merge, so the fewest mappings have to move."""
+    track_1, track_2 = await _build_duplicate_pair(mass)
+    await mass.music.tracks.add_provider_mapping(
+        track_2.item_id, _mapping("tidal_instance", "tidal-track")
+    )
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    surviving = await mass.music.tracks.get_library_item(track_2.item_id)
+    assert {mapping.provider_domain for mapping in surviving.provider_mappings} == {
+        "spotify",
+        "qobuz",
+        "tidal",
+    }
+    with pytest.raises(MediaNotFoundError):
+        await mass.music.tracks.get_library_item(track_1.item_id)
+
+
+# --------------------------------------------------------------------------- #
+#  batch mechanics                                                             #
+# --------------------------------------------------------------------------- #
+
+
+async def test_full_batch_advances_the_cursor() -> None:
+    """A full batch resumes after the last examined row on the next run."""
+    ctrl = _bare_controller(
+        [
+            {"item_id_1": index, "item_id_2": 1000 + index}
+            for index in range(1, TRACK_RECONCILIATION_BATCH_SIZE + 1)
+        ]
+    )
+    with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(return_value=True)) as merge:
+        await ctrl._reconcile_duplicate_tracks()
+
+    assert ctrl._track_reconciliation_cursor == TRACK_RECONCILIATION_BATCH_SIZE
+    assert merge.await_count == TRACK_RECONCILIATION_BATCH_SIZE
+
+
+async def test_partial_batch_restarts_the_cursor() -> None:
+    """A partial batch means the table is drained, so the next run starts over."""
+    ctrl = _bare_controller([{"item_id_1": 7, "item_id_2": 9}])
+    ctrl._track_reconciliation_cursor = 5
+
+    with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(return_value=True)):
+        await ctrl._reconcile_duplicate_tracks()
+
+    assert ctrl._track_reconciliation_cursor == 0
+
+
+async def test_empty_batch_restarts_the_cursor() -> None:
+    """With no candidates left the cursor rewinds so later additions are examined."""
+    ctrl = _bare_controller([])
+    ctrl._track_reconciliation_cursor = 500
+
+    await ctrl._reconcile_duplicate_tracks()
+
+    assert ctrl._track_reconciliation_cursor == 0
+
+
+async def test_batch_continues_quietly_after_an_already_merged_row() -> None:
+    """A row absorbed by an earlier merge in the same batch is expected, so it stays silent."""
+    ctrl = _bare_controller([{"item_id_1": 1, "item_id_2": 2}, {"item_id_1": 3, "item_id_2": 4}])
+    logger = Mock()
+    ctrl.logger = logger
+
+    with (
+        patch.object(
+            ctrl,
+            "_merge_duplicate_track_pair",
+            AsyncMock(side_effect=[MediaNotFoundError("gone"), True]),
+        ) as merge,
+        patch(_REPORT_FAILURE) as report_failure,
+    ):
+        await ctrl._reconcile_duplicate_tracks()
+
+    assert merge.await_count == 2
+    assert not logger.warning.called
+    assert not report_failure.called
+
+
+async def test_batch_continues_after_a_failing_pair() -> None:
+    """A failing pair is reported but does not abort the rest of the batch."""
+    ctrl = _bare_controller([{"item_id_1": 1, "item_id_2": 2}, {"item_id_1": 3, "item_id_2": 4}])
+    logger = Mock()
+    ctrl.logger = logger
+
+    with (
+        patch.object(
+            ctrl,
+            "_merge_duplicate_track_pair",
+            AsyncMock(side_effect=[MusicAssistantError("boom"), True]),
+        ) as merge,
+        patch(_REPORT_FAILURE) as report_failure,
+    ):
+        await ctrl._reconcile_duplicate_tracks()
+
+    assert merge.await_count == 2
+    assert logger.warning.called
+    assert report_failure.called

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -149,7 +149,7 @@ async def _build_duplicate_pair(
 def _bare_controller(candidate_rows: list[dict[str, int]]) -> MusicController:
     """Create a bare MusicController whose candidate query returns the given rows."""
     ctrl = MusicController.__new__(MusicController)
-    ctrl._track_reconciliation_cursor = 0
+    ctrl._track_reconciliation_cursor = (0, 0)
     ctrl.logger = Mock()
     ctrl._database = Mock(get_rows_from_query=AsyncMock(return_value=candidate_rows))
     return ctrl
@@ -260,29 +260,78 @@ async def test_full_batch_advances_the_cursor() -> None:
     with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(return_value=True)) as merge:
         await ctrl._reconcile_duplicate_tracks()
 
-    assert ctrl._track_reconciliation_cursor == TRACK_RECONCILIATION_BATCH_SIZE
+    assert ctrl._track_reconciliation_cursor == (
+        TRACK_RECONCILIATION_BATCH_SIZE,
+        1000 + TRACK_RECONCILIATION_BATCH_SIZE,
+    )
     assert merge.await_count == TRACK_RECONCILIATION_BATCH_SIZE
+
+
+async def test_full_batch_resumes_within_the_same_track() -> None:
+    """A batch boundary between two pairs of one track resumes at that exact pair."""
+    ctrl = _bare_controller(
+        [
+            {"item_id_1": 10, "item_id_2": 20 + offset}
+            for offset in range(TRACK_RECONCILIATION_BATCH_SIZE)
+        ]
+    )
+
+    with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(return_value=False)):
+        await ctrl._reconcile_duplicate_tracks()
+
+    # resuming at (10, ...) rather than past track 10 keeps its remaining pairs reachable
+    assert ctrl._track_reconciliation_cursor == (10, 19 + TRACK_RECONCILIATION_BATCH_SIZE)
+
+
+async def test_no_candidate_pair_is_starved() -> None:
+    """Repeated runs reach every candidate, including pairs a batch boundary cut off."""
+    # one track with more duplicate partners than fit in a single batch, so the boundary
+    # falls in the middle of its pairs, followed by candidates that must stay reachable
+    pairs = [(10, 20 + offset) for offset in range(TRACK_RECONCILIATION_BATCH_SIZE + 3)]
+    pairs += [(11, 40), (12, 50)]
+    seen: set[tuple[int, int]] = set()
+
+    async def _candidates(_sql: str, params: dict[str, int], limit: int) -> list[dict[str, int]]:
+        cursor = (params["cursor_item_id_1"], params["cursor_item_id_2"])
+        return [
+            {"item_id_1": item_id_1, "item_id_2": item_id_2}
+            for item_id_1, item_id_2 in [pair for pair in pairs if pair > cursor][:limit]
+        ]
+
+    async def _refuse(item_id_1: int, item_id_2: int) -> bool:
+        # refusing every pair keeps the candidate set intact, so a starved pair stays starved
+        seen.add((item_id_1, item_id_2))
+        return False
+
+    ctrl = _bare_controller([])
+    ctrl._database = Mock(get_rows_from_query=AsyncMock(side_effect=_candidates))
+
+    with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(side_effect=_refuse)):
+        for _ in range(4):
+            await ctrl._reconcile_duplicate_tracks()
+
+    assert seen == set(pairs)
 
 
 async def test_partial_batch_restarts_the_cursor() -> None:
     """A partial batch means the table is drained, so the next run starts over."""
     ctrl = _bare_controller([{"item_id_1": 7, "item_id_2": 9}])
-    ctrl._track_reconciliation_cursor = 5
+    ctrl._track_reconciliation_cursor = (5, 6)
 
     with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(return_value=True)):
         await ctrl._reconcile_duplicate_tracks()
 
-    assert ctrl._track_reconciliation_cursor == 0
+    assert ctrl._track_reconciliation_cursor == (0, 0)
 
 
 async def test_empty_batch_restarts_the_cursor() -> None:
     """With no candidates left the cursor rewinds so later additions are examined."""
     ctrl = _bare_controller([])
-    ctrl._track_reconciliation_cursor = 500
+    ctrl._track_reconciliation_cursor = (500, 900)
 
     await ctrl._reconcile_duplicate_tracks()
 
-    assert ctrl._track_reconciliation_cursor == 0
+    assert ctrl._track_reconciliation_cursor == (0, 0)
 
 
 async def test_batch_continues_quietly_after_an_already_merged_row() -> None:

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -250,6 +250,39 @@ async def test_keeps_an_album_edition_apart_from_the_original(mass: MusicAssista
     assert await mass.music.tracks.get_library_item(track_2.item_id)
 
 
+async def test_an_unrelated_appearance_cannot_approve_an_edition(mass: MusicAssistant) -> None:
+    """Only the album appearance the pair shares a position on may vouch for the edition."""
+    track_1, track_2 = await _build_duplicate_pair(mass)
+    artist = (await mass.music.artists.get_library_items_by_query(limit=1))[0]
+    # the appearance that made them candidates is an original against a remaster
+    for track, version in ((track_1, "Deluxe Edition"), (track_2, "2014 Remaster")):
+        album_id = (
+            await mass.music.database.get_rows(
+                DB_TABLE_ALBUM_TRACKS, {"track_id": int(track.item_id)}
+            )
+        )[0]["album_id"]
+        await mass.music.database.update(
+            DB_TABLE_ALBUMS, {"item_id": album_id}, {"version": version}
+        )
+    # both also turn up on one compilation, but at different positions on it
+    compilation = await _add_album(mass, "spotify_instance", artist, name="Some Compilation")
+    for track, track_number in ((track_1, 5), (track_2, 9)):
+        await mass.music.database.insert(
+            DB_TABLE_ALBUM_TRACKS,
+            {
+                "track_id": int(track.item_id),
+                "album_id": int(compilation.item_id),
+                "disc_number": 1,
+                "track_number": track_number,
+            },
+        )
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
 async def test_merges_across_an_ignorable_album_edition(mass: MusicAssistant) -> None:
     """A quality label like Hi-Res is not a different edition, so it must not block a merge."""
     track_1, track_2 = await _build_duplicate_pair(mass)
@@ -529,25 +562,27 @@ async def test_no_candidate_pair_is_starved() -> None:
     assert seen == set(pairs)
 
 
-async def test_drained_library_parks_the_cursor_at_the_end() -> None:
-    """Reaching the end leaves the cursor there, so later runs cost next to nothing."""
+async def test_a_short_batch_ends_the_walk() -> None:
+    """A batch that is not full means the end of the library has been reached."""
     ctrl = _bare_controller([{"item_id_1": 7, "item_id_2": 9}])
     ctrl._track_reconciliation_cursor = (5, 6)
 
     with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(return_value=True)):
         await ctrl._reconcile_duplicate_tracks()
 
-    assert ctrl._track_reconciliation_cursor == (7, 9)
+    assert ctrl._track_reconciliation_cursor is None
 
 
-async def test_empty_batch_leaves_the_cursor_alone() -> None:
-    """With nothing left to examine the cursor stays put rather than rescanning."""
+async def test_a_finished_walk_does_not_query_again() -> None:
+    """A duplicate-free library must not pay for a scan every hour to prove it."""
     ctrl = _bare_controller([])
-    ctrl._track_reconciliation_cursor = (500, 900)
+    candidate_query = AsyncMock(return_value=[])
+    ctrl._database = Mock(get_rows_from_query=candidate_query)
+    ctrl._track_reconciliation_cursor = None
 
     await ctrl._reconcile_duplicate_tracks()
 
-    assert ctrl._track_reconciliation_cursor == (500, 900)
+    assert not candidate_query.called
 
 
 async def test_a_completed_sync_does_not_restart_a_walk_in_progress() -> None:
@@ -578,13 +613,14 @@ async def test_a_completed_sync_does_not_restart_a_walk_in_progress() -> None:
 async def test_the_next_pass_starts_once_the_walk_reaches_the_end() -> None:
     """The rescan a sync asked for happens as soon as the current walk drains."""
     ctrl = _bare_controller([{"item_id_1": 7, "item_id_2": 9}])
-    ctrl._track_reconciliation_cursor = (5, 6)
+    ctrl._track_reconciliation_cursor = None
     ctrl._track_reconciliation_rescan_due = True
 
     with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(return_value=False)):
         await ctrl._reconcile_duplicate_tracks()
 
-    assert ctrl._track_reconciliation_cursor == (0, 0)
+    # the rescan rewound to the top, walked to the end again and finished there
+    assert ctrl._track_reconciliation_cursor is None
     assert not ctrl._track_reconciliation_rescan_due
 
 

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -176,6 +176,7 @@ def _bare_controller(candidate_rows: list[dict[str, int]]) -> MusicController:
     """Create a bare MusicController whose candidate query returns the given rows."""
     ctrl = MusicController.__new__(MusicController)
     ctrl._track_reconciliation_cursor = (0, 0)
+    ctrl._track_reconciliation_rescan_due = False
     ctrl.logger = Mock()
     ctrl._database = Mock(get_rows_from_query=AsyncMock(return_value=candidate_rows))
     ctrl.mass = Mock(tasks=Mock(get_tasks_by_metadata=Mock(return_value=[])))
@@ -549,16 +550,74 @@ async def test_empty_batch_leaves_the_cursor_alone() -> None:
     assert ctrl._track_reconciliation_cursor == (500, 900)
 
 
-async def test_completed_sync_rewinds_the_cursor() -> None:
-    """New content arrives through a sync, so that is when the library is walked again."""
-    ctrl = _bare_controller([])
-    ctrl._track_reconciliation_cursor = (500, 900)
+async def test_a_completed_sync_does_not_restart_a_walk_in_progress() -> None:
+    """Rewinding mid-walk would re-examine the same prefix forever, starving the rest."""
+    ctrl = _bare_controller(
+        [
+            {"item_id_1": index, "item_id_2": 900 + index}
+            for index in range(1, TRACK_RECONCILIATION_BATCH_SIZE + 1)
+        ]
+    )
     ctrl.mass = Mock(tasks=Mock(get_tasks_by_metadata=Mock(return_value=[])))
 
     with patch.object(ctrl, "_queue_database_cleanup_task", Mock()):
         ctrl._handle_sync_completion_check()
+    assert ctrl._track_reconciliation_cursor == (0, 0)
+
+    # a full batch means the walk is still in progress, so it keeps its place
+    with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(return_value=False)):
+        await ctrl._reconcile_duplicate_tracks()
+
+    assert ctrl._track_reconciliation_cursor == (
+        TRACK_RECONCILIATION_BATCH_SIZE,
+        900 + TRACK_RECONCILIATION_BATCH_SIZE,
+    )
+    assert ctrl._track_reconciliation_rescan_due
+
+
+async def test_the_next_pass_starts_once_the_walk_reaches_the_end() -> None:
+    """The rescan a sync asked for happens as soon as the current walk drains."""
+    ctrl = _bare_controller([{"item_id_1": 7, "item_id_2": 9}])
+    ctrl._track_reconciliation_cursor = (5, 6)
+    ctrl._track_reconciliation_rescan_due = True
+
+    with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(return_value=False)):
+        await ctrl._reconcile_duplicate_tracks()
 
     assert ctrl._track_reconciliation_cursor == (0, 0)
+    assert not ctrl._track_reconciliation_rescan_due
+
+
+async def test_no_candidate_survives_a_sync_driven_rewind() -> None:
+    """Repeated syncs must not keep a later candidate permanently out of reach."""
+    pairs = [(index, 900 + index) for index in range(1, TRACK_RECONCILIATION_BATCH_SIZE * 3)]
+    seen: set[tuple[int, int]] = set()
+
+    async def _candidates(_sql: str, params: dict[str, int], limit: int) -> list[dict[str, int]]:
+        cursor = (params["cursor_item_id_1"], params["cursor_item_id_2"])
+        return [
+            {"item_id_1": one, "item_id_2": two}
+            for one, two in [pair for pair in pairs if pair > cursor][:limit]
+        ]
+
+    async def _refuse(item_id_1: int, item_id_2: int) -> bool:
+        seen.add((item_id_1, item_id_2))
+        return False
+
+    ctrl = _bare_controller([])
+    ctrl._database = Mock(get_rows_from_query=AsyncMock(side_effect=_candidates))
+    ctrl.mass = Mock(tasks=Mock(get_tasks_by_metadata=Mock(return_value=[])))
+
+    with (
+        patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(side_effect=_refuse)),
+        patch.object(ctrl, "_queue_database_cleanup_task", Mock()),
+    ):
+        for _ in range(4):
+            # a sync completes before every run, as a busy library would do
+            ctrl._handle_sync_completion_check()
+            await ctrl._reconcile_duplicate_tracks()
+
+    assert seen == set(pairs)
 
 
 async def test_batch_continues_quietly_after_an_already_merged_row() -> None:

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -635,6 +635,46 @@ def _persisting_mass(stored: dict[str, object]) -> Mock:
     )
 
 
+async def test_an_unexpected_failure_keeps_the_pairs_it_never_reached() -> None:
+    """A run cut short resumes at the pair it got to, not past the whole batch."""
+    ctrl = _bare_controller(
+        [{"item_id_1": index, "item_id_2": 900 + index} for index in range(1, 6)]
+    )
+
+    async def _boom(item_id_1: int, _item_id_2: int) -> bool:
+        if item_id_1 == 3:
+            raise RuntimeError("something unexpected")
+        return False
+
+    with (
+        patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(side_effect=_boom)),
+        pytest.raises(RuntimeError),
+    ):
+        await ctrl._reconcile_duplicate_tracks()
+
+    assert ctrl._track_reconciliation_cursor == (2, 902)
+
+
+async def test_a_merge_asks_for_another_pass() -> None:
+    """Merging moves relations onto the surviving row, which may duplicate an earlier one."""
+    ctrl = _bare_controller([{"item_id_1": 1, "item_id_2": 2}])
+
+    with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(return_value=True)):
+        await ctrl._reconcile_duplicate_tracks()
+
+    assert ctrl._track_reconciliation_rescan_due
+
+
+async def test_a_run_without_merges_asks_for_nothing() -> None:
+    """A walk that changed nothing has no reason to start over."""
+    ctrl = _bare_controller([{"item_id_1": 1, "item_id_2": 2}])
+
+    with patch.object(ctrl, "_merge_duplicate_track_pair", AsyncMock(return_value=False)):
+        await ctrl._reconcile_duplicate_tracks()
+
+    assert not ctrl._track_reconciliation_rescan_due
+
+
 async def test_the_walk_resumes_after_a_restart() -> None:
     """Progress is kept across restarts, so a long run of refusals is only crossed once."""
     stored: dict[str, object] = {}

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import NamedTuple
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -29,6 +30,19 @@ from music_assistant.mass import MusicAssistant
 
 _DUPLICATE_NAME = "Shared Track Title"
 _REPORT_FAILURE = "music_assistant.controllers.music.controller.report_current_task_failure"
+
+
+class _TrackSpec(NamedTuple):
+    """How one side of a duplicate pair should differ from the other."""
+
+    provider: str = "spotify_instance"
+    title: str = _DUPLICATE_NAME
+    album_name: str = "Shared Album"
+    duration: int = 200
+    version: str = ""
+    track_number: int = 1
+    explicit: bool | None = None
+    mbid: str | None = None
 
 
 def _mapping(provider_instance: str, item_id: str) -> ProviderMapping:
@@ -82,6 +96,7 @@ async def _add_track(
     version: str = "",
     track_number: int = 1,
     explicit: bool | None = None,
+    mbid: str | None = None,
 ) -> Track:
     """Create a fixture track under a unique name, so it is stored as its own row."""
     return await mass.music.tracks.add_item_to_library(
@@ -92,6 +107,7 @@ async def _add_track(
             version=version,
             duration=duration,
             metadata=MediaItemMetadata(explicit=explicit),
+            external_ids={(ExternalID.MB_RECORDING, mbid)} if mbid else set(),
             provider_mappings={
                 _mapping(
                     provider_instance,
@@ -129,38 +145,31 @@ async def _make_titles_look_alike(mass: MusicAssistant, track: Track, title: str
 
 async def _build_duplicate_pair(
     mass: MusicAssistant,
-    *,
-    second_provider: str = "qobuz_instance",
-    second_duration: int = 200,
-    second_version: str = "",
-    second_track_number: int = 1,
-    second_album_name: str = "Shared Album",
-    first_explicit: bool | None = None,
-    second_explicit: bool | None = None,
-    first_title: str = _DUPLICATE_NAME,
-    second_title: str = _DUPLICATE_NAME,
+    first: _TrackSpec | None = None,
+    second: _TrackSpec | None = None,
 ) -> tuple[Track, Track]:
-    """Create two same-titled library tracks that differ only as the parameters say."""
-    artist_1 = await _add_artist(mass, "spotify_instance")
-    album_1 = await _add_album(mass, "spotify_instance", artist_1)
-    track_1 = await _add_track(
-        mass, "spotify_instance", artist_1, album_1, name="First Title", explicit=first_explicit
-    )
-    album_2 = await _add_album(mass, second_provider, artist_1, name=second_album_name)
-    track_2 = await _add_track(
-        mass,
-        second_provider,
-        artist_1,
-        album_2,
-        name="Second Title",
-        duration=second_duration,
-        version=second_version,
-        track_number=second_track_number,
-        explicit=second_explicit,
-    )
-    await _make_titles_look_alike(mass, track_1, first_title)
-    await _make_titles_look_alike(mass, track_2, second_title)
-    return track_1, track_2
+    """Create two same-titled library tracks that differ only as the specs say."""
+    first = first or _TrackSpec()
+    second = second or _TrackSpec(provider="qobuz_instance")
+    artist = await _add_artist(mass, first.provider)
+    tracks: list[Track] = []
+    for index, spec in enumerate((first, second)):
+        album = await _add_album(mass, spec.provider, artist, name=spec.album_name)
+        track = await _add_track(
+            mass,
+            spec.provider,
+            artist,
+            album,
+            name=f"Fixture Title {index}",
+            duration=spec.duration,
+            version=spec.version,
+            track_number=spec.track_number,
+            explicit=spec.explicit,
+            mbid=spec.mbid,
+        )
+        await _make_titles_look_alike(mass, track, spec.title)
+        tracks.append(track)
+    return tracks[0], tracks[1]
 
 
 def _bare_controller(candidate_rows: list[dict[str, int]]) -> MusicController:
@@ -195,7 +204,9 @@ async def test_merges_cross_provider_duplicate_tracks(mass: MusicAssistant) -> N
 
 async def test_keeps_different_versions_apart(mass: MusicAssistant) -> None:
     """A remaster is never merged into the original recording."""
-    track_1, track_2 = await _build_duplicate_pair(mass, second_version="Remastered 2011")
+    track_1, track_2 = await _build_duplicate_pair(
+        mass, second=_TrackSpec("qobuz_instance", version="Remastered 2011")
+    )
 
     await mass.music._reconcile_duplicate_tracks()
 
@@ -205,7 +216,9 @@ async def test_keeps_different_versions_apart(mass: MusicAssistant) -> None:
 
 async def test_merges_despite_disagreement_on_the_explicit_flag(mass: MusicAssistant) -> None:
     """Providers routinely disagree on the explicit flag; that alone must not block a merge."""
-    track_1, track_2 = await _build_duplicate_pair(mass, first_explicit=False, second_explicit=True)
+    track_1, track_2 = await _build_duplicate_pair(
+        mass, _TrackSpec(explicit=False), _TrackSpec("qobuz_instance", explicit=True)
+    )
 
     await mass.music._reconcile_duplicate_tracks()
 
@@ -259,11 +272,31 @@ async def test_merges_across_an_ignorable_album_edition(mass: MusicAssistant) ->
         await mass.music.tracks.get_library_item(track_2.item_id)
 
 
-async def test_keeps_differently_titled_tracks_apart(mass: MusicAssistant) -> None:
-    """Titles that only look alike once normalized still have to survive the full compare."""
-    # both titles normalize to the same search_name, so the candidate query pairs them up
+async def test_merges_titles_that_differ_only_in_punctuation(mass: MusicAssistant) -> None:
+    """A curly apostrophe against a straight one is the same title, so the rows still merge."""
     track_1, track_2 = await _build_duplicate_pair(
-        mass, first_title="Song, One", second_title="Song One!"
+        mass,
+        _TrackSpec(title="You\u2019re My Best Friend"),
+        _TrackSpec("qobuz_instance", title="You're My Best Friend"),
+    )
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    surviving = await mass.music.tracks.get_library_item(track_1.item_id)
+    assert {mapping.provider_domain for mapping in surviving.provider_mappings} == {
+        "spotify",
+        "qobuz",
+    }
+    with pytest.raises(MediaNotFoundError):
+        await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_keeps_distinct_recordings_apart(mass: MusicAssistant) -> None:
+    """Two different MusicBrainz recordings are different tracks, whatever else lines up."""
+    track_1, track_2 = await _build_duplicate_pair(
+        mass,
+        _TrackSpec(mbid="11111111-1111-1111-1111-111111111111"),
+        _TrackSpec("qobuz_instance", mbid="22222222-2222-2222-2222-222222222222"),
     )
 
     await mass.music._reconcile_duplicate_tracks()
@@ -327,7 +360,9 @@ async def test_ignores_tracks_with_an_unreported_album_position(mass: MusicAssis
 
 async def test_ignores_albums_whose_title_normalizes_to_nothing(mass: MusicAssistant) -> None:
     """Symbol-only album titles are not treated as agreement, they match everything."""
-    track_1, track_2 = await _build_duplicate_pair(mass, second_album_name="+")
+    track_1, track_2 = await _build_duplicate_pair(
+        mass, second=_TrackSpec("qobuz_instance", album_name="+")
+    )
     for track in (track_1, track_2):
         album_id = (
             await mass.music.database.get_rows(
@@ -346,7 +381,7 @@ async def test_ignores_albums_whose_title_normalizes_to_nothing(mass: MusicAssis
 
 async def test_ignores_tracks_from_the_same_provider(mass: MusicAssistant) -> None:
     """Two rows of the same provider are left alone, however alike they look."""
-    track_1, track_2 = await _build_duplicate_pair(mass, second_provider="spotify_instance")
+    track_1, track_2 = await _build_duplicate_pair(mass, second=_TrackSpec("spotify_instance"))
 
     await mass.music._reconcile_duplicate_tracks()
 
@@ -356,7 +391,9 @@ async def test_ignores_tracks_from_the_same_provider(mass: MusicAssistant) -> No
 
 async def test_requires_agreement_on_the_album(mass: MusicAssistant) -> None:
     """Tracks that sit on differently titled albums are not treated as duplicates."""
-    track_1, track_2 = await _build_duplicate_pair(mass, second_album_name="Greatest Hits")
+    track_1, track_2 = await _build_duplicate_pair(
+        mass, second=_TrackSpec("qobuz_instance", album_name="Greatest Hits")
+    )
 
     await mass.music._reconcile_duplicate_tracks()
 
@@ -366,7 +403,9 @@ async def test_requires_agreement_on_the_album(mass: MusicAssistant) -> None:
 
 async def test_requires_agreement_on_the_album_position(mass: MusicAssistant) -> None:
     """Tracks at a different position on the same album are not treated as duplicates."""
-    track_1, track_2 = await _build_duplicate_pair(mass, second_track_number=4)
+    track_1, track_2 = await _build_duplicate_pair(
+        mass, second=_TrackSpec("qobuz_instance", track_number=4)
+    )
 
     await mass.music._reconcile_duplicate_tracks()
 
@@ -376,7 +415,9 @@ async def test_requires_agreement_on_the_album_position(mass: MusicAssistant) ->
 
 async def test_ignores_tracks_with_a_large_duration_difference(mass: MusicAssistant) -> None:
     """A duration difference beyond the tolerance rules out a duplicate."""
-    track_1, track_2 = await _build_duplicate_pair(mass, second_duration=260)
+    track_1, track_2 = await _build_duplicate_pair(
+        mass, second=_TrackSpec("qobuz_instance", duration=260)
+    )
 
     await mass.music._reconcile_duplicate_tracks()
 


### PR DESCRIPTION
# What does this implement/fix?

Tracks that ended up in the library twice, once per music provider, stayed that way forever. The recent matching fixes only prevent *new* duplicates: when a provider syncs again, an existing track is found straight away by its own provider mapping, so the cross-provider comparison never runs a second time and the leftovers are never cleaned up.

This adds a small hourly maintenance pass that repairs them, merging the two rows into one through the existing safe merge path, so albums, artists, play counts and listening history are moved across before the duplicate row goes away.

To be sure it only merges genuine duplicates, a pair has to agree on quite a lot: same title, a shared artist, near-equal length, and both providers listing the track on the same album at the same position. Versions have to match too, so remasters, remixes, radio edits and re-recordings are left alone.

- New hourly "Reconcile duplicate tracks" background task, 100 candidate pairs per run, picking up where it left off after a restart
- Only merges tracks from different providers; two rows from the same provider are never touched
- Album editions are compared too, so an original and its remaster stay separate, while quality labels like Hi-Res are ignored
- Waits until any running library sync has finished before judging anything
- The row with the most provider mappings is the one that stays

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/4455

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.


