### PR TITLE
Repair library tracks that are missing their artist

### DIFF
--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -165,6 +165,7 @@ class TrackSyncDetails(LibraryItemSyncDetails):
     """Lightweight sync snapshot of a library track."""
 
     has_album: bool
+    has_artists: bool
 
 
 @dataclass(slots=True)

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -906,14 +906,19 @@ class TracksController(MediaControllerBase[Track]):
 
     def _sync_details_query_parts(self) -> tuple[str, str, dict[str, Any]]:
         """Return extra (columns, joins, params) for the tracks sync-details query."""
-        # the sync loop needs to know if the track has a (valid) album link
-        # to be able to backfill a missing album on existing library tracks
+        # the sync loop needs to know if the track has (valid) album and artist links
+        # to be able to backfill missing ones on existing library tracks
         extra_columns = """
             , EXISTS (
                 SELECT 1 FROM album_tracks
                 JOIN albums ON albums.item_id = album_tracks.album_id
                 WHERE album_tracks.track_id = tracks.item_id
             ) AS has_album
+            , EXISTS (
+                SELECT 1 FROM track_artists
+                JOIN artists ON artists.item_id = track_artists.artist_id
+                WHERE track_artists.track_id = tracks.item_id
+            ) AS has_artists
         """
         return extra_columns, "", {}
 
@@ -925,6 +930,7 @@ class TracksController(MediaControllerBase[Track]):
             date_added=datetime.fromtimestamp(db_row["timestamp_added"], tz=UTC),
             provider_mappings=self._parse_sync_details_mappings(db_row),
             has_album=bool(db_row["has_album"]),
+            has_artists=bool(db_row["has_artists"]),
         )
 
     def _parse_summary_row(self, db_row: Mapping[str, Any]) -> TrackSummary:

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -1584,9 +1584,12 @@ class MusicProvider(Provider):
                         library_item = await self.mass.music.tracks.add_item_to_library(prov_item)
                         db_id = int(library_item.item_id)
                         favorite = library_item.favorite
