### PR TITLE
Harden the stream server session handling

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1658,8 +1658,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             stream_duration=stream_duration,
             source_id=queue_item.queue_id,
             queue_item_id=queue_item.queue_item_id,
+            queue_session_id=queue_data.session_id,
             custom_data={
-                "session_id": queue_data.session_id,
                 "original_uri": queue_item.uri,
             },
         )

--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -506,8 +506,7 @@ def get_media_session_id(media: PlayerMedia) -> str | None:
 
     :param media: Player media that started the stream.
     """
-    value = (media.custom_data or {}).get("session_id")
-    return value if isinstance(value, str) else None
+    return media.queue_session_id
 
 
 def get_normalization_details(

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -453,7 +453,11 @@ class StreamsController(CoreController):
                     "/single/{session_id}/{queue_id}/{queue_item_id}/{player_id}.{fmt}",
                     self.serve_queue_item_stream,
                 ),
-                ("*", "/command/{queue_id}/{command}.mp3", self.serve_command_request),
+                (
+                    "*",
+                    "/command/{session_id}/{queue_id}/{command}.mp3",
+                    self.serve_command_request,
+                ),
                 ("*", "/announcement/{player_id}.{fmt}", self.serve_announcement_stream),
                 (
                     "GET",
@@ -528,8 +532,7 @@ class StreamsController(CoreController):
         # handle raw pcm without exact format specifiers
         if output_codec.is_pcm() and ";" not in fmt:
             fmt += f";codec=pcm;rate={44100};bitrate={16};channels={2}"
-        extra_data = media.custom_data or {}
-        session_id = extra_data.get("session_id")
+        session_id = media.queue_session_id
         queue_item_id = media.queue_item_id
         if not session_id or not queue_item_id:
             raise InvalidDataError("Can not resolve stream URL: Invalid PlayerMedia data")
@@ -1171,6 +1174,10 @@ class StreamsController(CoreController):
         """Handle special 'command' request for a player."""
         self._log_request(request)
         queue_id = request.match_info["queue_id"]
+        session_id = request.match_info["session_id"]
+        queue_data = self.mass.player_queues.queue_data_or_none(queue_id)
+        if queue_data is None or queue_data.session_id != session_id:
+            raise web.HTTPNotFound(reason=f"Unknown (or invalid) session: {session_id}")
         command = request.match_info["command"]
         if command == "next":
             self.mass.create_task(self.mass.player_queues.next(queue_id))
@@ -1253,9 +1260,17 @@ class StreamsController(CoreController):
 
         return resp
 
-    def get_command_url(self, player_or_queue_id: str, command: str) -> str:
-        """Get the url for the special command stream."""
-        return f"{self.base_url}/command/{player_or_queue_id}/{command}.mp3"
+    def get_command_url(self, player_or_queue_id: str, command: str) -> str | None:
+        """
+        Get the url for the special command stream, or None if the queue is not playing.
+
+        :param player_or_queue_id: Queue to send the command to.
+        :param command: Command the url triggers when fetched.
+        """
+        queue_data = self.mass.player_queues.queue_data_or_none(player_or_queue_id)
+        if queue_data is None or (session_id := queue_data.session_id) is None:
+            return None
+        return f"{self.base_url}/command/{session_id}/{player_or_queue_id}/{command}.mp3"
 
     def get_announcement_url(
         self,
@@ -1323,10 +1338,7 @@ class StreamsController(CoreController):
             protocol_player = self.mass.players.get_player(player_id) if player_id else None
             queue_id = media.source_id
             queue = self.mass.player_queues.get(queue_id)
-            queue_session_id = cast(
-                "str | None",
-                (media.custom_data or {}).get("session_id"),
-            )
+            queue_session_id = media.queue_session_id
             crossfade_needs_flow_mode = (
                 # crossfade only applies to tracks; if the queue has it enabled but the
                 # player(protocol) does not support gapless playback, we need to enforce flow mode

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -256,6 +256,7 @@ def _media_fingerprint(fingerprint: dict[str, Any], prefix: str, media: PlayerMe
     fingerprint[f"{prefix}.duration"] = media.duration
     fingerprint[f"{prefix}.source_id"] = media.source_id
     fingerprint[f"{prefix}.queue_item_id"] = media.queue_item_id
+    fingerprint[f"{prefix}.queue_session_id"] = media.queue_session_id
     fingerprint[f"{prefix}.elapsed_time"] = media.elapsed_time
     fingerprint[f"{prefix}.elapsed_time_last_updated"] = media.elapsed_time_last_updated
     # the palette object is carried/reused as-is until the image changes,

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -382,11 +382,12 @@ class ChromecastPlayer(Player):
                     media_controller.send_message, data=queuedata, inc_session_id=True
                 )
 
-            if len(getattr(media_controller.status, "items", [])) < 2:
+            if len(getattr(media_controller.status, "items", [])) < 2 and (
+                cmd_next_url := self.mass.streams.get_command_url(self.player_id, "next")
+            ):
                 # In flow mode, all queue tracks are sent to the player as continuous stream.
                 # add a special 'command' item to the queue
                 # this allows for on-player next buttons/commands to still work
-                cmd_next_url = self.mass.streams.get_command_url(self.player_id, "next")
                 msg = {
                     "type": "QUEUE_INSERT",
                     "mediaSessionId": media_controller.status.media_session_id,

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -340,9 +340,9 @@ class UniversalGroupPlayer(Player):
                             media_type=MediaType.FLOW_STREAM,
                             title=self.display_name,
                             source_id=self.player_id,
+                            queue_session_id=self.stream.session_id,
                             custom_data={
                                 "ugp_player_id": self.player_id,
-                                "session_id": self.stream.session_id,
                             },
                         ),
                     )
@@ -395,9 +395,9 @@ class UniversalGroupPlayer(Player):
                         media_type=MediaType.FLOW_STREAM,
                         title=self.display_name,
                         source_id=self.player_id,
+                        queue_session_id=self.stream.session_id,
                         custom_data={
                             "ugp_player_id": self.player_id,
-                            "session_id": self.stream.session_id,
                         },
                     ),
                 )

--- a/tests/controllers/streams/test_command_route.py
+++ b/tests/controllers/streams/test_command_route.py
@@ -1,0 +1,96 @@
+"""Tests for the command route that lets on-player buttons drive a flow stream."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+
+if TYPE_CHECKING:
+    from music_assistant.controllers.streams.controller import StreamsController
+
+
+def _queue_data(session_id: str | None) -> MagicMock:
+    """Return a queue record carrying the given playback session."""
+    queue_data = MagicMock()
+    queue_data.session_id = session_id
+    return queue_data
+
+
+def _request(session_id: str, queue_id: str = "queue-1", command: str = "next") -> MagicMock:
+    """Return a request for the command route."""
+    request = MagicMock()
+    request.method = "GET"
+    request.headers = {}
+    request.match_info = {
+        "session_id": session_id,
+        "queue_id": queue_id,
+        "command": command,
+    }
+    return request
+
+
+def test_command_url_is_bound_to_the_playback_session(
+    streams_controller: StreamsController,
+) -> None:
+    """The url carries the session, so it stops working once playback moves on."""
+    streams_controller.mass.player_queues = MagicMock()
+    streams_controller.mass.player_queues.queue_data_or_none.return_value = _queue_data("session-1")
+    url = streams_controller.get_command_url("queue-1", "next")
+    assert url is not None
+    assert url.endswith("/command/session-1/queue-1/next.mp3")
+
+
+@pytest.mark.parametrize(
+    ("queue_data", "reason"),
+    [(None, "unknown queue"), (_queue_data(None), "queue not playing")],
+)
+def test_command_url_is_absent_without_a_session(
+    streams_controller: StreamsController, queue_data: MagicMock | None, reason: str
+) -> None:
+    """Without an active session there is no url to hand to a player."""
+    streams_controller.mass.player_queues = MagicMock()
+    streams_controller.mass.player_queues.queue_data_or_none.return_value = queue_data
+    assert streams_controller.get_command_url("queue-1", "next") is None, reason
+
+
+async def test_command_request_advances_the_queue(
+    streams_controller: StreamsController, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A request carrying the current session skips to the next item."""
+    streams_controller.mass.player_queues = MagicMock()
+    streams_controller.mass.player_queues.queue_data_or_none.return_value = _queue_data("session-1")
+    create_task = MagicMock()
+    monkeypatch.setattr(streams_controller.mass, "create_task", create_task)
+    resp = await streams_controller.serve_command_request(_request("session-1"))
+    assert isinstance(resp, web.FileResponse)
+    create_task.assert_called_once()
+
+
+@pytest.mark.parametrize("session_id", ["session-2", ""])
+async def test_command_request_refuses_a_foreign_session(
+    streams_controller: StreamsController, session_id: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A caller that does not hold the current session cannot drive the queue."""
+    streams_controller.mass.player_queues = MagicMock()
+    streams_controller.mass.player_queues.queue_data_or_none.return_value = _queue_data("session-1")
+    create_task = MagicMock()
+    monkeypatch.setattr(streams_controller.mass, "create_task", create_task)
+    with pytest.raises(web.HTTPNotFound):
+        await streams_controller.serve_command_request(_request(session_id))
+    create_task.assert_not_called()
+
+
+async def test_command_request_refuses_an_unknown_queue(
+    streams_controller: StreamsController, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unregistered queue is refused rather than raising out of the handler."""
+    streams_controller.mass.player_queues = MagicMock()
+    streams_controller.mass.player_queues.queue_data_or_none.return_value = None
+    create_task = MagicMock()
+    monkeypatch.setattr(streams_controller.mass, "create_task", create_task)
+    with pytest.raises(web.HTTPNotFound):
+        await streams_controller.serve_command_request(_request("session-1"))
+    create_task.assert_not_called()

--- a/tests/controllers/streams/test_live_source_codec.py
+++ b/tests/controllers/streams/test_live_source_codec.py
@@ -48,7 +48,7 @@ def _media(media_type: MediaType) -> PlayerMedia:
         media_type=media_type,
         source_id="queue-1",
         queue_item_id="item-1",
-        custom_data={"session_id": "session-1"},
+        queue_session_id="session-1",
     )
 
 

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -130,7 +130,7 @@ def test_output_plan_is_registered_for_all_snapcast_members() -> None:
     provider.stream_audio_format = DEFAULT_SNAPCAST_FORMAT
     stream = _make_stream(provider)
     stream.media.source_id = "queue-1"
-    stream.media.custom_data = {"session_id": "session-1"}
+    stream.media.queue_session_id = "session-1"
     stream.snap_stream = MagicMock(identifier="stream-1")
     group = MagicMock(
         stream="stream-1",

--- a/tests/providers/universal_group/test_universal_group.py
+++ b/tests/providers/universal_group/test_universal_group.py
@@ -183,14 +183,14 @@ class TestPowerlessLifecycle:
                 MagicMock(
                     uri="track://x",
                     source_id="src",
-                    custom_data={"session_id": "session-1"},
+                    queue_session_id="session-1",
                 )
             )
 
         assert ugp.stream is not None
         assert mass.players._handle_play_media.await_count == 2
         for call in mass.players._handle_play_media.await_args_list:
-            assert call.args[1].custom_data["session_id"] == "session-1"
+            assert call.args[1].queue_session_id == "session-1"
         # power command was NOT used to capture the members
         mass.players.cmd_power.assert_not_awaited()
 


### PR DESCRIPTION
# What does this implement/fix?

The queue session id that builds and validates stream URLs was carried in
`PlayerMedia.custom_data`, which is serialized to API clients. It is server-internal
bookkeeping, so it now travels in a field that stays out of the payload.

The command route (used by Chromecast so the on-device next button works during a flow
stream) accepted any caller that knew a queue id. It now requires the queue's current
playback session, like the other stream routes already do.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

---

Needs models https://github.com/music-assistant/models/pull/366 released first (adds the `queue_session_id` field); kept as draft until then.
