### PR TITLE
Close MPD connections when connecting fails partway through

### DIFF
--- a/music_assistant/providers/mpd/player.py
+++ b/music_assistant/providers/mpd/player.py
@@ -150,7 +150,7 @@ class MPDPlayer(Player):
 
     async def _connect(self) -> None:
         """Establish both MPD connections and start the idle loop."""
-        # a failed attempt or a dead idle loop can leave connected clients behind
+        # A failed attempt or a dead idle loop can leave connected clients behind
         await self._disconnect()
         try:
             self._client = MPDClient()
@@ -204,7 +204,7 @@ class MPDPlayer(Player):
     async def _disconnect(self) -> None:
         """Cancel any pending reconnect, stop the idle loop and disconnect both MPD clients."""
         self.mass.cancel_timer(self._reconnect_task_id)
-        # connecting has no timeout, so an attempt may still be in flight and would
+        # Connecting has no timeout, so an attempt may still be in flight and would
         # otherwise arm a new reconnect after this teardown
         reconnect_task = self.mass.get_task(self._reconnect_task_id)
         if reconnect_task is not None and reconnect_task is not asyncio.current_task():

--- a/music_assistant/providers/mpd/player.py
+++ b/music_assistant/providers/mpd/player.py
@@ -204,6 +204,11 @@ class MPDPlayer(Player):
     async def _disconnect(self) -> None:
         """Cancel any pending reconnect, stop the idle loop and disconnect both MPD clients."""
         self.mass.cancel_timer(self._reconnect_task_id)
+        # connecting has no timeout, so an attempt may still be in flight and would
+        # otherwise arm a new reconnect after this teardown
+        reconnect_task = self.mass.get_task(self._reconnect_task_id)
+        if reconnect_task is not None and reconnect_task is not asyncio.current_task():
+            self.mass.cancel_task(self._reconnect_task_id)
         if self._idle_task:
             self._idle_task.cancel()
             self._idle_task = None

--- a/music_assistant/providers/mpd/player.py
+++ b/music_assistant/providers/mpd/player.py
@@ -70,6 +70,7 @@ class MPDPlayer(Player):
         self._client: MPDClient | None = None
         self._idle_client: MPDClient | None = None
         self._idle_task: asyncio.Task[None] | None = None
+        self._reconnect_task_id: str = f"mpd_reconnect_{self.player_id}"
         self._attr_needs_setup: bool = False
         self._attr_setup_reason: str | None = None
 
@@ -123,7 +124,6 @@ class MPDPlayer(Player):
         self.password = cast("str | None", self.get_setup_value(CONF_PASSWORD) or None)
         self._attr_needs_setup = False
         self._attr_setup_reason = None
-        await self._disconnect()
         await self._connect()
 
     async def run_setup_flow(self, session: SetupSession) -> None:
@@ -150,6 +150,8 @@ class MPDPlayer(Player):
 
     async def _connect(self) -> None:
         """Establish both MPD connections and start the idle loop."""
+        # a failed attempt or a dead idle loop can leave connected clients behind
+        await self._disconnect()
         try:
             self._client = MPDClient()
             await self._client.connect(self.host, self.port)
@@ -176,6 +178,7 @@ class MPDPlayer(Player):
             self.update_state()
 
         except CommandError as err:
