### PR TITLE
Make future changes to the album title suffix list safer

### DIFF
--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -66,7 +66,9 @@ _RECORDING_CONFLICT_VERSION_TOKENS = {
     "session",
 }
 
-# retail suffixes a provider (notably Apple Music) appends to an EP/single title
+# retail suffixes a provider (notably Apple Music) appends to an EP/single title.
+# Entries must be a single ASCII alphanumeric word: album_retail_suffix_sql_match matches
+# on the normalized key, so anything else stops covering what the pattern below matches.
 _ALBUM_RETAIL_SUFFIXES: Final = ("EP", "Single")
 # escaped, so an entry that happens to contain regex syntax stays a literal alternative
 _ALBUM_SUFFIX_ALTERNATION: Final = "|".join(re.escape(suffix) for suffix in _ALBUM_RETAIL_SUFFIXES)
@@ -83,8 +85,8 @@ _ALBUM_SUFFIX_PATTERN = re.compile(
 # normalizing a title drops the separator, so the suffix survives as a plain trailing
 # fragment of the name key ("Foo - EP" -> "fooep"): appending one of these to a key
 # yields the key the same album is stored under when a provider spells out the suffix.
-# It also reduces each key to alphanumerics, which is what lets the query builders
-# interpolate them into SQL directly.
+# create_safe_string reduces each key to lowercase ASCII alphanumerics, which is what
+# lets the query builders interpolate them into SQL directly.
 ALBUM_RETAIL_SUFFIX_KEYS: Final = tuple(
     create_safe_string(suffix, True, True) for suffix in _ALBUM_RETAIL_SUFFIXES
 )

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -68,19 +68,23 @@ _RECORDING_CONFLICT_VERSION_TOKENS = {
 
 # retail suffixes a provider (notably Apple Music) appends to an EP/single title
 _ALBUM_RETAIL_SUFFIXES: Final = ("EP", "Single")
+# escaped, so an entry that happens to contain regex syntax stays a literal alternative
+_ALBUM_SUFFIX_ALTERNATION: Final = "|".join(re.escape(suffix) for suffix in _ALBUM_RETAIL_SUFFIXES)
 # the trailing retail suffix as it appears in a raw album title: set off by a dash
 # (any style, and only the space in front of it counts, so "K-EP" keeps its name) or
 # wrapped in brackets, which need no space to be unambiguous. A bare trailing word is
 # deliberately not accepted, as it is just as likely part of the title itself
 # ("The SL2 EP", "Saturday Night Single")
 _ALBUM_SUFFIX_PATTERN = re.compile(
-    rf"\s+[-\u2013\u2014]\s*(?P<suffix>{'|'.join(_ALBUM_RETAIL_SUFFIXES)})\s*$"
-    rf"|\s*[(\[](?P<bracketed>{'|'.join(_ALBUM_RETAIL_SUFFIXES)})[)\]]\s*$",
+    rf"\s+[-\u2013\u2014]\s*(?P<suffix>{_ALBUM_SUFFIX_ALTERNATION})\s*$"
+    rf"|\s*[(\[](?P<bracketed>{_ALBUM_SUFFIX_ALTERNATION})[)\]]\s*$",
     re.IGNORECASE,
 )
 # normalizing a title drops the separator, so the suffix survives as a plain trailing
 # fragment of the name key ("Foo - EP" -> "fooep"): appending one of these to a key
-# yields the key the same album is stored under when a provider spells out the suffix
+# yields the key the same album is stored under when a provider spells out the suffix.
+# It also reduces each key to alphanumerics, which is what lets the query builders
+# interpolate them into SQL directly.
 ALBUM_RETAIL_SUFFIX_KEYS: Final = tuple(
     create_safe_string(suffix, True, True) for suffix in _ALBUM_RETAIL_SUFFIXES
 )


### PR DESCRIPTION
# What does this implement/fix?

We strip retail suffixes from album titles so "Foo - EP" and "Foo (Single)" are recognised
as the same album as plain "Foo". The list of those suffixes is written to be extended, but
nothing recorded what a safe entry looks like, and its values were dropped into a regular
expression without escaping. The two values we ship today are plain letters, so nothing is
wrong right now.

No behaviour change: for the current values the compiled pattern is byte-for-byte identical
before and after.

## Changes

- Escape the suffix values when building the album title pattern, so an entry containing
  punctuation cannot quietly change what the pattern matches.
- Record at the list itself that entries have to be a single plain word, since the matching
  query works off a normalized key that drops spaces and punctuation.
- Note that the same normalization is what makes those keys safe to place into a query
  directly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
