### PR TITLE
Repair albums that are already duplicated in your library

### DIFF
--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -607,33 +607,25 @@ class MetaDataController(
 
 def _duplicate_album_sibling_guard() -> str:
     """Return a query part that selects albums which may be a duplicate of another library row."""
-    own_version = f"LOWER(TRIM(COALESCE({DB_TABLE_ALBUMS}.version,'')))"
-    dup_version = "LOWER(TRIM(COALESCE(dup.version,'')))"
-    # approximates the cases the album comparison does not already rule out: a missing
-    # version on either side (providers often omit the edition of a remaster), and
-    # wording that is a whole-word subset of the other's ("2011 Remaster" vs "Deluxe
-    # Edition 2011 Remaster"). Both leave the editions undecided, which is what the
-    # comparison escalates to a tracklist and barcode check. Independently worded
-    # versions ("Remixes Pt. 1" vs "Remixes Pt. 2") mark a genuinely different edition.
-    # Both sides are space-padded so a version cannot match inside a longer word.
-    compatible_version = (
-        f"({own_version} = '' OR {dup_version} = '' OR "
-        f"INSTR(' ' || {own_version} || ' ', ' ' || {dup_version} || ' ') > 0 OR "
-        f"INSTR(' ' || {dup_version} || ' ', ' ' || {own_version} || ' ') > 0)"
-    )
     shares_artist = (
         f"EXISTS (SELECT 1 FROM {DB_TABLE_ALBUM_ARTISTS} own "
         f"JOIN {DB_TABLE_ALBUM_ARTISTS} other ON other.artist_id = own.artist_id "
         f"WHERE own.album_id = {DB_TABLE_ALBUMS}.item_id AND other.album_id = dup.item_id)"
     )
-    # titles that normalize to nothing (e.g. Ed Sheeran's '+', '=' and '÷')
-    # would otherwise all collapse onto each other
+    # a title that normalizes to nothing (e.g. Ed Sheeran's '+', '=' and '÷') matches every
+    # other such title, so those fall back to their raw spelling like the album comparison does
+    same_title = (
+        f"({DB_TABLE_ALBUMS}.search_name != '' OR "
+        f"REPLACE({DB_TABLE_ALBUMS}.name,' ','') = REPLACE(dup.name,' ',''))"
+    )
+    # deliberately an identity-only pre-filter: which editions may be merged is decided by
+    # the album comparison, which escalates an ambiguous edition to tracklists and
+    # MusicBrainz and rejects a recording-changing one (live, remix, ...) outright
     return (
-        f"({DB_TABLE_ALBUMS}.search_name != '' AND EXISTS ("
-        f"SELECT 1 FROM {DB_TABLE_ALBUMS} dup "
+        f"EXISTS (SELECT 1 FROM {DB_TABLE_ALBUMS} dup "
         f"WHERE dup.item_id != {DB_TABLE_ALBUMS}.item_id "
         f"AND dup.search_name = {DB_TABLE_ALBUMS}.search_name "
-        f"AND {compatible_version} AND {shares_artist}))"
+        f"AND {same_title} AND {shares_artist})"
     )
 
 

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -608,16 +608,17 @@ def _duplicate_album_sibling_guard() -> str:
     """Return a query part that selects albums which may be a duplicate of another library row."""
     own_version = f"LOWER(TRIM(COALESCE({DB_TABLE_ALBUMS}.version,'')))"
     dup_version = "LOWER(TRIM(COALESCE(dup.version,'')))"
-    # an equal version, or one whose wording is a whole-word subset of the other's
-    # ("2011 Remaster" vs "Deluxe Edition 2011 Remaster"), leaves the two editions
-    # undecided - exactly the case the album comparison escalates to a tracklist and
-    # barcode check. Differently worded versions ("Remixes Pt. 1" vs "Remixes Pt. 2")
-    # mark a genuinely different edition, so those rows are left alone. Both sides are
-    # space-padded so a version does not match inside a longer word ("Mix" vs "Remix").
+    # mirrors the cases the album comparison does not already rule out: a missing
+    # version on either side (providers often omit the edition of a remaster), and
+    # wording that is a whole-word subset of the other's ("2011 Remaster" vs "Deluxe
+    # Edition 2011 Remaster"). Both leave the editions undecided, which is what the
+    # comparison escalates to a tracklist and barcode check. Independently worded
+    # versions ("Remixes Pt. 1" vs "Remixes Pt. 2") mark a genuinely different edition.
+    # Both sides are space-padded so a version cannot match inside a longer word.
     compatible_version = (
-        f"({own_version} = {dup_version} OR ({own_version} != '' AND {dup_version} != '' AND ("
+        f"({own_version} = '' OR {dup_version} = '' OR "
         f"INSTR(' ' || {own_version} || ' ', ' ' || {dup_version} || ' ') > 0 OR "
-        f"INSTR(' ' || {dup_version} || ' ', ' ' || {own_version} || ' ') > 0)))"
+        f"INSTR(' ' || {dup_version} || ' ', ' ' || {own_version} || ' ') > 0)"
     )
     shares_artist = (
         f"EXISTS (SELECT 1 FROM {DB_TABLE_ALBUM_ARTISTS} own "

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -24,11 +24,12 @@ from music_assistant_models.enums import (
     ProviderFeature,
     ProviderType,
 )
-from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
 from music_assistant_models.media_items import BrowseFolder
 
 from music_assistant.constants import (
     CONF_LANGUAGE,
+    DB_TABLE_ALBUM_ARTISTS,
     DB_TABLE_ALBUMS,
     DB_TABLE_ARTISTS,
     DB_TABLE_PLAYLISTS,
@@ -497,13 +498,14 @@ class MetaDataController(
         update_current_task_progress(100, f"Processed {len(playlists)} playlist(s)")
 
     async def _reconcile_duplicate_albums(self) -> None:
-        """Enrich and re-match a small batch of sparse, unenriched albums."""
+        """Enrich and re-match a small batch of sparse or possibly duplicated albums."""
         update_current_task_progress_text("Searching for albums needing reconciliation")
         # albums that are still unknown-typed keep retrying at the normal REFRESH_INTERVAL
         # cadence (e.g. after a transient provider outage), rather than only ever once
         refresh_before = int(time() - REFRESH_INTERVAL)
         query = (
-            f"{DB_TABLE_ALBUMS}.album_type = '{AlbumType.UNKNOWN.value}' AND ("
+            f"({DB_TABLE_ALBUMS}.album_type = '{AlbumType.UNKNOWN.value}' "
+            f"OR {_duplicate_album_sibling_guard()}) AND ("
             f"json_extract({DB_TABLE_ALBUMS}.metadata,'$.last_refresh') ISNULL "
             f"OR json_extract({DB_TABLE_ALBUMS}.metadata,'$.last_refresh') < {refresh_before})"
         )
@@ -525,6 +527,10 @@ class MetaDataController(
                 await self._update_album_metadata(album, force_refresh=False)
                 reconciled_album = await self.mass.music.albums.get_library_item(album.item_id)
                 await self.mass.music.albums.match_providers(reconciled_album)
+            except MediaNotFoundError:
+                # both rows of a duplicate pair can share a batch, so this row may
+                # already have been merged into its duplicate earlier in the run
+                continue
             except (MusicAssistantError, aiohttp.ClientError, TimeoutError) as err:
                 report_current_task_failure(f"{album.name}: {err}")
                 self.logger.warning(
@@ -596,6 +602,37 @@ class MetaDataController(
             )
             report_current_task_failure(message)
             self.logger.warning(message)
+
+
+def _duplicate_album_sibling_guard() -> str:
+    """Return a query part that selects albums which may be a duplicate of another library row."""
+    own_version = f"LOWER(TRIM(COALESCE({DB_TABLE_ALBUMS}.version,'')))"
+    dup_version = "LOWER(TRIM(COALESCE(dup.version,'')))"
+    # an equal version, or one whose wording is a whole-word subset of the other's
+    # ("2011 Remaster" vs "Deluxe Edition 2011 Remaster"), leaves the two editions
+    # undecided - exactly the case the album comparison escalates to a tracklist and
+    # barcode check. Differently worded versions ("Remixes Pt. 1" vs "Remixes Pt. 2")
+    # mark a genuinely different edition, so those rows are left alone. Both sides are
+    # space-padded so a version does not match inside a longer word ("Mix" vs "Remix").
+    compatible_version = (
+        f"({own_version} = {dup_version} OR ({own_version} != '' AND {dup_version} != '' AND ("
+        f"INSTR(' ' || {own_version} || ' ', ' ' || {dup_version} || ' ') > 0 OR "
+        f"INSTR(' ' || {dup_version} || ' ', ' ' || {own_version} || ' ') > 0)))"
+    )
+    shares_artist = (
+        f"EXISTS (SELECT 1 FROM {DB_TABLE_ALBUM_ARTISTS} own "
+        f"JOIN {DB_TABLE_ALBUM_ARTISTS} other ON other.artist_id = own.artist_id "
+        f"WHERE own.album_id = {DB_TABLE_ALBUMS}.item_id AND other.album_id = dup.item_id)"
+    )
+    # titles that normalize to nothing (e.g. Ed Sheeran's '+', '=' and '÷')
+    # would otherwise all collapse onto each other
+    return (
+        f"({DB_TABLE_ALBUMS}.search_name != '' AND EXISTS ("
+        f"SELECT 1 FROM {DB_TABLE_ALBUMS} dup "
+        f"WHERE dup.item_id != {DB_TABLE_ALBUMS}.item_id "
+        f"AND dup.search_name = {DB_TABLE_ALBUMS}.search_name "
+        f"AND {compatible_version} AND {shares_artist}))"
+    )
 
 
 def _valid_metadata_guard(table: str) -> str:

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -500,8 +500,8 @@ class MetaDataController(
     async def _reconcile_duplicate_albums(self) -> None:
         """Enrich and re-match a small batch of sparse or possibly duplicated albums."""
         update_current_task_progress_text("Searching for albums needing reconciliation")
-        # albums that are still unknown-typed keep retrying at the normal REFRESH_INTERVAL
-        # cadence (e.g. after a transient provider outage), rather than only ever once
+        # candidates keep retrying at the normal REFRESH_INTERVAL cadence (e.g. after a
+        # transient provider outage), rather than only ever once
         refresh_before = int(time() - REFRESH_INTERVAL)
         query = (
             f"({DB_TABLE_ALBUMS}.album_type = '{AlbumType.UNKNOWN.value}' "
@@ -524,13 +524,14 @@ class MetaDataController(
                 # match has full album details to work with, then re-fetch the now-enriched
                 # library row before re-matching: match_providers merges a confirmed mapping
                 # into an existing duplicate through the safe add_provider_mappings path
-                await self._update_album_metadata(album, force_refresh=False)
-                reconciled_album = await self.mass.music.albums.get_library_item(album.item_id)
+                try:
+                    await self._update_album_metadata(album, force_refresh=False)
+                    reconciled_album = await self.mass.music.albums.get_library_item(album.item_id)
+                except MediaNotFoundError:
+                    # both rows of a duplicate pair can share a batch, so this row may
+                    # already have been merged into its duplicate earlier in the run
+                    continue
                 await self.mass.music.albums.match_providers(reconciled_album)
-            except MediaNotFoundError:
-                # both rows of a duplicate pair can share a batch, so this row may
-                # already have been merged into its duplicate earlier in the run
-                continue
             except (MusicAssistantError, aiohttp.ClientError, TimeoutError) as err:
                 report_current_task_failure(f"{album.name}: {err}")
                 self.logger.warning(
@@ -608,7 +609,7 @@ def _duplicate_album_sibling_guard() -> str:
     """Return a query part that selects albums which may be a duplicate of another library row."""
     own_version = f"LOWER(TRIM(COALESCE({DB_TABLE_ALBUMS}.version,'')))"
     dup_version = "LOWER(TRIM(COALESCE(dup.version,'')))"
-    # mirrors the cases the album comparison does not already rule out: a missing
+    # approximates the cases the album comparison does not already rule out: a missing
     # version on either side (providers often omit the edition of a remaster), and
     # wording that is a whole-word subset of the other's ("2011 Remaster" vs "Deluxe
     # Edition 2011 Remaster"). Both leave the editions undecided, which is what the

--- a/tests/controllers/metadata/test_album_reconciliation.py
+++ b/tests/controllers/metadata/test_album_reconciliation.py
@@ -24,6 +24,7 @@ from music_assistant.controllers.metadata.constants import (
     METADATA_SCAN_BATCH_SIZE,
     REFRESH_INTERVAL,
 )
+from music_assistant.controllers.metadata.controller import _duplicate_album_sibling_guard
 from music_assistant.mass import MusicAssistant
 
 _REPORT_FAILURE = "music_assistant.controllers.metadata.controller.report_current_task_failure"
@@ -51,8 +52,8 @@ def _album_stub(item_id: str = "1", name: str = "Test Album") -> Mock:
 # --------------------------------------------------------------------------- #
 
 
-async def test_reconcile_duplicate_albums_query_matches_unknown_stale_or_null_refresh() -> None:
-    """The candidate query selects unknown-typed albums that are stale or never refreshed."""
+async def test_reconcile_duplicate_albums_query_matches_unknown_or_duplicate_and_stale() -> None:
+    """The candidate query selects unknown-typed or possibly-duplicated stale albums."""
     ctrl = _controller()
     mass = Mock()
     mass.music.albums.get_library_items_by_query = AsyncMock(return_value=[])
@@ -64,7 +65,8 @@ async def test_reconcile_duplicate_albums_query_matches_unknown_stale_or_null_re
 
     _, kwargs = mass.music.albums.get_library_items_by_query.call_args
     assert kwargs["extra_query_parts"] == [
-        f"{DB_TABLE_ALBUMS}.album_type = 'unknown' AND ("
+        f"({DB_TABLE_ALBUMS}.album_type = 'unknown' "
+        f"OR {_duplicate_album_sibling_guard()}) AND ("
         f"json_extract({DB_TABLE_ALBUMS}.metadata,'$.last_refresh') ISNULL "
         f"OR json_extract({DB_TABLE_ALBUMS}.metadata,'$.last_refresh') < {refresh_before})"
     ]
@@ -116,6 +118,151 @@ async def test_reconcile_duplicate_albums_retries_stale_but_not_fresh_refresh(
 
     processed_ids = {call.args[0].item_id for call in update_metadata.await_args_list}
     assert processed_ids == {stale_album.item_id}
+
+
+async def _add_album(
+    mass: MusicAssistant,
+    name: str,
+    artist: Artist,
+    *,
+    version: str = "",
+    album_type: AlbumType = AlbumType.ALBUM,
+    provider_instance: str = "qobuz_1",
+) -> Album:
+    """Add a never-refreshed library album for the given artist."""
+    return await mass.music.albums.add_item_to_library(
+        Album(
+            item_id="0",
+            provider="library",
+            name=name,
+            version=version,
+            album_type=album_type,
+            artists=UniqueList([artist]),
+            provider_mappings={
+                ProviderMapping(
+                    item_id=f"{provider_instance}-{name}-{version}",
+                    provider_domain=provider_instance.rsplit("_", 1)[0],
+                    provider_instance=provider_instance,
+                )
+            },
+        )
+    )
+
+
+async def _reconciled_ids(mass: MusicAssistant) -> set[str]:
+    """Run the reconciliation task and return the item ids it picked up."""
+    with (
+        patch.object(mass.metadata, "_update_album_metadata", AsyncMock()) as update_metadata,
+        patch.object(mass.music.albums, "match_providers", AsyncMock()),
+    ):
+        await mass.metadata._reconcile_duplicate_albums()
+    return {call.args[0].item_id for call in update_metadata.await_args_list}
+
+
+async def test_reconcile_duplicate_albums_selects_typed_album_with_duplicate_sibling(
+    mass: MusicAssistant,
+) -> None:
+    """A fully-typed album is reconciled when another row shares its name, artist and version."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Phil Collins",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="test", provider_instance="library"
+                )
+            },
+        )
+    )
+    first = await _add_album(
+        mass, "...But Seriously", artist, version="2016 Remaster", provider_instance="spotify_1"
+    )
+    second = await _add_album(
+        mass, "...But Seriously", artist, version="2016 Remaster", provider_instance="qobuz_1"
+    )
+    # neither row is unknown-typed, so only the duplicate-sibling clause can select them
+    assert first.item_id != second.item_id
+
+    assert await _reconciled_ids(mass) == {first.item_id, second.item_id}
+
+
+async def test_reconcile_duplicate_albums_ignores_distinct_editions(
+    mass: MusicAssistant,
+) -> None:
+    """Rows whose version wording differs are separate editions and are left alone."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Antoine Clamaran",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="test", provider_instance="library"
+                )
+            },
+        )
+    )
+    await _add_album(
+        mass, "200 Years", artist, version="Remixes Pt. 1", provider_instance="spotify_1"
+    )
+    await _add_album(
+        mass, "200 Years", artist, version="Remixes Pt. 2", provider_instance="qobuz_1"
+    )
+
+    assert await _reconciled_ids(mass) == set()
+
+
+async def test_reconcile_duplicate_albums_selects_subset_version_wording(
+    mass: MusicAssistant,
+) -> None:
+    """A version whose wording is a whole-word subset of its sibling's stays a candidate."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Queen",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="test", provider_instance="library"
+                )
+            },
+        )
+    )
+    plain = await _add_album(
+        mass, "Innuendo", artist, version="2011 Remaster", provider_instance="spotify_1"
+    )
+    deluxe = await _add_album(
+        mass,
+        "Innuendo",
+        artist,
+        version="Deluxe Edition 2011 Remaster",
+        provider_instance="qobuz_1",
+    )
+
+    assert await _reconciled_ids(mass) == {plain.item_id, deluxe.item_id}
+
+
+async def test_reconcile_duplicate_albums_skips_row_merged_away_earlier_in_the_batch() -> None:
+    """A row already merged into its duplicate is skipped silently, not reported as a failure."""
+    ctrl = _controller()
+    mass = Mock()
+    merged_away = _album_stub("1", "Merged Away")
+    healthy = _album_stub("2", "Healthy Album")
+    reloaded_healthy = _album_stub("2", "Healthy Album")
+    mass.music.albums.get_library_items_by_query = AsyncMock(return_value=[merged_away, healthy])
+    mass.music.albums.get_library_item = AsyncMock(return_value=reloaded_healthy)
+    mass.music.albums.match_providers = AsyncMock()
+    ctrl.mass = mass
+    ctrl._update_album_metadata = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[MediaNotFoundError("album not found in library: 1"), None]
+    )
+
+    with patch(_REPORT_FAILURE) as report_failure:
+        await ctrl._reconcile_duplicate_albums()
+
+    report_failure.assert_not_called()
+    mass.music.albums.match_providers.assert_awaited_once_with(reloaded_healthy)
 
 
 async def test_reconcile_duplicate_albums_empty_queue_is_a_noop() -> None:

--- a/tests/controllers/metadata/test_album_reconciliation.py
+++ b/tests/controllers/metadata/test_album_reconciliation.py
@@ -263,10 +263,11 @@ async def test_reconcile_duplicate_albums_selects_siblings_whatever_the_edition(
     assert await _reconciled_ids(mass) == {first.item_id, second.item_id}
 
 
+@pytest.mark.parametrize(("first_title", "second_title"), [("!!!", "!!!"), ("( )", "()")])
 async def test_reconcile_duplicate_albums_selects_symbol_only_titles_spelled_the_same(
-    mass: MusicAssistant,
+    mass: MusicAssistant, first_title: str, second_title: str
 ) -> None:
-    """Titles that normalize to nothing still pair up when their raw spelling matches."""
+    """Titles that normalize to nothing pair up on their raw spelling, ignoring spacing."""
     artist = await mass.music.artists.add_item_to_library(
         Artist(
             item_id="0",
@@ -279,10 +280,32 @@ async def test_reconcile_duplicate_albums_selects_symbol_only_titles_spelled_the
             },
         )
     )
-    first = await _add_album(mass, "!!!", artist, provider_instance="spotify_1")
-    second = await _add_album(mass, "!!!", artist, provider_instance="qobuz_1")
+    first = await _add_album(mass, first_title, artist, provider_instance="spotify_1")
+    second = await _add_album(mass, second_title, artist, provider_instance="qobuz_1")
 
     assert await _reconciled_ids(mass) == {first.item_id, second.item_id}
+
+
+async def test_reconcile_duplicate_albums_ignores_other_albums_by_the_same_artist(
+    mass: MusicAssistant,
+) -> None:
+    """Sharing an artist is not enough; the titles have to match too."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Radiohead",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="test", provider_instance="library"
+                )
+            },
+        )
+    )
+    await _add_album(mass, "Kid A", artist, provider_instance="spotify_1")
+    await _add_album(mass, "Amnesiac", artist, provider_instance="qobuz_1")
+
+    assert await _reconciled_ids(mass) == set()
 
 
 async def test_reconcile_duplicate_albums_ignores_same_title_by_other_artist(

--- a/tests/controllers/metadata/test_album_reconciliation.py
+++ b/tests/controllers/metadata/test_album_reconciliation.py
@@ -213,6 +213,30 @@ async def test_reconcile_duplicate_albums_ignores_distinct_editions(
     assert await _reconciled_ids(mass) == set()
 
 
+async def test_reconcile_duplicate_albums_selects_missing_version_against_named_edition(
+    mass: MusicAssistant,
+) -> None:
+    """A sibling that omits the edition entirely stays a candidate for the tracklist check."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Amy Winehouse",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="test", provider_instance="library"
+                )
+            },
+        )
+    )
+    untagged = await _add_album(mass, "Back To Black", artist, provider_instance="qobuz_1")
+    tagged = await _add_album(
+        mass, "Back To Black", artist, version="Deluxe Edition", provider_instance="spotify_1"
+    )
+
+    assert await _reconciled_ids(mass) == {untagged.item_id, tagged.item_id}
+
+
 async def test_reconcile_duplicate_albums_selects_subset_version_wording(
     mass: MusicAssistant,
 ) -> None:

--- a/tests/controllers/metadata/test_album_reconciliation.py
+++ b/tests/controllers/metadata/test_album_reconciliation.py
@@ -187,86 +187,6 @@ async def test_reconcile_duplicate_albums_selects_typed_album_with_duplicate_sib
     assert await _reconciled_ids(mass) == {first.item_id, second.item_id}
 
 
-async def test_reconcile_duplicate_albums_ignores_distinct_editions(
-    mass: MusicAssistant,
-) -> None:
-    """Rows whose version wording differs are separate editions and are left alone."""
-    artist = await mass.music.artists.add_item_to_library(
-        Artist(
-            item_id="0",
-            provider="library",
-            name="Antoine Clamaran",
-            provider_mappings={
-                ProviderMapping(
-                    item_id="artist", provider_domain="test", provider_instance="library"
-                )
-            },
-        )
-    )
-    await _add_album(
-        mass, "200 Years", artist, version="Remixes Pt. 1", provider_instance="spotify_1"
-    )
-    await _add_album(
-        mass, "200 Years", artist, version="Remixes Pt. 2", provider_instance="qobuz_1"
-    )
-
-    assert await _reconciled_ids(mass) == set()
-
-
-async def test_reconcile_duplicate_albums_selects_missing_version_against_named_edition(
-    mass: MusicAssistant,
-) -> None:
-    """A sibling that omits the edition entirely stays a candidate for the tracklist check."""
-    artist = await mass.music.artists.add_item_to_library(
-        Artist(
-            item_id="0",
-            provider="library",
-            name="Amy Winehouse",
-            provider_mappings={
-                ProviderMapping(
-                    item_id="artist", provider_domain="test", provider_instance="library"
-                )
-            },
-        )
-    )
-    untagged = await _add_album(mass, "Back To Black", artist, provider_instance="qobuz_1")
-    tagged = await _add_album(
-        mass, "Back To Black", artist, version="Deluxe Edition", provider_instance="spotify_1"
-    )
-
-    assert await _reconciled_ids(mass) == {untagged.item_id, tagged.item_id}
-
-
-async def test_reconcile_duplicate_albums_selects_subset_version_wording(
-    mass: MusicAssistant,
-) -> None:
-    """A version whose wording is a whole-word subset of its sibling's stays a candidate."""
-    artist = await mass.music.artists.add_item_to_library(
-        Artist(
-            item_id="0",
-            provider="library",
-            name="Queen",
-            provider_mappings={
-                ProviderMapping(
-                    item_id="artist", provider_domain="test", provider_instance="library"
-                )
-            },
-        )
-    )
-    plain = await _add_album(
-        mass, "Innuendo", artist, version="2011 Remaster", provider_instance="spotify_1"
-    )
-    deluxe = await _add_album(
-        mass,
-        "Innuendo",
-        artist,
-        version="Deluxe Edition 2011 Remaster",
-        provider_instance="qobuz_1",
-    )
-
-    assert await _reconciled_ids(mass) == {plain.item_id, deluxe.item_id}
-
-
 async def test_reconcile_duplicate_albums_skips_row_merged_away_earlier_in_the_batch() -> None:
     """A row already merged into its duplicate is skipped silently, not reported as a failure."""
     ctrl = _controller()
@@ -306,6 +226,63 @@ async def test_reconcile_duplicate_albums_reports_match_providers_not_found() ->
         await ctrl._reconcile_duplicate_albums()
 
     report_failure.assert_called_once_with("Searched Album: No results for Bandcamp search")
+
+
+@pytest.mark.parametrize(
+    ("first_version", "second_version"),
+    [
+        ("", ""),
+        ("", "Deluxe Edition"),
+        ("2011 Remaster", "Deluxe Edition 2011 Remaster"),
+        ("Remixes Pt. 1", "Remixes Pt. 2"),
+    ],
+)
+async def test_reconcile_duplicate_albums_selects_siblings_whatever_the_edition(
+    mass: MusicAssistant, first_version: str, second_version: str
+) -> None:
+    """Candidate selection is identity-only; deciding the edition is the matcher's job."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Queen",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="test", provider_instance="library"
+                )
+            },
+        )
+    )
+    first = await _add_album(
+        mass, "Innuendo", artist, version=first_version, provider_instance="spotify_1"
+    )
+    second = await _add_album(
+        mass, "Innuendo", artist, version=second_version, provider_instance="qobuz_1"
+    )
+
+    assert await _reconciled_ids(mass) == {first.item_id, second.item_id}
+
+
+async def test_reconcile_duplicate_albums_selects_symbol_only_titles_spelled_the_same(
+    mass: MusicAssistant,
+) -> None:
+    """Titles that normalize to nothing still pair up when their raw spelling matches."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="!!!",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="test", provider_instance="library"
+                )
+            },
+        )
+    )
+    first = await _add_album(mass, "!!!", artist, provider_instance="spotify_1")
+    second = await _add_album(mass, "!!!", artist, provider_instance="qobuz_1")
+
+    assert await _reconciled_ids(mass) == {first.item_id, second.item_id}
 
 
 async def test_reconcile_duplicate_albums_ignores_same_title_by_other_artist(
@@ -353,28 +330,6 @@ async def test_reconcile_duplicate_albums_ignores_titles_that_normalize_to_nothi
     )
     for index, title in enumerate(("+", "=", "÷")):
         await _add_album(mass, title, artist, provider_instance=f"qobuz_{index}")
-
-    assert await _reconciled_ids(mass) == set()
-
-
-async def test_reconcile_duplicate_albums_ignores_version_matching_inside_a_word(
-    mass: MusicAssistant,
-) -> None:
-    """A version only matches whole words, so "Mix" is not a subset of "Remix"."""
-    artist = await mass.music.artists.add_item_to_library(
-        Artist(
-            item_id="0",
-            provider="library",
-            name="Daddy Yankee",
-            provider_mappings={
-                ProviderMapping(
-                    item_id="artist", provider_domain="test", provider_instance="library"
-                )
-            },
-        )
-    )
-    await _add_album(mass, "Dura", artist, version="Mix", provider_instance="spotify_1")
-    await _add_album(mass, "Dura", artist, version="Remix", provider_instance="qobuz_1")
 
     assert await _reconciled_ids(mass) == set()
 

--- a/tests/controllers/metadata/test_album_reconciliation.py
+++ b/tests/controllers/metadata/test_album_reconciliation.py
@@ -289,6 +289,96 @@ async def test_reconcile_duplicate_albums_skips_row_merged_away_earlier_in_the_b
     mass.music.albums.match_providers.assert_awaited_once_with(reloaded_healthy)
 
 
+async def test_reconcile_duplicate_albums_reports_match_providers_not_found() -> None:
+    """A not-found raised by a provider search is reported, not mistaken for a merged row."""
+    ctrl = _controller()
+    mass = Mock()
+    album = _album_stub("1", "Searched Album")
+    mass.music.albums.get_library_items_by_query = AsyncMock(return_value=[album])
+    mass.music.albums.get_library_item = AsyncMock(return_value=album)
+    mass.music.albums.match_providers = AsyncMock(
+        side_effect=MediaNotFoundError("No results for Bandcamp search")
+    )
+    ctrl.mass = mass
+    ctrl._update_album_metadata = AsyncMock()  # type: ignore[method-assign]
+
+    with patch(_REPORT_FAILURE) as report_failure:
+        await ctrl._reconcile_duplicate_albums()
+
+    report_failure.assert_called_once_with("Searched Album: No results for Bandcamp search")
+
+
+async def test_reconcile_duplicate_albums_ignores_same_title_by_other_artist(
+    mass: MusicAssistant,
+) -> None:
+    """Same-titled albums by unrelated artists are not treated as duplicates."""
+    artists = [
+        await mass.music.artists.add_item_to_library(
+            Artist(
+                item_id="0",
+                provider="library",
+                name=name,
+                provider_mappings={
+                    ProviderMapping(
+                        item_id=f"artist-{name}",
+                        provider_domain="test",
+                        provider_instance="library",
+                    )
+                },
+            )
+        )
+        for name in ("Tracy Chapman", "Chase & Status")
+    ]
+    for index, artist in enumerate(artists):
+        await _add_album(mass, "The Collection", artist, provider_instance=f"qobuz_{index}")
+
+    assert await _reconciled_ids(mass) == set()
+
+
+async def test_reconcile_duplicate_albums_ignores_titles_that_normalize_to_nothing(
+    mass: MusicAssistant,
+) -> None:
+    """Symbol-only titles all normalize to an empty search name and must not pair up."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Ed Sheeran",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="test", provider_instance="library"
+                )
+            },
+        )
+    )
+    for index, title in enumerate(("+", "=", "÷")):
+        await _add_album(mass, title, artist, provider_instance=f"qobuz_{index}")
+
+    assert await _reconciled_ids(mass) == set()
+
+
+async def test_reconcile_duplicate_albums_ignores_version_matching_inside_a_word(
+    mass: MusicAssistant,
+) -> None:
+    """A version only matches whole words, so "Mix" is not a subset of "Remix"."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Daddy Yankee",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="test", provider_instance="library"
+                )
+            },
+        )
+    )
+    await _add_album(mass, "Dura", artist, version="Mix", provider_instance="spotify_1")
+    await _add_album(mass, "Dura", artist, version="Remix", provider_instance="qobuz_1")
+
+    assert await _reconciled_ids(mass) == set()
+
+
 async def test_reconcile_duplicate_albums_empty_queue_is_a_noop() -> None:
     """An empty candidate batch does not touch any album."""
     ctrl = _controller()


### PR DESCRIPTION
# What does this implement/fix?

A recent fix stopped the same album being added twice when providers disagree on the
details, but it only guards new additions — albums that were already duplicated in a
library stayed that way.

The hourly reconciliation task that could clean them up only looked at albums whose type
was still unknown. On a real 3.4k-album library that left most existing duplicates
permanently out of reach, because a duplicate usually already has a proper album type on
at least one of the two rows.

The task now also picks up an album when another row shares its title and artist. Whether
those two rows are really the same album, or two different editions that must stay apart,
is left to the existing album comparison — it already checks tracklists and MusicBrainz
for an ambiguous edition and rejects live/remix versions outright.

**Related issue (if applicable):**

- follow-up to #5790

## Types of changes

- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Reconciliation now also considers albums that have a same-title, same-artist sibling row, instead of only albums with an unknown type.
- Titles made only of symbols (`+`, `=`, `÷`) fall back to their raw spelling, so they no longer all look like the same album.
- A row that an earlier item in the same run already merged away is skipped, while a genuine provider lookup failure is still reported.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
