### PR TITLE
Improve crossfade buffering and account for realtime streams

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2059,6 +2059,11 @@ class StreamsAudio:
                     queue.display_name,
                 )
                 continue
+            # a realtime source delivers at playback pace, so it has no audio to spare
+            # for an overlap in either direction
+            item_crossfade_mode = (
+                CrossfadeMode.DISABLED if queue_track.streamdetails.is_realtime else crossfade_mode
+            )
             if flow_session_id is not None:
                 self.mass.streams.audio_processing.update_item_context(
                     queue_id=queue.queue_id,
@@ -2070,12 +2075,7 @@ class StreamsAudio:
                             "float",
                             queue_track.extra_attributes.get("playback_speed", 1.0),
                         ),
-                        # a realtime source is never faded, in either direction
-                        crossfade_mode=(
-                            CrossfadeMode.DISABLED
-                            if queue_track.streamdetails.is_realtime
-                            else crossfade_mode
-                        ),
+                        crossfade_mode=item_crossfade_mode,
                         overlay_active=overlay_active(queue),
                     ),
                     alters_audio=queue_track.streamdetails.fade_in,
@@ -2101,7 +2101,7 @@ class StreamsAudio:
             # calculate crossfade buffer size
             crossfade_buffer_duration = (
                 SMART_CROSSFADE_DURATION
-                if crossfade_mode == CrossfadeMode.SMART_CROSSFADE
+                if item_crossfade_mode == CrossfadeMode.SMART_CROSSFADE
                 else standard_crossfade_duration
             )
             crossfade_buffer_duration = min(
@@ -2133,10 +2133,10 @@ class StreamsAudio:
             if last_fadeout_part and last_streamdetails:
                 transition_mode = CrossfadeMode.DISABLED
                 incoming_duration = 0.0
-                if crossfade_buffer_size > 0 and crossfade_mode != CrossfadeMode.DISABLED:
+                if crossfade_buffer_size > 0 and item_crossfade_mode != CrossfadeMode.DISABLED:
                     transition_mode, incoming_duration = self._select_buffered_crossfade(
                         queue_track.streamdetails,
-                        crossfade_mode,
+                        item_crossfade_mode,
                         standard_crossfade_duration,
                         track_playback_speed,
                     )
@@ -2207,7 +2207,7 @@ class StreamsAudio:
                         queue.queue_id, queue_track.queue_item_id
                     )
 
-                if crossfade_mode == CrossfadeMode.DISABLED:
+                if item_crossfade_mode == CrossfadeMode.DISABLED:
                     # no cross/smart fade: yield chunks directly without intermediate buffer
                     yield chunk
                     bytes_written += len(chunk)
@@ -2365,7 +2365,7 @@ class StreamsAudio:
             min_fade_out_size = int(pcm_sample_size * MIN_CROSSFADE_FALLBACK_DURATION)
             if len(crossfade_buffer) >= min_fade_out_size and self.crossfade_allowed(
                 queue_track,
-                crossfade_mode=crossfade_mode,
+                crossfade_mode=item_crossfade_mode,
                 player_id=queue.queue_id,
                 flow_mode=True,
             ):
@@ -2379,7 +2379,7 @@ class StreamsAudio:
                         await asyncio.sleep(0)
                     bytes_written += len(remaining_bytes)
                 del remaining_bytes
-            elif crossfade_mode != CrossfadeMode.DISABLED and crossfade_buffer:
+            elif item_crossfade_mode != CrossfadeMode.DISABLED and crossfade_buffer:
                 bytes_written += len(crossfade_buffer)
                 for pcm_slice in iter_pcm_slices(bytes(crossfade_buffer), pcm_format, 1000):
                     yield pcm_slice

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1672,7 +1672,6 @@ class StreamsAudio:
         warmup_bytes = 0
         total_chunks_received = 0
         holdback_armed = False
-        holdback_filled = False
         playback_speed = cast("float", queue_item.extra_attributes.get("playback_speed", 1.0))
         async for chunk in self.get_queue_item_stream(
             queue_item,
@@ -1711,7 +1710,6 @@ class StreamsAudio:
             if len(buffer) < crossfade_buffer_size:
                 await asyncio.sleep(0)
                 continue
-            holdback_filled = True
             # yield everything above the crossfade buffer
             while len(buffer) > crossfade_buffer_size:
                 yield bytes(buffer[: pcm_format.pcm_sample_size])
@@ -1747,9 +1745,10 @@ class StreamsAudio:
         transition_mode = CrossfadeMode.DISABLED
         fade_in_buffer_duration = 0.0
         fade_in_playback_speed = 1.0
-        # a fade needs a complete outgoing tail, which a holdback that armed too late
-        # (or not at all) never collected
-        if holdback_filled and next_queue_item and next_queue_item.streamdetails:
+        # a fade needs enough of the outgoing track to overlap with; a holdback that
+        # armed late (or not at all) leaves less than that
+        min_fade_out_size = int(pcm_format.pcm_sample_size * MIN_CROSSFADE_FALLBACK_DURATION)
+        if len(buffer) >= min_fade_out_size and next_queue_item and next_queue_item.streamdetails:
             fade_in_playback_speed = cast(
                 "float", next_queue_item.extra_attributes.get("playback_speed", 1.0)
             )
@@ -2071,7 +2070,12 @@ class StreamsAudio:
                             "float",
                             queue_track.extra_attributes.get("playback_speed", 1.0),
                         ),
-                        crossfade_mode=crossfade_mode,
+                        # a realtime source is never faded, in either direction
+                        crossfade_mode=(
+                            CrossfadeMode.DISABLED
+                            if queue_track.streamdetails.is_realtime
+                            else crossfade_mode
+                        ),
                         overlay_active=overlay_active(queue),
                     ),
                     alters_audio=queue_track.streamdetails.fade_in,
@@ -2173,7 +2177,6 @@ class StreamsAudio:
             warmup_bytes = 0
             first_chunk_received = False
             holdback_armed = False
