### PR TITLE
Clean up group memberships when a player is removed

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1614,8 +1614,10 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
             self.logger.exception("Error unloading player %s", player.name)
         if permanent:
             # player permanent removal: cleanup protocol links, delete config
-            # and signal PLAYER_REMOVED event
-            await self._cleanup_player_memberships(player_id)
+            # and signal PLAYER_REMOVED event.
+            # No group detach is issued here: the player is already out of the registry,
+            # so it is filtered out of every group's live member list, and its persisted
+            # membership is settled by delete_player_config below.
             self._cleanup_protocol_links(player)
             self.delete_player_config(player_id, replacement_player_id)
             self.logger.info("Player removed: %s", player.name)
@@ -1677,12 +1679,15 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         returns as a brand new player once it is discovered again. Protocol players that
         are still registered or that already moved to another parent keep their config;
         registered ones are detached from the removed player and re-evaluated.
+        Any group that lists the player as a member follows the replacement, or loses
+        the member when there is none.
 
         :param player_id: Player ID of the player to delete the configuration of.
         :param replacement_player_id: Player ID that takes this player's place, so users
                                       restricted to it follow the replacement.
         """
         self._detach_protocol_children(player_id)
+        self._update_group_memberships(player_id, replacement_player_id)
         player_ids = [
             protocol_id
             for protocol_id in self.mass.config.get(CONF_PLAYERS, {})

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1684,7 +1684,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
         :param player_id: Player ID of the player to delete the configuration of.
         :param replacement_player_id: Player ID that takes this player's place, so users
-                                      restricted to it follow the replacement.
+                                      restricted to it and groups it belongs to follow
+                                      the replacement.
         """
         self._detach_protocol_children(player_id)
         self._update_group_memberships(player_id, replacement_player_id)

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1254,9 +1254,11 @@ class ProtocolLinkingMixin:
         Other players that list the removed player as a group member (or allowed
         member) must follow its successor so those memberships are not silently
         lost. Without a successor the player is gone for good and its id is dropped
-        instead, so it can not linger in a group and pull a device that returns
-        under the same id back in. Updates the persisted config and keeps any
-        registered player whose membership changed in sync.
+        from the group members instead, so it can not linger in a group and pull a
+        device that returns under the same id back in. Its allow-list entry is left
+        alone there, since an allow-list that runs empty stops restricting at all.
+        Updates the persisted config and keeps any registered player whose
+        membership changed in sync.
 
         :param old_player_id: Player id that is being removed.
         :param new_player_id: Player id that replaces it, or None if there is none.
@@ -1270,9 +1272,15 @@ class ProtocolLinkingMixin:
             other_values = other_cfg.get("values")
             if not isinstance(other_values, dict):
                 continue
+            other_player = self.get_player(other_id)
+            changed = False
             for key in (CONF_GROUP_MEMBERS, CONF_ALLOWED_MEMBERS):
                 members = other_values.get(key)
                 if not isinstance(members, list) or old_player_id not in members:
+                    continue
+                if new_player_id is None and key == CONF_ALLOWED_MEMBERS:
+                    # an allow-list that runs empty reads as "everyone may join", so the
+                    # entry of a removed player stays: it can never join again anyway
                     continue
                 new_members: list[str] = []
                 for member_id in members:
@@ -1280,11 +1288,21 @@ class ProtocolLinkingMixin:
                     if resolved is not None and resolved not in new_members:
                         new_members.append(resolved)
                 self.mass.config.set(f"{CONF_PLAYERS}/{other_id}/values/{key}", new_members)
