### PR TITLE
Stop a track refresh from wiping its album and artist details

### DIFF
--- a/music_assistant/controllers/music/helpers.py
+++ b/music_assistant/controllers/music/helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import fields
 from typing import TYPE_CHECKING, Any, Final
 
 from music_assistant_models.helpers import create_safe_string
@@ -135,7 +136,7 @@ def metadata_for_update(
     :param update: Metadata of the item as delivered by the provider.
     :param overwrite: Whether the given item replaces the stored one.
     """
-    if overwrite and update != MediaItemMetadata():
+    if overwrite and any(getattr(update, field.name) for field in fields(update)):
         return update
     return stored.update(update)
 

--- a/music_assistant/controllers/music/helpers.py
+++ b/music_assistant/controllers/music/helpers.py
@@ -5,11 +5,18 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Final
 
 from music_assistant_models.helpers import create_safe_string
-from music_assistant_models.media_items import Artist, ItemMapping, MediaItemType, SearchResults
+from music_assistant_models.media_items import (
+    Artist,
+    ItemMapping,
+    MediaItemMetadata,
+    MediaItemType,
+    ProviderMapping,
+    SearchResults,
+)
 from music_assistant_models.unique_list import UniqueList
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
 
     from music_assistant_models.enums import MediaType
 
@@ -113,3 +120,44 @@ def filter_search_results(
         podcasts=[x for x in results.podcasts if _keep(x)],
         sound_effects=[x for x in results.sound_effects if _keep(x)],
     )
+
+
+def metadata_for_update(
+    stored: MediaItemMetadata, update: MediaItemMetadata, overwrite: bool
+) -> MediaItemMetadata:
+    """
+    Return the metadata to store for a library item update.
+
+    An overwrite replaces the stored metadata, unless the given item carries none at
+    all: providers embed a bare stub of an album or artist in their track payloads.
+
+    :param stored: Metadata currently stored for the library item.
+    :param update: Metadata of the item as delivered by the provider.
+    :param overwrite: Whether the given item replaces the stored one.
+    """
+    if overwrite and update != MediaItemMetadata():
+        return update
+    return stored.update(update)
+
+
+def provider_mappings_for_update(
+    stored: Iterable[ProviderMapping], update: Iterable[ProviderMapping], overwrite: bool
+) -> set[ProviderMapping]:
+    """
+    Return the provider mappings to store for a library item update.
+
+    An overwrite replaces the mappings of the providers the given item comes from, so a
+    changed item id (a moved file) drops its stale row, and keeps the mappings written
+    by the other providers the item is linked to.
+
+    :param stored: Provider mappings currently stored for the library item.
+    :param update: Provider mappings of the item as delivered by the provider.
+    :param overwrite: Whether the given item replaces the stored one.
+    """
+    if not overwrite:
+        return {*update, *stored}
+    updated_instances = {mapping.provider_instance for mapping in update}
+    return {
+        *update,
+        *(mapping for mapping in stored if mapping.provider_instance not in updated_instances),
+    }

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -637,8 +637,12 @@ class AlbumsController(MediaControllerBase[Album]):
             {
                 "name": name,
                 "sort_name": sort_name,
-                "version": update.version if overwrite else cur_item.version or update.version,
-                "year": update.year or cur_item.year,
+                "version": (update.version or cur_item.version)
+                if overwrite
+                else (cur_item.version or update.version),
+                "year": (update.year or cur_item.year)
+                if overwrite
+                else (cur_item.year or update.year),
                 "album_type": album_type.value,
                 "metadata": serialize_to_json(metadata),
                 "search_name": create_safe_string(name, True, True),

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -29,7 +29,11 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.constants import DB_TABLE_ALBUM_ARTISTS, DB_TABLE_ALBUM_TRACKS, DB_TABLE_ALBUMS
-from music_assistant.controllers.music.helpers import search_name_match_clause
+from music_assistant.controllers.music.helpers import (
+    metadata_for_update,
+    provider_mappings_for_update,
+    search_name_match_clause,
+)
 from music_assistant.helpers.compare import (
     ALBUM_RETAIL_SUFFIX_KEYS,
     AlbumMatchEvidence,
@@ -619,7 +623,7 @@ class AlbumsController(MediaControllerBase[Album]):
         """Update existing record in the database."""
         db_id = int(item_id)  # ensure integer
         cur_item = await self.get_library_item(db_id)
-        metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
+        metadata = metadata_for_update(cur_item.metadata, update.metadata, overwrite)
         if getattr(update, "album_type", AlbumType.UNKNOWN) != AlbumType.UNKNOWN:
             album_type = update.album_type
         else:
@@ -634,7 +638,7 @@ class AlbumsController(MediaControllerBase[Album]):
                 "name": name,
                 "sort_name": sort_name,
                 "version": update.version if overwrite else cur_item.version or update.version,
-                "year": update.year if overwrite else cur_item.year or update.year,
+                "year": update.year or cur_item.year,
                 "album_type": album_type.value,
                 "metadata": serialize_to_json(metadata),
                 "search_name": create_safe_string(name, True, True),
@@ -649,10 +653,8 @@ class AlbumsController(MediaControllerBase[Album]):
             db_id, update.external_ids if overwrite else cur_item.external_ids
         )
         # update/set provider_mappings table
-        provider_mappings = (
-            update.provider_mappings
-            if overwrite
-            else {*update.provider_mappings, *cur_item.provider_mappings}
+        provider_mappings = provider_mappings_for_update(
+            cur_item.provider_mappings, update.provider_mappings, overwrite
         )
         await self.set_provider_mappings(db_id, provider_mappings, overwrite)
         # set album artist(s)

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -41,6 +41,10 @@ from music_assistant.constants import (
     VARIOUS_ARTISTS_MBID,
     VARIOUS_ARTISTS_NAME,
 )
+from music_assistant.controllers.music.helpers import (
+    metadata_for_update,
+    provider_mappings_for_update,
+)
 from music_assistant.helpers.compare import (
     compare_album,
     compare_album_name,
@@ -1111,7 +1115,7 @@ class ArtistsController(MediaControllerBase[Artist]):
             update = self.artist_from_item_mapping(update)
             metadata = cur_item.metadata
         else:
-            metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
+            metadata = metadata_for_update(cur_item.metadata, update.metadata, overwrite)
         cur_item.external_ids.update(update.external_ids)
         # enforce various artists name + id
         mbid = cur_item.mbid
@@ -1144,10 +1148,8 @@ class ArtistsController(MediaControllerBase[Artist]):
             db_id, update.external_ids if overwrite else cur_item.external_ids
         )
         # update/set provider_mappings table
-        provider_mappings = (
-            update.provider_mappings
-            if overwrite
-            else {*update.provider_mappings, *cur_item.provider_mappings}
+        provider_mappings = provider_mappings_for_update(
+            cur_item.provider_mappings, update.provider_mappings, overwrite
         )
         await self.set_provider_mappings(db_id, provider_mappings, overwrite)
         self.logger.debug("updated %s in database: (id %s)", update.name, db_id)

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -1376,23 +1376,31 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         item_id: str | int,
         external_ids: Iterable[tuple[ExternalID, str]],
     ) -> None:
-        """Update the external_id_lookup table rows for the media item."""
+        """
+        Update the external_id_lookup table rows for the media item.
+
+        An empty set never clears the stored rows: identifiers are the strongest
+        evidence available when matching an item across providers.
+        """
         db_id = int(item_id)  # ensure integer
+        if not (external_ids := normalize_external_ids(external_ids)):
+            return
         await self.mass.music.database.delete(
             DB_TABLE_EXTERNAL_ID_LOOKUP,
             {"media_type": self.media_type.value, "item_id": db_id},
         )
-        external_ids = normalize_external_ids(external_ids)
-        if lookup_rows := [
-            {
-                "media_type": self.media_type.value,
-                "external_id_type": external_id_type,
-                "external_id": external_id,
-                "item_id": db_id,
-            }
-            for external_id_type, external_id in external_ids
-        ]:
-            await self.mass.music.database.upsert_many(DB_TABLE_EXTERNAL_ID_LOOKUP, lookup_rows)
+        await self.mass.music.database.upsert_many(
+            DB_TABLE_EXTERNAL_ID_LOOKUP,
+            [
+                {
+                    "media_type": self.media_type.value,
+                    "external_id_type": external_id_type,
+                    "external_id": external_id,
+                    "item_id": db_id,
+                }
+                for external_id_type, external_id in external_ids
+            ],
+        )
 
     @abstractmethod
     async def match_providers(self, db_item: ItemCls) -> None:

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -38,7 +38,10 @@ from music_assistant.constants import (
     DB_TABLE_TRACK_ARTISTS,
     DB_TABLE_TRACKS,
 )
-from music_assistant.controllers.music.helpers import search_name_match_clause
+from music_assistant.controllers.music.helpers import (
+    provider_mappings_for_update,
+    search_name_match_clause,
+)
 from music_assistant.helpers.compare import (
     compare_artists,
     compare_media_item,
@@ -773,10 +776,8 @@ class TracksController(MediaControllerBase[Track]):
             db_id, update.external_ids if overwrite else cur_item.external_ids
         )
         # update/set provider_mappings table
-        provider_mappings = (
-            update.provider_mappings
-            if overwrite
-            else {*update.provider_mappings, *cur_item.provider_mappings}
+        provider_mappings = provider_mappings_for_update(
+            cur_item.provider_mappings, update.provider_mappings, overwrite
         )
         await self.set_provider_mappings(db_id, provider_mappings, overwrite)
         # set track artist(s)

--- a/tests/controllers/music/test_albums.py
+++ b/tests/controllers/music/test_albums.py
@@ -161,3 +161,60 @@ async def test_overwrite_update_replaces_only_its_own_provider_mapping(
     assert {
         (mapping.provider_instance, mapping.item_id) for mapping in refreshed.provider_mappings
     } == {("spotify_1", "album2"), ("tidal_1", "tidal_album1")}
+
+
+async def test_track_overwrite_keeps_album_details_with_an_empty_image_list(
+    mass: MusicAssistant,
+) -> None:
+    """An empty image list is not metadata, so it must not replace the stored details."""
+    full = _detailed_album()
+    full.metadata.description = "About this album"
+    db_album = await mass.music.albums.add_item_to_library(full)
+    track = create_track("spotify_1", "track1")
+    track.album = create_album("spotify_1", "album1")
+    db_track = await mass.music.tracks.add_item_to_library(track)
+
+    # a provider that always assigns an image list, empty or not (as spotify does)
+    update = create_track("spotify_1", "track1")
+    stub = create_album("spotify_1", "album1")
+    stub.metadata.images = UniqueList([])
+    update.album = stub
+    await mass.music.tracks.update_item_in_library(db_track.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.albums.get_library_item(db_album.item_id)
+    assert refreshed.metadata.genres == {"rock"}
+    assert refreshed.metadata.description == "About this album"
+    assert [image.path for image in refreshed.metadata.images or []] == [ALBUM_IMAGE]
+
+
+async def test_track_overwrite_keeps_album_version(mass: MusicAssistant) -> None:
+    """A track update carrying a version-less album must not blank the stored edition."""
+    full = create_album("spotify_1", "album1")
+    full.version = "Deluxe Edition"
+    db_album = await mass.music.albums.add_item_to_library(full)
+    track = create_track("spotify_1", "track1")
+    track.album = create_album("spotify_1", "album1")
+    db_track = await mass.music.tracks.add_item_to_library(track)
+
+    update = create_track("spotify_1", "track1")
+    update.album = create_album("spotify_1", "album1")
+    await mass.music.tracks.update_item_in_library(db_track.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.albums.get_library_item(db_album.item_id)
+    assert refreshed.version == "Deluxe Edition"
+
+
+async def test_merge_update_keeps_the_stored_year_and_version(mass: MusicAssistant) -> None:
+    """A second provider matching an existing album does not restate its release."""
+    full = _detailed_album()
+    full.version = "Deluxe Edition"
+    db_album = await mass.music.albums.add_item_to_library(full)
+
+    # the same album on another provider, carrying a reissue year and no edition
+    update = create_album("tidal_1", "tidal_album1")
+    update.year = 2011
+    await mass.music.albums.update_item_in_library(db_album.item_id, update)
+
+    refreshed = await mass.music.albums.get_library_item(db_album.item_id)
+    assert refreshed.year == 1999
+    assert refreshed.version == "Deluxe Edition"

--- a/tests/controllers/music/test_albums.py
+++ b/tests/controllers/music/test_albums.py
@@ -4,12 +4,42 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from music_assistant_models.enums import ExternalID, ImageType
+from music_assistant_models.media_items import (
+    MediaItemImage,
+    ProviderMapping,
+    UniqueList,
+)
+
 from .helpers import create_album, create_track
 
 if TYPE_CHECKING:
     import pytest
+    from music_assistant_models.media_items import Album
 
     from music_assistant.mass import MusicAssistant
+
+RELEASE_GROUP_MBID = "7d4d1f70-1c99-4c1b-b0f1-9f2c1b2a3d44"
+ALBUM_IMAGE = "http://images/album1.jpg"
+
+
+def _detailed_album(item_id: str = "album1") -> Album:
+    """Return an album carrying the details only a full provider fetch delivers."""
+    album = create_album("spotify_1", item_id)
+    album.year = 1999
+    album.external_ids = {(ExternalID.MB_RELEASEGROUP, RELEASE_GROUP_MBID)}
+    album.metadata.genres = {"rock"}
+    album.metadata.images = UniqueList(
+        [MediaItemImage(type=ImageType.THUMB, path=ALBUM_IMAGE, provider="spotify_1")]
+    )
+    return album
+
+
+def _tidal_mapping() -> ProviderMapping:
+    """Return the album mapping cross-provider matching would have added."""
+    return ProviderMapping(
+        item_id="tidal_album1", provider_domain="tidal", provider_instance="tidal_1"
+    )
 
 
 async def test_overwrite_update_keeps_artists_when_none_are_given(
@@ -54,3 +84,80 @@ async def test_track_overwrite_keeps_album_artists(mass: MusicAssistant) -> None
 
     refreshed = await mass.music.albums.get_library_item(db_album.item_id)
     assert [artist.name for artist in refreshed.artists] == ["Test Artist"]
+
+
+async def test_track_overwrite_keeps_album_details(mass: MusicAssistant) -> None:
+    """A track update carrying a bare album stub must not blank that album's details."""
+    db_album = await mass.music.albums.add_item_to_library(_detailed_album())
+    track = create_track("spotify_1", "track1")
+    track.album = create_album("spotify_1", "album1")
+    db_track = await mass.music.tracks.add_item_to_library(track)
+
+    # a provider that embeds a bare album stub in every track (as emby does)
+    update = create_track("spotify_1", "track1")
+    update.album = create_album("spotify_1", "album1")
+    await mass.music.tracks.update_item_in_library(db_track.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.albums.get_library_item(db_album.item_id)
+    assert refreshed.year == 1999
+    assert refreshed.external_ids == {(ExternalID.MB_RELEASEGROUP, RELEASE_GROUP_MBID)}
+    assert refreshed.metadata.genres == {"rock"}
+    assert [image.path for image in refreshed.metadata.images or []] == [ALBUM_IMAGE]
+
+
+async def test_track_overwrite_keeps_other_provider_album_mapping(mass: MusicAssistant) -> None:
+    """A track update must not unlink its album from the other providers it matched."""
+    db_album = await mass.music.albums.add_item_to_library(create_album("spotify_1", "album1"))
+    await mass.music.albums.add_provider_mappings(db_album.item_id, [_tidal_mapping()])
+    track = create_track("spotify_1", "track1")
+    track.album = create_album("spotify_1", "album1")
+    db_track = await mass.music.tracks.add_item_to_library(track)
+
+    update = create_track("spotify_1", "track1")
+    update.album = create_album("spotify_1", "album1")
+    await mass.music.tracks.update_item_in_library(db_track.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.albums.get_library_item(db_album.item_id)
+    assert {mapping.provider_instance for mapping in refreshed.provider_mappings} == {
+        "spotify_1",
+        "tidal_1",
+    }
+
+
+async def test_overwrite_update_replaces_album_details(mass: MusicAssistant) -> None:
+    """An overwrite update carrying details still replaces the stored ones."""
+    db_album = await mass.music.albums.add_item_to_library(_detailed_album())
+
+    update = _detailed_album()
+    update.year = 2001
+    update.external_ids = {(ExternalID.MB_RELEASEGROUP, "11111111-2222-3333-4444-555555555555")}
+    update.metadata.genres = {"jazz"}
+    update.metadata.images = UniqueList(
+        [MediaItemImage(type=ImageType.THUMB, path="http://images/new.jpg", provider="spotify_1")]
+    )
+    await mass.music.albums.update_item_in_library(db_album.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.albums.get_library_item(db_album.item_id)
+    assert refreshed.year == 2001
+    assert refreshed.external_ids == {
+        (ExternalID.MB_RELEASEGROUP, "11111111-2222-3333-4444-555555555555")
+    }
+    assert refreshed.metadata.genres == {"jazz"}
+    assert [image.path for image in refreshed.metadata.images or []] == ["http://images/new.jpg"]
+
+
+async def test_overwrite_update_replaces_only_its_own_provider_mapping(
+    mass: MusicAssistant,
+) -> None:
+    """An overwrite replaces the mapping of its own provider and keeps the others."""
+    db_album = await mass.music.albums.add_item_to_library(create_album("spotify_1", "album1"))
+    await mass.music.albums.add_provider_mappings(db_album.item_id, [_tidal_mapping()])
+
+    # the same album under a new id on its own provider, as a moved folder produces
+    update = create_album("spotify_1", "album2")
+    await mass.music.albums.update_item_in_library(db_album.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.albums.get_library_item(db_album.item_id)
+    assert {
+        (mapping.provider_instance, mapping.item_id) for mapping in refreshed.provider_mappings
+    } == {("spotify_1", "album2"), ("tidal_1", "tidal_album1")}

--- a/tests/controllers/music/test_artists.py
+++ b/tests/controllers/music/test_artists.py
@@ -1,0 +1,111 @@
+"""Tests for the artists controller."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from music_assistant_models.enums import ExternalID, ImageType
+from music_assistant_models.media_items import (
+    Artist,
+    MediaItemImage,
+    ProviderMapping,
+    UniqueList,
+)
+
+from .helpers import create_track
+
+if TYPE_CHECKING:
+    from music_assistant.mass import MusicAssistant
+
+ARTIST_MBID = "aa1b2c3d-1c99-4c1b-b0f1-9f2c1b2a3d44"
+ARTIST_IMAGE = "http://images/artist1.jpg"
+
+
+def _artist_stub() -> Artist:
+    """Return the bare artist providers embed in their track payloads."""
+    return Artist(
+        item_id="track1_artist",
+        provider="spotify_1",
+        name="Test Artist",
+        provider_mappings={
+            ProviderMapping(
+                item_id="track1_artist",
+                provider_domain="spotify",
+                provider_instance="spotify_1",
+            )
+        },
+    )
+
+
+def _detailed_artist() -> Artist:
+    """Return an artist carrying the details only a full provider fetch delivers."""
+    artist = _artist_stub()
+    artist.external_ids = {(ExternalID.MB_ARTIST, ARTIST_MBID)}
+    artist.metadata.description = "A biography"
+    artist.metadata.genres = {"rock"}
+    artist.metadata.images = UniqueList(
+        [MediaItemImage(type=ImageType.THUMB, path=ARTIST_IMAGE, provider="spotify_1")]
+    )
+    return artist
+
+
+async def test_track_overwrite_keeps_artist_details(mass: MusicAssistant) -> None:
+    """A track update carrying a bare artist stub must not blank that artist's details."""
+    db_artist = await mass.music.artists.add_item_to_library(_detailed_artist())
+    db_track = await mass.music.tracks.add_item_to_library(create_track("spotify_1", "track1"))
+
+    update = create_track("spotify_1", "track1")
+    update.artists = UniqueList([_artist_stub()])
+    await mass.music.tracks.update_item_in_library(db_track.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.artists.get_library_item(db_artist.item_id)
+    assert refreshed.external_ids == {(ExternalID.MB_ARTIST, ARTIST_MBID)}
+    assert refreshed.metadata.description == "A biography"
+    assert refreshed.metadata.genres == {"rock"}
+    assert [image.path for image in refreshed.metadata.images or []] == [ARTIST_IMAGE]
+
+
+async def test_track_overwrite_keeps_other_provider_artist_mapping(mass: MusicAssistant) -> None:
+    """A track update must not unlink its artist from the other providers it matched."""
+    db_artist = await mass.music.artists.add_item_to_library(_artist_stub())
+    await mass.music.artists.add_provider_mappings(
+        db_artist.item_id,
+        [
+            ProviderMapping(
+                item_id="tidal_artist1",
+                provider_domain="tidal",
+                provider_instance="tidal_1",
+            )
+        ],
+    )
+    db_track = await mass.music.tracks.add_item_to_library(create_track("spotify_1", "track1"))
+
+    update = create_track("spotify_1", "track1")
+    update.artists = UniqueList([_artist_stub()])
+    await mass.music.tracks.update_item_in_library(db_track.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.artists.get_library_item(db_artist.item_id)
+    assert {mapping.provider_instance for mapping in refreshed.provider_mappings} == {
+        "spotify_1",
+        "tidal_1",
+    }
+
+
+async def test_overwrite_update_replaces_artist_details(mass: MusicAssistant) -> None:
+    """An overwrite update carrying details still replaces the stored ones."""
+    db_artist = await mass.music.artists.add_item_to_library(_detailed_artist())
+
+    update = _detailed_artist()
+    update.external_ids = {(ExternalID.MB_ARTIST, "11111111-2222-3333-4444-555555555555")}
+    update.metadata.description = "A better biography"
+    update.metadata.images = UniqueList(
+        [MediaItemImage(type=ImageType.THUMB, path="http://images/new.jpg", provider="spotify_1")]
+    )
+    await mass.music.artists.update_item_in_library(db_artist.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.artists.get_library_item(db_artist.item_id)
+    assert refreshed.external_ids == {
+        (ExternalID.MB_ARTIST, "11111111-2222-3333-4444-555555555555")
+    }
+    assert refreshed.metadata.description == "A better biography"
+    assert [image.path for image in refreshed.metadata.images or []] == ["http://images/new.jpg"]


### PR DESCRIPTION
# What does this implement/fix?

Refreshing a track could silently strip its album and artist bare.

Most music providers attach a stripped-down album (and artist) to every track they hand
over — often just a name and an id. Refreshing a track fed that stub straight into the
library, where it replaced the real album: the release year, barcode and MusicBrainz ids,
genres and artwork were all dropped, and the album lost its links to the other services it
had been matched to. The same happened to the track's artist, biography and all.

The catch is that replacing an item *is* wanted in other cases — it is how a local file
that moved to a new folder gets its old entry cleaned up. So instead of skipping the
replace, an update now only replaces the details it actually carries, and only unlinks the
service it came from.

**Related issue (if applicable):**

- https://github.com/music-assistant/server/issues/5853

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- An album or artist keeps its stored artwork, genres and description when the incoming
  item has none. An empty artwork list does not count as artwork.
- An album keeps its release year and edition (Deluxe, Remastered) when the incoming item
  has none.
- Items keep their stored barcode and MusicBrainz ids when the incoming item has none.
- A replacing update now only drops the links of the service it came from, so links to
  other services survive. A moved local file still cleans up its own stale entry.
- Same guards for albums, artists and tracks; radio stations keep their existing
  behaviour, where a station going dynamic deliberately sheds the other services.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
