### PR TITLE
Let a player recover when its setup fails during registration

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1490,6 +1490,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
                 # everywhere while it keeps blocking every later registration of the same
                 # id. Drop it again, but only while it is still ours: an unregister may
                 # have removed it already, and a blind delete would mask the real error.
+                # No on_unload here: the player never got far enough to own a queue,
+                # command locks or a sleep timer.
                 if self._players.get(player_id) is player:
                     del self._players[player_id]
                 raise

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1485,15 +1485,21 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
                 # Handle protocol linking
                 self._evaluate_protocol_links(player)
-            except Exception:
+            except Exception, asyncio.CancelledError:
                 # a player whose setup failed never becomes initialized, which hides it
-                # everywhere while it keeps blocking every later registration of the same
-                # id. Drop it again, but only while it is still ours: an unregister may
-                # have removed it already, and a blind delete would mask the real error.
-                # No on_unload here: the player never got far enough to own a queue,
-                # command locks or a sleep timer.
+                # everywhere while it keeps blocking every later registration of the same id.
+                # Cancellation counts too: a re-triggered provider discovery aborts the task
+                # this runs in. Only roll back while the player is still ours: an unregister
+                # may have dropped it already, and it unloads the player itself.
                 if self._players.get(player_id) is player:
                     del self._players[player_id]
+                    # players claim resources in their constructor (event subscriptions,
+                    # connections) that only on_unload releases. Best-effort, so a failing
+                    # teardown cannot mask the error that got us here.
+                    try:
+                        await player.on_unload()
+                    except Exception:
+                        self.logger.exception("Error unloading player %s", player.name)
                 raise
 
             # now we're ready to signal the player is added and available

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1465,25 +1465,34 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             # We use the 'initialized' attribute to indicate that the player
             # is still in the process of being registered so we can filter it out where needed.
             self._players[player_id] = player
-            # update state to ensure player.state reflects the final attributes
-            # (e.g. player type) set after super().__init__() in the player subclass,
-            # before we fetch config (which relies on state.type for entry resolution)
-            player.update_state(signal_event=False)
-            # ensure we fetch and set the latest/full config for the player
-            player_config = await self.mass.config.get_player_config(player_id)
-            if self._registration_aborted(player):
-                return
-            player.set_config(player_config)
-            # update state again now that config is loaded
-            player.update_state(signal_event=False)
-            self._save_underlying_player_id(player)
-            # call hook after the player is registered and config is set
-            await player.on_config_updated()
-            if self._registration_aborted(player):
-                return
+            try:
+                # update state to ensure player.state reflects the final attributes
+                # (e.g. player type) set after super().__init__() in the player subclass,
+                # before we fetch config (which relies on state.type for entry resolution)
+                player.update_state(signal_event=False)
+                # ensure we fetch and set the latest/full config for the player
+                player_config = await self.mass.config.get_player_config(player_id)
+                if self._registration_aborted(player):
+                    return
+                player.set_config(player_config)
+                # update state again now that config is loaded
+                player.update_state(signal_event=False)
+                self._save_underlying_player_id(player)
+                # call hook after the player is registered and config is set
+                await player.on_config_updated()
+                if self._registration_aborted(player):
+                    return
 
-            # Handle protocol linking
-            self._evaluate_protocol_links(player)
+                # Handle protocol linking
+                self._evaluate_protocol_links(player)
+            except Exception:
+                # a player whose setup failed never becomes initialized, which hides it
+                # everywhere while it keeps blocking every later registration of the same
+                # id. Drop it again, but only while it is still ours: an unregister may
+                # have removed it already, and a blind delete would mask the real error.
+                if self._players.get(player_id) is player:
+                    del self._players[player_id]
+                raise
 
             # now we're ready to signal the player is added and available
             player.set_initialized()

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1113,6 +1113,110 @@ def _set_play_media_override(mock_mass: MagicMock, value: bool) -> None:
     mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_side_effect)
 
 
