### PR TITLE
Keep a player usable when its saved queue cannot be read

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1178,12 +1178,12 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         queue_id = player.player_id
         queue_data: PlayerQueueData | None = None
         # try to restore previous state
-        if prev_state := await self.mass.cache.get(
-            key=queue_id,
-            provider=self.domain,
-            category=CACHE_CATEGORY_PLAYER_QUEUE_STATE,
-        ):
-            try:
+        try:
+            if prev_state := await self.mass.cache.get(
+                key=queue_id,
+                provider=self.domain,
+                category=CACHE_CATEGORY_PLAYER_QUEUE_STATE,
+            ):
                 prev_items = await self.mass.cache.get(
                     key=queue_id,
                     provider=self.domain,
@@ -1191,14 +1191,14 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                     default=[],
                 )
                 queue_data = PlayerQueueData.from_cache(prev_state, prev_items)
-            except Exception as err:
-                self.logger.warning(
-                    "Failed to restore the queue(items) for %s - %s",
-                    player.state.name,
-                    str(err),
-                )
-                # Reset to clean state on failure
-                queue_data = None
+        except Exception as err:
+            self.logger.warning(
+                "Failed to restore the queue(items) for %s - %s",
+                player.state.name,
+                str(err),
+            )
+            # Reset to clean state on failure
+            queue_data = None
         if queue_data is None:
             queue_data = PlayerQueueData(
                 queue=PlayerQueue(

--- a/tests/controllers/player_queues/test_queue_restore_failure.py
+++ b/tests/controllers/player_queues/test_queue_restore_failure.py
@@ -1,0 +1,53 @@
+"""
+Tests for player registration when the queue cache cannot be read.
+
+A cache failure must never leave a player registered without a queue: it falls back to a
+fresh queue so the player stays usable.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant.controllers.player_queues.controller import PlayerQueuesController
+
+
+def _controller(cache_get: AsyncMock) -> Any:
+    """
+    Build a queue-controller stand-in for ``on_player_register``.
+
+    :param cache_get: Stand-in for the cache lookups the queue restore performs.
+    """
+    queues = MagicMock()
+    queues._queue_data = {}
+    queues.mass.cache.get = cache_get
+    return queues
+
+
+def _player(player_id: str = "p1") -> Any:
+    """Build a player stand-in with the state fields the queue snapshot is built from."""
+    return SimpleNamespace(
+        player_id=player_id, state=SimpleNamespace(name="Player A", available=True)
+    )
+
+
+async def test_player_gets_a_queue_when_the_state_lookup_fails() -> None:
+    """A failing cache lookup for the stored queue state falls back to a fresh queue."""
+    queues = _controller(AsyncMock(side_effect=OSError("database error")))
+
+    await PlayerQueuesController.on_player_register(queues, _player())
+
+    assert queues._queue_data["p1"].queue.queue_id == "p1"
+    queues.logger.warning.assert_called_once()
+
+
+async def test_player_gets_a_queue_when_the_items_lookup_fails() -> None:
+    """A failing cache lookup for the stored queue items falls back to a fresh queue."""
+    queues = _controller(AsyncMock(side_effect=[{"queue": {}}, OSError("database error")]))
+
+    await PlayerQueuesController.on_player_register(queues, _player())
+
+    assert queues._queue_data["p1"].queue.queue_id == "p1"
+    queues.logger.warning.assert_called_once()


### PR DESCRIPTION
# What does this implement/fix?

When a player registers, Music Assistant tries to restore the queue it had before the restart. If reading that saved queue from the cache database failed, the error escaped the fallback that is meant to catch exactly this: the player was already added and announced, but ended up without a queue at all. It then shows up in the UI but cannot play anything until a restart.

The cache lookup now sits inside the existing guard, so any failure simply falls back to a fresh, empty queue - the player stays usable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