+            await self._disconnect()
             if err.errno in (FailureResponseCode.PASSWORD, FailureResponseCode.PERMISSION):
                 self.logger.warning(
                     "Authentication failed for MPD at %s:%s — configure password in player settings",
@@ -192,13 +195,15 @@ class MPDPlayer(Player):
                 self.update_state()
                 self.reconnect()
         except (MPDError, OSError) as err:
+            await self._disconnect()
             self.logger.warning("Failed to connect to MPD at %s:%s: %s", self.host, self.port, err)
             self._attr_available = False
             self.update_state()
             self.reconnect()
 
     async def _disconnect(self) -> None:
-        """Disconnect both MPD clients and cancel the idle loop task."""
+        """Cancel any pending reconnect, stop the idle loop and disconnect both MPD clients."""
+        self.mass.cancel_timer(self._reconnect_task_id)
         if self._idle_task:
             self._idle_task.cancel()
             self._idle_task = None
@@ -210,8 +215,7 @@ class MPDPlayer(Player):
 
     def reconnect(self) -> None:
         """Schedule a reconnect attempt, deduplicating any pending reconnect tasks."""
-        task_id = f"mpd_reconnect_{self.player_id}"
-        self.mass.call_later(RECONNECT_DELAY, self._connect, task_id=task_id)
+        self.mass.call_later(RECONNECT_DELAY, self._connect, task_id=self._reconnect_task_id)
 
     # ------------------------------------------------------------------
     # Background idle loop

--- a/tests/providers/mpd/conftest.py
+++ b/tests/providers/mpd/conftest.py
@@ -1,0 +1,22 @@
+"""Fixtures for testing the MPD player provider."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from music_assistant.providers.mpd.player import MPDPlayer
+from tests.common import MockProvider, create_mock_config
+
+
+@pytest.fixture
+def make_mpd_player() -> Callable[..., MPDPlayer]:
+    """Return a factory that builds an MPDPlayer with a decoupled (mocked) provider/mass."""
+
+    def _make_player(player_id: str = "mpd_test") -> MPDPlayer:
+        provider = MockProvider("mpd", instance_id="mpd--1")
+        provider.mass.config.get_base_player_config.return_value = create_mock_config("MPD Test")
+        return MPDPlayer(provider=provider, player_id=player_id, host="10.0.0.6")  # type: ignore[arg-type]
+
+    return _make_player

--- a/tests/providers/mpd/test_connection.py
+++ b/tests/providers/mpd/test_connection.py
@@ -1,0 +1,72 @@
+"""Tests for the MPD player connection handling."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mpd import CommandError
+from mpd import ConnectionError as MPDConnectionError
+
+from music_assistant.providers.mpd.player import MPDPlayer
+
+
+def _mock_client() -> MagicMock:
+    """Return a mocked MPDClient that connects successfully."""
+    client = MagicMock()
+    client.connect = AsyncMock()
+    client.password = AsyncMock()
+    client.status = AsyncMock(return_value={"state": "stop"})
+    return client
+
+
+async def test_failed_authentication_closes_the_connection(
+    make_mpd_player: Callable[..., MPDPlayer],
+) -> None:
+    """A rejected password must not leave the connected client behind."""
+    player = make_mpd_player()
+    player.password = "wrong"
+    client = _mock_client()
+    client.password = AsyncMock(side_effect=CommandError("[3@0] {password} incorrect password"))
+
+    with patch("music_assistant.providers.mpd.player.MPDClient", return_value=client):
+        await player._connect()
+
+    client.disconnect.assert_called_once()
+    assert player._client is None
+    assert player.needs_setup is True
+
+
+async def test_failed_idle_connection_closes_the_command_connection(
+    make_mpd_player: Callable[..., MPDPlayer],
+) -> None:
+    """When the idle connection fails, the command connection must be closed too."""
+    player = make_mpd_player()
+    player.password = None
+    command_client = _mock_client()
+    idle_client = _mock_client()
+    idle_client.connect = AsyncMock(side_effect=MPDConnectionError("connection lost"))
+
+    with patch(
+        "music_assistant.providers.mpd.player.MPDClient",
+        side_effect=[command_client, idle_client],
+    ):
+        await player._connect()
+
+    command_client.disconnect.assert_called_once()
+    idle_client.disconnect.assert_called_once()
+    assert player._client is None
+    assert player._idle_client is None
+    assert player.available is False
+
+
+async def test_disconnect_cancels_a_pending_reconnect(
+    make_mpd_player: Callable[..., MPDPlayer],
+) -> None:
+    """Unloading a player must not leave a reconnect attempt armed."""
+    player = make_mpd_player()
+
+    await player._disconnect()
+
+    cast("MagicMock", player.mass.cancel_timer).assert_called_once_with(player._reconnect_task_id)

--- a/tests/providers/mpd/test_connection.py
+++ b/tests/providers/mpd/test_connection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -66,7 +67,35 @@ async def test_disconnect_cancels_a_pending_reconnect(
 ) -> None:
     """Unloading a player must not leave a reconnect attempt armed."""
     player = make_mpd_player()
+    cast("MagicMock", player.mass.get_task).return_value = None
 
     await player._disconnect()
 
     cast("MagicMock", player.mass.cancel_timer).assert_called_once_with(player._reconnect_task_id)
+    cast("MagicMock", player.mass.cancel_task).assert_not_called()
+
+
+async def test_disconnect_stops_a_connect_attempt_in_flight(
+    make_mpd_player: Callable[..., MPDPlayer],
+) -> None:
+    """A connect attempt that already started must not outlive the teardown."""
+    player = make_mpd_player()
+    in_flight = asyncio.create_task(asyncio.sleep(30))
+    cast("MagicMock", player.mass.get_task).return_value = in_flight
+
+    await player._disconnect()
+
+    cast("MagicMock", player.mass.cancel_task).assert_called_once_with(player._reconnect_task_id)
+    in_flight.cancel()
+
+
+async def test_disconnect_never_cancels_its_own_connect_attempt(
+    make_mpd_player: Callable[..., MPDPlayer],
+) -> None:
+    """The teardown at the start of a connect attempt must not cancel that attempt."""
+    player = make_mpd_player()
+    cast("MagicMock", player.mass.get_task).return_value = asyncio.current_task()
+
+    await player._disconnect()
+
+    cast("MagicMock", player.mass.cancel_task).assert_not_called()

--- a/tests/providers/mpd/test_connection.py
+++ b/tests/providers/mpd/test_connection.py
@@ -65,7 +65,7 @@ async def test_failed_idle_connection_closes_the_command_connection(
 async def test_disconnect_cancels_a_pending_reconnect(
     make_mpd_player: Callable[..., MPDPlayer],
 ) -> None:
-    """Unloading a player must not leave a reconnect attempt armed."""
+    """Disconnecting must disarm a reconnect that is still waiting on its timer."""
     player = make_mpd_player()
     cast("MagicMock", player.mass.get_task).return_value = None
 

--- a/tests/providers/mpd/test_setup_flow.py
+++ b/tests/providers/mpd/test_setup_flow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,7 +13,6 @@ from music_assistant_models.enums import FlowStepType
 from music_assistant.constants import CONF_PASSWORD, CONF_PLAYERS
 from music_assistant.mass import MusicAssistant
 from music_assistant.providers.mpd.player import MPDPlayer
-from tests.common import MockProvider, create_mock_config
 
 
 @pytest.fixture
@@ -36,39 +35,35 @@ async def flow_mass(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicAssista
             sweep_handle.cancel()
 
 
-def _make_player(player_id: str = "mpd_test") -> MPDPlayer:
-    """Build a real MPDPlayer with a decoupled (mocked) provider/mass."""
-    provider = MockProvider("mpd", instance_id="mpd--1")
-    provider.mass.config.get_base_player_config.return_value = create_mock_config("MPD Test")
-    return MPDPlayer(provider=provider, player_id=player_id, host="10.0.0.6")  # type: ignore[arg-type]
-
-
-async def test_get_config_entries_excludes_password() -> None:
+async def test_get_config_entries_excludes_password(
+    make_mpd_player: Callable[..., MPDPlayer],
+) -> None:
     """The password is flow-managed now and must not appear in the options config entries."""
-    player = _make_player()
+    player = make_mpd_player()
     entries = await player.get_config_entries()
     assert CONF_PASSWORD not in {entry.key for entry in entries}
 
 
-async def test_on_config_updated_reads_password_via_setup_value() -> None:
+async def test_on_config_updated_reads_password_via_setup_value(
+    make_mpd_player: Callable[..., MPDPlayer],
+) -> None:
     """on_config_updated resolves the password from setup_data, not the options config."""
-    player = _make_player()
+    player = make_mpd_player()
     cast("MagicMock", player.mass.config.get).return_value = {CONF_PASSWORD: "encrypted-blob"}
     cast("MagicMock", player.mass.config.decrypt_string).return_value = "secret"
-    with (
-        patch.object(player, "_connect", AsyncMock()),
-        patch.object(player, "_disconnect", AsyncMock()),
-    ):
+    with patch.object(player, "_connect", AsyncMock()):
         await player.on_config_updated()
     assert player.password == "secret"
     assert player.needs_setup is False
     assert player.setup_reason is None
 
 
-async def test_setup_flow_collects_and_persists_password(flow_mass: MusicAssistant) -> None:
+async def test_setup_flow_collects_and_persists_password(
+    flow_mass: MusicAssistant, make_mpd_player: Callable[..., MPDPlayer]
+) -> None:
     """The setup flow shows a single password field and persists it encrypted."""
     player_id = "mpd_test"
-    player = _make_player(player_id)
+    player = make_mpd_player(player_id)
     flow_mass.config.set(
         f"{CONF_PLAYERS}/{player_id}",
         {"player_id": player_id, "provider": player.provider_id, "enabled": True},


### PR DESCRIPTION
# What does this implement/fix?

When connecting to an MPD server failed halfway through, Music Assistant left the connection it had already opened behind. The most common case is a password-protected MPD server: the connection is accepted, the password is then rejected, and the player is marked as needing setup — but the open connection stays there. Every retry adds another one, and MPD servers only allow a limited number of connections.

Unloading an MPD player also left a pending reconnect attempt armed, so a player that was removed while its server was unreachable could come back a few seconds later and open connections nobody would ever close.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Close both MPD connections whenever connecting fails partway through.
- Always start a (re)connect from a clean slate, so a reconnect can never overwrite a still-open connection.
- Cancel any pending reconnect when a player is disconnected or unloaded, including a connect attempt that is still in progress.
- Added tests covering the failed-password and failed-idle-connection paths.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
