### PR TITLE
Keep a library sync going when one item fails

### DIFF
--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -929,6 +929,7 @@ class MusicProvider(Provider):
         # process deletions (= no longer in library)
         update_current_task_progress_text("Checking library deletions")
         controller = self.mass.music.get_controller(media_type)
+        prev_library_items: list[int] | None
         if self._sync_incomplete:
             # a skipped item is missing from cur_db_ids just like a deleted one, but it is
             # still in the provider's library, so deleting it would throw away valid content
@@ -936,8 +937,16 @@ class MusicProvider(Provider):
                 summary = f"{self._sync_item_failures} item(s) could not be synced"
                 self.logger.warning("Skipping deletions for %s: %s", self.name, summary)
                 report_current_task_failure(f"Deletions skipped: {summary}")
+            # merge this run's id's into the stored ones instead of replacing them: that
+            # keeps both the deletions this run could not tell apart from its own failures
+            # and the items it saw for the first time, so a later complete run finds either
+            if prev_library_items := await self.mass.cache.get(
+                key=media_type.value,
+                provider=self.instance_id,
+                category=CACHE_CATEGORY_PREV_LIBRARY_IDS,
+            ):
+                cur_db_ids.update(prev_library_items)
         elif self.library_sync_deletions_enabled():
-            prev_library_items: list[int] | None
             if prev_library_items := await self.mass.cache.get(
                 key=media_type.value,
                 provider=self.instance_id,
@@ -976,17 +985,13 @@ class MusicProvider(Provider):
                                 db_id, library_item.provider_mappings
                             )
                         await asyncio.sleep(0)  # yield to eventloop
-        if not self._sync_incomplete:
-            # store current list of id's in cache so we can track changes. an incomplete run
-            # must keep the previous (complete) list: overwriting it with one that is missing
-            # both the skipped and the genuinely deleted items would drop the deletions this
-            # run could not process, leaving them undetectable on any later run
-            await self.mass.cache.set(
-                key=media_type.value,
-                data=list(cur_db_ids),
-                provider=self.instance_id,
-                category=CACHE_CATEGORY_PREV_LIBRARY_IDS,
-            )
+        # store current list of id's in cache so we can track changes
+        await self.mass.cache.set(
+            key=media_type.value,
+            data=list(cur_db_ids),
+            provider=self.instance_id,
+            category=CACHE_CATEGORY_PREV_LIBRARY_IDS,
+        )
         update_current_task_progress_text("Finalizing library sync")
 
     def _update_sync_task_item_status(
@@ -1053,10 +1058,10 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_artists():
             item_count += 1
             self._update_sync_task_item_status(MediaType.ARTIST, item_count, prov_item.name)
-            sync_details = await self.mass.music.artists.get_library_item_sync_details(
-                prov_item.provider_mappings,
-            )
             try:
+                sync_details = await self.mass.music.artists.get_library_item_sync_details(
+                    prov_item.provider_mappings,
+                )
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
                     if not sync_details:
@@ -1114,10 +1119,10 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_albums():
             item_count += 1
             self._update_sync_task_item_status(MediaType.ALBUM, item_count, prov_item.name)
-            sync_details = await self.mass.music.albums.get_library_item_sync_details(
-                prov_item.provider_mappings,
-            )
             try:
+                sync_details = await self.mass.music.albums.get_library_item_sync_details(
+                    prov_item.provider_mappings,
+                )
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
                     if not sync_details:
@@ -1180,10 +1185,10 @@ class MusicProvider(Provider):
             await self.get_album_tracks(prov_album_id), start=1
         ):
             self._update_sync_task_item_status(MediaType.TRACK, item_count, prov_track.name)
-            sync_details = await self.mass.music.tracks.get_library_item_sync_details(
-                prov_track.provider_mappings,
-            )
             try:
+                sync_details = await self.mass.music.tracks.get_library_item_sync_details(
+                    prov_track.provider_mappings,
+                )
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
                     if not sync_details:
@@ -1263,13 +1268,13 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_audiobooks():
             item_count += 1
             self._update_sync_task_item_status(MediaType.AUDIOBOOK, item_count, prov_item.name)
-            sync_details = cast(
-                "AudiobookSyncDetails | None",
-                await self.mass.music.audiobooks.get_library_item_sync_details(
-                    prov_item.provider_mappings,
-                ),
-            )
             try:
+                sync_details = cast(
+                    "AudiobookSyncDetails | None",
+                    await self.mass.music.audiobooks.get_library_item_sync_details(
+                        prov_item.provider_mappings,
+                    ),
+                )
                 self._validate_audiobook_author_narrator_types(prov_item)
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
@@ -1359,10 +1364,10 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_playlists():
             item_count += 1
             self._update_sync_task_item_status(MediaType.PLAYLIST, item_count, prov_item.name)
-            library_item = await self.mass.music.playlists.get_library_item_by_prov_mappings(
-                prov_item.provider_mappings,
-            )
             try:
+                library_item = await self.mass.music.playlists.get_library_item_by_prov_mappings(
+                    prov_item.provider_mappings,
+                )
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
                     if not library_item:
@@ -1433,10 +1438,10 @@ class MusicProvider(Provider):
             item_count += 1
             self._update_sync_task_item_status(MediaType.TRACK, item_count, prov_track.name)
             controller = self.mass.music.get_controller(prov_track.media_type)
-            sync_details = await controller.get_library_item_sync_details(
-                prov_track.provider_mappings,
-            )
             try:
+                sync_details = await controller.get_library_item_sync_details(
+                    prov_track.provider_mappings,
+                )
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
                     if not sync_details:
@@ -1477,13 +1482,13 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_tracks():
             item_count += 1
             self._update_sync_task_item_status(MediaType.TRACK, item_count, prov_item.name)
-            sync_details = cast(
-                "TrackSyncDetails | None",
-                await self.mass.music.tracks.get_library_item_sync_details(
-                    prov_item.provider_mappings,
-                ),
-            )
             try:
+                sync_details = cast(
+                    "TrackSyncDetails | None",
+                    await self.mass.music.tracks.get_library_item_sync_details(
+                        prov_item.provider_mappings,
+                    ),
+                )
                 if not sync_details and not prov_item.available:
                     # skip unavailable tracks
                     # TODO: do we want to search for substitutes at this point ?
@@ -1542,10 +1547,10 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_podcasts():
             item_count += 1
             self._update_sync_task_item_status(MediaType.PODCAST, item_count, prov_item.name)
-            sync_details = await self.mass.music.podcasts.get_library_item_sync_details(
-                prov_item.provider_mappings,
-            )
             try:
+                sync_details = await self.mass.music.podcasts.get_library_item_sync_details(
+                    prov_item.provider_mappings,
+                )
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
                     if not sync_details:
@@ -1602,10 +1607,10 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_radios():
             item_count += 1
             self._update_sync_task_item_status(MediaType.RADIO, item_count, prov_item.name)
-            library_item = await self.mass.music.radio.get_library_item_by_prov_mappings(
-                prov_item.provider_mappings,
-            )
             try:
