### PR TITLE
Keep a shared output from showing up on two players at once

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1400,6 +1400,9 @@ class ProtocolLinkingMixin:
 
         # Set protocol player's parent
         protocol_player.set_protocol_parent_id(native_player.player_id)
+        # Ownership is exclusive: a parent that still lists this protocol would show it
+        # twice and hold its domain slot against a genuine protocol of that domain.
+        self._evict_protocol_from_other_parents(protocol_player.player_id, native_player.player_id)
 
         # Persist linked protocol IDs to config for fast restart
         # (only for non-universal players, as universal players handle this themselves)
@@ -1447,6 +1450,36 @@ class ProtocolLinkingMixin:
             # removals because the merge approach will preserve the ID in the cache
         # Always clear the cached parent ID (for both native and universal parents)
         self._clear_protocol_parent_id(protocol_player_id)
+
+    def _evict_protocol_from_other_parents(self, protocol_player_id: str, parent_id: str) -> None:
+        """
+        Drop a protocol's output entry from every parent except the one that owns it.
+
+        A parent that still holds an active entry while another parent takes the protocol
+        is out of date, so its cached id is dropped as well. Parents that already gave up
+        the active entry keep their cached id and can still offer the protocol for re-enabling.
+
+        :param protocol_player_id: Player id of the protocol player that got a new parent.
+        :param parent_id: Player id of the parent that now owns it.
+        """
+        for player in list(self._players.values()):
+            if player.player_id == parent_id:
+                continue
+            remaining = [
+                link
+                for link in player.linked_output_protocols
+                if link.output_protocol_id != protocol_player_id
+            ]
+            if len(remaining) == len(player.linked_output_protocols):
+                continue
+            player.set_linked_output_protocols(remaining)
+            self._remove_protocol_id_from_cache(player.player_id, protocol_player_id)
+            self.logger.debug(
+                "Removed stale output %s from %s: it is owned by %s",
+                protocol_player_id,
+                player.player_id,
+                parent_id,
+            )
 
     def _save_linked_protocol_ids(self, native_player: Player) -> None:
         """

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1566,6 +1566,18 @@ class ProtocolLinkingMixin:
             if protocol_id in linked_protocol_ids:
                 continue  # Already linked
 
+            protocol_player = self.get_player(protocol_id)
+            # A protocol that another parent currently owns is not ours to claim: it would
+            # show up on both parents and occupy this parent's domain slot, keeping a
+            # genuine protocol of that domain out. The cached id is kept, so the protocol
+            # is recovered once its owner releases it.
+            if (
+                protocol_player is not None
+                and protocol_player.protocol_parent_id is not None
+                and protocol_player.protocol_parent_id != native_player.player_id
+            ):
+                continue
+
             # Get protocol player config to determine the protocol domain
             protocol_config = self.mass.config.get(f"{CONF_PLAYERS}/{protocol_id}")
             if not protocol_config:
@@ -1589,7 +1601,6 @@ class ProtocolLinkingMixin:
 
             # Resolve the derived-transport edge from the live player when
             # registered, else from the persisted edge in config
-            protocol_player = self.get_player(protocol_id)
             derived_from = (
                 protocol_player.underlying_player_id
                 if protocol_player

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1567,15 +1567,15 @@ class ProtocolLinkingMixin:
                 continue  # Already linked
 
             protocol_player = self.get_player(protocol_id)
-            # A protocol that another parent currently owns is not ours to claim: it would
-            # show up on both parents and occupy this parent's domain slot, keeping a
-            # genuine protocol of that domain out. The cached id is kept, so the protocol
-            # is recovered once its owner releases it.
-            if (
-                protocol_player is not None
-                and protocol_player.protocol_parent_id is not None
-                and protocol_player.protocol_parent_id != native_player.player_id
-            ):
+            # A protocol that another parent owns is not ours to claim: it would show up
+            # on both parents and occupy this parent's domain slot, keeping a genuine
+            # protocol of that domain out. The live owner leads; a protocol that is still
+            # waiting for its owner to register only has the persisted one. The cached id
+            # is kept, so the protocol is recovered once its owner releases it.
+            owner_id = protocol_player.protocol_parent_id if protocol_player else None
+            if owner_id is None:
+                owner_id = self._get_cached_protocol_parent_id(protocol_id)
+            if owner_id is not None and owner_id != native_player.player_id:
                 continue
 
             # Get protocol player config to determine the protocol domain

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1456,8 +1456,8 @@ class ProtocolLinkingMixin:
         Drop a protocol's output entry from every parent except the one that owns it.
 
         A parent that still holds an active entry while another parent takes the protocol
-        is out of date, so its cached id is dropped as well. Parents that already gave up
-        the active entry keep their cached id and can still offer the protocol for re-enabling.
+        is out of date, so its stored ownership is dropped as well. Parents that already gave
+        up the active entry keep theirs and can still offer the protocol for re-enabling.
 
         :param protocol_player_id: Player id of the protocol player that got a new parent.
         :param parent_id: Player id of the parent that now owns it.
@@ -1465,15 +1465,12 @@ class ProtocolLinkingMixin:
         for player in list(self._players.values()):
             if player.player_id == parent_id:
                 continue
-            remaining = [
-                link
+            if not any(
+                link.output_protocol_id == protocol_player_id
                 for link in player.linked_output_protocols
-                if link.output_protocol_id != protocol_player_id
-            ]
-            if len(remaining) == len(player.linked_output_protocols):
+            ):
                 continue
-            player.set_linked_output_protocols(remaining)
-            self._remove_protocol_id_from_cache(player.player_id, protocol_player_id)
+            self._remove_protocol_ids_from_parent(player, {protocol_player_id})
             self.logger.debug(
                 "Removed stale output %s from %s: it is owned by %s",
                 protocol_player_id,

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -8952,6 +8952,88 @@ class TestCachedProtocolLinkRecovery:
         assert heos_player.linked_output_protocols == []
         assert not controller._parent_has_active_protocol_from_domain(heos_player, "sendspin")
 
+    def test_claiming_a_protocol_clears_it_from_its_previous_parent(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A parent loses its output entry for a protocol that another parent claims.
+
+        A bridge that registers before the connection it runs on has no owner to
+        compare against yet, so a stale cached id still recovers it onto a native
+        player. Once the connection registers and takes the bridge along, the native
+        player must give up its entry instead of listing the bridge as well.
+        """
+        controller = PlayerController(mock_mass)
+
+        store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "cast_base": {
+                    "provider": "chromecast--x",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: STORED_UNIVERSAL_ID},
+                },
+                "spb_bridge": {
+                    "provider": "sendspin--y",
+                    "player_type": "protocol",
+                    "values": {
+                        CONF_PROTOCOL_PARENT_ID: "heos_player",
+                        CONF_UNDERLYING_PLAYER_ID: "cast_base",
+                    },
+                },
+                STORED_UNIVERSAL_ID: {
+                    "provider": "universal_player",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["cast_base"]},
+                },
+                "heos_player": {
+                    "provider": "heos--z",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["spb_bridge"]},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, store)
+
+        wrapper = _create_universal_player(
+            mock_mass, STORED_UNIVERSAL_ID, "AVR (wrapper)", ["cast_base"]
+        )
+        bridge = MockPlayer(
+            MockProvider("sendspin", mass=mock_mass),
+            "spb_bridge",
+            "AVR (Bridge)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        bridge._attr_underlying_player_id = "cast_base"
+        bridge.set_initialized()
+        heos_player = MockPlayer(MockProvider("heos", mass=mock_mass), "heos_player", "AVR")
+        controller._players = {
+            STORED_UNIVERSAL_ID: wrapper,
+            "spb_bridge": bridge,
+            "heos_player": heos_player,
+        }
+
+        # the bridge has no owner yet, so the cached id recovers it onto the native player
+        controller._recover_cached_protocol_links(heos_player)
+        assert [link.output_protocol_id for link in heos_player.linked_output_protocols] == [
+            "spb_bridge"
+        ]
+
+        # the connection registers and joins the wrapper, taking the bridge with it
+        base = MockPlayer(
+            MockProvider("chromecast", mass=mock_mass),
+            "cast_base",
+            "AVR (Cast 2)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        controller._players["cast_base"] = base
+        controller._try_link_protocol_to_native(base)
+
+        assert bridge.protocol_parent_id == STORED_UNIVERSAL_ID
+        assert heos_player.linked_output_protocols == []
+        assert not controller._parent_has_active_protocol_from_domain(heos_player, "sendspin")
+        # the stale cached id is gone too, so the bridge is not offered here as disabled
+        assert store[CONF_PLAYERS]["heos_player"]["values"]["linked_protocol_ids"] == []
+
 
 class TestMultiMACMatching:
     """Tests for multi-MAC matching (reported MAC vs ARP MAC)."""

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -8832,6 +8832,47 @@ class TestCachedProtocolLinkRecovery:
         # ap_disabled is not registered at all, dlna_own is registered without a parent
         assert recovered == {"ap_disabled", "dlna_own"}
 
+    def test_protocol_waiting_for_its_owner_is_not_recovered(self, mock_mass: MagicMock) -> None:
+        """A protocol whose owner has not registered yet is left to that owner."""
+        controller = PlayerController(mock_mass)
+
+        store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "ap_shared": {
+                    "provider": "airplay--x",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "cast_owner"},
+                },
+                "heos_player": {
+                    "provider": "heos--y",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["ap_shared"]},
+                },
+                "cast_owner": {
+                    "provider": "chromecast--z",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["ap_shared"]},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, store)
+
+        # the protocol is registered but still unparented: its owner is not registered yet
+        airplay = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_shared",
+            "AVR (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        heos_player = MockPlayer(MockProvider("heos", mass=mock_mass), "heos_player", "AVR")
+        controller._players = {"ap_shared": airplay, "heos_player": heos_player}
+
+        controller._recover_cached_protocol_links(heos_player)
+
+        assert airplay.protocol_parent_id is None
+        assert heos_player.linked_output_protocols == []
+        assert not controller._parent_has_active_protocol_from_domain(heos_player, "airplay")
+
     def test_bridge_owned_by_wrapper_leaves_native_domain_slot_free(
         self, mock_mass: MagicMock
     ) -> None:

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -8739,6 +8739,178 @@ class TestCachedProtocolLinkRecovery:
         controller._recover_cached_protocol_links(heos_player)
         mock_mass.players.trigger_player_update.assert_called_once_with("heos_player")
 
