### PR TITLE
Keep a duplicate merge repairable when it is cut short

### DIFF
--- a/music_assistant/controllers/music/database.py
+++ b/music_assistant/controllers/music/database.py
@@ -154,6 +154,23 @@ class MusicDatabaseSetupMixin:
                 f"AND item_id not in (select item_id from {ctrl.db_table})"
             )
             await self.mass.music.database.delete_where_query(DB_TABLE_PLAYLOG, where_clause)
+        update_current_task_progress_text("Cleaning orphaned relations")
+        # A relation row can outlive the item on either of its ends: the item deletions above
+        # leave one behind, and so do the removal paths that only delete their own side of the
+        # relation. Sweep them here rather than rely on foreign keys, which sqlite has off.
+        for table, column, parent_table in (
+            (DB_TABLE_ALBUM_ARTISTS, "album_id", DB_TABLE_ALBUMS),
+            (DB_TABLE_ALBUM_ARTISTS, "artist_id", DB_TABLE_ARTISTS),
+            (DB_TABLE_ALBUM_TRACKS, "album_id", DB_TABLE_ALBUMS),
+            (DB_TABLE_ALBUM_TRACKS, "track_id", DB_TABLE_TRACKS),
+            (DB_TABLE_AUDIOBOOK_ARTISTS, "artist_id", DB_TABLE_ARTISTS),
+            (DB_TABLE_AUDIOBOOK_ARTISTS, "audiobook_id", DB_TABLE_AUDIOBOOKS),
+            (DB_TABLE_TRACK_ARTISTS, "artist_id", DB_TABLE_ARTISTS),
+            (DB_TABLE_TRACK_ARTISTS, "track_id", DB_TABLE_TRACKS),
+        ):
+            await self.database.delete_where_query(
+                table, f"{column} not in (SELECT item_id from {parent_table})"
+            )
         update_current_task_progress_text("Database cleanup finished")
         self.logger.debug("Database cleanup done")
 

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -97,6 +97,16 @@ JSON_KEYS = (
     "audiobook_artists",
 )
 
+# The columns that make up a relation row, so a merge can copy it onto the target
+# without relying on SELECT *: album_tracks carries a surrogate autoincrement id that
+# must not be copied along.
+RELATION_TABLE_COLUMNS = {
+    DB_TABLE_ALBUM_ARTISTS: ("album_id", "artist_id"),
+    DB_TABLE_ALBUM_TRACKS: ("track_id", "album_id", "disc_number", "track_number"),
+    DB_TABLE_AUDIOBOOK_ARTISTS: ("audiobook_id", "artist_id"),
+    DB_TABLE_TRACK_ARTISTS: ("track_id", "artist_id"),
+}
+
 # When set (task-local), per-item MEDIA_ITEM_ADDED/UPDATED events and the on_item_updated
 # provider write-back are suppressed, so bulk operations (provider sync, provider cleanup)
 # don't flood subscribers with one event per touched item.
@@ -2495,7 +2505,12 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             await self._merge_genre_mappings(target_id, source_id)
             await self._merge_library_item_references(target_id, source_id)
             await self._merge_library_playlog(target_id, source_id)
-            await self._merge_library_item_relations(target_id, source_id)
+            # the transfer commits in steps (see `deferred_commit`), so it is ordered to
+            # leave the source repairable wherever it is cut short: relations are copied
+            # rather than moved, and only dropped once the target holds them and the
+            # provider mappings. A source that kept its relations stays a duplicate the
+            # reconciliation pass can finish; one that lost its mappings is cleaned up.
+            await self._copy_library_item_relations(target_id, source_id)
             await self.mass.music.database.execute_write(
                 f"UPDATE {DB_TABLE_PROVIDER_MAPPINGS} SET item_id = :target_id "
                 "WHERE media_type = :media_type AND item_id = :source_id",
@@ -2505,6 +2520,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                     "media_type": self.media_type.value,
                 },
             )
+            await self._drop_library_item_relations(source_id)
             await MediaControllerBase.remove_item_from_library(self, source_id, recursive=False)
             merged_item = await self.get_library_item(target_id)
         finally:
@@ -2531,28 +2547,45 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         """Merge model state into an existing library item."""
         await self._update_library_item(item_id, update)
 
