### PR TITLE
Keep the rest of a Tidal list when one item cannot be read

### DIFF
--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp.client_exceptions import ClientError
@@ -77,23 +78,27 @@ class TidalMediaManager:
         # Slice the resources before parsing so we only parse up to `limit` items.
         if MediaType.TRACK in wanted:
             results.tracks = [
-                parse_track_v2(self.provider, doc, res)
+                track
                 for res in doc.related(data, "tracks")[:limit]
+                if (track := self._parse_or_skip(parse_track_v2, doc, res)) is not None
             ]
         if MediaType.ALBUM in wanted:
             results.albums = [
-                parse_album_v2(self.provider, doc, res)
+                album
                 for res in doc.related(data, "albums")[:limit]
+                if (album := self._parse_or_skip(parse_album_v2, doc, res)) is not None
             ]
         if MediaType.ARTIST in wanted:
             results.artists = [
-                parse_artist_v2(self.provider, doc, res)
+                artist
                 for res in doc.related(data, "artists")[:limit]
+                if (artist := self._parse_or_skip(parse_artist_v2, doc, res)) is not None
             ]
         if MediaType.PLAYLIST in wanted:
             results.playlists = [
-                parse_playlist_v2(self.provider, doc, res)
+                playlist
                 for res in doc.related(data, "playlists")[:limit]
+                if (playlist := self._parse_or_skip(parse_playlist_v2, doc, res)) is not None
             ]
         return results
 
@@ -275,13 +280,15 @@ class TidalMediaManager:
             replace_media="items",
         ):
             for item in doc.data_list:
-                if resource := doc.resolve(item):
-                    track = parse_track_v2(self.provider, doc, resource)
-                    track.position = len(tracks) + 1
-                    tracks.append(track)
-                    # Feed the stale->live pairs Tidal computed for this read into
-                    # the churn cache, as the library walk already does.
-                    self.provider.note_replaced_track(item)
+                if not (resource := doc.resolve(item)):
+                    continue
+                if (track := self._parse_or_skip(parse_track_v2, doc, resource)) is None:
+                    continue
+                track.position = len(tracks) + 1
+                tracks.append(track)
+                # Feed the stale->live pairs Tidal computed for this read into
+                # the churn cache, as the library walk already does.
+                self.provider.note_replaced_track(item)
         return tracks
 
     async def _get_mix_tracks(self, mix_id: str, limit: int, offset: int) -> list[Track]:
@@ -316,6 +323,9 @@ class TidalMediaManager:
         """
         Parse the document's primary collection, leaving out the items that cannot be parsed.
 
+        Only for a collection of a single resource type: every resource is handed to the
+        same parser, so a mixed-type relationship has to be filtered by the caller.
+
         :param parser: The parser to apply to each resolved resource.
         :param doc: The JSON:API document holding the collection.
         """