-                    elif self._library_item_needs_update(sync_details, prov_item) or (
+                    elif (
+                        self._library_item_needs_update(sync_details, prov_item)
                         # or backfill a missing album(_tracks) link for existing tracks
-                        prov_item.album and not sync_details.has_album
+                        or (prov_item.album and not sync_details.has_album)
+                        # or backfill missing track_artists link(s) for existing tracks
+                        or (prov_item.artists and not sync_details.has_artists)
                     ):
                         library_item = await self.mass.music.tracks.update_item_in_library(
                             sync_details.item_id, prov_item

--- a/tests/controllers/music/test_sync_relation_backfill.py
+++ b/tests/controllers/music/test_sync_relation_backfill.py
@@ -1,0 +1,109 @@
+"""Tests that the library sync repairs missing album/artist links on existing tracks."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import ProviderType
+
+from music_assistant.constants import (
+    CONF_LOG_LEVEL,
+    DB_TABLE_ALBUM_TRACKS,
+    DB_TABLE_TRACK_ARTISTS,
+)
+from music_assistant.controllers.music import MusicController
+from music_assistant.providers.test import (
+    CONF_KEY_NUM_ALBUMS,
+    CONF_KEY_NUM_ARTISTS,
+    CONF_KEY_NUM_TRACKS,
+)
+from music_assistant.providers.test import TestProvider as FakeMusicProvider
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from music_assistant.mass import MusicAssistant
+
+NUM_ARTISTS = 1
+NUM_ALBUMS = 1
+NUM_TRACKS = 2  # per album
+
+
+@pytest.fixture
+async def music(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicController]:
+    """Return a music controller with initialized database on the minimal mass instance."""
+    controller = MusicController(mass_minimal)
+    mass_minimal.music = controller
+    await controller._setup_database()
+    yield controller
+    if controller._database:
+        await controller._database.close()
+
+
+@pytest.fixture
+def provider(mass_minimal: MusicAssistant) -> FakeMusicProvider:
+    """Return a fake music provider with a small deterministic library."""
+    manifest = MagicMock()
+    manifest.type = ProviderType.MUSIC
+    manifest.domain = "test"
+    config = MagicMock()
+    config.instance_id = "test--1"
+    config.domain = "test"
+    values = {
+        CONF_KEY_NUM_ARTISTS: NUM_ARTISTS,
+        CONF_KEY_NUM_ALBUMS: NUM_ALBUMS,
+        CONF_KEY_NUM_TRACKS: NUM_TRACKS,
+        CONF_LOG_LEVEL: "GLOBAL",
+    }
+    config.get_value.side_effect = lambda key, default=None: values.get(key, default)
+    return FakeMusicProvider(mass_minimal, manifest, config)
+
+
+async def _relation_count(music: MusicController, table: str, track_id: int) -> int:
+    """Return the number of relation rows the given table holds for a track."""
+    rows = await music.database.get_rows_from_query(
+        f"SELECT 1 FROM {table} WHERE track_id = :track_id", {"track_id": track_id}
+    )
+    return len(rows)
+
+
+async def test_sync_backfills_missing_track_artists(
+    music: MusicController, provider: FakeMusicProvider
+) -> None:
+    """
+    A library track that lost its artist link is repaired by the next sync.
+
+    A track row is written before its artist relations, so an interruption in between
+    leaves a committed track with no artists at all. Nothing else can spot it: it reads
+    back fine and the duplicate reconciliation pass needs exactly those rows.
+    """
+    synced_ids = await provider._sync_library_tracks()
+    track_id = next(iter(synced_ids))
+    assert await _relation_count(music, DB_TABLE_TRACK_ARTISTS, track_id) > 0
+
+    # simulate the interrupted add: the track (and its provider mappings) survive
+    # without any artist relations
+    await music.database.delete(DB_TABLE_TRACK_ARTISTS, {"track_id": track_id})
+    assert await _relation_count(music, DB_TABLE_TRACK_ARTISTS, track_id) == 0
+
+    await provider._sync_library_tracks()
+
+    assert await _relation_count(music, DB_TABLE_TRACK_ARTISTS, track_id) > 0
+
+
+async def test_sync_backfills_missing_track_album(
+    music: MusicController, provider: FakeMusicProvider
+) -> None:
+    """A library track that lost its album link is repaired by the next sync."""
+    synced_ids = await provider._sync_library_tracks()
+    track_id = next(iter(synced_ids))
+    assert await _relation_count(music, DB_TABLE_ALBUM_TRACKS, track_id) > 0
+
+    await music.database.delete(DB_TABLE_ALBUM_TRACKS, {"track_id": track_id})
+    assert await _relation_count(music, DB_TABLE_ALBUM_TRACKS, track_id) == 0
+
+    await provider._sync_library_tracks()
+
+    assert await _relation_count(music, DB_TABLE_ALBUM_TRACKS, track_id) > 0

--- a/tests/controllers/music/test_sync_relation_backfill.py
+++ b/tests/controllers/music/test_sync_relation_backfill.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import ProviderType
@@ -14,6 +14,7 @@ from music_assistant.constants import (
     DB_TABLE_TRACK_ARTISTS,
 )
 from music_assistant.controllers.music import MusicController
+from music_assistant.models.music_provider import MusicProvider
 from music_assistant.providers.test import (
     CONF_KEY_NUM_ALBUMS,
     CONF_KEY_NUM_ARTISTS,
@@ -24,6 +25,8 @@ from music_assistant.providers.test import TestProvider as FakeMusicProvider
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
+    from music_assistant_models.enums import MediaType
+
     from music_assistant.mass import MusicAssistant
 
 NUM_ARTISTS = 1
@@ -31,9 +34,24 @@ NUM_ALBUMS = 1
 NUM_TRACKS = 2  # per album
 
 
+@pytest.fixture(autouse=True)
+def strict_sync_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail the test when the sync loop swallows a per-item failure."""
+
+    def _raise(
+        self: MusicProvider, media_type: MediaType, item_ref: str | None, err: Exception
+    ) -> None:
+        del self, media_type
+        raise AssertionError(f"sync swallowed a failure for {item_ref}: {err!r}")
+
+    monkeypatch.setattr(MusicProvider, "_handle_sync_item_failure", _raise)
+
+
 @pytest.fixture
 async def music(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicController]:
     """Return a music controller with initialized database on the minimal mass instance."""
+    mass_minimal.metadata = MagicMock()
+    mass_minimal.metadata.invalidate_image_cache = AsyncMock()
     controller = MusicController(mass_minimal)
     mass_minimal.music = controller
     await controller._setup_database()
@@ -79,8 +97,7 @@ async def test_sync_backfills_missing_track_artists(
     leaves a committed track with no artists at all. Nothing else can spot it: it reads
     back fine and the duplicate reconciliation pass needs exactly those rows.
     """
-    synced_ids = await provider._sync_library_tracks()
-    track_id = next(iter(synced_ids))
+    track_id = min(await provider._sync_library_tracks())
     assert await _relation_count(music, DB_TABLE_TRACK_ARTISTS, track_id) > 0
 
     # simulate the interrupted add: the track (and its provider mappings) survive
@@ -97,8 +114,7 @@ async def test_sync_backfills_missing_track_album(
     music: MusicController, provider: FakeMusicProvider
 ) -> None:
     """A library track that lost its album link is repaired by the next sync."""
-    synced_ids = await provider._sync_library_tracks()
-    track_id = next(iter(synced_ids))
+    track_id = min(await provider._sync_library_tracks())
     assert await _relation_count(music, DB_TABLE_ALBUM_TRACKS, track_id) > 0
 
     await music.database.delete(DB_TABLE_ALBUM_TRACKS, {"track_id": track_id})
@@ -107,3 +123,18 @@ async def test_sync_backfills_missing_track_album(
     await provider._sync_library_tracks()
 
     assert await _relation_count(music, DB_TABLE_ALBUM_TRACKS, track_id) > 0
+
+
+async def test_sync_leaves_intact_tracks_alone(
+    music: MusicController,
+    provider: FakeMusicProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A track that still holds all its relations is not rewritten on every sync."""
+    await provider._sync_library_tracks()
+    updates = AsyncMock(wraps=music.tracks.update_item_in_library)
+    monkeypatch.setattr(music.tracks, "update_item_in_library", updates)
+
+    await provider._sync_library_tracks()
+
+    updates.assert_not_awaited()


### PR DESCRIPTION
# What does this implement/fix?

A track is written to the library before its artist links are, and that write is
never rolled back. If the sync is interrupted in between — a provider reload or a
shutdown cancelling it — the track is committed without any artist at all.

Nothing could repair that afterwards. The track still shows up in the library and
opens fine, so it looks healthy, but it fails when you try to play it. The sync
skips it on every later run because its change detection only looks at provider
mappings and the date added, and the duplicate-track pass can't see it either
because that needs the artist links it is missing.

The sync already repairs a track that lost its album this way. This adds the same
repair for a missing artist.

#5845 stops one way a track can lose its artists; this repairs the tracks that
already have none.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- Track the presence of artist links alongside the existing album check in the
  sync's lightweight library snapshot
- Update an existing library track when the provider lists artists but the library
  row has none
- Tests covering the new artist backfill, the existing album one, and that an
  intact track is not rewritten on every sync

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
