### PR TITLE
Match duplicate tracks across a spelled-out EP or single title

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -109,7 +109,13 @@ from music_assistant.controllers.tasks.context import (
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.collections import get_collection_item_media_type_from_item_id
-from music_assistant.helpers.compare import compare_strings, compare_track, compare_version
+from music_assistant.helpers.compare import (
+    ALBUM_RETAIL_SUFFIX_KEYS,
+    compare_album_name,
+    compare_strings,
+    compare_track,
+    compare_version,
+)
 from music_assistant.helpers.database import UNSET, DatabaseConnection
 from music_assistant.helpers.datetime import (
     from_utc_timestamp,
@@ -144,15 +150,41 @@ class RecentPlayedTrack(NamedTuple):
     artists: list[ItemMapping]
 
 
+def _album_title_match(base: str, other: str) -> str:
+    """
+    Return a query part relating two album rows that may name the same album.
+
+    :param base: Alias of the album row the match is expressed against.
+    :param other: Alias of the album row related to it.
+    """
+    # a provider that spells out the retail suffix stores the album under the plain name
+    # plus that suffix, so the pair is related from either side. The raw title decides which
+    # side spelled it out, so an ordinary title that merely ends in those letters ("Step") is
+    # left alone; any dash style qualifies, only the space in front counts. This relates more
+    # titles than the album comparison accepts, which is what confirms the pair afterwards.
+    matches = [f"{other}.search_name = {base}.search_name"]
+    for suffix in ALBUM_RETAIL_SUFFIX_KEYS:
+        matches.append(
+            f"(rtrim({other}.name) LIKE '% {suffix}' "
+            f"AND {other}.search_name = {base}.search_name || '{suffix}')"
+        )
+        matches.append(
+            f"(rtrim({base}.name) LIKE '% {suffix}' AND {other}.search_name = "
+            f"substr({base}.search_name, 1, length({base}.search_name) - {len(suffix)}))"
+        )
+    return " OR ".join(matches)
+
+
 # Selects pairs of library track rows that are likely the same recording held twice,
 # once per music provider. Both rows must carry the same normalized title, share a track
 # artist and sit within a few seconds of each other. The album term is the decisive one:
-# both rows must appear at the same position on an album with the same normalized title,
-# so the merge always rests on two providers agreeing on where the track belongs rather
-# than on title and duration alone. Titles that normalize to nothing (symbol-only album
-# names) are excluded there, as they would match every other such album. Rows that already
-# share a provider are skipped, as a provider listing the same recording twice is a
-# separate (and far riskier) case.
+# both rows must appear at the same position on an album with the same title, so the merge
+# always rests on two providers agreeing on where the track belongs rather than on title and
+# duration alone. Titles are related loosely enough to see past a spelled-out retail suffix,
+# leaving the identity for the album comparison the pair is then held to. Titles that
+# normalize to nothing (symbol-only album names) are excluded there, as they would match
+# every other such album. Rows that already share a provider are skipped, as a provider
+# listing the same recording twice is a separate (and far riskier) case.
 _DUPLICATE_TRACK_CANDIDATES_QUERY = f"""
 SELECT t1.item_id AS item_id_1, t2.item_id AS item_id_2
 FROM {DB_TABLE_TRACKS} t1
@@ -172,9 +204,12 @@ WHERE (t1.item_id > :cursor_item_id_1
     JOIN {DB_TABLE_ALBUMS} al1 ON al1.item_id = at1.album_id
     JOIN {DB_TABLE_ALBUM_TRACKS} at2 ON at2.track_id = t2.item_id
     JOIN {DB_TABLE_ALBUMS} al2
-      ON al2.item_id = at2.album_id AND al2.search_name = al1.search_name
+      ON al2.item_id = at2.album_id AND ({_album_title_match("al1", "al2")})
     WHERE at1.track_id = t1.item_id
+      -- a title that is nothing but the suffix strips to nothing, which would relate it to
+      -- every symbol-only album, so neither side may normalize away
       AND al1.search_name != ''
+      AND al2.search_name != ''
       -- an unreported position is stored as 0, so two of those agree on nothing;
       -- a missing disc number does read as disc 1, the way compare_track takes it
       -- for local files that carry no disc tag
@@ -190,19 +225,21 @@ WHERE (t1.item_id > :cursor_item_id_1
 ORDER BY t1.item_id, t2.item_id
 """
 
-# Returns the edition of every album appearance that made the two tracks a candidate, so the
-# pair can be held to agreeing on the edition and not just on the album title. The album terms
-# mirror the candidate query exactly: an appearance the pair does not share a position on says
-# nothing about the edition of the one it does.
+# Returns the title and edition of every album appearance that made the two tracks a
+# candidate, so the pair can be held to agreeing on both. The album terms mirror the candidate
+# query exactly: an appearance the pair does not share a position on says nothing about the
+# album of the one it does.
 _SHARED_ALBUM_EDITIONS_QUERY = f"""
-SELECT al1.version AS version_1, al2.version AS version_2
+SELECT al1.name AS name_1, al2.name AS name_2,
+       al1.version AS version_1, al2.version AS version_2
 FROM {DB_TABLE_ALBUM_TRACKS} at1
 JOIN {DB_TABLE_ALBUMS} al1 ON al1.item_id = at1.album_id
 JOIN {DB_TABLE_ALBUM_TRACKS} at2 ON at2.track_id = :item_id_2
 JOIN {DB_TABLE_ALBUMS} al2
-  ON al2.item_id = at2.album_id AND al2.search_name = al1.search_name
+  ON al2.item_id = at2.album_id AND ({_album_title_match("al1", "al2")})
 WHERE at1.track_id = :item_id_1
   AND al1.search_name != ''
+  AND al2.search_name != ''
   AND at1.track_number > 0
   AND coalesce(nullif(at1.disc_number, 0), 1) = coalesce(nullif(at2.disc_number, 0), 1)
   AND at1.track_number = at2.track_number
@@ -2834,14 +2871,19 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param item_id_1: Library ID of the first track.
         :param item_id_2: Library ID of the second track.
         """
-        # the candidate query can only compare album titles, and an edition is held apart
-        # from the title: without this an original and its remaster or deluxe edition look
-        # like the same album whenever neither track carries a version of its own
+        # the query relates titles loosely so a spelled-out retail suffix cannot hide a
+        # shared album, which leaves the identity for the album comparison to confirm. An
+        # edition is held apart from the title: without that an original and its remaster or
+        # deluxe edition look like the same album whenever neither track carries a version
         rows = await self.database.get_rows_from_query(
             _SHARED_ALBUM_EDITIONS_QUERY,
             {"item_id_1": item_id_1, "item_id_2": item_id_2},
         )
-        return any(compare_version(row["version_1"], row["version_2"]) for row in rows)
+        return any(
+            compare_album_name(row["name_1"], row["name_2"])
+            and compare_version(row["version_1"], row["version_2"])
+            for row in rows
+        )
 
     async def _merge_duplicate_track_pair(self, item_id_1: int, item_id_2: int) -> bool:
         """
@@ -2853,9 +2895,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         """
         track_1 = await self.tracks.get_library_item(item_id_1)
         track_2 = await self.tracks.get_library_item(item_id_2)
-        # the candidate query already established that both rows sit at the same position on
-        # an equally titled album, which is the album agreement strict mode looks for, so the
-        # remaining check is run in non-strict mode. Its version check is reinstated here
+        # the checks below establish that both rows sit at the same position on an equally
+        # titled album, which is the album agreement strict mode looks for, so the remaining
+        # check is run in non-strict mode. Its version check is reinstated here
         # explicitly: without it a remaster, remix or radio edit of equal length would be
         # accepted as the original.
         if not compare_version(track_1.version, track_2.version):

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -435,6 +435,86 @@ async def test_requires_agreement_on_the_album(mass: MusicAssistant) -> None:
     assert await mass.music.tracks.get_library_item(track_2.item_id)
 
 
+@pytest.mark.parametrize("suffix", ["EP", "Single"])
+@pytest.mark.parametrize("suffix_on_second", [False, True])
+async def test_merges_across_a_spelled_out_retail_suffix(
+    mass: MusicAssistant, suffix: str, suffix_on_second: bool
+) -> None:
+    """A provider that appends the format to an EP or single title still names the same album."""
+    specs = [_TrackSpec(), _TrackSpec("qobuz_instance")]
+    index = 1 if suffix_on_second else 0
+    specs[index] = specs[index]._replace(album_name=f"{specs[index].album_name} - {suffix}")
+    track_1, track_2 = await _build_duplicate_pair(mass, *specs)
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    surviving = await mass.music.tracks.get_library_item(track_1.item_id)
+    assert {mapping.provider_domain for mapping in surviving.provider_mappings} == {
+        "spotify",
+        "qobuz",
+    }
+    with pytest.raises(MediaNotFoundError):
+        await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_keeps_an_ep_apart_from_the_single_of_the_same_name(mass: MusicAssistant) -> None:
+    """Two titles that each name their format and disagree are different releases."""
+    track_1, track_2 = await _build_duplicate_pair(
+        mass,
+        _TrackSpec(album_name="Shared Album - EP"),
+        _TrackSpec("qobuz_instance", album_name="Shared Album - Single"),
+    )
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+@pytest.mark.parametrize("suffix_on_second", [False, True])
+async def test_a_suffix_without_a_dash_is_left_to_the_album_comparison(
+    mass: MusicAssistant, suffix_on_second: bool
+) -> None:
+    """The query relates titles the album comparison still refuses to call the same album."""
+    specs = [_TrackSpec(), _TrackSpec("qobuz_instance")]
+    index = 1 if suffix_on_second else 0
+    specs[index] = specs[index]._replace(album_name=f"{specs[index].album_name} EP")
+    track_1, track_2 = await _build_duplicate_pair(mass, *specs)
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_a_title_merely_ending_in_a_suffix_word_is_left_alone(
+    mass: MusicAssistant,
+) -> None:
+    """Only a spelled-out suffix relates two titles, not a word that happens to end in one."""
+    track_1, track_2 = await _build_duplicate_pair(
+        mass, _TrackSpec(album_name="Sle"), _TrackSpec("qobuz_instance", album_name="Sleep")
+    )
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
+async def test_keeps_albums_that_differ_only_by_a_symbol_apart(mass: MusicAssistant) -> None:
+    """Album titles that normalize alike are still held to the album comparison."""
+    track_1, track_2 = await _build_duplicate_pair(
+        mass,
+        _TrackSpec(album_name="Shared Album"),
+        _TrackSpec("qobuz_instance", album_name="Shared Album +"),
+    )
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    assert await mass.music.tracks.get_library_item(track_1.item_id)
+    assert await mass.music.tracks.get_library_item(track_2.item_id)
+
+
 async def test_requires_agreement_on_the_album_position(mass: MusicAssistant) -> None:
     """Tracks at a different position on the same album are not treated as duplicates."""
     track_1, track_2 = await _build_duplicate_pair(


### PR DESCRIPTION
# What does this implement/fix?

Some providers spell out the format in an album title — Apple Music stores an EP as "Stargazing - EP" rather than "Stargazing". The duplicate track lookup paired the two tracks' albums on the stored normalized title, which keeps that suffix, so the same track held on both a suffixed and a plain copy of the album was never recognised as a duplicate. #5809 closed this gap for the album reconciliation guard; this does the same for tracks, reusing the suffix keys that PR introduced.

The looser lookup on its own would be weaker evidence than an exact title match, so the pair is now also held to `compare_album_name()` before it can merge.

**Related issue (if applicable):**

- follow-up to #5809, on the queries added in #5792

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Both duplicate-track queries relate album titles through a shared `_album_title_match()` helper that sees past a spelled-out `- EP` / `- Single`, mirroring the guard in the metadata controller.
- The album agreement check now confirms the title with `compare_album_name()` as well as the edition, so the looser lookup cannot vouch for an identity the comparison rejects — including an EP against the single of the same name.
- Album titles that normalize to nothing are excluded from both sides, not just one.
- Regression tests for both suffixes from either side, plus the cases that must stay apart.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
