### PR TITLE
Fix AI Radio DJs reporting weather in Celcius when the country uses Fahrenheit

### DIFF
--- a/music_assistant/providers/ai_radio/constants.py
+++ b/music_assistant/providers/ai_radio/constants.py
@@ -61,6 +61,11 @@ MERGE_SECTION_PROMPT = (
 )
 DEFAULT_WEATHER_PROVIDER = "open_meteo"
 DEFAULT_WEATHER_TIMEOUT_SECONDS = 20
+
+# countries and US territories that use Fahrenheit for everyday temperatures
+FAHRENHEIT_COUNTRY_CODES = frozenset(
+    {"US", "PR", "GU", "VI", "AS", "MP", "LR", "MM", "BS", "BZ", "KY", "PW"}
+)
 DEFAULT_MAX_CONCURRENT_RUNS = 1
 MAX_FINISHED_SESSIONS = 20
 

--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -55,6 +55,7 @@ from .constants import (
     DEFAULT_WEATHER_PROVIDER,
     DEFAULT_WEATHER_TIMEOUT_SECONDS,
     DEFERRED_PLACEHOLDERS,
+    FAHRENHEIT_COUNTRY_CODES,
     SHOW_START_TIMEOUT_SECONDS,
     TTS_PRONUNCIATION_INSTRUCTIONS,
     VALID_WEB_SEARCH_MODES,
@@ -1011,6 +1012,7 @@ class AIRadioRuntimeMixin:
         timeout_seconds: int,
     ) -> tuple[str, str]:
         """Fetch weather strings from Open-Meteo for weather placeholders."""
+        use_fahrenheit = country.upper() in FAHRENHEIT_COUNTRY_CODES
         geocode_params: dict[str, str | int] = {
             "name": city,
             "count": 10,
@@ -1070,23 +1072,25 @@ class AIRadioRuntimeMixin:
                 f"Geocoding result for {city}, {country} has invalid coordinates"
             ) from err
         timezone_name = str(selected.get("timezone") or "UTC")
+        forecast_params: dict[str, str | int | float] = {
+            "latitude": lat,
+            "longitude": lon,
+            "current": "temperature_2m,apparent_temperature,weather_code",
+            "hourly": "temperature_2m,precipitation_probability,weather_code",
+            "daily": (
+                "temperature_2m_max,temperature_2m_min,precipitation_probability_max,weather_code"
+            ),
+            "forecast_days": 3,
+            "timezone": timezone_name,
+        }
+        if use_fahrenheit:
+            forecast_params["temperature_unit"] = "fahrenheit"
         forecast = await self._open_meteo_get_json(
             "https://api.open-meteo.com/v1/forecast",
-            {
-                "latitude": lat,
-                "longitude": lon,
-                "current": "temperature_2m,apparent_temperature,weather_code",
-                "hourly": "temperature_2m,precipitation_probability,weather_code",
-                "daily": (
-                    "temperature_2m_max,temperature_2m_min,"
-                    "precipitation_probability_max,weather_code"
-                ),
-                "forecast_days": 3,
-                "timezone": timezone_name,
-            },
+            forecast_params,
             timeout_seconds,
         )