+                library_item = await self.mass.music.radio.get_library_item_by_prov_mappings(
+                    prov_item.provider_mappings,
+                )
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
                     if not library_item:

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -64,6 +65,10 @@ if TYPE_CHECKING:
 
 CACHE_CATEGORY_PREV_LIBRARY_IDS: Final[int] = 1
 DEFAULT_MAX_CONCURRENT_STREAMS: Final[int] = 5
+# a provider-wide payload change fails every single item, so only the first failures
+# of a sync run are logged in full to keep the (rotating) log file usable
+MAX_LOGGED_SYNC_FAILURES: Final[int] = 25
+MAX_SYNC_ERROR_DETAIL: Final[int] = 200
 
 
 class ProviderStreamLimitError(AudioError):
@@ -90,6 +95,21 @@ class ProviderStreamLimitError(AudioError):
         self.limit = limit
 
 
+def describe_sync_error(err: Exception) -> str:
+    """Return a short description of a sync failure, safe to log and to report to clients."""
+    if isinstance(err, MusicAssistantError):
+        return str(err)
+    # an unexpected error can carry an entire api response as its message, which would end
+    # up in the log and - through the task failure list - in every connected client. report
+    # it by type with a clipped detail and leave the full payload to the debug traceback
+    detail = str(err)
+    if not detail:
+        return type(err).__name__
+    if len(detail) > MAX_SYNC_ERROR_DETAIL:
+        detail = f"{detail[:MAX_SYNC_ERROR_DETAIL]}..."
+    return f"{type(err).__name__}: {detail}"
+
+
 class MusicProvider(Provider):
     """
     Base representation of a Music Provider (controller).
@@ -114,6 +134,11 @@ class MusicProvider(Provider):
             if max_concurrent_streams is not None
             else None
         )
+        # state of the sync run that is currently active: whether it failed to collect an item
+        # (leaving its result set incomplete) and how many failures it reported so far.
+        # library syncs are serialized (by the music controller) so plain attributes suffice
+        self._sync_incomplete = False
+        self._sync_item_failures = 0
 
     @property
     def max_concurrent_streams(self) -> int | None:
@@ -881,6 +906,8 @@ class MusicProvider(Provider):
         if not self.mass.music.library_supported(self, media_type):
             raise UnsupportedFeaturedException("Library sync not supported for this media type")
 
+        self._sync_incomplete = False
+        self._sync_item_failures = 0
         if media_type == MediaType.ARTIST:
             cur_db_ids = await self._sync_library_artists()
         elif media_type == MediaType.ALBUM:
@@ -902,7 +929,14 @@ class MusicProvider(Provider):
         # process deletions (= no longer in library)
         update_current_task_progress_text("Checking library deletions")
         controller = self.mass.music.get_controller(media_type)
-        if self.library_sync_deletions_enabled():
+        if self._sync_incomplete:
+            # a skipped item is missing from cur_db_ids just like a deleted one, but it is
+            # still in the provider's library, so deleting it would throw away valid content
+            if self.library_sync_deletions_enabled():
+                summary = f"{self._sync_item_failures} item(s) could not be synced"
+                self.logger.warning("Skipping deletions for %s: %s", self.name, summary)
+                report_current_task_failure(f"Deletions skipped: {summary}")
+        elif self.library_sync_deletions_enabled():
             prev_library_items: list[int] | None
             if prev_library_items := await self.mass.cache.get(
                 key=media_type.value,
@@ -942,13 +976,17 @@ class MusicProvider(Provider):
                                 db_id, library_item.provider_mappings
                             )
                         await asyncio.sleep(0)  # yield to eventloop
-        # store current list of id's in cache so we can track changes
-        await self.mass.cache.set(
-            key=media_type.value,
-            data=list(cur_db_ids),
-            provider=self.instance_id,
-            category=CACHE_CATEGORY_PREV_LIBRARY_IDS,
-        )
+        if not self._sync_incomplete:
+            # store current list of id's in cache so we can track changes. an incomplete run
+            # must keep the previous (complete) list: overwriting it with one that is missing
+            # both the skipped and the genuinely deleted items would drop the deletions this
+            # run could not process, leaving them undetectable on any later run
+            await self.mass.cache.set(
+                key=media_type.value,
+                data=list(cur_db_ids),
+                provider=self.instance_id,
+                category=CACHE_CATEGORY_PREV_LIBRARY_IDS,
+            )
         update_current_task_progress_text("Finalizing library sync")
 
     def _update_sync_task_item_status(
@@ -960,12 +998,33 @@ class MusicProvider(Provider):
             message = f"{message}: {item_name}"
         update_current_task_progress_text(message)
 
-    def _report_sync_task_failure(
+    def _handle_sync_item_failure(
         self, media_type: MediaType, item_ref: str | None, err: Exception
     ) -> None:
-        """Record a non-fatal sync failure on the active background task."""
+        """Log a non-fatal sync failure and record it on the active background task."""
+        self._sync_item_failures += 1
+        error_detail = describe_sync_error(err)
+        if self._sync_item_failures <= MAX_LOGGED_SYNC_FAILURES:
+            if isinstance(err, MusicAssistantError):
+                self.logger.warning(
+                    "Skipping sync of %s %s - error details: %s",
+                    media_type.value,
+                    item_ref,
+                    error_detail,
+                )
+            else:
+                # not one of our own errors: usually a provider choking on its own api
+                # payload, but the per-item library writes raise the same way, so log the
+                # traceback (on debug) to make the actual origin traceable
+                self.logger.error(
+                    "Skipping sync of %s %s - unexpected error: %s",
+                    media_type.value,
+                    item_ref,
+                    error_detail,
+                    exc_info=err if self.logger.isEnabledFor(logging.DEBUG) else None,
+                )
         report_current_task_failure(
-            f"Failed to sync {media_type.value} {item_ref or '<unknown>'}: {err}"
+            f"Failed to sync {media_type.value} {item_ref or '<unknown>'}: {error_detail}"
         )
 
     async def _sync_item_genres(
@@ -1032,13 +1091,9 @@ class MusicProvider(Provider):
                     )
                 cur_db_ids.add(db_id)
                 await asyncio.sleep(0)  # yield to eventloop
-            except MusicAssistantError as err:
-                self.logger.warning(
-                    "Skipping sync of artist %s - error details: %s",
-                    prov_item.uri,
-                    str(err),
-                )
-                self._report_sync_task_failure(MediaType.ARTIST, prov_item.uri, err)
+            except Exception as err:
+                self._sync_incomplete = True
+                self._handle_sync_item_failure(MediaType.ARTIST, prov_item.uri, err)
         return cur_db_ids
 
     def library_sync_album_tracks_enabled(self) -> bool:
@@ -1097,16 +1152,17 @@ class MusicProvider(Provider):
                     )
                 cur_db_ids.add(db_id)
                 await asyncio.sleep(0)  # yield to eventloop
-                # optionally add album tracks to library
-                if sync_album_tracks:
+            except Exception as err:
+                self._sync_incomplete = True
+                self._handle_sync_item_failure(MediaType.ALBUM, prov_item.uri, err)
+                continue
+            # optionally add album tracks to library. the album is already collected here,
+            # so failing to import its tracks does not make the album result set incomplete
+            if sync_album_tracks:
+                try:
                     await self.import_album_tracks(prov_item.item_id, prov_item.name)
-            except MusicAssistantError as err:
-                self.logger.warning(
-                    "Skipping sync of album %s - error details: %s",
-                    prov_item.uri,
-                    str(err),
-                )
-                self._report_sync_task_failure(MediaType.ALBUM, prov_item.uri, err)
+                except Exception as err:
+                    self._handle_sync_item_failure(MediaType.ALBUM, prov_item.uri, err)
         return cur_db_ids
 
     async def import_album_tracks(self, prov_album_id: str, album_name: str | None = None) -> None:
@@ -1156,13 +1212,8 @@ class MusicProvider(Provider):
                         fallback_genres,
                     )
                 await asyncio.sleep(0)  # yield to eventloop
-            except MusicAssistantError as err:
-                self.logger.warning(
-                    "Skipping sync of album track %s - error details: %s",
-                    prov_track.uri,
-                    str(err),
-                )
-                self._report_sync_task_failure(MediaType.TRACK, prov_track.uri, err)
+            except Exception as err:
+                self._handle_sync_item_failure(MediaType.TRACK, prov_track.uri, err)
 
     def _validate_audiobook_author_narrator_types(self, prov_item: Audiobook) -> None:
         """
