### PR TITLE
Require a token to fetch audio from the MSX Bridge

### DIFF
--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -2591,6 +2591,9 @@ small {{ color: #666; display: block; margin-top: 4px; }}
 
         track_uri = body.get("track_uri")
         player_id = body.get("player_id")
+        # the body is untyped JSON, so the type matters as much as the presence
+        if not isinstance(track_uri, str) or not isinstance(player_id, str):
+            return web.json_response({"error": "Invalid track_uri or player_id"}, status=400)
         if not track_uri or not player_id:
             return web.json_response({"error": "Missing track_uri or player_id"}, status=400)
         if not await _is_media_item_uri(track_uri):

--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -9,6 +9,7 @@ import hashlib
 import io
 import json
 import logging
+import secrets
 import time
 from html import escape as html_escape
 from pathlib import Path
@@ -23,8 +24,13 @@ from music_assistant_models.media_items import AudioFormat, Track
 
 from music_assistant.constants import SENDSPIN_SERVER_PORT
 from music_assistant.controllers.streams.audio_processing import get_media_session_id
+from music_assistant.controllers.streams.constants import (
+    SINGLE_ITEM_READRATE,
+    SINGLE_ITEM_READRATE_INITIAL_BURST,
+)
 from music_assistant.controllers.webserver.helpers.auth_middleware import ImpersonatedUser
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
+from music_assistant.helpers.uri import BUILTIN_URL_SCHEMES
 from music_assistant.helpers.util import join_task
 
 from .constants import (
@@ -65,6 +71,16 @@ _KNOWN_EXTENSIONS = (".mp3", ".json", ".flac", ".aac")
 PARTY_CACHE_TTL = 10.0
 PARTY_CALL_TIMEOUT = 5.0
 
+# The local proxy modes encode audio themselves, so they carry the core streamserver's
+# pacing ceiling rather than handing a track over as fast as ffmpeg can produce it.
+# See the usage policy note on SINGLE_ITEM_READRATE.
+_READRATE_ARGS = [
+    "-readrate",
+    SINGLE_ITEM_READRATE,
+    "-readrate_initial_burst",
+    SINGLE_ITEM_READRATE_INITIAL_BURST,
+]
+
 
 class PartyInfo(NamedTuple):
     """Active-party details resolved from the MA Party plugin."""
@@ -81,6 +97,17 @@ def _int_param(query: MultiMapping[str], name: str, default: int, max_val: int =
         return max(0, min(int(query.get(name, str(default))), max_val))
     except ValueError, TypeError:
         return default
+
+
+def _is_media_item_uri(uri: str) -> bool:
+    """
+    Check that a caller-supplied uri names a media item rather than a raw stream URL.
+
+    A bare http(s)/rtsp/rtmp URL resolves to the builtin provider, which would make the
+    server fetch and play whatever the caller names. Every uri the bridge hands out is a
+    media item uri, so nothing legitimate is rejected here.
+    """
+    return "://" in uri and not uri.startswith(BUILTIN_URL_SCHEMES)
 
 
 def _strip_known_extension(value: str) -> str:
@@ -223,7 +250,7 @@ class MSXHTTPServer:
         )
 
         # We always use direct stream for maximum compatibility.
-        play_path = f"/stream/{player_id}"
+        play_path = f"/stream/{player_id}?token={self.provider.get_stream_token(player_id)}"
 
         payload: dict[str, Any] = {
             "type": "play",
@@ -1388,15 +1415,17 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         player_id = _strip_known_extension(request.match_info["player_id"])
 
         uri = request.query.get("uri")
-        if not uri or "://" not in uri:
+        if not uri or not _is_media_item_uri(uri):
             return web.Response(status=400, text="Invalid uri parameter")
 
         from_playlist = request.query.get("from_playlist") == "1"
 
-        self.provider.on_player_activity(player_id)
         player = self.provider.mass.players.get_player(player_id)
         if not player or not isinstance(player, MSXPlayer):
             return web.Response(status=404, text="Player not found")
+        if rejected := self._reject_invalid_stream_token(request, player):
+            return rejected
+        self.provider.on_player_activity(player_id)
 
         # When MA is driving the queue (next/prev from MA UI), current_media is
         # already set by player.play_media() before the WS goto_index reaches MSX.
@@ -1663,6 +1692,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
                 input_format=pcm_format,
                 output_format=out_format,
                 filter_params=output_plan.filter_params,
+                extra_input_args=_READRATE_ARGS,
             )
             shared_stream = await self.provider.get_or_create_shared_stream(
                 group_id, media_uri, audio_chunks
@@ -1803,6 +1833,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
                     input_format=pcm_format,
                     output_format=out_format,
                     filter_params=filter_params,
+                    extra_input_args=_READRATE_ARGS,
                 ):
                     await chunk_queue.put(chunk)
             finally:
@@ -2029,10 +2060,12 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         """Stream audio from MA to the TV using internal API."""
         player_id = _strip_known_extension(request.match_info["player_id"])
 
-        self.provider.on_player_activity(player_id)
         player = self.provider.mass.players.get_player(player_id)
         if not player or not isinstance(player, MSXPlayer):
             return web.Response(status=404, text="Player not found")
+        if rejected := self._reject_invalid_stream_token(request, player):
+            return rejected
+        self.provider.on_player_activity(player_id)
 
         media = player.current_media
         if not media:
@@ -2497,6 +2530,22 @@ small {{ color: #666; display: block; margin-top: 4px; }}
     # --- Playback Control ---
 
     @staticmethod
+    def _reject_invalid_stream_token(
+        request: web.Request, player: MSXPlayer
+    ) -> web.Response | None:
+        """
+        Reject an audio request that does not carry the player's own stream token.
+
+        A TV cannot send an auth header, so the token travels in the URL the bridge
+        itself generated. This stops a request that was never handed out — a web page
+        firing an <audio> tag at this LAN server, or an old URL replayed from a log.
+        """
+        expected = player.stream_token
+        if not expected or not secrets.compare_digest(request.query.get("token", ""), expected):
+            return web.Response(status=403, text="Invalid or missing stream token")
+        return None
+
+    @staticmethod
     def _reject_cross_site(request: web.Request) -> web.Response | None:
         """
         Reject browser cross-site requests to state-changing endpoints (CSRF guard).
@@ -2524,6 +2573,8 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         player_id = body.get("player_id")
         if not track_uri or not player_id:
             return web.json_response({"error": "Missing track_uri or player_id"}, status=400)
+        if not _is_media_item_uri(track_uri):
+            return web.json_response({"error": "Invalid track_uri"}, status=400)
 
         if self._get_msx_player(player_id) is None:
             return web.json_response({"error": "Unknown MSX player"}, status=404)

--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -20,6 +20,7 @@ from urllib.parse import quote, urlsplit, urlunsplit
 import aiohttp
 from aiohttp import WSMsgType, web
 from music_assistant_models.enums import ContentType
+from music_assistant_models.errors import InvalidProviderURI
 from music_assistant_models.media_items import AudioFormat, Track
 
 from music_assistant.constants import SENDSPIN_SERVER_PORT
@@ -30,7 +31,7 @@ from music_assistant.controllers.streams.constants import (
 )
 from music_assistant.controllers.webserver.helpers.auth_middleware import ImpersonatedUser
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
-from music_assistant.helpers.uri import BUILTIN_URL_SCHEMES
+from music_assistant.helpers.uri import parse_uri
 from music_assistant.helpers.util import join_task
 
 from .constants import (
@@ -99,15 +100,28 @@ def _int_param(query: MultiMapping[str], name: str, default: int, max_val: int =
         return default
 
 
-def _is_media_item_uri(uri: str) -> bool:
+async def _is_media_item_uri(uri: str) -> bool:
     """
     Check that a caller-supplied uri names a media item rather than a raw stream URL.
 
-    A bare http(s)/rtsp/rtmp URL resolves to the builtin provider, which would make the
-    server fetch and play whatever the caller names. Every uri the bridge hands out is a
-    media item uri, so nothing legitimate is rejected here.
+    Both spellings of a raw URL — bare, and wrapped as ``builtin://<media_type>/<url>`` —
+    resolve to the builtin provider, which would make the server fetch and play whatever
+    the caller names, so the resolved provider is what decides rather than the uri text.
+    The bridge only ever hands out uris of library or music provider items.
     """
-    return "://" in uri and not uri.startswith(BUILTIN_URL_SCHEMES)
+    if "://" not in uri:
+        # keeps an item_id-shaped value away from parse_uri's local-file branch
+        return False
+    try:
+        _, provider_instance_id_or_domain, _ = await parse_uri(uri)
+    except InvalidProviderURI:
+        return False
+    return provider_instance_id_or_domain != "builtin"
+
+
+def _is_audio_path(path: str) -> bool:
+    """Check whether the path is one of the audio routes."""
+    return path.startswith(("/stream/", "/msx/audio/"))
 
 
 def _strip_known_extension(value: str) -> str:
@@ -551,6 +565,11 @@ class MSXHTTPServer:
         The web player (/web) and MSX plugin (/msx/plugin.html) are served from the
         same origin, so browser playback-control POSTs are always same-origin.
         MSX TV app only makes GET requests. This matches MA's own webserver pattern.
+
+        The audio routes are the exception and get no header at all: a media element
+        plays a cross-origin source without CORS, and the kiosk visualizer reads the
+        stream same-origin, so withholding it costs nothing and keeps a cross-origin
+        fetch() from reading the audio.
         """
         if request.method == "OPTIONS":
             return web.Response(
@@ -561,7 +580,8 @@ class MSXHTTPServer:
                 }
             )
         response: web.StreamResponse = await handler(request)
-        response.headers["Access-Control-Allow-Origin"] = "*"
+        if not _is_audio_path(request.path):
+            response.headers["Access-Control-Allow-Origin"] = "*"
         return response
 
     # --- MSX Bootstrap Routes ---
@@ -1415,7 +1435,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         player_id = _strip_known_extension(request.match_info["player_id"])
 
         uri = request.query.get("uri")
-        if not uri or not _is_media_item_uri(uri):
+        if not uri or not await _is_media_item_uri(uri):
             return web.Response(status=400, text="Invalid uri parameter")
 
         from_playlist = request.query.get("from_playlist") == "1"
@@ -1423,7 +1443,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         player = self.provider.mass.players.get_player(player_id)
         if not player or not isinstance(player, MSXPlayer):
             return web.Response(status=404, text="Player not found")
-        if rejected := self._reject_invalid_stream_token(request, player):
+        if rejected := self._reject_invalid_stream_token(request, player_id):
             return rejected
         self.provider.on_player_activity(player_id)
 
@@ -2063,7 +2083,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         player = self.provider.mass.players.get_player(player_id)
         if not player or not isinstance(player, MSXPlayer):
             return web.Response(status=404, text="Player not found")
-        if rejected := self._reject_invalid_stream_token(request, player):
+        if rejected := self._reject_invalid_stream_token(request, player_id):
             return rejected
         self.provider.on_player_activity(player_id)
 
@@ -2529,9 +2549,8 @@ small {{ color: #666; display: block; margin-top: 4px; }}
 
     # --- Playback Control ---
 
-    @staticmethod
     def _reject_invalid_stream_token(
-        request: web.Request, player: MSXPlayer
+        self, request: web.Request, player_id: str
     ) -> web.Response | None:
         """
         Reject an audio request that does not carry the player's own stream token.
@@ -2540,7 +2559,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         itself generated. This stops a request that was never handed out — a web page
         firing an <audio> tag at this LAN server, or an old URL replayed from a log.
         """
-        expected = player.stream_token
+        expected = self.provider.get_stream_token(player_id)
         if not expected or not secrets.compare_digest(request.query.get("token", ""), expected):
             return web.Response(status=403, text="Invalid or missing stream token")
         return None
@@ -2573,7 +2592,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         player_id = body.get("player_id")
         if not track_uri or not player_id:
             return web.json_response({"error": "Missing track_uri or player_id"}, status=400)
-        if not _is_media_item_uri(track_uri):
+        if not await _is_media_item_uri(track_uri):
             return web.json_response({"error": "Invalid track_uri"}, status=400)
 
         if self._get_msx_player(player_id) is None:

--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -2557,10 +2557,11 @@ small {{ color: #666; display: block; margin-top: 4px; }}
 
         A TV cannot send an auth header, so the token travels in the URL the bridge
         itself generated. This stops a request that was never handed out — a web page
-        firing an <audio> tag at this LAN server, or an old URL replayed from a log.
+        firing an <audio> tag at this LAN server. A URL that was handed out stays valid
+        until the provider reloads, so this is not a defence against a captured URL.
         """
         expected = self.provider.get_stream_token(player_id)
-        if not expected or not secrets.compare_digest(request.query.get("token", ""), expected):
+        if not secrets.compare_digest(request.query.get("token", ""), expected):
             return web.Response(status=403, text="Invalid or missing stream token")
         return None
 

--- a/music_assistant/providers/msx_bridge/mappers.py
+++ b/music_assistant/providers/msx_bridge/mappers.py
@@ -102,12 +102,13 @@ def _build_audio_action(
     prefix: str,
     player_id: str,
     track_uri: str,
+    token: str,
     device_param: str = "",
     from_playlist: bool = False,
 ) -> str:
     """Build audio action URL for MSX playback."""
     # Standard HTTP streaming mode
-    audio_url = f"{prefix}/msx/audio/{player_id}?uri={quote(track_uri, safe='')}"
+    audio_url = f"{prefix}/msx/audio/{player_id}?uri={quote(track_uri, safe='')}&token={token}"
     if from_playlist:
         audio_url += "&from_playlist=1"
     audio_url = append_device_param(audio_url, device_param)
@@ -146,6 +147,7 @@ def map_track_to_msx(
             prefix=prefix,
             player_id=player_id,
             track_uri=track.uri,
+            token=provider.get_stream_token(player_id),
             device_param=device_param,
         )
 
@@ -179,6 +181,7 @@ def map_tracks_to_msx_playlist(
     :param qr_cover_base: When set (active party), item backgrounds are routed
         through this QR-compositing endpoint so the join QR shows on covers.
     """
+    token = provider.get_stream_token(player_id)
     msx_items = []
     for track in tracks:
         duration = getattr(track, "duration", 0) or 0
@@ -203,6 +206,7 @@ def map_tracks_to_msx_playlist(
             prefix=prefix,
             player_id=player_id,
             track_uri=track.uri,
+            token=token,
             device_param=device_param,
             from_playlist=True,
         )

--- a/music_assistant/providers/msx_bridge/player.py
+++ b/music_assistant/providers/msx_bridge/player.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import secrets
 import time
 from typing import TYPE_CHECKING, Any, cast
 
@@ -25,7 +24,6 @@ class MSXPlayer(Player):
 
     current_stream_url: str | None = None
     output_format: str = "mp3"
-    stream_token: str
     _skip_ws_notify: bool = False
     _propagating: bool = False
     _playing_from_queue: bool = False
@@ -72,10 +70,6 @@ class MSXPlayer(Player):
         self._attr_volume_level = 100
         self.output_format = output_format
         self._media_ready = asyncio.Event()
-        # TVs cannot send auth headers, so the audio routes are gated on this token
-        # carried in the URL. It is minted per player object, so it rotates whenever
-        # the player re-registers (idle timeout, provider reload).
-        self.stream_token = secrets.token_urlsafe(16)
 
     @property
     def requires_flow_mode(self) -> bool:

--- a/music_assistant/providers/msx_bridge/player.py
+++ b/music_assistant/providers/msx_bridge/player.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import secrets
 import time
 from typing import TYPE_CHECKING, Any, cast
 
@@ -24,6 +25,7 @@ class MSXPlayer(Player):
 
     current_stream_url: str | None = None
     output_format: str = "mp3"
+    stream_token: str
     _skip_ws_notify: bool = False
     _propagating: bool = False
     _playing_from_queue: bool = False
@@ -70,6 +72,10 @@ class MSXPlayer(Player):
         self._attr_volume_level = 100
         self.output_format = output_format
         self._media_ready = asyncio.Event()
+        # TVs cannot send auth headers, so the audio routes are gated on this token
+        # carried in the URL. It is minted per player object, so it rotates whenever
+        # the player re-registers (idle timeout, provider reload).
+        self.stream_token = secrets.token_urlsafe(16)
 
     @property
     def requires_flow_mode(self) -> bool:

--- a/music_assistant/providers/msx_bridge/provider.py
+++ b/music_assistant/providers/msx_bridge/provider.py
@@ -607,6 +607,17 @@ class MSXBridgeProvider(PlayerProvider):
         """
         return self.group_stream_mode == GROUP_STREAM_MODE_REDIRECT
 
+    def get_stream_token(self, player_id: str) -> str:
+        """
+        Return the token that authorizes the audio routes for the given player.
+
+        Empty for an unknown player, which yields a URL the audio routes reject.
+
+        :param player_id: The player to build an audio URL for.
+        """
+        player = self.mass.players.get_player(player_id, raise_unavailable=False)
+        return player.stream_token if isinstance(player, MSXPlayer) else ""
+
     def get_group_id_for_player(self, player: MSXPlayer) -> str | None:
         """
         Get group ID if player is in a group (as leader or member).

--- a/music_assistant/providers/msx_bridge/provider.py
+++ b/music_assistant/providers/msx_bridge/provider.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
+import hmac
 import logging
 import secrets
 import time
@@ -277,7 +279,7 @@ class MSXBridgeProvider(PlayerProvider):
     bridge_manager: MSXSendspinBridgeManager | None = None
     _player_last_activity: dict[str, float]
     _pending_unregisters: dict[str, asyncio.Event]
-    _stream_tokens: dict[str, str]  # player_id -> audio token
+    _stream_token_secret: bytes
     _timeout_task: asyncio.Task[None] | None = None
     _owner_username: str | None = None
     _shared_streams: dict[str, SharedGroupStream]  # group_id -> SharedGroupStream
@@ -289,7 +291,8 @@ class MSXBridgeProvider(PlayerProvider):
         super().__init__(*args, **kwargs)
         self._player_last_activity = {}
         self._pending_unregisters = {}
-        self._stream_tokens = {}
+        # one secret per provider instance; the per-player tokens derive from it
+        self._stream_token_secret = secrets.token_bytes(32)
         self._shared_streams = {}
         self._shared_stream_lock = asyncio.Lock()
         self._background_tasks = set()
@@ -424,7 +427,6 @@ class MSXBridgeProvider(PlayerProvider):
             except Exception:
                 self.logger.exception("Error unregistering player %s", player.player_id)
         self._player_last_activity.clear()
-        self._stream_tokens.clear()
         self.logger.info("MSX Bridge provider unloaded")
 
     async def get_owner_username(self) -> str | None:
@@ -613,17 +615,17 @@ class MSXBridgeProvider(PlayerProvider):
 
     def get_stream_token(self, player_id: str) -> str:
         """
-        Return the token that authorizes the audio routes for the given player, minting it once.
+        Return the token that authorizes the audio routes for the given player.
 
-        Kept for the provider's lifetime rather than the player's: an idle TV is unregistered
-        after the configured timeout, and rotating there would strand the URLs a long-running
-        kiosk has already cached. A reload restarts the HTTP server anyway.
+        Derived rather than stored, so a caller cannot grow provider state by asking for
+        tokens under new player ids. It stays the same for the provider's lifetime: an
+        idle TV is unregistered after the configured timeout, and changing the token there
+        would strand the URLs a long-running kiosk has already cached.
 
         :param player_id: The player to build an audio URL for.
         """
-        if (token := self._stream_tokens.get(player_id)) is None:
-            token = self._stream_tokens[player_id] = secrets.token_urlsafe(16)
-        return token
+        digest = hmac.new(self._stream_token_secret, player_id.encode(), hashlib.sha256)
+        return digest.hexdigest()[:32]
 
     def get_group_id_for_player(self, player: MSXPlayer) -> str | None:
         """

--- a/music_assistant/providers/msx_bridge/provider.py
+++ b/music_assistant/providers/msx_bridge/provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import secrets
 import time
 from collections import deque
 from collections.abc import AsyncIterator
@@ -276,6 +277,7 @@ class MSXBridgeProvider(PlayerProvider):
     bridge_manager: MSXSendspinBridgeManager | None = None
     _player_last_activity: dict[str, float]
     _pending_unregisters: dict[str, asyncio.Event]
+    _stream_tokens: dict[str, str]  # player_id -> audio token
     _timeout_task: asyncio.Task[None] | None = None
     _owner_username: str | None = None
     _shared_streams: dict[str, SharedGroupStream]  # group_id -> SharedGroupStream
@@ -287,6 +289,7 @@ class MSXBridgeProvider(PlayerProvider):
         super().__init__(*args, **kwargs)
         self._player_last_activity = {}
         self._pending_unregisters = {}
+        self._stream_tokens = {}
         self._shared_streams = {}
         self._shared_stream_lock = asyncio.Lock()
         self._background_tasks = set()
@@ -421,6 +424,7 @@ class MSXBridgeProvider(PlayerProvider):
             except Exception:
                 self.logger.exception("Error unregistering player %s", player.player_id)
         self._player_last_activity.clear()
+        self._stream_tokens.clear()
         self.logger.info("MSX Bridge provider unloaded")
 
     async def get_owner_username(self) -> str | None:
@@ -609,14 +613,17 @@ class MSXBridgeProvider(PlayerProvider):
 
     def get_stream_token(self, player_id: str) -> str:
         """
-        Return the token that authorizes the audio routes for the given player.
+        Return the token that authorizes the audio routes for the given player, minting it once.
 
-        Empty for an unknown player, which yields a URL the audio routes reject.
+        Kept for the provider's lifetime rather than the player's: an idle TV is unregistered
+        after the configured timeout, and rotating there would strand the URLs a long-running
+        kiosk has already cached. A reload restarts the HTTP server anyway.
 
         :param player_id: The player to build an audio URL for.
         """
-        player = self.mass.players.get_player(player_id, raise_unavailable=False)
-        return player.stream_token if isinstance(player, MSXPlayer) else ""
+        if (token := self._stream_tokens.get(player_id)) is None:
+            token = self._stream_tokens[player_id] = secrets.token_urlsafe(16)
+        return token
 
     def get_group_id_for_player(self, player: MSXPlayer) -> str | None:
         """

--- a/tests/providers/msx_bridge/test_group_stream.py
+++ b/tests/providers/msx_bridge/test_group_stream.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
 
+from music_assistant.providers.msx_bridge.http_server import MSXHTTPServer
+from music_assistant.providers.msx_bridge.player import MSXPlayer
 from music_assistant.providers.msx_bridge.provider import SharedGroupStream
 
 if TYPE_CHECKING:
@@ -144,3 +149,34 @@ async def test_cancel_stops_subscription() -> None:
         stream.producer_task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await stream.producer_task
+
+
+async def test_shared_stream_paces_output(provider: MSXBridgeProvider, mass_mock: Mock) -> None:
+    """The shared group encoder carries the same pacing ceiling as the per-player one."""
+    server = MSXHTTPServer(provider, 0)
+    player = MagicMock(spec=MSXPlayer)
+    player.player_id = "msx_leader"
+    media = Mock(source_id=None, queue_item_id=None)
+
+    mass_mock.streams = Mock()
+    mass_mock.streams.get_stream = Mock(return_value=_chunks(b"pcm"))
+    mass_mock.streams.audio.get_player_output_plan = Mock(return_value=Mock(filter_params=[]))
+    provider.get_or_create_shared_stream = AsyncMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("stop here")
+    )
+
+    pcm = AudioFormat(content_type=ContentType.PCM_S16LE)
+    out = AudioFormat(content_type=ContentType.MP3)
+    with (
+        patch(
+            "music_assistant.providers.msx_bridge.http_server.get_ffmpeg_stream",
+            return_value=_chunks(b"encoded"),
+        ) as ffmpeg_mock,
+        pytest.raises(RuntimeError),
+    ):
+        # leader path: player_id == group_id
+        await server._serve_shared_stream(Mock(), player, media, "msx_leader", pcm, out, {})
+
+    extra_args = ffmpeg_mock.call_args.kwargs["extra_input_args"]
+    assert "-readrate" in extra_args
+    assert "-readrate_initial_burst" in extra_args

--- a/tests/providers/msx_bridge/test_http_server.py
+++ b/tests/providers/msx_bridge/test_http_server.py
@@ -827,6 +827,27 @@ async def test_msx_audio_rejects_raw_stream_url(
         await client.close()
 
 
+async def test_api_play_rejects_non_string_body_values(
+    provider: MSXBridgeProvider, mass_mock: Mock
+) -> None:
+    """A malformed body must be a 400, not a 500 from the uri guard."""
+    server = MSXHTTPServer(provider, 0)
+    client = AiohttpTestClient(TestServer(server.app))
+    await client.start_server()
+    try:
+        _make_audio_player(mass_mock)
+        for body in (
+            {"track_uri": 123, "player_id": "msx_test"},
+            {"track_uri": True, "player_id": "msx_test"},
+            {"track_uri": "library://track/1", "player_id": 42},
+        ):
+            resp = await client.post("/api/play", json=body)
+            assert resp.status == 400
+        mass_mock.player_queues.play_media.assert_not_called()
+    finally:
+        await client.close()
+
+
 async def test_api_play_rejects_raw_stream_url(
     provider: MSXBridgeProvider, mass_mock: Mock
 ) -> None:

--- a/tests/providers/msx_bridge/test_http_server.py
+++ b/tests/providers/msx_bridge/test_http_server.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 
 import pytest
 from aiohttp.test_utils import TestClient as AiohttpTestClient
@@ -23,6 +24,8 @@ from music_assistant.providers.msx_bridge.provider import MSXBridgeProvider
 
 if TYPE_CHECKING:
     from aiohttp.test_utils import TestClient
+
+TEST_STREAM_TOKEN = "test-stream-token"
 
 # --- Bootstrap and CORS ---
 
@@ -125,6 +128,26 @@ async def test_stream_no_media(provider: MSXBridgeProvider, mass_mock: Mock) -> 
     """GET /stream/{id} should return 404 when player has no current media."""
     mock_player = Mock(spec=MSXPlayer)
     mock_player.current_media = None
+    mock_player.stream_token = TEST_STREAM_TOKEN
+    mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
+
+    server = MSXHTTPServer(provider, 0)
+    client = AiohttpTestClient(TestServer(server.app))
+    await client.start_server()
+    try:
+        resp = await client.get(f"/stream/msx_test?token={TEST_STREAM_TOKEN}")
+        assert resp.status == 404
+        body = await resp.text()
+        assert "No active stream" in body
+    finally:
+        await client.close()
+
+
+async def test_stream_rejects_missing_token(provider: MSXBridgeProvider, mass_mock: Mock) -> None:
+    """GET /stream/{id} without the player's token should be refused."""
+    mock_player = Mock(spec=MSXPlayer)
+    mock_player.current_media = Mock()
+    mock_player.stream_token = TEST_STREAM_TOKEN
     mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
 
     server = MSXHTTPServer(provider, 0)
@@ -132,9 +155,28 @@ async def test_stream_no_media(provider: MSXBridgeProvider, mass_mock: Mock) -> 
     await client.start_server()
     try:
         resp = await client.get("/stream/msx_test")
-        assert resp.status == 404
-        body = await resp.text()
-        assert "No active stream" in body
+        assert resp.status == 403
+        resp = await client.get("/stream/msx_test?token=wrong")
+        assert resp.status == 403
+    finally:
+        await client.close()
+
+
+async def test_stream_rejects_empty_player_token(
+    provider: MSXBridgeProvider, mass_mock: Mock
+) -> None:
+    """A player without a token must refuse every caller, not accept an empty one."""
+    mock_player = Mock(spec=MSXPlayer)
+    mock_player.current_media = Mock()
+    mock_player.stream_token = ""
+    mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
+
+    server = MSXHTTPServer(provider, 0)
+    client = AiohttpTestClient(TestServer(server.app))
+    await client.start_server()
+    try:
+        resp = await client.get("/stream/msx_test?token=")
+        assert resp.status == 403
     finally:
         await client.close()
 
@@ -167,6 +209,7 @@ async def test_stream_success(provider: MSXBridgeProvider, mass_mock: Mock) -> N
     mock_media.queue_item_id = None
     mock_player.current_media = mock_media
     mock_player.output_format = "mp3"
+    mock_player.stream_token = TEST_STREAM_TOKEN
     mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
 
     # Mock get_stream to return an async generator
@@ -182,7 +225,7 @@ async def test_stream_success(provider: MSXBridgeProvider, mass_mock: Mock) -> N
             "music_assistant.providers.msx_bridge.http_server.get_ffmpeg_stream",
             return_value=_async_iter(chunks),
         ):
-            resp = await client.get("/stream/msx_test")
+            resp = await client.get(f"/stream/msx_test?token={TEST_STREAM_TOKEN}")
             assert resp.status == 200
             assert resp.headers["Content-Type"] == "audio/mpeg"
             body = await resp.read()
@@ -511,6 +554,7 @@ def _make_audio_player(mass_mock: Mock) -> tuple[MagicMock, PlayerMedia]:
     player = MagicMock(spec=MSXPlayer)
     player.player_id = "msx_test"
     player.output_format = "mp3"
+    player.stream_token = TEST_STREAM_TOKEN
     player._skip_ws_notify = False
     media = PlayerMedia(
         uri="library://track/1",
@@ -690,6 +734,33 @@ async def test_msx_playlist_tracks(provider: MSXBridgeProvider, mass_mock: Mock)
         await client.close()
 
 
+async def test_broadcast_play_path_carries_token(
+    provider: MSXBridgeProvider, mass_mock: Mock
+) -> None:
+    """The pushed stream path must carry the token the /stream route now requires."""
+    player = Mock(spec=MSXPlayer)
+    player.stream_token = TEST_STREAM_TOKEN
+    mass_mock.players.get_player.return_value = player
+
+    server = MSXHTTPServer(provider, 0)
+    ws = AsyncMock()
+    ws.closed = False
+    server._ws_clients["msx_test"] = {ws}
+    coros: list[Any] = []
+
+    def _capture_task(coro: Any) -> Mock:
+        coros.append(coro)
+        return Mock()
+
+    mass_mock.create_task = Mock(side_effect=_capture_task)
+
+    server.broadcast_play("msx_test", title="T")
+
+    await coros[0]
+    payload = json.loads(ws.send_str.call_args[0][0])
+    assert payload["path"] == f"/stream/msx_test?token={TEST_STREAM_TOKEN}"
+
+
 # --- MSX audio endpoint ---
 
 
@@ -699,6 +770,65 @@ async def test_msx_audio_missing_uri(http_client: TestClient[Any, Any]) -> None:
     assert resp.status == 400
     body = await resp.text()
     assert "uri" in body.lower()  # "Missing uri" or "Invalid uri parameter"
+
+
+@pytest.mark.parametrize(
+    "uri",
+    ["http://evil.example/payload.mp3", "https://evil.example/x", "rtsp://evil.example/x"],
+)
+async def test_msx_audio_rejects_raw_stream_url(
+    provider: MSXBridgeProvider, mass_mock: Mock, uri: str
+) -> None:
+    """A bare stream URL resolves to the builtin provider and must never be enqueued."""
+    server = MSXHTTPServer(provider, 0)
+    client = AiohttpTestClient(TestServer(server.app))
+    await client.start_server()
+    try:
+        _make_audio_player(mass_mock)
+        resp = await client.get(
+            f"/msx/audio/msx_test?uri={quote(uri, safe='')}&token={TEST_STREAM_TOKEN}"
+        )
+        assert resp.status == 400
+        mass_mock.player_queues.play_media.assert_not_called()
+    finally:
+        await client.close()
+
+
+async def test_api_play_rejects_raw_stream_url(
+    provider: MSXBridgeProvider, mass_mock: Mock
+) -> None:
+    """POST /api/play must apply the same guard as the MSX audio route."""
+    server = MSXHTTPServer(provider, 0)
+    client = AiohttpTestClient(TestServer(server.app))
+    await client.start_server()
+    try:
+        _make_audio_player(mass_mock)
+        resp = await client.post(
+            "/api/play",
+            json={"track_uri": "http://evil.example/payload.mp3", "player_id": "msx_test"},
+        )
+        assert resp.status == 400
+        mass_mock.player_queues.play_media.assert_not_called()
+    finally:
+        await client.close()
+
+
+async def test_msx_audio_rejects_missing_token(
+    provider: MSXBridgeProvider, mass_mock: Mock
+) -> None:
+    """A caller that was never handed a URL cannot start playback."""
+    server = MSXHTTPServer(provider, 0)
+    client = AiohttpTestClient(TestServer(server.app))
+    await client.start_server()
+    try:
+        _make_audio_player(mass_mock)
+        resp = await client.get("/msx/audio/msx_test?uri=library://track/1")
+        assert resp.status == 403
+        resp = await client.get("/msx/audio/msx_test?uri=library://track/1&token=wrong")
+        assert resp.status == 403
+        mass_mock.player_queues.play_media.assert_not_called()
+    finally:
+        await client.close()
 
 
 async def test_msx_audio_player_not_found(http_client: TestClient[Any, Any]) -> None:
@@ -740,13 +870,41 @@ async def test_msx_audio_per_track_mode(provider: MSXBridgeProvider, mass_mock: 
             "music_assistant.providers.msx_bridge.http_server.get_ffmpeg_stream",
             return_value=_async_iter(chunks),
         ):
-            resp = await client.get("/msx/audio/msx_test?uri=library://track/1")
+            resp = await client.get(
+                "/msx/audio/msx_test?uri=library://track/1&token=" + TEST_STREAM_TOKEN
+            )
             assert resp.status == 200
 
         mass_mock.streams.get_stream.assert_called_once()
         _args, _pos, kwargs = mass_mock.streams.get_stream.mock_calls[0]
         assert kwargs.get("force_flow_mode") is False
 
+    finally:
+        await client.close()
+
+
+async def test_msx_audio_proxy_paces_output(provider: MSXBridgeProvider, mass_mock: Mock) -> None:
+    """The local proxy must carry the core streamserver's pacing ceiling."""
+    server = MSXHTTPServer(provider, 0)
+    client = AiohttpTestClient(TestServer(server.app))
+    await client.start_server()
+    try:
+        _make_audio_player(mass_mock)
+        mass_mock.streams = Mock()
+        mass_mock.streams.get_stream = Mock(return_value=_async_iter([b"pcm"]))
+
+        with patch(
+            "music_assistant.providers.msx_bridge.http_server.get_ffmpeg_stream",
+            return_value=_async_iter([b"encoded"]),
+        ) as ffmpeg_mock:
+            resp = await client.get(
+                "/msx/audio/msx_test?uri=library://track/1&token=" + TEST_STREAM_TOKEN
+            )
+            assert resp.status == 200
+
+        extra_args = ffmpeg_mock.call_args.kwargs["extra_input_args"]
+        assert "-readrate" in extra_args
+        assert "-readrate_initial_burst" in extra_args
     finally:
         await client.close()
 
@@ -777,7 +935,10 @@ async def test_msx_audio_from_playlist_skips_ws(
             "music_assistant.providers.msx_bridge.http_server.get_ffmpeg_stream",
             return_value=_async_iter(chunks),
         ):
-            resp = await client.get("/msx/audio/msx_test?uri=library://track/1&from_playlist=1")
+            resp = await client.get(
+                "/msx/audio/msx_test?uri=library://track/1&from_playlist=1&token="
+                + TEST_STREAM_TOKEN
+            )
             assert resp.status == 200
 
         # _skip_ws_notify should have been True during play_media call
@@ -814,7 +975,9 @@ async def test_msx_audio_arms_wait_before_enqueue(
             "music_assistant.providers.msx_bridge.http_server.get_ffmpeg_stream",
             return_value=_async_iter([b"encoded-chunk-1"]),
         ):
-            resp = await client.get("/msx/audio/msx_test?uri=library://track/1")
+            resp = await client.get(
+                "/msx/audio/msx_test?uri=library://track/1&token=" + TEST_STREAM_TOKEN
+            )
             assert resp.status == 200
 
         assert call_order == ["arm", "enqueue"]
@@ -1185,7 +1348,10 @@ async def test_msx_audio_redirect_mode(provider: MSXBridgeProvider, mass_mock: M
         mass_mock.streams = Mock()
         mass_mock.streams.resolve_stream_url = AsyncMock(return_value=stream_url)
 
-        resp = await client.get("/msx/audio/msx_test?uri=library://track/1", allow_redirects=False)
+        resp = await client.get(
+            "/msx/audio/msx_test?uri=library://track/1&token=" + TEST_STREAM_TOKEN,
+            allow_redirects=False,
+        )
         assert resp.status == 302
         # the URL host is rewritten to the client-reachable one (see the
         # dedicated rewrite test); the streamserver path must be intact
@@ -1215,7 +1381,10 @@ async def test_msx_audio_redirect_rewrites_host_for_client(
         mass_mock.streams = Mock()
         mass_mock.streams.resolve_stream_url = AsyncMock(return_value=stream_url)
 
-        resp = await client.get("/msx/audio/msx_test?uri=library://track/1", allow_redirects=False)
+        resp = await client.get(
+            "/msx/audio/msx_test?uri=library://track/1&token=" + TEST_STREAM_TOKEN,
+            allow_redirects=False,
+        )
         assert resp.status == 302
         location = urlsplit(resp.headers["Location"])
         assert location.hostname == "127.0.0.1"  # host the TestClient connects to
@@ -1250,7 +1419,8 @@ async def test_msx_audio_redirect_mode_falls_back_to_proxy(
             return_value=_async_iter([b"encoded-chunk-1"]),
         ) as ffmpeg_stream:
             resp = await client.get(
-                "/msx/audio/msx_test?uri=library://track/1", allow_redirects=False
+                "/msx/audio/msx_test?uri=library://track/1&token=" + TEST_STREAM_TOKEN,
+                allow_redirects=False,
             )
             assert resp.status == 200
             body = await resp.read()

--- a/tests/providers/msx_bridge/test_http_server.py
+++ b/tests/providers/msx_bridge/test_http_server.py
@@ -25,8 +25,6 @@ from music_assistant.providers.msx_bridge.provider import MSXBridgeProvider
 if TYPE_CHECKING:
     from aiohttp.test_utils import TestClient
 
-TEST_STREAM_TOKEN = "test-stream-token"
-
 # --- Bootstrap and CORS ---
 
 
@@ -128,14 +126,14 @@ async def test_stream_no_media(provider: MSXBridgeProvider, mass_mock: Mock) -> 
     """GET /stream/{id} should return 404 when player has no current media."""
     mock_player = Mock(spec=MSXPlayer)
     mock_player.current_media = None
-    provider._stream_tokens["msx_test"] = TEST_STREAM_TOKEN
+    token = provider.get_stream_token("msx_test")
     mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
 
     server = MSXHTTPServer(provider, 0)
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        resp = await client.get(f"/stream/msx_test?token={TEST_STREAM_TOKEN}")
+        resp = await client.get(f"/stream/msx_test?token={token}")
         assert resp.status == 404
         body = await resp.text()
         assert "No active stream" in body
@@ -172,7 +170,7 @@ async def test_audio_routes_send_no_cors_header(
     provider: MSXBridgeProvider, mass_mock: Mock
 ) -> None:
     """Audio must not be readable by a cross-origin fetch, unlike the MSX content pages."""
-    provider._stream_tokens["msx_test"] = TEST_STREAM_TOKEN
+    token = provider.get_stream_token("msx_test")
     mock_player = Mock(spec=MSXPlayer)
     mock_player.current_media = None
     mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
@@ -181,7 +179,7 @@ async def test_audio_routes_send_no_cors_header(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        resp = await client.get(f"/stream/msx_test?token={TEST_STREAM_TOKEN}")
+        resp = await client.get(f"/stream/msx_test?token={token}")
         assert resp.headers.get("Access-Control-Allow-Origin") is None
         resp = await client.get("/msx/audio/msx_test")
         assert resp.headers.get("Access-Control-Allow-Origin") is None
@@ -196,7 +194,6 @@ async def test_stream_rejects_missing_token(provider: MSXBridgeProvider, mass_mo
     """GET /stream/{id} without the player's token should be refused."""
     mock_player = Mock(spec=MSXPlayer)
     mock_player.current_media = Mock()
-    provider._stream_tokens["msx_test"] = TEST_STREAM_TOKEN
     mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
 
     server = MSXHTTPServer(provider, 0)
@@ -206,25 +203,6 @@ async def test_stream_rejects_missing_token(provider: MSXBridgeProvider, mass_mo
         resp = await client.get("/stream/msx_test")
         assert resp.status == 403
         resp = await client.get("/stream/msx_test?token=wrong")
-        assert resp.status == 403
-    finally:
-        await client.close()
-
-
-async def test_stream_rejects_empty_player_token(
-    provider: MSXBridgeProvider, mass_mock: Mock
-) -> None:
-    """A player without a token must refuse every caller, not accept an empty one."""
-    mock_player = Mock(spec=MSXPlayer)
-    mock_player.current_media = Mock()
-    provider._stream_tokens["msx_test"] = ""
-    mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
-
-    server = MSXHTTPServer(provider, 0)
-    client = AiohttpTestClient(TestServer(server.app))
-    await client.start_server()
-    try:
-        resp = await client.get("/stream/msx_test?token=")
         assert resp.status == 403
     finally:
         await client.close()
@@ -258,7 +236,7 @@ async def test_stream_success(provider: MSXBridgeProvider, mass_mock: Mock) -> N
     mock_media.queue_item_id = None
     mock_player.current_media = mock_media
     mock_player.output_format = "mp3"
-    provider._stream_tokens["msx_test"] = TEST_STREAM_TOKEN
+    token = provider.get_stream_token("msx_test")
     mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
 
     # Mock get_stream to return an async generator
@@ -274,7 +252,7 @@ async def test_stream_success(provider: MSXBridgeProvider, mass_mock: Mock) -> N
             "music_assistant.providers.msx_bridge.http_server.get_ffmpeg_stream",
             return_value=_async_iter(chunks),
         ):
-            resp = await client.get(f"/stream/msx_test?token={TEST_STREAM_TOKEN}")
+            resp = await client.get(f"/stream/msx_test?token={token}")
             assert resp.status == 200
             assert resp.headers["Content-Type"] == "audio/mpeg"
             body = await resp.read()
@@ -598,11 +576,8 @@ def _make_playlist_mock(item_id: int = 1, name: str = "Test Playlist") -> Mock:
     return playlist
 
 
-def _make_audio_player(
-    mass_mock: Mock, provider: MSXBridgeProvider
-) -> tuple[MagicMock, PlayerMedia]:
+def _make_audio_player(mass_mock: Mock) -> tuple[MagicMock, PlayerMedia]:
     """Wire a MagicMock MSXPlayer with queue-backed media into mass_mock for audio tests."""
-    provider._stream_tokens["msx_test"] = TEST_STREAM_TOKEN
     player = MagicMock(spec=MSXPlayer)
     player.player_id = "msx_test"
     player.output_format = "mp3"
@@ -789,7 +764,7 @@ async def test_broadcast_play_path_carries_token(
     provider: MSXBridgeProvider, mass_mock: Mock
 ) -> None:
     """The pushed stream path must carry the token the /stream route now requires."""
-    provider._stream_tokens["msx_test"] = TEST_STREAM_TOKEN
+    token = provider.get_stream_token("msx_test")
 
     server = MSXHTTPServer(provider, 0)
     ws = AsyncMock()
@@ -807,7 +782,7 @@ async def test_broadcast_play_path_carries_token(
 
     await coros[0]
     payload = json.loads(ws.send_str.call_args[0][0])
-    assert payload["path"] == f"/stream/msx_test?token={TEST_STREAM_TOKEN}"
+    assert payload["path"] == f"/stream/msx_test?token={token}"
 
 
 # --- MSX audio endpoint ---
@@ -843,10 +818,9 @@ async def test_msx_audio_rejects_raw_stream_url(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock, provider)
-        resp = await client.get(
-            f"/msx/audio/msx_test?uri={quote(uri, safe='')}&token={TEST_STREAM_TOKEN}"
-        )
+        _make_audio_player(mass_mock)
+        token = provider.get_stream_token("msx_test")
+        resp = await client.get(f"/msx/audio/msx_test?uri={quote(uri, safe='')}&token={token}")
         assert resp.status == 400
         mass_mock.player_queues.play_media.assert_not_called()
     finally:
@@ -861,7 +835,7 @@ async def test_api_play_rejects_raw_stream_url(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock, provider)
+        _make_audio_player(mass_mock)
         for track_uri in (
             "http://evil.example/payload.mp3",
             "builtin://track/http://evil.example/payload.mp3",
@@ -884,7 +858,7 @@ async def test_msx_audio_rejects_missing_token(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock, provider)
+        _make_audio_player(mass_mock)
         resp = await client.get("/msx/audio/msx_test?uri=library://track/1")
         assert resp.status == 403
         resp = await client.get("/msx/audio/msx_test?uri=library://track/1&token=wrong")
@@ -923,7 +897,8 @@ async def test_msx_audio_per_track_mode(provider: MSXBridgeProvider, mass_mock: 
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock, provider)
+        _make_audio_player(mass_mock)
+        token = provider.get_stream_token("msx_test")
 
         mass_mock.streams = Mock()
         mass_mock.streams.get_stream = Mock(return_value=_async_iter([b"pcm"]))
@@ -933,9 +908,7 @@ async def test_msx_audio_per_track_mode(provider: MSXBridgeProvider, mass_mock: 
             "music_assistant.providers.msx_bridge.http_server.get_ffmpeg_stream",
             return_value=_async_iter(chunks),
         ):
-            resp = await client.get(
-                "/msx/audio/msx_test?uri=library://track/1&token=" + TEST_STREAM_TOKEN
-            )
+            resp = await client.get(f"/msx/audio/msx_test?uri=library://track/1&token={token}")
             assert resp.status == 200
 
         mass_mock.streams.get_stream.assert_called_once()
@@ -952,7 +925,8 @@ async def test_msx_audio_proxy_paces_output(provider: MSXBridgeProvider, mass_mo
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock, provider)
+        _make_audio_player(mass_mock)
+        token = provider.get_stream_token("msx_test")
         mass_mock.streams = Mock()
         mass_mock.streams.get_stream = Mock(return_value=_async_iter([b"pcm"]))
 
@@ -960,9 +934,7 @@ async def test_msx_audio_proxy_paces_output(provider: MSXBridgeProvider, mass_mo
             "music_assistant.providers.msx_bridge.http_server.get_ffmpeg_stream",
             return_value=_async_iter([b"encoded"]),
         ) as ffmpeg_mock:
-            resp = await client.get(
-                "/msx/audio/msx_test?uri=library://track/1&token=" + TEST_STREAM_TOKEN
-            )
+            resp = await client.get(f"/msx/audio/msx_test?uri=library://track/1&token={token}")
             assert resp.status == 200
 
         extra_args = ffmpeg_mock.call_args.kwargs["extra_input_args"]
@@ -980,7 +952,8 @@ async def test_msx_audio_from_playlist_skips_ws(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        player, _media = _make_audio_player(mass_mock, provider)
+        player, _media = _make_audio_player(mass_mock)
+        token = provider.get_stream_token("msx_test")
 
         mass_mock.streams = Mock()
         mass_mock.streams.get_stream = Mock(return_value=_async_iter([b"pcm"]))
@@ -999,8 +972,7 @@ async def test_msx_audio_from_playlist_skips_ws(
             return_value=_async_iter(chunks),
         ):
             resp = await client.get(
-                "/msx/audio/msx_test?uri=library://track/1&from_playlist=1&token="
-                + TEST_STREAM_TOKEN
+                f"/msx/audio/msx_test?uri=library://track/1&from_playlist=1&token={token}"
             )
             assert resp.status == 200
 
@@ -1021,7 +993,8 @@ async def test_msx_audio_arms_wait_before_enqueue(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        player, _media = _make_audio_player(mass_mock, provider)
+        player, _media = _make_audio_player(mass_mock)
+        token = provider.get_stream_token("msx_test")
 
         mass_mock.streams = Mock()
         mass_mock.streams.get_stream = Mock(return_value=_async_iter([b"pcm"]))
@@ -1038,9 +1011,7 @@ async def test_msx_audio_arms_wait_before_enqueue(
             "music_assistant.providers.msx_bridge.http_server.get_ffmpeg_stream",
             return_value=_async_iter([b"encoded-chunk-1"]),
         ):
-            resp = await client.get(
-                "/msx/audio/msx_test?uri=library://track/1&token=" + TEST_STREAM_TOKEN
-            )
+            resp = await client.get(f"/msx/audio/msx_test?uri=library://track/1&token={token}")
             assert resp.status == 200
 
         assert call_order == ["arm", "enqueue"]
@@ -1405,14 +1376,15 @@ async def test_msx_audio_redirect_mode(provider: MSXBridgeProvider, mass_mock: M
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock, provider)
+        _make_audio_player(mass_mock)
+        token = provider.get_stream_token("msx_test")
 
         stream_url = "http://ma:8097/single/s1/q1/i1/msx_test.mp3"
         mass_mock.streams = Mock()
         mass_mock.streams.resolve_stream_url = AsyncMock(return_value=stream_url)
 
         resp = await client.get(
-            "/msx/audio/msx_test?uri=library://track/1&token=" + TEST_STREAM_TOKEN,
+            f"/msx/audio/msx_test?uri=library://track/1&token={token}",
             allow_redirects=False,
         )
         assert resp.status == 302
@@ -1438,14 +1410,15 @@ async def test_msx_audio_redirect_rewrites_host_for_client(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock, provider)
+        _make_audio_player(mass_mock)
+        token = provider.get_stream_token("msx_test")
 
         stream_url = "http://172.18.0.2:8097/single/s1/q1/i1/msx_test.mp3?flow=1"
         mass_mock.streams = Mock()
         mass_mock.streams.resolve_stream_url = AsyncMock(return_value=stream_url)
 
         resp = await client.get(
-            "/msx/audio/msx_test?uri=library://track/1&token=" + TEST_STREAM_TOKEN,
+            f"/msx/audio/msx_test?uri=library://track/1&token={token}",
             allow_redirects=False,
         )
         assert resp.status == 302
@@ -1467,7 +1440,8 @@ async def test_msx_audio_redirect_mode_falls_back_to_proxy(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock, provider)
+        _make_audio_player(mass_mock)
+        token = provider.get_stream_token("msx_test")
 
         mass_mock.streams = Mock()
         mass_mock.streams.resolve_stream_url = AsyncMock(side_effect=RuntimeError("boom"))
@@ -1482,7 +1456,7 @@ async def test_msx_audio_redirect_mode_falls_back_to_proxy(
             return_value=_async_iter([b"encoded-chunk-1"]),
         ) as ffmpeg_stream:
             resp = await client.get(
-                "/msx/audio/msx_test?uri=library://track/1&token=" + TEST_STREAM_TOKEN,
+                f"/msx/audio/msx_test?uri=library://track/1&token={token}",
                 allow_redirects=False,
             )
             assert resp.status == 200

--- a/tests/providers/msx_bridge/test_http_server.py
+++ b/tests/providers/msx_bridge/test_http_server.py
@@ -128,7 +128,7 @@ async def test_stream_no_media(provider: MSXBridgeProvider, mass_mock: Mock) -> 
     """GET /stream/{id} should return 404 when player has no current media."""
     mock_player = Mock(spec=MSXPlayer)
     mock_player.current_media = None
-    mock_player.stream_token = TEST_STREAM_TOKEN
+    provider._stream_tokens["msx_test"] = TEST_STREAM_TOKEN
     mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
 
     server = MSXHTTPServer(provider, 0)
@@ -143,11 +143,60 @@ async def test_stream_no_media(provider: MSXBridgeProvider, mass_mock: Mock) -> 
         await client.close()
 
 
+async def test_stream_token_is_unguessable_and_per_player(
+    provider: MSXBridgeProvider,
+) -> None:
+    """Tokens must be random and distinct per player, not a shared constant."""
+    first = provider.get_stream_token("msx_a")
+    second = provider.get_stream_token("msx_b")
+    assert first
+    assert second
+    assert first != second
+    assert len(first) >= 16
+
+
+async def test_stream_token_survives_player_reregistration(
+    provider: MSXBridgeProvider,
+) -> None:
+    """
+    A token outlives the player object.
+
+    An idle TV is unregistered after the configured timeout; rotating there would
+    strand the URLs a long-running kiosk already cached.
+    """
+    token = provider.get_stream_token("msx_kiosk")
+    assert provider.get_stream_token("msx_kiosk") == token
+
+
+async def test_audio_routes_send_no_cors_header(
+    provider: MSXBridgeProvider, mass_mock: Mock
+) -> None:
+    """Audio must not be readable by a cross-origin fetch, unlike the MSX content pages."""
+    provider._stream_tokens["msx_test"] = TEST_STREAM_TOKEN
+    mock_player = Mock(spec=MSXPlayer)
+    mock_player.current_media = None
+    mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
+
+    server = MSXHTTPServer(provider, 0)
+    client = AiohttpTestClient(TestServer(server.app))
+    await client.start_server()
+    try:
+        resp = await client.get(f"/stream/msx_test?token={TEST_STREAM_TOKEN}")
+        assert resp.headers.get("Access-Control-Allow-Origin") is None
+        resp = await client.get("/msx/audio/msx_test")
+        assert resp.headers.get("Access-Control-Allow-Origin") is None
+        # the MSX content pages still need it — the MSX app loads them cross-origin
+        resp = await client.get("/msx/menu.json")
+        assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+    finally:
+        await client.close()
+
+
 async def test_stream_rejects_missing_token(provider: MSXBridgeProvider, mass_mock: Mock) -> None:
     """GET /stream/{id} without the player's token should be refused."""
     mock_player = Mock(spec=MSXPlayer)
     mock_player.current_media = Mock()
-    mock_player.stream_token = TEST_STREAM_TOKEN
+    provider._stream_tokens["msx_test"] = TEST_STREAM_TOKEN
     mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
 
     server = MSXHTTPServer(provider, 0)
@@ -168,7 +217,7 @@ async def test_stream_rejects_empty_player_token(
     """A player without a token must refuse every caller, not accept an empty one."""
     mock_player = Mock(spec=MSXPlayer)
     mock_player.current_media = Mock()
-    mock_player.stream_token = ""
+    provider._stream_tokens["msx_test"] = ""
     mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
 
     server = MSXHTTPServer(provider, 0)
@@ -209,7 +258,7 @@ async def test_stream_success(provider: MSXBridgeProvider, mass_mock: Mock) -> N
     mock_media.queue_item_id = None
     mock_player.current_media = mock_media
     mock_player.output_format = "mp3"
-    mock_player.stream_token = TEST_STREAM_TOKEN
+    provider._stream_tokens["msx_test"] = TEST_STREAM_TOKEN
     mass_mock.players.get.return_value = mass_mock.players.get_player.return_value = mock_player
 
     # Mock get_stream to return an async generator
@@ -549,12 +598,14 @@ def _make_playlist_mock(item_id: int = 1, name: str = "Test Playlist") -> Mock:
     return playlist
 
 
-def _make_audio_player(mass_mock: Mock) -> tuple[MagicMock, PlayerMedia]:
+def _make_audio_player(
+    mass_mock: Mock, provider: MSXBridgeProvider
+) -> tuple[MagicMock, PlayerMedia]:
     """Wire a MagicMock MSXPlayer with queue-backed media into mass_mock for audio tests."""
+    provider._stream_tokens["msx_test"] = TEST_STREAM_TOKEN
     player = MagicMock(spec=MSXPlayer)
     player.player_id = "msx_test"
     player.output_format = "mp3"
-    player.stream_token = TEST_STREAM_TOKEN
     player._skip_ws_notify = False
     media = PlayerMedia(
         uri="library://track/1",
@@ -738,9 +789,7 @@ async def test_broadcast_play_path_carries_token(
     provider: MSXBridgeProvider, mass_mock: Mock
 ) -> None:
     """The pushed stream path must carry the token the /stream route now requires."""
-    player = Mock(spec=MSXPlayer)
-    player.stream_token = TEST_STREAM_TOKEN
-    mass_mock.players.get_player.return_value = player
+    provider._stream_tokens["msx_test"] = TEST_STREAM_TOKEN
 
     server = MSXHTTPServer(provider, 0)
     ws = AsyncMock()
@@ -774,7 +823,17 @@ async def test_msx_audio_missing_uri(http_client: TestClient[Any, Any]) -> None:
 
 @pytest.mark.parametrize(
     "uri",
-    ["http://evil.example/payload.mp3", "https://evil.example/x", "rtsp://evil.example/x"],
+    [
+        "http://evil.example/payload.mp3",
+        "https://evil.example/x",
+        "rtsp://evil.example/x",
+        # the same destination wrapped in a builtin uri — parse_uri resolves both to
+        # ('builtin', 'http://evil.example/…'), so the guard must reject both
+        "builtin://track/http://evil.example/payload.mp3",
+        "builtin://radio/http://evil.example/x",
+        "builtin://unknown/https://evil.example/x",
+        "not-a-uri",
+    ],
 )
 async def test_msx_audio_rejects_raw_stream_url(
     provider: MSXBridgeProvider, mass_mock: Mock, uri: str
@@ -784,7 +843,7 @@ async def test_msx_audio_rejects_raw_stream_url(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock)
+        _make_audio_player(mass_mock, provider)
         resp = await client.get(
             f"/msx/audio/msx_test?uri={quote(uri, safe='')}&token={TEST_STREAM_TOKEN}"
         )
@@ -802,12 +861,16 @@ async def test_api_play_rejects_raw_stream_url(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock)
-        resp = await client.post(
-            "/api/play",
-            json={"track_uri": "http://evil.example/payload.mp3", "player_id": "msx_test"},
-        )
-        assert resp.status == 400
+        _make_audio_player(mass_mock, provider)
+        for track_uri in (
+            "http://evil.example/payload.mp3",
+            "builtin://track/http://evil.example/payload.mp3",
+        ):
+            resp = await client.post(
+                "/api/play",
+                json={"track_uri": track_uri, "player_id": "msx_test"},
+            )
+            assert resp.status == 400
         mass_mock.player_queues.play_media.assert_not_called()
     finally:
         await client.close()
@@ -821,7 +884,7 @@ async def test_msx_audio_rejects_missing_token(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock)
+        _make_audio_player(mass_mock, provider)
         resp = await client.get("/msx/audio/msx_test?uri=library://track/1")
         assert resp.status == 403
         resp = await client.get("/msx/audio/msx_test?uri=library://track/1&token=wrong")
@@ -860,7 +923,7 @@ async def test_msx_audio_per_track_mode(provider: MSXBridgeProvider, mass_mock: 
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock)
+        _make_audio_player(mass_mock, provider)
 
         mass_mock.streams = Mock()
         mass_mock.streams.get_stream = Mock(return_value=_async_iter([b"pcm"]))
@@ -889,7 +952,7 @@ async def test_msx_audio_proxy_paces_output(provider: MSXBridgeProvider, mass_mo
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock)
+        _make_audio_player(mass_mock, provider)
         mass_mock.streams = Mock()
         mass_mock.streams.get_stream = Mock(return_value=_async_iter([b"pcm"]))
 
@@ -917,7 +980,7 @@ async def test_msx_audio_from_playlist_skips_ws(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        player, _media = _make_audio_player(mass_mock)
+        player, _media = _make_audio_player(mass_mock, provider)
 
         mass_mock.streams = Mock()
         mass_mock.streams.get_stream = Mock(return_value=_async_iter([b"pcm"]))
@@ -958,7 +1021,7 @@ async def test_msx_audio_arms_wait_before_enqueue(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        player, _media = _make_audio_player(mass_mock)
+        player, _media = _make_audio_player(mass_mock, provider)
 
         mass_mock.streams = Mock()
         mass_mock.streams.get_stream = Mock(return_value=_async_iter([b"pcm"]))
@@ -1342,7 +1405,7 @@ async def test_msx_audio_redirect_mode(provider: MSXBridgeProvider, mass_mock: M
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock)
+        _make_audio_player(mass_mock, provider)
 
         stream_url = "http://ma:8097/single/s1/q1/i1/msx_test.mp3"
         mass_mock.streams = Mock()
@@ -1375,7 +1438,7 @@ async def test_msx_audio_redirect_rewrites_host_for_client(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock)
+        _make_audio_player(mass_mock, provider)
 
         stream_url = "http://172.18.0.2:8097/single/s1/q1/i1/msx_test.mp3?flow=1"
         mass_mock.streams = Mock()
@@ -1404,7 +1467,7 @@ async def test_msx_audio_redirect_mode_falls_back_to_proxy(
     client = AiohttpTestClient(TestServer(server.app))
     await client.start_server()
     try:
-        _make_audio_player(mass_mock)
+        _make_audio_player(mass_mock, provider)
 
         mass_mock.streams = Mock()
         mass_mock.streams.resolve_stream_url = AsyncMock(side_effect=RuntimeError("boom"))

--- a/tests/providers/msx_bridge/test_mappers.py
+++ b/tests/providers/msx_bridge/test_mappers.py
@@ -18,6 +18,7 @@ def _mock_provider() -> MSXBridgeProvider:
     """Create a mock provider."""
     provider = MagicMock()
     provider.mass.metadata.get_image_url.return_value = "http://image.url"
+    provider.get_stream_token.return_value = "tok123"
     return provider
 
 
@@ -45,6 +46,7 @@ def test_map_track_to_msx() -> None:
     assert item.action is not None
     assert "audio:http://localhost/msx/audio/msx_123" in item.action
     assert "uri=library%3A%2F%2Ftrack%2F1" in item.action
+    assert "token=tok123" in item.action
     assert "device_id=abc" in item.action
 
 


### PR DESCRIPTION
# What does this implement/fix?

The MSX Bridge runs its own HTTP server bound to `0.0.0.0` so TVs on the LAN can reach it. Its two audio routes accepted any caller:

- `GET /msx/audio/{player_id}?uri=…` started playback of whatever the caller named and handed back the audio
- `GET /stream/{player_id}` served the player's current audio

The cross-site guard added in #4734 only covers the playback-control endpoints, so nothing gated these. Player IDs aren't secret either — they come from a caller-supplied `?device_id=`, and any content page registers the player on demand.

`?uri=` was also unvalidated beyond containing `://`, so a bare `http://…` URL resolved to the builtin provider and made the server fetch and play whatever was named.

## Changes

- Each player gets a token, derived from one provider secret and embedded in the audio URLs the bridge generates; both audio routes require it
- `?uri=` (and `/api/play`'s `track_uri`) are checked against the provider the uri *resolves* to, so a raw URL is rejected whether it is spelled bare or as `builtin://<media_type>/<url>`
- The audio routes no longer send `Access-Control-Allow-Origin`, so a cross-origin `fetch()` cannot read the audio
- The two local proxy stream modes pace their output at the same ceiling as the core streamserver
- Test coverage for each of the above

## Notes

TVs are unaffected. They follow the URLs the bridge hands them, the web player passes the pushed path through unchanged, and audio still plays cross-origin because a media element does not need CORS — the kiosk visualizer reads the stream same-origin. Tokens live for the provider's lifetime rather than the player's, so an idle TV being unregistered does not strand a URL a long-running kiosk has cached.

This does not make the bridge an authenticated server. The JSON pages that carry the tokens have to stay readable by a credential-less TV, and their CORS wildcard is load-bearing because the MSX app is hosted off-server and loads them cross-origin — so `Sec-Fetch-Site` gating cannot be extended to the MSX-facing routes either. What this does close: requests that were never handed out, using the endpoint to play an arbitrary URL, and reading the audio from another origin. A URL that *was* handed out stays valid until the provider reloads, so this is not a defence against a captured URL.

**Related issue (if applicable):**

- n/a — found during a stream-server hardening pass

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
