### PR TITLE
Show which provider hit its stream limit when playback stops

### DIFF
--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -69,6 +69,8 @@ DEFAULT_MAX_CONCURRENT_STREAMS: Final[int] = 5
 class ProviderStreamLimitError(AudioError):
     """Raised when a music provider has no source-stream slot available."""
 
+    translation_key = "provider_stream_limit"
+
     def __init__(self, provider: MusicProvider, wait_timeout: float | None) -> None:
         """
         Initialize the provider stream limit error.
@@ -81,7 +83,8 @@ class ProviderStreamLimitError(AudioError):
         wait_text = f" after waiting {wait_timeout:g} seconds" if wait_timeout is not None else ""
         super().__init__(
             f"{provider.name} has reached its limit of {limit} "
-            f"concurrent source streams{wait_text}."
+            f"concurrent source streams{wait_text}.",
+            translation_args=[provider.name, limit],
         )
         self.provider_instance = provider.instance_id
         self.limit = limit

--- a/music_assistant/strings.json
+++ b/music_assistant/strings.json
@@ -1183,6 +1183,7 @@
     "setup_failed": "Setup failed. Please check the configuration and try again.",
     "login_failed": "Login failed. Please check your credentials and try again.",
     "audio_error": "An error occurred while processing audio.",
+    "provider_stream_limit": "{0} has reached its limit of {1} simultaneous streams. Stop playback on another player and try again.",
     "queue_empty": "The queue is empty.",
     "unsupported_feature": "This feature is not supported.",
     "unsupported_system": "This is not supported on this system.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -287,6 +287,7 @@
   "common.errors.player_command_failed": "The command to the player failed.",
   "common.errors.player_unavailable": "The player is not available.",
   "common.errors.provider_permission_denied": "The provider denied this action due to insufficient permissions.",
+  "common.errors.provider_stream_limit": "{0} has reached its limit of {1} simultaneous streams. Stop playback on another player and try again.",
   "common.errors.provider_unavailable": "The provider is currently unavailable.",
   "common.errors.queue_empty": "The queue is empty.",
   "common.errors.rate_limited": "Rate limit reached. Please try again later.",

--- a/tests/controllers/translations/test_translations.py
+++ b/tests/controllers/translations/test_translations.py
@@ -618,6 +618,25 @@ def test_error_result_message_provider_specific_override() -> None:
         assert msg.to_dict()["details"] == "Je Spotify-sessie is verlopen."
 
 
+def test_error_result_message_provider_stream_limit() -> None:
+    """The provider stream limit error resolves with provider name and limit interpolated."""
+    ctrl = _make_controller()
+    ctrl._source = build_translations_source()
+    msg = ErrorResultMessage(
+        "m",
+        7,
+        "Spotify has reached its limit of 5 concurrent source streams.",
+        translation_key="provider_stream_limit",
+        translation_args=["Spotify", 5],
+    )
+    with _active_resolver(ctrl, None):
+        details = msg.to_dict()["details"]
+    assert details == (
+        "Spotify has reached its limit of 5 simultaneous streams. "
+        "Stop playback on another player and try again."
+    )
+
+
 def test_error_result_message_unresolved_key_keeps_details() -> None:
     """An unresolvable or absent translation_key leaves the raw `details` string intact."""
     ctrl = _nl_controller()

--- a/tests/models/test_music_provider.py
+++ b/tests/models/test_music_provider.py
@@ -76,9 +76,12 @@ async def test_stream_slot_is_scoped_per_provider_instance() -> None:
     async with first.acquire_stream_slot(0.1):
         assert not first.has_available_stream_slot
         assert second.has_available_stream_slot
-        with pytest.raises(ProviderStreamLimitError):
+        with pytest.raises(ProviderStreamLimitError) as exc_info:
             async with first.acquire_stream_slot(0):
                 pytest.fail("A second source slot was unexpectedly acquired")
+        # the error must carry the localizable reason (provider name + limit) for API clients
+        assert exc_info.value.translation_key == "provider_stream_limit"
+        assert exc_info.value.translation_args == ["Test Provider", 1]
 
     assert first.has_available_stream_slot
 


### PR DESCRIPTION
# What does this implement/fix?

When playback stops because a music provider has no free stream slot (the limit added in #5773), the app showed the generic "An error occurred while processing audio." — the actual reason never reached the user. The error shown now names the provider and its limit: "Spotify has reached its limit of 5 simultaneous streams. Stop playback on another player and try again."

- Give `ProviderStreamLimitError` its own `provider_stream_limit` translation key, with the provider name and limit as arguments
- Add the English source string to the shared error catalog
- Cover the new key with tests

No companion PRs needed: the error translation machinery in the models package already supports per-instance keys/args, and the message is resolved server-side before it reaches the frontend.

**Related issue (if applicable):**

- follow-up on #5773

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