@@ -1290,13 +1341,9 @@ class MusicProvider(Provider):
 
                 cur_db_ids.add(db_id)
                 await asyncio.sleep(0)  # yield to eventloop
-            except MusicAssistantError as err:
-                self.logger.warning(
-                    "Skipping sync of audiobook %s - error details: %s",
-                    prov_item.uri,
-                    str(err),
-                )
-                self._report_sync_task_failure(MediaType.AUDIOBOOK, prov_item.uri, err)
+            except Exception as err:
+                self._sync_incomplete = True
+                self._handle_sync_item_failure(MediaType.AUDIOBOOK, prov_item.uri, err)
         return cur_db_ids
 
     async def _sync_library_playlists(self) -> set[int]:
@@ -1355,19 +1402,20 @@ class MusicProvider(Provider):
                         await self.mass.music.playlists.set_favorite(library_item.item_id, True)
                 cur_db_ids.add(int(library_item.item_id))
                 await asyncio.sleep(0)  # yield to eventloop
-                # optionally sync playlist tracks
-                if (
-                    prov_item.name in conf_sync_playlist_tracks
-                    or prov_item.uri in conf_sync_playlist_tracks
-                ):
+            except Exception as err:
+                self._sync_incomplete = True
+                self._handle_sync_item_failure(MediaType.PLAYLIST, prov_item.uri, err)
+                continue
+            # optionally sync playlist tracks. the playlist is already collected here, so
+            # failing on its tracks does not make the playlist result set incomplete
+            if (
+                prov_item.name in conf_sync_playlist_tracks
+                or prov_item.uri in conf_sync_playlist_tracks
+            ):
+                try:
                     await self._sync_playlist_tracks(prov_item)
-            except MusicAssistantError as err:
-                self.logger.warning(
-                    "Skipping sync of playlist %s - error details: %s",
-                    prov_item.uri,
-                    str(err),
-                )
-                self._report_sync_task_failure(MediaType.PLAYLIST, prov_item.uri, err)
+                except Exception as err:
+                    self._handle_sync_item_failure(MediaType.PLAYLIST, prov_item.uri, err)
         return cur_db_ids
 
     async def _sync_playlist_tracks(self, provider_playlist: Playlist) -> None:
@@ -1418,13 +1466,8 @@ class MusicProvider(Provider):
                         fallback_genres,
                     )
                 await asyncio.sleep(0)  # yield to eventloop
-            except MusicAssistantError as err:
-                self.logger.warning(
-                    "Skipping sync of album track %s - error details: %s",
-                    prov_track.uri,
-                    str(err),
-                )
-                self._report_sync_task_failure(MediaType.TRACK, prov_track.uri, err)
+            except Exception as err:
+                self._handle_sync_item_failure(MediaType.TRACK, prov_track.uri, err)
 
     async def _sync_library_tracks(self) -> set[int]:
         """Sync Library Tracks to Music Assistant library."""
@@ -1486,13 +1529,9 @@ class MusicProvider(Provider):
                     )
                 cur_db_ids.add(db_id)
                 await asyncio.sleep(0)  # yield to eventloop
-            except MusicAssistantError as err:
-                self.logger.warning(
-                    "Skipping sync of track %s - error details: %s",
-                    prov_item.uri,
-                    str(err),
-                )
-                self._report_sync_task_failure(MediaType.TRACK, prov_item.uri, err)
+            except Exception as err:
+                self._sync_incomplete = True
+                self._handle_sync_item_failure(MediaType.TRACK, prov_item.uri, err)
         return cur_db_ids
 
     async def _sync_library_podcasts(self) -> set[int]:
@@ -1541,17 +1580,18 @@ class MusicProvider(Provider):
                     )
                 cur_db_ids.add(db_id)
                 await asyncio.sleep(0)  # yield to eventloop
-
+            except Exception as err:
+                self._sync_incomplete = True
+                self._handle_sync_item_failure(MediaType.PODCAST, prov_item.uri, err)
+                continue
+            # the podcast is already collected here, so a feed that fails to deliver its
+            # episodes does not make the podcast result set incomplete
+            try:
                 # precache podcast episodes
                 async for _ in self.mass.music.podcasts.episodes(str(db_id), "library"):
                     await asyncio.sleep(0)  # yield to eventloop
-            except MusicAssistantError as err:
-                self.logger.warning(
-                    "Skipping sync of podcast %s - error details: %s",
-                    prov_item.uri,
-                    str(err),
-                )
-                self._report_sync_task_failure(MediaType.PODCAST, prov_item.uri, err)
+            except Exception as err:
+                self._handle_sync_item_failure(MediaType.PODCAST, prov_item.uri, err)
         return cur_db_ids
 
     async def _sync_library_radios(self) -> set[int]:
@@ -1597,13 +1637,9 @@ class MusicProvider(Provider):
                 cur_db_ids.add(int(library_item.item_id))
                 await asyncio.sleep(0)  # yield to eventloop
 
-            except MusicAssistantError as err:
-                self.logger.warning(
-                    "Skipping sync of Radio %s - error details: %s",
-                    prov_item.uri,
-                    str(err),
-                )
-                self._report_sync_task_failure(MediaType.RADIO, prov_item.uri, err)
+            except Exception as err:
+                self._sync_incomplete = True
+                self._handle_sync_item_failure(MediaType.RADIO, prov_item.uri, err)
         return cur_db_ids
 
     # DO NOT OVERRIDE BELOW

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -6,6 +6,8 @@ import asyncio
 import logging
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Final, cast
 
