### PR TITLE
Keep a duplicate stream request from confusing the queue's progress

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1954,7 +1954,13 @@ class StreamsAudio:
             )
             return
         queue.flow_mode = True
-        pq_data.flow_mode_stream_log = []
+        # A session can also be handed a second producer, which the session check does not
+        # catch: players such as DLNA renderers sometimes open the same flow url twice to
+        # probe the audio. Append to the list published here rather than to whatever the
+        # queue currently holds, so the entries of a producer that has since been replaced
+        # end up in a list nobody reads instead of interleaving with the live one's.
+        flow_log: list[PlayLogEntry] = []
+        pq_data.flow_mode_stream_log = flow_log
         if not start_queue_item:
             # this can happen in some (edge case) race conditions
             return
@@ -2137,7 +2143,7 @@ class StreamsAudio:
                     )
             # append to play log so the queue controller can work out which track is playing
             play_log_entry = PlayLogEntry(queue_track.queue_item_id)
-            pq_data.flow_mode_stream_log.append(play_log_entry)
+            flow_log.append(play_log_entry)
 
             bytes_written = 0
             crossfade_buffer = bytearray()

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -931,6 +931,80 @@ async def test_stale_flow_generator_does_not_mutate_active_session() -> None:
 
 
 @pytest.mark.asyncio
+async def test_duplicate_flow_producer_does_not_interleave_the_play_log() -> None:
+    """A second flow request for one session keeps the play log of the first out of the queue."""
+
+    def _flow_item(item_id: str) -> Any:
+        return SimpleNamespace(
+            queue_item_id=item_id,
+            name=item_id,
+            media_type=MediaType.TRACK,
+            duration=300,
+            extra_attributes={},
+            streamdetails=SimpleNamespace(
+                fade_in=False,
+                stream_error=False,
+                uri=f"test://{item_id}",
+                seek_position=0,
+                duration=300,
+                buffer=None,
+                seconds_streamed=None,
+                audio_format=_format(ContentType.PCM_F32LE, 48000, 32),
+            ),
+        )
+
+    items = {item_id: _flow_item(item_id) for item_id in ("item-1", "item-2")}
+
+    async def _load_next(_queue_id: str, current_id: str) -> Any:
+        if current_id == "item-1":
+            return items["item-2"]
+        raise QueueEmpty
+
+    mass = MagicMock()
+    queue_data = SimpleNamespace(session_id="session-1", flow_mode_stream_log=[])
+    mass.player_queues.queue_data.return_value = queue_data
+    mass.player_queues.load_next_queue_item = _load_next
+    mass.streams.get_crossfade_mode.return_value = CrossfadeMode.DISABLED
+    mass.config.get_raw_core_config_value.return_value = 0
+    mass.player_queues.get_active_queue.return_value = None
+    audio = StreamsAudio(cast("Any", mass))
+
+    async def _one_chunk(*_args: object, **_kwargs: object) -> AsyncGenerator[bytes]:
+        yield b"\x00" * 16
+
+    audio.get_queue_item_stream = _one_chunk  # type: ignore[method-assign]
+    queue = cast(
+        "Any",
+        SimpleNamespace(
+            queue_id="queue-1",
+            display_name="Queue",
+            flow_mode=False,
+            overlay_enabled=False,
+            overlay_source=None,
+        ),
+    )
+    pcm_format = _format(ContentType.PCM_F32LE, 48000, 32)
+
+    # the probing connection opens the flow url and logs its first track
+    first = audio.get_queue_flow_stream(queue, items["item-1"], pcm_format, session_id="session-1")
+    await anext(first)
+    assert [entry.queue_item_id for entry in queue_data.flow_mode_stream_log] == ["item-1"]
+
+    # the connection that really plays opens the same url and publishes its own play log
+    second = audio.get_queue_flow_stream(queue, items["item-1"], pcm_format, session_id="session-1")
+    await anext(second)
+    live_log = queue_data.flow_mode_stream_log
+
+    # the first producer moves on to its next track; that entry must not reach the live log
+    await anext(first)
+    assert queue_data.flow_mode_stream_log is live_log
+    assert [entry.queue_item_id for entry in live_log] == ["item-1"]
+
+    await first.aclose()
+    await second.aclose()
+
+
+@pytest.mark.asyncio
 async def test_flow_source_error_skips_item_without_completing_it() -> None:
     """An item-stream error skips to the next queue item; the flow itself continues."""
     mass = MagicMock()


### PR DESCRIPTION
# What does this implement/fix?

Some players (DLNA renderers in particular) open the same flow stream URL twice in a row to probe the audio before playing it. Both requests start a producer for the same playback session, and both write to the queue's flow play log — the list Music Assistant uses to work out which track is playing and how far into it we are. The log then ends up mixing entries from the connection that plays with entries from one that no longer does, which can show the wrong track or a progress bar that jumps.

Each producer now appends to the play log it published itself. A producer that has since been replaced writes to a list nobody reads, so it can no longer interleave with the live one. Nothing is cut short: both connections keep streaming exactly as before, only the bookkeeping stays separate.

This is the root cause behind the symptom worked around on the read side in #5228.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- A flow producer keeps a reference to the play log it publishes and appends to that, instead of to whatever the queue currently holds.
- Added a test for two producers on one session.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
