### PR TITLE
Test single titles the same way as EP titles

### DIFF
--- a/tests/controllers/metadata/test_album_reconciliation.py
+++ b/tests/controllers/metadata/test_album_reconciliation.py
@@ -29,6 +29,18 @@ from music_assistant.mass import MusicAssistant
 
 _REPORT_FAILURE = "music_assistant.controllers.metadata.controller.report_current_task_failure"
 _CONTROLLER_TIME = "music_assistant.controllers.metadata.controller.time"
+# every way a provider may spell out the retail suffix on one and the same album
+_RETAIL_SUFFIX_NAMES = [
+    "Stargazing - EP",
+    "Stargazing -EP",
+    "Stargazing (EP)",
+    "Stargazing [EP]",
+    "Stargazing - Single",
+    "Stargazing -Single",
+    "Stargazing (Single)",
+    "Stargazing [Single]",
+    "Stargazing (single)",
+]
 
 
 def _controller() -> MetaDataController:
@@ -286,10 +298,11 @@ async def test_reconcile_duplicate_albums_selects_symbol_only_titles_spelled_the
     assert await _reconciled_ids(mass) == {first.item_id, second.item_id}
 
 
+@pytest.mark.parametrize("suffixed_name", _RETAIL_SUFFIX_NAMES)
 async def test_reconcile_duplicate_albums_selects_spelled_out_retail_suffix_sibling(
-    mass: MusicAssistant,
+    mass: MusicAssistant, suffixed_name: str
 ) -> None:
-    """A leftover 'X - EP' row is paired with its plain-title sibling, which now stores it."""
+    """A leftover row naming the format is paired with its plain-title sibling, which stores it."""
     artist = await mass.music.artists.add_item_to_library(
         Artist(
             item_id="0",
@@ -305,7 +318,7 @@ async def test_reconcile_duplicate_albums_selects_spelled_out_retail_suffix_sibl
     plain = await _add_album(mass, "Stargazing", artist, provider_instance="spotify_1")
     suffixed = await _add_album(
         mass,
-        "Stargazing - EP",
+        suffixed_name,
         artist,
         album_type=AlbumType.SINGLE,
         provider_instance="apple_music_1",

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -36,6 +36,18 @@ THIRD_BARCODE = "093624912514"
 BASE_MAPPING = ProviderMapping(
     item_id="base-prov", provider_domain="tidal", provider_instance="tidal_1"
 )
+# every way a provider may spell out the retail suffix on one and the same album
+RETAIL_SUFFIX_NAMES = [
+    "Stargazing - EP",
+    "Stargazing -EP",
+    "Stargazing (EP)",
+    "Stargazing [EP]",
+    "Stargazing - Single",
+    "Stargazing -Single",
+    "Stargazing (Single)",
+    "Stargazing [Single]",
+    "Stargazing (single)",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -840,14 +852,11 @@ async def test_insert_match_looks_up_the_retail_suffix_spellings() -> None:
     expected = ["stargazing", "stargazingep", "stargazingsingle"]
     with _insert_harness(candidates=[]) as harness:
         assert await searched_names(harness, "Stargazing") == expected
-        for spelling in ("Stargazing - EP", "Stargazing -EP", "Stargazing (EP)", "Stargazing [EP]"):
+        for spelling in RETAIL_SUFFIX_NAMES:
             assert await searched_names(harness, spelling) == expected, spelling
 
 
-@pytest.mark.parametrize(
-    "suffixed_name",
-    ["Stargazing - EP", "Stargazing -EP", "Stargazing (EP)", "Stargazing [EP]"],
-)
+@pytest.mark.parametrize("suffixed_name", RETAIL_SUFFIX_NAMES)
 async def test_insert_match_links_a_spelled_out_retail_suffix_to_the_plain_title(
     mass: MusicAssistant, suffixed_name: str
 ) -> None:

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -860,7 +860,7 @@ async def test_insert_match_looks_up_the_retail_suffix_spellings() -> None:
 async def test_insert_match_links_a_spelled_out_retail_suffix_to_the_plain_title(
     mass: MusicAssistant, suffixed_name: str
 ) -> None:
-    """An 'X - EP' from one provider joins the existing 'X' row instead of duplicating it."""
+    """A title naming the format joins the existing plain-title row instead of duplicating it."""
     artist = await mass.music.artists.add_item_to_library(
         Artist(
             item_id="0",

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -32,7 +32,7 @@ _DUPLICATE_NAME = "Shared Track Title"
 _REPORT_FAILURE = "music_assistant.controllers.music.controller.report_current_task_failure"
 # every way a provider may set off a retail suffix, next to the plain dashed spelling
 # another provider uses for the same format
-_RETAIL_SUFFIX_SPELLINGS = [
+_RETAIL_SUFFIX_SPELLING_PAIRS = [
     ("EP", "-EP"),
     ("EP", "(EP)"),
     ("EP", "[EP]"),
@@ -468,7 +468,7 @@ async def test_merges_across_a_spelled_out_retail_suffix(
         await mass.music.tracks.get_library_item(track_2.item_id)
 
 
-@pytest.mark.parametrize(("suffix", "spelling"), _RETAIL_SUFFIX_SPELLINGS)
+@pytest.mark.parametrize(("suffix", "spelling"), _RETAIL_SUFFIX_SPELLING_PAIRS)
 async def test_merges_when_providers_set_off_the_suffix_differently(
     mass: MusicAssistant, suffix: str, spelling: str
 ) -> None:
@@ -504,7 +504,7 @@ async def test_keeps_an_ep_apart_from_the_single_of_the_same_name(mass: MusicAss
     assert await mass.music.tracks.get_library_item(track_2.item_id)
 
 
-@pytest.mark.parametrize("spelling", [spelling for _, spelling in _RETAIL_SUFFIX_SPELLINGS])
+@pytest.mark.parametrize("spelling", [spelling for _, spelling in _RETAIL_SUFFIX_SPELLING_PAIRS])
 @pytest.mark.parametrize("suffix_on_second", [False, True])
 async def test_merges_a_plain_title_with_any_spelled_out_suffix(
     mass: MusicAssistant, spelling: str, suffix_on_second: bool

--- a/tests/controllers/music/test_track_reconciliation.py
+++ b/tests/controllers/music/test_track_reconciliation.py
@@ -30,6 +30,17 @@ from music_assistant.mass import MusicAssistant
 
 _DUPLICATE_NAME = "Shared Track Title"
 _REPORT_FAILURE = "music_assistant.controllers.music.controller.report_current_task_failure"
+# every way a provider may set off a retail suffix, next to the plain dashed spelling
+# another provider uses for the same format
+_RETAIL_SUFFIX_SPELLINGS = [
+    ("EP", "-EP"),
+    ("EP", "(EP)"),
+    ("EP", "[EP]"),
+    ("Single", "-Single"),
+    ("Single", "(Single)"),
+    ("Single", "[Single]"),
+    ("Single", "(single)"),
+]
 
 
 class _TrackSpec(NamedTuple):
@@ -457,14 +468,14 @@ async def test_merges_across_a_spelled_out_retail_suffix(
         await mass.music.tracks.get_library_item(track_2.item_id)
 
 
-@pytest.mark.parametrize("spelling", ["-EP", "(EP)", "[EP]"])
+@pytest.mark.parametrize(("suffix", "spelling"), _RETAIL_SUFFIX_SPELLINGS)
 async def test_merges_when_providers_set_off_the_suffix_differently(
-    mass: MusicAssistant, spelling: str
+    mass: MusicAssistant, suffix: str, spelling: str
 ) -> None:
     """Providers disagreeing on how the retail suffix is written still share an album."""
     track_1, track_2 = await _build_duplicate_pair(
         mass,
-        _TrackSpec(album_name="Shared Album - EP"),
+        _TrackSpec(album_name=f"Shared Album - {suffix}"),
         _TrackSpec("qobuz_instance", album_name=f"Shared Album {spelling}"),
     )
 
@@ -493,7 +504,7 @@ async def test_keeps_an_ep_apart_from_the_single_of_the_same_name(mass: MusicAss
     assert await mass.music.tracks.get_library_item(track_2.item_id)
 
 
-@pytest.mark.parametrize("spelling", ["-EP", "(EP)", "[EP]"])
+@pytest.mark.parametrize("spelling", [spelling for _, spelling in _RETAIL_SUFFIX_SPELLINGS])
 @pytest.mark.parametrize("suffix_on_second", [False, True])
 async def test_merges_a_plain_title_with_any_spelled_out_suffix(
     mass: MusicAssistant, spelling: str, suffix_on_second: bool


### PR DESCRIPTION
# What does this implement/fix?

The tests added in #5818 for the new EP/single suffix spellings only ever used the "EP" wording, so the "Single" side of the same code went untested — including the lowercase, bracketed form that was the only spelling actually seen in the reporter's library ("... (single)" from a local file library).

This extends those tests to the single spellings. Tests only, no behaviour change.

**Related issue (if applicable):**

- follow-up to #5818

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Cover `-Single`, `(Single)`, `[Single]` and lowercase `(single)` next to the existing EP spellings in the duplicate-track, album-insert and duplicate-album tests.
- Extend the duplicate-album test the same way — it only had the dashed `- EP` spelling and so proved nothing about the rest.
- Each new case was checked to actually pull weight: with the title matching deliberately broken (dropping the bracket trim, the case fold, or the suffix length), the new cases fail. The lowercase spelling is the only case in these files that catches a lost case fold.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
