### PR TITLE
Keep albums that differ only by a symbol from being merged

### DIFF
--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -42,6 +42,7 @@ from music_assistant.controllers.tasks.context import (
     update_current_task_progress_text,
 )
 from music_assistant.helpers.api import api_command
+from music_assistant.helpers.compare import ALBUM_RETAIL_SUFFIX_KEYS
 from music_assistant.helpers.images import cleanup_thumb_cache
 from music_assistant.helpers.lyrics import extract_lrc_lyrics, normalize_lrc_lyrics
 from music_assistant.helpers.throttle_retry import Throttler
@@ -618,13 +619,25 @@ def _duplicate_album_sibling_guard() -> str:
         f"({DB_TABLE_ALBUMS}.search_name != '' OR "
         f"REPLACE({DB_TABLE_ALBUMS}.name,' ','') = REPLACE(dup.name,' ',''))"
     )
+    # a sibling whose provider spells out the retail suffix is stored under the same name
+    # plus that suffix; only this direction is expressed, because either row of the pair
+    # entering the batch reconciles both, and an equality keeps the search_name index usable
+    name_keys = ", ".join(
+        [
+            f"{DB_TABLE_ALBUMS}.search_name",
+            *(
+                f"{DB_TABLE_ALBUMS}.search_name || '{suffix}'"
+                for suffix in ALBUM_RETAIL_SUFFIX_KEYS
+            ),
+        ]
+    )
     # deliberately an identity-only pre-filter: which editions may be merged is decided by
     # the album comparison, which escalates an ambiguous edition to tracklists and
     # MusicBrainz and rejects a recording-changing one (live, remix, ...) outright
     return (
         f"EXISTS (SELECT 1 FROM {DB_TABLE_ALBUMS} dup "
         f"WHERE dup.item_id != {DB_TABLE_ALBUMS}.item_id "
-        f"AND dup.search_name = {DB_TABLE_ALBUMS}.search_name "
+        f"AND dup.search_name IN ({name_keys}) "
         f"AND {same_title} AND {shares_artist})"
     )
 

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -619,18 +619,18 @@ def _duplicate_album_sibling_guard() -> str:
         f"({DB_TABLE_ALBUMS}.search_name != '' OR "
         f"REPLACE({DB_TABLE_ALBUMS}.name,' ','') = REPLACE(dup.name,' ',''))"
     )
-    # a sibling whose provider spells out the retail suffix is stored under the same name
-    # plus that suffix; only this direction is expressed, because either row of the pair
-    # entering the batch reconciles both, and an equality keeps the search_name index usable
-    name_keys = ", ".join(
-        [
-            f"{DB_TABLE_ALBUMS}.search_name",
-            *(
-                f"{DB_TABLE_ALBUMS}.search_name || '{suffix}'"
-                for suffix in ALBUM_RETAIL_SUFFIX_KEYS
-            ),
-        ]
-    )
+    # a provider that spells out the retail suffix stores the album under the plain name
+    # plus that suffix, so both spellings are sought from either row of the pair; each
+    # stays an equality on dup.search_name so the search_name index remains usable
+    own_name = f"{DB_TABLE_ALBUMS}.search_name"
+    keys = [own_name]
+    for suffix in ALBUM_RETAIL_SUFFIX_KEYS:
+        keys.append(f"{own_name} || '{suffix}'")
+        keys.append(
+            f"CASE WHEN {own_name} LIKE '%{suffix}' "
+            f"THEN substr({own_name}, 1, length({own_name}) - {len(suffix)}) END"
+        )
+    name_keys = ", ".join(keys)
     # deliberately an identity-only pre-filter: which editions may be merged is decided by
     # the album comparison, which escalates an ambiguous edition to tracklists and
     # MusicBrainz and rejects a recording-changing one (live, remix, ...) outright

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -620,24 +620,28 @@ def _duplicate_album_sibling_guard() -> str:
         f"REPLACE({DB_TABLE_ALBUMS}.name,' ','') = REPLACE(dup.name,' ',''))"
     )
     # a provider that spells out the retail suffix stores the album under the plain name
-    # plus that suffix, so both spellings are sought from either row of the pair; each
-    # stays an equality on dup.search_name so the search_name index remains usable
+    # plus that suffix, so the pair is related from either side. The raw title decides
+    # which side spelled it out, so an ordinary title that merely ends in those letters
+    # ("Step") is left alone; any dash style qualifies, only the space in front counts.
+    # Every alternative stays an equality on dup.search_name, keeping the name index in use.
     own_name = f"{DB_TABLE_ALBUMS}.search_name"
-    keys = [own_name]
+    matches_name = [f"dup.search_name = {own_name}"]
     for suffix in ALBUM_RETAIL_SUFFIX_KEYS:
