### PR TITLE
Keep the Plex library sync going when one item cannot be read

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -754,7 +754,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         plex_album: PlexAlbum = await self._get_data(prov_album_id, PlexAlbum)
         tracks = []
         for plex_track in await self._run_async(plex_album.tracks):
-            if track := await self._parse_or_skip(self._parse_track, plex_track):
+            if (track := await self._parse_or_skip(self._parse_track, plex_track)) is not None:
                 tracks.append(track)
         return tracks
 
@@ -829,7 +829,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             # Collections can contain tracks, albums, or artists - we only want tracks
             for item in collection_items:
                 if item.type == "track":
-                    if track := await self._parse_or_skip(self._parse_track, item):
+                    if (track := await self._parse_or_skip(self._parse_track, item)) is not None:
                         track.position = len(result) + 1
                         result.append(track)
                 elif item.type == "album":
@@ -850,7 +850,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             plex_tracks = await self._run_async(self._plex_library.fetchItems, tracks_key)
             random.shuffle(plex_tracks)
             for plex_track in plex_tracks:
-                if track := await self._parse_or_skip(self._parse_track, plex_track):
+                if (track := await self._parse_or_skip(self._parse_track, plex_track)) is not None:
                     track.position = len(result) + 1
                     result.append(track)
             return result
@@ -859,7 +859,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         if not (playlist_items := await self._run_async(plex_playlist.items)):
             return result
         for plex_track in playlist_items:
-            if track := await self._parse_or_skip(self._parse_track, plex_track):
+            if (track := await self._parse_or_skip(self._parse_track, plex_track)) is not None:
                 track.position = len(result) + 1
                 result.append(track)
         return result
@@ -1213,8 +1213,9 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             return await parse_coro(plex_item)
         except InvalidDataError as err:
             # only an item we can not build a media item from is skippable. anything else
-            # affects every item that follows, so it has to abort the sync, which is what
-            # holds back the deletion pass that would otherwise drop the whole library.
+            # may be a server or connection failure rather than a property of this item,
+            # and we can not tell those apart here, so it has to abort the sync - that is
+            # what holds back the deletion pass that would otherwise drop valid items.
             #
             # read the identifiers from the cached payload, so reporting a failed item
             # can not trigger a reload that fails all over again

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -162,6 +162,12 @@ RetType = TypeVar("RetType")
 PlexObjectT = TypeVar("PlexObjectT", bound=PlexObject)
 MediaItemT = TypeVar("MediaItemT", bound=MediaItem)
 
+# errors that make a single item unusable without affecting the rest of the library: its
+# metadata is too incomplete to build a media item from, or it was removed from the server
+# between listing and parsing. connection and auth errors affect every item and must abort
+# the sync instead, so the deletion pass is held back.
+SKIPPABLE_PARSE_ERRORS = (InvalidDataError, plexapi.exceptions.NotFound)
+
 
 class PlexProvider(RecommendationPayloadMixin, MusicProvider):
     """Provider for a plex music library."""
@@ -440,25 +446,33 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         """Retrieve all library artists from Plex Music."""
         artists_obj = await self._run_async(self._plex_library.all)
         for artist in artists_obj:
-            yield await self._parse_artist(artist)
+            parsed = await self._parse_or_skip(self._parse_artist, artist)
+            if parsed is not None:
+                yield parsed
 
     async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve all library albums from Plex Music."""
         albums_obj = await self._run_async(self._plex_library.albums)
         for album in albums_obj:
-            yield await self._parse_album(album)
+            parsed = await self._parse_or_skip(self._parse_album, album)
+            if parsed is not None:
+                yield parsed
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve all library playlists from the provider."""
         playlists_obj = await self._run_async(self._plex_library.playlists)
         for playlist in playlists_obj:
-            yield await self._parse_playlist(playlist)
+            parsed = await self._parse_or_skip(self._parse_playlist, playlist)
+            if parsed is not None:
+                yield parsed
 
         # Import collections as playlists if enabled
         if self.config.get_value(CONF_IMPORT_COLLECTIONS):
             collections_obj = await self._run_async(self._plex_library.collections)
             for collection in collections_obj:
-                yield await self._parse_collection(collection)
+                parsed = await self._parse_or_skip(self._parse_collection, collection)
+                if parsed is not None:
+                    yield parsed
 
     async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from Plex Music."""
@@ -481,33 +495,25 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             if not batch:
                 break
             for plex_track in batch:
-                yield await self._parse_track(plex_track)
+                parsed = await self._parse_or_skip(self._parse_track, plex_track)
+                if parsed is not None:
+                    yield parsed
             offset += page_size
 
     async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook]:
         """Retrieve all library audiobooks from the configured Plex audiobook section."""
         if self._get_library_type() != LIBRARY_TYPE_AUDIOBOOKS:
             return
-        try:
-            albums_obj = await self._run_async(self._plex_library.albums)
-        except Exception:
-            self.logger.exception("Failed to list albums from audiobook library")
-            return
+        albums_obj = await self._run_async(self._plex_library.albums)
         self.logger.debug(
             "Found %d albums in audiobook library '%s'",
             len(albums_obj),
             self._plex_library.title,
         )
         for album in albums_obj:
-            try:
-                yield await self._parse_audiobook(album, include_chapters=False)
-            except Exception:
-                self.logger.warning(
-                    "Failed to parse audiobook album '%s' (key=%s); skipping",
-                    getattr(album, "title", "[unknown]"),
-                    getattr(album, "key", "[no key]"),
-                    exc_info=True,
-                )
+            parsed = await self._parse_or_skip(self._parse_audiobook, album)
+            if parsed is not None:
+                yield parsed
 
     @use_cache(3600 * 3)  # Cache for 3 hours
     async def get_audiobook(self, prov_audiobook_id: str) -> Audiobook:
@@ -530,21 +536,11 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         """Retrieve all library podcasts from the configured Plex podcast section."""
         if self._get_library_type() != LIBRARY_TYPE_PODCASTS:
             return
-        try:
-            albums_obj = await self._run_async(self._plex_library.albums)
-        except Exception:
-            self.logger.exception("Failed to list albums from podcast library")
-            return
+        albums_obj = await self._run_async(self._plex_library.albums)
         for album in albums_obj:
-            try:
-                yield await self._parse_podcast(album, include_episodes=False)
-            except Exception:
-                self.logger.warning(
-                    "Failed to parse podcast album '%s' (key=%s); skipping",
-                    getattr(album, "title", "[unknown]"),
-                    getattr(album, "key", "[no key]"),
-                    exc_info=True,
-                )
+            parsed = await self._parse_or_skip(self._parse_podcast, album)
+            if parsed is not None:
+                yield parsed
 
     @use_cache(3600 * 3)  # Cache for 3 hours
     async def get_podcast(self, prov_podcast_id: str) -> Podcast:
@@ -1209,6 +1205,31 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             results.append(task.result())
 
         return results
+
+    async def _parse_or_skip(
+        self,
+        parse_coro: Callable[[PlexObjectT], Coroutine[Any, Any, MediaItemT]],
+        plex_item: PlexObjectT,
+    ) -> MediaItemT | None:
+        """
+        Parse a plex object into a media item, or return None if the item must be skipped.
+
+        :param parse_coro: The parse method to apply to the given plex object.
+        :param plex_item: The plex object to parse.
+        """
+        try:
+            return await parse_coro(plex_item)
+        except SKIPPABLE_PARSE_ERRORS as err:
+            # read the identifiers from the cached payload, so reporting a failed item
+            # can not trigger a reload that fails all over again
+            attrib = plex_item._data.attrib
+            self.logger.warning(
+                "Skipping Plex item '%s' (key=%s): %s",
+                attrib.get("title", "[unknown]"),
+                attrib.get("key", "[no key]"),
+                err,
+            )
+            return None
 
     async def _parse_album(self, plex_album: PlexAlbum) -> Album:
         """Parse a Plex Album response to an Album model object."""

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -8,7 +8,7 @@ import random
 import warnings
 from asyncio import Task, TaskGroup
 from collections.abc import Awaitable
-from datetime import UTC, datetime
+from datetime import MAXYEAR, MINYEAR, UTC, datetime
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 
 import plexapi.exceptions
@@ -161,12 +161,6 @@ Param = ParamSpec("Param")
 RetType = TypeVar("RetType")
 PlexObjectT = TypeVar("PlexObjectT", bound=PlexObject)
 MediaItemT = TypeVar("MediaItemT", bound=MediaItem)
-
-# errors that make a single item unusable without affecting the rest of the library: its
-# metadata is too incomplete to build a media item from, or it was removed from the server
-# between listing and parsing. connection and auth errors affect every item and must abort
-# the sync instead, so the deletion pass is held back.
-SKIPPABLE_PARSE_ERRORS = (InvalidDataError, plexapi.exceptions.NotFound)
 
 
 class PlexProvider(RecommendationPayloadMixin, MusicProvider):
@@ -760,10 +754,8 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         plex_album: PlexAlbum = await self._get_data(prov_album_id, PlexAlbum)
         tracks = []
         for plex_track in await self._run_async(plex_album.tracks):
-            track = await self._parse_track(
-                plex_track,
-            )
-            tracks.append(track)
+            if track := await self._parse_or_skip(self._parse_track, plex_track):
+                tracks.append(track)
         return tracks
 
     @use_cache(3600 * 3)  # Cache for 3 hours
@@ -837,7 +829,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             # Collections can contain tracks, albums, or artists - we only want tracks
             for item in collection_items:
                 if item.type == "track":
-                    if track := await self._parse_track(item):
+                    if track := await self._parse_or_skip(self._parse_track, item):
                         track.position = len(result) + 1
                         result.append(track)
                 elif item.type == "album":
@@ -857,18 +849,18 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             tracks_key = f"{mix_key}&type={plexapi.utils.searchType('track')}"
             plex_tracks = await self._run_async(self._plex_library.fetchItems, tracks_key)
             random.shuffle(plex_tracks)
-            for index, plex_track in enumerate(plex_tracks, 1):
-                if track := await self._parse_track(plex_track):
-                    track.position = index
+            for plex_track in plex_tracks:
+                if track := await self._parse_or_skip(self._parse_track, plex_track):
+                    track.position = len(result) + 1
                     result.append(track)
             return result
 
         plex_playlist: PlexPlaylist = await self._get_data(prov_playlist_id, PlexPlaylist)
         if not (playlist_items := await self._run_async(plex_playlist.items)):
             return result
-        for index, plex_track in enumerate(playlist_items, 1):
-            if track := await self._parse_track(plex_track):
-                track.position = index
+        for plex_track in playlist_items:
+            if track := await self._parse_or_skip(self._parse_track, plex_track):
+                track.position = len(result) + 1
                 result.append(track)
         return result
 
@@ -1219,7 +1211,11 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         """
         try:
             return await parse_coro(plex_item)
