### PR TITLE
Keep a speaker's outputs with the speaker they belong to

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -204,7 +204,7 @@ class ProtocolLinkingMixin:
         :param protocol_player: The protocol player to link.
         :param cached_parent_id: The cached parent player ID.
         :param protocol_domain: The protocol domain (e.g., "airplay").
-        :return: True if handled (linked or waiting), False if should fall through.
+        :return: True if the link was restored, False if the caller must resolve the parent.
         """
         if parent_player := self.get_player(cached_parent_id):
             if parent_player.state.type == PlayerType.GROUP:
@@ -972,6 +972,8 @@ class ProtocolLinkingMixin:
             if protocol_player.underlying_player_id:
                 # Derived protocol players link via their underlying player instead
                 continue
+            if self._awaits_unregistered_owner(protocol_player, native_player.player_id):
+                continue
 
             protocol_domain = protocol_player.provider.domain
 
@@ -1002,6 +1004,8 @@ class ProtocolLinkingMixin:
                 continue
             if protocol_player.underlying_player_id:
                 continue
+            if self._awaits_unregistered_owner(protocol_player, native_player.player_id):
+                continue
             protocol_domain = protocol_player.provider.domain
             if self._parent_has_active_protocol_from_domain(native_player, protocol_domain):
                 continue
@@ -1016,6 +1020,18 @@ class ProtocolLinkingMixin:
         # native player (derived players riding on the protocol players linked
         # above are handled by _add_protocol_link itself).
         self._link_derived_protocols_of(native_player)
+
+    def _awaits_unregistered_owner(self, protocol_player: Player, candidate_parent_id: str) -> bool:
+        """
+        Check if a protocol player is reserved for a persisted owner that is still starting up.
+
+        :param protocol_player: The unlinked protocol player.
+        :param candidate_parent_id: The player that wants to claim it.
+        """
+        owner_id = self._get_cached_protocol_parent_id(protocol_player.player_id)
+        if owner_id is None or owner_id == candidate_parent_id:
+            return False
+        return self.get_player(owner_id) is None
 
     def _check_replace_universal_player(self, native_player: Player) -> None:
         """Check if a universal player should be replaced by this native player."""

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -178,6 +178,13 @@ class ProtocolLinkingMixin:
             )
             if result:
                 return
+            if not self.get_player(cached_parent_id):
+                # The persisted owner has not registered yet: wait for it instead of
+                # letting another parent's cached ids or identifiers claim this
+                # protocol. Delayed evaluation links it elsewhere if the owner
+                # never shows up.
+                self._schedule_protocol_evaluation(protocol_player)
+                return
             # Link was refused or parent has active domain - fall through to search
 
         # Look for a matching native player

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -1317,6 +1317,64 @@ class TestCachedProtocolParentRestore:
         assert airplay.protocol_parent_id is None
         assert other_native.linked_output_protocols == []
 
+    def test_other_native_does_not_claim_a_protocol_reserved_for_its_owner(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A native registering before the persisted owner leaves that owner's protocol alone."""
+        controller = PlayerController(mock_mass)
+
+        store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "ap_shared": {
+                    "provider": "airplay--x",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "sonos_owner"},
+                },
+                "sonos_owner": {"provider": "sonos--z", "player_type": "player", "values": {}},
+            }
+        }
+        _wire_nested_config(mock_mass, store)
+
+        airplay = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_shared",
+            "Speaker (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        airplay.set_initialized()
+        controller._players = {"ap_shared": airplay}
+
+        controller._try_link_protocol_to_native(airplay)
+        assert airplay.protocol_parent_id is None
+
+        # another native with a colliding identifier registers before the owner
+        other_native = MockPlayer(
+            MockProvider("heos", mass=mock_mass),
+            "heos_player",
+            "Other Receiver",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        other_native.set_initialized()
+        controller._players["heos_player"] = other_native
+        controller._try_link_protocols_to_native(other_native)
+
+        assert airplay.protocol_parent_id is None
+        assert other_native.linked_output_protocols == []
+
+        # the owner still gets its own protocol
+        sonos_owner = MockPlayer(
+            MockProvider("sonos", mass=mock_mass),
+            "sonos_owner",
+            "Speaker",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        sonos_owner.set_initialized()
+        controller._players["sonos_owner"] = sonos_owner
+        controller._try_link_protocols_to_native(sonos_owner)
+
+        assert airplay.protocol_parent_id == "sonos_owner"
+
     @pytest.mark.asyncio
     async def test_protocol_links_elsewhere_when_its_owner_never_registers(
         self, mock_mass: MagicMock

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -1208,6 +1208,162 @@ class TestCachedProtocolParentRestore:
         assert protocol_player.protocol_parent_id is None
         mock_schedule.assert_called_once_with(protocol_player)
 
+    def test_stale_cache_does_not_claim_a_protocol_waiting_for_its_owner(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A protocol whose persisted owner is still starting up is not claimed by another parent."""
+        controller = PlayerController(mock_mass)
+
+        store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "ap_shared": {
+                    "provider": "airplay--x",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "sonos_owner"},
+                },
+                "heos_player": {
+                    "provider": "heos--y",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["ap_shared"]},
+                },
+                "sonos_owner": {
+                    "provider": "sonos--z",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["ap_shared"]},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, store)
+
+        # a native player that kept a stale cached id for a protocol it no longer owns
+        heos_player = MockPlayer(
+            MockProvider("heos", mass=mock_mass),
+            "heos_player",
+            "Old Receiver",
+            identifiers={IdentifierType.MAC_ADDRESS: "11:22:33:44:55:66"},
+        )
+        heos_player.set_initialized()
+        airplay = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_shared",
+            "Speaker (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        airplay.set_initialized()
+        controller._players = {"heos_player": heos_player, "ap_shared": airplay}
+
+        # the persisted owner has not registered yet
+        controller._try_link_protocol_to_native(airplay)
+
+        assert airplay.protocol_parent_id is None
+        assert heos_player.linked_output_protocols == []
+        assert mock_mass.loop.call_later.call_args.args[0] == 45.0
+
+        # once the owner registers it takes its own protocol
+        sonos_owner = MockPlayer(
+            MockProvider("sonos", mass=mock_mass),
+            "sonos_owner",
+            "Speaker",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        sonos_owner.set_initialized()
+        controller._players["sonos_owner"] = sonos_owner
+        controller._try_link_protocols_to_native(sonos_owner)
+
+        assert airplay.protocol_parent_id == "sonos_owner"
+        assert [  # type: ignore[unreachable]
+            link.output_protocol_id for link in sonos_owner.linked_output_protocols
+        ] == ["ap_shared"]
+
+    def test_identifier_match_does_not_claim_a_protocol_waiting_for_its_owner(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Identifier matching does not override a protocol's own persisted owner."""
+        controller = PlayerController(mock_mass)
+
+        store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "ap_shared": {
+                    "provider": "airplay--x",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "sonos_owner"},
+                },
+                "sonos_owner": {"provider": "sonos--z", "player_type": "player", "values": {}},
+            }
+        }
+        _wire_nested_config(mock_mass, store)
+
+        # shares identifiers with the protocol but is not its persisted owner
+        other_native = MockPlayer(
+            MockProvider("heos", mass=mock_mass),
+            "heos_player",
+            "Other Receiver",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        other_native.set_initialized()
+        airplay = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_shared",
+            "Speaker (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        airplay.set_initialized()
+        controller._players = {"heos_player": other_native, "ap_shared": airplay}
+
+        controller._try_link_protocol_to_native(airplay)
+
+        assert airplay.protocol_parent_id is None
+        assert other_native.linked_output_protocols == []
+
+    @pytest.mark.asyncio
+    async def test_protocol_links_elsewhere_when_its_owner_never_registers(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A protocol whose persisted owner never registers still links on delayed evaluation."""
+        controller = PlayerController(mock_mass)
+
+        store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "ap_shared": {
+                    "provider": "airplay--x",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "gone_owner"},
+                },
+                "heos_player": {
+                    "provider": "heos--y",
+                    "player_type": "player",
+                    "values": {"linked_protocol_ids": ["ap_shared"]},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, store)
+
+        heos_player = MockPlayer(
+            MockProvider("heos", mass=mock_mass),
+            "heos_player",
+            "Receiver",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        heos_player.set_initialized()
+        airplay = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_shared",
+            "Speaker (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        airplay.set_initialized()
+        controller._players = {"heos_player": heos_player, "ap_shared": airplay}
+
+        controller._try_link_protocol_to_native(airplay)
+        assert airplay.protocol_parent_id is None
+
+        await controller._delayed_protocol_evaluation("ap_shared")
+
+        assert airplay.protocol_parent_id == "heos_player"
+
     @pytest.mark.asyncio
     async def test_cached_parent_registers_before_delayed_eval_links_without_universal(
         self, mock_mass: MagicMock


### PR DESCRIPTION
# What does this implement/fix?

When a speaker's AirPlay/Chromecast/DLNA output starts up before the speaker itself, it could get attached to the wrong speaker. Another player that still listed that output in an outdated config entry would grab it first, and once that happened the real speaker never got its own output back — it stayed on the wrong player permanently.

The output now waits for the speaker it was saved against, instead of being handed to whichever player happens to be ready first. If that speaker never appears (removed or replaced device), the existing delayed check still attaches the output elsewhere, so nothing gets stranded.

Follow-up to #5801, which fixed the related double-listing but deliberately left this startup ordering alone.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- An output whose saved speaker has not registered yet now waits for that speaker instead of being matched to whatever else is available.
- Other speakers registering during that wait also leave the output alone, so it cannot be taken from the other direction either.
- Added startup-order tests: an outdated cached entry, a matching identifier, a speaker registering first, and the case where the saved speaker never returns.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
