### PR TITLE
Finish replacing a universal player that lists the speaker itself

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1068,10 +1068,18 @@ class ProtocolLinkingMixin:
             # A derived protocol rides on another output, so a base and everything riding
             # on it can only move together: refusing one of them holds back the group.
             for group in self._group_protocol_links(player):
+                # A device that kept its id across a type change is listed as a protocol
+                # of the wrapper that replaces it. It cannot move onto itself, so leaving
+                # it in would mark it refused and abort the takeover below.
+                movable = [
+                    entry for entry in group if entry[1].player_id != native_player.player_id
+                ]
+                if not movable:
+                    continue
                 domains = {
                     protocol_player.player_id: linked.protocol_domain
                     or protocol_player.provider.domain
-                    for linked, protocol_player in group
+                    for linked, protocol_player in movable
                 }
                 if any(
                     self._parent_has_active_protocol_from_domain(
@@ -1081,7 +1089,7 @@ class ProtocolLinkingMixin:
                 ):
                     refused_protocol_ids.update(domains.keys())
                     continue
-                for _, protocol_player in group:
+                for _, protocol_player in movable:
                     protocol_player.set_protocol_parent_id(None)
                     self._add_protocol_link(
                         native_player, protocol_player, domains[protocol_player.player_id]

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1068,11 +1068,13 @@ class ProtocolLinkingMixin:
             # A derived protocol rides on another output, so a base and everything riding
             # on it can only move together: refusing one of them holds back the group.
             for group in self._group_protocol_links(player):
-                # A device that kept its id across a type change is listed as a protocol
-                # of the wrapper that replaces it. It cannot move onto itself, so leaving
-                # it in would mark it refused and abort the takeover below.
+                # A device that kept its id across a type change is still listed as one of
+                # the outputs of the wrapper it replaces. It cannot be taken over from
+                # itself, so leaving it in would mark it refused and abort the takeover.
                 movable = [
-                    entry for entry in group if entry[1].player_id != native_player.player_id
+                    (linked, protocol_player)
+                    for linked, protocol_player in group
+                    if protocol_player.player_id != native_player.player_id
                 ]
                 if not movable:
                     continue

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1120,6 +1120,10 @@ class ProtocolLinkingMixin:
             self._remove_protocol_ids_from_parent(
                 player, migrated_protocol_ids | {native_player.player_id}
             )
+            # Drop the player's own side of that entry as well, so its config cannot
+            # claim to be a protocol child of the wrapper it is replacing.
+            if self._get_cached_protocol_parent_id(native_player.player_id) == player.player_id:
+                self._clear_protocol_parent_id(native_player.player_id)
             native_player.refresh_state()
 
             if refused_protocol_ids:

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -7783,7 +7783,12 @@ class TestUniversalPlayerReplacement:
         controller = PlayerController(mock_mass)
         config_store: dict[str, Any] = {
             CONF_PLAYERS: {
-                "esp_client": {"enabled": True, "provider": "sendspin--test", "values": {}},
+                "esp_client": {
+                    "enabled": True,
+                    "provider": "sendspin--test",
+                    # left over from before the device changed type
+                    "values": {CONF_PROTOCOL_PARENT_ID: "up_old"},
+                },
                 "up_old": {
                     "enabled": True,
                     "provider": "universal_player",
@@ -7794,6 +7799,13 @@ class TestUniversalPlayerReplacement:
                 "ap_live": {
                     "enabled": True,
                     "provider": "airplay--test",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "up_old"},
+                },
+                # a disabled protocol that never registered, so it only exists in config
+                "dlna_off": {
+                    "enabled": False,
+                    "provider": "dlna--test",
                     "player_type": "protocol",
                     "values": {CONF_PROTOCOL_PARENT_ID: "up_old"},
                 },
@@ -7830,7 +7842,7 @@ class TestUniversalPlayerReplacement:
             mock_mass,
             "up_old",
             "ESP (Universal)",
-            ["ap_live", "esp_client"],
+            ["ap_live", "esp_client", "dlna_off"],
             identifiers=identifiers,
         )
         native = MockPlayer(
@@ -7877,8 +7889,15 @@ class TestUniversalPlayerReplacement:
         # and the user's configuration is carried over before that removal deletes it
         assert config_store[CONF_PLAYERS]["esp_client"]["name"] == "Living Room"
         assert config_store[CONF_PLAYERS]["esp_client"]["values"]["hide_in_ui"] is True
+        # ownership is handed over in config as well, for the protocol that moved and for
+        # the one that only exists in config: nothing may keep pointing at the removed wrapper
+        ap_values = config_store[CONF_PLAYERS]["ap_live"]["values"]
+        assert ap_values[CONF_PROTOCOL_PARENT_ID] == "esp_client"
+        dlna_values = config_store[CONF_PLAYERS]["dlna_off"]["values"]
+        assert dlna_values[CONF_PROTOCOL_PARENT_ID] == "esp_client"
         # the native player is never left pointing at the wrapper it replaces
         assert native.protocol_parent_id is None
+        assert config_store[CONF_PLAYERS]["esp_client"]["values"][CONF_PROTOCOL_PARENT_ID] is None
 
     async def test_wrapper_holding_only_the_native_id_completes_the_takeover(
         self, mock_mass: MagicMock
@@ -7939,6 +7958,7 @@ class TestUniversalPlayerReplacement:
         native = MockPlayer(MockProvider("sendspin", mass=mock_mass), "esp_client", "ESP")
         native.set_initialized()
         controller._players = {"up_old": universal, "esp_client": native}
+        scheduled_tasks.clear()
 
         with patch.object(controller, "unregister", new=AsyncMock()) as mock_unregister:
             controller._check_replace_universal_player(native)
@@ -7953,6 +7973,127 @@ class TestUniversalPlayerReplacement:
         assert config_store[CONF_PLAYERS]["esp_client"]["name"] == "Living Room"
         assert config_store[CONF_PLAYERS]["esp_client"]["values"]["hide_in_ui"] is True
         assert native.protocol_parent_id is None
+
+    async def test_wrapper_with_a_bridge_riding_on_the_native_completes_the_takeover(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A protocol riding on the native player's own id moves along with the takeover.
+
+        The wrapper lists the device that kept its id across a type change together with
+        the bridge riding on it, so both sit in one group with the device as its base.
+        Leaving the device out of the transfer must not hold the bridge back: the bridge
+        moves over as a protocol derived from the native player itself.
+        """
+        controller = PlayerController(mock_mass)
+        config_store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "cast_base": {"enabled": True, "provider": "chromecast--test", "values": {}},
+                "up_old": {
+                    "enabled": True,
+                    "provider": "universal_player",
+                    "name": "Kitchen",
+                    "default_name": "Speaker (Universal)",
+                    "values": {"hide_in_ui": True},
+                },
+                "spb_bridge": {
+                    "enabled": True,
+                    "provider": "sendspin--test",
+                    "player_type": "protocol",
+                    "values": {
+                        CONF_PROTOCOL_PARENT_ID: "up_old",
+                        CONF_UNDERLYING_PLAYER_ID: "cast_base",
+                    },
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, config_store)
+
+        scheduled_tasks: list[Awaitable[object]] = []
+
+        def capture_task(task: Awaitable[object], *_args: Any, **_kwargs: Any) -> None:
+            scheduled_tasks.append(task)
+
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        # keep the state refreshes below from scheduling an unrelated palette fetch
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        mock_mass.call_later = MagicMock()
+        mock_mass.loop = MagicMock()
+        mock_mass.create_task = MagicMock(side_effect=capture_task)
+        mock_mass.config.get_player_config = AsyncMock(
+            return_value=PlayerConfig.parse(
+                [],
+                {
+                    "player_id": "cast_base",
+                    "provider": "chromecast--test",
+                    "name": "Kitchen",
+                    "default_name": "Speaker",
+                },
+            )
+        )
+
+        identifiers = {IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"}
+        universal = _create_universal_player(
+            mock_mass,
+            "up_old",
+            "Speaker (Universal)",
+            ["cast_base", "spb_bridge"],
+            identifiers=identifiers,
+        )
+        native = MockPlayer(
+            MockProvider("chromecast", mass=mock_mass),
+            "cast_base",
+            "Speaker",
+            identifiers=identifiers,
+        )
+        native.set_initialized()
+        bridge = MockPlayer(
+            MockProvider("sendspin", mass=mock_mass),
+            "spb_bridge",
+            "Speaker (Bridge)",
+            player_type=PlayerType.PROTOCOL,
+        )
+        bridge._attr_underlying_player_id = "cast_base"
+        bridge.set_initialized()
+        controller._players = {"up_old": universal, "cast_base": native, "spb_bridge": bridge}
+
+        controller._add_protocol_link(universal, bridge, "sendspin")
+        # the wrapper linked the device as a protocol before it changed type, which makes
+        # it the base of the group the bridge rides on
+        universal.set_linked_output_protocols(
+            [
+                *universal.linked_output_protocols,
+                LinkedOutputProtocol(
+                    output_protocol_id="cast_base", protocol_domain="chromecast", priority=30
+                ),
+            ]
+        )
+        scheduled_tasks.clear()
+
+        with patch.object(controller, "unregister", new=AsyncMock()) as mock_unregister:
+            controller._check_replace_universal_player(native)
+            # replay what the takeover scheduled, otherwise the unregister assertion below
+            # would hold for a task that never got the chance to run
+            for task in scheduled_tasks:
+                await task
+
+        assert bridge.protocol_parent_id == "cast_base"
+        # the bridge now rides on the parent player itself, recorded as "native"
+        bridge_link = next(
+            link
+            for link in native.linked_output_protocols
+            if link.output_protocol_id == "spb_bridge"
+        )
+        assert bridge_link.derived_from == "native"
+        # the native player is never left pointing at the wrapper it replaces
+        assert native.protocol_parent_id is None
+        # the wrapper is left without any output and permanently removed
+        assert universal.linked_output_protocols == []
+        assert universal._protocol_player_ids == []
+        mock_unregister.assert_awaited_once_with(
+            "up_old", permanent=True, replacement_player_id="cast_base"
+        )
 
 
 class TestEndToEndDuplicateProtocol:

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -7688,6 +7688,272 @@ class TestUniversalPlayerReplacement:
         assert ap_owned.protocol_parent_id == "up_old"
         assert not group.linked_output_protocols
 
+    async def test_eviction_from_an_emptied_wrapper_does_not_schedule_its_removal(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        Eviction leaves a wrapper it empties registered, and deliberately so.
+
+        `_add_protocol_link` evicts a protocol from every other parent, but tearing
+        down a parent it empties is not its job: that belongs to the flow that owns
+        the takeover (`_check_replace_universal_player`, `_merge_universal_players`
+        or `_unlink_from_protocol_parent`). Scheduling a removal here would even be
+        harmful, because `mass.create_task` runs with `eager_start=True` and
+        `PlayerController.unregister` drops the player from `_players` before its
+        first await: the removal would run synchronously and turn the owning flow's
+        later `permanent=True` removal into a silent no-op, skipping the config
+        deletion and the PLAYER_REMOVED event.
+        """
+        controller = PlayerController(mock_mass)
+        config_store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "sonos_1": {"enabled": True, "values": {}},
+                "up_old": {"enabled": True, "provider": "universal_player", "values": {}},
+                "ap_live": {
+                    "enabled": True,
+                    "provider": "airplay--test",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "up_old"},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, config_store)
+
+        scheduled_tasks: list[Awaitable[object]] = []
+
+        def capture_task(task: Awaitable[object], *_args: Any, **_kwargs: Any) -> None:
+            scheduled_tasks.append(task)
+
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.call_later = MagicMock()
+        mock_mass.loop = MagicMock()
+        mock_mass.create_task = MagicMock(side_effect=capture_task)
+
+        identifiers = {IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"}
+        universal = _create_universal_player(
+            mock_mass, "up_old", "Old Universal", ["ap_live"], identifiers=identifiers
+        )
+        native = MockPlayer(
+            MockProvider("sonos", mass=mock_mass), "sonos_1", "Sonos", identifiers=identifiers
+        )
+        native.set_initialized()
+        ap_live = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_live",
+            "AirPlay",
+            player_type=PlayerType.PROTOCOL,
+            identifiers=identifiers,
+        )
+        ap_live.set_initialized()
+        controller._players = {"up_old": universal, "sonos_1": native, "ap_live": ap_live}
+
+        controller._add_protocol_link(universal, ap_live, "airplay")
+        assert [link.output_protocol_id for link in universal.linked_output_protocols] == [
+            "ap_live"
+        ]
+        scheduled_tasks.clear()
+
+        with patch.object(controller, "unregister", new=AsyncMock()) as mock_unregister:
+            controller._add_protocol_link(native, ap_live, "airplay")
+            # replay whatever the eviction scheduled, so a missing unregister is what makes
+            # the assertion below hold and not a task that never got the chance to run
+            for task in scheduled_tasks:
+                await task
+
+        assert ap_live.protocol_parent_id == "sonos_1"
+        assert universal.linked_output_protocols == []
+        assert universal._protocol_player_ids == []
+        assert "up_old" in controller._players
+        # removing the emptied wrapper is left to the flow that owns the takeover
+        assert mock_unregister.call_args_list == []
+
+    async def test_wrapper_listing_the_native_id_as_its_protocol_completes_the_takeover(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A wrapper that lists the native player's own id is still fully replaced.
+
+        A device that keeps its player id across a PROTOCOL -> PLAYER type change stays
+        one of the wrapper's linked protocols. It cannot be taken over from itself, so it
+        is left out of the transfer: the wrapper's genuine protocol moves to the native
+        player, the user's configuration is carried over and the emptied wrapper is
+        permanently removed.
+        """
+        controller = PlayerController(mock_mass)
+        config_store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "esp_client": {"enabled": True, "provider": "sendspin--test", "values": {}},
+                "up_old": {
+                    "enabled": True,
+                    "provider": "universal_player",
+                    "name": "Living Room",
+                    "default_name": "ESP (Universal)",
+                    "values": {"hide_in_ui": True},
+                },
+                "ap_live": {
+                    "enabled": True,
+                    "provider": "airplay--test",
+                    "player_type": "protocol",
+                    "values": {CONF_PROTOCOL_PARENT_ID: "up_old"},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, config_store)
+
+        scheduled_tasks: list[Awaitable[object]] = []
+
+        def capture_task(task: Awaitable[object], *_args: Any, **_kwargs: Any) -> None:
+            scheduled_tasks.append(task)
+
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        # keep the state refreshes below from scheduling an unrelated palette fetch
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        mock_mass.call_later = MagicMock()
+        mock_mass.loop = MagicMock()
+        mock_mass.create_task = MagicMock(side_effect=capture_task)
+        mock_mass.config.get_player_config = AsyncMock(
+            return_value=PlayerConfig.parse(
+                [],
+                {
+                    "player_id": "esp_client",
+                    "provider": "sendspin--test",
+                    "name": "Living Room",
+                    "default_name": "ESP",
+                },
+            )
+        )
+
+        identifiers = {IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"}
+        universal = _create_universal_player(
+            mock_mass,
+            "up_old",
+            "ESP (Universal)",
+            ["ap_live", "esp_client"],
+            identifiers=identifiers,
+        )
+        native = MockPlayer(
+            MockProvider("sendspin", mass=mock_mass), "esp_client", "ESP", identifiers=identifiers
+        )
+        native.set_initialized()
+        ap_live = MockPlayer(
+            MockProvider("airplay", mass=mock_mass),
+            "ap_live",
+            "AirPlay",
+            player_type=PlayerType.PROTOCOL,
+            identifiers=identifiers,
+        )
+        ap_live.set_initialized()
+        controller._players = {"up_old": universal, "esp_client": native, "ap_live": ap_live}
+
+        controller._add_protocol_link(universal, ap_live, "airplay")
+        # the wrapper linked the device as a protocol before it changed type
+        universal.set_linked_output_protocols(
+            [
+                *universal.linked_output_protocols,
+                LinkedOutputProtocol(
+                    output_protocol_id="esp_client", protocol_domain="sendspin", priority=20
+                ),
+            ]
+        )
+        scheduled_tasks.clear()
+
+        with patch.object(controller, "unregister", new=AsyncMock()) as mock_unregister:
+            controller._check_replace_universal_player(native)
+            # replay what the takeover scheduled, otherwise the unregister assertion below
+            # would hold for a task that never got the chance to run
+            for task in scheduled_tasks:
+                await task
+
+        # the genuine protocol moved over and the wrapper is left without any output
+        assert ap_live.protocol_parent_id == "esp_client"
+        assert universal.linked_output_protocols == []
+        assert universal._protocol_player_ids == []
+        # the emptied wrapper is permanently removed in favour of the native player
+        mock_unregister.assert_awaited_once_with(
+            "up_old", permanent=True, replacement_player_id="esp_client"
+        )
+        # and the user's configuration is carried over before that removal deletes it
+        assert config_store[CONF_PLAYERS]["esp_client"]["name"] == "Living Room"
+        assert config_store[CONF_PLAYERS]["esp_client"]["values"]["hide_in_ui"] is True
+        # the native player is never left pointing at the wrapper it replaces
+        assert native.protocol_parent_id is None
+
+    async def test_wrapper_holding_only_the_native_id_completes_the_takeover(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A wrapper whose only protocol is the native player itself is cleaned up.
+
+        Leaving the native player out of the transfer empties the wrapper without
+        anything to hand over, which still carries the user's configuration across
+        and removes the wrapper next to the player that replaces it.
+        """
+        controller = PlayerController(mock_mass)
+        config_store: dict[str, Any] = {
+            CONF_PLAYERS: {
+                "esp_client": {"enabled": True, "provider": "sendspin--test", "values": {}},
+                "up_old": {
+                    "enabled": True,
+                    "provider": "universal_player",
+                    "name": "Living Room",
+                    "default_name": "ESP (Universal)",
+                    "values": {"hide_in_ui": True},
+                },
+            }
+        }
+        _wire_nested_config(mock_mass, config_store)
+
+        scheduled_tasks: list[Awaitable[object]] = []
+
+        def capture_task(task: Awaitable[object], *_args: Any, **_kwargs: Any) -> None:
+            scheduled_tasks.append(task)
+
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        mock_mass.call_later = MagicMock()
+        mock_mass.loop = MagicMock()
+        mock_mass.create_task = MagicMock(side_effect=capture_task)
+        mock_mass.config.get_player_config = AsyncMock(
+            return_value=PlayerConfig.parse(
+                [],
+                {
+                    "player_id": "esp_client",
+                    "provider": "sendspin--test",
+                    "name": "Living Room",
+                    "default_name": "ESP",
+                },
+            )
+        )
+
+        universal = _create_universal_player(mock_mass, "up_old", "ESP (Universal)", ["esp_client"])
+        universal.set_linked_output_protocols(
+            [
+                LinkedOutputProtocol(
+                    output_protocol_id="esp_client", protocol_domain="sendspin", priority=20
+                )
+            ]
+        )
+        native = MockPlayer(MockProvider("sendspin", mass=mock_mass), "esp_client", "ESP")
+        native.set_initialized()
+        controller._players = {"up_old": universal, "esp_client": native}
+
+        with patch.object(controller, "unregister", new=AsyncMock()) as mock_unregister:
+            controller._check_replace_universal_player(native)
+            for task in scheduled_tasks:
+                await task
+
+        assert universal.linked_output_protocols == []
+        assert universal._protocol_player_ids == []
+        mock_unregister.assert_awaited_once_with(
+            "up_old", permanent=True, replacement_player_id="esp_client"
+        )
+        assert config_store[CONF_PLAYERS]["esp_client"]["name"] == "Living Room"
+        assert config_store[CONF_PLAYERS]["esp_client"]["values"]["hide_in_ui"] is True
+        assert native.protocol_parent_id is None
+
 
 class TestEndToEndDuplicateProtocol:
     """


### PR DESCRIPTION
# What does this implement/fix?

When a speaker changes from being one of a universal player's outputs into a regular player of its own (it keeps the same player id), the universal player still lists that speaker as one of its outputs. The replacement then tried to hand the speaker over to itself, which was treated as a refusal and stopped the replacement halfway.

The result was a leftover, unusable universal player: its outputs had already moved to the speaker, but the empty universal player stayed behind in the UI and the user's settings (custom name, hidden, etc.) were never carried over to the speaker.

Leaving the replacing speaker out of the transfer lets the replacement finish as intended.

**Related issue (if applicable):**

- follow-up to #5801

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Skip the replacing speaker itself when moving a universal player's outputs across, so the replacement no longer aborts.
- The universal player's settings are now carried over and the leftover empty player is removed.
- The speaker is no longer left pointing back at the universal player it replaced, in memory or in its stored settings.
- Added tests for these cases, plus a guard test covering why removing an emptied universal player is deliberately left to the flow that owns the takeover.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