-        except SKIPPABLE_PARSE_ERRORS as err:
+        except InvalidDataError as err:
+            # only an item we can not build a media item from is skippable. anything else
+            # affects every item that follows, so it has to abort the sync, which is what
+            # holds back the deletion pass that would otherwise drop the whole library.
+            #
             # read the identifiers from the cached payload, so reporting a failed item
             # can not trigger a reload that fails all over again
             attrib = plex_item._data.attrib
@@ -1582,7 +1578,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             audiobook.authors = UniqueList([author_name])
         if plex_album.summary:
             audiobook.metadata.description = plex_album.summary
-        if plex_album.year:
+        if plex_album.year and MINYEAR <= plex_album.year <= MAXYEAR:
             audiobook.metadata.release_date = datetime(plex_album.year, 1, 1, tzinfo=UTC)
         if images := get_thumbnail_images(plex_album, self.instance_id):
             audiobook.metadata.images = images
@@ -1645,7 +1641,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             podcast.publisher = publisher
         if plex_album.summary:
             podcast.metadata.description = plex_album.summary
-        if plex_album.year:
+        if plex_album.year and MINYEAR <= plex_album.year <= MAXYEAR:
             podcast.metadata.release_date = datetime(plex_album.year, 1, 1, tzinfo=UTC)
         if images := get_thumbnail_images(plex_album, self.instance_id):
             podcast.metadata.images = images

