### PR TITLE
Fix the Docker base image build (pipewire vs pulseaudio conflict)

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -244,8 +244,8 @@ RUN set -x \
         libasound2 \
         # PortAudio for local audio output (sounddevice)
         libportaudio2 \
-        # PipeWire client stack for host pipewire access in docker (local audio);
-        # the ALSA plugin itself is unpacked from pipewire-alsa below
+        # PipeWire stack (daemon + libs) required by the pipewire-alsa plugin
+        # unpacked below (host pipewire access in docker, local audio)
         pipewire \
         # Allows pulse audio devices to be detected using pactl. (local audio)
         pulseaudio-utils \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -244,8 +244,9 @@ RUN set -x \
         libasound2 \
         # PortAudio for local audio output (sounddevice)
         libportaudio2 \
-        # Allows pipewire devices to be detected when running in docker container. (local audio)
-        pipewire-alsa \
+        # PipeWire client stack for host pipewire access in docker (local audio);
+        # the ALSA plugin itself is unpacked from pipewire-alsa below
+        pipewire \
         # Allows pulse audio devices to be detected using pactl. (local audio)
         pulseaudio-utils \
         # PulseAudio daemon for MA's private audio-capture server (spotify connect soloist)
@@ -257,6 +258,18 @@ RUN set -x \
         # AirPlay receiver dependencies (shairport-sync)
         libconfig11 \
         libpopt0 \
+    # pipewire-alsa (ALSA apps -> host pipewire, needed for local audio in docker)
+    # declares Conflicts: pulseaudio because both want to own the ALSA default
+    # device, but there is no file overlap, so unpack it outside dpkg and keep
+    # the ALSA default routed to pipewire by removing pulseaudio's
+    # default-routing and autospawn snippets
+    && (cd /tmp && apt-get download pipewire-alsa) \
+    && dpkg-deb -x /tmp/pipewire-alsa_*.deb / \
+    && rm /tmp/pipewire-alsa_*.deb \
+    && rm -f \
+        /etc/alsa/conf.d/99-pulse.conf \
+        /usr/share/alsa/alsa.conf.d/pulse.conf \
+        /etc/pulse/client.conf.d/01-enable-autospawn.conf \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -f \


### PR DESCRIPTION
# What does this implement/fix?

The Docker base image fails to build since #5797: on Debian trixie the `pipewire-alsa` package (used so ALSA apps can reach a host pipewire for local audio in docker) cannot be co-installed with the `pulseaudio` daemon (needed for the Spotify Soloist audio capture server). apt aborts with a package conflict. The conflict is only about which sound server owns the ALSA `default` device — the two packages have no overlapping files.

- install `pipewire` and `pulseaudio` via apt (these do not conflict)
- unpack the small `pipewire-alsa` package directly from its .deb instead
- drop pulseaudio's ALSA default-routing and autospawn config so ALSA keeps routing to pipewire, same as before

Verified in a trixie container: the pipewire ALSA plugin loads, the ALSA default stays on PipeWire, the private pulseaudio capture server starts and loads its modules, and the apt database stays consistent.

**Related issue (if applicable):**

- related issue n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
