### PR TITLE
Match an EP or single title however the service writes the format

### DIFF
--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -42,7 +42,10 @@ from music_assistant.controllers.tasks.context import (
     update_current_task_progress_text,
 )
 from music_assistant.helpers.api import api_command
-from music_assistant.helpers.compare import ALBUM_RETAIL_SUFFIX_KEYS
+from music_assistant.helpers.compare import (
+    ALBUM_RETAIL_SUFFIX_KEYS,
+    album_retail_suffix_sql_match,
+)
 from music_assistant.helpers.images import cleanup_thumb_cache
 from music_assistant.helpers.lyrics import extract_lrc_lyrics, normalize_lrc_lyrics
 from music_assistant.helpers.throttle_retry import Throttler
@@ -622,16 +625,18 @@ def _duplicate_album_sibling_guard() -> str:
     # a provider that spells out the retail suffix stores the album under the plain name
     # plus that suffix, so the pair is related from either side. The raw title decides
     # which side spelled it out, so an ordinary title that merely ends in those letters
-    # ("Step") is left alone; any dash style qualifies, only the space in front counts.
+    # ("Step") is left alone.
     # Every alternative stays an equality on dup.search_name, keeping the name index in use.
     own_name = f"{DB_TABLE_ALBUMS}.search_name"
     matches_name = [f"dup.search_name = {own_name}"]
     for suffix in ALBUM_RETAIL_SUFFIX_KEYS:
         matches_name.append(
-            f"(rtrim(dup.name) LIKE '% {suffix}' AND dup.search_name = {own_name} || '{suffix}')"
+            f"({album_retail_suffix_sql_match('dup.name', suffix)} "
+            f"AND dup.search_name = {own_name} || '{suffix}')"
         )
         matches_name.append(
-            f"(rtrim({DB_TABLE_ALBUMS}.name) LIKE '% {suffix}' AND dup.search_name = "
+            f"({album_retail_suffix_sql_match(f'{DB_TABLE_ALBUMS}.name', suffix)} "
+            f"AND dup.search_name = "
             f"substr({own_name}, 1, length({own_name}) - {len(suffix)}))"
         )
     same_name = " OR ".join(matches_name)

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -112,6 +112,7 @@ from music_assistant.helpers.api import api_command
 from music_assistant.helpers.collections import get_collection_item_media_type_from_item_id
 from music_assistant.helpers.compare import (
     ALBUM_RETAIL_SUFFIX_KEYS,
+    album_retail_suffix_sql_match,
     compare_album_name,
     compare_strings,
     compare_track,
@@ -161,16 +162,17 @@ def _album_title_match(base: str, other: str) -> str:
     # a provider that spells out the retail suffix stores the album under the plain name
     # plus that suffix, so the pair is related from either side. The raw title decides which
     # side spelled it out, so an ordinary title that merely ends in those letters ("Step") is
-    # left alone; any dash style qualifies, only the space in front counts. This relates more
-    # titles than the album comparison accepts, which is what confirms the pair afterwards.
+    # left alone. This relates more titles than the album comparison accepts, which is what
+    # confirms the pair afterwards.
     matches = [f"{other}.search_name = {base}.search_name"]
     for suffix in ALBUM_RETAIL_SUFFIX_KEYS:
         matches.append(
-            f"(rtrim({other}.name) LIKE '% {suffix}' "
+            f"({album_retail_suffix_sql_match(f'{other}.name', suffix)} "
             f"AND {other}.search_name = {base}.search_name || '{suffix}')"
         )
         matches.append(
-            f"(rtrim({base}.name) LIKE '% {suffix}' AND {other}.search_name = "
+            f"({album_retail_suffix_sql_match(f'{base}.name', suffix)} "
+            f"AND {other}.search_name = "
             f"substr({base}.search_name, 1, length({base}.search_name) - {len(suffix)}))"
         )
     return " OR ".join(matches)

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -68,9 +68,14 @@ _RECORDING_CONFLICT_VERSION_TOKENS = {
 
 # retail suffixes a provider (notably Apple Music) appends to an EP/single title
 _ALBUM_RETAIL_SUFFIXES: Final = ("EP", "Single")
-# the trailing retail suffix (any dash style) as it appears in a raw album title
+# the trailing retail suffix as it appears in a raw album title: set off by a dash
+# (any style, the space after it is optional) or wrapped in brackets. A bare trailing
+# word is deliberately not accepted, as it is just as likely part of the title itself
+# ("The SL2 EP", "Saturday Night Single")
 _ALBUM_SUFFIX_PATTERN = re.compile(
-    rf"\s+[-\u2013\u2014]\s+(?P<suffix>{'|'.join(_ALBUM_RETAIL_SUFFIXES)})\s*$", re.IGNORECASE
+    rf"\s+[-\u2013\u2014]\s*(?P<suffix>{'|'.join(_ALBUM_RETAIL_SUFFIXES)})\s*$"
+    rf"|\s*[(\[](?P<bracketed>{'|'.join(_ALBUM_RETAIL_SUFFIXES)})[)\]]\s*$",
+    re.IGNORECASE,
 )
 # normalizing a title drops the separator, so the suffix survives as a plain trailing
 # fragment of the name key ("Foo - EP" -> "fooep"): appending one of these to a key
@@ -793,7 +798,9 @@ def _normalize_version_tokens(value: str) -> tuple[str, ...]:
 def _album_retail_suffix(name: str) -> str:
     """Return the retail suffix an album title spells out, or an empty string."""
     match = _ALBUM_SUFFIX_PATTERN.search(name)
-    return match.group("suffix").casefold() if match else ""
+    if not match:
+        return ""
+    return (match.group("suffix") or match.group("bracketed")).casefold()
 
 
 def _is_dynamic_radio(item: Radio | ItemMapping) -> bool:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -69,8 +69,9 @@ _RECORDING_CONFLICT_VERSION_TOKENS = {
 # retail suffixes a provider (notably Apple Music) appends to an EP/single title
 _ALBUM_RETAIL_SUFFIXES: Final = ("EP", "Single")
 # the trailing retail suffix as it appears in a raw album title: set off by a dash
-# (any style, the space after it is optional) or wrapped in brackets. A bare trailing
-# word is deliberately not accepted, as it is just as likely part of the title itself
+# (any style, and only the space in front of it counts, so "K-EP" keeps its name) or
+# wrapped in brackets, which need no space to be unambiguous. A bare trailing word is
+# deliberately not accepted, as it is just as likely part of the title itself
 # ("The SL2 EP", "Saturday Night Single")
 _ALBUM_SUFFIX_PATTERN = re.compile(
     rf"\s+[-\u2013\u2014]\s*(?P<suffix>{'|'.join(_ALBUM_RETAIL_SUFFIXES)})\s*$"
@@ -770,6 +771,19 @@ def strip_album_retail_suffix(name: str) -> str:
     # the suffix carries no identity information: Apple Music appends it to EP/single
     # titles while already setting album_type
     return _ALBUM_SUFFIX_PATTERN.sub("", name)
+
+
+def album_retail_suffix_sql_match(name_column: str, suffix_key: str) -> str:
+    """
+    Return a SQL condition that holds when a raw album title spells out a retail suffix.
+
+    :param name_column: SQL expression yielding the raw album title.
+    :param suffix_key: One of :data:`ALBUM_RETAIL_SUFFIX_KEYS`.
+    """
+    # any non-alphanumeric in front of the word sets it off, so an ordinary title that
+    # merely ends in those letters ("Step", "Singles") is left alone. Trailing brackets are
+    # trimmed first, which lets one condition cover every separator a provider may use
+    return f"upper(rtrim({name_column}, ' )]')) GLOB '*[^A-Z0-9]{suffix_key.upper()}'"
 
 
 def compare_explicit(base: MediaItemMetadata, compare: MediaItemMetadata) -> bool | None:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -782,7 +782,9 @@ def album_retail_suffix_sql_match(name_column: str, suffix_key: str) -> str:
     """
     # any non-alphanumeric in front of the word sets it off, so an ordinary title that
     # merely ends in those letters ("Step", "Singles") is left alone. Trailing brackets are
-    # trimmed first, which lets one condition cover every separator a provider may use
+    # trimmed first, which lets one condition cover every separator a provider may use.
+    # Deliberately looser than the pattern above, as this only selects the pairs the album
+    # comparison is then held to
     return f"upper(rtrim({name_column}, ' )]')) GLOB '*[^A-Z0-9]{suffix_key.upper()}'"
 
 

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
 from music_assistant_models.enums import ExternalID
 from music_assistant_models.errors import MediaNotFoundError, RetriesExhausted
 from music_assistant_models.media_items import (
@@ -839,11 +840,16 @@ async def test_insert_match_looks_up_the_retail_suffix_spellings() -> None:
     expected = ["stargazing", "stargazingep", "stargazingsingle"]
     with _insert_harness(candidates=[]) as harness:
         assert await searched_names(harness, "Stargazing") == expected
-        assert await searched_names(harness, "Stargazing - EP") == expected
+        for spelling in ("Stargazing - EP", "Stargazing -EP", "Stargazing (EP)", "Stargazing [EP]"):
+            assert await searched_names(harness, spelling) == expected, spelling
 
 
+@pytest.mark.parametrize(
+    "suffixed_name",
+    ["Stargazing - EP", "Stargazing -EP", "Stargazing (EP)", "Stargazing [EP]"],
+)
 async def test_insert_match_links_a_spelled_out_retail_suffix_to_the_plain_title(
-    mass: MusicAssistant,
+    mass: MusicAssistant, suffixed_name: str
 ) -> None:
     """An 'X - EP' from one provider joins the existing 'X' row instead of duplicating it."""
     artist = await mass.music.artists.add_item_to_library(
@@ -875,7 +881,7 @@ async def test_insert_match_links_a_spelled_out_retail_suffix_to_the_plain_title
         Album(
             item_id="suffixed",
             provider="apple_music_1",
-            name="Stargazing - EP",
+            name=suffixed_name,
             artists=UniqueList([artist]),
             provider_mappings={
                 ProviderMapping(

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -457,6 +457,28 @@ async def test_merges_across_a_spelled_out_retail_suffix(
         await mass.music.tracks.get_library_item(track_2.item_id)
 
 
+@pytest.mark.parametrize("spelling", ["-EP", "(EP)", "[EP]"])
+async def test_merges_when_providers_set_off_the_suffix_differently(
+    mass: MusicAssistant, spelling: str
+) -> None:
+    """Providers disagreeing on how the retail suffix is written still share an album."""
+    track_1, track_2 = await _build_duplicate_pair(
+        mass,
+        _TrackSpec(album_name="Shared Album - EP"),
+        _TrackSpec("qobuz_instance", album_name=f"Shared Album {spelling}"),
+    )
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    surviving = await mass.music.tracks.get_library_item(track_1.item_id)
+    assert {mapping.provider_domain for mapping in surviving.provider_mappings} == {
+        "spotify",
+        "qobuz",
+    }
+    with pytest.raises(MediaNotFoundError):
+        await mass.music.tracks.get_library_item(track_2.item_id)
+
+
 async def test_keeps_an_ep_apart_from_the_single_of_the_same_name(mass: MusicAssistant) -> None:
     """Two titles that each name their format and disagree are different releases."""
     track_1, track_2 = await _build_duplicate_pair(

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -493,6 +493,28 @@ async def test_keeps_an_ep_apart_from_the_single_of_the_same_name(mass: MusicAss
     assert await mass.music.tracks.get_library_item(track_2.item_id)
 
 
+@pytest.mark.parametrize("spelling", ["-EP", "(EP)", "[EP]"])
+@pytest.mark.parametrize("suffix_on_second", [False, True])
+async def test_merges_a_plain_title_with_any_spelled_out_suffix(
+    mass: MusicAssistant, spelling: str, suffix_on_second: bool
+) -> None:
+    """A plain title and one naming the format are the same album, however it is written."""
+    specs = [_TrackSpec(), _TrackSpec("qobuz_instance")]
+    index = 1 if suffix_on_second else 0
+    specs[index] = specs[index]._replace(album_name=f"{specs[index].album_name} {spelling}")
+    track_1, track_2 = await _build_duplicate_pair(mass, *specs)
+
+    await mass.music._reconcile_duplicate_tracks()
+
+    surviving = await mass.music.tracks.get_library_item(track_1.item_id)
+    assert {mapping.provider_domain for mapping in surviving.provider_mappings} == {
+        "spotify",
+        "qobuz",
+    }
+    with pytest.raises(MediaNotFoundError):
+        await mass.music.tracks.get_library_item(track_2.item_id)
+
+
 @pytest.mark.parametrize("suffix_on_second", [False, True])
 async def test_a_suffix_without_a_dash_is_left_to_the_album_comparison(
     mass: MusicAssistant, suffix_on_second: bool

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1,5 +1,7 @@
 """Tests for mediaitem compare helper functions."""
 
+import sqlite3
+
 import pytest
 from music_assistant_models import media_items
 from music_assistant_models.enums import ExternalID
@@ -471,6 +473,35 @@ def test_compare_album_evidence_retail_suffix_spelled_differently_matches() -> N
         assert (
             compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
         ), spelling
+
+
+def test_album_retail_suffix_sql_match_needs_the_suffix_set_off() -> None:
+    """The pre-filter condition sees every separator style, but not an ordinary title."""
+    connection = sqlite3.connect(":memory:")
+
+    def relates(name: str, suffix_key: str) -> bool:
+        condition = compare.album_retail_suffix_sql_match("?", suffix_key)
+        return bool(connection.execute(f"SELECT {condition}", (name,)).fetchone()[0])
+
+    for name in (
+        "Album A - EP",
+        "Album A -EP",
+        "Album A \u2013 EP",
+        "Album A \u2014EP",
+        "Album A (EP)",
+        "Album A [EP]",
+        "Album A - ep",
+        # a bare trailing word is related here on purpose and refused by the comparison
+        "The SL2 EP",
+    ):
+        assert relates(name, "ep"), name
+    for name in ("Step", "Sleep", "EP"):
+        assert not relates(name, "ep"), name
+
+    assert relates("Think of You - Single", "single")
+    assert relates("Brazen 'Weep' (CD1) (single)", "single")
+    for name in ("Singles", "Every Single Day"):
+        assert not relates(name, "single"), name
 
 
 def test_compare_album_evidence_bare_suffix_word_stays_part_of_the_title() -> None:

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -446,13 +446,46 @@ def test_compare_album_evidence_name_hyphenation_vs_spacing_matches() -> None:
 
 
 def test_compare_album_evidence_name_retail_suffix_stripped() -> None:
-    """An Apple-style ' - EP'/' - Single' retail suffix does not block a match."""
-    for suffix in (" - EP", " - Single", " \u2013 EP"):
+    """A retail suffix, however a provider sets it off, does not block a match."""
+    for suffix in (
+        " - EP",
+        " -EP",
+        " \u2013 EP",
+        " (EP)",
+        " [EP]",
+        " - Single",
+        " (Single)",
+    ):
         album_a = _album(name=f"Album A{suffix}")
         album_b = _album(item_id="2", provider="test2", name="Album A")
         assert (
             compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
         ), suffix
+
+
+def test_compare_album_evidence_retail_suffix_spelled_differently_matches() -> None:
+    """Two providers setting off the same retail suffix differently name the same album."""
+    for spelling in (" -EP", " \u2013 EP", " (EP)", " [EP]"):
+        album_a = _album(name="Album A - EP")
+        album_b = _album(item_id="2", provider="test2", name=f"Album A{spelling}")
+        assert (
+            compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
+        ), spelling
+
+
+def test_compare_album_evidence_bare_suffix_word_stays_part_of_the_title() -> None:
+    """A trailing suffix word that is not set off belongs to the title itself."""
+    for name in ("The SL2 EP", "Saturday Night Single"):
+        album_a = _album(name=name)
+        album_b = _album(item_id="2", provider="test2", name=name.rsplit(" ", 1)[0])
+        assert (
+            compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.NO_MATCH
+        ), name
+
+    # two providers spelling that same title identically still match
+    album_a = _album(name="The SL2 EP")
+    album_b = _album(item_id="2", provider="test2", name="The SL2 EP")
+    assert compare.compare_album_evidence(album_a, album_b) == compare.AlbumMatchEvidence.MATCH
 
 
 def test_compare_album_evidence_bordering_symbol_marks_a_different_release() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Streaming services append the format to an EP or single title, but they don't
agree on how to write it. We only recognised the spaced-dash form ("Album - EP"),
so "Album (EP)", "Album [EP]" and "Album -EP" were left untouched. Since both
titles get cleaned up before they are compared, a release written one way on one
service and another way on another service was treated as two different albums.

A trailing "EP" or "Single" with nothing setting it off is deliberately still
left alone, because plenty of albums are genuinely called that ("The SL2 EP",
"Saturday Night Single").

- Recognise a bracketed or tight-dash format suffix alongside the spaced-dash form
- Match the same spellings when looking for an album's counterpart in the library
- Added tests for the extra spellings and for titles that really end in the word

**Related issue (if applicable):**

- follow-up to #5817

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
