### PR TITLE
Fix a resume seeking far past the track end after an output protocol handover

### DIFF
--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -27,7 +27,7 @@ from aiosendspin.models.core import ClientHelloPayload
 from aiosendspin.models.core import DeviceInfo as SendspinDeviceInfo
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
 from aiosendspin.models.types import AudioCodec, PlayerCommand
-from music_assistant_models.enums import IdentifierType
+from music_assistant_models.enums import IdentifierType, PlaybackState
 
 from music_assistant.constants import CONF_SYNC_ADJUST
 from music_assistant.helpers.util import is_valid_mac_address
@@ -1196,6 +1196,10 @@ class SendspinAirPlayBridge:
         if stream:
             with suppress(Exception):
                 await stream.stop(force=True)
+            # The stop's own IDLE reset is dropped because the stream was
+            # detached first; restore it unless a newer stream owns the player.
+            if self.airplay_player.stream is None:
+                self.airplay_player.set_state_from_stream(state=PlaybackState.IDLE, elapsed_time=0)
 
     def _on_audio_chunk(self, chunk: AudioChunk) -> None:
         """Handle audio chunk from Sendspin PushStream."""

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -1198,8 +1198,7 @@ class SendspinAirPlayBridge:
         if stream:
             with suppress(Exception):
                 await stream.stop(force=True)
-            # The stop's own IDLE reset is dropped because the stream was
-            # detached first; restore it unless a newer stream owns the player.
+            # Restore the IDLE reset that stop() dropped because the stream was detached first
             if self.airplay_player.stream is None:
                 self.airplay_player.set_state_from_stream(state=PlaybackState.IDLE, elapsed_time=0)
 

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -1170,6 +1170,8 @@ class SendspinAirPlayBridge:
         """
         Clean up captured resources from a previous stream.
 
+        Leaves the player idle at position 0 unless a newer stream owns it.
+
         Unlike _stop_streaming(), this operates on explicitly captured references
         rather than instance variables. This prevents a race condition where the
         async cleanup runs after a new stream has already reused the instance

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -39,6 +39,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aiosendspin.clock import ManualClock
 from aiosendspin.server.roles import AudioChunk
+from music_assistant_models.enums import PlaybackState
 
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_CLOCK_READY_LEAD_MS,
@@ -788,6 +789,37 @@ async def test_superseded_cold_stream_teardown_spares_the_newer_owner() -> None:
     newer_stream.stop.assert_not_awaited()
     assert bridge._airplay_stream is newer_stream
     assert bridge.airplay_player.stream is newer_stream
+
+
+# --- Teardown player state reset ---
+
+
+async def test_bridge_teardown_resets_the_players_stream_state() -> None:
+    """A torn-down bridge stream leaves the AirPlay player IDLE at position 0."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    stream = MagicMock()
+    stream.stop = AsyncMock()
+    bridge._airplay_stream = stream
+    bridge.airplay_player.stream = stream
+
+    await bridge._stop_streaming()
+
+    stream.stop.assert_awaited_once_with(force=True)
+    cast("MagicMock", bridge.airplay_player).set_state_from_stream.assert_called_once_with(
+        state=PlaybackState.IDLE, elapsed_time=0
+    )
+
+
+async def test_bridge_teardown_spares_a_newer_streams_state() -> None:
+    """Cleanup of a superseded stream never resets state a newer stream owns."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    old_stream = MagicMock()
+    old_stream.stop = AsyncMock()
+    bridge.airplay_player.stream = MagicMock()
+
+    await bridge._cleanup_old_stream(old_stream, None, None)
+
+    cast("MagicMock", bridge.airplay_player).set_state_from_stream.assert_not_called()
 
 
 # --- Anchoring: command an instant the device can hit, then honour the ack ---


### PR DESCRIPTION
# What does this implement/fix?

When a player's audio is carried by the Sendspin AirPlay bridge, tearing the bridge stream down leaves the underlying AirPlay player reporting "playing" with a frozen position. That phantom position then grows with the wall clock for as long as the player sits unused. When Music Assistant later hands the player's output over to AirPlay (for example when an AirPlay-only speaker joins the group), it resumes from that phantom position — hours past the end of the track — and the track is silently skipped.

Cause: the bridge detaches the stream from the player before stopping it, so the stream's own "reset to idle" on stop is ignored as coming from a stale stream.

- Reset the AirPlay player to idle/position 0 when the bridge tears its stream down, unless a newer stream has already taken over
- Add regression tests for both cases

**Related issue (if applicable):**

- related issue N/A (found via server log triage)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
