### PR TITLE
Play a track from another provider when its own provider is at the stream limit

### DIFF
--- a/music_assistant/controllers/player_queues/stream_feeder.py
+++ b/music_assistant/controllers/player_queues/stream_feeder.py
@@ -77,6 +77,9 @@ class StreamFeederMixin(_PlayerQueuesBase):
                     next_item,
                     reason="prepare_next",
                     capacity_wait_timeout=STREAM_SLOT_WAIT_TIMEOUT,
+                    # speculative preparation gives up softly, so it must stay cheap:
+                    # leave the cross-provider search to the actual playback start
+                    allow_provider_match=False,
                 )
             except (AudioError, MediaNotFoundError) as err:
                 self.logger.debug("Failed to prepare next audio buffer: %s", err)

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -43,6 +43,7 @@ from music_assistant_models.enums import (
     CrossfadeMode,
     MediaType,
     PlayerFeature,
+    ProviderFeature,
     ProviderType,
     StreamType,
     VolumeNormalizationMode,
@@ -100,6 +101,7 @@ from music_assistant.controllers.streams.constants import (
     CACHE_CATEGORY_RESOLVED_RADIO_URL,
     CACHE_PROVIDER,
     CONF_ALLOW_CROSSFADE_SAME_ALBUM,
+    STREAM_SLOT_MATCH_TIMEOUT,
     STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT,
     STREAM_SLOT_WAIT_TIMEOUT,
     STREAMDETAILS_INBAND_TITLE_HANDOFF_KEY,
@@ -426,6 +428,7 @@ class StreamsAudio:
         seek_position_ms: int = 0,
         reason: str = "",
         capacity_wait_timeout: float = STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT,
+        allow_provider_match: bool = True,
     ) -> AudioBuffer:
         """
         Return a ready AudioBuffer for the given queue item.
@@ -437,6 +440,8 @@ class StreamsAudio:
         :param seek_position_ms: Position in milliseconds to start from.
         :param reason: Caller context for logging (e.g. 'prepare_next', 'streaming').
         :param capacity_wait_timeout: Total seconds to spend waiting for source capacity.
+        :param allow_provider_match: Whether an on-demand cross-provider match may widen
+            the candidates when all are saturated.
         :raises ProviderStreamLimitError: If no source slot becomes available within the budget.
         """
         lock_key = (queue_item.queue_id, queue_item.queue_item_id)
@@ -445,7 +450,7 @@ class StreamsAudio:
             self._audio_buffer_locks[lock_key] = buffer_lock
         async with buffer_lock:
             return await self._get_audio_buffer(
-                queue_item, seek_position_ms, reason, capacity_wait_timeout
+                queue_item, seek_position_ms, reason, capacity_wait_timeout, allow_provider_match
             )
 
     async def get_media_stream(
@@ -2744,6 +2749,7 @@ class StreamsAudio:
         seek_position_ms: int,
         reason: str,
         capacity_wait_timeout: float,
+        allow_provider_match: bool,
     ) -> AudioBuffer:
         """
         Create or reuse a ready AudioBuffer within one queue-item preparation lock.
@@ -2752,6 +2758,8 @@ class StreamsAudio:
         :param seek_position_ms: Position in milliseconds to start from.
         :param reason: Caller context for logging.
         :param capacity_wait_timeout: Total seconds to spend waiting for source capacity.
+        :param allow_provider_match: Whether an on-demand cross-provider match may widen
+            the candidates when all are saturated.
         """
         loop = asyncio.get_running_loop()
         # the playback intent lives on the details we start from; keep it across a reselection
@@ -2775,6 +2783,13 @@ class StreamsAudio:
         }
         if initial_streamdetails is not None:
             all_candidate_instances.add(initial_streamdetails.provider)
+        # a track may also exist on streaming providers it has no mapping for yet; such a
+        # match is only searched once, and only when every known candidate is saturated
+        match_pending = (
+            allow_provider_match
+            and isinstance(queue_item.media_item, Track)
+            and self._has_alternative_match_providers(queue_item.media_item)
+        )
 
         deadline = loop.time() + capacity_wait_timeout
         busy_instances: set[str] = set()
