### PR TITLE
Fix missing and incorrect album details from TheAudioDB

### DIFF
--- a/music_assistant/providers/theaudiodb/__init__.py
+++ b/music_assistant/providers/theaudiodb/__init__.py
@@ -301,23 +301,6 @@ class AudioDbMetadataProvider(MetadataProvider):
             adb_album, "strDescription"
         )
         metadata.review = adb_album.get("strReview")
-        # images
-        if not self.config.get_value(CONF_ENABLE_IMAGES):
-            return metadata
-        metadata.images = UniqueList()
-        for key, img_type in IMG_MAPPING.items():
-            for postfix in ("", "2", "3", "4", "5", "6", "7", "8", "9", "10"):
-                if img := adb_album.get(f"{key}{postfix}"):
-                    metadata.images.append(
-                        MediaItemImage(
-                            type=img_type,
-                            path=img,
-                            provider=self.instance_id,
-                            remotely_accessible=True,
-                        )
-                    )
-                else:
-                    break
         # fill in some missing album info if needed
         if not album.year:
             album.year = int(adb_album.get("intYearReleased", "0"))
@@ -336,6 +319,23 @@ class AudioDbMetadataProvider(MetadataProvider):
                     album_artist.item_id,
                     album_artist,
                 )
+        # images
+        if not self.config.get_value(CONF_ENABLE_IMAGES):
+            return metadata
+        metadata.images = UniqueList()
+        for key, img_type in IMG_MAPPING.items():
+            for postfix in ("", "2", "3", "4", "5", "6", "7", "8", "9", "10"):
+                if img := adb_album.get(f"{key}{postfix}"):
+                    metadata.images.append(
+                        MediaItemImage(
+                            type=img_type,
+                            path=img,
+                            provider=self.instance_id,
+                            remotely_accessible=True,
+                        )
+                    )
+                else:
+                    break
         return metadata
 
     async def __parse_track(self, track: Track, adb_track: dict[str, Any]) -> MediaItemMetadata:
@@ -351,23 +351,6 @@ class AudioDbMetadataProvider(MetadataProvider):
         metadata.description, metadata.description_language = self._localized_field(
             adb_track, "strDescription"
         )
-        # images
-        if not self.config.get_value(CONF_ENABLE_IMAGES):
-            return metadata
-        metadata.images = UniqueList([])
-        for key, img_type in IMG_MAPPING.items():
-            for postfix in ("", "2", "3", "4", "5", "6", "7", "8", "9", "10"):
-                if img := adb_track.get(f"{key}{postfix}"):
-                    metadata.images.append(
-                        MediaItemImage(
-                            type=img_type,
-                            path=img,
-                            provider=self.instance_id,
-                            remotely_accessible=True,
-                        )
-                    )
-                else:
-                    break
         # update the artist mbid while at it
         for album_artist in track.artists:
             if not compare_strings(album_artist.name, adb_track["strArtist"]):
@@ -386,11 +369,31 @@ class AudioDbMetadataProvider(MetadataProvider):
             and not track.album.get_external_id(ExternalID.MB_RELEASEGROUP)
             and track.album.provider == "library"
             and isinstance(track.album, Album)
+            # a recording is shared by every release it appears on, so the album id is
+            # only ours to take when the matched record is for this album as well
+            and compare_strings(track.album.name, adb_track["strAlbum"], strict=False)
         ):
             track.album.add_external_id(
                 ExternalID.MB_RELEASEGROUP, adb_track["strMusicBrainzAlbumID"]
             )
             await self.mass.music.albums.update_item_in_library(track.album.item_id, track.album)
+        # images
+        if not self.config.get_value(CONF_ENABLE_IMAGES):
+            return metadata
+        metadata.images = UniqueList([])
+        for key, img_type in IMG_MAPPING.items():
+            for postfix in ("", "2", "3", "4", "5", "6", "7", "8", "9", "10"):
+                if img := adb_track.get(f"{key}{postfix}"):
+                    metadata.images.append(
+                        MediaItemImage(
+                            type=img_type,
+                            path=img,
+                            provider=self.instance_id,
+                            remotely_accessible=True,
+                        )
+                    )
+                else:
+                    break
         return metadata
 
     def _localized_field(self, obj: dict[str, Any], prefix: str) -> tuple[str | None, str | None]:

--- a/music_assistant/providers/theaudiodb/__init__.py
+++ b/music_assistant/providers/theaudiodb/__init__.py
@@ -366,17 +366,15 @@ class AudioDbMetadataProvider(MetadataProvider):
         # update the album mbid while at it
         if (
             track.album
-            and not track.album.get_external_id(ExternalID.MB_RELEASEGROUP)
             and track.album.provider == "library"
-            and isinstance(track.album, Album)
+            and not track.album.get_external_id(ExternalID.MB_RELEASEGROUP)
             # a recording is shared by every release it appears on, so the album id is
             # only ours to take when the matched record is for this album as well
             and compare_album_name(track.album.name, adb_track["strAlbum"])
         ):