-            holdback_filled = False
 
             async for chunk in self.get_queue_item_stream(
                 queue_track,
@@ -2244,9 +2247,6 @@ class StreamsAudio:
                 if len(crossfade_buffer) < required_buffer_size:
                     await asyncio.sleep(0)
                     continue
-                if holdback_armed:
-                    holdback_filled = True
-
                 # handle crossfade of previous track and new track
                 if (
                     last_fadeout_part
@@ -2360,9 +2360,10 @@ class StreamsAudio:
                 queue_track.streamdetails.seek_position = raw_seek_position
                 # full tail was pre-counted and is now yielded as-is
                 last_fadeout_part = b""
-            # a fade needs a complete outgoing tail, which a holdback that armed too late
-            # (or not at all) never collected
-            if holdback_filled and self.crossfade_allowed(
+            # a fade needs enough of the outgoing track to overlap with; a holdback that
+            # armed late (or not at all) leaves less than that
+            min_fade_out_size = int(pcm_sample_size * MIN_CROSSFADE_FALLBACK_DURATION)
+            if len(crossfade_buffer) >= min_fade_out_size and self.crossfade_allowed(
                 queue_track,
                 crossfade_mode=crossfade_mode,
                 player_id=queue.queue_id,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -3330,7 +3330,9 @@ class StreamsAudio:
         if tail_seconds <= 0 or streamdetails.is_realtime:
             return False
         audio_buffer = cast("AudioBuffer | None", streamdetails.buffer)
-        if audio_buffer is None:
+        if audio_buffer is None or audio_buffer.has_error:
+            # a failed source is skipped without a fade, so its remaining audio is
+            # better off played out than held back for one
             return False
         # While the source is still delivering, it is what limits playback: withholding
         # a tail on top of that eats into the lead the player needs. Once the source is

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2128,6 +2128,8 @@ class StreamsAudio:
             # Build eagerly so seek_position is set before PlayLogEntry is appended —
             # consumer-paced mix() would otherwise let the queue briefly report 0.
             crossfade_smart_fade: SmartFade | None = None
+            collect_started = 0.0
+            collect_resident = 0.0
             incoming_crossfade_size = crossfade_buffer_size
             incoming_audio_buffer: AudioBuffer | None = None
             if last_fadeout_part and last_streamdetails:
@@ -2153,6 +2155,10 @@ class StreamsAudio:
                     incoming_audio_buffer = cast("AudioBuffer", queue_track.streamdetails.buffer)
                     incoming_crossfade_size = int(pcm_format.pcm_sample_size * incoming_duration)
                     incoming_crossfade_size = (incoming_crossfade_size // frame_size) * frame_size
+                    # no audio is emitted while the incoming overlap is collected, so a
+                    # slow collection here is heard as a gap at the transition
+                    collect_started = asyncio.get_event_loop().time()
+                    collect_resident = incoming_audio_buffer.duration_available
                     crossfade_smart_fade = await self.smart_fades_mixer.build(
                         fade_in_streamdetails=queue_track.streamdetails,
                         fade_out_streamdetails=last_streamdetails,
@@ -2254,6 +2260,14 @@ class StreamsAudio:
                     and crossfade_smart_fade is not None
                     and last_play_log_entry is not None
                 ):
+                    self.logger.debug(
+                        "Collected %.1fs of incoming audio for the transition into %s in %.1fs"
+                        " (%.1fs was resident when it started)",
+                        len(crossfade_buffer) / pcm_sample_size,
+                        queue_track.name,
+                        asyncio.get_event_loop().time() - collect_started,
+                        collect_resident,
+                    )
                     fadein_part = bytes(crossfade_buffer[:incoming_crossfade_size])
                     remaining_bytes = bytes(crossfade_buffer[incoming_crossfade_size:])
                     try:

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -377,6 +377,10 @@ class StreamsAudio:
             self.logger.warning("seeking is not possible on duration-less streams!")
             seek_position = 0
 
+        if streamdetails.media_type in (MediaType.RADIO, MediaType.AUDIO_SOURCE):
+            # radio stations and live audio sources hand over their audio at playback pace
+            streamdetails.is_realtime = True
+
         # set queue_id on the streamdetails so we know what is being streamed
         streamdetails.queue_id = queue_item.queue_id
         # handle skip/fade_in details
@@ -1666,6 +1670,7 @@ class StreamsAudio:
         warmup_size = int(pcm_format.pcm_sample_size * WARMUP_DURATION)
         warmup_bytes = 0
         total_chunks_received = 0
+        holdback_armed = False
         playback_speed = cast("float", queue_item.extra_attributes.get("playback_speed", 1.0))
         async for chunk in self.get_queue_item_stream(
             queue_item,
@@ -1685,6 +1690,17 @@ class StreamsAudio:
                 bytes_written += len(chunk)
                 del chunk
                 continue
+
+            if not holdback_armed:
+                holdback_armed = self._crossfade_holdback_allowed(
+                    queue_item.streamdetails or streamdetails, crossfade_buffer_size
+                )
+                if not holdback_armed:
+                    # holding audio back now would only shrink the player's lead
+                    yield chunk
+                    bytes_written += len(chunk)
+                    del chunk
+                    continue
 
             buffer.extend(chunk)
             del chunk
@@ -1726,7 +1742,10 @@ class StreamsAudio:
         transition_mode = CrossfadeMode.DISABLED
         fade_in_buffer_duration = 0.0
         fade_in_playback_speed = 1.0
-        if next_queue_item and next_queue_item.streamdetails:
+        # a fade needs the complete outgoing tail: a holdback that armed too late
+        # (or not at all) leaves too little audio of this track to fade out with
+        fade_out_ready = 0 < crossfade_buffer_size <= len(buffer)
+        if fade_out_ready and next_queue_item and next_queue_item.streamdetails:
             fade_in_playback_speed = cast(
                 "float", next_queue_item.extra_attributes.get("playback_speed", 1.0)
             )
@@ -2149,6 +2168,7 @@ class StreamsAudio:
             crossfade_buffer = bytearray()
             warmup_bytes = 0
             first_chunk_received = False
+            holdback_armed = False
 
             async for chunk in self.get_queue_item_stream(
                 queue_track,
@@ -2196,6 +2216,17 @@ class StreamsAudio:
                     bytes_written += len(chunk)
                     del chunk
                     continue
+
+                if not last_fadeout_part and not holdback_armed:
+                    holdback_armed = self._crossfade_holdback_allowed(
+                        queue_track.streamdetails, crossfade_buffer_size
+                    )
+                    if not holdback_armed:
+                        # holding audio back now would only shrink the player's lead
+                        yield chunk
+                        bytes_written += len(chunk)
+                        del chunk
+                        continue
 
                 # smart fades enabled: accumulate chunks in crossfade buffer
                 crossfade_buffer.extend(chunk)
@@ -2320,7 +2351,9 @@ class StreamsAudio:
                 queue_track.streamdetails.seek_position = raw_seek_position
                 # full tail was pre-counted and is now yielded as-is
                 last_fadeout_part = b""
-            if self.crossfade_allowed(
+            # a fade needs the complete outgoing tail: a holdback that armed too late
+            # (or not at all) leaves too little audio of this track to fade out with
+            if 0 < crossfade_buffer_size <= len(crossfade_buffer) and self.crossfade_allowed(
                 queue_track,
                 crossfade_mode=crossfade_mode,
                 player_id=queue.queue_id,
@@ -3280,6 +3313,23 @@ class StreamsAudio:
                 streamdetails.uri,
             )
 
+    def _crossfade_holdback_allowed(
+        self, streamdetails: StreamDetails, crossfade_buffer_size: int
+    ) -> bool:
+        """
+        Return whether the outgoing tail may be held back for a crossfade.
+
+        :param streamdetails: Stream details of the track being streamed.
+        :param crossfade_buffer_size: Size of the tail to hold back, in bytes.
+        """
+        if crossfade_buffer_size <= 0 or streamdetails.is_realtime:
+            return False
+        # While the source is still delivering, it is what limits playback: withholding
+        # a tail on top of that eats into the lead the player needs. Once the source is
+        # done the remaining audio is resident, so the tail comes for free.
+        audio_buffer = cast("AudioBuffer | None", streamdetails.buffer)
+        return audio_buffer is not None and audio_buffer.eof
+
     def _select_buffered_crossfade(
         self,
         streamdetails: StreamDetails,
@@ -3300,6 +3350,9 @@ class StreamsAudio:
         if (
             crossfade_mode == CrossfadeMode.DISABLED
             or playback_speed <= 0
+            # a realtime source has no more than its banked lead: fading in would spend
+            # that at the start of the track and leave nothing for the rest of it
+            or streamdetails.is_realtime
             or audio_buffer is None
             or audio_buffer.has_error
             or not audio_buffer.is_valid()

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1695,7 +1695,9 @@ class StreamsAudio:
 
             if not holdback_armed:
                 holdback_armed = self._crossfade_holdback_allowed(
-                    queue_item.streamdetails or streamdetails, crossfade_buffer_duration
+                    queue_item.streamdetails or streamdetails,
+                    crossfade_buffer_duration,
+                    playback_speed,
                 )
                 if not holdback_armed:
                     # holding audio back now would only shrink the player's lead
@@ -2222,7 +2224,9 @@ class StreamsAudio:
 
                 if not last_fadeout_part and not holdback_armed:
                     holdback_armed = self._crossfade_holdback_allowed(
-                        queue_track.streamdetails, crossfade_buffer_duration
+                        queue_track.streamdetails,
+                        crossfade_buffer_duration,
+                        track_playback_speed,
                     )
                     if not holdback_armed:
                         # holding audio back now would only shrink the player's lead
@@ -3319,15 +3323,16 @@ class StreamsAudio:
             )
 
     def _crossfade_holdback_allowed(
-        self, streamdetails: StreamDetails, tail_seconds: float
+        self, streamdetails: StreamDetails, tail_seconds: float, playback_speed: float = 1.0
     ) -> bool:
         """
         Return whether the outgoing tail may be held back for a crossfade.
 
         :param streamdetails: Stream details of the track being streamed.
-        :param tail_seconds: Length of the tail to hold back, in seconds.
+        :param tail_seconds: Length of the tail to hold back, in seconds of playback.
+        :param playback_speed: Playback-speed multiplier of the track.
         """
-        if tail_seconds <= 0 or streamdetails.is_realtime:
+        if tail_seconds <= 0 or playback_speed <= 0 or streamdetails.is_realtime:
             return False
         audio_buffer = cast("AudioBuffer | None", streamdetails.buffer)
         if audio_buffer is None or audio_buffer.has_error:
@@ -3339,7 +3344,7 @@ class StreamsAudio:
         # done the remaining audio is resident, so the tail comes for free. A buffer that
         # is too small to ever hold the tail is the exception - waiting for the source
         # there would only lose the fade.
-        return audio_buffer.eof or audio_buffer.max_size_seconds < tail_seconds
+        return audio_buffer.eof or audio_buffer.max_size_seconds / playback_speed < tail_seconds
 
     def _select_buffered_crossfade(
         self,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -171,7 +171,8 @@ if TYPE_CHECKING:
 
 # ruff: noqa: PLR0915
 
-# Seconds of PCM yielded directly to the player before the crossfade holdback starts buffering.
+# Seconds of PCM at the start of a track that are yielded straight to the player,
+# never held back for a crossfade.
 WARMUP_DURATION = 8
 # Minimum overlap used when the full incoming crossfade buffer was not prepared.
 MIN_CROSSFADE_FALLBACK_DURATION = 5
@@ -1671,6 +1672,7 @@ class StreamsAudio:
         warmup_bytes = 0
         total_chunks_received = 0
         holdback_armed = False
+        holdback_filled = False
         playback_speed = cast("float", queue_item.extra_attributes.get("playback_speed", 1.0))
         async for chunk in self.get_queue_item_stream(
             queue_item,
@@ -1693,7 +1695,7 @@ class StreamsAudio:
 
             if not holdback_armed:
                 holdback_armed = self._crossfade_holdback_allowed(
-                    queue_item.streamdetails or streamdetails, crossfade_buffer_size
+                    queue_item.streamdetails or streamdetails, crossfade_buffer_duration
                 )
                 if not holdback_armed:
                     # holding audio back now would only shrink the player's lead
@@ -1707,6 +1709,7 @@ class StreamsAudio:
             if len(buffer) < crossfade_buffer_size:
                 await asyncio.sleep(0)
                 continue
+            holdback_filled = True
             # yield everything above the crossfade buffer
             while len(buffer) > crossfade_buffer_size:
                 yield bytes(buffer[: pcm_format.pcm_sample_size])
@@ -1742,10 +1745,9 @@ class StreamsAudio:
         transition_mode = CrossfadeMode.DISABLED
         fade_in_buffer_duration = 0.0
         fade_in_playback_speed = 1.0
-        # a fade needs the complete outgoing tail: a holdback that armed too late
-        # (or not at all) leaves too little audio of this track to fade out with
-        fade_out_ready = 0 < crossfade_buffer_size <= len(buffer)
-        if fade_out_ready and next_queue_item and next_queue_item.streamdetails:
+        # a fade needs a complete outgoing tail, which a holdback that armed too late
+        # (or not at all) never collected
+        if holdback_filled and next_queue_item and next_queue_item.streamdetails:
             fade_in_playback_speed = cast(
                 "float", next_queue_item.extra_attributes.get("playback_speed", 1.0)
             )
@@ -2169,6 +2171,7 @@ class StreamsAudio:
             warmup_bytes = 0
             first_chunk_received = False
             holdback_armed = False
+            holdback_filled = False
 
             async for chunk in self.get_queue_item_stream(
                 queue_track,
@@ -2219,7 +2222,7 @@ class StreamsAudio:
 
                 if not last_fadeout_part and not holdback_armed:
                     holdback_armed = self._crossfade_holdback_allowed(
-                        queue_track.streamdetails, crossfade_buffer_size
+                        queue_track.streamdetails, crossfade_buffer_duration
                     )
                     if not holdback_armed:
                         # holding audio back now would only shrink the player's lead
@@ -2237,6 +2240,8 @@ class StreamsAudio:
                 if len(crossfade_buffer) < required_buffer_size:
                     await asyncio.sleep(0)
                     continue
+                if holdback_armed:
+                    holdback_filled = True
 
                 # handle crossfade of previous track and new track
                 if (
@@ -2351,9 +2356,9 @@ class StreamsAudio:
                 queue_track.streamdetails.seek_position = raw_seek_position
                 # full tail was pre-counted and is now yielded as-is
                 last_fadeout_part = b""
-            # a fade needs the complete outgoing tail: a holdback that armed too late
-            # (or not at all) leaves too little audio of this track to fade out with
-            if 0 < crossfade_buffer_size <= len(crossfade_buffer) and self.crossfade_allowed(
+            # a fade needs a complete outgoing tail, which a holdback that armed too late
+            # (or not at all) never collected
+            if holdback_filled and self.crossfade_allowed(
                 queue_track,
                 crossfade_mode=crossfade_mode,
                 player_id=queue.queue_id,
@@ -3314,21 +3319,25 @@ class StreamsAudio:
             )
 
     def _crossfade_holdback_allowed(
-        self, streamdetails: StreamDetails, crossfade_buffer_size: int
+        self, streamdetails: StreamDetails, tail_seconds: float
     ) -> bool:
         """
         Return whether the outgoing tail may be held back for a crossfade.
 
         :param streamdetails: Stream details of the track being streamed.
-        :param crossfade_buffer_size: Size of the tail to hold back, in bytes.
+        :param tail_seconds: Length of the tail to hold back, in seconds.
         """
-        if crossfade_buffer_size <= 0 or streamdetails.is_realtime:
+        if tail_seconds <= 0 or streamdetails.is_realtime:
+            return False
+        audio_buffer = cast("AudioBuffer | None", streamdetails.buffer)
+        if audio_buffer is None:
             return False
         # While the source is still delivering, it is what limits playback: withholding
         # a tail on top of that eats into the lead the player needs. Once the source is
-        # done the remaining audio is resident, so the tail comes for free.
-        audio_buffer = cast("AudioBuffer | None", streamdetails.buffer)
-        return audio_buffer is not None and audio_buffer.eof
+        # done the remaining audio is resident, so the tail comes for free. A buffer that
+        # is too small to ever hold the tail is the exception - waiting for the source
+        # there would only lose the fade.
+        return audio_buffer.eof or audio_buffer.max_size_seconds < tail_seconds
 
     def _select_buffered_crossfade(
         self,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -109,7 +109,7 @@ from music_assistant.controllers.streams.constants import (
 )
 from music_assistant.controllers.streams.ogg_handler import get_chained_ogg_stream
 from music_assistant.controllers.streams.smart_fades import SmartFadesMixer
-from music_assistant.controllers.streams.smart_fades.fades import SmartFade
+from music_assistant.controllers.streams.smart_fades.fades import SmartFade, StandardCrossFade
 from music_assistant.controllers.streams.smart_fades.helpers import (
     MIN_EFFECTIVE_FADE_BUFFER,
     SMART_CROSSFADE_DURATION,
@@ -2169,6 +2169,20 @@ class StreamsAudio:
                         fade_in_bytes_len=incoming_crossfade_size,
                     )
                     timing_info = crossfade_smart_fade.timing_info
+                    if isinstance(crossfade_smart_fade, StandardCrossFade):
+                        # A standard fade blends its overlap and passes everything after it
+                        # through untouched, so only the overlap has to be in hand before
+                        # the transition can start. Holding back the rest buys nothing and
+                        # keeps the player waiting - a smart fade does need its full window,
+                        # which is only chosen when the analysis it needs is already there.
+                        blended_seconds = (
+                            timing_info.fadein_trimmed_duration + timing_info.crossfade_duration
+                        )
+                        blended_size = int(pcm_format.pcm_sample_size * blended_seconds)
+                        incoming_crossfade_size = min(
+                            incoming_crossfade_size,
+                            (blended_size // frame_size) * frame_size,
+                        )
                     queue_track.streamdetails.seek_position = (
                         raw_seek_position
                         + (timing_info.fadein_trimmed_duration + timing_info.crossfade_duration)

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -155,7 +155,12 @@ class AudioBuffer:
 
     @property
     def eof(self) -> bool:
-        """Return whether the source delivered all of its audio."""
+        """
+        Return whether the source stopped producing.
+
+        A source that failed after delivering audio also ends here, so pair this with
+        ``has_error`` when a clean finish is what matters.
+        """
         return self._eof_received
 
     @property

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -154,6 +154,11 @@ class AudioBuffer:
         return self._producer_task is not None and not self._producer_task.done()
 
     @property
+    def eof(self) -> bool:
+        """Return whether the source delivered all of its audio."""
+        return self._eof_received
+
+    @property
     def first_buffered_chunk(self) -> int:
         """Return the chunk number of the oldest chunk still retained in the buffer."""
         return self._discarded_chunks
@@ -460,8 +465,10 @@ class AudioBuffer:
         # convert ms to seconds for get_media_stream (FFmpeg works in seconds)
         seek_seconds = seek_position_ms // 1000
 
-        # for large seeks without existing buffer, start at seek position
-        buffer_seek_seconds = seek_seconds if seek_seconds > 60 else 0
+        # for large seeks without existing buffer, start at seek position.
+        # A realtime source can not produce the skipped audio any faster than playback,
+        # so it always seeks at the source instead of buffering up to the seek point.
+        buffer_seek_seconds = seek_seconds if streamdetails.is_realtime or seek_seconds > 60 else 0
 
         pcm_format = AudioFormat(
             content_type=ContentType.from_bit_depth(streamdetails.audio_format.bit_depth),
@@ -478,9 +485,16 @@ class AudioBuffer:
         crossfade_enabled = bool(
             queue and queue.crossfade_enabled and streamdetails.media_type == MediaType.TRACK
         )
-        if crossfade_enabled:
+        dynamic_normalization = (
+            streamdetails.volume_normalization_mode == VolumeNormalizationMode.DYNAMIC
+        )
+        if streamdetails.is_realtime:
+            # a realtime source fills the buffer at playback pace, so every second of
+            # audio asked for here is a second of extra startup delay
+            ready_threshold = 2 if crossfade_enabled or dynamic_normalization else 1
+        elif crossfade_enabled:
             ready_threshold = 8
-        elif streamdetails.volume_normalization_mode == VolumeNormalizationMode.DYNAMIC:
+        elif dynamic_normalization:
             # radio streams are continuous so the normalization will converge quickly,
             # use a lower threshold to reduce startup latency
             ready_threshold = 3 if streamdetails.media_type == MediaType.RADIO else 5

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1421,7 +1421,9 @@ class StreamsController(CoreController):
                     pcm_format=pcm_format,
                     crossfade_mode=(
                         self.get_crossfade_mode(queue)
+                        # a realtime source is never faded, in either direction
                         if queue_item.media_type == MediaType.TRACK
+                        and not (queue_item.streamdetails and queue_item.streamdetails.is_realtime)
                         else CrossfadeMode.DISABLED
                     ),
                     overlay_enabled=(

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -760,6 +760,10 @@ class StreamsController(CoreController):
             )
             if queue_item.media_type != MediaType.TRACK:
                 crossfade_mode = CrossfadeMode.DISABLED
+            elif queue_item.streamdetails.is_realtime:
+                # a realtime source delivers at playback pace, so it has no audio to
+                # spare for an overlap in either direction
+                crossfade_mode = CrossfadeMode.DISABLED
             else:
                 crossfade_mode = self.get_crossfade_mode(queue)
             if (

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -55,12 +55,13 @@ _DEFAULT_SENDSPIN_PCM_FORMAT = SendspinAudioFormat(
 # grow after playback begins, so their send-ahead stays at the min_buffer_ms floor.
 # Buffered types (tracks, podcasts, etc.) race ahead and fill the queue naturally, so
 # their send-ahead may extend to a larger required_lead_time_ms without lasting cost.
+# A queue flow carries those same buffered items - radio and live sources always play
+# as a single item, never in flow mode - so it belongs with the buffered types.
 _LIVE_MEDIA_TYPES: frozenset[MediaType] = frozenset(
     {
         MediaType.RADIO,
         MediaType.AUDIO_SOURCE,
         MediaType.PLUGIN_SOURCE,
-        MediaType.FLOW_STREAM,
     }
 )
 

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -1081,7 +1081,7 @@ async def test_flow_zero_audio_skip_restores_seek_position(
         seek_position=0,
         seconds_streamed=0,
         duration=120,
-        buffer=SimpleNamespace(eof=True, cancelled=False),
+        buffer=SimpleNamespace(eof=True, cancelled=False, has_error=False, max_size_seconds=300),
         is_realtime=False,
     )
     first_item = SimpleNamespace(

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -949,6 +949,7 @@ async def test_duplicate_flow_producer_does_not_interleave_the_play_log() -> Non
                 duration=300,
                 buffer=None,
                 seconds_streamed=None,
+                is_realtime=False,
                 audio_format=_format(ContentType.PCM_F32LE, 48000, 32),
             ),
         )

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -1014,6 +1014,7 @@ async def test_flow_source_error_skips_item_without_completing_it() -> None:
         uri="audiobookshelf://book",
         seek_position=0,
         duration=3600,
+        is_realtime=False,
     )
     queue_item = SimpleNamespace(
         queue_item_id="item-1",
@@ -1201,6 +1202,7 @@ async def test_flow_does_not_write_back_a_duration_for_an_aborted_source(
         seek_position=0,
         seconds_streamed=0,
         duration=300,
+        is_realtime=False,
     )
     queue_track = SimpleNamespace(
         queue_id="queue-1",

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -1081,7 +1081,8 @@ async def test_flow_zero_audio_skip_restores_seek_position(
         seek_position=0,
         seconds_streamed=0,
         duration=120,
-        buffer=None,
+        buffer=SimpleNamespace(eof=True, cancelled=False),
+        is_realtime=False,
     )
     first_item = SimpleNamespace(
         queue_id="queue-1",
@@ -1107,6 +1108,7 @@ async def test_flow_zero_audio_skip_restores_seek_position(
         seek_position=raw_seek_position,
         seconds_streamed=0,
         duration=120,
+        is_realtime=False,
     )
     skipped_item = SimpleNamespace(
         queue_id="queue-1",
@@ -1156,8 +1158,9 @@ async def test_flow_zero_audio_skip_restores_seek_position(
         **_kwargs: object,
     ) -> AsyncGenerator[bytes]:
         if queue_item is first_item:
+            # warmup worth of audio, then a full crossfade tail
             yield bytes(pcm_format.pcm_sample_size * 8)
-            yield bytes(pcm_format.pcm_sample_size)
+            yield bytes(pcm_format.pcm_sample_size * 8)
         else:
             eager_seek_positions.append(queue_item.streamdetails.seek_position)
 

--- a/tests/controllers/streams/test_crossfade_capacity.py
+++ b/tests/controllers/streams/test_crossfade_capacity.py
@@ -48,7 +48,7 @@ def _buffer(duration_available: float, ready: bool) -> AudioBuffer:
 
 def _delivered_buffer() -> SimpleNamespace:
     """Build the outgoing track's buffer, with its source done delivering."""
-    return SimpleNamespace(eof=True, cancelled=False)
+    return SimpleNamespace(eof=True, cancelled=False, has_error=False, max_size_seconds=300)
 
 
 def test_ready_incoming_buffer_keeps_smart_crossfade() -> None:

--- a/tests/controllers/streams/test_crossfade_capacity.py
+++ b/tests/controllers/streams/test_crossfade_capacity.py
@@ -46,6 +46,11 @@ def _buffer(duration_available: float, ready: bool) -> AudioBuffer:
     return audio_buffer
 
 
+def _delivered_buffer() -> SimpleNamespace:
+    """Build the outgoing track's buffer, with its source done delivering."""
+    return SimpleNamespace(eof=True, cancelled=False)
+
+
 def test_ready_incoming_buffer_keeps_smart_crossfade() -> None:
     """A fully resident incoming buffer keeps the requested Smart Fade."""
     audio = StreamsAudio(MagicMock())
@@ -128,7 +133,8 @@ async def test_unprepared_next_track_flushes_outgoing_tail_without_opening_sourc
         seek_position=0,
         seconds_streamed=0,
         uri="test://current",
-        buffer=None,
+        buffer=_delivered_buffer(),
+        is_realtime=False,
     )
     next_details = SimpleNamespace(
         audio_format=pcm_format,
@@ -136,6 +142,7 @@ async def test_unprepared_next_track_flushes_outgoing_tail_without_opening_sourc
         duration=16,
         seek_position=0,
         uri="test://next",
+        is_realtime=False,
     )
     current_item = SimpleNamespace(
         queue_id="queue-1",
@@ -216,7 +223,8 @@ async def test_partial_crossfade_resumes_at_consumed_media_time(
         seek_position=0,
         seconds_streamed=0,
         uri="test://current",
-        buffer=None,
+        buffer=_delivered_buffer(),
+        is_realtime=False,
     )
     next_details = SimpleNamespace(
         audio_format=pcm_format,
@@ -225,6 +233,7 @@ async def test_partial_crossfade_resumes_at_consumed_media_time(
         seek_position=0,
         uri="test://next",
         volume_normalization_mode=None,
+        is_realtime=False,
     )
     current_item = SimpleNamespace(
         queue_id="queue-1",

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1,0 +1,757 @@
+"""Tests for the is_realtime gate across the buffer, holdback, and stream paths."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import (
+    ContentType,
+    CrossfadeMode,
+    MediaType,
+    StreamType,
+    VolumeNormalizationMode,
+)
+from music_assistant_models.errors import QueueEmpty
+from music_assistant_models.media_items import (
+    AudioFormat,
+    AudioSource,
+    ProviderMapping,
+    Radio,
+    Track,
+)
+from music_assistant_models.queue_item import QueueItem
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.controllers.streams.audio import StreamsAudio
+from music_assistant.controllers.streams.audio_buffer import AudioBuffer
+from music_assistant.controllers.streams.constants import BufferSize
+from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
+
+# Standard test PCM format: 44100Hz, 16-bit, stereo
+TEST_PCM_FORMAT = AudioFormat(
+    content_type=ContentType.PCM_S16LE,
+    sample_rate=44100,
+    bit_depth=16,
+    channels=2,
+)
+
+# One second of silence in the test format
+ONE_SECOND_CHUNK = b"\x00" * TEST_PCM_FORMAT.pcm_sample_size
+
+
+def _make_stream_details(
+    media_type: MediaType,
+    *,
+    is_realtime: bool = False,
+    volume_normalization_mode: VolumeNormalizationMode | None = None,
+    queue_id: str | None = None,
+) -> StreamDetails:
+    """Build minimal stream details for AudioBuffer.get_buffer tests."""
+    return StreamDetails(
+        provider="builtin",
+        item_id="item-1",
+        audio_format=TEST_PCM_FORMAT,
+        media_type=media_type,
+        stream_type=StreamType.HTTP,
+        path="http://example.com/audio.mp3",
+        duration=180,
+        can_seek=True,
+        allow_seek=True,
+        queue_id=queue_id,
+        is_realtime=is_realtime,
+        volume_normalization_mode=volume_normalization_mode,
+    )
+
+
+async def _make_source(num_chunks: int) -> AsyncGenerator[bytes]:
+    """Create an async generator that yields one-second PCM chunks."""
+    for _ in range(num_chunks):
+        yield ONE_SECOND_CHUNK
+
+
+def _make_mass_for_get_buffer(
+    *, queue: Any | None = None
+) -> tuple[MagicMock, list[asyncio.Task[None]], list[float | None]]:
+    """Build a minimal mass stub for AudioBuffer.get_buffer tests."""
+    received_seek_positions: list[float | None] = []
+
+    def _get_media_stream(*_args: Any, **kwargs: Any) -> AsyncGenerator[bytes]:
+        received_seek_positions.append(kwargs.get("seek_position"))
+        return _make_source(1)
+
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value.return_value = BufferSize.BALANCED.value
+    mass.player_queues.get.return_value = queue
+    mass.streams = SimpleNamespace(
+        audio_analysis=SimpleNamespace(start_analysis=AsyncMock(return_value=None)),
+        audio=SimpleNamespace(get_media_stream=_get_media_stream),
+    )
+    scheduled_tasks: list[asyncio.Task[None]] = []
+
+    def _create_task(coro: Any) -> asyncio.Task[None]:
+        task: asyncio.Task[None] = asyncio.ensure_future(coro)
+        scheduled_tasks.append(task)
+        return task
+
+    mass.create_task.side_effect = _create_task
+    return mass, scheduled_tasks, received_seek_positions
+
+
+def _streamdetails_for_crossfade(
+    audio_buffer: AudioBuffer | None, *, is_realtime: bool = False
+) -> StreamDetails:
+    """Build incoming track details with an optional prepared buffer."""
+    streamdetails = StreamDetails(
+        provider="test--1",
+        item_id="track-1",
+        audio_format=AudioFormat(content_type=ContentType.FLAC),
+        media_type=MediaType.TRACK,
+        stream_type=StreamType.HTTP,
+        path="http://test.invalid/track.flac",
+        duration=180,
+        is_realtime=is_realtime,
+    )
+    streamdetails.buffer = audio_buffer
+    return streamdetails
+
+
+async def _empty_mix(*_args: object, **_kwargs: object) -> AsyncGenerator[bytes]:
+    """Stand in for the mixer, producing no audio."""
+    no_audio: tuple[bytes, ...] = ()
+    for chunk in no_audio:
+        yield chunk
+
+
+def _buffer(duration_available: float, ready: bool) -> AudioBuffer:
+    """Build a valid buffer with the requested resident duration."""
+    audio_buffer = MagicMock(spec=AudioBuffer)
+    audio_buffer.has_error = False
+    audio_buffer.is_valid.return_value = True
+    audio_buffer.duration_available = duration_available
+    audio_buffer.ready = MagicMock()
+    audio_buffer.ready.is_set.return_value = ready
+    return audio_buffer
+
+
+def _stream_details_provider(streamdetails: StreamDetails) -> StreamsAudio:
+    """Build a StreamsAudio whose single provider hands back the given streamdetails."""
+    provider = MagicMock()
+    provider.instance_id = "test--1"
+    provider.domain = "test"
+    provider.available = True
+    provider.is_streaming_provider = True
+    provider.get_stream_details = AsyncMock(return_value=streamdetails)
+    mass = MagicMock()
+    mass.get_provider.side_effect = lambda instance, **_kwargs: (
+        provider if instance == "test--1" else None
+    )
+    mass.providers = []
+    mass.player_queues.queue_data_or_none.return_value = None
+    mass.streams.get_config_value.return_value = -17
+    return StreamsAudio(mass)
+
+
+def _queue_item_with_mapping(media_item_cls: type) -> QueueItem:
+    """Build a queue item whose media item carries one matching provider mapping."""
+    mapping = ProviderMapping(item_id="item-1", provider_domain="test", provider_instance="test--1")
+    media_item = media_item_cls(
+        item_id="item-1", provider="test--1", name="Item", provider_mappings={mapping}
+    )
+    return QueueItem(
+        queue_id="q1", queue_item_id="qi1", name="Item", duration=None, media_item=media_item
+    )
+
+
+# -- AudioBuffer.get_buffer: ready threshold ladder --
+
+
+@pytest.mark.parametrize(
+    (
+        "is_realtime",
+        "crossfade_enabled",
+        "normalization_mode",
+        "media_type",
+        "expected_threshold",
+    ),
+    [
+        pytest.param(True, False, None, MediaType.RADIO, 1, id="realtime_base"),
+        pytest.param(True, False, None, MediaType.AUDIO_SOURCE, 1, id="realtime_audio_source"),
+        pytest.param(True, True, None, MediaType.TRACK, 2, id="realtime_crossfade"),
+        pytest.param(
+            True,
+            False,
+            VolumeNormalizationMode.DYNAMIC,
+            MediaType.TRACK,
+            2,
+            id="realtime_dynamic_normalization",
+        ),
+        pytest.param(False, True, None, MediaType.TRACK, 8, id="non_realtime_crossfade"),
+        pytest.param(
+            False,
+            False,
+            VolumeNormalizationMode.DYNAMIC,
+            MediaType.RADIO,
+            3,
+            id="non_realtime_dynamic_radio",
+        ),
+        pytest.param(
+            False,
+            False,
+            VolumeNormalizationMode.DYNAMIC,
+            MediaType.TRACK,
+            5,
+            id="non_realtime_dynamic_track",
+        ),
+        pytest.param(False, False, None, MediaType.TRACK, 2, id="non_realtime_default"),
+    ],
+)
+async def test_ready_threshold_ladder(
+    is_realtime: bool,
+    crossfade_enabled: bool,
+    normalization_mode: VolumeNormalizationMode | None,
+    media_type: MediaType,
+    expected_threshold: int,
+) -> None:
+    """The buffered-ready threshold follows the realtime ladder, leaving the old one intact."""
+    queue = SimpleNamespace(crossfade_enabled=crossfade_enabled)
+    mass, scheduled_tasks, _seek_positions = _make_mass_for_get_buffer(queue=queue)
+    streamdetails = _make_stream_details(
+        media_type,
+        is_realtime=is_realtime,
+        volume_normalization_mode=normalization_mode,
+        queue_id="queue-1",
+    )
+
+    buffer = await AudioBuffer.get_buffer(mass, streamdetails, reason="test")
+
+    assert buffer._ready_threshold == expected_threshold
+    await asyncio.gather(*scheduled_tasks)
+    await buffer.clear()
+
+
+# -- AudioBuffer.get_buffer: seek handling --
+
+
+@pytest.mark.parametrize(
+    ("is_realtime", "seek_seconds", "expected_source_seek"),
+    [
+        pytest.param(True, 30, 30, id="realtime_short_seek_reaches_source"),
+        pytest.param(False, 30, 0, id="non_realtime_short_seek_buffers_from_start"),
+        pytest.param(False, 90, 90, id="non_realtime_long_seek_reaches_source"),
+    ],
+)
+async def test_get_buffer_seek_position_reaches_the_source(
+    is_realtime: bool, seek_seconds: int, expected_source_seek: int
+) -> None:
+    """A realtime source always seeks at the source; a non-realtime one only for a large seek."""
+    mass, scheduled_tasks, received_seek_positions = _make_mass_for_get_buffer()
+    streamdetails = _make_stream_details(MediaType.TRACK, is_realtime=is_realtime)
+
+    buffer = await AudioBuffer.get_buffer(
+        mass, streamdetails, seek_position_ms=seek_seconds * 1000, reason="test"
+    )
+
+    assert received_seek_positions == [expected_source_seek]
+    assert buffer._discarded_chunks == expected_source_seek
+    await asyncio.gather(*scheduled_tasks)
+    await buffer.clear()
+
+
+# -- AudioBuffer.eof --
+
+
+async def test_eof_reflects_producer_completion() -> None:
+    """The eof flag turns True only once the producer has delivered everything."""
+    buf = AudioBuffer(TEST_PCM_FORMAT)
+    assert not buf.eof
+    await buf._put(ONE_SECOND_CHUNK)
+    assert not buf.eof
+    await buf._set_eof()
+    assert buf.eof
+
+
+# -- StreamsAudio._crossfade_holdback_allowed --
+
+
+def test_holdback_rejected_when_crossfade_buffer_size_is_zero() -> None:
+    """A zero-size crossfade buffer has nothing to hold back."""
+    audio = StreamsAudio(MagicMock())
+    streamdetails = SimpleNamespace(
+        is_realtime=False, buffer=SimpleNamespace(eof=True, max_size_seconds=300)
+    )
+
+    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 0) is False
+
+
+def test_holdback_rejected_for_realtime_source() -> None:
+    """A realtime source's tail is never held back, even once its buffer reaches EOF."""
+    audio = StreamsAudio(MagicMock())
+    streamdetails = SimpleNamespace(
+        is_realtime=True, buffer=SimpleNamespace(eof=True, max_size_seconds=300)
+    )
+
+    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
+
+
+def test_holdback_rejected_without_a_buffer() -> None:
+    """A source with no buffer yet has nothing to hold back."""
+    audio = StreamsAudio(MagicMock())
+    streamdetails = SimpleNamespace(is_realtime=False, buffer=None)
+
+    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
+
+
+def test_holdback_rejected_before_source_reaches_eof() -> None:
+    """A still-filling buffer keeps limiting playback, so its tail is not held back yet."""
+    audio = StreamsAudio(MagicMock())
+    streamdetails = SimpleNamespace(
+        is_realtime=False, buffer=SimpleNamespace(eof=False, max_size_seconds=300)
+    )
+
+    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
+
+
+def test_holdback_allowed_once_source_reaches_eof() -> None:
+    """A fully delivered, non-realtime source may hold back its tail for a crossfade."""
+    audio = StreamsAudio(MagicMock())
+    streamdetails = SimpleNamespace(
+        is_realtime=False, buffer=SimpleNamespace(eof=True, max_size_seconds=300)
+    )
+
+    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is True
+
+
+def test_holdback_allowed_when_the_buffer_can_never_hold_the_tail() -> None:
+    """A buffer smaller than the tail collects it while the source runs, or loses the fade."""
+    audio = StreamsAudio(MagicMock())
+    streamdetails = SimpleNamespace(
+        is_realtime=False, buffer=SimpleNamespace(eof=False, max_size_seconds=15)
+    )
+
+    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 45) is True
+    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
+
+
+# -- StreamsAudio._select_buffered_crossfade --
+
+
+def test_realtime_incoming_source_disables_crossfade_even_when_ready() -> None:
+    """A realtime incoming source never gets a fade-in, no matter how ready its buffer is."""
+    audio = StreamsAudio(MagicMock())
+
+    mode, duration = audio._select_buffered_crossfade(
+        _streamdetails_for_crossfade(
+            _buffer(SMART_CROSSFADE_DURATION, ready=True), is_realtime=True
+        ),
+        CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+
+    assert mode == CrossfadeMode.DISABLED
+    assert duration == 0
+
+
+# -- Path level: get_queue_item_stream_with_smartfade --
+
+
+async def test_smartfade_realtime_current_item_yields_all_audio_without_crossfade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A realtime current item streams straight through; nothing is held back for a fade."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=2,
+    )
+    # the source is done delivering, so only the realtime flag can deny the holdback
+    current_details = SimpleNamespace(
+        duration=16,
+        seek_position=0,
+        seconds_streamed=0,
+        uri="test://current",
+        buffer=SimpleNamespace(eof=True, cancelled=False, max_size_seconds=300),
+        is_realtime=True,
+    )
+    # a fully resident, ready incoming buffer - the realtime flag on the outgoing
+    # track must be what blocks the fade, not an unprepared next item
+    next_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=_buffer(SMART_CROSSFADE_DURATION, ready=True),
+        duration=16,
+        seek_position=0,
+        uri="test://next",
+        is_realtime=False,
+    )
+    current_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="current",
+        name="Current",
+        streamdetails=current_details,
+        extra_attributes={},
+    )
+    next_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="next",
+        name="Next",
+        streamdetails=next_details,
+        extra_attributes={},
+        available=True,
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        index_in_buffer=0,
+    )
+    player = SimpleNamespace(player_id="player-1", name="Player")
+    mass = MagicMock()
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.load_next_queue_item = AsyncMock(return_value=next_item)
+    mass.player_queues.index_by_id.return_value = 1
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+    build = AsyncMock()
+    monkeypatch.setattr(audio.smart_fades_mixer, "build", build)
+
+    async def _current_stream(
+        queue_item: object,
+        *_args: object,
+        **_kwargs: object,
+    ) -> AsyncGenerator[bytes]:
+        if queue_item is not current_item:
+            pytest.fail("The incoming source was opened while the current item was realtime")
+        yield bytes(pcm_format.pcm_sample_size * 8)
+        yield bytes(pcm_format.pcm_sample_size * 8)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _current_stream)
+    stream = audio.get_queue_item_stream_with_smartfade(
+        cast("Any", player),
+        cast("Any", current_item),
+        pcm_format,
+        crossfade_mode=CrossfadeMode.STANDARD_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+
+    output = b"".join([chunk async for chunk in stream])
+
+    assert len(output) == pcm_format.pcm_sample_size * 16
+    build.assert_not_awaited()
+    assert "queue-1" not in audio._crossfade_data
+
+
+async def test_smartfade_still_filling_buffer_yields_all_audio_without_crossfade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-realtime source that has not yet reached EOF is also never held back for a fade."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=2,
+    )
+    current_details = SimpleNamespace(
+        duration=16,
+        seek_position=0,
+        seconds_streamed=0,
+        uri="test://current",
+        buffer=SimpleNamespace(eof=False, cancelled=False, max_size_seconds=300),
+        is_realtime=False,
+    )
+    next_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=_buffer(SMART_CROSSFADE_DURATION, ready=True),
+        duration=16,
+        seek_position=0,
+        uri="test://next",
+        is_realtime=False,
+    )
+    current_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="current",
+        name="Current",
+        streamdetails=current_details,
+        extra_attributes={},
+    )
+    next_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="next",
+        name="Next",
+        streamdetails=next_details,
+        extra_attributes={},
+        available=True,
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        index_in_buffer=0,
+    )
+    player = SimpleNamespace(player_id="player-1", name="Player")
+    mass = MagicMock()
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.load_next_queue_item = AsyncMock(return_value=next_item)
+    mass.player_queues.index_by_id.return_value = 1
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+    build = AsyncMock()
+    monkeypatch.setattr(audio.smart_fades_mixer, "build", build)
+
+    async def _current_stream(
+        queue_item: object,
+        *_args: object,
+        **_kwargs: object,
+    ) -> AsyncGenerator[bytes]:
+        if queue_item is not current_item:
+            pytest.fail("The incoming source was opened while the current buffer was still open")
+        yield bytes(pcm_format.pcm_sample_size * 8)
+        yield bytes(pcm_format.pcm_sample_size * 8)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _current_stream)
+    stream = audio.get_queue_item_stream_with_smartfade(
+        cast("Any", player),
+        cast("Any", current_item),
+        pcm_format,
+        crossfade_mode=CrossfadeMode.STANDARD_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+
+    output = b"".join([chunk async for chunk in stream])
+
+    assert len(output) == pcm_format.pcm_sample_size * 16
+    build.assert_not_awaited()
+    assert "queue-1" not in audio._crossfade_data
+
+
+# -- Path level: get_queue_flow_stream --
+
+
+async def test_flow_realtime_item_yields_all_audio_as_plain_concatenation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A realtime item's flow audio is passed straight through and simply concatenated."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=2,
+    )
+    # the source is done delivering, so only the realtime flag can deny the holdback
+    realtime_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=SimpleNamespace(eof=True, cancelled=False, max_size_seconds=300),
+        fade_in=False,
+        stream_error=False,
+        uri="test://realtime",
+        seek_position=0,
+        seconds_streamed=0,
+        duration=20,
+        is_realtime=True,
+    )
+    realtime_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-1",
+        name="Realtime",
+        media_type=MediaType.TRACK,
+        media_item=None,
+        streamdetails=realtime_details,
+        duration=20,
+        extra_attributes={},
+    )
+    next_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=None,
+        fade_in=False,
+        stream_error=False,
+        uri="test://next",
+        seek_position=0,
+        seconds_streamed=0,
+        duration=20,
+        is_realtime=False,
+    )
+    next_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-2",
+        name="Next",
+        media_type=MediaType.TRACK,
+        media_item=None,
+        streamdetails=next_details,
+        duration=20,
+        extra_attributes={},
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        flow_mode=False,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
+    queue_data = SimpleNamespace(session_id="session-1", flow_mode_stream_log=[])
+    mass = MagicMock()
+    mass.player_queues.queue_data.return_value = queue_data
+    mass.player_queues.load_next_queue_item = AsyncMock(side_effect=[next_item, QueueEmpty])
+    mass.player_queues.get.return_value = queue
+    mass.streams.get_crossfade_mode.return_value = CrossfadeMode.STANDARD_CROSSFADE
+    mass.config.get_raw_core_config_value.return_value = 8
+    mass.streams.audio_processing.update_item_context = MagicMock()
+    mass.player_queues.queue_buffer_completed = MagicMock()
+    player = MagicMock()
+    player.config.get_value.return_value = "fixed_48000"
+    player.get_supported_sample_rates.return_value = []
+    mass.players.get_player.return_value = player
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+    build = AsyncMock()
+    monkeypatch.setattr(audio.smart_fades_mixer, "build", build)
+
+    realtime_chunks = [
+        bytes(pcm_format.pcm_sample_size * 8),
+        bytes(pcm_format.pcm_sample_size * 8),
+    ]
+    next_chunks = [bytes(pcm_format.pcm_sample_size * 2)]
+
+    async def _item_stream(
+        queue_item: SimpleNamespace, *_args: object, **_kwargs: object
+    ) -> AsyncGenerator[bytes]:
+        chunks = realtime_chunks if queue_item is realtime_item else next_chunks
+        for chunk in chunks:
+            yield chunk
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
+    select_crossfade = MagicMock(wraps=audio._select_buffered_crossfade)
+    monkeypatch.setattr(audio, "_select_buffered_crossfade", select_crossfade)
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", realtime_item), pcm_format, session_id="session-1"
+    )
+
+    output = b"".join([chunk async for chunk in stream])
+
+    assert output == b"".join(realtime_chunks) + b"".join(next_chunks)
+    build.assert_not_awaited()
+    # no tail was held back, so the next item is never asked to fade into anything
+    select_crossfade.assert_not_called()
+    mass.player_queues.queue_buffer_completed.assert_called_once()
+
+
+async def test_smartfade_unaligned_chunks_still_crossfade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A source whose chunks are not whole seconds still collects a complete fade tail."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=2,
+    )
+    current_details = SimpleNamespace(
+        duration=30,
+        seek_position=0,
+        seconds_streamed=0,
+        uri="test://current",
+        buffer=SimpleNamespace(eof=True, cancelled=False, max_size_seconds=300),
+        is_realtime=False,
+    )
+    next_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=_buffer(SMART_CROSSFADE_DURATION, ready=True),
+        duration=30,
+        seek_position=0,
+        uri="test://next",
+        is_realtime=False,
+        volume_normalization_mode=None,
+    )
+    current_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="current",
+        name="Current",
+        streamdetails=current_details,
+        extra_attributes={},
+    )
+    next_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="next",
+        name="Next",
+        streamdetails=next_details,
+        extra_attributes={},
+        available=True,
+    )
+    queue = SimpleNamespace(queue_id="queue-1", display_name="Queue", index_in_buffer=0)
+    player = SimpleNamespace(player_id="player-1", name="Player")
+    mass = MagicMock()
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.load_next_queue_item = AsyncMock(return_value=next_item)
+    mass.player_queues.index_by_id.return_value = 1
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+    audio.select_pcm_format = AsyncMock(return_value=pcm_format)  # type: ignore[method-assign]
+    audio.crossfade_allowed = MagicMock(return_value=True)  # type: ignore[method-assign]
+    build = AsyncMock(
+        return_value=SimpleNamespace(
+            timing_info=SimpleNamespace(
+                pre_crossfade_duration=2,
+                crossfade_duration=6,
+                fadein_trimmed_duration=0,
+            )
+        )
+    )
+    monkeypatch.setattr(audio.smart_fades_mixer, "build", build)
+    monkeypatch.setattr(audio.smart_fades_mixer, "mix", _empty_mix)
+
+    async def _current_stream(
+        queue_item: object, *_args: object, **_kwargs: object
+    ) -> AsyncGenerator[bytes]:
+        if queue_item is not current_item:
+            return
+        # a whole second, then chunks that never line up with a second boundary
+        yield bytes(pcm_format.pcm_sample_size * 8)
+        for _ in range(30):
+            yield bytes(pcm_format.pcm_sample_size // 3)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _current_stream)
+    stream = audio.get_queue_item_stream_with_smartfade(
+        cast("Any", player),
+        cast("Any", current_item),
+        pcm_format,
+        crossfade_mode=CrossfadeMode.STANDARD_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+
+    async for _chunk in stream:
+        pass
+
+    build.assert_awaited_once()
+
+
+# -- StreamsAudio.get_stream_details --
+
+
+@pytest.mark.parametrize(
+    ("media_item_cls", "media_type", "expected_is_realtime"),
+    [
+        pytest.param(Radio, MediaType.RADIO, True, id="radio"),
+        pytest.param(AudioSource, MediaType.AUDIO_SOURCE, True, id="audio_source"),
+        pytest.param(Track, MediaType.TRACK, False, id="track"),
+    ],
+)
+async def test_get_stream_details_sets_is_realtime_by_media_type(
+    media_item_cls: type, media_type: MediaType, expected_is_realtime: bool
+) -> None:
+    """RADIO and AUDIO_SOURCE streams are marked realtime; a TRACK's flag is left alone."""
+    provider_streamdetails = StreamDetails(
+        provider="test--1",
+        item_id="item-1",
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        media_type=media_type,
+        stream_type=StreamType.CUSTOM,
+        duration=180 if media_type == MediaType.TRACK else None,
+    )
+    audio = _stream_details_provider(provider_streamdetails)
+
+    streamdetails = await audio.get_stream_details(
+        queue_item=_queue_item_with_mapping(media_item_cls)
+    )
+
+    assert streamdetails.is_realtime is expected_is_realtime

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -32,6 +32,7 @@ from music_assistant.controllers.streams.audio import StreamsAudio
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
 from music_assistant.controllers.streams.constants import BufferSize
 from music_assistant.controllers.streams.controller import StreamsController
+from music_assistant.controllers.streams.smart_fades.fades import StandardCrossFade
 from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
 
 # Standard test PCM format: 44100Hz, 16-bit, stereo
@@ -987,6 +988,119 @@ async def test_flow_reports_no_crossfade_for_a_realtime_item(
     update_item_context.assert_called()
     reported = update_item_context.call_args.kwargs["queue_processing"]
     assert reported.crossfade_mode == CrossfadeMode.DISABLED
+
+
+async def test_flow_standard_fade_only_holds_back_its_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A standard transition waits for its overlap, not for the whole requested window."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=2,
+    )
+    first_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=SimpleNamespace(eof=True, cancelled=False, has_error=False, max_size_seconds=300),
+        fade_in=False,
+        stream_error=False,
+        uri="test://first",
+        seek_position=0,
+        seconds_streamed=0,
+        duration=300,
+        is_realtime=False,
+    )
+    second_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=_buffer(SMART_CROSSFADE_DURATION, ready=True),
+        fade_in=False,
+        stream_error=False,
+        uri="test://second",
+        seek_position=0,
+        seconds_streamed=0,
+        duration=300,
+        is_realtime=False,
+        volume_normalization_mode=None,
+    )
+    first_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-1",
+        name="First",
+        media_type=MediaType.TRACK,
+        media_item=None,
+        streamdetails=first_details,
+        duration=300,
+        extra_attributes={},
+    )
+    second_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-2",
+        name="Second",
+        media_type=MediaType.TRACK,
+        media_item=None,
+        streamdetails=second_details,
+        duration=300,
+        extra_attributes={},
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        flow_mode=False,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
+    mass = MagicMock()
+    mass.player_queues.queue_data.return_value = SimpleNamespace(
+        session_id="session-1", flow_mode_stream_log=[]
+    )
+    mass.player_queues.load_next_queue_item = AsyncMock(side_effect=[second_item, QueueEmpty])
+    mass.player_queues.get.return_value = queue
+    mass.streams.get_crossfade_mode.return_value = CrossfadeMode.SMART_CROSSFADE
+    mass.config.get_raw_core_config_value.return_value = 8
+    player = MagicMock()
+    player.config.get_value.return_value = "fixed_48000"
+    player.get_supported_sample_rates.return_value = []
+    mass.players.get_player.return_value = player
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+    audio.crossfade_allowed = MagicMock(return_value=True)  # type: ignore[method-assign]
+    # the incoming analysis is not ready, so the mixer degrades to a standard fade
+    standard = StandardCrossFade(logger=MagicMock(), crossfade_duration=8)
+    standard.build(
+        pcm_format.pcm_sample_size * SMART_CROSSFADE_DURATION,
+        pcm_format.pcm_sample_size * SMART_CROSSFADE_DURATION,
+        pcm_format,
+    )
+    monkeypatch.setattr(audio.smart_fades_mixer, "build", AsyncMock(return_value=standard))
+    monkeypatch.setattr(audio.smart_fades_mixer, "mix", _empty_mix)
+
+    consumed: dict[str, int] = {"second": 0}
+
+    async def _item_stream(
+        queue_item: SimpleNamespace, *_args: object, **_kwargs: object
+    ) -> AsyncGenerator[bytes]:
+        if queue_item is first_item:
+            for _ in range(60):
+                yield bytes(pcm_format.pcm_sample_size)
+            return
+        for _ in range(SMART_CROSSFADE_DURATION + 20):
+            consumed["second"] += 1
+            yield bytes(pcm_format.pcm_sample_size)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), pcm_format, session_id="session-1"
+    )
+
+    seconds_before_transition: int | None = None
+    async for _chunk in stream:
+        if seconds_before_transition is None and consumed["second"]:
+            seconds_before_transition = consumed["second"]
+
+    # the overlap is 8s, so the transition must not wait for the full 45s window
+    assert seconds_before_transition is not None
+    assert seconds_before_transition <= SMART_CROSSFADE_DURATION / 2
 
 
 # -- StreamsController.serve_queue_item_stream steering --

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -13,6 +13,7 @@ from music_assistant_models.enums import (
     ContentType,
     CrossfadeMode,
     MediaType,
+    PlayerFeature,
     StreamType,
     VolumeNormalizationMode,
 )
@@ -30,6 +31,7 @@ from music_assistant_models.streamdetails import StreamDetails
 from music_assistant.controllers.streams.audio import StreamsAudio
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
 from music_assistant.controllers.streams.constants import BufferSize
+from music_assistant.controllers.streams.controller import StreamsController
 from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
 
 # Standard test PCM format: 44100Hz, 16-bit, stereo
@@ -985,6 +987,92 @@ async def test_flow_reports_no_crossfade_for_a_realtime_item(
     update_item_context.assert_called()
     reported = update_item_context.call_args.kwargs["queue_processing"]
     assert reported.crossfade_mode == CrossfadeMode.DISABLED
+
+
+# -- StreamsController.serve_queue_item_stream steering --
+
+
+class _PcmFormatRequested(Exception):
+    """Raised to stop the handler once it has decided on crossfading."""
+
+
+def _single_item_handler(*, is_realtime: bool) -> tuple[Any, MagicMock, dict[str, Any]]:
+    """Return a single-item stream handler that stops once the PCM format is picked."""
+    streamdetails = _make_stream_details(MediaType.TRACK, is_realtime=is_realtime)
+    queue_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-1",
+        name="Track",
+        duration=180,
+        streamdetails=streamdetails,
+        media_item=None,
+        media_type=MediaType.TRACK,
+        extra_attributes={},
+        image=None,
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        current_item=queue_item,
+        crossfade_enabled=True,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
+    mass = MagicMock()
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.queue_data.return_value = SimpleNamespace(session_id="session-1")
+    mass.player_queues.get_item.return_value = queue_item
+    mass.config.get_raw_core_config_value.return_value = 8
+    player = MagicMock(player_id="player-1", protocol_parent_id=None)
+    player.state.supported_features = {PlayerFeature.GAPLESS_PLAYBACK}
+    player.state.name = "Player"
+    mass.players.get_player.return_value = player
+
+    seen: dict[str, Any] = {}
+
+    async def _select_pcm_format(**kwargs: Any) -> None:
+        seen["crossfade_enabled"] = kwargs["crossfade_enabled"]
+        raise _PcmFormatRequested
+
+    audio = MagicMock()
+    audio.select_pcm_format = _select_pcm_format
+    controller = cast("Any", object.__new__(StreamsController))
+    controller.mass = mass
+    controller.audio = audio
+    controller.logger = MagicMock()
+    controller._log_request = MagicMock()
+    controller.get_crossfade_mode = MagicMock(return_value=CrossfadeMode.SMART_CROSSFADE)
+    request = MagicMock()
+    request.method = "GET"
+    request.match_info = {
+        "queue_id": "queue-1",
+        "player_id": "player-1",
+        "session_id": "session-1",
+        "queue_item_id": "item-1",
+    }
+    return controller, request, seen
+
+
+async def test_single_item_handler_skips_crossfade_for_a_realtime_item() -> None:
+    """A realtime item is never steered into the crossfaded single-item stream."""
+    controller, request, seen = _single_item_handler(is_realtime=True)
+
+    with pytest.raises(_PcmFormatRequested):
+        await controller.serve_queue_item_stream(request)
+
+    assert seen["crossfade_enabled"] is False
+    controller.get_crossfade_mode.assert_not_called()
+
+
+async def test_single_item_handler_keeps_crossfade_for_a_buffered_item() -> None:
+    """A buffered item still gets the queue's configured crossfade."""
+    controller, request, seen = _single_item_handler(is_realtime=False)
+
+    with pytest.raises(_PcmFormatRequested):
+        await controller.serve_queue_item_stream(request)
+
+    assert seen["crossfade_enabled"] is True
+    controller.get_crossfade_mode.assert_called_once()
 
 
 # -- StreamsAudio.get_stream_details --

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -747,6 +747,246 @@ async def test_smartfade_unaligned_chunks_still_crossfade(
     build.assert_awaited_once()
 
 
+async def test_smartfade_short_remainder_still_crossfades(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Less audio left than the configured overlap still fades with what is there."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=2,
+    )
+    current_details = SimpleNamespace(
+        duration=180,
+        seek_position=146,
+        seconds_streamed=0,
+        uri="test://current",
+        buffer=SimpleNamespace(eof=True, cancelled=False, has_error=False, max_size_seconds=300),
+        is_realtime=False,
+    )
+    next_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=_buffer(SMART_CROSSFADE_DURATION, ready=True),
+        duration=180,
+        seek_position=0,
+        uri="test://next",
+        is_realtime=False,
+        volume_normalization_mode=None,
+    )
+    current_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="current",
+        name="Current",
+        streamdetails=current_details,
+        extra_attributes={},
+    )
+    next_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="next",
+        name="Next",
+        streamdetails=next_details,
+        extra_attributes={},
+        available=True,
+    )
+    queue = SimpleNamespace(queue_id="queue-1", display_name="Queue", index_in_buffer=0)
+    player = SimpleNamespace(player_id="player-1", name="Player")
+    mass = MagicMock()
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.load_next_queue_item = AsyncMock(return_value=next_item)
+    mass.player_queues.index_by_id.return_value = 1
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+    audio.select_pcm_format = AsyncMock(return_value=pcm_format)  # type: ignore[method-assign]
+    audio.crossfade_allowed = MagicMock(return_value=True)  # type: ignore[method-assign]
+    build = AsyncMock(
+        return_value=SimpleNamespace(
+            timing_info=SimpleNamespace(
+                pre_crossfade_duration=2,
+                crossfade_duration=6,
+                fadein_trimmed_duration=0,
+            )
+        )
+    )
+    monkeypatch.setattr(audio.smart_fades_mixer, "build", build)
+    monkeypatch.setattr(audio.smart_fades_mixer, "mix", _empty_mix)
+
+    async def _current_stream(
+        queue_item: object, *_args: object, **_kwargs: object
+    ) -> AsyncGenerator[bytes]:
+        if queue_item is not current_item:
+            return
+        # a seek near the end leaves 34s, less than the 45s smart overlap
+        yield bytes(pcm_format.pcm_sample_size * 8)
+        yield bytes(pcm_format.pcm_sample_size * 26)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _current_stream)
+    stream = audio.get_queue_item_stream_with_smartfade(
+        cast("Any", player),
+        cast("Any", current_item),
+        pcm_format,
+        crossfade_mode=CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+
+    async for _chunk in stream:
+        pass
+
+    build.assert_awaited_once()
+    assert build.await_args is not None
+    fade_out_seconds = len(build.await_args.kwargs["fade_out_data"]) / pcm_format.pcm_sample_size
+    assert fade_out_seconds == pytest.approx(26, abs=1)
+
+
+async def test_smartfade_stub_remainder_does_not_crossfade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A remainder too short to overlap with is played out instead of faded."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=2,
+    )
+    current_details = SimpleNamespace(
+        duration=180,
+        seek_position=176,
+        seconds_streamed=0,
+        uri="test://current",
+        buffer=SimpleNamespace(eof=True, cancelled=False, has_error=False, max_size_seconds=300),
+        is_realtime=False,
+    )
+    next_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=_buffer(SMART_CROSSFADE_DURATION, ready=True),
+        duration=180,
+        seek_position=0,
+        uri="test://next",
+        is_realtime=False,
+        volume_normalization_mode=None,
+    )
+    current_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="current",
+        name="Current",
+        streamdetails=current_details,
+        extra_attributes={},
+    )
+    next_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="next",
+        name="Next",
+        streamdetails=next_details,
+        extra_attributes={},
+        available=True,
+    )
+    queue = SimpleNamespace(queue_id="queue-1", display_name="Queue", index_in_buffer=0)
+    player = SimpleNamespace(player_id="player-1", name="Player")
+    mass = MagicMock()
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.load_next_queue_item = AsyncMock(return_value=next_item)
+    mass.player_queues.index_by_id.return_value = 1
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+    audio.select_pcm_format = AsyncMock(return_value=pcm_format)  # type: ignore[method-assign]
+    audio.crossfade_allowed = MagicMock(return_value=True)  # type: ignore[method-assign]
+    build = AsyncMock()
+    monkeypatch.setattr(audio.smart_fades_mixer, "build", build)
+
+    async def _current_stream(
+        queue_item: object, *_args: object, **_kwargs: object
+    ) -> AsyncGenerator[bytes]:
+        if queue_item is not current_item:
+            return
+        yield bytes(pcm_format.pcm_sample_size * 8)
+        yield bytes(pcm_format.pcm_sample_size * 2)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _current_stream)
+    stream = audio.get_queue_item_stream_with_smartfade(
+        cast("Any", player),
+        cast("Any", current_item),
+        pcm_format,
+        crossfade_mode=CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+
+    output = b"".join([chunk async for chunk in stream])
+
+    assert len(output) == pcm_format.pcm_sample_size * 10
+    build.assert_not_awaited()
+
+
+async def test_flow_reports_no_crossfade_for_a_realtime_item(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The audio pipeline shown for a realtime item reports that no crossfade is applied."""
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        sample_rate=8000,
+        bit_depth=16,
+        channels=2,
+    )
+    realtime_details = SimpleNamespace(
+        audio_format=pcm_format,
+        buffer=SimpleNamespace(eof=True, cancelled=False, has_error=False, max_size_seconds=300),
+        fade_in=False,
+        stream_error=False,
+        uri="test://realtime",
+        seek_position=0,
+        seconds_streamed=0,
+        duration=20,
+        is_realtime=True,
+    )
+    realtime_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-1",
+        name="Realtime",
+        media_type=MediaType.TRACK,
+        media_item=None,
+        streamdetails=realtime_details,
+        duration=20,
+        extra_attributes={},
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        flow_mode=False,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
+    mass = MagicMock()
+    mass.player_queues.queue_data.return_value = SimpleNamespace(
+        session_id="session-1", flow_mode_stream_log=[]
+    )
+    mass.player_queues.load_next_queue_item = AsyncMock(side_effect=QueueEmpty)
+    mass.player_queues.get.return_value = queue
+    mass.streams.get_crossfade_mode.return_value = CrossfadeMode.SMART_CROSSFADE
+    mass.config.get_raw_core_config_value.return_value = 8
+    update_item_context = MagicMock()
+    mass.streams.audio_processing.update_item_context = update_item_context
+    player = MagicMock()
+    player.config.get_value.return_value = "fixed_48000"
+    player.get_supported_sample_rates.return_value = []
+    mass.players.get_player.return_value = player
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+
+    async def _item_stream(*_args: object, **_kwargs: object) -> AsyncGenerator[bytes]:
+        yield bytes(pcm_format.pcm_sample_size * 4)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", realtime_item), pcm_format, session_id="session-1"
+    )
+
+    async for _chunk in stream:
+        pass
+
+    update_item_context.assert_called()
+    reported = update_item_context.call_args.kwargs["queue_processing"]
+    assert reported.crossfade_mode == CrossfadeMode.DISABLED
+
+
 # -- StreamsAudio.get_stream_details --
 
 

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -282,7 +282,7 @@ def test_holdback_rejected_when_crossfade_buffer_size_is_zero() -> None:
     """A zero-size crossfade buffer has nothing to hold back."""
     audio = StreamsAudio(MagicMock())
     streamdetails = SimpleNamespace(
-        is_realtime=False, buffer=SimpleNamespace(eof=True, max_size_seconds=300)
+        is_realtime=False, buffer=SimpleNamespace(eof=True, has_error=False, max_size_seconds=300)
     )
 
     assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 0) is False
@@ -292,7 +292,7 @@ def test_holdback_rejected_for_realtime_source() -> None:
     """A realtime source's tail is never held back, even once its buffer reaches EOF."""
     audio = StreamsAudio(MagicMock())
     streamdetails = SimpleNamespace(
-        is_realtime=True, buffer=SimpleNamespace(eof=True, max_size_seconds=300)
+        is_realtime=True, buffer=SimpleNamespace(eof=True, has_error=False, max_size_seconds=300)
     )
 
     assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
@@ -310,7 +310,7 @@ def test_holdback_rejected_before_source_reaches_eof() -> None:
     """A still-filling buffer keeps limiting playback, so its tail is not held back yet."""
     audio = StreamsAudio(MagicMock())
     streamdetails = SimpleNamespace(
-        is_realtime=False, buffer=SimpleNamespace(eof=False, max_size_seconds=300)
+        is_realtime=False, buffer=SimpleNamespace(eof=False, has_error=False, max_size_seconds=300)
     )
 
     assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
@@ -320,17 +320,28 @@ def test_holdback_allowed_once_source_reaches_eof() -> None:
     """A fully delivered, non-realtime source may hold back its tail for a crossfade."""
     audio = StreamsAudio(MagicMock())
     streamdetails = SimpleNamespace(
-        is_realtime=False, buffer=SimpleNamespace(eof=True, max_size_seconds=300)
+        is_realtime=False, buffer=SimpleNamespace(eof=True, has_error=False, max_size_seconds=300)
     )
 
     assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is True
+
+
+def test_holdback_rejected_for_a_failed_source() -> None:
+    """A source that failed is skipped without a fade, so its tail is played out instead."""
+    audio = StreamsAudio(MagicMock())
+    streamdetails = SimpleNamespace(
+        is_realtime=False,
+        buffer=SimpleNamespace(eof=True, has_error=True, max_size_seconds=300),
+    )
+
+    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
 
 
 def test_holdback_allowed_when_the_buffer_can_never_hold_the_tail() -> None:
     """A buffer smaller than the tail collects it while the source runs, or loses the fade."""
     audio = StreamsAudio(MagicMock())
     streamdetails = SimpleNamespace(
-        is_realtime=False, buffer=SimpleNamespace(eof=False, max_size_seconds=15)
+        is_realtime=False, buffer=SimpleNamespace(eof=False, has_error=False, max_size_seconds=15)
     )
 
     assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 45) is True
@@ -375,7 +386,7 @@ async def test_smartfade_realtime_current_item_yields_all_audio_without_crossfad
         seek_position=0,
         seconds_streamed=0,
         uri="test://current",
-        buffer=SimpleNamespace(eof=True, cancelled=False, max_size_seconds=300),
+        buffer=SimpleNamespace(eof=True, cancelled=False, has_error=False, max_size_seconds=300),
         is_realtime=True,
     )
     # a fully resident, ready incoming buffer - the realtime flag on the outgoing