-                # keep a registered player's in-place config copy and state in sync
-                if other_player := self.get_player(other_id):
-                    if entry := other_player.config.values.get(key):
-                        entry.value = new_members
-                    other_player.refresh_state()
+                changed = True
+                # keep a registered player's in-place config copy in sync
+                if other_player and (entry := other_player.config.values.get(key)):
+                    entry.value = new_members
+            if changed and other_player:
+                self.mass.create_task(self._reload_group_members(other_player))
+
+    async def _reload_group_members(self, player: Player) -> None:
+        """
+        Let a group re-read its member config so its live member list follows along.
+
+        :param player: The group player whose stored member list changed.
+        """
+        await player.on_config_updated()
+        player.refresh_state()
 
     async def _stop_and_unregister(self, player: Player, replacement_player_id: str) -> None:
         """

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -885,7 +885,7 @@ class ProtocolLinkingMixin:
         # Carry over the user's configuration and re-point group memberships
         # before the permanent removal below deletes the losing wrapper's config
         self._migrate_universal_player_config(remove.player_id, keep.player_id)
-        self._repoint_group_memberships(remove.player_id, keep.player_id)
+        self._update_group_memberships(remove.player_id, keep.player_id)
 
         # Stop playback and remove the obsolete player
         self.mass.create_task(self._stop_and_unregister(remove, keep.player_id))
@@ -1094,7 +1094,7 @@ class ProtocolLinkingMixin:
             # Carry over the user's configuration and re-point group memberships
             # before the permanent removal below deletes the universal player's config
             self._migrate_universal_player_config(player.player_id, native_player.player_id)
-            self._repoint_group_memberships(player.player_id, native_player.player_id)
+            self._update_group_memberships(player.player_id, native_player.player_id)
 
             # Stop playback and remove the now-obsolete universal player
             self.mass.create_task(self._stop_and_unregister(player, native_player.player_id))
@@ -1247,18 +1247,19 @@ class ProtocolLinkingMixin:
         player.update_state()
         self.mass.signal_event(EventType.PLAYER_CONFIG_UPDATED, object_id=player_id, data=config)
 
-    def _repoint_group_memberships(self, old_player_id: str, new_player_id: str) -> None:
+    def _update_group_memberships(self, old_player_id: str, new_player_id: str | None) -> None:
         """
-        Re-point group memberships from a removed player to its successor.
+        Hand a removed player's group memberships over to its successor, or drop them.
 
-        When a universal player is replaced by a native player or merged into
-        another universal player, other players that list the removed player as
-        a group member (or allowed member) must follow its successor so those
-        memberships are not silently lost. Updates the persisted config and keeps
-        any registered player whose membership changed in sync.
+        Other players that list the removed player as a group member (or allowed
+        member) must follow its successor so those memberships are not silently
+        lost. Without a successor the player is gone for good and its id is dropped
+        instead, so it can not linger in a group and pull a device that returns
+        under the same id back in. Updates the persisted config and keeps any
+        registered player whose membership changed in sync.
 
         :param old_player_id: Player id that is being removed.
-        :param new_player_id: Player id that replaces it.
+        :param new_player_id: Player id that replaces it, or None if there is none.
         """
         all_player_configs = self.mass.config.get(CONF_PLAYERS, {})
         if not isinstance(all_player_configs, dict):
@@ -1276,7 +1277,7 @@ class ProtocolLinkingMixin:
                 new_members: list[str] = []
                 for member_id in members:
                     resolved = new_player_id if member_id == old_player_id else member_id
-                    if resolved not in new_members:
+                    if resolved is not None and resolved not in new_members:
                         new_members.append(resolved)
                 self.mass.config.set(f"{CONF_PLAYERS}/{other_id}/values/{key}", new_members)
                 # keep a registered player's in-place config copy and state in sync

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -382,7 +382,6 @@ class UniversalPlayerProvider(PlayerProvider):
                     default_parent,
                 )
                 self.mass.players._migrate_universal_player_config(player_id, default_parent)
-                self.mass.players._repoint_group_memberships(player_id, default_parent)
                 self.mass.players.delete_player_config(
                     player_id, replacement_player_id=default_parent
                 )

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -5366,7 +5366,8 @@ class TestDeletePlayerConfigGroupMemberships:
         controller.delete_player_config("sonos_1")
 
         assert config_store["players/group_1/values/group_members"] == ["sonos_2"]
-        assert config_store["players/group_1/values/allowed_members"] == []
+        # the allow-list is left alone: emptying it would stop it restricting anything
+        assert "players/group_1/values/allowed_members" not in config_store
 
     def test_replacement_hands_the_membership_to_the_new_player(self, mock_mass: MagicMock) -> None:
         """A replaced player hands its group memberships over to its replacement."""
@@ -5402,6 +5403,32 @@ class TestDeletePlayerConfigGroupMemberships:
         await controller.unregister("sonos_1")
 
         assert "players/group_1/values/group_members" not in config_store
+
+    async def test_a_registered_group_re_reads_its_members(self, mock_mass: MagicMock) -> None:
+        """A registered group is told to re-read its members so its live list follows."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+        self._config_store(mock_mass)
+        scheduled: list[Any] = []
+        mock_mass.create_task = MagicMock(side_effect=lambda task: scheduled.append(task))
+        group = MockPlayer(MockProvider("sync_group", mass=mock_mass), "group_1", "Group")
+        entry = ConfigEntry(key="group_members", type=ConfigEntryType.STRING, multi_value=True)
+        entry.value = ["sonos_1", "sonos_2"]
+        group.config.values = {"group_members": entry}
+        controller._players = {"group_1": group}
+
+        with (
+            patch.object(group, "on_config_updated", AsyncMock()) as mock_reload,
+            patch.object(group, "refresh_state") as mock_refresh,
+        ):
+            controller.delete_player_config("sonos_1")
+            for task in [t for t in scheduled if "_reload_group_members" in repr(t)]:
+                await task
+
+        # the in-place config copy is pruned before the group re-reads it
+        assert group.config.values["group_members"].value == ["sonos_2"]
+        mock_reload.assert_awaited_once()
+        mock_refresh.assert_called_once()
 
 
 class TestConfigChangeRestartsPlayback:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -5333,6 +5333,77 @@ class TestDeletePlayerConfigUserFilters:
         mock_mass.webserver.auth.remove_from_user_filters.assert_not_called()
 
 