+    def test_protocol_owned_by_another_parent_is_not_recovered(self, mock_mass: MagicMock) -> None:
+        """A cached protocol that another parent owns stays out of this parent's outputs."""
+        controller = PlayerController(mock_mass)
+
+        store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "ap_shared": {
+                    "provider": "airplay--x",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "cast_owner"},
+                },
+                "heos_player": {
+                    "provider": "heos--y",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["ap_shared"]},
+                },
+                "cast_owner": {
+                    "provider": "chromecast--z",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["ap_shared"]},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, store)
+
+        airplay = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_shared",
+            "AVR (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        airplay.set_protocol_parent_id("cast_owner")
+        owner = MockPlayer(MockProvider("chromecast", mass=mock_mass), "cast_owner", "AVR (Cast)")
+        owner.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="ap_shared", protocol_domain="airplay")]
+        )
+        heos_player = MockPlayer(MockProvider("heos", mass=mock_mass), "heos_player", "AVR")
+        controller._players = {
+            "ap_shared": airplay,
+            "cast_owner": owner,
+            "heos_player": heos_player,
+        }
+
+        controller._recover_cached_protocol_links(heos_player)
+
+        assert heos_player.linked_output_protocols == []
+        # the domain slot stays free for this parent's own AirPlay endpoint
+        assert not controller._parent_has_active_protocol_from_domain(heos_player, "airplay")
+        assert airplay.protocol_parent_id == "cast_owner"
+
+    def test_unowned_and_own_cached_protocols_are_still_recovered(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A disabled protocol without a live parent is still recovered for its parent."""
+        controller = PlayerController(mock_mass)
+
+        store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "ap_disabled": {
+                    "provider": "airplay--x",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "heos_player"},
+                },
+                "dlna_own": {
+                    "provider": "dlna--x",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "heos_player"},
+                },
+                "heos_player": {
+                    "provider": "heos--y",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["ap_disabled", "dlna_own"]},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, store)
+
+        # registered but not owned by anyone (e.g. freshly detached)
+        dlna = MockPlayer(
+            MockProvider("dlna", mass=mock_mass),
+            "dlna_own",
+            "AVR (DLNA)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        heos_player = MockPlayer(MockProvider("heos", mass=mock_mass), "heos_player", "AVR")
+        controller._players = {"dlna_own": dlna, "heos_player": heos_player}
+
+        controller._recover_cached_protocol_links(heos_player)
+
+        recovered = {link.output_protocol_id for link in heos_player.linked_output_protocols}
+        # ap_disabled is not registered at all, dlna_own is registered without a parent
+        assert recovered == {"ap_disabled", "dlna_own"}
+
+    def test_bridge_owned_by_wrapper_leaves_native_domain_slot_free(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A bridge that stayed with its wrapper is not recovered onto a native player.
+
+        A native player may carry a stale cached id for a bridge whose underlying
+        connection it could not claim. The bridge follows that connection, so the
+        native player must leave the domain slot free for its own bridge.
+        """
+        controller = PlayerController(mock_mass)
+
+        store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "cast_base": {
+                    "provider": "chromecast--x",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: STORED_UNIVERSAL_ID},
+                },
+                "spb_bridge": {
+                    "provider": "sendspin--y",
+                    "player_type": "protocol",
+                    "values": {
+                        CONF_PROTOCOL_PARENT_ID: "heos_player",
+                        CONF_UNDERLYING_PLAYER_ID: "cast_base",
+                    },
+                },
+                STORED_UNIVERSAL_ID: {
+                    "provider": "universal_player",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["cast_base"]},
+                },
+                "heos_player": {
+                    "provider": "heos--z",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["spb_bridge"]},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, store)
+
+        wrapper = _create_universal_player(
+            mock_mass, STORED_UNIVERSAL_ID, "AVR (wrapper)", ["cast_base"]
+        )
+        base = MockPlayer(
+            MockProvider("chromecast", mass=mock_mass),
+            "cast_base",
+            "AVR (Cast 2)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        base.set_protocol_parent_id(STORED_UNIVERSAL_ID)
+        wrapper.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="cast_base", protocol_domain="chromecast")]
+        )
+        bridge = MockPlayer(
+            MockProvider("sendspin", mass=mock_mass),
+            "spb_bridge",
+            "AVR (Bridge)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        bridge._attr_underlying_player_id = "cast_base"
+        bridge.set_initialized()
+        heos_player = MockPlayer(MockProvider("heos", mass=mock_mass), "heos_player", "AVR")
+        controller._players = {
+            STORED_UNIVERSAL_ID: wrapper,
+            "cast_base": base,
+            "spb_bridge": bridge,
+            "heos_player": heos_player,
+        }
+
+        # the bridge resolves via its underlying connection, so it joins the wrapper
+        controller._try_link_protocol_to_native(bridge)
+        assert bridge.protocol_parent_id == STORED_UNIVERSAL_ID
+
+        controller._recover_cached_protocol_links(heos_player)
+
+        assert heos_player.linked_output_protocols == []
+        assert not controller._parent_has_active_protocol_from_domain(heos_player, "sendspin")
+
 
 class TestMultiMACMatching:
     """Tests for multi-MAC matching (reported MAC vs ARP MAC)."""

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -9034,6 +9034,60 @@ class TestCachedProtocolLinkRecovery:
         # the stale cached id is gone too, so the bridge is not offered here as disabled
         assert store[CONF_PLAYERS]["heos_player"]["values"]["linked_protocol_ids"] == []
 
+    def test_claiming_a_protocol_clears_universal_membership(self, mock_mass: MagicMock) -> None:
+        """A wrapper that loses a protocol also gives up its stored membership."""
+        controller = PlayerController(mock_mass)
+
+        store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "ap_shared": {
+                    "provider": "airplay--x",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: STORED_UNIVERSAL_ID},
+                },
+                STORED_UNIVERSAL_ID: {
+                    "provider": "universal_player",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["ap_shared"]},
+                },
+                "heos_player": {
+                    "provider": "heos--z",
+                    "player_type": "player",
+                    "values": {},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, store)
+
+        wrapper = _create_universal_player(
+            mock_mass, STORED_UNIVERSAL_ID, "AVR (wrapper)", ["ap_shared"]
+        )
+        wrapper.set_linked_output_protocols(
+            [LinkedOutputProtocol(output_protocol_id="ap_shared", protocol_domain="airplay")]
+        )
+        airplay = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_shared",
+            "AVR (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        airplay.set_protocol_parent_id(STORED_UNIVERSAL_ID)
+        heos_player = MockPlayer(MockProvider("heos", mass=mock_mass), "heos_player", "AVR")
+        controller._players = {
+            STORED_UNIVERSAL_ID: wrapper,
+            "ap_shared": airplay,
+            "heos_player": heos_player,
+        }
+
+        controller._add_protocol_link(heos_player, airplay, "airplay")
+
+        assert airplay.protocol_parent_id == "heos_player"
+        assert wrapper.linked_output_protocols == []
+        # the wrapper's stored membership is authoritative and gets written back on save,
+        # so it has to give up the protocol there as well
+        assert wrapper._protocol_player_ids == []
+        assert store[CONF_PLAYERS][STORED_UNIVERSAL_ID]["values"]["linked_protocol_ids"] == []
+
 
 class TestMultiMACMatching:
     """Tests for multi-MAC matching (reported MAC vs ARP MAC)."""


### PR DESCRIPTION
# What does this implement/fix?

Speakers can expose several connections of the same kind, and a bridged output
(like a Sendspin bridge) always follows the connection it runs on. When a player
cannot claim such a connection, it stays with the wrapper it came from — but the
player's saved list of outputs could still name it.

On startup that saved list is replayed, and it was replayed without checking who
owns those outputs now. A connection owned by another player got added anyway, so
it appeared under two players at once and took up that player's slot for its kind
of connection — keeping the player's own connection of that kind from ever
showing up.

The replay now skips a connection that another player currently owns. The saved
entry is kept, so the connection still comes back if its owner releases it.

**Related issue (if applicable):**

- follow-up to #5786, which stopped new occurrences but left existing configs unrepaired

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