@@ -459,7 +470,7 @@ async def test_smartfade_still_filling_buffer_yields_all_audio_without_crossfade
         seek_position=0,
         seconds_streamed=0,
         uri="test://current",
-        buffer=SimpleNamespace(eof=False, cancelled=False, max_size_seconds=300),
+        buffer=SimpleNamespace(eof=False, cancelled=False, has_error=False, max_size_seconds=300),
         is_realtime=False,
     )
     next_details = SimpleNamespace(
@@ -542,7 +553,7 @@ async def test_flow_realtime_item_yields_all_audio_as_plain_concatenation(
     # the source is done delivering, so only the realtime flag can deny the holdback
     realtime_details = SimpleNamespace(
         audio_format=pcm_format,
-        buffer=SimpleNamespace(eof=True, cancelled=False, max_size_seconds=300),
+        buffer=SimpleNamespace(eof=True, cancelled=False, has_error=False, max_size_seconds=300),
         fade_in=False,
         stream_error=False,
         uri="test://realtime",
@@ -651,7 +662,7 @@ async def test_smartfade_unaligned_chunks_still_crossfade(
         seek_position=0,
         seconds_streamed=0,
         uri="test://current",
-        buffer=SimpleNamespace(eof=True, cancelled=False, max_size_seconds=300),
+        buffer=SimpleNamespace(eof=True, cancelled=False, has_error=False, max_size_seconds=300),
         is_realtime=False,
     )
     next_details = SimpleNamespace(

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -348,6 +348,17 @@ def test_holdback_allowed_when_the_buffer_can_never_hold_the_tail() -> None:
     assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
 
 
+def test_holdback_capacity_accounts_for_playback_speed() -> None:
+    """Buffer capacity is source time, so faster playback leaves fewer seconds to fade with."""
+    audio = StreamsAudio(MagicMock())
+    streamdetails = SimpleNamespace(
+        is_realtime=False, buffer=SimpleNamespace(eof=False, has_error=False, max_size_seconds=60)
+    )
+
+    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 45) is False
+    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 45, 2.0) is True
+
+
 # -- StreamsAudio._select_buffered_crossfade --
 
 


### PR DESCRIPTION
# What does this implement/fix?

Two things that both come down to holding audio back longer than there is any reason to.

**Crossfade buffering.** The tail of a track was held back from the player for its whole length, and at every transition the flow then waited for the *entire* requested fade window of the next track before emitting anything — up to 45 seconds of audio, even when the fade being built only blends 8 of them and passes the rest through untouched. Measured on a real transition: 41 seconds collected, 8.5 seconds of silence, for an 8 second crossfade. After a seek near the end of a track, where the player has only its warmup in hand, that silence is audible as a skip.

**Realtime streams.** Radio, live audio sources and music providers that stream through a paced local daemon hand over their audio at about playback pace. The stream logic assumed every source can be read ahead of playback, so it spent that headroom on buffering and fades the source cannot afford.

- Hold a track's tail back only once its source is done delivering, so the audio a player has in hand is never traded for a fade that may not happen.
- Wait only for the part of the incoming track a fade actually blends, instead of the whole requested window.
- Keep a source that delivers at playback pace out of the crossfade path entirely, in both the flow and single-track paths, and report that honestly in the audio pipeline.
- Start such sources with a smaller buffer, and pass a seek to the source instead of playing the skipped audio away first (a 30 second seek used to exceed the startup budget and marked the track unplayable).
- Mark radio and live audio sources as delivering at playback pace, so radio starts about a second sooner.
- Treat a queue flow as buffered audio on Sendspin: a flow only ever carries buffered items, so it was being denied the startup lead its player asked for.
- Log how long each transition waits for the incoming track, since nothing measured this before.

Groundwork for #5832 (Spotify Soloist playback), which needs the realtime half.

**Related issue (if applicable):**

- needs music-assistant/models#368 (adds the `StreamDetails.is_realtime` flag)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.