@@ -71,6 +73,35 @@ MAX_LOGGED_SYNC_FAILURES: Final[int] = 25
 MAX_SYNC_ERROR_DETAIL: Final[int] = 200
 
 
+@dataclass
+class SyncRunState:
+    """
+    Failure state of one library sync run.
+
+    :param incomplete: True once the run failed to collect an item, which makes its
+        result set an unsafe basis for deleting anything from the library.
+    :param failures: Number of item failures reported by the run so far.
+    """
+
+    incomplete: bool = False
+    failures: int = 0
+
+
+# scoped per run rather than per provider: a standalone import_album_tracks() is
+# launched as its own task, so it must not consume or inflate a running sync's state
+SYNC_RUN_STATE: Final[ContextVar[SyncRunState | None]] = ContextVar(
+    "music_provider_sync_run", default=None
+)
+
+
+def sync_run_state() -> SyncRunState:
+    """Return the state of the sync run in progress, starting one if there is none."""
+    if (state := SYNC_RUN_STATE.get()) is None:
+        state = SyncRunState()
+        SYNC_RUN_STATE.set(state)
+    return state
+
+
 class ProviderStreamLimitError(AudioError):
     """Raised when a music provider has no source-stream slot available."""
 
@@ -134,11 +165,6 @@ class MusicProvider(Provider):
             if max_concurrent_streams is not None
             else None
         )
-        # state of the sync run that is currently active: whether it failed to collect an item
-        # (leaving its result set incomplete) and how many failures it reported so far.
-        # library syncs are serialized (by the music controller) so plain attributes suffice
-        self._sync_incomplete = False
-        self._sync_item_failures = 0
 
     @property
     def max_concurrent_streams(self) -> int | None:
@@ -900,14 +926,21 @@ class MusicProvider(Provider):
 
     async def sync_library(self, media_type: MediaType) -> None:
         """Run library sync for this provider."""
+        token = SYNC_RUN_STATE.set(SyncRunState())
+        try:
+            await self._run_library_sync(media_type)
+        finally:
+            SYNC_RUN_STATE.reset(token)
+
+    async def _run_library_sync(self, media_type: MediaType) -> None:
+        """Sync the given media type into the library and process its deletions."""
         # this reference implementation may be overridden
         # with a provider specific approach if needed
 
         if not self.mass.music.library_supported(self, media_type):
             raise UnsupportedFeaturedException("Library sync not supported for this media type")
 
-        self._sync_incomplete = False
-        self._sync_item_failures = 0
+        sync_state = sync_run_state()
         if media_type == MediaType.ARTIST:
             cur_db_ids = await self._sync_library_artists()
         elif media_type == MediaType.ALBUM:
@@ -930,11 +963,11 @@ class MusicProvider(Provider):
         update_current_task_progress_text("Checking library deletions")
         controller = self.mass.music.get_controller(media_type)
         prev_library_items: list[int] | None
-        if self._sync_incomplete:
+        if sync_state.incomplete:
             # a skipped item is missing from cur_db_ids just like a deleted one, but it is
             # still in the provider's library, so deleting it would throw away valid content
             if self.library_sync_deletions_enabled():
-                summary = f"{self._sync_item_failures} item(s) could not be synced"
+                summary = f"{sync_state.failures} item(s) could not be synced"
                 self.logger.warning("Skipping deletions for %s: %s", self.name, summary)
                 report_current_task_failure(f"Deletions skipped: {summary}")
             # merge this run's id's into the stored ones instead of replacing them: that
@@ -1007,9 +1040,10 @@ class MusicProvider(Provider):
         self, media_type: MediaType, item_ref: str | None, err: Exception
     ) -> None:
         """Log a non-fatal sync failure and record it on the active background task."""
-        self._sync_item_failures += 1
+        state = sync_run_state()
+        state.failures += 1
         error_detail = describe_sync_error(err)
-        if self._sync_item_failures <= MAX_LOGGED_SYNC_FAILURES:
+        if state.failures <= MAX_LOGGED_SYNC_FAILURES:
             if isinstance(err, MusicAssistantError):
                 self.logger.warning(
                     "Skipping sync of %s %s - error details: %s",
@@ -1097,7 +1131,7 @@ class MusicProvider(Provider):
                     )
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                self._sync_incomplete = True
+                sync_run_state().incomplete = True
                 self._handle_sync_item_failure(MediaType.ARTIST, prov_item.uri, err)
         return cur_db_ids
 
@@ -1158,7 +1192,7 @@ class MusicProvider(Provider):
                     )
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                self._sync_incomplete = True
+                sync_run_state().incomplete = True
                 self._handle_sync_item_failure(MediaType.ALBUM, prov_item.uri, err)
                 continue
             # optionally add album tracks to library. the album is already collected here,
@@ -1347,7 +1381,7 @@ class MusicProvider(Provider):
 
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                self._sync_incomplete = True
+                sync_run_state().incomplete = True
                 self._handle_sync_item_failure(MediaType.AUDIOBOOK, prov_item.uri, err)
         return cur_db_ids
 
@@ -1408,7 +1442,7 @@ class MusicProvider(Provider):
                         await self.mass.music.playlists.set_favorite(library_item.item_id, True)
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                self._sync_incomplete = True
+                sync_run_state().incomplete = True
                 self._handle_sync_item_failure(MediaType.PLAYLIST, prov_item.uri, err)
                 continue
             # optionally sync playlist tracks. the playlist is already collected here, so
@@ -1535,7 +1569,7 @@ class MusicProvider(Provider):
                     )
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                self._sync_incomplete = True
+                sync_run_state().incomplete = True
                 self._handle_sync_item_failure(MediaType.TRACK, prov_item.uri, err)
         return cur_db_ids
 
@@ -1586,7 +1620,7 @@ class MusicProvider(Provider):
                     )
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                self._sync_incomplete = True
+                sync_run_state().incomplete = True
                 self._handle_sync_item_failure(MediaType.PODCAST, prov_item.uri, err)
                 continue
             # the podcast is already collected here, so a feed that fails to deliver its
@@ -1643,7 +1677,7 @@ class MusicProvider(Provider):
                 await asyncio.sleep(0)  # yield to eventloop
 
             except Exception as err:
-                self._sync_incomplete = True
+                sync_run_state().incomplete = True
                 self._handle_sync_item_failure(MediaType.RADIO, prov_item.uri, err)
         return cur_db_ids
 

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -225,6 +225,17 @@ class MusicProvider(Provider):
         return True
 
     @property
