### PR TITLE
Skip empty Spotify saved tracks instead of stopping the sync

### DIFF
--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -258,7 +258,7 @@ class SpotifyProvider(MusicProvider):
     async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from the provider."""
         async for item in self._get_all_items("me/tracks"):
-            if item and item["track"]["id"]:
+            if item and item["track"] and item["track"]["id"]:
                 yield parse_track(item["track"], self)
 
     async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:

--- a/tests/providers/spotify/test_library_tracks.py
+++ b/tests/providers/spotify/test_library_tracks.py
@@ -1,0 +1,54 @@
+"""Tests for the Spotify library tracks listing."""
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import MagicMock
+
+from music_assistant.providers.spotify.provider import SpotifyProvider
+
+
+def _make_provider(instance_id: str = "spotify--test") -> SpotifyProvider:
+    """Return a Spotify provider with only what the library listing needs."""
+    provider = object.__new__(SpotifyProvider)
+    provider.config = MagicMock(instance_id=instance_id)
+    provider.manifest = MagicMock(domain="spotify")
+    provider.logger = MagicMock()
+    provider.mass = MagicMock()
+    return provider
+
+
+def _saved_track(track_id: str) -> dict[str, Any]:
+    """Return a saved track entry as returned by the me/tracks endpoint."""
+    return {
+        "added_at": "2026-01-01T00:00:00Z",
+        "track": {
+            "id": track_id,
+            "name": track_id,
+            "duration_ms": 180000,
+            "external_urls": {"spotify": f"https://open.spotify.com/track/{track_id}"},
+            "is_local": False,
+            "is_playable": True,
+            "explicit": False,
+        },
+    }
+
+
+async def test_library_tracks_skips_entry_without_track() -> None:
+    """
+    A saved track entry that carries no track at all is skipped.
+
+    Spotify returns such an entry for a track that is no longer available, which would
+    otherwise abort the whole track sync.
+    """
+    provider = _make_provider()
+    items: list[Any] = [_saved_track("track1"), {"added_at": "x", "track": None}, None]
+
+    async def _iter_items() -> AsyncGenerator[Any]:
+        for item in items:
+            yield item
+
+    provider._get_all_items = MagicMock(return_value=_iter_items())  # type: ignore[method-assign]
+
+    tracks = [track async for track in provider.get_library_tracks()]
+
+    assert [track.item_id for track in tracks] == ["track1"]

--- a/tests/providers/spotify/test_library_tracks.py
+++ b/tests/providers/spotify/test_library_tracks.py
@@ -41,7 +41,13 @@ async def test_library_tracks_skips_entry_without_track() -> None:
     otherwise abort the whole track sync.
     """
     provider = _make_provider()
-    items: list[Any] = [_saved_track("track1"), {"added_at": "x", "track": None}, None]
+    # a valid track after the empty ones, so stopping at an empty entry fails this test
+    items: list[Any] = [
+        _saved_track("track1"),
+        {"added_at": "2026-01-01T00:00:00Z", "track": None},
+        None,
+        _saved_track("track2"),
+    ]
 
     async def _iter_items() -> AsyncGenerator[Any]:
         for item in items:
@@ -51,4 +57,4 @@ async def test_library_tracks_skips_entry_without_track() -> None:
 
     tracks = [track async for track in provider.get_library_tracks()]
 
-    assert [track.item_id for track in tracks] == ["track1"]
+    assert [track.item_id for track in tracks] == ["track1", "track2"]


### PR DESCRIPTION
# What does this implement/fix?

Spotify can list a saved track that has no track details attached, for example when the
track is no longer available. Reading your saved tracks then stopped right there, so any
track after it was never imported and the sync failed the same way on every run.

The saved albums, podcasts and audiobooks listings already check for this, and so does the
Liked Songs playlist, which reads the very same endpoint. Only the saved tracks listing
was missing the check.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Skip a saved track that carries no track details, so the rest of your library still
  imports.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
