### PR TITLE
Mark players that are private to one device

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -297,6 +297,7 @@ def _state_fingerprint(state: PlayerState) -> dict[str, Any]:
         "active_group": state.active_group,
         "enabled": state.enabled,
         "hide_in_ui": state.hide_in_ui,
+        "private": state.private,
         "expose_to_ha": state.expose_to_ha,
         "icon": state.icon,
         "group_volume": state.group_volume,
@@ -2378,6 +2379,7 @@ class Player(ABC):
         device_info = self._attr_device_info
         return {
             "type": self.type,
+            "private": self.private,
             "available": self.available,
             "name": self.name,
             "needs_setup": self.needs_setup,

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -381,6 +381,7 @@ class Player(ABC):
     _attr_needs_poll: bool = False
     _attr_poll_interval: int = 30
     _attr_hidden_by_default: bool = False
+    _attr_private: bool = False
     _attr_expose_to_ha_by_default: bool = True
     _attr_enabled_by_default: bool = True
     _attr_needs_setup: bool = False
@@ -526,6 +527,11 @@ class Player(ABC):
     def hidden_by_default(self) -> bool:
         """Return if the player should be hidden in the UI by default."""
         return self._attr_hidden_by_default
+
+    @property
+    def private(self) -> bool:
+        """Return if the player may not be offered to other clients as a target."""
+        return self._attr_private
 
     @property
     def expose_to_ha_by_default(self) -> bool:
@@ -2513,6 +2519,7 @@ class Player(ABC):
             name=self.display_name,
             enabled=self.enabled,
             hide_in_ui=self.hide_in_ui,
+            private=self.private,
             expose_to_ha=self.expose_to_ha,
             icon=self.icon,
             group_volume=self.group_volume,

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -1213,6 +1213,7 @@ class SendspinPlayer(SendspinBasePlayer):
             self._attr_device_info.add_identifier(id_type, id_value)
         self.is_web_player = False
         self._attr_hidden_by_default = False
+        self._attr_private = False
         self._attr_expose_to_ha_by_default = True
         self._attr_type = PlayerType.PROTOCOL
 
@@ -1659,6 +1660,7 @@ class SendspinPlayer(SendspinBasePlayer):
         ).is_virtual_player(self.player_id)
         self._attr_expose_to_ha_by_default = not is_standalone
         self._attr_hidden_by_default = is_standalone
+        self._attr_private = is_standalone
         # register web/app player as native player type because it doesn't need to be linked
         # every web/app player is just a standalone player.
         self._attr_type = PlayerType.PLAYER if is_standalone else PlayerType.PROTOCOL
@@ -2206,4 +2208,5 @@ class SendspinSourcePlayer(SendspinBasePlayer):
 
     _attr_type = PlayerType.UNKNOWN
     _attr_hidden_by_default = True
+    _attr_private = True
     _attr_expose_to_ha_by_default = False

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -641,6 +641,7 @@ class SendspinProvider(PlayerProvider):
         # (hidden). Restore protocol semantics so UI links it under its native peer.
         player.is_web_player = False
         player._attr_hidden_by_default = False
+        player._attr_private = False
         player._attr_expose_to_ha_by_default = True
         player._attr_type = PlayerType.PROTOCOL
         self.logger.info(

--- a/tests/models/test_player_state_updates.py
+++ b/tests/models/test_player_state_updates.py
@@ -99,6 +99,18 @@ class TestUpdateStateChangeDetection:
         state_cls.assert_called_once()
         assert player.state.volume_level == 55
 
+    def test_changed_privacy_rebuilds_state(self, player: MockPlayer) -> None:
+        """A player turning private must reach clients, which decide where to show it."""
+        player._attr_private = True
+
+        with patch.object(
+            player_module, "PlayerState", wraps=player_module.PlayerState
+        ) as state_cls:
+            player.update_state(signal_event=False)
+
+        state_cls.assert_called_once()
+        assert player.state.private is True
+
     def test_mark_state_dirty_forces_recalculation(self, player: MockPlayer) -> None:
         """mark_state_dirty recalculates even when no own input changed."""
         with patch.object(

--- a/tests/providers/sendspin/test_refresh_player.py
+++ b/tests/providers/sendspin/test_refresh_player.py
@@ -10,7 +10,11 @@ import pytest
 from music_assistant_models.enums import PlayerType
 
 import music_assistant.providers.sendspin.provider as provider_module
-from music_assistant.providers.sendspin.player import SendspinBasePlayer
+from music_assistant.providers.sendspin.player import (
+    SendspinBasePlayer,
+    SendspinSourcePlayer,
+    SendspinVisualizerPlayer,
+)
 from music_assistant.providers.sendspin.provider import SendspinProvider
 
 if TYPE_CHECKING:
@@ -132,3 +136,15 @@ def test_create_player_uses_the_capture_only_class_for_source_only_clients(
     # A device that also plays keeps the full player class.
     combo = provider._create_player("c", _client(["source@v1", "player@v1"]), None)
     assert not isinstance(cast("object", combo), _StubSourcePlayer)
+
+
+def test_player_classes_declare_their_privacy() -> None:
+    """
+    Only players owned by a single device or by the server itself are private.
+
+    Visualizers and lights are hidden by default too, but clients keep offering
+    them as group members, so they must not be marked private.
+    """
+    assert SendspinVisualizerPlayer._attr_hidden_by_default is True
+    assert SendspinVisualizerPlayer._attr_private is False
+    assert SendspinSourcePlayer._attr_private is True

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -55,6 +55,7 @@ async def test_create_virtual_player(mass: MusicAssistant) -> None:
     assert player is not None
     assert player.type == PlayerType.PLAYER
     assert player.hidden_by_default is True
+    assert player.private is True
     assert player.expose_to_ha_by_default is False
     assert PlayerFeature.VOLUME_SET not in player.supported_features
     assert PlayerFeature.VOLUME_MUTE not in player.supported_features


### PR DESCRIPTION
# What does this implement/fix?

Tells clients which players are private, so a UI can stop conflating "the user hid this speaker" with "this is somebody's phone".

Both currently arrive as `hide_in_ui`, which means a UI has to hide both everywhere. That makes a speaker you hide disappear from the group-member picker too, even though hiding is only meant to clear it out of the main listings.

The new `private` flag is set for Sendspin web/app clients, virtual anchor players and capture-only source players. Visualizers and lights are deliberately left alone: they are hidden by default for tidiness, not privacy, so clients keep offering them as group members.

No behaviour change on its own - it only adds the field.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked: https://github.com/music-assistant/models/pull/367
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: https://github.com/music-assistant/frontend/pull/2566
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