@@ -2818,7 +2833,9 @@ class StreamsAudio:
             # acquired instantly, while a busy one fails fast instead of spending the
             # whole budget on this candidate. Block only on the last resort.
             source_wait = (
-                0.0 if (not final_pass and (alternatives_left or busy_instances)) else remaining
+                0.0
+                if (not final_pass and (alternatives_left or busy_instances or match_pending))
+                else remaining
             )
             try:
                 return await AudioBuffer.get_buffer(
@@ -2836,9 +2853,18 @@ class StreamsAudio:
                 if final_pass or loop.time() >= deadline:
                     raise
                 if all_candidate_instances.issubset(busy_instances):
-                    # every candidate is saturated: one last blocking wait on the best one
-                    busy_instances.clear()
-                    final_pass = True
+                    discovered: set[str] = set()
+                    if match_pending:
+                        match_pending = False
+                        discovered = await self._discover_alternative_provider_mappings(
+                            queue_item, busy_instances, max(deadline - loop.time(), 0)
+                        )
+                    if discovered:
+                        all_candidate_instances.update(discovered)
+                    else:
+                        # every candidate is saturated: one last blocking wait on the best one
+                        busy_instances.clear()
+                        final_pass = True
                 queue_item.streamdetails = None
             except AudioError:
                 if last_capacity_error is None or final_pass:
@@ -2916,6 +2942,112 @@ class StreamsAudio:
         if not providers:
             self.logger.debug("Skipping %s - provider not available", mapping)
         return providers
+
+    def _is_match_candidate_provider(
+        self, provider: MusicProvider, known_domains: set[str]
+    ) -> bool:
+        """
+        Return whether a provider is eligible to search a track match on.
+
+        :param provider: Music provider to check.
+        :param known_domains: Provider domains the track already has mappings for.
+        """
+        return (
+            provider.available
+            and provider.is_streaming_provider
+            and ProviderFeature.SEARCH in provider.supported_features
+            and provider.domain not in known_domains
+            and self.mass.music.library_supported(provider, MediaType.TRACK)
+        )
+
+    def _has_alternative_match_providers(self, media_item: Track) -> bool:
+        """
+        Return whether any configured streaming provider could carry an unmapped match.
+
+        :param media_item: Track whose existing mappings define the known provider domains.
+        """
+        known_domains = {mapping.provider_domain for mapping in media_item.provider_mappings}
+        return any(
+            self._is_match_candidate_provider(provider, known_domains)
+            for provider in self.mass.music.providers
+        )
+
+    async def _discover_alternative_provider_mappings(
+        self, queue_item: QueueItem, busy_instances: set[str], remaining: float
+    ) -> set[str]:
+        """
+        Search other streaming providers for the queue item's track and widen its mappings.
+
+        A found mapping is added to the media item (and persisted for library items) so the
+        capacity reselection can continue on the discovered provider.
+
+        :param queue_item: Queue item whose track should be matched on another provider.
+        :param busy_instances: Provider instances already known to be saturated.
+        :param remaining: Seconds left of the caller's capacity budget.
+        :return: Provider instances able to serve the discovered mappings.
+        """
+        media_item = queue_item.media_item
+        if not isinstance(media_item, Track):
+            return set()
+        known_domains = {mapping.provider_domain for mapping in media_item.provider_mappings}
+        candidates: list[MusicProvider] = []
+        for provider in self.mass.music.providers:
+            if (
+                not self._is_match_candidate_provider(provider, known_domains)
+                or provider.instance_id in busy_instances
+                or not provider.has_available_stream_slot
+            ):
+                continue
+            # one instance per domain: a found mapping widens to sibling instances anyway
+            known_domains.add(provider.domain)
+            candidates.append(provider)
+        if not candidates:
+            return set()
+        # mirror the playback user's provider steering for the search order
+        if (
+            (pq_data := self.mass.player_queues.queue_data_or_none(queue_item.queue_id))
+            and pq_data.userid
+            and (playback_user := await self.mass.webserver.auth.get_user(pq_data.userid))
+            and playback_user.provider_filter
+        ):
+            preferred = set(playback_user.provider_filter)
+            candidates.sort(key=lambda provider: provider.instance_id not in preferred)
+        matches: list[ProviderMapping] = []
+        try:
+            async with asyncio.timeout(min(STREAM_SLOT_MATCH_TIMEOUT, remaining)):
+                for provider in candidates:
+                    if matches := await self.mass.music.tracks.match_provider(
+                        media_item, provider, strict=True
+                    ):
+                        break
+        except (TimeoutError, MusicAssistantError, aiohttp.ClientError) as err:
+            self.logger.debug(
+                "Searching an alternative provider for %s failed: %s", media_item.name, err
+            )
+        if not matches:
+            return set()
+        media_item.provider_mappings.update(matches)
+        if media_item.provider == "library":
+            try:
+                # persist so future plays have the mapping ahead of time
+                await self.mass.music.tracks.add_provider_mappings(media_item.item_id, matches)
+            except MusicAssistantError as err:
+                # a failed write-back must not fail the rescue; the mapping still
+                # serves this playback from memory
+                self.logger.warning(
+                    "Failed to persist discovered mapping for %s: %s", media_item.name, err
+                )
+        self.logger.info(
+            "All known sources for %s are at their stream limit, "
+            "using a matching track found on %s",
+            media_item.name,
+            matches[0].provider_domain,
+        )
+        return {
+            provider.instance_id
+            for mapping in matches
+            for provider in self._get_mapping_providers(mapping)
+        }
 
     async def _request_streamdetails(
         self,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -58,7 +58,7 @@ from music_assistant_models.errors import (
     QueueEmpty,
     RetriesExhausted,
 )
-from music_assistant_models.media_items import AudioFormat, Track
+from music_assistant_models.media_items import Album, AudioFormat, Track
 from music_assistant_models.player_queue import PlayLogEntry
 from music_assistant_models.streamdetails import MultiPartPath, StreamMetadata
 
@@ -2856,9 +2856,18 @@ class StreamsAudio:
                     discovered: set[str] = set()
                     if match_pending:
                         match_pending = False
-                        discovered = await self._discover_alternative_provider_mappings(
-                            queue_item, busy_instances, max(deadline - loop.time(), 0)
-                        )
+                        try:
+                            discovered = await self._discover_alternative_provider_mappings(
+                                queue_item, busy_instances, max(deadline - loop.time(), 0)
+                            )
+                        except Exception as err:
+                            # discovery is best-effort: any failure falls back to the
+                            # final blocking wait instead of replacing the typed error
+                            self.logger.warning(
+                                "Alternative provider search for %s failed: %s",
+                                queue_item.name,
+                                err,
+                            )
                     if discovered:
                         all_candidate_instances.update(discovered)
                     else:
@@ -2990,18 +2999,14 @@ class StreamsAudio:
         if not isinstance(media_item, Track):
             return set()
         known_domains = {mapping.provider_domain for mapping in media_item.provider_mappings}
-        candidates: list[MusicProvider] = []
-        for provider in self.mass.music.providers:
-            if (
-                not self._is_match_candidate_provider(provider, known_domains)
-                or provider.instance_id in busy_instances
-                or not provider.has_available_stream_slot
-            ):
-                continue
-            # one instance per domain: a found mapping widens to sibling instances anyway
-            known_domains.add(provider.domain)
-            candidates.append(provider)
-        if not candidates:
+        eligible = [
+            provider
+            for provider in self.mass.music.providers
+            if self._is_match_candidate_provider(provider, known_domains)
+            and provider.instance_id not in busy_instances
+            and provider.has_available_stream_slot
+        ]
+        if not eligible:
             return set()
         # mirror the playback user's provider steering for the search order
         if (
@@ -3011,32 +3016,42 @@ class StreamsAudio:
             and playback_user.provider_filter
         ):
             preferred = set(playback_user.provider_filter)
-            candidates.sort(key=lambda provider: provider.instance_id not in preferred)
+            eligible.sort(key=lambda provider: provider.instance_id not in preferred)
+        # one instance per domain: a found mapping widens to sibling instances anyway
+        candidates: list[MusicProvider] = []
+        for provider in eligible:
+            if provider.domain in known_domains:
+                continue
+            known_domains.add(provider.domain)
+            candidates.append(provider)
+        # the track's own album is free, sufficient evidence for the strict compare and
+        # avoids match_provider's multi-provider album lookup on every call
+        ref_albums = [media_item.album] if isinstance(media_item.album, Album) else []
         matches: list[ProviderMapping] = []
         try:
             async with asyncio.timeout(min(STREAM_SLOT_MATCH_TIMEOUT, remaining)):
                 for provider in candidates:
-                    if matches := await self.mass.music.tracks.match_provider(
-                        media_item, provider, strict=True
-                    ):
+                    # one failing provider must not end the search on the others
+                    try:
+                        matches = await self.mass.music.tracks.match_provider(
+                            media_item, provider, strict=True, ref_albums=ref_albums
+                        )
+                    except Exception as err:
+                        self.logger.debug("Searching a match on %s failed: %s", provider.name, err)
+                        continue
+                    if matches:
                         break
-        except (TimeoutError, MusicAssistantError, aiohttp.ClientError) as err:
-            self.logger.debug(
-                "Searching an alternative provider for %s failed: %s", media_item.name, err
-            )
+        except TimeoutError:
+            self.logger.debug("Searching an alternative provider for %s timed out", media_item.name)
         if not matches:
             return set()
         media_item.provider_mappings.update(matches)
         if media_item.provider == "library":
-            try:
-                # persist so future plays have the mapping ahead of time
-                await self.mass.music.tracks.add_provider_mappings(media_item.item_id, matches)
-            except MusicAssistantError as err:
-                # a failed write-back must not fail the rescue; the mapping still
-                # serves this playback from memory
-                self.logger.warning(
-                    "Failed to persist discovered mapping for %s: %s", media_item.name, err
-                )
+            # persist in the background so future plays have the mapping ahead of time;
+            # cancellation of this playback must never interrupt the library write
+            self.mass.create_task(
+                self.mass.music.tracks.add_provider_mappings(media_item.item_id, matches)
+            )
         self.logger.info(
             "All known sources for %s are at their stream limit, "
             "using a matching track found on %s",

--- a/music_assistant/controllers/streams/constants.py
+++ b/music_assistant/controllers/streams/constants.py
@@ -96,6 +96,10 @@ STREAM_SLOT_WAIT_TIMEOUT: Final[float] = 5.0
 # Total capacity budget when an actual playback start retries/reselects provider mappings.
 STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT: Final[float] = 15.0
 
+# Maximum time spent searching other streaming providers for an alternative mapping
+# when every known candidate is capacity-saturated.
+STREAM_SLOT_MATCH_TIMEOUT: Final[float] = 5.0
+
 # Maximum seconds we wait for the buffer to catch up on a forward seek.
 # Beyond this, the stream is re-fetched at the seek position.
 SEEK_WAIT_THRESHOLD: Final[int] = 20

--- a/tests/controllers/player_queues/test_stream_feeder.py
+++ b/tests/controllers/player_queues/test_stream_feeder.py
@@ -148,6 +148,7 @@ async def test_prepare_next_uses_the_speculative_capacity_budget() -> None:
         next_item,
         reason="prepare_next",
         capacity_wait_timeout=STREAM_SLOT_WAIT_TIMEOUT,
+        allow_provider_match=False,
     )
     assert mass.create_task.call_args.kwargs == {
         "task_id": "prepare_next_audio_buffer_queue-1",

--- a/tests/controllers/streams/test_stream_capacity_provider_match.py
+++ b/tests/controllers/streams/test_stream_capacity_provider_match.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -17,6 +19,7 @@ from music_assistant.models.music_provider import MusicProvider, ProviderStreamL
 
 BUSY_INSTANCE = "spotify--busy"
 MATCH_INSTANCE = "tidal--match"
+FAILING_INSTANCE = "qobuz--failing"
 ITEM_ID = "item-1"
 MATCHED_ITEM_ID = "item-on-tidal"
 
@@ -98,6 +101,13 @@ def _mass(providers: dict[str, MagicMock]) -> MagicMock:
     mass.music.library_supported.return_value = True
     mass.music.tracks.match_provider = AsyncMock(return_value=[])
     mass.music.tracks.add_provider_mappings = AsyncMock()
+
+    def _schedule(coro: Any, *_args: Any, **_kwargs: Any) -> asyncio.Task[Any]:
+        task = asyncio.get_running_loop().create_task(coro)
+        task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
+        return task
+
+    mass.create_task.side_effect = _schedule
     return mass
 
 
@@ -132,6 +142,8 @@ async def test_saturated_single_mapping_is_rescued_by_a_cross_provider_match(
     assert waits == [0, 0]
     mass.music.tracks.match_provider.assert_awaited_once()
     assert mass.music.tracks.match_provider.await_args.args[1] is providers[MATCH_INSTANCE]
+    # strictness is what prevents ever playing the wrong track
+    assert mass.music.tracks.match_provider.await_args.kwargs["strict"] is True
     # a non-library track keeps the mapping in memory only
     mass.music.tracks.add_provider_mappings.assert_not_awaited()
 
@@ -239,7 +251,39 @@ async def test_a_library_track_persists_the_discovered_mapping(
     result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
 
     assert result is expected_buffer
+    # the write-back runs as a background task, detached from this playback request
+    await asyncio.sleep(0)
     mass.music.tracks.add_provider_mappings.assert_awaited_once_with("42", [matched_mapping])
+
+
+async def test_one_failing_provider_does_not_end_the_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider that errors while searching is skipped in favor of the next one."""
+    queue_item = _queue_item(_mapping(BUSY_INSTANCE, quality=ContentType.FLAC))
+    queue_item.streamdetails = _streamdetails(BUSY_INSTANCE)
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        FAILING_INSTANCE: _music_provider(FAILING_INSTANCE),
+        MATCH_INSTANCE: _music_provider(MATCH_INSTANCE),
+    }
+    mass = _mass(providers)
+    matched_mapping = _mapping(MATCH_INSTANCE, item_id=MATCHED_ITEM_ID)
+    # a raw (non MusicAssistantError) provider bug must be contained as well
+    mass.music.tracks.match_provider = AsyncMock(
+        side_effect=[KeyError("unexpected api response"), [matched_mapping]]
+    )
+    audio = StreamsAudio(mass)
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    get_buffer = AsyncMock(side_effect=[_limit_error(BUSY_INSTANCE), expected_buffer])
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    assert result is expected_buffer
+    assert mass.music.tracks.match_provider.await_count == 2
+    assert queue_item.streamdetails is not None
+    assert queue_item.streamdetails.provider == MATCH_INSTANCE
 
 
 async def test_a_failed_mapping_write_back_does_not_fail_the_rescue(
@@ -271,6 +315,7 @@ async def test_a_failed_mapping_write_back_does_not_fail_the_rescue(
     assert result is expected_buffer
     assert queue_item.streamdetails is not None
     assert queue_item.streamdetails.provider == MATCH_INSTANCE
+    await asyncio.sleep(0)
     mass.music.tracks.add_provider_mappings.assert_awaited_once()
 
 

--- a/tests/controllers/streams/test_stream_capacity_provider_match.py
+++ b/tests/controllers/streams/test_stream_capacity_provider_match.py
@@ -1,0 +1,312 @@
+"""Tests for the cross-provider track match when every known source is capacity-saturated."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import ContentType, MediaType, ProviderFeature, StreamType
+from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.media_items import AudioFormat, ProviderMapping, Track
+from music_assistant_models.queue_item import QueueItem
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.controllers.streams.audio import StreamsAudio
+from music_assistant.controllers.streams.audio_buffer import AudioBuffer
+from music_assistant.models.music_provider import MusicProvider, ProviderStreamLimitError
+
+BUSY_INSTANCE = "spotify--busy"
+MATCH_INSTANCE = "tidal--match"
+ITEM_ID = "item-1"
+MATCHED_ITEM_ID = "item-on-tidal"
+
+
+def _mapping(
+    instance: str, item_id: str = ITEM_ID, quality: ContentType = ContentType.MP3
+) -> ProviderMapping:
+    """Build a streamable provider mapping."""
+    return ProviderMapping(
+        item_id=item_id,
+        provider_domain=instance.split("--", maxsplit=1)[0],
+        provider_instance=instance,
+        audio_format=AudioFormat(content_type=quality),
+    )
+
+
+def _streamdetails(instance: str) -> StreamDetails:
+    """Build HTTP stream details for one provider instance."""
+    return StreamDetails(
+        provider=instance,
+        item_id=ITEM_ID,
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        media_type=MediaType.TRACK,
+        stream_type=StreamType.HTTP,
+        path="http://test.invalid/item.mp3",
+        duration=30,
+    )
+
+
+def _queue_item(
+    *mappings: ProviderMapping, provider: str | None = None, item_id: str = ITEM_ID
+) -> QueueItem:
+    """Build a queue item whose track carries the given provider mappings."""
+    media_item = Track(
+        item_id=item_id,
+        provider=provider or mappings[0].provider_instance,
+        name="Song",
+        provider_mappings=set(mappings),
+    )
+    return QueueItem(
+        queue_id="queue-1",
+        queue_item_id="queue-item-1",
+        name="Song",
+        duration=30,
+        media_item=media_item,
+    )
+
+
+def _limit_error(instance: str) -> ProviderStreamLimitError:
+    """Build a typed source-capacity error for a provider instance."""
+    provider = MagicMock(spec=MusicProvider)
+    provider.max_concurrent_streams = 1
+    provider.name = "Limited"
+    provider.instance_id = instance
+    return ProviderStreamLimitError(provider, 0)
+
+
+def _music_provider(instance: str, has_slot: bool = True) -> MagicMock:
+    """Build a loaded, match-eligible streaming provider instance."""
+    provider = MagicMock(spec=MusicProvider)
+    provider.instance_id = instance
+    provider.domain = instance.split("--", maxsplit=1)[0]
+    provider.available = True
+    provider.is_streaming_provider = True
+    provider.has_available_stream_slot = has_slot
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.get_stream_details = AsyncMock(return_value=_streamdetails(instance))
+    return provider
+
+
+def _mass(providers: dict[str, MagicMock]) -> MagicMock:
+    """Build a mass double that resolves the given provider instances."""
+    mass = MagicMock()
+    mass.providers = list(providers.values())
+    mass.get_provider.side_effect = lambda instance, **_kwargs: providers.get(instance)
+    mass.player_queues.queue_data_or_none.return_value = None
+    mass.streams.get_config_value.return_value = -17
+    mass.music.providers = list(providers.values())
+    mass.music.library_supported.return_value = True
+    mass.music.tracks.match_provider = AsyncMock(return_value=[])
+    mass.music.tracks.add_provider_mappings = AsyncMock()
+    return mass
+
+
+async def test_saturated_single_mapping_is_rescued_by_a_cross_provider_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A track with one saturated source plays through a match found on another provider."""
+    queue_item = _queue_item(_mapping(BUSY_INSTANCE, quality=ContentType.FLAC))
+    queue_item.streamdetails = _streamdetails(BUSY_INSTANCE)
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        MATCH_INSTANCE: _music_provider(MATCH_INSTANCE),
+    }
+    mass = _mass(providers)
+    matched_mapping = _mapping(MATCH_INSTANCE, item_id=MATCHED_ITEM_ID)
+    mass.music.tracks.match_provider = AsyncMock(return_value=[matched_mapping])
+    audio = StreamsAudio(mass)
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    get_buffer = AsyncMock(side_effect=[_limit_error(BUSY_INSTANCE), expected_buffer])
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    assert result is expected_buffer
+    assert queue_item.streamdetails is not None
+    assert queue_item.streamdetails.provider == MATCH_INSTANCE
+    # the discovered mapping is kept on the media item, so the reselection loop can use it
+    assert isinstance(queue_item.media_item, Track)
+    assert matched_mapping in queue_item.media_item.provider_mappings
+    # the saturated source is only probed, never granted a blocking wait
+    waits = [call.kwargs["source_wait_timeout"] for call in get_buffer.await_args_list]
+    assert waits == [0, 0]
+    mass.music.tracks.match_provider.assert_awaited_once()
+    assert mass.music.tracks.match_provider.await_args.args[1] is providers[MATCH_INSTANCE]
+    # a non-library track keeps the mapping in memory only
+    mass.music.tracks.add_provider_mappings.assert_not_awaited()
+
+
+async def test_a_matchless_search_falls_back_to_the_blocking_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a match, the budget is still spent waiting on the known source."""
+    queue_item = _queue_item(_mapping(BUSY_INSTANCE, quality=ContentType.FLAC))
+    queue_item.streamdetails = _streamdetails(BUSY_INSTANCE)
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        MATCH_INSTANCE: _music_provider(MATCH_INSTANCE),
+    }
+    # match_provider finds nothing (the _mass default)
+    mass = _mass(providers)
+    audio = StreamsAudio(mass)
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    get_buffer = AsyncMock(side_effect=[_limit_error(BUSY_INSTANCE), expected_buffer])
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    assert result is expected_buffer
+    mass.music.tracks.match_provider.assert_awaited_once()
+    waits = [call.kwargs["source_wait_timeout"] for call in get_buffer.await_args_list]
+    assert waits[0] == 0
+    assert waits[1] > 0
+    assert get_buffer.await_args_list[1].kwargs["streamdetails"].provider == BUSY_INSTANCE
+
+
+async def test_a_matchless_search_still_raises_when_the_slot_never_frees(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a match and without a freed slot, the typed capacity error surfaces."""
+    queue_item = _queue_item(_mapping(BUSY_INSTANCE, quality=ContentType.FLAC))
+    queue_item.streamdetails = _streamdetails(BUSY_INSTANCE)
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        MATCH_INSTANCE: _music_provider(MATCH_INSTANCE),
+    }
+    mass = _mass(providers)
+    audio = StreamsAudio(mass)
+    get_buffer = AsyncMock(side_effect=_limit_error(BUSY_INSTANCE))
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    with pytest.raises(ProviderStreamLimitError):
+        await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=0.2)
+
+    mass.music.tracks.match_provider.assert_awaited_once()
+    assert get_buffer.await_count == 2
+
+
+async def test_disallowed_provider_match_is_never_attempted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller that opts out of matching keeps the plain blocking behavior."""
+    queue_item = _queue_item(_mapping(BUSY_INSTANCE, quality=ContentType.FLAC))
+    queue_item.streamdetails = _streamdetails(BUSY_INSTANCE)
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        MATCH_INSTANCE: _music_provider(MATCH_INSTANCE),
+    }
+    mass = _mass(providers)
+    mass.music.tracks.match_provider = AsyncMock(
+        return_value=[_mapping(MATCH_INSTANCE, item_id=MATCHED_ITEM_ID)]
+    )
+    audio = StreamsAudio(mass)
+    get_buffer = AsyncMock(side_effect=_limit_error(BUSY_INSTANCE))
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    with pytest.raises(ProviderStreamLimitError):
+        await audio.get_audio_buffer(
+            queue_item,
+            reason="prepare_next",
+            capacity_wait_timeout=0.2,
+            allow_provider_match=False,
+        )
+
+    mass.music.tracks.match_provider.assert_not_awaited()
+    # without a pending match, the sole candidate gets the blocking wait right away
+    assert get_buffer.await_args_list[0].kwargs["source_wait_timeout"] > 0
+
+
+async def test_a_library_track_persists_the_discovered_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A match for a library track is written back to the library."""
+    queue_item = _queue_item(
+        _mapping(BUSY_INSTANCE, quality=ContentType.FLAC), provider="library", item_id="42"
+    )
+    queue_item.streamdetails = _streamdetails(BUSY_INSTANCE)
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        MATCH_INSTANCE: _music_provider(MATCH_INSTANCE),
+    }
+    mass = _mass(providers)
+    matched_mapping = _mapping(MATCH_INSTANCE, item_id=MATCHED_ITEM_ID)
+    mass.music.tracks.match_provider = AsyncMock(return_value=[matched_mapping])
+    audio = StreamsAudio(mass)
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    get_buffer = AsyncMock(side_effect=[_limit_error(BUSY_INSTANCE), expected_buffer])
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    assert result is expected_buffer
+    mass.music.tracks.add_provider_mappings.assert_awaited_once_with("42", [matched_mapping])
+
+
+async def test_a_failed_mapping_write_back_does_not_fail_the_rescue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A library write-back error still leaves the discovered mapping serving playback."""
+    queue_item = _queue_item(
+        _mapping(BUSY_INSTANCE, quality=ContentType.FLAC), provider="library", item_id="42"
+    )
+    queue_item.streamdetails = _streamdetails(BUSY_INSTANCE)
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        MATCH_INSTANCE: _music_provider(MATCH_INSTANCE),
+    }
+    mass = _mass(providers)
+    mass.music.tracks.match_provider = AsyncMock(
+        return_value=[_mapping(MATCH_INSTANCE, item_id=MATCHED_ITEM_ID)]
+    )
+    mass.music.tracks.add_provider_mappings = AsyncMock(
+        side_effect=MediaNotFoundError("Track not found: 42")
+    )
+    audio = StreamsAudio(mass)
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    get_buffer = AsyncMock(side_effect=[_limit_error(BUSY_INSTANCE), expected_buffer])
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    assert result is expected_buffer
+    assert queue_item.streamdetails is not None
+    assert queue_item.streamdetails.provider == MATCH_INSTANCE
+    mass.music.tracks.add_provider_mappings.assert_awaited_once()
+
+
+async def test_discovery_runs_at_most_once_per_buffer_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A discovered provider that is itself saturated does not trigger a second search."""
+    queue_item = _queue_item(_mapping(BUSY_INSTANCE, quality=ContentType.FLAC))
+    queue_item.streamdetails = _streamdetails(BUSY_INSTANCE)
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        MATCH_INSTANCE: _music_provider(MATCH_INSTANCE),
+    }
+    mass = _mass(providers)
+    mass.music.tracks.match_provider = AsyncMock(
+        return_value=[_mapping(MATCH_INSTANCE, item_id=MATCHED_ITEM_ID)]
+    )
+    audio = StreamsAudio(mass)
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    get_buffer = AsyncMock(
+        side_effect=[
+            _limit_error(BUSY_INSTANCE),
+            _limit_error(MATCH_INSTANCE),
+            expected_buffer,
+        ]
+    )
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    assert result is expected_buffer
+    mass.music.tracks.match_provider.assert_awaited_once()
+    assert get_buffer.await_count == 3
+    # after the one search, saturation everywhere ends in the final blocking pass as before
+    waits = [call.kwargs["source_wait_timeout"] for call in get_buffer.await_args_list]
+    assert waits[0] == 0
+    assert waits[1] == 0
+    assert waits[2] > 0
+    assert get_buffer.await_args_list[2].kwargs["streamdetails"].provider == BUSY_INSTANCE


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5773 (per-provider concurrent stream limits). When a track's provider has no free stream slot, playback retries other mappings of the track — but a track that only exists on that one provider had nowhere to go: playback waited out the full capacity budget and stopped, even when the same track is available on another configured streaming service.

Now, when every known source for a track is at its stream limit, Music Assistant searches the user's other streaming providers for the same track (using the existing strict matching) and plays it from there.

- When all known sources are saturated, other configured streaming providers are searched for a matching track and the match joins the normal source selection.
- The search is strict (never plays a wrong track), bounded to a few seconds within the existing capacity budget, and only runs when playback would otherwise fail — zero cost in normal operation.
- For library tracks the discovered mapping is saved, so future plays have it available right away.
- Speculative next-track preparation skips the search and stays cheap; if nothing is found, behavior is unchanged (one final wait on the busy provider).

**Related issue (if applicable):**

- follow-up to #5773

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
