### PR TITLE
Include search-only providers in cross-provider matching

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -121,7 +121,7 @@ from music_assistant.helpers.tags import split_artists
 from music_assistant.helpers.uri import parse_uri
 from music_assistant.helpers.util import parse_optional_bool, parse_title_and_version
 from music_assistant.models.core_controller import CoreController
-from music_assistant.models.music_provider import MusicProvider
+from music_assistant.models.music_provider import LIBRARY_FEATURE_BY_MEDIA_TYPE, MusicProvider
 from music_assistant.models.plugin import PluginProvider
 
 if TYPE_CHECKING:
@@ -2265,21 +2265,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         """Return whether the provider declares LIBRARY support for the given media type."""
         if provider.type != ProviderType.MUSIC:
             return False
-        if media_type == MediaType.ARTIST:
-            return provider.supports_feature(ProviderFeature.LIBRARY_ARTISTS)
-        if media_type == MediaType.ALBUM:
-            return provider.supports_feature(ProviderFeature.LIBRARY_ALBUMS)
-        if media_type == MediaType.TRACK:
-            return provider.supports_feature(ProviderFeature.LIBRARY_TRACKS)
-        if media_type == MediaType.PLAYLIST:
-            return provider.supports_feature(ProviderFeature.LIBRARY_PLAYLISTS)
-        if media_type == MediaType.RADIO:
-            return provider.supports_feature(ProviderFeature.LIBRARY_RADIOS)
-        if media_type == MediaType.AUDIOBOOK:
-            return provider.supports_feature(ProviderFeature.LIBRARY_AUDIOBOOKS)
-        if media_type == MediaType.PODCAST:
-            return provider.supports_feature(ProviderFeature.LIBRARY_PODCASTS)
-        return False
+        if (feature := LIBRARY_FEATURE_BY_MEDIA_TYPE.get(media_type)) is None:
+            return False
+        return provider.supports_feature(feature)
 
     def library_edit_supported(self, provider: Provider, media_type: MediaType) -> bool:
         """Return whether the provider supports library add/remove for the given media type."""

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -471,7 +471,7 @@ class AlbumsController(MediaControllerBase[Album]):
             provider = self.mass.get_provider(provider_id)
             if not provider or not isinstance(provider, MusicProvider):
                 continue
-            if not self.mass.music.library_supported(provider, MediaType.ALBUM):
+            if MediaType.ALBUM not in provider.supported_media_types:
                 continue
             # TODO: filter by artists in db for non-streaming providers
             search_query = streaming_search_query if provider.is_streaming_provider else album.name
@@ -552,7 +552,7 @@ class AlbumsController(MediaControllerBase[Album]):
                 continue
             if ProviderFeature.SEARCH not in provider.supported_features:
                 continue
-            if not self.mass.music.library_supported(provider, MediaType.ALBUM):
+            if MediaType.ALBUM not in provider.supported_media_types:
                 continue
             if not provider.is_streaming_provider:
                 # matching on unique providers is pointless as they push (all) their content to MA

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -1004,7 +1004,7 @@ class ArtistsController(MediaControllerBase[Artist]):
                 continue
             if ProviderFeature.SEARCH not in provider.supported_features:
                 continue
-            if not self.mass.music.library_supported(provider, MediaType.ARTIST):
+            if MediaType.ARTIST not in provider.supported_media_types:
                 continue
             if not provider.is_streaming_provider:
                 # matching on unique providers is pointless as they push (all) their content to MA

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -293,7 +293,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             provider = self.mass.get_provider(provider_id)
             if not isinstance(provider, MusicProvider):
                 continue
-            if not self.mass.music.library_supported(provider, MediaType.AUDIOBOOK):
+            if MediaType.AUDIOBOOK not in provider.supported_media_types:
                 continue
             result.extend(
                 prov_item
@@ -359,7 +359,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
                 continue
             if ProviderFeature.SEARCH not in provider.supported_features:
                 continue
-            if not self.mass.music.library_supported(provider, MediaType.AUDIOBOOK):
+            if MediaType.AUDIOBOOK not in provider.supported_media_types:
                 continue
             if not provider.is_streaming_provider:
                 # matching on unique providers is pointless as they push (all) their content to MA

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -624,11 +624,12 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             )
         if not (prov := self.mass.get_provider(provider_instance_id_or_domain)):
             return []