@@ -342,13 +352,16 @@ class TidalMediaManager:
         """
         try:
             return parser(self.provider, doc, resource)
-        except (KeyError, TypeError, ValueError) as err:
-            # a single unusable item must not discard the rest of the collection
+        except (AttributeError, KeyError, TypeError, ValueError) as err:
+            # Tidal sending one item in a shape its parser can not read must not discard
+            # the rest of the collection. Log the traceback (on debug) as well, so a
+            # parser bug caught here is still traceable to its origin.
             self.logger.warning(
                 "Skipping Tidal %s %s: %s",
                 resource.get("type", "item"),
                 resource.get("id", "[no id]"),
                 err,
+                exc_info=err if self.logger.isEnabledFor(logging.DEBUG) else None,
             )
             return None
 

--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -24,8 +24,11 @@ from .parsers_v2 import parse_playlist as parse_playlist_v2
 from .parsers_v2 import parse_track as parse_track_v2
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from music_assistant_models.media_items import Album, Artist, Playlist, Track
 
+    from .jsonapi import JsonApiDocument
     from .provider import TidalProvider
 
 
@@ -156,97 +159,67 @@ class TidalMediaManager:
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
         """Get album tracks."""
         tracks: list[Track] = []
-        try:
-            async for doc in self.api.paginate_jsonapi(
-                f"albums/{prov_album_id}/relationships/items",
-                include=["items.artists", "items.albums.coverArt"],
-                replace_media="items",
-            ):
-                for item in doc.data_list:
-                    # The items relationship is mixed-type: an album's music
-                    # videos appear here too, and parsing one as a track would
-                    # yield an id that 404s on playback and shift trackNumber.
-                    if item.get("type") != "tracks":
-                        continue
-                    if not (resource := doc.resolve(item)):
-                        continue
-                    track = parse_track_v2(self.provider, doc, resource)
-                    item_meta = item.get("meta") or {}
-                    track.track_number = item_meta.get("trackNumber", 0) or 0
-                    track.disc_number = item_meta.get("volumeNumber", 0) or 0
-                    tracks.append(track)
-        except (ClientError, KeyError, ValueError) as err:
-            raise MediaNotFoundError(f"Album {prov_album_id} not found") from err
+        async for doc in self.api.paginate_jsonapi(
+            f"albums/{prov_album_id}/relationships/items",
+            include=["items.artists", "items.albums.coverArt"],
+            replace_media="items",
+        ):
+            for item in doc.data_list:
+                # The items relationship is mixed-type: an album's music
+                # videos appear here too, and parsing one as a track would
+                # yield an id that 404s on playback and shift trackNumber.
+                if item.get("type") != "tracks":
+                    continue
+                if not (resource := doc.resolve(item)):
+                    continue
+                if (track := self._parse_or_skip(parse_track_v2, doc, resource)) is None:
+                    continue
+                item_meta = item.get("meta") or {}
+                track.track_number = item_meta.get("trackNumber", 0) or 0
+                track.disc_number = item_meta.get("volumeNumber", 0) or 0
+                tracks.append(track)
         return tracks
 
     async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
         """Get artist albums."""
         albums: list[Album] = []
-        try:
-            async for doc in self.api.paginate_jsonapi(
-                f"artists/{prov_artist_id}/relationships/albums",
-                include=["albums.artists", "albums.coverArt"],
-                replace_media="albums",
-            ):
-                for item in doc.data_list:
-                    if resource := doc.resolve(item):
-                        albums.append(parse_album_v2(self.provider, doc, resource))
-        except (ClientError, KeyError, ValueError) as err:
-            raise MediaNotFoundError(f"Artist {prov_artist_id} not found") from err
+        async for doc in self.api.paginate_jsonapi(
+            f"artists/{prov_artist_id}/relationships/albums",
+            include=["albums.artists", "albums.coverArt"],
+            replace_media="albums",
+        ):
+            albums.extend(self._parse_items(parse_album_v2, doc))
         return albums
 
     async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
         """Get artist top tracks."""
         # Top tracks are a bounded, ranked list: the first page is enough.
-        try:
-            doc = await self.api.get_jsonapi(
-                f"artists/{prov_artist_id}/relationships/tracks",
-                params={"collapseBy": "FINGERPRINT"},
-                include=["tracks.artists", "tracks.albums.coverArt"],
-                replace_media="tracks",
-            )
-            return [
-                parse_track_v2(self.provider, doc, resource)
-                for item in doc.data_list
-                if (resource := doc.resolve(item))
-            ]
-        except (ClientError, KeyError, ValueError) as err:
-            raise MediaNotFoundError(f"Artist {prov_artist_id} not found") from err
+        doc = await self.api.get_jsonapi(
+            f"artists/{prov_artist_id}/relationships/tracks",
+            params={"collapseBy": "FINGERPRINT"},
+            include=["tracks.artists", "tracks.albums.coverArt"],
+            replace_media="tracks",
+        )
+        return self._parse_items(parse_track_v2, doc)
 
     async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
         """Get similar tracks."""
         # Similar tracks are a bounded, ranked list: the first page is enough.
-        try:
-            doc = await self.api.get_jsonapi(
-                f"tracks/{prov_track_id}/relationships/similarTracks",
-                include=["similarTracks.artists", "similarTracks.albums.coverArt"],
-                replace_media="similarTracks",
-            )
-            tracks = [
-                parse_track_v2(self.provider, doc, resource)
-                for item in doc.data_list
-                if (resource := doc.resolve(item))
-            ]
-            return tracks[:limit]
-        except (ClientError, KeyError, ValueError) as err:
-            raise MediaNotFoundError(f"Track {prov_track_id} not found") from err
+        doc = await self.api.get_jsonapi(
+            f"tracks/{prov_track_id}/relationships/similarTracks",
+            include=["similarTracks.artists", "similarTracks.albums.coverArt"],
+            replace_media="similarTracks",
+        )
+        return self._parse_items(parse_track_v2, doc)[:limit]
 
     async def get_similar_artists(self, prov_artist_id: str, limit: int = 25) -> list[Artist]:
         """Get similar artists."""
         # Similar artists are a bounded, ranked list: the first page is enough.
-        try:
-            doc = await self.api.get_jsonapi(
-                f"artists/{prov_artist_id}/relationships/similarArtists",
-                include=["similarArtists.profileArt"],
-            )
-            artists = [
-                parse_artist_v2(self.provider, doc, resource)
-                for item in doc.data_list
-                if (resource := doc.resolve(item))
-            ]
-            return artists[:limit]
-        except (ClientError, KeyError, ValueError) as err:
-            raise MediaNotFoundError(f"Artist {prov_artist_id} not found") from err
+        doc = await self.api.get_jsonapi(
+            f"artists/{prov_artist_id}/relationships/similarArtists",
+            include=["similarArtists.profileArt"],
+        )
+        return self._parse_items(parse_artist_v2, doc)[:limit]
 
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
         """Get playlist tracks."""
@@ -333,6 +306,50 @@ class TidalMediaManager:
             return await self.api.get(f"tracks/{prov_track_id}/lyrics")
         except (ClientError, MusicAssistantError) as err:
             self.logger.debug("Failed to fetch lyrics for track %s: %s", prov_track_id, err)
+            return None
+
+    def _parse_items[ItemT](
+        self,
+        parser: Callable[[TidalProvider, JsonApiDocument, dict[str, Any]], ItemT],
+        doc: JsonApiDocument,
+    ) -> list[ItemT]:
+        """
+        Parse the document's primary collection, leaving out the items that cannot be parsed.
+
+        :param parser: The parser to apply to each resolved resource.
+        :param doc: The JSON:API document holding the collection.
+        """
+        items: list[ItemT] = []
+        for identifier in doc.data_list:
+            if not (resource := doc.resolve(identifier)):
+                continue
+            if (item := self._parse_or_skip(parser, doc, resource)) is not None:
+                items.append(item)
+        return items
+
+    def _parse_or_skip[ItemT](
+        self,
+        parser: Callable[[TidalProvider, JsonApiDocument, dict[str, Any]], ItemT],
+        doc: JsonApiDocument,
+        resource: dict[str, Any],
+    ) -> ItemT | None:
+        """
+        Parse a resource into a media item, or return None if it cannot be parsed.
+
+        :param parser: The parser to apply to the resource.
+        :param doc: The JSON:API document holding the resource.
+        :param resource: The resource object to parse.
+        """
+        try:
+            return parser(self.provider, doc, resource)
+        except (KeyError, TypeError, ValueError) as err:
+            # a single unusable item must not discard the rest of the collection
+            self.logger.warning(
+                "Skipping Tidal %s %s: %s",
+                resource.get("type", "item"),
+                resource.get("id", "[no id]"),
+                err,
+            )
             return None
 
     def _process_tracks(self, items: list[dict[str, Any]], offset: int) -> list[Track]:

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -5,6 +5,8 @@ import pathlib
 from typing import Any
 from unittest.mock import Mock, patch
 
+import pytest
+from aiohttp.client_exceptions import ClientError
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import RetriesExhausted
 from music_assistant_models.media_items import Playlist
@@ -23,6 +25,15 @@ def _load_raw(name: str) -> dict[str, Any]:
 
 def _load_doc(name: str) -> JsonApiDocument:
     return JsonApiDocument(_load_raw(name))
+
+
+def _break_resource(raw: dict[str, Any], resource_id: str) -> dict[str, Any]:
+    """Blank the title of one included resource, which its parser cannot handle."""
+    for resource in raw["included"]:
+        if resource["id"] == resource_id:
+            resource["attributes"]["title"] = None
+            return raw
+    raise AssertionError(f"resource {resource_id} not in fixture")
 
 
 async def test_search(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
@@ -200,6 +211,75 @@ async def test_get_album_tracks_skips_videos(
     assert all(track.item_id != "99999" for track in tracks)
 
 
+async def test_get_album_tracks_skips_unparsable_track(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test one unusable track does not take the rest of the album down with it."""
+    doc = JsonApiDocument(_break_resource(_load_raw("album_items.json"), "58756128"))
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    tracks = await media_manager.get_album_tracks("58756127")
+
+    assert len(tracks) == 10
+    assert all(track.item_id != "58756128" for track in tracks)
+    provider_mock.logger.warning.assert_called_once()
+
+
+async def test_get_album_tracks_keeps_tracks_from_earlier_pages(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test an unusable track on a later page does not discard the earlier pages."""
+    first_page = _load_doc("album_items.json")
+    second_page = JsonApiDocument(
+        {
+            "data": [
+                {"id": "998", "type": "tracks", "meta": {"volumeNumber": 1, "trackNumber": 12}},
+                {"id": "999", "type": "tracks", "meta": {"volumeNumber": 1, "trackNumber": 13}},
+            ],
+            "included": [
+                {"id": "998", "type": "tracks", "attributes": {"title": None}},
+                {
+                    "id": "999",
+                    "type": "tracks",
+                    "attributes": {"title": "Hidden Track", "duration": "PT3M0S"},
+                },
+            ],
+        }
+    )
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield first_page
+        yield second_page
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    tracks = await media_manager.get_album_tracks("58756127")
+
+    assert len(tracks) == 12
+    assert tracks[0].name == "7 Years"
+    assert tracks[-1].name == "Hidden Track"
+    assert tracks[-1].track_number == 13
+
+
+async def test_get_album_tracks_fetch_failure_propagates(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test a failure to read a page is raised instead of returning a partial album."""
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield _load_doc("album_items.json")
+        raise ClientError("connection lost")
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    with pytest.raises(ClientError):
+        await media_manager.get_album_tracks("58756127")
+
+
 async def test_get_artist_albums(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
     """Test artist albums read from the official relationship endpoint."""
     doc = _load_doc("artist_albums.json")
@@ -228,6 +308,47 @@ async def test_get_artist_toptracks(media_manager: TidalMediaManager, provider_m
         include=["tracks.artists", "tracks.albums.coverArt"],
         replace_media="tracks",
     )
+
+
+async def test_get_artist_albums_skips_unparsable_album(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test one unusable album does not empty the artist's discography."""
+    doc = JsonApiDocument(_break_resource(_load_raw("artist_albums.json"), "541774424"))
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    albums = await media_manager.get_artist_albums("4184211")
+
+    assert len(albums) == 19
+    assert all(album.item_id != "541774424" for album in albums)
+
+
+async def test_get_artist_toptracks_skips_unparsable_track(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test one unusable track does not empty the artist's top tracks."""
+    provider_mock.api.get_jsonapi.return_value = JsonApiDocument(
+        _break_resource(_load_raw("artist_toptracks.json"), "58503071")
+    )
+
+    tracks = await media_manager.get_artist_toptracks("4184211")
+
+    assert len(tracks) == 19
+    assert all(track.item_id != "58503071" for track in tracks)
+
+
+async def test_get_artist_toptracks_fetch_failure_propagates(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test a failure to read the top tracks is raised instead of reported as empty."""
+    provider_mock.api.get_jsonapi.side_effect = ClientError("connection lost")
+
+    with pytest.raises(ClientError):
+        await media_manager.get_artist_toptracks("4184211")
 
 
 async def test_get_similar_tracks_respects_limit(

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 import pytest
 from aiohttp.client_exceptions import ClientError
 from music_assistant_models.enums import MediaType
-from music_assistant_models.errors import RetriesExhausted
+from music_assistant_models.errors import MediaNotFoundError, RetriesExhausted
 from music_assistant_models.media_items import Playlist
 
 from music_assistant.providers.tidal.jsonapi import JsonApiDocument
@@ -31,7 +31,9 @@ def _break_resource(raw: dict[str, Any], resource_id: str) -> dict[str, Any]:
     """Blank the title of one included resource, which its parser cannot handle."""
     for resource in raw["included"]:
         if resource["id"] == resource_id:
-            resource["attributes"]["title"] = None
+            attributes = resource["attributes"]
+            # artists carry a name where tracks and albums carry a title
+            attributes["name" if "name" in attributes else "title"] = None
             return raw
     raise AssertionError(f"resource {resource_id} not in fixture")
 
@@ -280,6 +282,22 @@ async def test_get_album_tracks_fetch_failure_propagates(
         await media_manager.get_album_tracks("58756127")
 
 
+async def test_get_album_tracks_missing_album_still_not_found(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test an album that is gone is still reported as not found."""
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        for _ in ():  # never yields: the api client raises while fetching the first page
+            yield
+        raise MediaNotFoundError("Item not found: albums/1/relationships/items")
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    with pytest.raises(MediaNotFoundError):
+        await media_manager.get_album_tracks("1")
+
+
 async def test_get_artist_albums(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
     """Test artist albums read from the official relationship endpoint."""
     doc = _load_doc("artist_albums.json")
@@ -362,6 +380,21 @@ async def test_get_similar_tracks_respects_limit(
     assert len(tracks) == 5
 
 
+async def test_get_similar_tracks_fills_the_limit_around_an_unparsable_track(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test the limit is still filled when one of the similar tracks cannot be parsed."""
+    raw = _load_raw("similar_tracks.json")
+    provider_mock.api.get_jsonapi.return_value = JsonApiDocument(
+        _break_resource(raw, raw["data"][0]["id"])
+    )
+
+    tracks = await media_manager.get_similar_tracks("58756128", limit=5)
+
+    assert len(tracks) == 5
+    assert all(track.item_id != raw["data"][0]["id"] for track in tracks)
+
+
 async def test_get_similar_artists(media_manager: TidalMediaManager, provider_mock: Mock) -> None:
     """Test similar artists read from the official relationship endpoint."""
     provider_mock.api.get_jsonapi.return_value = _load_doc("similar_artists.json")
@@ -373,6 +406,67 @@ async def test_get_similar_artists(media_manager: TidalMediaManager, provider_mo
         "artists/4184211/relationships/similarArtists",
         include=["similarArtists.profileArt"],
     )
+
+
+async def test_get_similar_artists_skips_unparsable_artist(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test one unusable artist does not empty the similar artists."""
+    raw = _load_raw("similar_artists.json")
+    provider_mock.api.get_jsonapi.return_value = JsonApiDocument(
+        _break_resource(raw, raw["data"][0]["id"])
+    )
+
+    artists = await media_manager.get_similar_artists("4184211")
+
+    assert len(artists) == 19
+    assert all(artist.item_id != raw["data"][0]["id"] for artist in artists)
+
+
+async def test_search_skips_unparsable_track(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test one unusable track does not drop the whole search result."""
+    raw = _load_raw("search.json")
+    broken_id = raw["data"][0]["relationships"]["tracks"]["data"][0]["id"]
+    provider_mock.api.get_jsonapi.return_value = JsonApiDocument(_break_resource(raw, broken_id))
+
+    results = await media_manager.search("lukas graham", [MediaType.TRACK], limit=5)
+
+    assert len(results.tracks) == 4
+    assert all(track.item_id != broken_id for track in results.tracks)
+
+
+@patch("music_assistant.providers.tidal.media.parse_track_v2")
+async def test_favorite_tracks_skips_unparsable_track(
+    mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test one unusable favourite does not fail the whole favourites playlist."""
+    doc = JsonApiDocument(
+        {
+            "data": [
+                {"type": "tracks", "id": "1"},
+                {"type": "tracks", "id": "2"},
+                {"type": "tracks", "id": "3"},
+            ],
+            "included": [
+                {"type": "tracks", "id": "1", "attributes": {}},
+                {"type": "tracks", "id": "2", "attributes": {}},
+                {"type": "tracks", "id": "3", "attributes": {}},
+            ],
+        }
+    )
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+    mock_parse_track.side_effect = [Mock(item_id="1"), KeyError("id"), Mock(item_id="3")]
+
+    tracks = await media_manager.get_playlist_tracks("favorite_tracks", page=0)
+
+    assert [track.item_id for track in tracks] == ["1", "3"]
+    assert [track.position for track in tracks] == [1, 2]
 
 
 @patch("music_assistant.providers.tidal.media.parse_playlist")


### PR DESCRIPTION
# What does this implement/fix?

A single item that Tidal returns in a form we cannot read discarded the whole list it was
part of. That covers an album's tracks, an artist's albums and top tracks, and the similar
tracks and artists behind radio mode - one odd item and the list came back as "not found"
instead of "one track short". On an album big enough to span several pages, the tracks
already collected from the earlier pages were thrown away as well.

The same walk also turned a connection failure halfway through into "album not found", so a
list that simply failed to load looked exactly like a list that is genuinely gone.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- An item we cannot read is skipped and logged, and the rest of the list still loads, for
  album tracks, artist albums, artist top tracks, similar tracks and similar artists,
  search results, and the favourites playlist.
- A failure to fetch a page is passed on instead of being reported as a missing album or
  artist, so a truncated list is never taken for the real one. An album that is genuinely
  gone is still reported as not found.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
