### PR TITLE
Never leave a library album without its artists

### DIFF
--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -707,8 +707,9 @@ class AlbumsController(MediaControllerBase[Album]):
         """Search one provider and return the mappings of every confirmed album match."""
         self.logger.debug("Trying to match album %s on provider %s", db_album.name, provider.name)
         matches: list[ProviderMapping] = []
-        artist_name = db_album.artists[0].name
-        search_str = f"{artist_name} - {db_album.name}"
+        search_str = (
+            f"{db_album.artists[0].name} - {db_album.name}" if db_album.artists else db_album.name
+        )
         for search_result_item in await self.search(search_str, provider.instance_id):
             if not search_result_item.available:
                 continue
@@ -893,7 +894,19 @@ class AlbumsController(MediaControllerBase[Album]):
         artists: Iterable[Artist | ItemMapping],
         overwrite: bool = False,
     ) -> None:
-        """Store Album Artists."""
+        """
+        Store Album Artists.
+
+        An empty set of artists never clears the stored rows: an album that lost its
+        artists disappears from their discography and is skipped by provider matching.
+        """
+        all_artists = list(artists)
+        if not all_artists:
+            if overwrite:
+                # a caller asking to replace all artists with none is a bug,
+                # so keep the stored rows and make the attempt visible
+                self.logger.warning("Ignoring request to clear all artists of album id %s", db_id)
+            return
         if overwrite:
             # on overwrite, clear the album_artists table first
             await self.mass.music.database.delete(
@@ -902,7 +915,7 @@ class AlbumsController(MediaControllerBase[Album]):
                     "album_id": db_id,
                 },
             )
-        for artist in artists:
+        for artist in all_artists:
             await self._set_album_artist(db_id, artist=artist, overwrite=overwrite)
 
     async def _set_album_artist(

--- a/tests/controllers/music/helpers.py
+++ b/tests/controllers/music/helpers.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from music_assistant_models.enums import ExternalID
 from music_assistant_models.media_items import (
+    Album,
     Artist,
     AudioFormat,
+    ItemMapping,
     ProviderMapping,
     Track,
     UniqueList,
@@ -62,4 +64,52 @@ def create_track(
                 )
             ]
         ),
+    )
+
+
+def create_album(
+    provider_instance: str,
+    item_id: str,
+    name: str = "Test Album",
+    artist_name: str | None = "Test Artist",
+) -> Album:
+    """
+    Create an Album as it would be received from a music provider.
+
+    :param provider_instance: The provider instance id the album originates from.
+    :param item_id: The item id of the album on the provider.
+    :param name: The album name.
+    :param artist_name: The album artist name, or None for an album without artists.
+    """
+    provider_domain = provider_instance.split("_", maxsplit=1)[0]
+    artists: UniqueList[Artist | ItemMapping] = UniqueList()
+    if artist_name is not None:
+        artists.append(
+            Artist(
+                item_id=f"{item_id}_artist",
+                provider=provider_instance,
+                name=artist_name,
+                provider_mappings={
+                    ProviderMapping(
+                        item_id=f"{item_id}_artist",
+                        provider_domain=provider_domain,
+                        provider_instance=provider_instance,
+                        audio_format=AudioFormat(),
+                    )
+                },
+            )
+        )
+    return Album(
+        item_id=item_id,
+        provider=provider_instance,
+        name=name,
+        provider_mappings={
+            ProviderMapping(
+                item_id=item_id,
+                provider_domain=provider_domain,
+                provider_instance=provider_instance,
+                audio_format=AudioFormat(),
+            )
+        },
+        artists=artists,
     )

--- a/tests/controllers/music/helpers.py
+++ b/tests/controllers/music/helpers.py
@@ -72,6 +72,7 @@ def create_album(
     item_id: str,
     name: str = "Test Album",
     artist_name: str | None = "Test Artist",
+    artist_item_id: str | None = None,
 ) -> Album:
     """
     Create an Album as it would be received from a music provider.
@@ -80,18 +81,21 @@ def create_album(
     :param item_id: The item id of the album on the provider.
     :param name: The album name.
     :param artist_name: The album artist name, or None for an album without artists.
+    :param artist_item_id: The item id of the album artist on the provider,
+        defaults to one derived from the album item id.
     """
     provider_domain = provider_instance.split("_", maxsplit=1)[0]
     artists: UniqueList[Artist | ItemMapping] = UniqueList()
     if artist_name is not None:
+        artist_id = artist_item_id or f"{item_id}_artist"
         artists.append(
             Artist(
-                item_id=f"{item_id}_artist",
+                item_id=artist_id,
                 provider=provider_instance,
                 name=artist_name,
                 provider_mappings={
                     ProviderMapping(
-                        item_id=f"{item_id}_artist",
+                        item_id=artist_id,
                         provider_domain=provider_domain,
                         provider_instance=provider_instance,
                         audio_format=AudioFormat(),

--- a/tests/controllers/music/test_albums.py
+++ b/tests/controllers/music/test_albums.py
@@ -1,0 +1,53 @@
+"""Tests for the albums controller."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .helpers import create_album, create_track
+
+if TYPE_CHECKING:
+    import pytest
+
+    from music_assistant.mass import MusicAssistant
+
+
+async def test_overwrite_update_keeps_artists_when_none_are_given(
+    mass: MusicAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An overwrite update carrying no artists must not clear the stored ones."""
+    db_album = await mass.music.albums.add_item_to_library(create_album("spotify_1", "album1"))
+
+    update = create_album("spotify_1", "album1", artist_name=None)
+    await mass.music.albums.update_item_in_library(db_album.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.albums.get_library_item(db_album.item_id)
+    assert [artist.name for artist in refreshed.artists] == ["Test Artist"]
+    assert "Ignoring request to clear all artists" in caplog.text
+
+
+async def test_overwrite_update_replaces_artists(mass: MusicAssistant) -> None:
+    """An overwrite update carrying artists still replaces the stored ones."""
+    db_album = await mass.music.albums.add_item_to_library(create_album("spotify_1", "album1"))
+
+    update = create_album("spotify_1", "album1", artist_name="Other Artist")
+    await mass.music.albums.update_item_in_library(db_album.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.albums.get_library_item(db_album.item_id)
+    assert [artist.name for artist in refreshed.artists] == ["Other Artist"]
+
+
+async def test_track_overwrite_keeps_album_artists(mass: MusicAssistant) -> None:
+    """A track update carrying an artist-less album must not clear that album's artists."""
+    db_album = await mass.music.albums.add_item_to_library(create_album("spotify_1", "album1"))
+    track = create_track("spotify_1", "track1")
+    track.album = create_album("spotify_1", "album1")
+    db_track = await mass.music.tracks.add_item_to_library(track)
+
+    # a provider that builds an album object without artists (as qqmusic does)
+    update = create_track("spotify_1", "track1")
+    update.album = create_album("spotify_1", "album1", artist_name=None)
+    await mass.music.tracks.update_item_in_library(db_track.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.albums.get_library_item(db_album.item_id)
+    assert [artist.name for artist in refreshed.artists] == ["Test Artist"]

--- a/tests/controllers/music/test_albums.py
+++ b/tests/controllers/music/test_albums.py
@@ -30,7 +30,10 @@ async def test_overwrite_update_replaces_artists(mass: MusicAssistant) -> None:
     """An overwrite update carrying artists still replaces the stored ones."""
     db_album = await mass.music.albums.add_item_to_library(create_album("spotify_1", "album1"))
 
-    update = create_album("spotify_1", "album1", artist_name="Other Artist")
+    # a distinct artist id, so the stored relation is replaced rather than renamed
+    update = create_album(
+        "spotify_1", "album1", artist_name="Other Artist", artist_item_id="other_artist"
+    )
     await mass.music.albums.update_item_in_library(db_album.item_id, update, overwrite=True)
 
     refreshed = await mass.music.albums.get_library_item(db_album.item_id)

--- a/tests/controllers/music/test_albums_match.py
+++ b/tests/controllers/music/test_albums_match.py
@@ -273,6 +273,25 @@ async def test_clear_no_match_search_result_skips_full_fetch() -> None:
     harness.get_provider_item.assert_not_awaited()
 
 
+async def test_search_string_combines_artist_and_album_name() -> None:
+    """The provider search is made on the album artist and the album name."""
+    with _harness(search_results=[], provider_items={}) as harness:
+        await harness.match(_library_album())
+
+    harness.search.assert_awaited_once_with("Sigur Rós - ( )", "spotify_1")
+
+
+async def test_album_without_artists_searches_on_name_only() -> None:
+    """An album that has no artists is still searchable instead of raising."""
+    base = _library_album()
+    base.artists = UniqueList()
+    with _harness(search_results=[], provider_items={}) as harness:
+        matches = await harness.match(base)
+
+    assert matches == []
+    harness.search.assert_awaited_once_with("( )", "spotify_1")
+
+
 async def test_insufficient_search_result_proceeds_to_one_full_fetch() -> None:
     """An ambiguous search result is confirmed against exactly one full provider album."""
     base = _library_album(external_ids={(ExternalID.MB_ALBUM, MB_ALBUM_ID)})


### PR DESCRIPTION
# What does this implement/fix?

A library album could lose all of its artists. Updating an album with `overwrite=True`
and an empty artist list cleared every stored artist relation for that album.

You reach it by refreshing a track: a provider that hands the track a full album object
without artists makes the track update overwrite that album's artist rows with nothing.
Emby does this on every track, qqmusic on most. The album then shows no artist, drops out
of the artist's discography, and is silently skipped by provider matching from that point
on, so it cannot repair itself.

This is the artist half of a wider problem: the same refresh also replaces the album's
year, genres, images, barcode and cross-provider links with whatever the stub album carries,
which is usually nothing. That part is tracked separately in #5853.

Unlike tracks, an album with no artists is a legitimate state (albums added from an item
mapping start out that way), so this only refuses to *clear* artists — it never requires
them. Same hole that #5845 closed for tracks and #5548 for provider mappings.

Also fixes a nearby crash waiting to happen: the album matcher read `artists[0]` without
checking, which would raise on any album that has no artists. Not reachable today (the
caller happens to guard first), but the same method 240 lines up already handles this,
so the two now agree.

## Changes

- An overwrite update that carries no artists now keeps the stored ones instead of
  clearing them, and logs a warning so the attempt is visible.
- The album matcher searches on the album name alone when the album has no artists.
- Added tests for the refusal, a normal artist replacement, the track-refresh path that
  triggered it, and both search-string forms.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