-            track.album.add_external_id(
-                ExternalID.MB_RELEASEGROUP, adb_track["strMusicBrainzAlbumID"]
+            await self.mass.music.albums.set_release_group(
+                int(track.album.item_id), adb_track["strMusicBrainzAlbumID"]
             )
-            await self.mass.music.albums.update_item_in_library(track.album.item_id, track.album)
         # images
         if not self.config.get_value(CONF_ENABLE_IMAGES):
             return metadata

--- a/music_assistant/providers/theaudiodb/__init__.py
+++ b/music_assistant/providers/theaudiodb/__init__.py
@@ -28,7 +28,7 @@ from music_assistant_models.media_items import (
 
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.app_vars import app_var
-from music_assistant.helpers.compare import compare_strings
+from music_assistant.helpers.compare import compare_album_name, compare_strings
 from music_assistant.helpers.throttle_retry import Throttler
 from music_assistant.models.metadata_provider import MetadataProvider
 
@@ -371,7 +371,7 @@ class AudioDbMetadataProvider(MetadataProvider):
             and isinstance(track.album, Album)
             # a recording is shared by every release it appears on, so the album id is
             # only ours to take when the matched record is for this album as well
-            and compare_strings(track.album.name, adb_track["strAlbum"], strict=False)
+            and compare_album_name(track.album.name, adb_track["strAlbum"])
         ):
             track.album.add_external_id(
                 ExternalID.MB_RELEASEGROUP, adb_track["strMusicBrainzAlbumID"]

--- a/tests/providers/theaudiodb/__init__.py
+++ b/tests/providers/theaudiodb/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for TheAudioDB metadata provider."""

--- a/tests/providers/theaudiodb/test_theaudiodb.py
+++ b/tests/providers/theaudiodb/test_theaudiodb.py
@@ -1,0 +1,152 @@
+"""Tests for the identifier backfill of TheAudioDB metadata provider."""
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import AlbumType, ExternalID
+from music_assistant_models.media_items import Album, Artist, ProviderMapping, Track, UniqueList
+
+from music_assistant.providers.theaudiodb import (
+    CONF_ENABLE_ALBUM_METADATA,
+    CONF_ENABLE_IMAGES,
+    CONF_ENABLE_TRACK_METADATA,
+    SUPPORTED_FEATURES,
+    AudioDbMetadataProvider,
+)
+
+ARTIST_MBID = "7cf0ea9d-86b9-4dad-ba9e-2355a64899ea"
+RELEASEGROUP_MBID = "1b022e01-4da6-387b-8658-8678046e4cef"
+RECORDING_MBID = "b1a9c0e9-d987-4042-ae91-78d6a3267d69"
+
+
+async def test_album_backfill_runs_with_images_disabled() -> None:
+    """Album and artist identifiers are backfilled even when images are turned off."""
+    provider = _provider(images_enabled=False)
+    artist = _artist("Nirvana")
+    album = Album(
+        item_id="album",
+        provider="library",
+        name="Nevermind",
+        artists=UniqueList([artist]),
+        external_ids={(ExternalID.MB_RELEASEGROUP, RELEASEGROUP_MBID)},
+        provider_mappings=_mappings("album"),
+    )
+    provider._get_data = AsyncMock(  # type: ignore[method-assign]
+        return_value={"album": [_adb_album()]}
+    )
+
+    metadata = await provider.get_album_metadata(album)
+
+    assert metadata is not None
+    assert metadata.images is None
+    assert album.year == 1991
+    assert album.album_type == AlbumType.ALBUM
+    assert artist.mbid == ARTIST_MBID
+    cast("AsyncMock", provider.mass.music.artists.update_item_in_library).assert_awaited_once()
+
+
+async def test_track_release_group_written_when_album_matches() -> None:
+    """The album gets TheAudioDB's release group id when the matched record is that album."""
+    provider = _provider()
+    track = _track("Nevermind")
+    provider._get_data = AsyncMock(  # type: ignore[method-assign]
+        return_value={"track": [_adb_track()]}
+    )
+
+    await provider.get_track_metadata(track)
+
+    assert track.album is not None
+    assert track.album.get_external_id(ExternalID.MB_RELEASEGROUP) == RELEASEGROUP_MBID
+    cast("AsyncMock", provider.mass.music.albums.update_item_in_library).assert_awaited_once()
+
+
+async def test_track_release_group_skipped_for_another_release() -> None:
+    """A recording shared with another release must not stamp its id on our album."""
+    provider = _provider()
+    track = _track("Nirvana: The Best Of")
+    provider._get_data = AsyncMock(  # type: ignore[method-assign]
+        return_value={"track": [_adb_track()]}
+    )
+
+    await provider.get_track_metadata(track)
+
+    assert track.album is not None
+    assert track.album.get_external_id(ExternalID.MB_RELEASEGROUP) is None
+    cast("AsyncMock", provider.mass.music.albums.update_item_in_library).assert_not_awaited()
+    # the artist backfill is independent of the album, so it still happens
+    assert track.artists[0].mbid == ARTIST_MBID
+
+
+def _provider(*, images_enabled: bool = True) -> AudioDbMetadataProvider:
+    """
+    Return a provider with mocked dependencies and every metadata lookup enabled.
+
+    :param images_enabled: Whether the provider's image option is turned on.
+    """
+    mass = AsyncMock()
+    mass.metadata.locale = "en_US"
+    manifest = MagicMock()
+    manifest.domain = "theaudiodb"
+    config = MagicMock()
+    flags = {
+        CONF_ENABLE_ALBUM_METADATA: True,
+        CONF_ENABLE_TRACK_METADATA: True,
+        CONF_ENABLE_IMAGES: images_enabled,
+    }
+    config.get_value.side_effect = lambda key: flags.get(key, "GLOBAL")
+    return AudioDbMetadataProvider(mass, manifest, config, SUPPORTED_FEATURES)
+
+
+def _mappings(item_id: str) -> set[ProviderMapping]:
+    """Return a single library provider mapping for the given item id."""
+    return {ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="library")}
+
+
+def _artist(name: str) -> Artist:
+    """Return a library artist without a MusicBrainz id."""
+    return Artist(
+        item_id="artist",
+        provider="library",
+        name=name,
+        provider_mappings=_mappings("artist"),
+    )
+
+
+def _track(album_name: str) -> Track:
+    """Return a library track matched by its MusicBrainz recording id."""
+    return Track(
+        item_id="track",
+        provider="library",
+        name="Come as You Are",
+        external_ids={(ExternalID.MB_RECORDING, RECORDING_MBID)},
+        artists=UniqueList([_artist("Nirvana")]),
+        album=Album(
+            item_id="album",
+            provider="library",
+            name=album_name,
+            provider_mappings=_mappings("album"),
+        ),
+        provider_mappings=_mappings("track"),
+    )
+
+
+def _adb_album() -> dict[str, Any]:
+    """Return a minimal TheAudioDB album record."""
+    return {
+        "strArtist": "Nirvana",
+        "strAlbum": "Nevermind",
+        "strMusicBrainzArtistID": ARTIST_MBID,
+        "intYearReleased": "1991",
+        "strReleaseFormat": "Album",
+    }
+
+
+def _adb_track() -> dict[str, Any]:
+    """Return a minimal TheAudioDB track record."""
+    return {
+        "strArtist": "Nirvana",
+        "strAlbum": "Nevermind",
+        "strTrack": "Come as You Are",
+        "strMusicBrainzArtistID": ARTIST_MBID,
+        "strMusicBrainzAlbumID": RELEASEGROUP_MBID,
+    }

--- a/tests/providers/theaudiodb/test_theaudiodb.py
+++ b/tests/providers/theaudiodb/test_theaudiodb.py
@@ -3,6 +3,7 @@
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from music_assistant_models.enums import AlbumType, ExternalID
 from music_assistant_models.media_items import Album, Artist, ProviderMapping, Track, UniqueList
 
@@ -45,10 +46,19 @@ async def test_album_backfill_runs_with_images_disabled() -> None:
     cast("AsyncMock", provider.mass.music.artists.update_item_in_library).assert_awaited_once()
 
 
-async def test_track_release_group_written_when_album_matches() -> None:
+@pytest.mark.parametrize(
+    "library_album",
+    [
+        "Nevermind",
+        # the retail suffix Apple Music appends carries no identity of its own
+        "Nevermind - EP",
+    ],
+)
+async def test_track_release_group_written_when_album_matches(library_album: str) -> None:
     """The album gets TheAudioDB's release group id when the matched record is that album."""
-    provider = _provider()
-    track = _track("Nevermind")
+    # images off, so this covers the track backfill not being tied to the images option
+    provider = _provider(images_enabled=False)
+    track = _track(library_album)
     provider._get_data = AsyncMock(  # type: ignore[method-assign]
         return_value={"track": [_adb_track()]}
     )
@@ -60,12 +70,22 @@ async def test_track_release_group_written_when_album_matches() -> None:
     cast("AsyncMock", provider.mass.music.albums.update_item_in_library).assert_awaited_once()
 
 
-async def test_track_release_group_skipped_for_another_release() -> None:
+@pytest.mark.parametrize(
+    ("library_album", "adb_album"),
+    [
+        ("Nirvana: The Best Of", "Nevermind"),
+        # near-identical titles are still separate releases
+        ("Vol. 1", "Vol. 2"),
+    ],
+)
+async def test_track_release_group_skipped_for_another_release(
+    library_album: str, adb_album: str
+) -> None:
     """A recording shared with another release must not stamp its id on our album."""
     provider = _provider()
-    track = _track("Nirvana: The Best Of")
+    track = _track(library_album)
     provider._get_data = AsyncMock(  # type: ignore[method-assign]
-        return_value={"track": [_adb_track()]}
+        return_value={"track": [_adb_track(adb_album)]}
     )
 
     await provider.get_track_metadata(track)
@@ -99,7 +119,7 @@ def _provider(*, images_enabled: bool = True) -> AudioDbMetadataProvider:
 
 def _mappings(item_id: str) -> set[ProviderMapping]:
     """Return a single library provider mapping for the given item id."""
-    return {ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="library")}
+    return {ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")}
 
 
 def _artist(name: str) -> Artist:
@@ -141,11 +161,11 @@ def _adb_album() -> dict[str, Any]:
     }
 
 