+class TestDeletePlayerConfigGroupMemberships:
+    """Test how a deleted player config is reflected in the stored group member lists."""
+
+    @staticmethod
+    def _config_store(mock_mass: MagicMock) -> dict[str, Any]:
+        """Back the mocked config with a store holding a group that lists sonos_1."""
+        config_store: dict[str, Any] = {
+            "players": {
+                "group_1": {
+                    "values": {
+                        "group_members": ["sonos_1", "sonos_2"],
+                        "allowed_members": ["sonos_1"],
+                    }
+                },
+            },
+        }
+        mock_mass.config.get = MagicMock(
+            side_effect=lambda key, default=None: config_store.get(key, default)
+        )
+        mock_mass.config.set = MagicMock(
+            side_effect=lambda key, value: config_store.__setitem__(key, value)
+        )
+        return config_store
+
+    def test_removal_drops_the_player_from_the_member_lists(self, mock_mass: MagicMock) -> None:
+        """A removed player is dropped from the member lists of every group."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+        config_store = self._config_store(mock_mass)
+
+        controller.delete_player_config("sonos_1")
+
+        assert config_store["players/group_1/values/group_members"] == ["sonos_2"]
+        assert config_store["players/group_1/values/allowed_members"] == []
+
+    def test_replacement_hands_the_membership_to_the_new_player(self, mock_mass: MagicMock) -> None:
+        """A replaced player hands its group memberships over to its replacement."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+        config_store = self._config_store(mock_mass)
+
+        controller.delete_player_config("sonos_1", replacement_player_id="sonos_3")
+
+        assert config_store["players/group_1/values/group_members"] == ["sonos_3", "sonos_2"]
+        assert config_store["players/group_1/values/allowed_members"] == ["sonos_3"]
+
+    async def test_permanent_unregister_drops_the_membership(self, mock_mass: MagicMock) -> None:
+        """A permanently removed player does not linger in a group's stored member list."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+        config_store = self._config_store(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test_prov", mass=mock_mass)
+        controller._players = {"sonos_1": MockPlayer(provider, "sonos_1", "Sonos 1")}
+
+        await controller.unregister("sonos_1", permanent=True)
+
+        assert config_store["players/group_1/values/group_members"] == ["sonos_2"]
+
+    async def test_temporary_unregister_keeps_the_membership(self, mock_mass: MagicMock) -> None:
+        """A player that is only temporarily gone keeps its spot in the group."""
+        controller = PlayerController(mock_mass)
+        mock_mass.players = controller
+        config_store = self._config_store(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test_prov", mass=mock_mass)
+        controller._players = {"sonos_1": MockPlayer(provider, "sonos_1", "Sonos 1")}
+
+        await controller.unregister("sonos_1")
+
+        assert "players/group_1/values/group_members" not in config_store
+
+
 class TestConfigChangeRestartsPlayback:
     """Test that a changed player setting which needs a reload restarts playback."""
 

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -6437,7 +6437,7 @@ class TestUniversalPlayerMerging:
             },
             "players/ap_keep": {"enabled": True},
             "players/dlna_live": {"enabled": True},
-            # nested players dict scanned by _repoint_group_memberships
+            # nested players dict scanned by _update_group_memberships
             "players": {
                 "group_1": {
                     "enabled": True,
@@ -7247,7 +7247,7 @@ class TestUniversalPlayerReplacement:
                 "values": {"linked_protocol_ids": ["ap_live"]},
             },
             "players/ap_live": {"enabled": True},
-            # nested players dict scanned by _repoint_group_memberships
+            # nested players dict scanned by _update_group_memberships
             "players": {
                 "group_1": {
                     "enabled": True,
@@ -9593,9 +9593,6 @@ class TestUniversalPlayerRestoreOrphanCleanup:
         mock_mass.players._migrate_universal_player_config.assert_called_once_with(
             universal_id, native_parent_id
         )
-        mock_mass.players._repoint_group_memberships.assert_called_once_with(
-            universal_id, native_parent_id
-        )
         mock_mass.players.delete_player_config.assert_called_once_with(
             universal_id, replacement_player_id=native_parent_id
         )
@@ -9686,7 +9683,6 @@ class TestUniversalPlayerRestoreOrphanCleanup:
         mock_mass.players._migrate_universal_player_config.assert_called_once_with(
             universal_id, shell_id
         )
-        mock_mass.players._repoint_group_memberships.assert_called_once_with(universal_id, shell_id)
         mock_mass.players.delete_player_config.assert_called_once_with(
             universal_id, replacement_player_id=shell_id
         )
@@ -9761,9 +9757,6 @@ class TestUniversalPlayerRestoreOrphanCleanup:
         # The wrapper's settings are handed to the first claimer, then its
         # config is deleted
         mock_mass.players._migrate_universal_player_config.assert_called_once_with(
-            universal_id, "native_a"
-        )
-        mock_mass.players._repoint_group_memberships.assert_called_once_with(
             universal_id, "native_a"
         )
         mock_mass.players.delete_player_config.assert_called_once_with(
@@ -9992,7 +9985,6 @@ class TestUniversalPlayerRestoreOrphanCleanup:
         }
         # but the registered wrapper keeps its config and group memberships
         mock_mass.players._migrate_universal_player_config.assert_not_called()
-        mock_mass.players._repoint_group_memberships.assert_not_called()
         mock_mass.players.delete_player_config.assert_not_called()
         mock_mass.player_queues.on_player_remove.assert_not_called()
 

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -7236,7 +7236,7 @@ class TestUniversalPlayerReplacement:
         signaled_events = [call.args[0] for call in mock_mass.signal_event.call_args_list]
         assert EventType.PLAYER_CONFIG_UPDATED in signaled_events
 
-    def test_replace_repoints_group_memberships(self, mock_mass: MagicMock) -> None:
+    async def test_replace_repoints_group_memberships(self, mock_mass: MagicMock) -> None:
         """Replacement re-points group memberships from the wrapper to the native player."""
         config_store: dict[str, Any] = {
             "players/cast_1": {"enabled": True},
@@ -7263,20 +7263,24 @@ class TestUniversalPlayerReplacement:
                 },
             },
         }
-        controller, native, _ = self._setup_carry_over_scenario(mock_mass, config_store)
+        controller, native, scheduled_tasks = self._setup_carry_over_scenario(
+            mock_mass, config_store
+        )
         group_1 = MockPlayer(MockProvider("player_group", mass=mock_mass), "group_1", "Group")
         group_1.set_initialized()
         controller._players["group_1"] = group_1
 
         with patch.object(group_1, "refresh_state") as mock_refresh:
             controller._check_replace_universal_player(native)
+            for task in [t for t in scheduled_tasks if "_reload_group_members" in repr(t)]:
+                await task
 
         # the wrapper id is replaced by the native id on both membership keys
         assert config_store["players/group_1/values/group_members"] == ["cast_1", "other"]
         assert config_store["players/group_1/values/allowed_members"] == ["cast_1"]
         # no duplicate when the native id is already a member
         assert config_store["players/group_2/values/group_members"] == ["cast_1", "extra"]
-        # a registered player whose membership changed is refreshed
+        # a registered player whose membership changed re-reads it and is refreshed
         mock_refresh.assert_called()
 
     async def test_replace_stops_playing_universal_before_unregister(


### PR DESCRIPTION
# What does this implement/fix?

Removing a player left its id behind in the stored member list of every group it was part of. Nothing ever cleaned those lists up, so the group config kept referring to a device that no longer exists, and a device that later returned under the same id was silently pulled back into the group.

While tracing this, the membership detach that was supposed to run on removal turned out to be unreachable: it looks the player up in the registry, but the player is already removed from that registry a few lines earlier, so it always returned immediately. It has been dead since Feb 2026. Restoring it would not have helped here (it only ever touched live state, never the stored config), so it is removed instead - the stored member lists are now handled where the rest of the player's config is cleaned up.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- A removed player is dropped from the stored member list of every group it was in
- The group also re-reads its members right away, so its live list follows along
- A replaced player hands its memberships over to its replacement, as before
- Removed the unreachable group detach from the player removal path

Note: removing a player provider and adding it back now leaves the groups its speakers were in empty, where before the memberships survived. That matches the rest of the removal, which already wipes the player's name, DSP and queue settings.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
