### PR TITLE
Cover the universal player handover with a regression test

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1776,9 +1776,11 @@ class ProtocolLinkingMixin:
                 return
             parent = self.get_player(parent_id)
             if parent is not None and parent.provider.domain == "universal_player":
-                # drop only the active edge and leave the rest to the link evaluation,
-                # which replaces the wrapper with this player: a leftover edge makes it
-                # hand the player over to itself, which it refuses, abandoning the swap
+                # release only this player's own edge: dropping the rest belongs to the
+                # takeover that replaces the wrapper with it. The generic unlink below
+                # would instead unregister the wrapper it empties, and that removal lands
+                # before the takeover, stranding the user's settings on a player on its
+                # way out
                 self._remove_protocol_link(parent, existing.player_id)
                 return
             existing.set_protocol_parent_id(parent_id)

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -1575,6 +1575,9 @@ class TestRegisterOrUpdateTypeTransition:
     ) -> None:
         """A universal parent hands its config to the player that replaces it."""
         controller = self._prepare(mock_mass)
+        # tasks start eagerly, so a removal scheduled while the player is released runs
+        # before the handover does and would take the wrapper out from under it
+        use_real_create_task(mock_mass)
         provider = MockProvider("sendspin", instance_id="sendspin", mass=mock_mass)
         universal_provider = MockProvider(
             "universal_player", instance_id="universal_player", mass=mock_mass
@@ -1593,18 +1596,26 @@ class TestRegisterOrUpdateTypeTransition:
         )
         migrated: list[tuple[str, str]] = []
 
-        with patch.object(
-            controller,
-            "_migrate_universal_player_config",
-            side_effect=lambda old, new: migrated.append((old, new)),
+        with (
+            patch.object(
+                controller,
+                "_migrate_universal_player_config",
+                side_effect=lambda old, new: migrated.append((old, new)),
+            ),
+            patch.object(controller, "unregister", wraps=controller.unregister) as mock_unregister,
         ):
             child._attr_type = PlayerType.PLAYER
             await controller.register_or_update(child)
 
-        # a leftover active link makes the wrapper refuse the handover to the player it
-        # is being replaced by, stranding the user's settings on a player on its way out
+        # the wrapper is on its way out, so the user's settings have to move to the
+        # player that replaces it, which is left standalone rather than a child of it
         assert migrated == [("universal_1", "child")]
         assert child.protocol_parent_id is None
+        # an earlier removal never gets that far: it leaves the wrapper's config behind
+        # and the handover no longer finds the wrapper to carry anything over
+        mock_unregister.assert_awaited_once_with(
+            "universal_1", permanent=True, replacement_player_id="child"
+        )
 
     async def test_player_to_protocol_detaches_its_children(self, mock_mass: MagicMock) -> None:
         """A player that becomes a protocol child releases the protocols it owned."""


### PR DESCRIPTION
# What does this implement/fix?

When a speaker stops being one of a universal player's outputs and becomes a
regular player, it first has to be released from that universal player. Since
#5814 the handover that follows cleans up after itself, which makes that release
step look like it can go.

It cannot: without it the release path takes the emptied universal player out
straight away, and that lands before the handover runs, so the user's settings
(custom name, hidden, group memberships) are never carried over. Nothing in the
test suite noticed, because the tests replace the task scheduler with a mock and
the real one starts tasks immediately.

**Related issue (if applicable):**

- follow-up to #5814

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- The existing handover test now runs with the real task scheduler, so dropping
  the release step fails the suite instead of passing unnoticed.
- Updated the comments around it to state why the step is still needed.

No behaviour change.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