-        return self._format_weather_strings(forecast)
+        return self._format_weather_strings(forecast, unit_suffix="F" if use_fahrenheit else "C")
 
     async def _open_meteo_get_json(
         self,
@@ -1111,7 +1115,9 @@ class AIRadioRuntimeMixin:
             raise MusicAssistantError("Open-Meteo response is not a JSON object")
         return data
 
-    def _format_weather_strings(self, payload: dict[str, Any]) -> tuple[str, str]:
+    def _format_weather_strings(
+        self, payload: dict[str, Any], unit_suffix: str = "C"
+    ) -> tuple[str, str]:
         """Format Open-Meteo payload into weather placeholder strings."""
         hourly = payload.get("hourly", {})
         daily = payload.get("daily", {})
@@ -1148,14 +1154,14 @@ class AIRadioRuntimeMixin:
         for index in range(start_index, min(start_index + 6, max_items)):
             ts = str(hourly_times[index]).replace("T", " ")
             hourly_parts.append(
-                f"{ts}: {self._format_number(hourly_temp[index])}C, "
+                f"{ts}: {self._format_number(hourly_temp[index])}{unit_suffix}, "
                 f"rain {self._format_number(hourly_prec[index])}%"
             )
         current_text = ""
         if current:
             current_text = (
-                f"now {self._format_number(current.get('temperature_2m'))}C "
-                f"(feels {self._format_number(current.get('apparent_temperature'))}C)"
+                f"now {self._format_number(current.get('temperature_2m'))}{unit_suffix} "
+                f"(feels {self._format_number(current.get('apparent_temperature'))}{unit_suffix})"
             )
         weather_hourly = "; ".join(([current_text] if current_text else []) + hourly_parts)
 
@@ -1175,8 +1181,8 @@ class AIRadioRuntimeMixin:
         for index in range(min(len(daily_times), len(max_t), len(min_t), len(max_prec))):
             daily_parts.append(
                 f"{daily_times[index]}: "
-                f"{self._format_number(min_t[index])}-{self._format_number(max_t[index])}C, "
-                f"rain {self._format_number(max_prec[index])}%"
+                f"{self._format_number(min_t[index])}-{self._format_number(max_t[index])}"
+                f"{unit_suffix}, rain {self._format_number(max_prec[index])}%"
             )
         weather_daily = "; ".join(daily_parts)
         return weather_hourly, weather_daily

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -412,6 +412,114 @@ def test_weather_strings_hourly_window_starts_at_the_first_upcoming_hour() -> No
     assert "2026-08-19 00:00" not in hourly
 
 
+def test_format_weather_strings_uses_the_requested_unit_suffix() -> None:
+    """The unit suffix passed in replaces the default C in every emitted string."""
+    runtime = DummyRuntime()
+    payload = {
+        "current": {
+            "time": "2026-08-10T09:00",
+            "temperature_2m": 70.0,
+            "apparent_temperature": 68.0,
+        },
+        "hourly": {
+            "time": ["2026-08-10T09:00"],
+            "temperature_2m": [70.0],
+            "precipitation_probability": [10],
+        },
+        "daily": {
+            "time": ["2026-08-10"],
+            "temperature_2m_min": [60.0],
+            "temperature_2m_max": [75.0],
+            "precipitation_probability_max": [20],
+        },
+    }
+
+    hourly, daily = runtime._format_weather_strings(payload, unit_suffix="F")
+
+    assert hourly == "now 70F (feels 68F); 2026-08-10 09:00: 70F, rain 10%"
+    assert daily == "2026-08-10: 60-75F, rain 20%"
+
+
+def _stub_open_meteo_responses(
+    calls: list[tuple[str, dict[str, Any]]],
+    country_code: str = "US",
+) -> Callable[[str, dict[str, Any], int], Awaitable[dict[str, Any]]]:
+    """Return an ``_open_meteo_get_json`` stand-in recording calls and faking both endpoints."""
+
+    async def _get_json(
+        base_url: str, params: dict[str, Any], _timeout_seconds: int
+    ) -> dict[str, Any]:
+        calls.append((base_url, params))
+        if "geocoding" in base_url:
+            return {
+                "results": [
+                    {
+                        "latitude": 40.71,
+                        "longitude": -74.01,
+                        "timezone": "America/New_York",
+                        "country": "",
+                        "country_code": country_code,
+                    }
+                ]
+            }
+        return {
+            "current": {
+                "time": "2026-08-10T09:00",
+                "temperature_2m": 70.0,
+                "apparent_temperature": 68.0,
+            },
+            "hourly": {
+                "time": ["2026-08-10T09:00"],
+                "temperature_2m": [70.0],
+                "precipitation_probability": [10],
+            },
+            "daily": {
+                "time": ["2026-08-10"],
+                "temperature_2m_min": [60.0],
+                "temperature_2m_max": [75.0],
+                "precipitation_probability_max": [20],
+            },
+        }
+
+    return _get_json
+
+
+async def test_fetch_open_meteo_weather_requests_fahrenheit_for_a_us_location() -> None:
+    """A US-configured location asks Open-Meteo for Fahrenheit and formats with an F suffix."""
+    runtime = DummyRuntime()
+    calls: list[tuple[str, dict[str, Any]]] = []
+    runtime._open_meteo_get_json = _stub_open_meteo_responses(  # type: ignore[method-assign, assignment]
+        calls
+    )
+
+    hourly, daily = await runtime._fetch_open_meteo_weather(
+        city="New York", country="US", timeout_seconds=20
+    )
+
+    forecast_params = calls[1][1]
+    assert forecast_params["temperature_unit"] == "fahrenheit"
+    assert "70F" in hourly
+    assert daily.endswith("F, rain 20%")
+
+
+async def test_fetch_open_meteo_weather_omits_temperature_unit_for_a_nl_location() -> None:
+    """A non-Fahrenheit country sends no temperature_unit param and formats with a C suffix."""
+    runtime = DummyRuntime()
+    calls: list[tuple[str, dict[str, Any]]] = []
+    runtime._open_meteo_get_json = _stub_open_meteo_responses(  # type: ignore[method-assign, assignment]
+        calls, country_code="NL"
+    )
+
+    hourly, daily = await runtime._fetch_open_meteo_weather(
+        city="Amsterdam", country="NL", timeout_seconds=20
+    )
+
+    forecast_params = calls[1][1]
+    assert "temperature_unit" not in forecast_params
+    assert "70C" in hourly
+    assert daily.endswith("C, rain 20%")
+
+
 async def test_prepare_runtime_tokens_ignores_missing_location(caplog: Any) -> None:
     """Skip weather preparation when the configured location is incomplete."""
     runtime = DummyRuntime()


### PR DESCRIPTION
# What does this implement/fix?

AI Radio weather segments always announced temperatures in Celsius: the Open-Meteo forecast request never set a temperature unit, and the placeholder formatter hardcoded the `C` suffix. Listeners in Fahrenheit countries heard Celsius values.

- Request `temperature_unit=fahrenheit` from Open-Meteo when the configured weather country uses Fahrenheit (US and its territories, Liberia, Myanmar, Bahamas, Belize, Cayman Islands, Palau)
- Label the temperatures in the weather placeholder strings with the matching `F`/`C` suffix

The unit follows the existing weather country config entry (a validated ISO code), so no new config is needed. Celsius output is unchanged for everyone else.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