-    async def _merge_library_item_relations(self, target_id: int, source_id: int) -> None:
-        """Transfer relations that reference the merged media item."""
+    async def _copy_library_item_relations(self, target_id: int, source_id: int) -> None:
+        """Copy the relations that reference the merged media item onto the target."""
+        for table, item_column in self._library_item_relations():
+            columns = RELATION_TABLE_COLUMNS[table]
+            selected = ", ".join(
+                ":target_id" if column == item_column else column for column in columns
+            )
+            await self.mass.music.database.execute_write(
+                f"INSERT OR IGNORE INTO {table}({', '.join(columns)}) "
+                f"SELECT {selected} FROM {table} WHERE {item_column} = :source_id",
+                {"target_id": target_id, "source_id": source_id},
+            )
+
+    async def _drop_library_item_relations(self, source_id: int) -> None:
+        """Drop the relations of a merged media item once the target holds them."""
+        for table, item_column in self._library_item_relations():
+            await self.mass.music.database.delete(table, {item_column: source_id})
+
+    def _library_item_relations(self) -> tuple[tuple[str, str], ...]:
+        """Return the (table, column) pairs holding relations to this controller's items."""
         if self.media_type == MediaType.ALBUM:
-            await self._move_relation_rows(DB_TABLE_ALBUM_ARTISTS, "album_id", target_id, source_id)
-            await self._move_relation_rows(DB_TABLE_ALBUM_TRACKS, "album_id", target_id, source_id)
-        elif self.media_type == MediaType.ARTIST:
-            await self._move_relation_rows(
-                DB_TABLE_ALBUM_ARTISTS, "artist_id", target_id, source_id
+            return (
+                (DB_TABLE_ALBUM_ARTISTS, "album_id"),
+                (DB_TABLE_ALBUM_TRACKS, "album_id"),
             )
-            await self._move_relation_rows(
-                DB_TABLE_AUDIOBOOK_ARTISTS, "artist_id", target_id, source_id
+        if self.media_type == MediaType.ARTIST:
+            return (
+                (DB_TABLE_ALBUM_ARTISTS, "artist_id"),
+                (DB_TABLE_AUDIOBOOK_ARTISTS, "artist_id"),
+                (DB_TABLE_TRACK_ARTISTS, "artist_id"),
             )
-            await self._move_relation_rows(
-                DB_TABLE_TRACK_ARTISTS, "artist_id", target_id, source_id
+        if self.media_type == MediaType.AUDIOBOOK:
+            return ((DB_TABLE_AUDIOBOOK_ARTISTS, "audiobook_id"),)
+        if self.media_type == MediaType.TRACK:
+            return (
+                (DB_TABLE_ALBUM_TRACKS, "track_id"),
+                (DB_TABLE_TRACK_ARTISTS, "track_id"),
             )
-        elif self.media_type == MediaType.AUDIOBOOK:
-            await self._move_relation_rows(
-                DB_TABLE_AUDIOBOOK_ARTISTS, "audiobook_id", target_id, source_id
-            )
-        elif self.media_type == MediaType.TRACK:
-            await self._move_relation_rows(DB_TABLE_ALBUM_TRACKS, "track_id", target_id, source_id)
-            await self._move_relation_rows(DB_TABLE_TRACK_ARTISTS, "track_id", target_id, source_id)
+        return ()
 
     async def _merge_library_item_references(self, target_id: int, source_id: int) -> None:
         """Transfer references to the source item owned by specialized controllers."""
@@ -2693,15 +2726,3 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 "media_type": self.media_type.value,
             },
         )
-
-    async def _move_relation_rows(
-        self, table: str, item_column: str, target_id: int, source_id: int
-    ) -> None:
-        """Move a relation column to the target item, retaining target duplicates."""
-        values = {"target_id": target_id, "source_id": source_id}
-        await self.mass.music.database.execute_write(
-            f"UPDATE OR IGNORE {table} SET {item_column} = :target_id "
-            f"WHERE {item_column} = :source_id",
-            values,
-        )
-        await self.mass.music.database.delete(table, {item_column: source_id})

--- a/tests/controllers/music/test_library_item_merge.py
+++ b/tests/controllers/music/test_library_item_merge.py
@@ -657,6 +657,122 @@ async def test_merge_retry_does_not_double_play_count(mass: MusicAssistant) -> N
     assert merged_row["play_count"] == 5
 
 
+async def test_merge_interrupted_after_relation_transfer_leaves_source_reconcilable(
+    mass: MusicAssistant,
+) -> None:
+    """A merge cut short right after the relation transfer keeps the source row repairable."""
+    artist = await _add_artist(mass, "Shared Artist", "target_instance", "shared-artist")
+    album = await _add_album(
+        mass, "Shared Album", "target_instance", "shared-album", artist, "shared-barcode"
+    )
+    target = await _add_track(
+        mass, "Target Track", "target_instance", "target-track", artist, album
+    )
+    source = await _add_track(
+        mass, "Source Track", "source_instance", "source-track", artist, album
+    )
+
+    original = MediaControllerBase._copy_library_item_relations
+
+    async def _fail_after_relation_transfer(
+        self: MediaControllerBase[Track], target_id: int, source_id: int
+    ) -> None:
+        await original(self, target_id, source_id)
+        raise MusicAssistantError("interrupted")
+
+    with (
+        patch.object(
+            MediaControllerBase, "_copy_library_item_relations", _fail_after_relation_transfer
+        ),
+        pytest.raises(MusicAssistantError, match="interrupted"),
+    ):
+        await mass.music.tracks.merge_library_items(target.item_id, source.item_id)
+
+    # the source still owns the album and artist relations that identify it, so the
+    # duplicate reconciliation pass can still see the pair and finish the merge later
+    assert await mass.music.database.get_rows(
+        DB_TABLE_ALBUM_TRACKS, {"track_id": int(source.item_id)}
+    )
+    assert await mass.music.database.get_rows(
+        DB_TABLE_TRACK_ARTISTS, {"track_id": int(source.item_id)}
+    )
+    assert await mass.music.database.get_rows(
+        DB_TABLE_PROVIDER_MAPPINGS,
+        {"media_type": MediaType.TRACK.value, "item_id": int(source.item_id)},
+    )
+
+    await mass.music.tracks.merge_library_items(target.item_id, source.item_id)
+
+    with pytest.raises(MediaNotFoundError):
+        await mass.music.tracks.get_library_item(source.item_id)
+    assert {
+        int(row["album_id"])
+        for row in await mass.music.database.get_rows(
+            DB_TABLE_ALBUM_TRACKS, {"track_id": int(target.item_id)}
+        )
+    } == {int(album.item_id)}
+    assert not await mass.music.database.get_rows(
+        DB_TABLE_ALBUM_TRACKS, {"track_id": int(source.item_id)}
+    )
+    assert not await mass.music.database.get_rows(
+        DB_TABLE_TRACK_ARTISTS, {"track_id": int(source.item_id)}
+    )
+    assert {
+        int(row["item_id"])
+        for row in await mass.music.database.get_rows(
+            DB_TABLE_PROVIDER_MAPPINGS, {"media_type": MediaType.TRACK.value}
+        )
+    } == {int(target.item_id)}
+
+
+async def test_merge_interrupted_before_relation_drop_keeps_target_complete(
+    mass: MusicAssistant,
+) -> None:
+    """A merge cut short before the source relations are dropped leaves nothing to lose."""
+    artist = await _add_artist(mass, "Shared Artist", "target_instance", "shared-artist")
+    album = await _add_album(
+        mass, "Shared Album", "target_instance", "shared-album", artist, "shared-barcode"
+    )
+    source_album = await _add_album(
+        mass, "Source Album", "source_instance", "source-album", artist, "source-barcode"
+    )
+    target = await _add_track(
+        mass, "Target Track", "target_instance", "target-track", artist, album
+    )
+    source = await _add_track(
+        mass, "Source Track", "source_instance", "source-track", artist, source_album
+    )
+
+    with (
+        patch.object(
+            MediaControllerBase,
+            "_drop_library_item_relations",
+            AsyncMock(side_effect=MusicAssistantError("interrupted")),
+        ),
+        pytest.raises(MusicAssistantError, match="interrupted"),
+    ):
+        await mass.music.tracks.merge_library_items(target.item_id, source.item_id)
+
+    # the source has already handed over its provider mappings, so the source-less item
+    # cleanup may delete it at any time: the target must hold every relation by now
+    assert not await mass.music.database.get_rows(
+        DB_TABLE_PROVIDER_MAPPINGS,
+        {"media_type": MediaType.TRACK.value, "item_id": int(source.item_id)},
+    )
+    assert {
+        int(row["album_id"])
+        for row in await mass.music.database.get_rows(
+            DB_TABLE_ALBUM_TRACKS, {"track_id": int(target.item_id)}
+        )
+    } == {int(album.item_id), int(source_album.item_id)}
+    assert {
+        int(row["artist_id"])
+        for row in await mass.music.database.get_rows(
+            DB_TABLE_TRACK_ARTISTS, {"track_id": int(target.item_id)}
+        )
+    } == {int(artist.item_id)}
+
+
 async def _assert_album_merge_result(
     mass: MusicAssistant,
     target: Album,

--- a/tests/controllers/music/test_provider_cleanup.py
+++ b/tests/controllers/music/test_provider_cleanup.py
@@ -9,16 +9,24 @@ import pytest
 from music_assistant_models.enums import EventType, ImageType
 from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
 from music_assistant_models.media_items import (
+    Album,
     Artist,
     Audiobook,
     MediaItemImage,
     Playlist,
     Podcast,
     ProviderMapping,
+    Track,
     UniqueList,
 )
 
-from music_assistant.constants import DB_TABLE_PROVIDER_MAPPINGS
+from music_assistant.constants import (
+    DB_TABLE_ALBUM_ARTISTS,
+    DB_TABLE_ALBUM_TRACKS,
+    DB_TABLE_PROVIDER_MAPPINGS,
+    DB_TABLE_TRACK_ARTISTS,
+    DB_TABLE_TRACKS,
+)
 from music_assistant.controllers.music.media.base import MediaControllerBase
 from music_assistant.mass import MusicAssistant
 
@@ -377,3 +385,68 @@ async def test_item_without_provider_mappings_raises_media_not_found(
     with pytest.raises(MediaNotFoundError):
         async for _ in playlists.tracks(str(db_id), "library"):
             pass
+
+
+async def test_database_cleanup_removes_relations_of_deleted_items(mass: MusicAssistant) -> None:
+    """Relation rows left pointing at a deleted item are swept, sparing the ones still in use."""
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="rel-artist",
+            provider=FS_INSTANCE,
+            name="Relation Artist",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="rel-artist",
+                    provider_domain="filesystem_local",
+                    provider_instance=FS_INSTANCE,
+                )
+            },
+        )
+    )
+    album = await mass.music.albums.add_item_to_library(
+        Album(
+            item_id="rel-album",
+            provider=FS_INSTANCE,
+            name="Relation Album",
+            artists=UniqueList([artist]),
+            provider_mappings={
+                ProviderMapping(
+                    item_id="rel-album",
+                    provider_domain="filesystem_local",
+                    provider_instance=FS_INSTANCE,
+                )
+            },
+        )
+    )
+    track = await mass.music.tracks.add_item_to_library(
+        Track(
+            item_id="rel-track",
+            provider=FS_INSTANCE,
+            name="Relation Track",
+            artists=UniqueList([artist]),
+            album=album,
+            provider_mappings={
+                ProviderMapping(
+                    item_id="rel-track",
+                    provider_domain="filesystem_local",
+                    provider_instance=FS_INSTANCE,
+                )
+            },
+        )
+    )
+    track_id = int(track.item_id)
+    assert await mass.music.database.get_rows(DB_TABLE_ALBUM_TRACKS, {"track_id": track_id})
+    assert await mass.music.database.get_rows(DB_TABLE_TRACK_ARTISTS, {"track_id": track_id})
+
+    # drop the track row itself, the way a removal that only deletes its own side leaves it
+    await mass.music.database.delete(DB_TABLE_TRACKS, {"item_id": track_id})
+
+    await mass.music._cleanup_database()
+
+    assert not await mass.music.database.get_rows(DB_TABLE_ALBUM_TRACKS, {"track_id": track_id})
+    assert not await mass.music.database.get_rows(DB_TABLE_TRACK_ARTISTS, {"track_id": track_id})
+    # the album is still there with its artist, so that relation must survive
+    assert await mass.music.database.get_rows(
+        DB_TABLE_ALBUM_ARTISTS,
+        {"album_id": int(album.item_id), "artist_id": int(artist.item_id)},
+    )


### PR DESCRIPTION
# What does this implement/fix?

Merging two library items writes in steps and commits as it goes, so an interruption
(a shutdown cancelling the hourly duplicate-track pass, for example) could stop the merge
halfway. The source row then kept its provider mappings but had already lost its album and
artist links — a track that still shows up in the library with no artist and no album, opens
fine, and only fails when you try to play it. Nothing in the codebase could spot or repair
that afterwards, because every pass that looks for duplicates needs exactly those links.

The merge now copies the relations onto the target instead of moving them, and only drops the
source's copies once the target holds both them and the provider mappings. Every point the
merge can be cut short at is now one that an existing pass finishes on a later run.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Copy an item's album/artist relations onto the merge target rather than moving them,
  and drop the source's copies only after the provider mappings have moved
- Clean up relation rows whose item no longer exists during the periodic database cleanup
- Tests covering both points a merge can be interrupted at, and the new cleanup

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