-        keys.append(f"{own_name} || '{suffix}'")
-        keys.append(
-            f"CASE WHEN {own_name} LIKE '%{suffix}' "
-            f"THEN substr({own_name}, 1, length({own_name}) - {len(suffix)}) END"
+        matches_name.append(
+            f"(rtrim(dup.name) LIKE '% {suffix}' AND dup.search_name = {own_name} || '{suffix}')"
         )
-    name_keys = ", ".join(keys)
+        matches_name.append(
+            f"(rtrim({DB_TABLE_ALBUMS}.name) LIKE '% {suffix}' AND dup.search_name = "
+            f"substr({own_name}, 1, length({own_name}) - {len(suffix)}))"
+        )
+    same_name = " OR ".join(matches_name)
     # deliberately an identity-only pre-filter: which editions may be merged is decided by
     # the album comparison, which escalates an ambiguous edition to tracklists and
     # MusicBrainz and rejects a recording-changing one (live, remix, ...) outright
     return (
         f"EXISTS (SELECT 1 FROM {DB_TABLE_ALBUMS} dup "
         f"WHERE dup.item_id != {DB_TABLE_ALBUMS}.item_id "
-        f"AND dup.search_name IN ({name_keys}) "
+        f"AND ({same_name}) "
         f"AND {same_title} AND {shares_artist})"
     )
 

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -31,11 +31,13 @@ from music_assistant_models.media_items import (
 from music_assistant.constants import DB_TABLE_ALBUM_ARTISTS, DB_TABLE_ALBUM_TRACKS, DB_TABLE_ALBUMS
 from music_assistant.controllers.music.helpers import search_name_match_clause
 from music_assistant.helpers.compare import (
+    ALBUM_RETAIL_SUFFIX_KEYS,
     AlbumMatchEvidence,
     album_tracks_have_positions,
     compare_album_evidence,
     compare_artists,
     loose_compare_strings,
+    strip_album_retail_suffix,
 )
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.external_ids import barcode_to_upc, is_valid_barcode
@@ -666,6 +668,11 @@ class AlbumsController(MediaControllerBase[Album]):
             prov = cast("MusicProvider", prov)
             return await prov.get_album_tracks(item_id)
         return []
+
+    def _library_match_names(self, item: Album | ItemMapping) -> list[str]:
+        """Return the normalized album names, with and without a spelled-out retail suffix."""
+        base_name = create_safe_string(strip_album_retail_suffix(item.name), True, True)
+        return [base_name, *(f"{base_name}{suffix}" for suffix in ALBUM_RETAIL_SUFFIX_KEYS)]
 
     async def _confirm_library_candidate(self, db_item: Album, item: Album | ItemMapping) -> bool:
         """

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -672,6 +672,10 @@ class AlbumsController(MediaControllerBase[Album]):
     def _library_match_names(self, item: Album | ItemMapping) -> list[str]:
         """Return the normalized album names, with and without a spelled-out retail suffix."""
         base_name = create_safe_string(strip_album_retail_suffix(item.name), True, True)
+        own_name = create_safe_string(item.name, True, True)
+        if own_name != base_name:
+            # the title spells out one retail suffix, and a different one is a different release
+            return [base_name, own_name]
         return [base_name, *(f"{base_name}{suffix}" for suffix in ALBUM_RETAIL_SUFFIX_KEYS)]
 
     async def _confirm_library_candidate(self, db_item: Album, item: Album | ItemMapping) -> bool:

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -672,10 +672,6 @@ class AlbumsController(MediaControllerBase[Album]):
     def _library_match_names(self, item: Album | ItemMapping) -> list[str]:
         """Return the normalized album names, with and without a spelled-out retail suffix."""
         base_name = create_safe_string(strip_album_retail_suffix(item.name), True, True)
-        own_name = create_safe_string(item.name, True, True)
-        if own_name != base_name:
-            # the title spells out one retail suffix, and a different one is a different release
-            return [base_name, own_name]
         return [base_name, *(f"{base_name}{suffix}" for suffix in ALBUM_RETAIL_SUFFIX_KEYS)]
 
     async def _confirm_library_candidate(self, db_item: Album, item: Album | ItemMapping) -> bool:

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -1592,11 +1592,11 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                     return int(cur_item.item_id)
         # search by normalized exact name match
         query = (
-            f"{self.db_table}.search_name = :search_name "
+            f"{self.db_table}.search_name IN :search_names "
             f"OR {self.db_table}.search_sort_name = :search_sort_name"
         )
         query_params = {
-            "search_name": create_safe_string(item.name, True, True),
+            "search_names": self._library_match_names(item),
             "search_sort_name": create_safe_string(item.sort_name or "", True, True),
         }
         for db_item in await self.get_library_items_by_query(
@@ -1605,6 +1605,15 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             if await self._confirm_library_candidate(db_item, item):
                 return int(db_item.item_id)
         return None
+
+    def _library_match_names(self, item: ItemCls | ItemMapping) -> list[str]:
+        """
+        Return the normalized names a library row for this item may be stored under.
+
+        Override in a subclass when a media type's title carries formatting that the
+        stored name keeps but its identity comparison ignores.
+        """
+        return [create_safe_string(item.name, True, True)]
 
     async def _confirm_library_candidate(
         self, db_item: ItemCls, item: ItemCls | ItemMapping

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import re
+import unicodedata
 from collections.abc import Sequence
 from difflib import SequenceMatcher
 from enum import Enum
 from functools import lru_cache
+from typing import Final
 
 from music_assistant_models.enums import ExternalID, MediaType
 from music_assistant_models.helpers import create_safe_string
@@ -64,8 +66,18 @@ _RECORDING_CONFLICT_VERSION_TOKENS = {
     "session",
 }
 
-# trailing " - EP" / " - Single" retail suffix (any dash style), as appended by Apple Music
-_ALBUM_SUFFIX_PATTERN = re.compile(r"\s+[-\u2013\u2014]\s+(?:EP|Single)\s*$", re.IGNORECASE)
+# retail suffixes a provider (notably Apple Music) appends to an EP/single title
+_ALBUM_RETAIL_SUFFIXES: Final = ("EP", "Single")
+# the trailing retail suffix (any dash style) as it appears in a raw album title
+_ALBUM_SUFFIX_PATTERN = re.compile(
+    rf"\s+[-\u2013\u2014]\s+(?:{'|'.join(_ALBUM_RETAIL_SUFFIXES)})\s*$", re.IGNORECASE
+)
+# normalizing a title drops the separator, so the suffix survives as a plain trailing
+# fragment of the name key ("Foo - EP" -> "fooep"): appending one of these to a key
+# yields the key the same album is stored under when a provider spells out the suffix
+ALBUM_RETAIL_SUFFIX_KEYS: Final = tuple(
+    create_safe_string(suffix, True, True) for suffix in _ALBUM_RETAIL_SUFFIXES
+)
 
 # duration tolerances (seconds) for track comparisons: an external-id corroborated
 # match allows more duration drift than a bare title/version fallback
@@ -737,12 +749,16 @@ def compare_version(base_version: str, compare_version: str) -> bool:
 
 def compare_album_name(base_name: str, compare_name: str) -> bool:
     """Return True if two album titles are the same identity, ignoring formatting drift."""
-    # the retail suffix carries no identity information: Apple Music appends it to
-    # EP/single titles while already setting album_type
     return compare_strings(
-        _ALBUM_SUFFIX_PATTERN.sub("", base_name),
-        _ALBUM_SUFFIX_PATTERN.sub("", compare_name),
+        strip_album_retail_suffix(base_name), strip_album_retail_suffix(compare_name)
     )
+
+
+def strip_album_retail_suffix(name: str) -> str:
+    """Return an album title without its retail suffix ("Foo - EP" -> "Foo")."""
+    # the suffix carries no identity information: Apple Music appends it to EP/single
+    # titles while already setting album_type
+    return _ALBUM_SUFFIX_PATTERN.sub("", name)
 
 
 def compare_explicit(base: MediaItemMetadata, compare: MediaItemMetadata) -> bool | None:
@@ -814,7 +830,26 @@ def _compare_safe_strings(base: str, compare: str) -> bool:
 @lru_cache(maxsize=1024)
 def _normalize_name(name: str) -> str:
     """Return a punctuation/diacritic/whitespace-insensitive name for identity checks."""
-    return create_safe_string(name, True, True)
+    core = create_safe_string(name, True, True)
+    tokens = name.split()
+    if not tokens:
+        return core
+    # a standalone symbol is part of the title where it sits at an edge ("MOTOMAMI +"),
+    # but only a separator between words ("HIStory - Past, Present and Future")
+    lead = _symbol_token(tokens[0])
+    trail = _symbol_token(tokens[-1]) if len(tokens) > 1 else ""
+    return f"{lead}{core}{trail}"
+
+
+def _symbol_token(token: str) -> str:
+    """Return the identity form of a token that is a bare symbol, else an empty string."""
+    if create_safe_string(token, True, True):
+        # the token has alphanumeric content, so it is already part of the normalized name
+        return ""
+    if not any(unicodedata.category(char).startswith("S") for char in token):
+        # punctuation only (e.g. "!!!" or "( )"): formatting drift rather than identity
+        return ""
+    return token.casefold()
 
 
 def _track_positions(tracks: Sequence[Track]) -> dict[tuple[int, int], Track]:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -831,25 +831,27 @@ def _compare_safe_strings(base: str, compare: str) -> bool:
 def _normalize_name(name: str) -> str:
     """Return a punctuation/diacritic/whitespace-insensitive name for identity checks."""
     core = create_safe_string(name, True, True)
-    tokens = name.split()
-    if not tokens:
-        return core
-    # a standalone symbol is part of the title where it sits at an edge ("MOTOMAMI +"),
-    # but only a separator between words ("HIStory - Past, Present and Future")
-    lead = _symbol_token(tokens[0])
-    trail = _symbol_token(tokens[-1]) if len(tokens) > 1 else ""
+    stripped = name.strip()
+    # a symbol bordering the title belongs to it ("MOTOMAMI +"), however it is spaced,
+    # while punctuation and symbols between words are drift two spellings may differ on
+    lead = _edge_symbols(stripped)
+    trail = _edge_symbols(stripped[::-1])[::-1]
+    if len(lead) + len(trail) > len(stripped):
+        # a title made up entirely of symbols is reached from both ends
+        trail = ""
     return f"{lead}{core}{trail}"
 
 
-def _symbol_token(token: str) -> str:
-    """Return the identity form of a token that is a bare symbol, else an empty string."""
-    if create_safe_string(token, True, True):
-        # the token has alphanumeric content, so it is already part of the normalized name
-        return ""
-    if not any(unicodedata.category(char).startswith("S") for char in token):
-        # punctuation only (e.g. "!!!" or "( )"): formatting drift rather than identity
-        return ""
-    return token.casefold()
+def _edge_symbols(name: str) -> str:
+    """Return the run of identity-bearing symbols at the start of a title."""
+    # only a mathematical symbol is a title's own wording (Ed Sheeran's operators);
+    # currency and modifier symbols stand in for letters ("bbno$", a backtick for an
+    # apostrophe), which normalization folds away like the punctuation they replace
+    for index, char in enumerate(name):
+        # a symbol anyascii spells out (∂ -> d) already sits in the normalized name
+        if unicodedata.category(char) != "Sm" or create_safe_string(char, True, True):
+            return name[:index].casefold()
+    return name.casefold()
 
 
 def _track_positions(tracks: Sequence[Track]) -> dict[tuple[int, int], Track]:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -831,15 +831,13 @@ def _compare_safe_strings(base: str, compare: str) -> bool:
 def _normalize_name(name: str) -> str:
     """Return a punctuation/diacritic/whitespace-insensitive name for identity checks."""
     core = create_safe_string(name, True, True)
+    if not core:
+        # a name made up entirely of symbols is decided on its complete raw spelling
+        return core
     stripped = name.strip()
     # a symbol bordering the title belongs to it ("MOTOMAMI +"), however it is spaced,
     # while punctuation and symbols between words are drift two spellings may differ on
-    lead = _edge_symbols(stripped)
-    trail = _edge_symbols(stripped[::-1])[::-1]
-    if len(lead) + len(trail) > len(stripped):
-        # a title made up entirely of symbols is reached from both ends
-        trail = ""
-    return f"{lead}{core}{trail}"
+    return f"{_edge_symbols(stripped)}{core}{_edge_symbols(stripped[::-1])[::-1]}"
 
 
 def _edge_symbols(name: str) -> str:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -70,7 +70,7 @@ _RECORDING_CONFLICT_VERSION_TOKENS = {
 _ALBUM_RETAIL_SUFFIXES: Final = ("EP", "Single")
 # the trailing retail suffix (any dash style) as it appears in a raw album title
 _ALBUM_SUFFIX_PATTERN = re.compile(
-    rf"\s+[-\u2013\u2014]\s+(?:{'|'.join(_ALBUM_RETAIL_SUFFIXES)})\s*$", re.IGNORECASE
+    rf"\s+[-\u2013\u2014]\s+(?P<suffix>{'|'.join(_ALBUM_RETAIL_SUFFIXES)})\s*$", re.IGNORECASE
 )
 # normalizing a title drops the separator, so the suffix survives as a plain trailing
 # fragment of the name key ("Foo - EP" -> "fooep"): appending one of these to a key
@@ -749,6 +749,12 @@ def compare_version(base_version: str, compare_version: str) -> bool:
 
 def compare_album_name(base_name: str, compare_name: str) -> bool:
     """Return True if two album titles are the same identity, ignoring formatting drift."""
+    base_suffix = _album_retail_suffix(base_name)
+    compare_suffix = _album_retail_suffix(compare_name)
+    if base_suffix and compare_suffix and base_suffix != compare_suffix:
+        # both titles name their format and they disagree: an EP is not the single of
+        # the same name, however much of the title the two share
+        return False
     return compare_strings(
         strip_album_retail_suffix(base_name), strip_album_retail_suffix(compare_name)
     )
@@ -782,6 +788,12 @@ def _normalize_version_tokens(value: str) -> tuple[str, ...]:
         _VERSION_WORD_ALIASES.get(token, token) for token in re.findall(r"[^\W_]+", stripped_value)
     )
     return tuple(sorted({token for token in tokens if token not in _VERSION_IGNORE_WORDS}))
+
+
+def _album_retail_suffix(name: str) -> str:
+    """Return the retail suffix an album title spells out, or an empty string."""
+    match = _ALBUM_SUFFIX_PATTERN.search(name)
+    return match.group("suffix").casefold() if match else ""
 
 
 def _is_dynamic_radio(item: Radio | ItemMapping) -> bool:

--- a/tests/controllers/metadata/test_album_reconciliation.py
+++ b/tests/controllers/metadata/test_album_reconciliation.py
@@ -286,6 +286,35 @@ async def test_reconcile_duplicate_albums_selects_symbol_only_titles_spelled_the
     assert await _reconciled_ids(mass) == {first.item_id, second.item_id}
 
 
+async def test_reconcile_duplicate_albums_selects_spelled_out_retail_suffix_sibling(
+    mass: MusicAssistant,
+) -> None:
+    """A leftover 'X - EP' row is paired with its plain-title sibling, which now stores it."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Kygo",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="test", provider_instance="library"
+                )
+            },
+        )
+    )
+    plain = await _add_album(mass, "Stargazing", artist, provider_instance="spotify_1")
+    suffixed = await _add_album(
+        mass,
+        "Stargazing - EP",
+        artist,
+        album_type=AlbumType.SINGLE,
+        provider_instance="apple_music_1",
+    )
+    assert plain.item_id != suffixed.item_id
+
+    assert plain.item_id in await _reconciled_ids(mass)
+
+
 async def test_reconcile_duplicate_albums_ignores_other_albums_by_the_same_artist(
     mass: MusicAssistant,
 ) -> None:

--- a/tests/controllers/metadata/test_album_reconciliation.py
+++ b/tests/controllers/metadata/test_album_reconciliation.py
@@ -312,7 +312,35 @@ async def test_reconcile_duplicate_albums_selects_spelled_out_retail_suffix_sibl
     )
     assert plain.item_id != suffixed.item_id
 
-    assert plain.item_id in await _reconciled_ids(mass)
+    assert await _reconciled_ids(mass) == {plain.item_id, suffixed.item_id}
+
+
+async def test_reconcile_duplicate_albums_selects_retail_suffix_on_a_symbol_only_title(
+    mass: MusicAssistant,
+) -> None:
+    """A retail suffix on a title that normalizes to nothing still reaches the matcher."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Nils Frahm",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="test", provider_instance="library"
+                )
+            },
+        )
+    )
+    await _add_album(mass, "...", artist, provider_instance="spotify_1")
+    suffixed = await _add_album(
+        mass,
+        "... - EP",
+        artist,
+        album_type=AlbumType.SINGLE,
+        provider_instance="apple_music_1",
+    )
+
+    assert await _reconciled_ids(mass) == {suffixed.item_id}
 
 
 async def test_reconcile_duplicate_albums_ignores_other_albums_by_the_same_artist(

--- a/tests/controllers/metadata/test_album_reconciliation.py
+++ b/tests/controllers/metadata/test_album_reconciliation.py
@@ -343,6 +343,28 @@ async def test_reconcile_duplicate_albums_selects_retail_suffix_on_a_symbol_only
     assert await _reconciled_ids(mass) == {suffixed.item_id}
 
 
+async def test_reconcile_duplicate_albums_ignores_a_title_merely_ending_in_a_suffix_word(
+    mass: MusicAssistant,
+) -> None:
+    """An ordinary title that just ends in the suffix letters is not a retail-suffix sibling."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Vangelis",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="test", provider_instance="library"
+                )
+            },
+        )
+    )
+    await _add_album(mass, "Step", artist, provider_instance="spotify_1")
+    await _add_album(mass, "St", artist, provider_instance="qobuz_1")
+
+    assert await _reconciled_ids(mass) == set()
+
+
 async def test_reconcile_duplicate_albums_ignores_other_albums_by_the_same_artist(
     mass: MusicAssistant,
 ) -> None:

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -894,6 +894,49 @@ async def test_insert_match_links_a_spelled_out_retail_suffix_to_the_plain_title
     assert suffixed.item_id == plain.item_id
 
 