+    def unskippable_sync_errors(self) -> tuple[type[Exception], ...]:
+        """
+        Return the errors a library sync must never treat as a skippable item failure.
+
+        Declare the errors this provider raises to signal something a wrapper around its
+        own methods has to act on, such as an expired token that triggers a reauthenticate
+        and a retry. Anything listed here is re-raised instead of skipping the item.
+        """
+        return ()
+
+    @property
     def supported_artist_types(self) -> set[ArtistType]:
         """
         Return all supported artist types by this provider.
@@ -1039,7 +1050,14 @@ class MusicProvider(Provider):
     def _handle_sync_item_failure(
         self, media_type: MediaType, item_ref: str | None, err: Exception
     ) -> None:
-        """Log a non-fatal sync failure and record it on the active background task."""
+        """
+        Log a non-fatal sync failure and record it on the active background task.
+
+        :raises Exception: If the provider declared this error unskippable, so that its own
+            error handling can act on it instead of the item being skipped.
+        """
+        if isinstance(err, self.unskippable_sync_errors):
+            raise err
         state = sync_run_state()
         state.failures += 1
         error_detail = describe_sync_error(err)

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -1080,6 +1080,7 @@ class MusicProvider(Provider):
                     else:
                         db_id = sync_details.item_id
                         favorite = sync_details.favorite
+                    cur_db_ids.add(db_id)
                     if not favorite and prov_item.favorite:
                         # existing library item not favorite but should be
                         await self.mass.music.artists.set_favorite(db_id, True)
@@ -1094,7 +1095,6 @@ class MusicProvider(Provider):
                         db_id,
                         fallback_genres,
                     )
-                cur_db_ids.add(db_id)
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
                 self._sync_incomplete = True
@@ -1141,6 +1141,7 @@ class MusicProvider(Provider):
                     else:
                         db_id = sync_details.item_id
                         favorite = sync_details.favorite
+                    cur_db_ids.add(db_id)
                     if not favorite and prov_item.favorite:
                         # existing library item not favorite but should be
                         await self.mass.music.albums.set_favorite(db_id, True)
@@ -1155,7 +1156,6 @@ class MusicProvider(Provider):
                         db_id,
                         fallback_genres,
                     )
-                cur_db_ids.add(db_id)
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
                 self._sync_incomplete = True
@@ -1318,6 +1318,7 @@ class MusicProvider(Provider):
                             lib_fully_played = sync_details.fully_played
                             lib_resume_position_ms = sync_details.resume_position_ms
 
+                    cur_db_ids.add(db_id)
                     if not favorite and prov_item.favorite:
                         # existing library item not favorite but should be
                         await self.mass.music.audiobooks.set_favorite(db_id, True)
@@ -1344,7 +1345,6 @@ class MusicProvider(Provider):
                         fallback_genres,
                     )
 
-                cur_db_ids.add(db_id)
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
                 self._sync_incomplete = True
@@ -1402,10 +1402,10 @@ class MusicProvider(Provider):
                         library_item = await self.mass.music.playlists.update_item_in_library(
                             library_item.item_id, prov_item, overwrite=True
                         )
+                    cur_db_ids.add(int(library_item.item_id))
                     if not library_item.favorite and prov_item.favorite:
                         # existing library item not favorite but should be
                         await self.mass.music.playlists.set_favorite(library_item.item_id, True)
-                cur_db_ids.add(int(library_item.item_id))
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
                 self._sync_incomplete = True
@@ -1432,13 +1432,13 @@ class MusicProvider(Provider):
         item_count = 0
         async for _prov_track in self.iter_playlist_tracks(provider_playlist.item_id):
             prov_track: PlaylistPlayableItem | Podcast = _prov_track
-            if isinstance(_prov_track, PodcastEpisode):
-                # In MA, only full podcasts can be synced to the library
-                prov_track = await self.get_podcast(_prov_track.podcast.item_id)
             item_count += 1
-            self._update_sync_task_item_status(MediaType.TRACK, item_count, prov_track.name)
-            controller = self.mass.music.get_controller(prov_track.media_type)
             try:
+                if isinstance(_prov_track, PodcastEpisode):
+                    # In MA, only full podcasts can be synced to the library
+                    prov_track = await self.get_podcast(_prov_track.podcast.item_id)
+                self._update_sync_task_item_status(MediaType.TRACK, item_count, prov_track.name)
+                controller = self.mass.music.get_controller(prov_track.media_type)
                 sync_details = await controller.get_library_item_sync_details(
                     prov_track.provider_mappings,
                 )
@@ -1518,6 +1518,7 @@ class MusicProvider(Provider):
                     else:
                         db_id = sync_details.item_id
                         favorite = sync_details.favorite
+                    cur_db_ids.add(db_id)
                     if not favorite and prov_item.favorite:
                         # existing library item not favorite but should be
                         await self.mass.music.tracks.set_favorite(db_id, True)
@@ -1532,7 +1533,6 @@ class MusicProvider(Provider):
                         db_id,
                         fallback_genres,
                     )
-                cur_db_ids.add(db_id)
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
                 self._sync_incomplete = True
@@ -1569,6 +1569,7 @@ class MusicProvider(Provider):
                     else:
                         db_id = sync_details.item_id
                         favorite = sync_details.favorite
+                    cur_db_ids.add(db_id)
                     if not favorite and prov_item.favorite:
                         # existing library item not favorite but should be
                         await self.mass.music.podcasts.set_favorite(db_id, True)
@@ -1583,7 +1584,6 @@ class MusicProvider(Provider):
                         db_id,
                         fallback_genres,
                     )
-                cur_db_ids.add(db_id)
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
                 self._sync_incomplete = True
@@ -1636,10 +1636,10 @@ class MusicProvider(Provider):
                         library_item = await self.mass.music.radio.update_item_in_library(
                             library_item.item_id, prov_item
                         )
+                    cur_db_ids.add(int(library_item.item_id))
                     if not library_item.favorite and prov_item.favorite:
                         # existing library item not favorite but should be
                         await self.mass.music.radio.set_favorite(library_item.item_id, True)
-                cur_db_ids.add(int(library_item.item_id))
                 await asyncio.sleep(0)  # yield to eventloop
 
             except Exception as err:

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -409,6 +409,12 @@ for more details.
         """Supported artist types."""
         return {ArtistType.AUTHOR, ArtistType.NARRATOR}
 
+    @property
+    def unskippable_sync_errors(self) -> tuple[type[Exception], ...]:
+        """Return the errors a library sync must not swallow as an item failure."""
+        # handle_refresh_token needs to see this to renew the token and retry
+        return (RefreshTokenExpiredError,)
+
     @handle_refresh_token
     async def sync_library(self, media_type: MediaType) -> None:
         """Obtain audiobook library ids and podcast library ids."""

--- a/tests/controllers/music/test_sync_resilience.py
+++ b/tests/controllers/music/test_sync_resilience.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,7 +16,11 @@ from music_assistant.constants import (
     CONF_ENTRY_LIBRARY_SYNC_DELETIONS,
     CONF_LOG_LEVEL,
 )
-from music_assistant.models.music_provider import MusicProvider, describe_sync_error
+from music_assistant.models.music_provider import (
+    MAX_LOGGED_SYNC_FAILURES,
+    MusicProvider,
+    describe_sync_error,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -44,11 +50,14 @@ class FailingAlbumProvider(MusicProvider):
             album.provider_mappings = [MagicMock()]
             yield album
 
+    #: tracks handed back by ``get_album_tracks``
+    album_tracks: list[Any] | None = None
+
     async def get_album_tracks(self, prov_album_id: str) -> list[Any]:
-        """Return no tracks, or raise for the album under test."""
+        """Return the configured tracks, or raise for the album under test."""
         if prov_album_id == self.fail_album_tracks_for:
             raise ValueError("malformed album tracks payload")
-        return []
+        return self.album_tracks or []
 
 
 def _build_provider(
@@ -329,3 +338,29 @@ async def test_item_stays_tracked_when_ancillary_work_fails() -> None:
 
     assert mass.music.albums.set_favorite.await_count == len(ALBUM_IDS)
     assert sorted(mass.cache.set.await_args.kwargs["data"]) == [1, 2, 3]
+
+
+async def test_standalone_import_keeps_its_own_failure_state(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Each ad-hoc album-track import starts from a clean failure state.
+
+    They are launched as their own task when an album is added, so a shared counter would
+    silence every import after the first one had used up the logging budget.
+    """
+    mass = _build_mass()
+    provider = _build_provider(mass)
+    mass.music.tracks.get_library_item_sync_details = AsyncMock(return_value=None)
+    mass.music.tracks.add_item_to_library = AsyncMock(side_effect=KeyError("bad track"))
+    provider.album_tracks = [
+        MagicMock(item_id=f"t{i}", uri=f"test://track/{i}") for i in range(MAX_LOGGED_SYNC_FAILURES)
+    ]
+
+    await asyncio.create_task(provider.import_album_tracks("album_1"))
+    caplog.clear()
+    with caplog.at_level(logging.ERROR):
+        await asyncio.create_task(provider.import_album_tracks("album_2"))
+
+    # the second import reports its failures just like the first one did
+    assert len(caplog.records) == MAX_LOGGED_SYNC_FAILURES