+        if prov.type != ProviderType.MUSIC:
+            return []
         prov = cast("MusicProvider", prov)
         if ProviderFeature.SEARCH not in prov.supported_features:
             return []
-        if not self.mass.music.library_supported(prov, self.media_type):
-            # assume library supported also means that this mediatype is supported
+        if self.media_type not in prov.supported_media_types:
             return []
         searchresult = await prov.search(
             search_query,

--- a/music_assistant/controllers/music/media/podcasts.py
+++ b/music_assistant/controllers/music/media/podcasts.py
@@ -192,7 +192,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
             provider = self.mass.get_provider(provider_id)
             if not isinstance(provider, MusicProvider):
                 continue
-            if not self.mass.music.library_supported(provider, MediaType.PODCAST):
+            if MediaType.PODCAST not in provider.supported_media_types:
                 continue
             result.extend(
                 prov_item
@@ -257,7 +257,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
                 continue
             if ProviderFeature.SEARCH not in provider.supported_features:
                 continue
-            if not self.mass.music.library_supported(provider, MediaType.PODCAST):
+            if MediaType.PODCAST not in provider.supported_media_types:
                 continue
             if not provider.is_streaming_provider:
                 # matching on unique providers is pointless as they push (all) their content to MA

--- a/music_assistant/controllers/music/media/radio.py
+++ b/music_assistant/controllers/music/media/radio.py
@@ -250,7 +250,7 @@ class RadioController(MediaControllerBase[Radio]):
                 continue
             if ProviderFeature.SEARCH not in provider.supported_features:
                 continue
-            if not self.mass.music.library_supported(provider, MediaType.RADIO):
+            if MediaType.RADIO not in provider.supported_media_types:
                 continue
             if not provider.is_streaming_provider:
                 # matching on unique providers is pointless as they push (all) their content to MA

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -375,7 +375,7 @@ class TracksController(MediaControllerBase[Track]):
             provider = self.mass.get_provider(provider_id)
             if not isinstance(provider, MusicProvider):
                 continue
-            if not self.mass.music.library_supported(provider, MediaType.TRACK):
+            if MediaType.TRACK not in provider.supported_media_types:
                 continue
             result.extend(
                 prov_item
@@ -683,7 +683,7 @@ class TracksController(MediaControllerBase[Track]):
                 continue
             if ProviderFeature.SEARCH not in provider.supported_features:
                 continue
-            if not self.mass.music.library_supported(provider, MediaType.TRACK):
+            if MediaType.TRACK not in provider.supported_media_types:
                 continue
             if not provider.is_streaming_provider:
                 # matching on unique providers is pointless as they push (all) their content to MA

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2966,7 +2966,7 @@ class StreamsAudio:
             and provider.is_streaming_provider
             and ProviderFeature.SEARCH in provider.supported_features
             and provider.domain not in known_domains
-            and self.mass.music.library_supported(provider, MediaType.TRACK)
+            and MediaType.TRACK in provider.supported_media_types
         )
 
     def _has_alternative_match_providers(self, media_item: Track) -> bool:

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -72,6 +72,16 @@ DEFAULT_MAX_CONCURRENT_STREAMS: Final[int] = 5
 MAX_LOGGED_SYNC_FAILURES: Final[int] = 25
 MAX_SYNC_ERROR_DETAIL: Final[int] = 200
 
+LIBRARY_FEATURE_BY_MEDIA_TYPE: Final[dict[MediaType, ProviderFeature]] = {
+    MediaType.ARTIST: ProviderFeature.LIBRARY_ARTISTS,
+    MediaType.ALBUM: ProviderFeature.LIBRARY_ALBUMS,
+    MediaType.TRACK: ProviderFeature.LIBRARY_TRACKS,
+    MediaType.PLAYLIST: ProviderFeature.LIBRARY_PLAYLISTS,
+    MediaType.RADIO: ProviderFeature.LIBRARY_RADIOS,
+    MediaType.AUDIOBOOK: ProviderFeature.LIBRARY_AUDIOBOOKS,
+    MediaType.PODCAST: ProviderFeature.LIBRARY_PODCASTS,
+}
+
 
 @dataclass
 class SyncRunState:
@@ -223,6 +233,22 @@ class MusicProvider(Provider):
         Setting this to False will query all instances of this provider for search and lookups.
         """
         return True
+
+    @property
+    def supported_media_types(self) -> set[MediaType]:
+        """
+        Return the media types this provider can serve.
+
+        Defaults to the media types the provider declares library support for.
+        Override for providers that can serve (search/stream) media types they
+        cannot list as library items, so they are eligible for search-based
+        lookups such as cross-provider matching and versions.
+        """
+        return {
+            media_type
+            for media_type, feature in LIBRARY_FEATURE_BY_MEDIA_TYPE.items()
+            if feature in self.supported_features
+        }
 
     @property
     def unskippable_sync_errors(self) -> tuple[type[Exception], ...]:

--- a/music_assistant/providers/_demo_music_provider/__init__.py
+++ b/music_assistant/providers/_demo_music_provider/__init__.py
@@ -200,6 +200,19 @@ class MyDemoMusicprovider(MusicProvider):
         # For streaming providers return True here but for local file based providers return False.
         return True
 
+    @property
+    def supported_media_types(self) -> set[MediaType]:
+        """
+        Return the media types this provider can serve.
+
+        Defaults to the media types the provider declares library support for.
+        Override for providers that can serve (search/stream) media types they
+        cannot list as library items, so they are eligible for search-based
+        lookups such as cross-provider matching and versions.
+        """
+        # OPTIONAL - the default (derived from the LIBRARY_* features) is usually correct.
+        return super().supported_media_types
+
     async def search(  # type: ignore[empty-body]
         self,
         search_query: str,

--- a/music_assistant/providers/internet_archive/provider.py
+++ b/music_assistant/providers/internet_archive/provider.py
@@ -85,6 +85,18 @@ class InternetArchiveProvider(MusicProvider):
         """Return True if provider is a streaming provider."""
         return True
 
+    @property
+    def supported_media_types(self) -> set[MediaType]:
+        """Return the media types this provider can serve."""
+        # catalogue access is search/browse only, there are no library items at all
+        return {
+            MediaType.ARTIST,
+            MediaType.ALBUM,
+            MediaType.TRACK,
+            MediaType.AUDIOBOOK,
+            MediaType.PODCAST,
+        }
+
     @throttle_with_retries
     async def _get_json(self, url: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         """Make a GET request and return JSON response with throttling."""

--- a/music_assistant/providers/musicme/provider.py
+++ b/music_assistant/providers/musicme/provider.py
@@ -75,6 +75,12 @@ class MusicMeProvider(MusicProvider):
     http_session: aiohttp.ClientSession
     throttler: ThrottlerManager
 
+    @property
+    def supported_media_types(self) -> set[MediaType]:
+        """Return the media types this provider can serve."""
+        # full catalogue access via search/browse, but only playlists as library items
+        return {MediaType.ARTIST, MediaType.ALBUM, MediaType.TRACK, MediaType.PLAYLIST}
+
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
         return (CONF_ENTRY_UNOFFICIAL_PROVIDER,)

--- a/music_assistant/providers/nicovideo/provider_mixins/core.py
+++ b/music_assistant/providers/nicovideo/provider_mixins/core.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import Any, override
 
+from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import LoginFailed
 
 from music_assistant.providers.nicovideo.config import NicovideoConfig
@@ -48,6 +49,13 @@ class NicovideoMusicProviderCoreMixin(NicovideoMusicProviderMixinBase):
         """Return True if the provider is a streaming provider."""
         # For streaming providers return True here but for local file based providers return False.
         return True
+
+    @property
+    @override
+    def supported_media_types(self) -> set[MediaType]:
+        """Return the media types this provider can serve."""
+        # tracks and albums are served through search, but cannot be listed as library items
+        return {MediaType.ARTIST, MediaType.ALBUM, MediaType.TRACK, MediaType.PLAYLIST}
 
     @override
     async def handle_async_init_for_mixin(self) -> None:

--- a/music_assistant/providers/phishin/provider.py
+++ b/music_assistant/providers/phishin/provider.py
@@ -66,6 +66,12 @@ class PhishInProvider(MusicProvider):
         """Return True if the provider is a streaming provider."""
         return True
 
+    @property
+    def supported_media_types(self) -> set[MediaType]:
+        """Return the media types this provider can serve."""
+        # full catalogue access via search/browse, but only the artist as library item
+        return {MediaType.ARTIST, MediaType.ALBUM, MediaType.TRACK, MediaType.PLAYLIST}
+
     async def search(
         self,
         search_query: str,

--- a/tests/controllers/metadata/test_album_reconciliation.py
+++ b/tests/controllers/metadata/test_album_reconciliation.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import aiohttp
 import pytest
-from music_assistant_models.enums import AlbumType, ProviderFeature
+from music_assistant_models.enums import AlbumType, MediaType, ProviderFeature
 from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
 from music_assistant_models.helpers import set_global_cache_values
 from music_assistant_models.media_items import (
@@ -591,6 +591,7 @@ async def test_reconcile_duplicate_albums_merges_conflicting_mapping_via_safe_pa
     provider.domain = "spotify"
     provider.instance_id = "spotify_1"
     provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.ALBUM}
     provider.is_streaming_provider = True
 
     search_result = Album(
@@ -612,7 +613,6 @@ async def test_reconcile_duplicate_albums_merges_conflicting_mapping_via_safe_pa
     with (
         patch.object(mass.music.albums, "search", AsyncMock(return_value=[search_result])),
         patch.object(mass.music.albums, "get_provider_item", AsyncMock(return_value=search_result)),
-        patch.object(mass.music, "library_supported", Mock(return_value=True)),
         patch.object(type(mass.music), "providers", new_callable=PropertyMock) as providers_mock,
     ):
         providers_mock.return_value = [provider]

--- a/tests/controllers/streams/test_stream_capacity_provider_match.py
+++ b/tests/controllers/streams/test_stream_capacity_provider_match.py
@@ -86,6 +86,7 @@ def _music_provider(instance: str, has_slot: bool = True) -> MagicMock:
     provider.is_streaming_provider = True
     provider.has_available_stream_slot = has_slot
     provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
     provider.get_stream_details = AsyncMock(return_value=_streamdetails(instance))
     return provider
 
@@ -98,7 +99,6 @@ def _mass(providers: dict[str, MagicMock]) -> MagicMock:
     mass.player_queues.queue_data_or_none.return_value = None
     mass.streams.get_config_value.return_value = -17
     mass.music.providers = list(providers.values())
-    mass.music.library_supported.return_value = True
     mass.music.tracks.match_provider = AsyncMock(return_value=[])
     mass.music.tracks.add_provider_mappings = AsyncMock()
 
@@ -146,6 +146,36 @@ async def test_saturated_single_mapping_is_rescued_by_a_cross_provider_match(
     assert mass.music.tracks.match_provider.await_args.kwargs["strict"] is True
     # a non-library track keeps the mapping in memory only
     mass.music.tracks.add_provider_mappings.assert_not_awaited()
+
+
+async def test_a_provider_without_track_support_is_never_searched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Matching only consults providers that declare support for tracks."""
+    queue_item = _queue_item(_mapping(BUSY_INSTANCE, quality=ContentType.FLAC))
+    queue_item.streamdetails = _streamdetails(BUSY_INSTANCE)
+    radio_only = _music_provider("radioprov--1")
+    radio_only.supported_media_types = {MediaType.RADIO}
+    providers = {
+        BUSY_INSTANCE: _music_provider(BUSY_INSTANCE, has_slot=False),
+        "radioprov--1": radio_only,
+        MATCH_INSTANCE: _music_provider(MATCH_INSTANCE),
+    }
+    mass = _mass(providers)
+    mass.music.tracks.match_provider = AsyncMock(
+        return_value=[_mapping(MATCH_INSTANCE, item_id=MATCHED_ITEM_ID)]
+    )
+    audio = StreamsAudio(mass)
+    expected_buffer = MagicMock(spec=AudioBuffer)
+    get_buffer = AsyncMock(side_effect=[_limit_error(BUSY_INSTANCE), expected_buffer])
+    monkeypatch.setattr(AudioBuffer, "get_buffer", get_buffer)
+
+    result = await audio.get_audio_buffer(queue_item, reason="streaming", capacity_wait_timeout=1)
+
+    assert result is expected_buffer
+    # the radio-only provider is skipped; the track-capable provider gets the search
+    mass.music.tracks.match_provider.assert_awaited_once()
+    assert mass.music.tracks.match_provider.await_args.args[1] is providers[MATCH_INSTANCE]
 
 
 async def test_a_matchless_search_falls_back_to_the_blocking_wait(

--- a/tests/models/test_music_provider.py
+++ b/tests/models/test_music_provider.py
@@ -1,4 +1,4 @@
-"""Tests for MusicProvider source-stream capacity."""
+"""Tests for the MusicProvider base model."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
-from music_assistant_models.enums import ProviderType
+from music_assistant_models.enums import MediaType, ProviderFeature, ProviderType
 
 from music_assistant.models.music_provider import (
     DEFAULT_MAX_CONCURRENT_STREAMS,
@@ -38,7 +38,9 @@ class _SingleStreamProvider(MusicProvider):
         return 1
 
 
-def _make_provider[ProviderT: MusicProvider](provider_cls: type[ProviderT]) -> ProviderT:
+def _make_provider[ProviderT: MusicProvider](
+    provider_cls: type[ProviderT], supported_features: set[ProviderFeature] | None = None
+) -> ProviderT:
     """Construct a minimal MusicProvider instance."""
     mass = MagicMock()
     manifest = MagicMock()
@@ -49,7 +51,21 @@ def _make_provider[ProviderT: MusicProvider](provider_cls: type[ProviderT]) -> P
     config.name = "Test Provider"
     config.instance_id = "test_provider--1"
     config.get_value.return_value = "GLOBAL"
-    return provider_cls(mass, manifest, config)
+    return provider_cls(mass, manifest, config, supported_features)
+
+
+def test_supported_media_types_default_follows_library_features() -> None:
+    """Without an override, media type support is derived from the library features."""
+    provider = _make_provider(
+        _StreamingProvider,
+        supported_features={
+            ProviderFeature.SEARCH,
+            ProviderFeature.LIBRARY_TRACKS,
+            ProviderFeature.LIBRARY_PLAYLISTS,
+        },
+    )
+
+    assert provider.supported_media_types == {MediaType.TRACK, MediaType.PLAYLIST}
 
 
 def test_streaming_provider_has_conservative_default() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Whether a provider supports a media type was assumed from its library-listing support. Providers that can search and stream a media type but cannot list it as library items (such as MusicMe for tracks) were therefore excluded from all cross-provider matching, even though they are perfectly good alternative sources.

Music providers now declare which media types they can serve. The default is derived from the declared `LIBRARY_*` features, so behavior is unchanged for all providers that don't override it.

- add `supported_media_types` to the music provider model
- use it in the search, versions and matching paths (including the playback-time capacity rescue), while library sync keeps checking library support
- declare the served media types for MusicMe, Phish.in, Internet Archive and Nicovideo so they can participate in matching

**Related issue (if applicable):**

- related issue N/A (surfaced by a review comment on #5807)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