--- a/tests/providers/plex/test_library_sync.py
+++ b/tests/providers/plex/test_library_sync.py
@@ -14,6 +14,14 @@ from music_assistant.providers.plex.helpers import SUPPORTED_FEATURES
 
 LIBRARY_TYPE_AUDIOBOOKS = "audiobooks"
 LIBRARY_TYPE_MUSIC = "music"
+LIBRARY_TYPE_PODCASTS = "podcasts"
+
+# both listings guard the same destructive failure, so they are covered the same way
+SPOKEN_LIBRARIES = [
+    (LIBRARY_TYPE_AUDIOBOOKS, "get_library_audiobooks", "_parse_audiobook"),
+    (LIBRARY_TYPE_PODCASTS, "get_library_podcasts", "_parse_podcast"),
+]
+SPOKEN_LIBRARY_LISTINGS = [(library, generator) for library, generator, _ in SPOKEN_LIBRARIES]
 
 
 class _FakePlexData:
@@ -147,33 +155,39 @@ async def test_library_tracks_does_not_swallow_connection_errors(error: Exceptio
         _ = [track async for track in provider.get_library_tracks()]
 
 
-async def test_library_audiobooks_skips_unparsable_item() -> None:
-    """An audiobook that cannot be parsed is skipped, the rest still syncs."""
-    provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+@pytest.mark.parametrize(("library_type", "generator", "parse_method"), SPOKEN_LIBRARIES)
+async def test_spoken_library_skips_unparsable_item(
+    library_type: str, generator: str, parse_method: str
+) -> None:
+    """An audiobook or podcast that cannot be parsed is skipped, the rest still syncs."""
+    provider = _make_provider(library_type)
     good_album = _FakePlexAlbum(key="/501")
     provider._plex_library.albums = MagicMock(return_value=[_FakePlexAlbum(), good_album])
 
-    async def _parse_audiobook(plex_album: Any) -> Any:
+    async def _parse(plex_album: Any, **_kwargs: Any) -> Any:
         if plex_album is good_album:
             return "parsed"
         raise InvalidDataError("no title")
 
-    provider._parse_audiobook = _parse_audiobook
+    setattr(provider, parse_method, _parse)
 
-    audiobooks = [audiobook async for audiobook in provider.get_library_audiobooks()]
+    items = [item async for item in getattr(provider, generator)()]
 
-    assert audiobooks == ["parsed"]
+    assert items == ["parsed"]
 
 
-async def test_library_audiobooks_does_not_swallow_listing_error() -> None:
+@pytest.mark.parametrize(("library_type", "generator"), SPOKEN_LIBRARY_LISTINGS)
+async def test_spoken_library_does_not_swallow_listing_error(
+    library_type: str, generator: str
+) -> None:
     """
-    A failure to list the audiobook library aborts the sync.
+    A failure to list the audiobook or podcast library aborts the sync.
 
     Yielding nothing would look exactly like an emptied library, which makes the sync
-    deletion pass remove every audiobook that is still on the server.
+    deletion pass remove every item that is still on the server.
     """
-    provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+    provider = _make_provider(library_type)
     provider._plex_library.albums = MagicMock(side_effect=ConnectionError("server gone"))
 
     with pytest.raises(ConnectionError):
-        _ = [audiobook async for audiobook in provider.get_library_audiobooks()]
+        _ = [item async for item in getattr(provider, generator)()]

--- a/tests/providers/plex/test_library_sync.py
+++ b/tests/providers/plex/test_library_sync.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import plexapi.exceptions
 import pytest
 from music_assistant_models.errors import InvalidDataError
+from music_assistant_models.media_items import Track
 
 from music_assistant.providers.plex import PlexProvider
 from music_assistant.providers.plex.helpers import SUPPORTED_FEATURES
@@ -76,10 +77,25 @@ class _FakePlexTrack:
 class _FakePlexAlbum:
     """Minimal PlexAlbum stub for the audiobook library."""
 
-    def __init__(self, key: str = "/library/metadata/500", title: str = "Audiobook 1") -> None:
+    def __init__(
+        self,
+        key: str = "/library/metadata/500",
+        title: str = "Audiobook 1",
+        year: int | None = None,
+    ) -> None:
         self.key = key
         self.title = title
+        self.year = year
+        self.parentTitle = "Author 1"
+        self.grandparentTitle = None
+        self.summary = ""
         self._data = _FakePlexData({"title": title, "key": key})
+
+    def getWebURL(self, baseurl: str) -> str:  # noqa: N802
+        return f"{baseurl}/web/index.html#!/server/item/{self.key}"
+
+    def firstAttr(self, *attrs: str) -> str | None:  # noqa: N802
+        return None
 
 
 def _make_provider(library_type: str = LIBRARY_TYPE_MUSIC) -> Any:
@@ -119,8 +135,8 @@ async def test_library_tracks_skips_track_without_artist() -> None:
     assert [track.item_id for track in tracks] == ["/2"]
 
 
-async def test_library_artists_skips_vanished_item() -> None:
-    """An artist removed from the server between listing and parsing is skipped."""
+async def test_library_artists_skips_item_without_valid_id() -> None:
+    """An artist Plex holds no usable id for is skipped, the rest still syncs."""
     provider = _make_provider()
     good_artist = MagicMock()
     provider._plex_library.all = MagicMock(return_value=[MagicMock(), good_artist])
@@ -128,7 +144,7 @@ async def test_library_artists_skips_vanished_item() -> None:
     async def _parse_artist(plex_artist: Any) -> Any:
         if plex_artist is good_artist:
             return "parsed"
-        raise plexapi.exceptions.NotFound("gone")
+        raise InvalidDataError("Artist does not have a valid ID")
 
     provider._parse_artist = _parse_artist
 
@@ -139,12 +155,23 @@ async def test_library_artists_skips_vanished_item() -> None:
 
 @pytest.mark.parametrize(
     "error",
-    [plexapi.exceptions.Unauthorized("invalid token"), ConnectionError("server gone")],
+    [
+        plexapi.exceptions.Unauthorized("invalid token"),
+        plexapi.exceptions.NotFound("gone"),
+        ConnectionError("server gone"),
+    ],
 )
-async def test_library_tracks_does_not_swallow_connection_errors(error: Exception) -> None:
-    """An error that affects every item aborts the sync instead of skipping one track."""
+async def test_library_tracks_does_not_swallow_server_errors(error: Exception) -> None:
+    """
+    An error that is not about the item itself aborts the sync instead of skipping a track.
+
+    Skipping would drop the track from this run, and the sync deletion pass then removes
+    it from the library even though it is still on the server.
+    """
     provider = _make_provider()
-    provider._plex_library.searchTracks = MagicMock(return_value=[_FakePlexTrack()])
+    # a terminating second batch, so widening the caught errors fails the test instead
+    # of looping on the same batch forever
+    provider._plex_library.searchTracks = MagicMock(side_effect=[[_FakePlexTrack()], []])
 
     async def _parse_track(_plex_track: Any) -> Any:
         raise error
@@ -191,3 +218,64 @@ async def test_spoken_library_does_not_swallow_listing_error(
 
     with pytest.raises(ConnectionError):
         _ = [item async for item in getattr(provider, generator)()]
+
+
+async def test_audiobook_accepts_out_of_range_year() -> None:
+    """A year Plex cannot express as a date is ignored instead of failing the item."""
+    provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+
+    audiobook = await provider._parse_audiobook(_FakePlexAlbum(year=19999))
+
+    assert audiobook.metadata.release_date is None
+
+
+async def test_album_tracks_skips_unparsable_track() -> None:
+    """An unusable track no longer costs the whole tracklist of an album."""
+    provider = _make_provider()
+    bad_track, good_track = _FakePlexTrack(key="/1"), _FakePlexTrack(key="/2")
+    plex_album = MagicMock()
+    plex_album.tracks = MagicMock(return_value=[bad_track, good_track])
+    provider._get_data = AsyncMock(return_value=plex_album)
+
+    async def _parse_track(plex_track: Any) -> Any:
+        if plex_track is bad_track:
+            raise InvalidDataError("No artist was found for track")
+        return "parsed"
+
+    provider._parse_track = _parse_track
+
+    get_album_tracks: Any = PlexProvider.get_album_tracks.__wrapped__  # type: ignore[attr-defined]
+
+    assert await get_album_tracks(provider, "/library/metadata/100") == ["parsed"]
+
+
+async def test_playlist_tracks_skips_unparsable_track() -> None:
+    """
+    An unusable track no longer makes the whole playlist unplayable.
+
+    The remaining tracks keep consecutive positions, so the skip does not leave a hole in
+    the queue built from this playlist.
+    """
+    provider = _make_provider()
+    tracks = [_FakePlexTrack(key="/1"), _FakePlexTrack(key="/2"), _FakePlexTrack(key="/3")]
+    plex_playlist = MagicMock()
+    plex_playlist.items = MagicMock(return_value=tracks)
+    provider._get_data = AsyncMock(return_value=plex_playlist)
+
+    async def _parse_track(plex_track: Any) -> Any:
+        if plex_track is tracks[0]:
+            raise InvalidDataError("No artist was found for track")
+        return Track(
+            item_id=plex_track.key,
+            provider=provider.instance_id,
+            name=plex_track.title,
+            provider_mappings=set(),
+        )
+
+    provider._parse_track = _parse_track
+
+    get_playlist_tracks: Any = PlexProvider.get_playlist_tracks.__wrapped__  # type: ignore[attr-defined]
+    result = await get_playlist_tracks(provider, "/playlists/1")
+
+    assert [track.item_id for track in result] == ["/2", "/3"]
+    assert [track.position for track in result] == [1, 2]

--- a/tests/providers/plex/test_library_sync.py
+++ b/tests/providers/plex/test_library_sync.py
@@ -23,6 +23,7 @@ SPOKEN_LIBRARIES = [
     (LIBRARY_TYPE_PODCASTS, "get_library_podcasts", "_parse_podcast"),
 ]
 SPOKEN_LIBRARY_LISTINGS = [(library, generator) for library, generator, _ in SPOKEN_LIBRARIES]
+SPOKEN_LIBRARY_PARSERS = [(library, parser) for library, _, parser in SPOKEN_LIBRARIES]
 
 
 class _FakePlexData:
@@ -86,6 +87,7 @@ class _FakePlexAlbum:
         self.key = key
         self.title = title
         self.year = year
+        self.studio = None
         self.parentTitle = "Author 1"
         self.grandparentTitle = None
         self.summary = ""
@@ -220,13 +222,14 @@ async def test_spoken_library_does_not_swallow_listing_error(
         _ = [item async for item in getattr(provider, generator)()]
 
 
-async def test_audiobook_accepts_out_of_range_year() -> None:
+@pytest.mark.parametrize(("library_type", "parse_method"), SPOKEN_LIBRARY_PARSERS)
+async def test_spoken_item_ignores_out_of_range_year(library_type: str, parse_method: str) -> None:
     """A year Plex cannot express as a date is ignored instead of failing the item."""
-    provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+    provider = _make_provider(library_type)
 
-    audiobook = await provider._parse_audiobook(_FakePlexAlbum(year=19999))
+    parsed = await getattr(provider, parse_method)(_FakePlexAlbum(year=19999))
 
-    assert audiobook.metadata.release_date is None
+    assert parsed.metadata.release_date is None
 
 
 async def test_album_tracks_skips_unparsable_track() -> None:

--- a/tests/providers/plex/test_library_sync.py
+++ b/tests/providers/plex/test_library_sync.py
@@ -1,0 +1,179 @@
+"""Tests that a single unusable Plex item does not abort a library sync."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import plexapi.exceptions
+import pytest
+from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.providers.plex import PlexProvider
+from music_assistant.providers.plex.helpers import SUPPORTED_FEATURES
+
+LIBRARY_TYPE_AUDIOBOOKS = "audiobooks"
+LIBRARY_TYPE_MUSIC = "music"
+
+
+class _FakePlexData:
+    """Stub for the cached xml payload of a plex object."""
+
+    def __init__(self, attrib: dict[str, str]) -> None:
+        self.attrib = attrib
+
+    def findall(self, _tag: str) -> list[Any]:
+        return []
+
+
+class _FakePlexTrack:
+    """
+    Minimal PlexTrack stub carrying what the track parser reads.
+
+    Leaving both original_title and grandparent_key empty reproduces a track that Plex
+    holds no artist for, which the parser rejects with an InvalidDataError.
+    """
+
+    def __init__(
+        self,
+        key: str = "/library/metadata/1",
+        title: str = "Track 1",
+        original_title: str | None = None,
+        grandparent_key: str | None = "/library/metadata/10",
+    ) -> None:
+        self.key = key
+        self.title = title
+        self.originalTitle = original_title
+        self.grandparentKey = grandparent_key
+        self.grandparentTitle = "Artist 1"
+        self.parentKey = "/library/metadata/100"
+        self.parentTitle = "Album 1"
+        self.parentIndex = 1
+        self.trackNumber = 1
+        self.duration = 180000
+        self.genres: list[Any] = []
+        self.moods: list[Any] = []
+        media = MagicMock()
+        media.container = "mp3"
+        self.media = [media]
+        self._data = _FakePlexData({"title": title, "key": key})
+
+    def getWebURL(self, baseurl: str) -> str:  # noqa: N802
+        return f"{baseurl}/web/index.html#!/server/item/{self.key}"
+
+    def firstAttr(self, *attrs: str) -> str | None:  # noqa: N802
+        return None
+
+
+class _FakePlexAlbum:
+    """Minimal PlexAlbum stub for the audiobook library."""
+
+    def __init__(self, key: str = "/library/metadata/500", title: str = "Audiobook 1") -> None:
+        self.key = key
+        self.title = title
+        self._data = _FakePlexData({"title": title, "key": key})
+
+
+def _make_provider(library_type: str = LIBRARY_TYPE_MUSIC) -> Any:
+    """Create a minimal PlexProvider instance for testing."""
+    mock_mass = MagicMock()
+    mock_config = MagicMock()
+    mock_config.instance_id = "plex_instance_1"
+    config_values: dict[str, Any] = {"library_type": library_type, "log_level": "INFO"}
+    mock_config.get_value = lambda key: config_values.get(key)
+
+    setup_data = {"library_type": library_type, "token": "local_auth"}
+    mock_mass.config.get = lambda key, default=None: (
+        setup_data if str(key).endswith("/setup_data") else default
+    )
+    mock_mass.config.get_raw_provider_config_value = lambda _instance_id, _key: None
+    mock_mass.config.decrypt_string = lambda value: value
+
+    mock_manifest = MagicMock()
+    mock_manifest.type = "music"
+    mock_manifest.domain = "plex"
+
+    provider = PlexProvider(mock_mass, mock_manifest, mock_config, SUPPORTED_FEATURES)
+    provider._baseurl = "http://localhost:32400"
+    provider._plex_server = MagicMock()
+    provider._plex_library = MagicMock()
+    return provider
+
+
+async def test_library_tracks_skips_track_without_artist() -> None:
+    """A track that Plex holds no artist for is skipped, the rest still syncs."""
+    provider = _make_provider()
+    batches = [[_FakePlexTrack(key="/1", grandparent_key=None), _FakePlexTrack(key="/2")], []]
+    provider._plex_library.searchTracks = MagicMock(side_effect=batches)
+
+    tracks = [track async for track in provider.get_library_tracks()]
+
+    assert [track.item_id for track in tracks] == ["/2"]
+
+
+async def test_library_artists_skips_vanished_item() -> None:
+    """An artist removed from the server between listing and parsing is skipped."""
+    provider = _make_provider()
+    good_artist = MagicMock()
+    provider._plex_library.all = MagicMock(return_value=[MagicMock(), good_artist])
+
+    async def _parse_artist(plex_artist: Any) -> Any:
+        if plex_artist is good_artist:
+            return "parsed"
+        raise plexapi.exceptions.NotFound("gone")
+
+    provider._parse_artist = _parse_artist
+
+    artists = [artist async for artist in provider.get_library_artists()]
+
+    assert artists == ["parsed"]
+
+
+@pytest.mark.parametrize(
+    "error",
+    [plexapi.exceptions.Unauthorized("invalid token"), ConnectionError("server gone")],
+)
+async def test_library_tracks_does_not_swallow_connection_errors(error: Exception) -> None:
+    """An error that affects every item aborts the sync instead of skipping one track."""
+    provider = _make_provider()
+    provider._plex_library.searchTracks = MagicMock(return_value=[_FakePlexTrack()])
+
+    async def _parse_track(_plex_track: Any) -> Any:
+        raise error
+
+    provider._parse_track = _parse_track
+
+    with pytest.raises(type(error)):
+        _ = [track async for track in provider.get_library_tracks()]
+
+
+async def test_library_audiobooks_skips_unparsable_item() -> None:
+    """An audiobook that cannot be parsed is skipped, the rest still syncs."""
+    provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+    good_album = _FakePlexAlbum(key="/501")
+    provider._plex_library.albums = MagicMock(return_value=[_FakePlexAlbum(), good_album])
+
+    async def _parse_audiobook(plex_album: Any) -> Any:
+        if plex_album is good_album:
+            return "parsed"
+        raise InvalidDataError("no title")
+
+    provider._parse_audiobook = _parse_audiobook
+
+    audiobooks = [audiobook async for audiobook in provider.get_library_audiobooks()]
+
+    assert audiobooks == ["parsed"]
+
+
+async def test_library_audiobooks_does_not_swallow_listing_error() -> None:
+    """
+    A failure to list the audiobook library aborts the sync.
+
+    Yielding nothing would look exactly like an emptied library, which makes the sync
+    deletion pass remove every audiobook that is still on the server.
+    """
+    provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+    provider._plex_library.albums = MagicMock(side_effect=ConnectionError("server gone"))
+
+    with pytest.raises(ConnectionError):
+        _ = [audiobook async for audiobook in provider.get_library_audiobooks()]


### PR DESCRIPTION
# What does this implement/fix?

Reading one Plex item could stop the whole library sync for that media type. A track
that Plex holds no artist for is rejected while parsing, and because that happens while
listing the library there is no way to skip it - the sync stops there and picks up nothing
after it, every run. The same track also made the album or playlist it sits in fail to
load, so a playlist containing one such track could not be played at all.

Separately, when listing the audiobook or podcast library failed, the provider logged the
error and returned nothing. An empty listing looks exactly like an emptied library, so the
cleanup step that follows removed every audiobook and podcast that is still on the server.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- An item we cannot build is skipped and the rest still loads, for artists, albums,
  tracks, playlists, collections, audiobooks and podcasts, and for the tracks of an album
  or a playlist.
- Only an item we cannot build counts as skippable. Anything else, including an item that
  disappeared from the server mid-sync, still stops the sync, so the cleanup step is held
  back rather than removing items that are still there.
- A failure to list the audiobook or podcast library now stops the sync instead of
  silently reporting an empty library.
- A release year that cannot be expressed as a date is ignored instead of failing the
  audiobook or podcast it belongs to.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
