### PR TITLE
Never leave a library track without an artist

### DIFF
--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -848,7 +848,19 @@ class TracksController(MediaControllerBase[Track]):
         artists: Iterable[Artist | ItemMapping],
         overwrite: bool = False,
     ) -> None:
-        """Store Track Artists."""
+        """
+        Store Track Artists.
+
+        An empty set of artists never clears the stored rows: a track without any
+        artist can not be played or resolved.
+        """
+        all_artists = list(artists)
+        if not all_artists:
+            if overwrite:
+                # a caller asking to replace all artists with none is a bug,
+                # so keep the stored rows and make the attempt visible
+                self.logger.warning("Ignoring request to clear all artists of track id %s", db_id)
+            return
         if overwrite:
             # on overwrite, clear the track_artists table first
             await self.mass.music.database.delete(
@@ -857,10 +869,8 @@ class TracksController(MediaControllerBase[Track]):
                     "track_id": db_id,
                 },
             )
-        artist_mappings: UniqueList[ItemMapping] = UniqueList()
-        for artist in artists:
-            mapping = await self._set_track_artist(db_id, artist=artist, overwrite=overwrite)
-            artist_mappings.append(mapping)
+        for artist in all_artists:
+            await self._set_track_artist(db_id, artist=artist, overwrite=overwrite)
 
     async def _set_track_artist(
         self, db_id: int, artist: Artist | ItemMapping, overwrite: bool = False

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -1,11 +1,11 @@
-"""Tests for the tracks controller explicit filter."""
+"""Tests for the tracks controller."""
 
 from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.media_items import ProviderMapping
+from music_assistant_models.media_items import Artist, ProviderMapping, UniqueList
 
 from music_assistant.controllers.music import MusicController
 from music_assistant.mass import MusicAssistant
@@ -159,3 +159,45 @@ async def test_match_provider_uses_full_track_mapping(music: MusicController) ->
         mappings = await music.tracks.match_provider(base_track, provider, ref_albums=[])
 
     assert mappings == list(full_track.provider_mappings)
+
+
+async def test_overwrite_update_keeps_artists_when_none_are_given(
+    mass: MusicAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An overwrite update carrying no artists must not clear the stored ones."""
+    db_track = await mass.music.tracks.add_item_to_library(create_track("spotify_1", "track1"))
+
+    update = create_track("spotify_1", "track1")
+    update.artists = UniqueList()
+    await mass.music.tracks.update_item_in_library(db_track.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.tracks.get_library_item(db_track.item_id)
+    assert [artist.name for artist in refreshed.artists] == ["Test Artist"]
+    assert "Ignoring request to clear all artists" in caplog.text
+
+
+async def test_overwrite_update_replaces_artists(mass: MusicAssistant) -> None:
+    """An overwrite update carrying artists still replaces the stored ones."""
+    db_track = await mass.music.tracks.add_item_to_library(create_track("spotify_1", "track1"))
+
+    update = create_track("spotify_1", "track1")
+    update.artists = UniqueList(
+        [
+            Artist(
+                item_id="other_artist",
+                provider="spotify_1",
+                name="Other Artist",
+                provider_mappings={
+                    ProviderMapping(
+                        item_id="other_artist",
+                        provider_domain="spotify",
+                        provider_instance="spotify_1",
+                    )
+                },
+            )
+        ]
+    )
+    await mass.music.tracks.update_item_in_library(db_track.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.tracks.get_library_item(db_track.item_id)
+    assert [artist.name for artist in refreshed.artists] == ["Other Artist"]


### PR DESCRIPTION
# What does this implement/fix?

A library track could end up with no artists at all. Updating a track with
`overwrite=True` and an empty artist list cleared every stored artist relation
for that track.

Nothing noticed afterwards: the track still listed and opened normally (the
artists lookup simply returns an empty list), so it only failed once you tried
to play it, and the duplicate-track cleanup skips tracks without artists, so it
could never repair itself either.

This closes the same hole for artists that #5548 closed for provider mappings.

## Changes

- An update that carries no artists now keeps the stored ones instead of
  clearing them, and logs a warning so the attempt is visible.
- Dropped an unused list that was being built and thrown away in the same method.
- Added tests covering both the refusal and a normal artist replacement.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