--- a/tests/controllers/music/test_sync_resilience.py
+++ b/tests/controllers/music/test_sync_resilience.py
@@ -61,7 +61,11 @@ class FailingAlbumProvider(MusicProvider):
 
 
 def _build_provider(
-    mass: MagicMock, *, sync_album_tracks: bool = False, sync_deletions: bool = True
+    mass: MagicMock,
+    *,
+    sync_album_tracks: bool = False,
+    sync_deletions: bool = True,
+    cls: type[FailingAlbumProvider] = FailingAlbumProvider,
 ) -> FailingAlbumProvider:
     """Return a provider instance wired to the given (mocked) mass."""
     manifest = MagicMock()
@@ -76,7 +80,7 @@ def _build_provider(
         CONF_ENTRY_LIBRARY_SYNC_DELETIONS.key: sync_deletions,
     }
     config.get_value.side_effect = lambda key, default=None: values.get(key, default)
-    return FailingAlbumProvider(mass, manifest, config)
+    return cls(mass, manifest, config)
 
 
 def _build_mass(prev_library_ids: list[int] | None = None) -> MagicMock:
@@ -364,3 +368,34 @@ async def test_standalone_import_keeps_its_own_failure_state(
 
     # the second import reports its failures just like the first one did
     assert len(caplog.records) == MAX_LOGGED_SYNC_FAILURES
+
+
+class _AuthSignal(Exception):
+    """Stands in for a provider error a wrapper around sync_library has to act on."""
+
+
+class AuthSignallingProvider(FailingAlbumProvider):
+    """Provider that declares its auth signal unskippable."""
+
+    @property
+    def unskippable_sync_errors(self) -> tuple[type[Exception], ...]:
+        """Return the errors a library sync must not swallow as an item failure."""
+        return (_AuthSignal,)
+
+
+async def test_declared_unskippable_error_is_not_swallowed() -> None:
+    """
+    An error the provider declared unskippable escapes instead of skipping the item.
+
+    Providers use these to signal something their own wrapper must handle, such as an
+    expired token that needs a reauthenticate and a retry.
+    """
+    mass = _build_mass()
+    provider = _build_provider(mass, cls=AuthSignallingProvider)
+    mass.music.albums.add_item_to_library = AsyncMock(side_effect=_AuthSignal("token expired"))
+
+    with pytest.raises(_AuthSignal):
+        await provider.sync_library(MediaType.ALBUM)
+
+    # the run aborted, so nothing was recorded as a completed sync
+    mass.cache.set.assert_not_called()

--- a/tests/controllers/music/test_sync_resilience.py
+++ b/tests/controllers/music/test_sync_resilience.py
@@ -29,6 +29,8 @@ class FailingAlbumProvider(MusicProvider):
 
     #: provider album id whose ``get_album_tracks`` raises
     fail_album_tracks_for: str | None = None
+    #: yield the albums as provider favorites, so the sync performs its favorite work
+    mark_favorite: bool = False
 
     async def get_library_albums(self) -> AsyncGenerator[Any]:
         """Yield the three test albums."""
@@ -37,7 +39,7 @@ class FailingAlbumProvider(MusicProvider):
             album.item_id = item_id
             album.name = f"Album {item_id}"
             album.uri = f"test://album/{item_id}"
-            album.favorite = False
+            album.favorite = self.mark_favorite
             album.metadata.genres = None
             album.provider_mappings = [MagicMock()]
             yield album
@@ -309,3 +311,21 @@ async def test_item_lookup_failure_skips_only_that_item() -> None:
     # all three were reached, and the two healthy ones were still added
     assert calls == list(ALBUM_IDS)
     assert _synced_album_ids(mass) == ["album_1", "album_3"]
+
+
+async def test_item_stays_tracked_when_ancillary_work_fails() -> None:
+    """
+    An item whose favorite work fails is still recorded as seen.
+
+    Its library row is committed regardless, so leaving it out of the id's would make it
+    an orphan no later cleanup run could ever discover.
+    """
+    mass = _build_mass()
+    provider = _build_provider(mass)
+    provider.mark_favorite = True
+    mass.music.albums.set_favorite = AsyncMock(side_effect=TypeError("bad favorite"))
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    assert mass.music.albums.set_favorite.await_count == len(ALBUM_IDS)
+    assert sorted(mass.cache.set.await_args.kwargs["data"]) == [1, 2, 3]

--- a/tests/controllers/music/test_sync_resilience.py
+++ b/tests/controllers/music/test_sync_resilience.py
@@ -1,0 +1,269 @@
+"""Tests that a single failing item does not abort a library sync or trigger deletions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.enums import MediaType, ProviderType
+from music_assistant_models.errors import MediaNotFoundError
+
+from music_assistant.constants import (
+    CONF_ENTRY_LIBRARY_SYNC_ALBUM_TRACKS,
+    CONF_ENTRY_LIBRARY_SYNC_DELETIONS,
+    CONF_LOG_LEVEL,
+)
+from music_assistant.models.music_provider import MusicProvider, describe_sync_error
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+ALBUM_IDS = ("album_1", "album_2", "album_3")
+# db id the mocked library controller hands out per provider album
+DB_IDS = {"album_1": 1, "album_2": 2, "album_3": 3}
+
+
+class FailingAlbumProvider(MusicProvider):
+    """Provider yielding three albums, of which one may fail to sync."""
+
+    #: provider album id whose ``get_album_tracks`` raises
+    fail_album_tracks_for: str | None = None
+
+    async def get_library_albums(self) -> AsyncGenerator[Any]:
+        """Yield the three test albums."""
+        for item_id in ALBUM_IDS:
+            album = MagicMock()
+            album.item_id = item_id
+            album.name = f"Album {item_id}"
+            album.uri = f"test://album/{item_id}"
+            album.favorite = False
+            album.metadata.genres = None
+            album.provider_mappings = [MagicMock()]
+            yield album
+
+    async def get_album_tracks(self, prov_album_id: str) -> list[Any]:
+        """Return no tracks, or raise for the album under test."""
+        if prov_album_id == self.fail_album_tracks_for:
+            raise ValueError("malformed album tracks payload")
+        return []
+
+
+def _build_provider(
+    mass: MagicMock, *, sync_album_tracks: bool = False, sync_deletions: bool = True
+) -> FailingAlbumProvider:
+    """Return a provider instance wired to the given (mocked) mass."""
+    manifest = MagicMock()
+    manifest.type = ProviderType.MUSIC
+    manifest.domain = "test"
+    config = MagicMock()
+    config.instance_id = "test--1"
+    config.domain = "test"
+    values = {
+        CONF_LOG_LEVEL: "GLOBAL",
+        CONF_ENTRY_LIBRARY_SYNC_ALBUM_TRACKS.key: sync_album_tracks,
+        CONF_ENTRY_LIBRARY_SYNC_DELETIONS.key: sync_deletions,
+    }
+    config.get_value.side_effect = lambda key, default=None: values.get(key, default)
+    return FailingAlbumProvider(mass, manifest, config)
+
+
+def _build_mass(prev_library_ids: list[int] | None = None) -> MagicMock:
+    """Return a mocked mass whose album controller records every synced album."""
+    mass = MagicMock()
+    mass.cache = MagicMock()
+    mass.cache.get = AsyncMock(return_value=prev_library_ids)
+    mass.cache.set = AsyncMock()
+
+    albums = mass.music.albums
+    albums.get_library_item_sync_details = AsyncMock(return_value=None)
+
+    async def add_item_to_library(prov_item: Any) -> Any:
+        library_item = MagicMock()
+        library_item.item_id = DB_IDS[prov_item.item_id]
+        library_item.favorite = False
+        return library_item
+
+    albums.add_item_to_library = AsyncMock(side_effect=add_item_to_library)
+    mass.music.genres.sync_media_item_genres = AsyncMock()
+    mass.music.library_supported = MagicMock(return_value=True)
+
+    # controller used by the deletion pass
+    controller = AsyncMock()
+    mass.music.get_controller = MagicMock(return_value=controller)
+    return mass
+
+
+def _fail_add_for(mass: MagicMock, item_id: str) -> None:
+    """Make adding the given provider album raise a plain (non-MA) error."""
+    original = mass.music.albums.add_item_to_library.side_effect
+
+    async def add_item_to_library(prov_item: Any) -> Any:
+        if prov_item.item_id == item_id:
+            raise KeyError("release_date")
+        return await original(prov_item)
+
+    mass.music.albums.add_item_to_library = AsyncMock(side_effect=add_item_to_library)
+
+
+def _synced_album_ids(mass: MagicMock) -> list[str]:
+    """Return the provider album ids that were added to the library."""
+    return [call.args[0].item_id for call in mass.music.albums.add_item_to_library.await_args_list]
+
+
+async def test_unexpected_error_skips_one_item_and_continues() -> None:
+    """An error that is not a MusicAssistantError skips its item instead of the whole sync."""
+    mass = _build_mass()
+    provider = _build_provider(mass)
+
+    _fail_add_for(mass, "album_2")
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    # the failing album did not stop the loop: the one after it was synced too
+    assert _synced_album_ids(mass) == list(ALBUM_IDS)
+
+
+async def test_unexpected_error_from_provider_album_tracks_does_not_abort_sync() -> None:
+    """A provider raising while returning album tracks does not take down the album sync."""
+    mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
+    provider = _build_provider(mass, sync_album_tracks=True)
+    provider.fail_album_tracks_for = "album_2"
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    assert _synced_album_ids(mass) == list(ALBUM_IDS)
+    # the album itself synced fine before its tracks were imported, so it stays in the result
+    assert sorted(mass.cache.set.await_args.kwargs["data"]) == [1, 2, 3]
+    # and the album id set is complete, so deletions are not held back
+    mass.music.get_controller.return_value.get_library_item.assert_awaited_once_with(99)
+
+
+async def test_deletions_skipped_when_an_item_failed() -> None:
+    """A skipped item must not be read as removed from the provider."""
+    mass = _build_mass(prev_library_ids=[1, 2, 3])
+    provider = _build_provider(mass)
+
+    _fail_add_for(mass, "album_2")
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    controller = mass.music.get_controller.return_value
+    controller.get_library_item.assert_not_called()
+    controller.set_provider_mappings.assert_not_called()
+    controller.remove_item_from_library.assert_not_called()
+
+
+async def test_deletions_run_on_a_clean_sync() -> None:
+    """A sync without failures still processes items that are gone from the provider."""
+    mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
+    provider = _build_provider(mass)
+
+    controller = mass.music.get_controller.return_value
+    library_item = MagicMock()
+    mapping = MagicMock()
+    mapping.provider_instance = provider.instance_id
+    mapping.in_library = True
+    library_item.provider_mappings = [mapping]
+    library_item.favorite = False
+    controller.get_library_item = AsyncMock(return_value=library_item)
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    # only db id 99 is gone from the provider
+    controller.get_library_item.assert_awaited_once_with(99)
+    controller.set_provider_mappings.assert_awaited_once()
+    assert mapping.in_library is False
+
+
+async def test_library_generator_error_still_propagates() -> None:
+    """
+    A provider failing while listing its library aborts the sync.
+
+    The listing is an async generator: once it raises it is closed, so there is no item
+    to skip and no complete result set to run deletions against.
+    """
+    mass = _build_mass(prev_library_ids=[1, 2, 3])
+    provider = _build_provider(mass)
+
+    async def broken_library_albums() -> AsyncGenerator[Any]:
+        raise KeyError("items")
+        yield  # type: ignore[unreachable]  # pragma: no cover
+
+    provider.get_library_albums = broken_library_albums  # type: ignore[method-assign]
+
+    with pytest.raises(KeyError):
+        await provider.sync_library(MediaType.ALBUM)
+
+    mass.cache.set.assert_not_called()
+    mass.music.get_controller.return_value.set_provider_mappings.assert_not_called()
+
+
+async def test_expected_error_also_holds_back_deletions() -> None:
+    """A MusicAssistantError leaves the same gap in the result set as any other error."""
+    mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
+    provider = _build_provider(mass)
+    mass.music.albums.add_item_to_library = AsyncMock(side_effect=MediaNotFoundError("gone"))
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    mass.music.get_controller.return_value.get_library_item.assert_not_called()
+
+
+async def test_incomplete_run_keeps_the_previous_id_snapshot() -> None:
+    """
+    A run that skipped items must not overwrite the cached id's.
+
+    Those id's are what a later run compares against; replacing them with an incomplete
+    set would drop the deletions this run could not process.
+    """
+    mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
+    provider = _build_provider(mass)
+    _fail_add_for(mass, "album_2")
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    mass.cache.set.assert_not_called()
+
+
+async def test_deletions_not_reported_when_disabled() -> None:
+    """A failed item is not reported as skipped deletions when deletions are turned off."""
+    mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
+    provider = _build_provider(mass, sync_deletions=False)
+    _fail_add_for(mass, "album_2")
+
+    with patch("music_assistant.models.music_provider.report_current_task_failure") as reported:
+        await provider.sync_library(MediaType.ALBUM)
+
+    assert not any("Deletions skipped" in call.args[0] for call in reported.call_args_list)
+
+
+async def test_payload_bearing_error_is_clipped() -> None:
+    """
+    A provider error carrying its whole api response is reported by type and clipped.
+
+    Those messages reach the log and, via the task failure list, every connected client.
+    """
+    mass = _build_mass()
+    provider = _build_provider(mass)
+    payload = "x" * 5000
+    mass.music.albums.add_item_to_library = AsyncMock(side_effect=KeyError(payload))
+
+    with patch("music_assistant.models.music_provider.report_current_task_failure") as reported:
+        await provider.sync_library(MediaType.ALBUM)
+
+    item_failures = [
+        call.args[0]
+        for call in reported.call_args_list
+        if call.args[0].startswith("Failed to sync")
+    ]
+    assert len(item_failures) == len(ALBUM_IDS)
+    for message in item_failures:
+        assert "KeyError" in message
+        assert len(message) < 400
+        assert payload not in message
+
+
+def test_our_own_errors_are_reported_verbatim() -> None:
+    """Our own error messages are already short and stay unchanged."""
+    assert describe_sync_error(MediaNotFoundError("album not found")) == "album not found"

--- a/tests/controllers/music/test_sync_resilience.py
+++ b/tests/controllers/music/test_sync_resilience.py
@@ -212,7 +212,7 @@ async def test_expected_error_also_holds_back_deletions() -> None:
 
 async def test_incomplete_run_keeps_the_previous_id_snapshot() -> None:
     """
-    A run that skipped items must not overwrite the cached id's.
+    A run that skipped items merges into the cached id's instead of replacing them.
 
     Those id's are what a later run compares against; replacing them with an incomplete
     set would drop the deletions this run could not process.
@@ -223,7 +223,8 @@ async def test_incomplete_run_keeps_the_previous_id_snapshot() -> None:
 
     await provider.sync_library(MediaType.ALBUM)
 
-    mass.cache.set.assert_not_called()
+    # 99 (gone from the provider) and 2 (failed this run) both survive for the next run
+    assert sorted(mass.cache.set.await_args.kwargs["data"]) == [1, 2, 3, 99]
 
 
 async def test_deletions_not_reported_when_disabled() -> None:
@@ -267,3 +268,44 @@ async def test_payload_bearing_error_is_clipped() -> None:
 def test_our_own_errors_are_reported_verbatim() -> None:
     """Our own error messages are already short and stay unchanged."""
     assert describe_sync_error(MediaNotFoundError("album not found")) == "album not found"
+
+
+async def test_incomplete_run_keeps_newly_seen_items() -> None:
+    """An item first seen on an incomplete run is still tracked for later cleanup."""
+    # 1 and 2 were known before; 3 is new in this run
+    mass = _build_mass(prev_library_ids=[1, 2])
+    provider = _build_provider(mass)
+    _fail_add_for(mass, "album_2")
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    assert 3 in mass.cache.set.await_args.kwargs["data"]
+
+
+async def test_item_lookup_failure_skips_only_that_item() -> None:
+    """A failure while resolving an item's mappings skips the item, not the whole sync."""
+    mass = _build_mass()
+    provider = _build_provider(mass)
+    lookups = {"album_2": TypeError("bad provider mapping")}
+
+    async def get_sync_details(mappings: Any) -> Any:
+        del mappings
+        return None
+
+    calls: list[str] = []
+
+    async def sync_details_for(prov_mappings: Any) -> Any:
+        del prov_mappings
+        item_id = ALBUM_IDS[len(calls)]
+        calls.append(item_id)
+        if err := lookups.get(item_id):
+            raise err
+        return await get_sync_details(None)
+
+    mass.music.albums.get_library_item_sync_details = AsyncMock(side_effect=sync_details_for)
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    # all three were reached, and the two healthy ones were still added
+    assert calls == list(ALBUM_IDS)
+    assert _synced_album_ids(mass) == ["album_1", "album_3"]

--- a/tests/test_dynamic_playlist_framework.py
+++ b/tests/test_dynamic_playlist_framework.py
@@ -220,7 +220,7 @@ async def _run_sync(provider: MusicProvider, prov_item: Mock) -> None:
         get_library_playlists=Mock(return_value=_get_single_playlist(prov_item)),
         _check_provider_mappings=Mock(return_value=True),
         _update_sync_task_item_status=Mock(),
-        _report_sync_task_failure=Mock(),
+        _handle_sync_item_failure=Mock(),
     ):
         await provider._sync_library_playlists()
 