+class TestRegisterFailureRollback:
+    """Test registration that fails while setting the player up."""
+
+    @staticmethod
+    def _stub_register_calls(mock_mass: MagicMock) -> None:
+        """Stub the awaited mass calls made during register."""
+        mock_mass.config.get = MagicMock(side_effect=lambda _key, default=None: default)
+        mock_mass.cache.get = AsyncMock(return_value=None)
+        mock_mass.config.get_player_config = AsyncMock(return_value=create_mock_config("Player 1"))
+        mock_mass.player_queues.on_player_register = AsyncMock()
+        mock_mass.player_queues.on_player_remove = MagicMock()
+
+    async def test_failed_config_load_leaves_no_stale_registration(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player whose config fails to load can be registered again afterwards."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        mock_mass.config.get_player_config = AsyncMock(side_effect=KeyError("no config"))
+
+        with (
+            patch(
+                "music_assistant.controllers.players.controller.enrich_device_mac_address",
+                AsyncMock(),
+            ),
+            pytest.raises(KeyError),
+        ):
+            await controller.register(player)
+
+        assert "player_1" not in controller._players
+
+        # the provider retries with a fresh player object once the device reappears
+        self._stub_register_calls(mock_mass)
+        retried = MockPlayer(provider, "player_1", "Player 1")
+        with patch(
+            "music_assistant.controllers.players.controller.enrich_device_mac_address",
+            AsyncMock(),
+        ):
+            await controller.register(retried)
+
+        assert controller._players["player_1"] is retried
+        assert retried.initialized.is_set()
+
+    async def test_failed_config_hook_leaves_no_stale_registration(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player whose on_config_updated hook fails can be registered again afterwards."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+
+        with (
+            patch(
+                "music_assistant.controllers.players.controller.enrich_device_mac_address",
+                AsyncMock(),
+            ),
+            patch.object(
+                player, "on_config_updated", AsyncMock(side_effect=BrokenPipeError("device gone"))
+            ),
+            pytest.raises(BrokenPipeError),
+        ):
+            await controller.register(player)
+
+        assert "player_1" not in controller._players
+
+        retried = MockPlayer(provider, "player_1", "Player 1")
+        with patch(
+            "music_assistant.controllers.players.controller.enrich_device_mac_address",
+            AsyncMock(),
+        ):
+            await controller.register(retried)
+
+        assert controller._players["player_1"] is retried
+        assert retried.initialized.is_set()
+
+    async def test_failed_setup_after_unregister_reports_the_real_error(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """The setup error survives an unregister that already dropped the player."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+
+        async def _unregister_then_fail() -> None:
+            await controller.unregister("player_1")
+            raise BrokenPipeError("device gone")
+
+        with (
+            patch(
+                "music_assistant.controllers.players.controller.enrich_device_mac_address",
+                AsyncMock(),
+            ),
+            patch.object(player, "on_config_updated", AsyncMock(side_effect=_unregister_then_fail)),
+            pytest.raises(BrokenPipeError),
+        ):
+            await controller.register(player)
+
+        assert "player_1" not in controller._players
+
+
 class TestRegisterOrUpdateTypeTransition:
     """Tests for a registered player moving in or out of the protocol role."""
 

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1240,6 +1240,79 @@ class TestRegisterFailureRollback:
         assert controller._players["player_1"] is player
         assert player.initialized.is_set()
 
+    async def test_cancelled_setup_leaves_no_stale_registration(self, mock_mass: MagicMock) -> None:
+        """A registration cancelled while it runs can be registered again afterwards."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        setup_running = asyncio.Event()
+
+        async def _block_forever() -> None:
+            setup_running.set()
+            await asyncio.sleep(60)
+
+        with (
+            patch(
+                "music_assistant.controllers.players.controller.enrich_device_mac_address",
+                AsyncMock(),
+            ),
+            patch.object(player, "on_config_updated", AsyncMock(side_effect=_block_forever)),
+        ):
+            # stands in for a re-triggered provider discovery aborting the running task
+            task = asyncio.create_task(controller.register(player))
+            await setup_running.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert "player_1" not in controller._players
+
+    async def test_failed_setup_releases_the_player_resources(self, mock_mass: MagicMock) -> None:
+        """A player dropped after a failed setup is unloaded so it releases its resources."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        unload = AsyncMock()
+
+        with (
+            patch(
+                "music_assistant.controllers.players.controller.enrich_device_mac_address",
+                AsyncMock(),
+            ),
+            patch.object(
+                player, "on_config_updated", AsyncMock(side_effect=BrokenPipeError("device gone"))
+            ),
+            patch.object(player, "on_unload", unload),
+            pytest.raises(BrokenPipeError),
+        ):
+            await controller.register(player)
+
+        unload.assert_awaited_once()
+
+    async def test_failing_teardown_keeps_the_setup_error(self, mock_mass: MagicMock) -> None:
+        """A teardown that fails does not hide why the registration failed."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+
+        with (
+            patch(
+                "music_assistant.controllers.players.controller.enrich_device_mac_address",
+                AsyncMock(),
+            ),
+            patch.object(
+                player, "on_config_updated", AsyncMock(side_effect=BrokenPipeError("device gone"))
+            ),
+            patch.object(player, "on_unload", AsyncMock(side_effect=RuntimeError("teardown"))),
+            pytest.raises(BrokenPipeError),
+        ):
+            await controller.register(player)
+
+        assert "player_1" not in controller._players
+
 
 class TestRegisterOrUpdateTypeTransition:
     """Tests for a registered player moving in or out of the protocol role."""

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1216,6 +1216,30 @@ class TestRegisterFailureRollback:
 
         assert "player_1" not in controller._players
 
+    async def test_failure_after_the_player_was_added_keeps_it_registered(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A failure after the player was announced leaves it registered."""
+        controller = PlayerController(mock_mass)
+        self._stub_register_calls(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        mock_mass.player_queues.on_player_register = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with (
+            patch(
+                "music_assistant.controllers.players.controller.enrich_device_mac_address",
+                AsyncMock(),
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            await controller.register(player)
+
+        # PLAYER_ADDED was already signalled, so dropping the player now would
+        # remove it from every listing without a matching PLAYER_REMOVED
+        assert controller._players["player_1"] is player
+        assert player.initialized.is_set()
+
 
 class TestRegisterOrUpdateTypeTransition:
     """Tests for a registered player moving in or out of the protocol role."""


### PR DESCRIPTION
# What does this implement/fix?

When a player is registered, it is added to the player controller early on so the rest of the
setup can find it. If that setup then fails — the player config could not be loaded, or the
provider's own `on_config_updated` hook hit a device that just dropped off the network — the
player was left behind in the controller without ever being marked as initialized.

Such a player is hidden from every player list, but still counts as registered. Providers check
"do I already know this player?" before registering it again, so the next discovery round, mDNS
re-announce or device reconnect quietly skipped it. The player stayed gone until the server was
restarted.

The player is now removed again when its setup fails, so a later retry can register it properly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