-def _adb_track() -> dict[str, Any]:
+def _adb_track(album_name: str = "Nevermind") -> dict[str, Any]:
     """Return a minimal TheAudioDB track record."""
     return {
         "strArtist": "Nirvana",
-        "strAlbum": "Nevermind",
+        "strAlbum": album_name,
         "strTrack": "Come as You Are",
         "strMusicBrainzArtistID": ARTIST_MBID,
         "strMusicBrainzAlbumID": RELEASEGROUP_MBID,

--- a/tests/providers/theaudiodb/test_theaudiodb.py
+++ b/tests/providers/theaudiodb/test_theaudiodb.py
@@ -25,12 +25,12 @@ async def test_album_backfill_runs_with_images_disabled() -> None:
     provider = _provider(images_enabled=False)
     artist = _artist("Nirvana")
     album = Album(
-        item_id="album",
+        item_id="1",
         provider="library",
         name="Nevermind",
         artists=UniqueList([artist]),
         external_ids={(ExternalID.MB_RELEASEGROUP, RELEASEGROUP_MBID)},
-        provider_mappings=_mappings("album"),
+        provider_mappings=_mappings("1"),
     )
     provider._get_data = AsyncMock(  # type: ignore[method-assign]
         return_value={"album": [_adb_album()]}
@@ -65,9 +65,9 @@ async def test_track_release_group_written_when_album_matches(library_album: str
 
     await provider.get_track_metadata(track)
 
-    assert track.album is not None
-    assert track.album.get_external_id(ExternalID.MB_RELEASEGROUP) == RELEASEGROUP_MBID
-    cast("AsyncMock", provider.mass.music.albums.update_item_in_library).assert_awaited_once()
+    cast("AsyncMock", provider.mass.music.albums.set_release_group).assert_awaited_once_with(
+        1, RELEASEGROUP_MBID
+    )
 
 
 @pytest.mark.parametrize(
@@ -90,9 +90,7 @@ async def test_track_release_group_skipped_for_another_release(
 
     await provider.get_track_metadata(track)
 
-    assert track.album is not None
-    assert track.album.get_external_id(ExternalID.MB_RELEASEGROUP) is None
-    cast("AsyncMock", provider.mass.music.albums.update_item_in_library).assert_not_awaited()
+    cast("AsyncMock", provider.mass.music.albums.set_release_group).assert_not_awaited()
     # the artist backfill is independent of the album, so it still happens
     assert track.artists[0].mbid == ARTIST_MBID
 
@@ -141,10 +139,10 @@ def _track(album_name: str) -> Track:
         external_ids={(ExternalID.MB_RECORDING, RECORDING_MBID)},
         artists=UniqueList([_artist("Nirvana")]),
         album=Album(
-            item_id="album",
+            item_id="1",
             provider="library",
             name=album_name,
-            provider_mappings=_mappings("album"),
+            provider_mappings=_mappings("1"),
         ),
         provider_mappings=_mappings("track"),
     )


### PR DESCRIPTION
# What does this implement/fix?

While fetching metadata, TheAudioDB also fills in details we are missing on an album or artist — release year, album type and MusicBrainz ids. Two things were wrong with that:

- Those updates sat below the provider's "enable images" option, so turning images off silently stopped them too.
- When a track was matched on its MusicBrainz recording id, the album id from that match was copied onto whatever album the track sits on. A recording appears on many releases, so a compilation or reissue could end up carrying the original album's id — which is then trusted over the correct one for all future matching.

Changes:

- Fill in year, album type and MusicBrainz ids regardless of the images setting.
- Only take TheAudioDB's album id when the matched record is for that same album.
- Added tests for both.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
