### PR TITLE
Refresh stale dependency bump PRs after every dev push

### DIFF
--- a/.github/workflows/auto-merge-dependency-updates.yml
+++ b/.github/workflows/auto-merge-dependency-updates.yml
@@ -11,9 +11,6 @@ on:
   push:
     branches:
       - dev
-    paths:
-      - pyproject.toml
-      - requirements_all.txt
   # Manual escape hatch to drain a stranded bump PR without a human merge commit
   workflow_dispatch:
 


### PR DESCRIPTION
# What does this implement/fix?

Dependency bump PRs get stranded at "behind" and never auto-merge. `dev` requires branches to be up to date, so any commit landing on `dev` makes an open bump PR out of date. The workflow that re-cuts those PRs only listened to pushes that touched `pyproject.toml` or `requirements_all.txt`, so an ordinary commit stranded the PR with no way back except a manual `workflow_dispatch`.

PRs #5827 and #5826 are both stuck this way: all checks green, approved, auto-merge enabled, blocked only on being one commit behind `dev`.

Dropping the `paths` filter makes every `dev` push re-check open bump PRs. `discover-stale` already skips PRs that are up to date or carry more than a version pin, so the extra runs are cheap.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