### PR DESCRIPTION
# What does this implement/fix?

When a music provider hands back an unexpected response for a single item, it usually fails with a plain Python error rather than one of our own error types. The sync loops only caught our own errors, so instead of skipping that one album or track, the whole library sync for that media type stopped there and did not resume until the next scheduled run.

This has been showing up per provider for a while now (#5629 for YouTube Music, #5738 for Soundcloud, #4089 for Apple Music), fixed one provider at a time. This catches it in the shared sync loop so it applies to every provider.

Skipping an item has a second effect that was already there for our own errors: a skipped item looks exactly like one that was removed on the provider side, so the cleanup step that follows could unmark it as being in your library, or delete it outright for local/server providers. Cleanup is now held back whenever a run did not complete, the same way the filesystem provider already does it.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- A failing item is skipped and the sync carries on, instead of stopping the whole media type.
- Library cleanup is held back for any run that could not sync every item, so nothing that is still on the provider gets removed. This now also covers items that fail with one of our own errors, which were previously skipped but still treated as removed.
- A held-back run keeps the previous item list, so deletions it could not process are still picked up by the next clean run.
- Failing to import an album's tracks, a playlist's tracks or a podcast's episodes no longer holds back cleanup, since the item itself synced fine.
- Unexpected errors are logged apart from expected ones, with a traceback on debug, and per-item logging is capped so one bad provider cannot flood the log.
- The nine near-identical error handlers in the sync loops now share one helper.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