+async def test_insert_match_keeps_an_ep_and_a_single_of_the_same_name_apart(
+    mass: MusicAssistant,
+) -> None:
+    """An EP and a single sharing a base title are separate releases, not one library row."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Kygo",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="spotify", provider_instance="spotify_1"
+                )
+            },
+        )
+    )
+
+    async def add(name: str, instance: str) -> Album:
+        return await mass.music.albums.add_item_to_library(
+            Album(
+                item_id=f"{instance}-item",
+                provider=instance,
+                name=name,
+                artists=UniqueList([artist]),
+                provider_mappings={
+                    ProviderMapping(
+                        item_id=f"{instance}-item",
+                        provider_domain=instance.rsplit("_", 1)[0],
+                        provider_instance=instance,
+                    )
+                },
+            )
+        )
+
+    ep = await add("Stargazing - EP", "apple_music_1")
+    single = await add("Stargazing - Single", "tidal_1")
+    assert ep.item_id != single.item_id
+
+    # the plain spelling still joins one of them rather than becoming a third row
+    plain = await add("Stargazing", "spotify_1")
+    assert plain.item_id in {ep.item_id, single.item_id}
+
+
 async def test_insert_match_does_not_escalate_an_unambiguous_candidate() -> None:
     """A candidate the albums' own metadata already decides is never escalated."""
     # a recording-changing edition conflict is decisive on metadata alone

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -826,7 +826,7 @@ async def test_insert_match_is_io_free_without_candidates() -> None:
 
 
 async def test_insert_match_looks_up_the_retail_suffix_spellings() -> None:
-    """A plain title is sought under every retail suffix, a suffixed one only under its own."""
+    """An album is sought under its plain title and every spelled-out retail suffix."""
 
     async def searched_names(harness: _InsertHarness, name: str) -> list[str]:
         assert (
@@ -836,14 +836,10 @@ async def test_insert_match_looks_up_the_retail_suffix_spellings() -> None:
         params = harness.get_library_items_by_query.await_args_list[-1].kwargs["extra_query_params"]
         return list(params["search_names"])
 
+    expected = ["stargazing", "stargazingep", "stargazingsingle"]
     with _insert_harness(candidates=[]) as harness:
-        assert await searched_names(harness, "Stargazing") == [
-            "stargazing",
-            "stargazingep",
-            "stargazingsingle",
-        ]
-        # a title spelling out one suffix is a different release from one spelling out another
-        assert await searched_names(harness, "Stargazing - EP") == ["stargazing", "stargazingep"]
+        assert await searched_names(harness, "Stargazing") == expected
+        assert await searched_names(harness, "Stargazing - EP") == expected
 
 
 async def test_insert_match_links_a_spelled_out_retail_suffix_to_the_plain_title(

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -825,17 +825,25 @@ async def test_insert_match_is_io_free_without_candidates() -> None:
     assert harness.album_track_calls() == []
 
 
-async def test_insert_match_looks_up_every_retail_suffix_spelling() -> None:
-    """An album is looked up under its plain title and both spelled-out retail suffixes."""
+async def test_insert_match_looks_up_the_retail_suffix_spellings() -> None:
+    """A plain title is sought under every retail suffix, a suffixed one only under its own."""
+
+    async def searched_names(harness: _InsertHarness, name: str) -> list[str]:
+        assert (
+            await harness.ctrl._get_library_item_by_match(_album("a1", "spotify_1", name=name))
+            is None
+        )
+        params = harness.get_library_items_by_query.await_args_list[-1].kwargs["extra_query_params"]
+        return list(params["search_names"])
+
     with _insert_harness(candidates=[]) as harness:
-        item = _album("a1", "spotify_1", name="Stargazing - EP")
-
-        assert await harness.ctrl._get_library_item_by_match(item) is None
-
-    query_params = harness.get_library_items_by_query.await_args_list[-1].kwargs[
-        "extra_query_params"
-    ]
-    assert query_params["search_names"] == ["stargazing", "stargazingep", "stargazingsingle"]
+        assert await searched_names(harness, "Stargazing") == [
+            "stargazing",
+            "stargazingep",
+            "stargazingsingle",
+        ]
+        # a title spelling out one suffix is a different release from one spelling out another
+        assert await searched_names(harness, "Stargazing - EP") == ["stargazing", "stargazingep"]
 
 
 async def test_insert_match_links_a_spelled_out_retail_suffix_to_the_plain_title(

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -25,6 +25,8 @@ from music_assistant.helpers.compare import AlbumMatchEvidence
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
 
+    from music_assistant.mass import MusicAssistant
+
 MB_ALBUM_ID = "11111111-1111-1111-1111-111111111111"
 BASE_BARCODE = "888072439412"
 OTHER_BARCODE = "075678643224"
@@ -735,6 +737,7 @@ class _InsertHarness:
     ctrl: AlbumsController
     get_provider: Mock
     get_provider_album_tracks: AsyncMock
+    get_library_items_by_query: AsyncMock
 
     def album_track_calls(self) -> list[str]:
         """Return the album item ids passed to each provider album-track lookup."""
@@ -779,6 +782,7 @@ def _insert_harness(
     # a single recorder backs both the base mapping lookup (_get_provider_album_tracks)
     # and the candidate lookup (provider.get_album_tracks), so their calls stay ordered
     get_provider_album_tracks = AsyncMock(side_effect=_album_tracks)
+    get_library_items_by_query = AsyncMock(return_value=list(candidates))
     incoming_provider = _loaded_provider(incoming_instance)
     incoming_provider.get_album_tracks = get_provider_album_tracks
     registry = {"tidal_1": _loaded_provider("tidal_1"), "spotify_1": incoming_provider}
@@ -799,13 +803,15 @@ def _insert_harness(
         get_library_item_by_prov_id=AsyncMock(return_value=None),
         get_library_item_by_prov_mappings=AsyncMock(return_value=None),
         get_library_items_by_external_id=AsyncMock(return_value=[]),
-        get_library_items_by_query=AsyncMock(return_value=list(candidates)),
+        get_library_items_by_query=get_library_items_by_query,
         _get_provider_album_tracks=get_provider_album_tracks,
         # the insert path resolves an album from the library, it never searches a provider
         search=AsyncMock(side_effect=AssertionError("search during insert")),
         get_provider_item=AsyncMock(side_effect=AssertionError("provider fetch during insert")),
     ):
-        yield _InsertHarness(ctrl, mass.get_provider, get_provider_album_tracks)
+        yield _InsertHarness(
+            ctrl, mass.get_provider, get_provider_album_tracks, get_library_items_by_query
+        )
 
 
 async def test_insert_match_is_io_free_without_candidates() -> None:
@@ -817,6 +823,67 @@ async def test_insert_match_is_io_free_without_candidates() -> None:
 
     harness.get_provider.assert_not_called()
     assert harness.album_track_calls() == []
+
+
+async def test_insert_match_looks_up_every_retail_suffix_spelling() -> None:
+    """An album is looked up under its plain title and both spelled-out retail suffixes."""
+    with _insert_harness(candidates=[]) as harness:
+        item = _album("a1", "spotify_1", name="Stargazing - EP")
+
+        assert await harness.ctrl._get_library_item_by_match(item) is None
+
+    query_params = harness.get_library_items_by_query.await_args_list[-1].kwargs[
+        "extra_query_params"
+    ]
+    assert query_params["search_names"] == ["stargazing", "stargazingep", "stargazingsingle"]
+
+
+async def test_insert_match_links_a_spelled_out_retail_suffix_to_the_plain_title(
+    mass: MusicAssistant,
+) -> None:
+    """An 'X - EP' from one provider joins the existing 'X' row instead of duplicating it."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0",
+            provider="library",
+            name="Kygo",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="artist", provider_domain="spotify", provider_instance="spotify_1"
+                )
+            },
+        )
+    )
+    plain = await mass.music.albums.add_item_to_library(
+        Album(
+            item_id="0",
+            provider="library",
+            name="Stargazing",
+            artists=UniqueList([artist]),
+            provider_mappings={
+                ProviderMapping(
+                    item_id="plain", provider_domain="spotify", provider_instance="spotify_1"
+                )
+            },
+        )
+    )
+    suffixed = await mass.music.albums.add_item_to_library(
+        Album(
+            item_id="suffixed",
+            provider="apple_music_1",
+            name="Stargazing - EP",
+            artists=UniqueList([artist]),
+            provider_mappings={
+                ProviderMapping(
+                    item_id="suffixed",
+                    provider_domain="apple_music",
+                    provider_instance="apple_music_1",
+                )
+            },
+        )
+    )
+
+    assert suffixed.item_id == plain.item_id
 
 
 async def test_insert_match_does_not_escalate_an_unambiguous_candidate() -> None:

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -455,6 +455,46 @@ def test_compare_album_evidence_name_retail_suffix_stripped() -> None:
         ), suffix
 
 
+def test_compare_album_evidence_trailing_symbol_marks_a_different_release() -> None:
+    """A bonus edition marked by a trailing symbol is a release of its own."""
+    album_a = _album(name="MOTOMAMI", year=2022)
+    album_b = _album(item_id="2", provider="test2", name="MOTOMAMI +", year=2022)
+
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.NO_MATCH
+    assert compare.compare_album(album_a, album_b) is False
+
+
+def test_compare_album_evidence_symbol_only_titles_identify_their_own_album() -> None:
+    """A symbol-titled album (Ed Sheeran's '+', '=', '÷') matches only its own spelling."""
+    for name in ("+", "=", "÷"):
+        assert (
+            compare.compare_album_evidence(
+                _album(name=name), _album(item_id="2", provider="test2", name=f"{name} ")
+            )
+            == compare.AlbumMatchEvidence.MATCH
+        ), name
+    for base_name, compare_name in (("+", "="), ("+", "÷"), ("=", "÷")):
+        assert (
+            compare.compare_album_evidence(
+                _album(name=base_name), _album(item_id="2", provider="test2", name=compare_name)
+            )
+            == compare.AlbumMatchEvidence.NO_MATCH
+        ), (base_name, compare_name)
+
+
+def test_compare_album_evidence_standalone_separator_between_words_is_drift() -> None:
+    """A symbol standing between words is a separator, so it never blocks a match."""
+    album_a = _album(name="HIStory - PAST, PRESENT AND FUTURE - BOOK I", year=1995)
+    album_b = _album(
+        item_id="2",
+        provider="test2",
+        name="HIStory: Past, Present and Future, Book I",
+        year=1995,
+    )
+
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+
+
 def test_compare_album_evidence_punctuation_only_title_whitespace_drift_matches() -> None:
     """Whitespace drift within a punctuation-only title does not block a match."""
     album_a = _album(name="( )")

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -525,6 +525,22 @@ def test_compare_album_evidence_standalone_separator_between_words_is_drift() ->
     assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
 
 
+def test_compare_album_evidence_ep_and_single_of_the_same_name_stay_distinct() -> None:
+    """Two titles naming a different format are separate releases, whatever base they share."""
+    album_a = _album(name="Stargazing - EP", year=2023)
+    album_b = _album(item_id="2", provider="test2", name="Stargazing - Single", year=2023)
+
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.NO_MATCH
+
+    # either spelling still matches the plain title, which names no format at all
+    for name in ("Stargazing - EP", "Stargazing - Single"):
+        album_a = _album(name=name, year=2023)
+        album_b = _album(item_id="2", provider="test2", name="Stargazing", year=2023)
+        assert (
+            compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+        ), name
+
+
 def test_compare_album_evidence_punctuation_only_title_whitespace_drift_matches() -> None:
     """Whitespace drift within a punctuation-only title does not block a match."""
     album_a = _album(name="( )")

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -496,7 +496,14 @@ def test_compare_album_evidence_symbol_only_titles_identify_their_own_album() ->
             )
             == compare.AlbumMatchEvidence.MATCH
         ), name
-    for base_name, compare_name in (("+", "="), ("+", "÷"), ("=", "÷"), ("\u00d7", "÷")):
+    # a symbol-only title is decided on its complete raw spelling, punctuation included
+    for base_name, compare_name in (
+        ("+", "="),
+        ("+", "÷"),
+        ("=", "÷"),
+        ("\u00d7", "÷"),
+        ("+", "+!"),
+    ):
         assert (
             compare.compare_album_evidence(
                 _album(name=base_name), _album(item_id="2", provider="test2", name=compare_name)

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -455,9 +455,9 @@ def test_compare_album_evidence_name_retail_suffix_stripped() -> None:
         ), suffix
 
 
-def test_compare_album_evidence_trailing_symbol_marks_a_different_release() -> None:
-    """A bonus edition marked by a trailing symbol is a release of its own."""
-    for name in ("MOTOMAMI +", "MOTOMAMI+"):
+def test_compare_album_evidence_bordering_symbol_marks_a_different_release() -> None:
+    """A bonus edition marked by a symbol at either end of the title is a release of its own."""
+    for name in ("MOTOMAMI +", "MOTOMAMI+", "+ MOTOMAMI", "+MOTOMAMI"):
         album_a = _album(name="MOTOMAMI", year=2022)
         album_b = _album(item_id="2", provider="test2", name=name, year=2022)
 

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -457,23 +457,46 @@ def test_compare_album_evidence_name_retail_suffix_stripped() -> None:
 
 def test_compare_album_evidence_trailing_symbol_marks_a_different_release() -> None:
     """A bonus edition marked by a trailing symbol is a release of its own."""
-    album_a = _album(name="MOTOMAMI", year=2022)
-    album_b = _album(item_id="2", provider="test2", name="MOTOMAMI +", year=2022)
+    for name in ("MOTOMAMI +", "MOTOMAMI+"):
+        album_a = _album(name="MOTOMAMI", year=2022)
+        album_b = _album(item_id="2", provider="test2", name=name, year=2022)
 
-    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.NO_MATCH
-    assert compare.compare_album(album_a, album_b) is False
+        assert (
+            compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.NO_MATCH
+        ), name
+        assert compare.compare_album(album_a, album_b) is False, name
+
+    # how the symbol is spaced is still formatting the two providers may differ on
+    album_a = _album(name="MOTOMAMI +", year=2022)
+    album_b = _album(item_id="2", provider="test2", name="MOTOMAMI+", year=2022)
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+
+
+def test_compare_album_evidence_symbol_standing_in_for_letters_is_still_drift() -> None:
+    """A symbol used to spell a letter is folded away, so both spellings still match."""
+    for stylized, plain in (("bbno$", "bbno"), ("\u0060Round Midnight", "'Round Midnight")):
+        album_a = _album(name=stylized)
+        album_b = _album(item_id="2", provider="test2", name=plain)
+        assert (
+            compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+        ), stylized
+
+    # a mathematical symbol anyascii spells out is counted once, not twice
+    album_a = _album(name="Partial \u2202")
+    album_b = _album(item_id="2", provider="test2", name="Partial d")
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
 
 
 def test_compare_album_evidence_symbol_only_titles_identify_their_own_album() -> None:
     """A symbol-titled album (Ed Sheeran's '+', '=', '÷') matches only its own spelling."""
-    for name in ("+", "=", "÷"):
+    for name in ("+", "=", "÷", "\u00d7"):
         assert (
             compare.compare_album_evidence(
                 _album(name=name), _album(item_id="2", provider="test2", name=f"{name} ")
             )
             == compare.AlbumMatchEvidence.MATCH
         ), name
-    for base_name, compare_name in (("+", "="), ("+", "÷"), ("=", "÷")):
+    for base_name, compare_name in (("+", "="), ("+", "÷"), ("=", "÷"), ("\u00d7", "÷")):
         assert (
             compare.compare_album_evidence(
                 _album(name=base_name), _album(item_id="2", provider="test2", name=compare_name)


### PR DESCRIPTION
# What does this implement/fix?

Album title identity was decided in two places that disagreed with each other.

The comparer ignored a trailing symbol, so `MOTOMAMI` and `MOTOMAMI +` looked like the same album — and because that was a confident match, no tracklist check ran and one of the two library rows was merged away. Ed Sheeran's `+`, `=` and `÷` are the same class of title. In the other direction, the duplicate-repair task matched on the stored name, which keeps the ` - EP` that Apple Music appends, so those pairs never reached the comparer at all.

Both are dev-only, so nothing in a release is affected.

**Related issue (if applicable):**

- follow-up to #5798

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- A standalone symbol at the start or end of a title now counts as part of the title, while one between words stays a separator — so `HIStory - Past, Present and Future` still matches its differently punctuated spelling.
- The ` - EP`/` - Single` suffix is derived from a single constant that the comparer, the library lookup and the duplicate-repair query all share.
- Adding an `X - EP` from one provider now links to an existing `X` row instead of creating a second one.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.