### PR TITLE
Document the pipewire-alsa workaround in the base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -262,7 +262,12 @@ RUN set -x \
     # declares Conflicts: pulseaudio because both want to own the ALSA default
     # device, but there is no file overlap, so unpack it outside dpkg and keep
     # the ALSA default routed to pipewire by removing pulseaudio's
-    # default-routing and autospawn snippets
+    # default-routing and autospawn snippets.
+    # NOTE: the unpacked package is not registered in dpkg, so package/CVE
+    # scanners will not list pipewire-alsa.
+    # This whole workaround (and the pipewire package above) exists only for
+    # the local audio provider and can be dropped once that moves to its own
+    # dedicated container, leaving a plain apt install of pulseaudio.
     && (cd /tmp && apt-get download pipewire-alsa) \
     && dpkg-deb -x /tmp/pipewire-alsa_*.deb / \
     && rm /tmp/pipewire-alsa_*.deb \


### PR DESCRIPTION
# What does this implement/fix?

Comment-only follow-up to #5834: the pipewire-alsa unpack workaround will stay in the base image for months (until the local audio provider moves to its own dedicated container), so document its lifetime and side effect directly in Dockerfile.base.

- note that the unpacked package is not registered in dpkg, so package/CVE scanners will not list pipewire-alsa
- note that the workaround (and the pipewire package) can be dropped once local audio moves out

No image rebuild needed; comments only.

**Related issue (if applicable):**

- related issue n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
