### PR TITLE
Stop a library item a provider cannot read from being removed from the library

### DIFF
--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Final, cast
 
@@ -91,10 +91,13 @@ class SyncRunState:
     :param incomplete: True once the run failed to collect an item, which makes its
         result set an unsafe basis for deleting anything from the library.
     :param failures: Number of item failures reported by the run so far.
+    :param skipped_item_ids: Provider item id's the provider dropped while listing its
+        library, per media type.
     """
 
     incomplete: bool = False
     failures: int = 0
+    skipped_item_ids: dict[MediaType, set[str]] = field(default_factory=dict)
 
 
 # scoped per run rather than per provider: a standalone import_album_tracks() is
@@ -969,6 +972,31 @@ class MusicProvider(Provider):
         finally:
             SYNC_RUN_STATE.reset(token)
 
+    def report_skipped_sync_item(
+        self, media_type: MediaType, item_id: str | None, err: Exception
+    ) -> None:
+        """
+        Report a library item that was dropped while listing this provider's library.
+
+        Call this from a get_library_*() generator whenever it swallows an error instead of
+        yielding the item, so the failure is reported on the sync task rather than the item
+        looking like it was removed at the provider.
+
+        :param media_type: Media type of the skipped item.
+        :param item_id: The provider item id of the skipped item, which keeps that single item
+            out of this sync's deletion pass. Pass None if the item cannot be identified, which
+            holds back the deletion pass for the entire run instead.
+        :param err: The error that made the item unusable.
+        :raises Exception: If this provider declared the error unskippable, so that its own
+            error handling can act on it instead of the item being skipped.
+        """
+        self._handle_sync_item_failure(media_type, item_id, err)
+        state = sync_run_state()
+        if item_id:
+            state.skipped_item_ids.setdefault(media_type, set()).add(item_id)
+        else:
+            state.incomplete = True
+
     async def _run_library_sync(self, media_type: MediaType) -> None:
         """Sync the given media type into the library and process its deletions."""
         # this reference implementation may be overridden
@@ -999,6 +1027,7 @@ class MusicProvider(Provider):
         # process deletions (= no longer in library)
         update_current_task_progress_text("Checking library deletions")
         controller = self.mass.music.get_controller(media_type)
+        await self._keep_skipped_items(media_type, cur_db_ids)
         prev_library_items: list[int] | None
         if sync_state.incomplete:
             # a skipped item is missing from cur_db_ids just like a deleted one, but it is
@@ -1109,6 +1138,22 @@ class MusicProvider(Provider):
         report_current_task_failure(
             f"Failed to sync {media_type.value} {item_ref or '<unknown>'}: {error_detail}"
         )
+
+    async def _keep_skipped_items(self, media_type: MediaType, cur_db_ids: set[int]) -> None:
+        """
+        Add the library id's of the items the provider skipped to this run's result set.
+
+        A skipped item is still in the provider's library, so leaving it out would let the
+        deletion pass read it as removed. Does nothing when that pass is disabled.
+        """
+        if not self.library_sync_deletions_enabled():
+            return
+        controller = self.mass.music.get_controller(media_type)
+        for item_id in sync_run_state().skipped_item_ids.get(media_type, ()):
+            if library_item := await controller.get_library_item_by_prov_id(
+                item_id, self.instance_id
+            ):
+                cur_db_ids.add(int(library_item.item_id))
 
     async def _sync_item_genres(
         self,

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -71,6 +71,8 @@ DEFAULT_MAX_CONCURRENT_STREAMS: Final[int] = 5
 # of a sync run are logged in full to keep the (rotating) log file usable
 MAX_LOGGED_SYNC_FAILURES: Final[int] = 25
 MAX_SYNC_ERROR_DETAIL: Final[int] = 200
+# skipped id's are resolved back to library id's in batches of this size
+SKIPPED_ITEM_QUERY_LIMIT: Final[int] = 500
 
 LIBRARY_FEATURE_BY_MEDIA_TYPE: Final[dict[MediaType, ProviderFeature]] = {
     MediaType.ARTIST: ProviderFeature.LIBRARY_ARTISTS,
@@ -88,14 +90,14 @@ class SyncRunState:
     """
     Failure state of one library sync run.
 
-    :param incomplete: True once the run failed to collect an item, which makes its
-        result set an unsafe basis for deleting anything from the library.
+    :param incomplete_media_types: Media types the run failed to collect an item for, which
+        makes their result set an unsafe basis for deleting anything from the library.
     :param failures: Number of item failures reported by the run so far.
     :param skipped_item_ids: Provider item id's the provider dropped while listing its
         library, per media type.
     """
 
-    incomplete: bool = False
+    incomplete_media_types: set[MediaType] = field(default_factory=set)
     failures: int = 0
     skipped_item_ids: dict[MediaType, set[str]] = field(default_factory=dict)
 
@@ -995,7 +997,7 @@ class MusicProvider(Provider):
         if item_id:
             state.skipped_item_ids.setdefault(media_type, set()).add(item_id)
         else:
-            state.incomplete = True
+            state.incomplete_media_types.add(media_type)
 
     async def _run_library_sync(self, media_type: MediaType) -> None:
         """Sync the given media type into the library and process its deletions."""
@@ -1029,7 +1031,7 @@ class MusicProvider(Provider):
         controller = self.mass.music.get_controller(media_type)
         await self._keep_skipped_items(media_type, cur_db_ids)
         prev_library_items: list[int] | None
-        if sync_state.incomplete:
+        if media_type in sync_state.incomplete_media_types:
             # a skipped item is missing from cur_db_ids just like a deleted one, but it is
             # still in the provider's library, so deleting it would throw away valid content
             if self.library_sync_deletions_enabled():
@@ -1144,14 +1146,16 @@ class MusicProvider(Provider):
         Add the library id's of the items the provider skipped to this run's result set.
 
         A skipped item is still in the provider's library, so leaving it out would let the
-        deletion pass read it as removed. Does nothing when that pass is disabled.
+        deletion pass read it as removed.
         """
-        if not self.library_sync_deletions_enabled():
+        if not (skipped_item_ids := sorted(sync_run_state().skipped_item_ids.get(media_type, ()))):
             return
         controller = self.mass.music.get_controller(media_type)
-        for item_id in sync_run_state().skipped_item_ids.get(media_type, ()):
-            if library_item := await controller.get_library_item_by_prov_id(
-                item_id, self.instance_id
+        for index in range(0, len(skipped_item_ids), SKIPPED_ITEM_QUERY_LIMIT):
+            for library_item in await controller.get_library_items_by_prov_id(
+                provider_instance=self.instance_id,
+                provider_item_ids=skipped_item_ids[index : index + SKIPPED_ITEM_QUERY_LIMIT],
+                limit=SKIPPED_ITEM_QUERY_LIMIT,
             ):
                 cur_db_ids.add(int(library_item.item_id))
 
@@ -1220,7 +1224,7 @@ class MusicProvider(Provider):
                     )
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                sync_run_state().incomplete = True
+                sync_run_state().incomplete_media_types.add(MediaType.ARTIST)
                 self._handle_sync_item_failure(MediaType.ARTIST, prov_item.uri, err)
         return cur_db_ids
 
@@ -1281,7 +1285,7 @@ class MusicProvider(Provider):
                     )
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                sync_run_state().incomplete = True
+                sync_run_state().incomplete_media_types.add(MediaType.ALBUM)
                 self._handle_sync_item_failure(MediaType.ALBUM, prov_item.uri, err)
                 continue
             # optionally add album tracks to library. the album is already collected here,
@@ -1470,7 +1474,7 @@ class MusicProvider(Provider):
 
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                sync_run_state().incomplete = True
+                sync_run_state().incomplete_media_types.add(MediaType.AUDIOBOOK)
                 self._handle_sync_item_failure(MediaType.AUDIOBOOK, prov_item.uri, err)
         return cur_db_ids
 
@@ -1531,7 +1535,7 @@ class MusicProvider(Provider):
                         await self.mass.music.playlists.set_favorite(library_item.item_id, True)
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                sync_run_state().incomplete = True
+                sync_run_state().incomplete_media_types.add(MediaType.PLAYLIST)
                 self._handle_sync_item_failure(MediaType.PLAYLIST, prov_item.uri, err)
                 continue
             # optionally sync playlist tracks. the playlist is already collected here, so
@@ -1661,7 +1665,7 @@ class MusicProvider(Provider):
                     )
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                sync_run_state().incomplete = True
+                sync_run_state().incomplete_media_types.add(MediaType.TRACK)
                 self._handle_sync_item_failure(MediaType.TRACK, prov_item.uri, err)
         return cur_db_ids
 
@@ -1712,7 +1716,7 @@ class MusicProvider(Provider):
                     )
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                sync_run_state().incomplete = True
+                sync_run_state().incomplete_media_types.add(MediaType.PODCAST)
                 self._handle_sync_item_failure(MediaType.PODCAST, prov_item.uri, err)
                 continue
             # the podcast is already collected here, so a feed that fails to deliver its
@@ -1769,7 +1773,7 @@ class MusicProvider(Provider):
                 await asyncio.sleep(0)  # yield to eventloop
 
             except Exception as err:
-                sync_run_state().incomplete = True
+                sync_run_state().incomplete_media_types.add(MediaType.RADIO)
                 self._handle_sync_item_failure(MediaType.RADIO, prov_item.uri, err)
         return cur_db_ids
 

--- a/music_assistant/providers/audible/__init__.py
+++ b/music_assistant/providers/audible/__init__.py
@@ -139,6 +139,7 @@ class Audibleprovider(MusicProvider):
                 client=self._client,
                 provider_instance=self.instance_id,
                 provider_domain=self.domain,
+                provider=self,
                 logger=self.logger,
             )
 

--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -23,6 +23,8 @@ from audible import AsyncClient
 
 if TYPE_CHECKING:
     from aiohttp import ClientSession
+
+    from music_assistant.models.music_provider import MusicProvider
 from music_assistant_models.enums import ContentType, ImageType, MediaType, StreamType
 from music_assistant_models.errors import (
     LoginFailed,
@@ -145,13 +147,24 @@ class AudibleHelper:
         client: AsyncClient,
         provider_domain: str,
         provider_instance: str,
+        provider: MusicProvider,
         logger: logging.Logger | None = None,
     ):
-        """Initialize the Audible Helper."""
+        """
+        Initialize the Audible Helper.
+
+        :param mass: The MusicAssistant instance.
+        :param client: An authenticated Audible API client.
+        :param provider_domain: Domain of the owning provider.
+        :param provider_instance: Instance id of the owning provider.
+        :param provider: The owning provider, used to report library items it had to skip.
+        :param logger: Logger to use, defaults to a module level logger.
+        """
         self.mass = mass
         self.client = client
         self.provider_domain = provider_domain
         self.provider_instance = provider_instance
+        self.provider = provider
         self.logger = logger or logging.getLogger("audible_helper")
         self._acr_cache: dict[tuple[str, MediaType], str] = {}
 
@@ -230,13 +243,8 @@ class AudibleHelper:
             if cached_book is not None:
                 return self._parse_audiobook(cached_book)
             return self._parse_audiobook(audiobook_data)
-        except MediaNotFoundError as exc:
-            self.logger.warning(f"Skipping invalid audiobook: {exc}")
-            return None
         except Exception as exc:
-            self.logger.warning(
-                f"Error processing audiobook {audiobook_data.get('asin', 'unknown')}: {exc}"
-            )
+            self.provider.report_skipped_sync_item(MediaType.AUDIOBOOK, asin or None, exc)
             return None
 
     async def get_library(self) -> AsyncGenerator[Audiobook]:
@@ -759,13 +767,8 @@ class AudibleHelper:
             if cached_podcast is not None:
                 return self._parse_podcast(cached_podcast)
             return self._parse_podcast(podcast_data)
-        except MediaNotFoundError as exc:
-            self.logger.warning(f"Skipping invalid podcast: {exc}")
-            return None
         except Exception as exc:
-            self.logger.warning(
-                f"Error processing podcast {podcast_data.get('asin', 'unknown')}: {exc}"
-            )
+            self.provider.report_skipped_sync_item(MediaType.PODCAST, asin or None, exc)
             return None
 
     async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -299,7 +299,7 @@ class BuiltinProvider(MusicProvider):
             try:
                 yield await self.get_track(item["item_id"])
             except MediaNotFoundError as err:
-                self.logger.warning("Track %s not found: %s", item, err)
+                self.report_skipped_sync_item(MediaType.TRACK, item["item_id"], err)
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library/subscribed playlists from the provider."""
@@ -310,8 +310,8 @@ class BuiltinProvider(MusicProvider):
             playlist_id = filename[:-4]  # strip .m3u extension
             try:
                 yield await self.get_playlist(playlist_id)
-            except MediaNotFoundError:
-                self.logger.warning("Playlist file %s not found", filename)
+            except MediaNotFoundError as err:
+                self.report_skipped_sync_item(MediaType.PLAYLIST, playlist_id, err)
         # return builtin playlists
         for item_id in BUILTIN_PLAYLISTS:
             if self.config.get_value(item_id) is False:

--- a/music_assistant/providers/deezer/media.py
+++ b/music_assistant/providers/deezer/media.py
@@ -276,7 +276,8 @@ class DeezerMediaManager:
             for raw in result.favorites.raw_audiobooks:
                 try:
                     item = await self.get_audiobook(raw.id)
-                except MediaNotFoundError:
+                except MediaNotFoundError as err:
+                    self.provider.report_skipped_sync_item(MediaType.AUDIOBOOK, raw.id, err)
                     continue
                 seen_ids.add(raw.id)
                 if raw.favorited_at:
@@ -289,7 +290,8 @@ class DeezerMediaManager:
                 continue
             try:
                 yield await self.get_audiobook(ab_id)
-            except MediaNotFoundError:
+            except MediaNotFoundError as err:
+                self.provider.report_skipped_sync_item(MediaType.AUDIOBOOK, ab_id, err)
                 continue
 
     # -- Search --

--- a/music_assistant/providers/digitally_incorporated/__init__.py
+++ b/music_assistant/providers/digitally_incorporated/__init__.py
@@ -306,12 +306,10 @@ class DigitallyIncorporatedProvider(MusicProvider):
                 ValueError,
                 KeyError,
             ) as err:
-                self.logger.debug(
-                    "%s: Failed to get favorites for network %s: %s",
-                    self.domain,
-                    network_key,
-                    err,
-                )
+                # the try block spans the whole per-network fetch and yield loop, so a
+                # failure partway through leaves an unknown subset of this network's
+                # favourites unreported; item_id=None holds back deletions for the run
+                self.report_skipped_sync_item(MediaType.RADIO, None, err)
                 continue
 
     async def get_radio(self, prov_radio_id: str) -> Radio:

--- a/music_assistant/providers/gpodder/__init__.py
+++ b/music_assistant/providers/gpodder/__init__.py
@@ -213,8 +213,8 @@ class GPodder(MusicProvider):
                     feed_url=feed_url,
                     max_episodes=self.max_episodes,
                 )
-            except MediaNotFoundError:
-                self.logger.warning(f"Was unable to obtain podcast with feed {feed_url}")
+            except MediaNotFoundError as err:
+                self.report_skipped_sync_item(MediaType.PODCAST, feed_url, err)
                 continue
 
             # playlog

--- a/music_assistant/providers/ibroadcast/__init__.py
+++ b/music_assistant/providers/ibroadcast/__init__.py
@@ -95,7 +95,7 @@ class IBroadcastProvider(MusicProvider):
             try:
                 yield await self._parse_album(album)
             except (KeyError, TypeError, InvalidDataError, IndexError) as error:
-                self.logger.debug("Parse album failed: %s", album, exc_info=error)
+                self._report_skipped_item(MediaType.ALBUM, album, "album_id", error)
                 continue
 
     @use_cache(3600 * 24 * 7)  # Cache for 7 days
@@ -110,7 +110,7 @@ class IBroadcastProvider(MusicProvider):
             try:
                 yield await self._parse_artist(artist)
             except (KeyError, TypeError, InvalidDataError, IndexError) as error:
-                self.logger.debug("Parse artist failed: %s", artist, exc_info=error)
+                self._report_skipped_item(MediaType.ARTIST, artist, "artist_id", error)
                 continue
 
     @use_cache(3600 * 24 * 7, allow_expired_cache=True)  # Cache for 7 days
@@ -153,10 +153,11 @@ class IBroadcastProvider(MusicProvider):
         for track in (await self._client.get_tracks()).values():
             try:
                 yield await self._parse_track(track)
-            except IndexError:
+            except IndexError as error:
+                self._report_skipped_item(MediaType.TRACK, track, "track_id", error)
                 continue
             except (KeyError, TypeError, InvalidDataError) as error:
-                self.logger.debug("Parse track failed: %s", track, exc_info=error)
+                self._report_skipped_item(MediaType.TRACK, track, "track_id", error)
                 continue
 
     def _get_artist_item_mapping(self, artist_id: str, artist_obj: dict[str, Any]) -> ItemMapping:
@@ -437,3 +438,20 @@ class IBroadcastProvider(MusicProvider):
         if "description" in playlist_obj:
             playlist.metadata.description = playlist_obj["description"]
         return playlist
+
+    def _report_skipped_item(
+        self, media_type: MediaType, item_obj: dict[str, Any], id_key: str, err: Exception
+    ) -> None:
+        """
+        Report a library item that was dropped while listing the library.
+
+        :param media_type: Media type of the skipped item.
+        :param item_obj: Raw api object of the skipped item.
+        :param id_key: Key under which the raw object holds the item id, which iBroadcast
+            returns as a number while the library stores it as text.
+        :param err: The error that made the item unusable.
+        """
+        item_id = item_obj.get(id_key)
+        self.report_skipped_sync_item(
+            media_type, str(item_id) if item_id is not None else None, err
+        )

--- a/music_assistant/providers/kion_music/provider.py
+++ b/music_assistant/providers/kion_music/provider.py
@@ -2572,7 +2572,8 @@ class KionMusicProvider(MusicProvider):
             try:
                 yield parse_artist(self, artist)
             except InvalidDataError as err:
-                self.logger.debug("Error parsing library artist: %s", err)
+                # only raised for a missing artist id, so the item is unidentifiable
+                self.report_skipped_sync_item(MediaType.ARTIST, None, err)
 
     async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from KION Music."""
@@ -2582,7 +2583,9 @@ class KionMusicProvider(MusicProvider):
             try:
                 yield parse_album(self, album)
             except InvalidDataError as err:
-                self.logger.debug("Error parsing library album: %s", err)
+                # album.id may still be usable even if one of its artists is not
+                item_id = str(album.id) if album.id is not None else None
+                self.report_skipped_sync_item(MediaType.ALBUM, item_id, err)
 
     async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from KION Music."""
@@ -2600,7 +2603,9 @@ class KionMusicProvider(MusicProvider):
                 try:
                     yield parse_track(self, track)
                 except InvalidDataError as err:
-                    self.logger.debug("Error parsing library track: %s", err)
+                    # track.id may still be usable even if its artist/album is not
+                    item_id = str(track.id) if track.id is not None else None
+                    self.report_skipped_sync_item(MediaType.TRACK, item_id, err)
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """
@@ -2620,7 +2625,11 @@ class KionMusicProvider(MusicProvider):
                 seen_ids.add(parsed.item_id)
                 yield parsed
             except InvalidDataError as err:
-                self.logger.debug("Error parsing library playlist: %s", err)
+                # mirrors the "owner_id:kind" id parse_playlist() derives
+                owner_id = str(playlist.owner.uid) if playlist.owner else str(self.client.user_id)
+                self.report_skipped_sync_item(
+                    MediaType.PLAYLIST, f"{owner_id}:{playlist.kind}", err
+                )
         # User-liked editorial playlists (not in users_playlists_list)
         liked_playlists = await self.client.get_liked_playlists()
         for playlist in liked_playlists:
@@ -2629,7 +2638,11 @@ class KionMusicProvider(MusicProvider):
                 if parsed.item_id not in seen_ids:
                     yield parsed
             except InvalidDataError as err:
-                self.logger.debug("Error parsing liked playlist: %s", err)
+                # mirrors the "owner_id:kind" id parse_playlist() derives
+                owner_id = str(playlist.owner.uid) if playlist.owner else str(self.client.user_id)
+                self.report_skipped_sync_item(
+                    MediaType.PLAYLIST, f"{owner_id}:{playlist.kind}", err
+                )
 
     # Library edit methods
 

--- a/music_assistant/providers/neteasecloudmusic/__init__.py
+++ b/music_assistant/providers/neteasecloudmusic/__init__.py
@@ -1453,11 +1453,22 @@ class NeteaseCloudMusicProvider(MusicProvider):
         for idx in range(0, len(track_ids), chunk_size):
             chunk_ids = track_ids[idx : idx + chunk_size]
             songs = await self._get_song_detail(",".join(chunk_ids))
+            fetched_ids: set[str] = set()
             for song_obj in songs:
+                fetched_ids.add(str(song_obj.get("id") or song_obj.get("songId") or "").strip())
                 try:
                     yield self._parse_track(song_obj)
                 except InvalidDataError as err:
                     self.report_skipped_sync_item(MediaType.TRACK, None, err)
+            # the liked list is authoritative, so a track the detail call left out is still
+            # in the library and must not be read as removed
+            for missing_id in chunk_ids:
+                if missing_id not in fetched_ids:
+                    self.report_skipped_sync_item(
+                        MediaType.TRACK,
+                        missing_id,
+                        MediaNotFoundError(f"NCM did not return track {missing_id}"),
+                    )
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve user playlists from NCM."""

--- a/music_assistant/providers/neteasecloudmusic/__init__.py
+++ b/music_assistant/providers/neteasecloudmusic/__init__.py
@@ -1402,8 +1402,10 @@ class NeteaseCloudMusicProvider(MusicProvider):
             for artist_obj in artists:
                 if not isinstance(artist_obj, dict):
                     continue
-                with suppress(InvalidDataError):
+                try:
                     yield self._parse_artist(artist_obj)
+                except InvalidDataError as err:
+                    self.report_skipped_sync_item(MediaType.ARTIST, None, err)
             has_more = bool(data.get("more") or data.get("hasMore"))
             offset += limit
             if not has_more and len(artists) < limit:
@@ -1426,8 +1428,10 @@ class NeteaseCloudMusicProvider(MusicProvider):
             for album_obj in albums:
                 if not isinstance(album_obj, dict):
                     continue
-                with suppress(InvalidDataError):
+                try:
                     yield self._parse_album(album_obj)
+                except InvalidDataError as err:
+                    self.report_skipped_sync_item(MediaType.ALBUM, None, err)
             has_more = bool(data.get("more") or data.get("hasMore"))
             offset += limit
             if not has_more and len(albums) < limit:
@@ -1450,8 +1454,10 @@ class NeteaseCloudMusicProvider(MusicProvider):
             chunk_ids = track_ids[idx : idx + chunk_size]
             songs = await self._get_song_detail(",".join(chunk_ids))
             for song_obj in songs:
-                with suppress(InvalidDataError):
+                try:
                     yield self._parse_track(song_obj)
+                except InvalidDataError as err:
+                    self.report_skipped_sync_item(MediaType.TRACK, None, err)
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve user playlists from NCM."""
@@ -1467,8 +1473,10 @@ class NeteaseCloudMusicProvider(MusicProvider):
         for playlist_obj in playlists:
             if not isinstance(playlist_obj, dict):
                 continue
-            with suppress(InvalidDataError):
+            try:
                 yield self._parse_playlist(playlist_obj)
+            except InvalidDataError as err:
+                self.report_skipped_sync_item(MediaType.PLAYLIST, None, err)
 
     async def _get_recommend_payload_cached(
         self,

--- a/music_assistant/providers/overcast/provider.py
+++ b/music_assistant/providers/overcast/provider.py
@@ -151,8 +151,8 @@ class OvercastProvider(MusicProvider):
                     feed_url=feed_url,
                     max_episodes=self.max_episodes,
                 )
-            except MediaNotFoundError:
-                self.logger.warning("Was unable to obtain podcast with feed %s", feed_url)
+            except MediaNotFoundError as err:
+                self.report_skipped_sync_item(MediaType.PODCAST, feed_url, err)
                 continue
             applied = await self._apply_playback_states(feed_url, subscription, parsed_podcast)
             if applied is not None:

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -440,7 +440,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         """Retrieve all library artists from Plex Music."""
         artists_obj = await self._run_async(self._plex_library.all)
         for artist in artists_obj:
-            parsed = await self._parse_or_skip(self._parse_artist, artist)
+            parsed = await self._parse_or_skip(self._parse_artist, artist, MediaType.ARTIST)
             if parsed is not None:
                 yield parsed
 
@@ -448,7 +448,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         """Retrieve all library albums from Plex Music."""
         albums_obj = await self._run_async(self._plex_library.albums)
         for album in albums_obj:
-            parsed = await self._parse_or_skip(self._parse_album, album)
+            parsed = await self._parse_or_skip(self._parse_album, album, MediaType.ALBUM)
             if parsed is not None:
                 yield parsed
 
@@ -456,7 +456,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         """Retrieve all library playlists from the provider."""
         playlists_obj = await self._run_async(self._plex_library.playlists)
         for playlist in playlists_obj:
-            parsed = await self._parse_or_skip(self._parse_playlist, playlist)
+            parsed = await self._parse_or_skip(self._parse_playlist, playlist, MediaType.PLAYLIST)
             if parsed is not None:
                 yield parsed
 
@@ -464,7 +464,9 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         if self.config.get_value(CONF_IMPORT_COLLECTIONS):
             collections_obj = await self._run_async(self._plex_library.collections)
             for collection in collections_obj:
-                parsed = await self._parse_or_skip(self._parse_collection, collection)
+                parsed = await self._parse_or_skip(
+                    self._parse_collection, collection, MediaType.PLAYLIST, COLLECTION_ID_PREFIX
+                )
                 if parsed is not None:
                     yield parsed
 
@@ -489,7 +491,7 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             if not batch:
                 break
             for plex_track in batch:
-                parsed = await self._parse_or_skip(self._parse_track, plex_track)
+                parsed = await self._parse_or_skip(self._parse_track, plex_track, MediaType.TRACK)
                 if parsed is not None:
                     yield parsed
             offset += page_size
@@ -505,7 +507,9 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             self._plex_library.title,
         )
         for album in albums_obj:
-            parsed = await self._parse_or_skip(self._parse_audiobook, album)
+            parsed = await self._parse_or_skip(
+                self._parse_audiobook, album, MediaType.AUDIOBOOK, AUDIOBOOK_PREFIX
+            )
             if parsed is not None:
                 yield parsed
 
@@ -532,7 +536,9 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             return
         albums_obj = await self._run_async(self._plex_library.albums)
         for album in albums_obj:
-            parsed = await self._parse_or_skip(self._parse_podcast, album)
+            parsed = await self._parse_or_skip(
+                self._parse_podcast, album, MediaType.PODCAST, PODCAST_PREFIX
+            )
             if parsed is not None:
                 yield parsed
 
@@ -754,7 +760,9 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         plex_album: PlexAlbum = await self._get_data(prov_album_id, PlexAlbum)
         tracks = []
         for plex_track in await self._run_async(plex_album.tracks):
-            if (track := await self._parse_or_skip(self._parse_track, plex_track)) is not None:
+            if (
+                track := await self._parse_or_skip(self._parse_track, plex_track, MediaType.TRACK)
+            ) is not None:
                 tracks.append(track)
         return tracks
 
@@ -829,7 +837,9 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             # Collections can contain tracks, albums, or artists - we only want tracks
             for item in collection_items:
                 if item.type == "track":
-                    if (track := await self._parse_or_skip(self._parse_track, item)) is not None:
+                    if (
+                        track := await self._parse_or_skip(self._parse_track, item, MediaType.TRACK)
+                    ) is not None:
                         track.position = len(result) + 1
                         result.append(track)
                 elif item.type == "album":
@@ -850,7 +860,11 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             plex_tracks = await self._run_async(self._plex_library.fetchItems, tracks_key)
             random.shuffle(plex_tracks)
             for plex_track in plex_tracks:
-                if (track := await self._parse_or_skip(self._parse_track, plex_track)) is not None:
+                if (
+                    track := await self._parse_or_skip(
+                        self._parse_track, plex_track, MediaType.TRACK
+                    )
+                ) is not None:
                     track.position = len(result) + 1
                     result.append(track)
             return result
@@ -859,7 +873,9 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         if not (playlist_items := await self._run_async(plex_playlist.items)):
             return result
         for plex_track in playlist_items:
-            if (track := await self._parse_or_skip(self._parse_track, plex_track)) is not None:
+            if (
+                track := await self._parse_or_skip(self._parse_track, plex_track, MediaType.TRACK)
+            ) is not None:
                 track.position = len(result) + 1
                 result.append(track)
         return result
@@ -1202,12 +1218,17 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
         self,
         parse_coro: Callable[[PlexObjectT], Coroutine[Any, Any, MediaItemT]],
         plex_item: PlexObjectT,
+        media_type: MediaType,
+        id_prefix: str = "",
     ) -> MediaItemT | None:
         """
         Parse a plex object into a media item, or return None if the item must be skipped.
 
         :param parse_coro: The parse method to apply to the given plex object.
         :param plex_item: The plex object to parse.
+        :param media_type: Media type the given plex object is listed as.
+        :param id_prefix: Prefix this provider puts in front of the plex key to build the
+            item id for this media type.
         """
         try:
             return await parse_coro(plex_item)
@@ -1217,14 +1238,19 @@ class PlexProvider(RecommendationPayloadMixin, MusicProvider):
             # and we can not tell those apart here, so it has to abort the sync - that is
             # what holds back the deletion pass that would otherwise drop valid items.
             #
-            # read the identifiers from the cached payload, so reporting a failed item
-            # can not trigger a reload that fails all over again
-            attrib = plex_item._data.attrib
-            self.logger.warning(
-                "Skipping Plex item '%s' (key=%s): %s",
-                attrib.get("title", "[unknown]"),
-                attrib.get("key", "[no key]"),
-                err,
+            # the key is the identifier the parsers build the item id from, and one of the
+            # few attributes plexapi never reloads a partial object for, so reporting a
+            # failed item can not trigger a reload that fails all over again
+            plex_key = plex_item.key
+            # the title comes from the cached payload, which keeps the same no-reload
+            # property as the key above
+            self.logger.debug(
+                "Skipping Plex item '%s' (key=%s)",
+                plex_item._data.attrib.get("title", UNKNOWN_NAME),
+                plex_key,
+            )
+            self.report_skipped_sync_item(
+                media_type, f"{id_prefix}{plex_key}" if plex_key else None, err
             )
             return None
 

--- a/music_assistant/providers/qqmusic/__init__.py
+++ b/music_assistant/providers/qqmusic/__init__.py
@@ -72,7 +72,14 @@ from .constants import (
     QUALITY_MP3_128,
     QUALITY_MP3_320,
 )
-from .helpers import extract_first_text, normalize_qq_lyric_text, qrc_to_lrc
+from .helpers import (
+    extract_album_mid,
+    extract_first_text,
+    extract_playlist_ids,
+    extract_track_mid,
+    normalize_qq_lyric_text,
+    qrc_to_lrc,
+)
 from .parsers import (
     build_playlist_id,
     extract_guess_recommend_tracks,
@@ -759,6 +766,11 @@ class QQMusicProvider(MusicProvider):
     def _parse_playlist(self, playlist_obj: dict[str, Any]) -> Playlist:
         return parse_playlist(playlist_obj, self.domain, self.instance_id)
 
+    def _skipped_playlist_id(self, playlist_obj: dict[str, Any]) -> str | None:
+        """Return the provider playlist id of a playlist that could not be parsed."""
+        dissid, dirid = extract_playlist_ids(playlist_obj)
+        return build_playlist_id(dissid, dirid) if dissid else None
+
     @use_cache(3600 * 3)
     async def search(
         self,
@@ -1048,7 +1060,10 @@ class QQMusicProvider(MusicProvider):
                 try:
                     yield self._parse_artist(artist_obj)
                     total_yielded += 1
-                except InvalidDataError, TypeError, ValueError:
+                except (InvalidDataError, TypeError, ValueError) as error:
+                    mapping = self._get_artist_mapping(artist_obj)
+                    item_id = mapping.item_id if mapping else None
+                    self.report_skipped_sync_item(MediaType.ARTIST, item_id, error)
                     continue
             if len(artists) < num:
                 break
@@ -1076,7 +1091,10 @@ class QQMusicProvider(MusicProvider):
                 try:
                     yield self._parse_track(song)
                     yielded += 1
-                except InvalidDataError, TypeError, ValueError:
+                except (InvalidDataError, TypeError, ValueError) as error:
+                    self.report_skipped_sync_item(
+                        MediaType.TRACK, extract_track_mid(song) or None, error
+                    )
                     continue
             if total and yielded >= total:
                 break
@@ -1110,7 +1128,10 @@ class QQMusicProvider(MusicProvider):
                 try:
                     yield self._parse_album(album_obj)
                     total_yielded += 1
-                except InvalidDataError, TypeError, ValueError:
+                except (InvalidDataError, TypeError, ValueError) as error:
+                    self.report_skipped_sync_item(
+                        MediaType.ALBUM, extract_album_mid(album_obj) or None, error
+                    )
                     continue
             if len(albums) < num:
                 break
@@ -1129,7 +1150,10 @@ class QQMusicProvider(MusicProvider):
         ):
             try:
                 yield self._parse_playlist(playlist_obj)
-            except InvalidDataError, TypeError, ValueError:
+            except (InvalidDataError, TypeError, ValueError) as error:
+                self.report_skipped_sync_item(
+                    MediaType.PLAYLIST, self._skipped_playlist_id(playlist_obj), error
+                )
                 continue
 
         page = 1
@@ -1149,7 +1173,10 @@ class QQMusicProvider(MusicProvider):
             for playlist_obj in fav_playlists:
                 try:
                     yield self._parse_playlist(playlist_obj)
-                except InvalidDataError, TypeError, ValueError:
+                except (InvalidDataError, TypeError, ValueError) as error:
+                    self.report_skipped_sync_item(
+                        MediaType.PLAYLIST, self._skipped_playlist_id(playlist_obj), error
+                    )
                     continue
             if len(fav_playlists) < num:
                 break

--- a/music_assistant/providers/qqmusic/helpers.py
+++ b/music_assistant/providers/qqmusic/helpers.py
@@ -59,6 +59,38 @@ def extract_artist_mid(artist_obj: dict[str, Any]) -> str:
     )
 
 
+def extract_album_mid(album_obj: dict[str, Any]) -> str:
+    """Extract QQ album mid from common field variants."""
+    return str(
+        album_obj.get("mid")
+        or album_obj.get("albumMid")
+        or album_obj.get("albumMID")
+        or album_obj.get("album_mid")
+        or album_obj.get("albummid")
+        or album_obj.get("id")
+        or album_obj.get("albumID")
+        or ""
+    )
+
+
+def extract_track_mid(track_obj: dict[str, Any]) -> str:
+    """Extract QQ song mid from common field variants."""
+    return str(
+        track_obj.get("mid")
+        or track_obj.get("songMid")
+        or track_obj.get("songmid")
+        or track_obj.get("id")
+        or ""
+    )
+
+
+def extract_playlist_ids(playlist_obj: dict[str, Any]) -> tuple[Any, Any]:
+    """Extract the QQ (dissid, dirid) pair from common field variants."""
+    dissid = playlist_obj.get("tid") or playlist_obj.get("dissid") or playlist_obj.get("id") or 0
+    dirid = playlist_obj.get("dirid") or playlist_obj.get("dirId") or 0
+    return (dissid, dirid)
+
+
 def normalize_qq_lyric_text(raw_text: str) -> str:
     """Normalize QQ lyric/qrc payload to readable plain text."""
     text = html.unescape(raw_text).replace("\r\n", "\n").replace("\r", "\n")

--- a/music_assistant/providers/qqmusic/parsers.py
+++ b/music_assistant/providers/qqmusic/parsers.py
@@ -23,7 +23,15 @@ from music_assistant_models.media_items import (
 
 from music_assistant.helpers.util import parse_title_and_version
 
-from .helpers import clean_text, extract_artist_mid, extract_first_text, normalize_image_url
+from .helpers import (
+    clean_text,
+    extract_album_mid,
+    extract_artist_mid,
+    extract_first_text,
+    extract_playlist_ids,
+    extract_track_mid,
+    normalize_image_url,
+)
 
 
 def extract_song_id(track_obj: dict[str, Any]) -> int | None:
@@ -248,16 +256,7 @@ def parse_album(
     provider_instance_id: str,
 ) -> Album:
     """Parse raw qqmusic album object."""
-    album_id = str(
-        album_obj.get("mid")
-        or album_obj.get("albumMid")
-        or album_obj.get("albumMID")
-        or album_obj.get("album_mid")
-        or album_obj.get("albummid")
-        or album_obj.get("id")
-        or album_obj.get("albumID")
-        or ""
-    )
+    album_id = extract_album_mid(album_obj)
     if not album_id:
         raise InvalidDataError("Album object does not contain id/mid")
     raw_album_name = str(
@@ -354,13 +353,7 @@ def parse_track(  # noqa: PLR0915
     get_max_supported_audio_format: Callable[[dict[str, Any]], tuple[AudioFormat, str | None]],
 ) -> Track:
     """Parse raw qqmusic track object."""
-    track_id = str(
-        track_obj.get("mid")
-        or track_obj.get("songMid")
-        or track_obj.get("songmid")
-        or track_obj.get("id")
-        or ""
-    )
+    track_id = extract_track_mid(track_obj)
     if not track_id:
         raise InvalidDataError("Track object does not contain id/mid")
     raw_track_name = clean_text(
@@ -540,8 +533,7 @@ def parse_playlist(
     provider_instance_id: str,
 ) -> Playlist:
     """Parse raw qqmusic playlist object."""
-    dissid = playlist_obj.get("tid") or playlist_obj.get("dissid") or playlist_obj.get("id") or 0
-    dirid = playlist_obj.get("dirid") or playlist_obj.get("dirId") or 0
+    dissid, dirid = extract_playlist_ids(playlist_obj)
     if not dissid:
         raise InvalidDataError("Playlist object missing dissid/tid")
     playlist_id = build_playlist_id(dissid, dirid)

--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -166,7 +166,7 @@ class SoundcloudMusicProvider(RecommendationPayloadMixin, MusicProvider):
             try:
                 yield await self._parse_artist(artist)
             except (KeyError, TypeError, InvalidDataError, IndexError) as error:
-                self.logger.debug("Parse artist failed: %s", artist, exc_info=error)
+                self._report_skipped_item(MediaType.ARTIST, artist, error)
                 continue
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
@@ -175,11 +175,9 @@ class SoundcloudMusicProvider(RecommendationPayloadMixin, MusicProvider):
         async for item in self._soundcloud.get_account_playlists():
             try:
                 raw_playlist = item["playlist"]
-            except KeyError:
-                self.logger.debug(
-                    "Unexpected Soundcloud API response when parsing playlists: %s",
-                    item,
-                )
+            except KeyError as error:
+                # the entry holds no playlist payload at all, so there is no id to name
+                self.report_skipped_sync_item(MediaType.PLAYLIST, None, error)
                 continue
 
             try:
@@ -189,11 +187,7 @@ class SoundcloudMusicProvider(RecommendationPayloadMixin, MusicProvider):
 
                 yield await self._parse_playlist(playlist)
             except (KeyError, TypeError, InvalidDataError, IndexError) as error:
-                self.logger.debug(
-                    "Failed to obtain Soundcloud playlist details: %s",
-                    raw_playlist,
-                    exc_info=error,
-                )
+                self._report_skipped_item(MediaType.PLAYLIST, raw_playlist, error)
                 continue
 
         self.logger.debug(
@@ -209,16 +203,13 @@ class SoundcloudMusicProvider(RecommendationPayloadMixin, MusicProvider):
             try:
                 yield await self._parse_track(track)
             except DrmProtectedTrackError:
+                # a permanent restriction on the track rather than a failure to read it, so
+                # it is counted and logged once below instead of reported as a sync failure
                 drm_protected += 1
                 continue
             except (KeyError, TypeError, InvalidDataError, IndexError) as error:
                 # somehow certain track id's don't exist (anymore)
-                self.logger.debug(
-                    "%s: Parse track with id %s failed: %s",
-                    type(error).__name__,
-                    track["id"],
-                    track,
-                )
+                self._report_skipped_item(MediaType.TRACK, track, error)
                 continue
 
         if drm_protected:
@@ -669,6 +660,19 @@ class SoundcloudMusicProvider(RecommendationPayloadMixin, MusicProvider):
         """Patch artwork URL to a high quality thumbnail."""
         # This is undocumented in their API docs, but was previously
         return artwork_url.replace("large", "t500x500")
+
+    def _report_skipped_item(
+        self, media_type: MediaType, item_obj: dict[str, Any], err: Exception
+    ) -> None:
+        """
+        Report a library item that was dropped while listing the library.
+
+        :param media_type: Media type of the skipped item.
+        :param item_obj: Raw api object of the skipped item, whose id is its item id.
+        :param err: The error that made the item unusable.
+        """
+        item_id = item_obj.get("id")
+        self.report_skipped_sync_item(media_type, str(item_id) if item_id else None, err)
 
 
 def _is_drm_protected(track_obj: dict[str, Any]) -> bool:

--- a/music_assistant/providers/storytel/__init__.py
+++ b/music_assistant/providers/storytel/__init__.py
@@ -292,7 +292,7 @@ class Storytel(RecommendationPayloadMixin, MusicProvider):
             except (MediaNotFoundError, ProviderUnavailableError, InvalidDataError) as err:
                 if isinstance(err, ProviderUnavailableError):
                     failed_provider_error = failed_provider_error or err
-                self.logger.debug("Skipping Storytel book %s: %s", consumable_id, err)
+                self.report_skipped_sync_item(MediaType.AUDIOBOOK, consumable_id, err)
 
         if not yielded_any and failed_provider_error is not None:
             raise failed_provider_error
@@ -584,7 +584,7 @@ class Storytel(RecommendationPayloadMixin, MusicProvider):
             except (MediaNotFoundError, ProviderUnavailableError, InvalidDataError) as err:
                 if isinstance(err, ProviderUnavailableError):
                     failed_provider_error = failed_provider_error or err
-                self.logger.debug("Skipping Storytel podcast %s: %s", podcast_id, err)
+                self.report_skipped_sync_item(MediaType.PODCAST, podcast_id or None, err)
 
         if not yielded_any and failed_provider_error is not None:
             raise failed_provider_error

--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -196,7 +196,7 @@ class TuneInProvider(MusicProvider):
                         yield self._parse_radio(item)
                     except InvalidDataError as err:
                         # there may be invalid custom urls, ignore those
-                        self.logger.warning(str(err))
+                        self.report_skipped_sync_item(MediaType.RADIO, item["URL"], err)
                 elif item_type == "link":
                     # stations are in sublevel (new style)
                     if sublevel := await self.__get_data(item["URL"], render="json"):

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -1479,7 +1479,8 @@ class YandexMusicProvider(MusicProvider):
             try:
                 yield parse_artist(self, artist)
             except InvalidDataError as err:
-                self.logger.debug("Error parsing library artist: %s", err)
+                # only raised for a missing artist id, so the item is unidentifiable
+                self.report_skipped_sync_item(MediaType.ARTIST, None, err)
 
     async def get_library_albums(self) -> AsyncGenerator[Album]:
         """
@@ -1494,7 +1495,9 @@ class YandexMusicProvider(MusicProvider):
             try:
                 yield parse_album(self, album)
             except InvalidDataError as err:
-                self.logger.debug("Error parsing library album: %s", err)
+                # album.id may still be usable even if one of its artists is not
+                item_id = str(album.id) if album.id is not None else None
+                self.report_skipped_sync_item(MediaType.ALBUM, item_id, err)
 
     async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Retrieve library podcasts from Yandex Music (filtered liked albums)."""
@@ -1504,7 +1507,8 @@ class YandexMusicProvider(MusicProvider):
             try:
                 yield parse_podcast(self, album)
             except InvalidDataError as err:
-                self.logger.debug("Error parsing library podcast: %s", err)
+                # only raised for a missing album id, so the item is unidentifiable
+                self.report_skipped_sync_item(MediaType.PODCAST, None, err)
 
     async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook]:
         """Retrieve library audiobooks from Yandex Music (filtered liked albums)."""
@@ -1514,7 +1518,8 @@ class YandexMusicProvider(MusicProvider):
             try:
                 yield parse_audiobook(self, album)
             except InvalidDataError as err:
-                self.logger.debug("Error parsing library audiobook: %s", err)
+                # only raised for a missing album id, so the item is unidentifiable
+                self.report_skipped_sync_item(MediaType.AUDIOBOOK, None, err)
 
     async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from Yandex Music."""
@@ -1532,7 +1537,9 @@ class YandexMusicProvider(MusicProvider):
                 try:
                     yield parse_track(self, track)
                 except InvalidDataError as err:
-                    self.logger.debug("Error parsing library track: %s", err)
+                    # track.id may still be usable even if its artist/album is not
+                    item_id = str(track.id) if track.id is not None else None
+                    self.report_skipped_sync_item(MediaType.TRACK, item_id, err)
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """
@@ -1552,7 +1559,11 @@ class YandexMusicProvider(MusicProvider):
                 seen_ids.add(parsed.item_id)
                 yield parsed
             except InvalidDataError as err:
-                self.logger.debug("Error parsing library playlist: %s", err)
+                # mirrors the "owner_id:kind" id parse_playlist() derives
+                owner_id = str(playlist.owner.uid) if playlist.owner else str(self.client.user_id)
+                self.report_skipped_sync_item(
+                    MediaType.PLAYLIST, f"{owner_id}:{playlist.kind}", err
+                )
         # User-liked editorial playlists (not in users_playlists_list)
         liked_playlists = await self.client.get_liked_playlists()
         for playlist in liked_playlists:
@@ -1561,7 +1572,11 @@ class YandexMusicProvider(MusicProvider):
                 if parsed.item_id not in seen_ids:
                     yield parsed
             except InvalidDataError as err:
-                self.logger.debug("Error parsing liked playlist: %s", err)
+                # mirrors the "owner_id:kind" id parse_playlist() derives
+                owner_id = str(playlist.owner.uid) if playlist.owner else str(self.client.user_id)
+                self.report_skipped_sync_item(
+                    MediaType.PLAYLIST, f"{owner_id}:{playlist.kind}", err
+                )
 
     # Library edit methods
 

--- a/music_assistant/providers/zvuk_music/provider.py
+++ b/music_assistant/providers/zvuk_music/provider.py
@@ -802,11 +802,22 @@ class ZvukMusicProvider(MusicProvider):
         for i in range(0, len(ids), DEFAULT_LIMIT):
             batch = ids[i : i + DEFAULT_LIMIT]
             items = await fetcher(batch)
+            fetched_ids: set[str] = set()
             for item in items:
+                fetched_ids.add(str(item.id))
                 try:
                     yield parser(self, item)
                 except InvalidDataError as err:
                     self.report_skipped_sync_item(media_type, str(item.id), err)
+            # the id's come from the user's own collection, so anything the fetch left out
+            # (a whole batch is dropped when it raises NotFound) is still in the library
+            for missing_id in batch:
+                if missing_id not in fetched_ids:
+                    self.report_skipped_sync_item(
+                        media_type,
+                        missing_id,
+                        MediaNotFoundError(f"Zvuk did not return {media_type.value} {missing_id}"),
+                    )
 
     async def _get_for_you_playlists(self) -> list[Playlist]:
         """Fetch and parse Zvuk's personalized synthesis playlists («Плейлисты для вас»)."""

--- a/music_assistant/providers/zvuk_music/provider.py
+++ b/music_assistant/providers/zvuk_music/provider.py
@@ -388,7 +388,7 @@ class ZvukMusicProvider(MusicProvider):
             return
         ids = [str(item.id) for item in collection.artists if item.id]
         async for artist in self._iter_batched(
-            ids, self.client.get_artists, parse_artist, "artist"
+            ids, self.client.get_artists, parse_artist, MediaType.ARTIST
         ):
             yield artist
 
@@ -398,7 +398,9 @@ class ZvukMusicProvider(MusicProvider):
         if not collection or not collection.releases:
             return
         ids = [str(item.id) for item in collection.releases if item.id]
-        async for album in self._iter_batched(ids, self.client.get_releases, parse_album, "album"):
+        async for album in self._iter_batched(
+            ids, self.client.get_releases, parse_album, MediaType.ALBUM
+        ):
             yield album
 
     async def get_library_tracks(self) -> AsyncGenerator[Track]:
@@ -407,7 +409,9 @@ class ZvukMusicProvider(MusicProvider):
         if not collection or not collection.tracks:
             return
         ids = [str(item.id) for item in collection.tracks if item.id]
-        async for track in self._iter_batched(ids, self.client.get_tracks, parse_track, "track"):
+        async for track in self._iter_batched(
+            ids, self.client.get_tracks, parse_track, MediaType.TRACK
+        ):
             yield track
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
@@ -421,7 +425,7 @@ class ZvukMusicProvider(MusicProvider):
         if collection_items:
             ids = [str(item.id) for item in collection_items if item.id]
             async for playlist in self._iter_batched(
-                ids, self.client.get_playlists, parse_playlist, "playlist"
+                ids, self.client.get_playlists, parse_playlist, MediaType.PLAYLIST
             ):
                 yield playlist
 
@@ -431,7 +435,7 @@ class ZvukMusicProvider(MusicProvider):
             try:
                 yield parse_playlist(self, simple_pl)
             except InvalidDataError as err:
-                self.logger.debug("Error parsing synthesis playlist: %s", err)
+                self.report_skipped_sync_item(MediaType.PLAYLIST, str(simple_pl.id), err)
 
     async def get_recommendations(self) -> list[RecommendationFolder]:
         """
@@ -785,7 +789,7 @@ class ZvukMusicProvider(MusicProvider):
         ids: list[str],
         fetcher: Any,
         parser: Any,
-        item_type: str,
+        media_type: MediaType,
     ) -> AsyncGenerator[Any]:
         """
         Yield parsed items by fetching ``ids`` in batches of DEFAULT_LIMIT.
@@ -793,7 +797,7 @@ class ZvukMusicProvider(MusicProvider):
         :param ids: List of item IDs to fetch.
         :param fetcher: Async callable that accepts a list of IDs and returns a list of raw items.
         :param parser: Callable(provider, raw_item) → MA media item.
-        :param item_type: Human-readable type name for debug log messages.
+        :param media_type: Media type of the items, for skip reporting.
         """
         for i in range(0, len(ids), DEFAULT_LIMIT):
             batch = ids[i : i + DEFAULT_LIMIT]
@@ -802,7 +806,7 @@ class ZvukMusicProvider(MusicProvider):
                 try:
                     yield parser(self, item)
                 except InvalidDataError as err:
-                    self.logger.debug("Error parsing library %s: %s", item_type, err)
+                    self.report_skipped_sync_item(media_type, str(item.id), err)
 
     async def _get_for_you_playlists(self) -> list[Playlist]:
         """Fetch and parse Zvuk's personalized synthesis playlists («Плейлисты для вас»)."""

--- a/tests/controllers/music/test_sync_resilience.py
+++ b/tests/controllers/music/test_sync_resilience.py
@@ -424,14 +424,19 @@ class SkippingAlbumProvider(FailingAlbumProvider):
 def _library_holds(mass: MagicMock, known: dict[str, int]) -> None:
     """Let the deletion pass resolve the given provider item id's to library db id's."""
 
-    async def get_library_item_by_prov_id(item_id: str, provider: str) -> Any:
-        del provider
-        if (db_id := known.get(item_id)) is None:
-            return None
-        return MagicMock(item_id=db_id)
+    async def get_library_items_by_prov_id(
+        provider_instance: str, provider_item_ids: list[str], limit: int
+    ) -> list[Any]:
+        del limit
+        # only this provider instance's own mappings may resolve, never a sibling instance
+        if provider_instance != "test--1":
+            return []
+        return [
+            MagicMock(item_id=known[item_id]) for item_id in provider_item_ids if item_id in known
+        ]
 
-    mass.music.get_controller.return_value.get_library_item_by_prov_id = AsyncMock(
-        side_effect=get_library_item_by_prov_id
+    mass.music.get_controller.return_value.get_library_items_by_prov_id = AsyncMock(
+        side_effect=get_library_items_by_prov_id
     )
 
 
@@ -479,6 +484,22 @@ async def test_skipped_item_we_do_not_hold_does_not_hold_back_deletions() -> Non
     mass.music.get_controller.return_value.get_library_item.assert_awaited_once_with(99)
 
 
+SKIPPED_TRACK_ID = "track_9"
+
+
+class TrackSkippingAlbumProvider(FailingAlbumProvider):
+    """Provider that drops tracks while listing the tracks of an album."""
+
+    async def get_album_tracks(self, prov_album_id: str) -> list[Any]:
+        """Report the tracks that could not be read instead of returning them."""
+        del prov_album_id
+        self.report_skipped_sync_item(
+            MediaType.TRACK, SKIPPED_TRACK_ID, InvalidDataError("no artist")
+        )
+        self.report_skipped_sync_item(MediaType.TRACK, None, InvalidDataError("no id"))
+        return []
+
+
 class UnidentifiedSkipProvider(SkippingAlbumProvider):
     """Provider that drops an album it cannot identify."""
 
@@ -496,15 +517,56 @@ async def test_unidentified_skip_holds_back_deletions() -> None:
     mass.music.get_controller.return_value.get_library_item.assert_not_called()
 
 
-async def test_skipped_items_are_not_resolved_when_deletions_are_disabled() -> None:
-    """With deletions off there is nothing to protect an item from, so nothing is looked up."""
+async def test_skipped_item_stays_in_the_snapshot_when_deletions_are_disabled() -> None:
+    """
+    A skipped item is recorded as seen even while deletions are off.
+
+    That snapshot is what a later run compares against, so dropping the item here would
+    leave it untracked once the user turns deletions back on.
+    """
     mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
     provider = _build_provider(mass, cls=SkippingAlbumProvider, sync_deletions=False)
     _library_holds(mass, {SKIPPED_ID: 2})
 
     await provider.sync_library(MediaType.ALBUM)
 
-    mass.music.get_controller.return_value.get_library_item_by_prov_id.assert_not_called()
+    assert sorted(mass.cache.set.await_args.kwargs["data"]) == [1, 2, 3]
+
+
+async def test_skipped_items_resolve_against_this_provider_instance_only() -> None:
+    """
+    A skipped id is resolved against the instance that skipped it, not the whole domain.
+
+    A second instance of the same provider holds its own mappings under the same item id's,
+    and protecting one instance's item would leave the other's exposed.
+    """
+    mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
+    provider = _build_provider(mass, cls=SkippingAlbumProvider)
+    _library_holds(mass, {SKIPPED_ID: 2})
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    lookup = mass.music.get_controller.return_value.get_library_items_by_prov_id
+    assert lookup.await_args.kwargs["provider_instance"] == provider.instance_id
+
+
+async def test_a_skipped_track_does_not_reach_the_album_deletion_pass() -> None:
+    """
+    Skips are kept apart per media type.
+
+    Importing an album's tracks runs inside the album sync, so a track it had to skip must
+    not put a track db id into the album result set, nor hold back the album deletions.
+    """
+    mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
+    provider = _build_provider(mass, cls=TrackSkippingAlbumProvider, sync_album_tracks=True)
+    _library_holds(mass, {SKIPPED_TRACK_ID: 77})
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    # 77 is a track db id, so it may not end up in the album snapshot
+    assert sorted(mass.cache.set.await_args.kwargs["data"]) == [1, 2, 3]
+    # and a track that could not be named does not stop the albums from being cleaned up
+    mass.music.get_controller.return_value.get_library_item.assert_awaited_once_with(99)
 
 
 class UnskippableSkipProvider(SkippingAlbumProvider):

--- a/tests/controllers/music/test_sync_resilience.py
+++ b/tests/controllers/music/test_sync_resilience.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType, ProviderType
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 
 from music_assistant.constants import (
     CONF_ENTRY_LIBRARY_SYNC_ALBUM_TRACKS,
@@ -398,4 +398,130 @@ async def test_declared_unskippable_error_is_not_swallowed() -> None:
         await provider.sync_library(MediaType.ALBUM)
 
     # the run aborted, so nothing was recorded as a completed sync
+    mass.cache.set.assert_not_called()
+
+
+SKIPPED_ID = "album_2"
+
+
+class SkippingAlbumProvider(FailingAlbumProvider):
+    """Provider that drops one album while listing its library."""
+
+    #: item id handed to report_skipped_sync_item, None to report an unidentifiable item
+    reported_item_id: str | None = SKIPPED_ID
+
+    async def get_library_albums(self) -> AsyncGenerator[Any]:
+        """Yield the test albums, dropping the one that cannot be read."""
+        async for album in super().get_library_albums():
+            if album.item_id == SKIPPED_ID:
+                self.report_skipped_sync_item(
+                    MediaType.ALBUM, self.reported_item_id, InvalidDataError("no artist")
+                )
+                continue
+            yield album
+
+
+def _library_holds(mass: MagicMock, known: dict[str, int]) -> None:
+    """Let the deletion pass resolve the given provider item id's to library db id's."""
+
+    async def get_library_item_by_prov_id(item_id: str, provider: str) -> Any:
+        del provider
+        if (db_id := known.get(item_id)) is None:
+            return None
+        return MagicMock(item_id=db_id)
+
+    mass.music.get_controller.return_value.get_library_item_by_prov_id = AsyncMock(
+        side_effect=get_library_item_by_prov_id
+    )
+
+
+async def test_skipped_item_is_reported_on_the_sync_task() -> None:
+    """An item the provider drops while listing is reported instead of vanishing silently."""
+    mass = _build_mass()
+    provider = _build_provider(mass, cls=SkippingAlbumProvider)
+    _library_holds(mass, {})
+
+    with patch("music_assistant.models.music_provider.report_current_task_failure") as reported:
+        await provider.sync_library(MediaType.ALBUM)
+
+    assert SKIPPED_ID in reported.call_args.args[0]
+    # the rest of the library still synced
+    assert _synced_album_ids(mass) == ["album_1", "album_3"]
+
+
+async def test_skipped_item_we_already_hold_survives_the_deletion_pass() -> None:
+    """
+    A skipped item stays in the result set, while the rest of the deletions still run.
+
+    The item is still in the provider's library, so it must not be read as removed - but
+    a permanently unreadable item may not disable the cleanup for everything else either.
+    """
+    mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
+    provider = _build_provider(mass, cls=SkippingAlbumProvider)
+    _library_holds(mass, {SKIPPED_ID: 2})
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    controller = mass.music.get_controller.return_value
+    # only the album that is really gone is processed, the skipped one is left alone
+    controller.get_library_item.assert_awaited_once_with(99)
+    assert sorted(mass.cache.set.await_args.kwargs["data"]) == [1, 2, 3]
+
+
+async def test_skipped_item_we_do_not_hold_does_not_hold_back_deletions() -> None:
+    """An item that was never imported cannot be deleted, so the cleanup runs as usual."""
+    mass = _build_mass(prev_library_ids=[1, 3, 99])
+    provider = _build_provider(mass, cls=SkippingAlbumProvider)
+    _library_holds(mass, {})
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    mass.music.get_controller.return_value.get_library_item.assert_awaited_once_with(99)
+
+
+class UnidentifiedSkipProvider(SkippingAlbumProvider):
+    """Provider that drops an album it cannot identify."""
+
+    reported_item_id = None
+
+
+async def test_unidentified_skip_holds_back_deletions() -> None:
+    """A provider that cannot say what it dropped holds back the deletions for the whole run."""
+    mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
+    provider = _build_provider(mass, cls=UnidentifiedSkipProvider)
+    _library_holds(mass, {})
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    mass.music.get_controller.return_value.get_library_item.assert_not_called()
+
+
+async def test_skipped_items_are_not_resolved_when_deletions_are_disabled() -> None:
+    """With deletions off there is nothing to protect an item from, so nothing is looked up."""
+    mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
+    provider = _build_provider(mass, cls=SkippingAlbumProvider, sync_deletions=False)
+    _library_holds(mass, {SKIPPED_ID: 2})
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    mass.music.get_controller.return_value.get_library_item_by_prov_id.assert_not_called()
+
+
+class UnskippableSkipProvider(SkippingAlbumProvider):
+    """Provider that declares the error behind its skip unskippable."""
+
+    @property
+    def unskippable_sync_errors(self) -> tuple[type[Exception], ...]:
+        """Return the errors a library sync must not swallow as an item failure."""
+        return (InvalidDataError,)
+
+
+async def test_reported_skip_respects_unskippable_errors() -> None:
+    """Reporting a skip re-raises an error the provider declared unskippable."""
+    mass = _build_mass(prev_library_ids=[1, 2, 3])
+    provider = _build_provider(mass, cls=UnskippableSkipProvider)
+
+    with pytest.raises(InvalidDataError):
+        await provider.sync_library(MediaType.ALBUM)
+
     mass.cache.set.assert_not_called()

--- a/tests/providers/audible/test_audible.py
+++ b/tests/providers/audible/test_audible.py
@@ -38,6 +38,7 @@ def helper(mass_mock: AsyncMock, audible_client_mock: AsyncMock) -> AudibleHelpe
         client=audible_client_mock,
         provider_domain="audible",
         provider_instance="audible_test",
+        provider=MagicMock(),
     )
 
 

--- a/tests/providers/neteasecloudmusic/test_library_tracks.py
+++ b/tests/providers/neteasecloudmusic/test_library_tracks.py
@@ -1,0 +1,68 @@
+"""Tests for NetEase Cloud Music liked-track listing."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock
+
+import pytest
+from music_assistant_models.enums import MediaType
+
+from music_assistant.models.music_provider import SYNC_RUN_STATE, SyncRunState
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from music_assistant.providers.neteasecloudmusic import NeteaseCloudMusicProvider
+
+
+@pytest.fixture
+def sync_run() -> Iterator[SyncRunState]:
+    """Run the library listing as part of a sync run, so its skips are recorded."""
+    state = SyncRunState()
+    token = SYNC_RUN_STATE.set(state)
+    yield state
+    SYNC_RUN_STATE.reset(token)
+
+
+def _song(song_id: int) -> dict[str, Any]:
+    """Return a minimal song payload NCM would hand back."""
+    return {"id": song_id, "name": f"Track {song_id}", "dt": 1000}
+
+
+async def test_liked_track_the_detail_call_left_out_is_reported(
+    provider: NeteaseCloudMusicProvider, sync_run: SyncRunState
+) -> None:
+    """
+    A liked track missing from the detail response is reported, not treated as removed.
+
+    The liked list is what says the track is in the library, so a detail call that leaves
+    it out must not make the deletion pass drop it.
+    """
+    provider._client = AsyncMock()
+    provider._client.get = AsyncMock(return_value={"ids": [1, 2, 3]})
+    provider._get_song_detail = AsyncMock(  # type: ignore[method-assign]
+        return_value=[_song(1), _song(3)]
+    )
+
+    tracks = [track async for track in provider.get_library_tracks()]
+
+    assert [track.item_id for track in tracks] == ["1", "3"]
+    assert sync_run.skipped_item_ids == {MediaType.TRACK: {"2"}}
+    assert not sync_run.incomplete_media_types
+
+
+async def test_complete_detail_response_reports_nothing(
+    provider: NeteaseCloudMusicProvider, sync_run: SyncRunState
+) -> None:
+    """A response holding every liked track reports no skips at all."""
+    provider._client = AsyncMock()
+    provider._client.get = AsyncMock(return_value={"ids": [1, 2]})
+    provider._get_song_detail = AsyncMock(  # type: ignore[method-assign]
+        return_value=[_song(1), _song(2)]
+    )
+
+    tracks = [track async for track in provider.get_library_tracks()]
+
+    assert [track.item_id for track in tracks] == ["1", "2"]
+    assert sync_run.skipped_item_ids == {}

--- a/tests/providers/plex/test_library_sync.py
+++ b/tests/providers/plex/test_library_sync.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import plexapi.exceptions
 import pytest
+from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import Track
 
+from music_assistant.models.music_provider import SYNC_RUN_STATE, SyncRunState
 from music_assistant.providers.plex import PlexProvider
+from music_assistant.providers.plex.constants import CONF_IMPORT_COLLECTIONS
 from music_assistant.providers.plex.helpers import SUPPORTED_FEATURES
 
 LIBRARY_TYPE_AUDIOBOOKS = "audiobooks"
@@ -19,11 +24,14 @@ LIBRARY_TYPE_PODCASTS = "podcasts"
 
 # both listings guard the same destructive failure, so they are covered the same way
 SPOKEN_LIBRARIES = [
-    (LIBRARY_TYPE_AUDIOBOOKS, "get_library_audiobooks", "_parse_audiobook"),
-    (LIBRARY_TYPE_PODCASTS, "get_library_podcasts", "_parse_podcast"),
+    (LIBRARY_TYPE_AUDIOBOOKS, "get_library_audiobooks", "_parse_audiobook", MediaType.AUDIOBOOK),
+    (LIBRARY_TYPE_PODCASTS, "get_library_podcasts", "_parse_podcast", MediaType.PODCAST),
 ]
-SPOKEN_LIBRARY_LISTINGS = [(library, generator) for library, generator, _ in SPOKEN_LIBRARIES]
-SPOKEN_LIBRARY_PARSERS = [(library, parser) for library, _, parser in SPOKEN_LIBRARIES]
+SPOKEN_LIBRARY_LISTINGS = [(library, generator) for library, generator, _, _ in SPOKEN_LIBRARIES]
+SPOKEN_LIBRARY_PARSERS = [(library, parser) for library, _, parser, _ in SPOKEN_LIBRARIES]
+SPOKEN_LIBRARY_ITEMS = [
+    (library, generator, parser) for library, generator, parser, _ in SPOKEN_LIBRARIES
+]
 
 
 class _FakePlexData:
@@ -100,12 +108,41 @@ class _FakePlexAlbum:
         return None
 
 
-def _make_provider(library_type: str = LIBRARY_TYPE_MUSIC) -> Any:
+class _FakePlexCollection:
+    """Minimal PlexCollection stub for the collections-as-playlists listing."""
+
+    def __init__(self, key: str = "/library/collections/5", title: str = "Collection 1") -> None:
+        self.key = key
+        self.title = title
+        # plexapi strips the /children suffix off the raw key, so the payload holds a
+        # different key than the one the item id is built from
+        self._data = _FakePlexData({"title": title, "key": f"{key}/children"})
+
+    def firstAttr(self, *attrs: str) -> str | None:  # noqa: N802
+        return None
+
+
+@contextmanager
+def _sync_run() -> Iterator[SyncRunState]:
+    """Run a library listing as part of a sync run, so its skips are recorded."""
+    state = SyncRunState()
+    token = SYNC_RUN_STATE.set(state)
+    try:
+        yield state
+    finally:
+        SYNC_RUN_STATE.reset(token)
+
+
+def _make_provider(library_type: str = LIBRARY_TYPE_MUSIC, import_collections: bool = False) -> Any:
     """Create a minimal PlexProvider instance for testing."""
     mock_mass = MagicMock()
     mock_config = MagicMock()
     mock_config.instance_id = "plex_instance_1"
-    config_values: dict[str, Any] = {"library_type": library_type, "log_level": "INFO"}
+    config_values: dict[str, Any] = {
+        "library_type": library_type,
+        "log_level": "INFO",
+        CONF_IMPORT_COLLECTIONS: import_collections,
+    }
     mock_config.get_value = lambda key: config_values.get(key)
 
     setup_data = {"library_type": library_type, "token": "local_auth"}
@@ -184,7 +221,7 @@ async def test_library_tracks_does_not_swallow_server_errors(error: Exception) -
         _ = [track async for track in provider.get_library_tracks()]
 
 
-@pytest.mark.parametrize(("library_type", "generator", "parse_method"), SPOKEN_LIBRARIES)
+@pytest.mark.parametrize(("library_type", "generator", "parse_method"), SPOKEN_LIBRARY_ITEMS)
 async def test_spoken_library_skips_unparsable_item(
     library_type: str, generator: str, parse_method: str
 ) -> None:
@@ -282,3 +319,86 @@ async def test_playlist_tracks_skips_unparsable_track() -> None:
 
     assert [track.item_id for track in result] == ["/2", "/3"]
     assert [track.position for track in result] == [1, 2]
+
+
+async def test_skipped_track_is_reported_with_its_item_id() -> None:
+    """
+    A skipped track is reported under the id its provider mapping carries.
+
+    That id is what the deletion pass resolves the item by, so the track it could not read
+    is left alone instead of being removed from the library.
+    """
+    provider = _make_provider()
+    provider._plex_library.searchTracks = MagicMock(
+        side_effect=[[_FakePlexTrack(key="/1", grandparent_key=None)], []]
+    )
+
+    with _sync_run() as state:
+        tracks = [track async for track in provider.get_library_tracks()]
+
+    assert tracks == []
+    assert state.skipped_item_ids == {MediaType.TRACK: {"/1"}}
+    assert state.incomplete is False
+
+
+async def test_unidentifiable_artist_holds_back_the_deletion_pass() -> None:
+    """An artist Plex holds no key for cannot be named, so the whole run is held back."""
+    provider = _make_provider()
+    provider._plex_library.all = MagicMock(return_value=[MagicMock(key="")])
+
+    with _sync_run() as state:
+        assert [artist async for artist in provider.get_library_artists()] == []
+
+    assert state.skipped_item_ids == {}
+    assert state.incomplete is True
+
+
+async def test_skipped_collection_is_reported_as_a_prefixed_playlist() -> None:
+    """
+    A skipped collection is reported under the prefixed id it is stored as a playlist under.
+
+    The bare Plex key belongs to no library item, so reporting that would leave the
+    collection unprotected against the deletion pass.
+    """
+    provider = _make_provider(import_collections=True)
+    collection = _FakePlexCollection()
+    provider._plex_library.playlists = MagicMock(return_value=[])
+    provider._plex_library.collections = MagicMock(return_value=[collection])
+    # take the expectation from the parser itself, so the two can not drift apart
+    parsed = await provider._parse_collection(collection)
+
+    async def _parse_collection(_collection: Any) -> Any:
+        raise InvalidDataError("no title")
+
+    provider._parse_collection = _parse_collection
+
+    with _sync_run() as state:
+        assert [item async for item in provider.get_library_playlists()] == []
+
+    assert state.skipped_item_ids == {MediaType.PLAYLIST: {parsed.item_id}}
+    assert parsed.item_id.startswith("collection:")
+
+
+@pytest.mark.parametrize(
+    ("library_type", "generator", "parse_method", "media_type"), SPOKEN_LIBRARIES
+)
+async def test_spoken_library_reports_skip_with_its_item_id(
+    library_type: str, generator: str, parse_method: str, media_type: MediaType
+) -> None:
+    """An audiobook or podcast is reported under the prefixed id it is stored under."""
+    provider = _make_provider(library_type)
+    album = _FakePlexAlbum()
+    provider._plex_library.albums = MagicMock(return_value=[album])
+    # take the expectation from the parser itself, so the two can not drift apart
+    parsed = await getattr(provider, parse_method)(album)
+
+    async def _parse(_album: Any, **_kwargs: Any) -> Any:
+        raise InvalidDataError("no title")
+
+    setattr(provider, parse_method, _parse)
+
+    with _sync_run() as state:
+        assert [item async for item in getattr(provider, generator)()] == []
+
+    assert state.skipped_item_ids == {media_type: {parsed.item_id}}
+    assert parsed.item_id != album.key

--- a/tests/providers/plex/test_library_sync.py
+++ b/tests/providers/plex/test_library_sync.py
@@ -338,7 +338,7 @@ async def test_skipped_track_is_reported_with_its_item_id() -> None:
 
     assert tracks == []
     assert state.skipped_item_ids == {MediaType.TRACK: {"/1"}}
-    assert state.incomplete is False
+    assert not state.incomplete_media_types
 
 
 async def test_unidentifiable_artist_holds_back_the_deletion_pass() -> None:
@@ -350,7 +350,7 @@ async def test_unidentifiable_artist_holds_back_the_deletion_pass() -> None:
         assert [artist async for artist in provider.get_library_artists()] == []
 
     assert state.skipped_item_ids == {}
-    assert state.incomplete is True
+    assert MediaType.ARTIST in state.incomplete_media_types
 
 
 async def test_skipped_collection_is_reported_as_a_prefixed_playlist() -> None:

--- a/tests/providers/soundcloud/conftest.py
+++ b/tests/providers/soundcloud/conftest.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from music_assistant.models.music_provider import SYNC_RUN_STATE, SyncRunState
 from music_assistant.providers.soundcloud import SUPPORTED_FEATURES, SoundcloudMusicProvider
+
+
+@pytest.fixture
+def sync_run() -> Iterator[SyncRunState]:
+    """Run the library listings as part of a sync run, so their skips are recorded."""
+    state = SyncRunState()
+    token = SYNC_RUN_STATE.set(state)
+    yield state
+    SYNC_RUN_STATE.reset(token)
 
 
 @pytest.fixture

--- a/tests/providers/soundcloud/test_drm_tracks.py
+++ b/tests/providers/soundcloud/test_drm_tracks.py
@@ -126,7 +126,7 @@ async def test_library_drm_tracks_are_not_reported_as_sync_failures(
     assert [track.item_id for track in tracks] == ["2"]
     assert sync_run.skipped_item_ids == {}
     assert sync_run.failures == 0
-    assert sync_run.incomplete is False
+    assert not sync_run.incomplete_media_types
 
 
 async def test_playlist_tracks_skip_drm(provider: SoundcloudMusicProvider) -> None:

--- a/tests/providers/soundcloud/test_drm_tracks.py
+++ b/tests/providers/soundcloud/test_drm_tracks.py
@@ -10,6 +10,7 @@ import pytest
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 
+from music_assistant.models.music_provider import SyncRunState
 from music_assistant.providers.soundcloud import (
     DrmProtectedTrackError,
     SoundcloudMusicProvider,
@@ -102,6 +103,30 @@ async def test_library_tracks_skip_drm_and_log_count(
     assert [track.item_id for track in tracks] == ["2"]
     assert "2" in caplog.text
     assert "DRM" in caplog.text
+
+
+async def test_library_drm_tracks_are_not_reported_as_sync_failures(
+    provider: SoundcloudMusicProvider, sync_run: SyncRunState
+) -> None:
+    """
+    A DRM protected track is left out without counting as a failed sync item.
+
+    Soundcloud never allows those to be imported, so they are a permanent and expected
+    category rather than something that went wrong, and the count is logged in one go.
+    """
+
+    async def _liked_tracks(_user_id: str) -> AsyncGenerator[dict[str, Any]]:
+        yield _track_obj(1, "Danceteria", DRM_TRANSCODINGS)
+        yield _track_obj(2, "Lofi Beat", PLAIN_TRANSCODINGS)
+
+    provider._soundcloud.get_track_details_liked = _liked_tracks
+
+    tracks = [track async for track in provider.get_library_tracks()]
+
+    assert [track.item_id for track in tracks] == ["2"]
+    assert sync_run.skipped_item_ids == {}
+    assert sync_run.failures == 0
+    assert sync_run.incomplete is False
 
 
 async def test_playlist_tracks_skip_drm(provider: SoundcloudMusicProvider) -> None:

--- a/tests/providers/soundcloud/test_library.py
+++ b/tests/providers/soundcloud/test_library.py
@@ -42,7 +42,7 @@ async def test_library_artists_skip_unparsable(
     assert artists[0].name == "Real Artist"
     # the skipped artist has no id to report, so the run can not be a basis for deletions
     assert sync_run.skipped_item_ids == {}
-    assert sync_run.incomplete is True
+    assert MediaType.ARTIST in sync_run.incomplete_media_types
 
 
 async def test_skipped_artist_is_reported_with_its_item_id(
@@ -62,7 +62,7 @@ async def test_skipped_artist_is_reported_with_its_item_id(
     assert [artist async for artist in provider.get_library_artists()] == []
 
     assert sync_run.skipped_item_ids == {MediaType.ARTIST: {"7"}}
-    assert sync_run.incomplete is False
+    assert not sync_run.incomplete_media_types
 
 
 async def test_library_playlists(provider: SoundcloudMusicProvider, sync_run: SyncRunState) -> None:
@@ -80,7 +80,7 @@ async def test_library_playlists(provider: SoundcloudMusicProvider, sync_run: Sy
     assert [playlist.item_id for playlist in playlists] == ["10"]
     assert playlists[0].name == "Summer Mix"
     # the unexpected entry holds no id at all, so the deletion pass is held back
-    assert sync_run.incomplete is True
+    assert MediaType.PLAYLIST in sync_run.incomplete_media_types
 
 
 async def test_library_playlists_skip_failing_details(
@@ -98,7 +98,7 @@ async def test_library_playlists_skip_failing_details(
 
     assert playlists == []
     assert sync_run.skipped_item_ids == {MediaType.PLAYLIST: {"10"}}
-    assert sync_run.incomplete is False
+    assert not sync_run.incomplete_media_types
 
 
 async def test_library_tracks_skip_unparsable(
@@ -116,7 +116,7 @@ async def test_library_tracks_skip_unparsable(
 
     assert [track.item_id for track in tracks] == ["2"]
     assert sync_run.skipped_item_ids == {MediaType.TRACK: {"1"}}
-    assert sync_run.incomplete is False
+    assert not sync_run.incomplete_media_types
 
 
 async def test_recommendation_payload(provider: SoundcloudMusicProvider) -> None:

--- a/tests/providers/soundcloud/test_library.py
+++ b/tests/providers/soundcloud/test_library.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from music_assistant_models.enums import MediaType
+
+from music_assistant.models.music_provider import SyncRunState
 from music_assistant.providers.soundcloud import SoundcloudMusicProvider
 
 
@@ -24,7 +27,9 @@ def _track_obj(track_id: int, title: str = "Some Track") -> dict[str, Any]:
     }
 
 
-async def test_library_artists_skip_unparsable(provider: SoundcloudMusicProvider) -> None:
+async def test_library_artists_skip_unparsable(
+    provider: SoundcloudMusicProvider, sync_run: SyncRunState
+) -> None:
     """An artist without a valid id is skipped, the rest is returned."""
     provider._soundcloud.get_following.return_value = {
         "collection": [_artist_obj(None), _artist_obj(7, "Real Artist")]
@@ -35,9 +40,32 @@ async def test_library_artists_skip_unparsable(provider: SoundcloudMusicProvider
     provider._soundcloud.get_following.assert_awaited_once_with("1")
     assert [artist.item_id for artist in artists] == ["7"]
     assert artists[0].name == "Real Artist"
+    # the skipped artist has no id to report, so the run can not be a basis for deletions
+    assert sync_run.skipped_item_ids == {}
+    assert sync_run.incomplete is True
 
 
-async def test_library_playlists(provider: SoundcloudMusicProvider) -> None:
+async def test_skipped_artist_is_reported_with_its_item_id(
+    provider: SoundcloudMusicProvider, sync_run: SyncRunState
+) -> None:
+    """
+    A skipped artist is reported under the id its provider mapping carries.
+
+    That id is what the deletion pass resolves the item by, so an artist Soundcloud still
+    follows is left alone instead of being removed from the library.
+    """
+    # an artist that carries an id, but no username to build the item from
+    provider._soundcloud.get_following.return_value = {
+        "collection": [{"id": 7, "permalink": "some-artist"}]
+    }
+
+    assert [artist async for artist in provider.get_library_artists()] == []
+
+    assert sync_run.skipped_item_ids == {MediaType.ARTIST: {"7"}}
+    assert sync_run.incomplete is False
+
+
+async def test_library_playlists(provider: SoundcloudMusicProvider, sync_run: SyncRunState) -> None:
     """Playlists are resolved to their full object before being parsed."""
 
     async def _account_playlists() -> AsyncGenerator[dict[str, Any]]:
@@ -51,10 +79,14 @@ async def test_library_playlists(provider: SoundcloudMusicProvider) -> None:
 
     assert [playlist.item_id for playlist in playlists] == ["10"]
     assert playlists[0].name == "Summer Mix"
+    # the unexpected entry holds no id at all, so the deletion pass is held back
+    assert sync_run.incomplete is True
 
 
-async def test_library_playlists_skip_failing_details(provider: SoundcloudMusicProvider) -> None:
-    """A playlist whose details cannot be parsed is skipped."""
+async def test_library_playlists_skip_failing_details(
+    provider: SoundcloudMusicProvider, sync_run: SyncRunState
+) -> None:
+    """A playlist whose details cannot be parsed is skipped and reported under its id."""
 
     async def _account_playlists() -> AsyncGenerator[dict[str, Any]]:
         yield {"playlist": {"id": 10}}
@@ -65,9 +97,13 @@ async def test_library_playlists_skip_failing_details(provider: SoundcloudMusicP
     playlists = [playlist async for playlist in provider.get_library_playlists()]
 
     assert playlists == []
+    assert sync_run.skipped_item_ids == {MediaType.PLAYLIST: {"10"}}
+    assert sync_run.incomplete is False
 
 
-async def test_library_tracks_skip_unparsable(provider: SoundcloudMusicProvider) -> None:
+async def test_library_tracks_skip_unparsable(
+    provider: SoundcloudMusicProvider, sync_run: SyncRunState
+) -> None:
     """A track that cannot be parsed is skipped without failing the sync."""
 
     async def _liked_tracks(_user_id: str) -> AsyncGenerator[dict[str, Any]]:
@@ -79,6 +115,8 @@ async def test_library_tracks_skip_unparsable(provider: SoundcloudMusicProvider)
     tracks = [track async for track in provider.get_library_tracks()]
 
     assert [track.item_id for track in tracks] == ["2"]
+    assert sync_run.skipped_item_ids == {MediaType.TRACK: {"1"}}
+    assert sync_run.incomplete is False
 
 
 async def test_recommendation_payload(provider: SoundcloudMusicProvider) -> None:

--- a/tests/providers/zvuk_music/test_library.py
+++ b/tests/providers/zvuk_music/test_library.py
@@ -86,7 +86,7 @@ class TestGetLibraryArtists:
         collection.artists = [_make_item(1), _make_item(2)]
         provider.client.get_collection = AsyncMock(return_value=collection)
 
-        raw_1, raw_2 = Mock(), Mock()
+        raw_1, raw_2 = _make_item(1), _make_item(2)
         provider.client.get_artists = AsyncMock(return_value=[raw_1, raw_2])
 
         parsed_1, parsed_2 = Mock(), Mock()
@@ -104,7 +104,7 @@ class TestGetLibraryArtists:
         collection.artists = [_make_item(1), _make_item(2)]
         provider.client.get_collection = AsyncMock(return_value=collection)
 
-        raw_1, raw_2 = Mock(), Mock()
+        raw_1, raw_2 = _make_item(1), _make_item(2)
         provider.client.get_artists = AsyncMock(return_value=[raw_1, raw_2])
 
         parsed_2 = Mock()
@@ -168,7 +168,7 @@ class TestGetLibraryAlbums:
         collection.releases = [_make_item(10), _make_item(20)]
         provider.client.get_collection = AsyncMock(return_value=collection)
 
-        raw_1, raw_2 = Mock(), Mock()
+        raw_1, raw_2 = _make_item(10), _make_item(20)
         provider.client.get_releases = AsyncMock(return_value=[raw_1, raw_2])
 
         parsed_1, parsed_2 = Mock(), Mock()
@@ -185,7 +185,7 @@ class TestGetLibraryAlbums:
         collection = Mock()
         collection.releases = [_make_item(10)]
         provider.client.get_collection = AsyncMock(return_value=collection)
-        raw = Mock()
+        raw = _make_item(10)
         provider.client.get_releases = AsyncMock(return_value=[raw])
 
         err = InvalidDataError("bad release")
@@ -222,7 +222,7 @@ class TestGetLibraryTracks:
         collection.tracks = [_make_item(100), _make_item(200)]
         provider.client.get_collection = AsyncMock(return_value=collection)
 
-        raw_1, raw_2 = Mock(), Mock()
+        raw_1, raw_2 = _make_item(100), _make_item(200)
         provider.client.get_tracks = AsyncMock(return_value=[raw_1, raw_2])
 
         parsed_1, parsed_2 = Mock(), Mock()
@@ -279,7 +279,7 @@ class TestGetLibraryPlaylists:
         """User playlists are fetched in batch and parsed."""
         provider = _make_provider()
         provider.client.get_user_playlists = AsyncMock(return_value=[_make_item(1), _make_item(2)])
-        raw_1, raw_2 = Mock(), Mock()
+        raw_1, raw_2 = _make_item(1), _make_item(2)
         provider.client.get_playlists = AsyncMock(return_value=[raw_1, raw_2])
         provider.client.get_short_playlists = AsyncMock(return_value=[])
 
@@ -314,7 +314,7 @@ class TestGetLibraryPlaylists:
         provider = _make_provider()
         # Need at least one user playlist so the method doesn't return early
         provider.client.get_user_playlists = AsyncMock(return_value=[_make_item(1)])
-        provider.client.get_playlists = AsyncMock(return_value=[Mock()])
+        provider.client.get_playlists = AsyncMock(return_value=[_make_item(1)])
         raw_synth = Mock()
         provider.client.get_short_playlists = AsyncMock(return_value=[raw_synth])
 
@@ -338,7 +338,7 @@ class TestGetLibraryPlaylists:
         """InvalidDataError from parse_playlist on a user playlist is skipped."""
         provider = _make_provider()
         provider.client.get_user_playlists = AsyncMock(return_value=[_make_item(1), _make_item(2)])
-        raw_1, raw_2 = Mock(), Mock()
+        raw_1, raw_2 = _make_item(1), _make_item(2)
         provider.client.get_playlists = AsyncMock(return_value=[raw_1, raw_2])
         provider.client.get_short_playlists = AsyncMock(return_value=[])
 
@@ -351,3 +351,44 @@ class TestGetLibraryPlaylists:
             results = [p async for p in provider.get_library_playlists()]
 
         assert results == [good_parsed]
+
+
+class TestBatchFetchGaps:
+    """Tests for id's a batch fetch does not return."""
+
+    @pytest.mark.asyncio
+    async def test_id_the_fetch_left_out_is_reported(self) -> None:
+        """
+        An id the batch fetch did not return is reported instead of looking removed.
+
+        The fetch returns an empty list for a batch it cannot find, which would otherwise
+        drop every item in that batch out of the library.
+        """
+        provider = _make_provider()
+        collection = Mock()
+        collection.artists = [_make_item(1), _make_item(2)]
+        provider.client.get_collection = AsyncMock(return_value=collection)
+        provider.client.get_artists = AsyncMock(return_value=[])
+
+        with patch(f"{_PROVIDER_MODULE}.parse_artist"):
+            results = [a async for a in provider.get_library_artists()]
+
+        assert results == []
+        reported = {call.args[1] for call in provider.report_skipped_sync_item.call_args_list}
+        assert reported == {"1", "2"}
+
+    @pytest.mark.asyncio
+    async def test_id_the_fetch_returned_is_not_reported(self) -> None:
+        """An item that came back fine is not reported as missing."""
+        provider = _make_provider()
+        collection = Mock()
+        collection.artists = [_make_item(1), _make_item(2)]
+        provider.client.get_collection = AsyncMock(return_value=collection)
+        provider.client.get_artists = AsyncMock(return_value=[_make_item(1)])
+
+        with patch(f"{_PROVIDER_MODULE}.parse_artist"):
+            results = [a async for a in provider.get_library_artists()]
+
+        assert len(results) == 1
+        reported = {call.args[1] for call in provider.report_skipped_sync_item.call_args_list}
+        assert reported == {"2"}

--- a/tests/providers/zvuk_music/test_library.py
+++ b/tests/providers/zvuk_music/test_library.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.providers.zvuk_music.constants import DEFAULT_LIMIT
@@ -96,8 +97,8 @@ class TestGetLibraryArtists:
         assert results == [parsed_1, parsed_2]
 
     @pytest.mark.asyncio
-    async def test_invalid_data_error_is_logged_and_item_skipped(self) -> None:
-        """InvalidDataError from parse_artist is logged and the item is skipped."""
+    async def test_invalid_data_error_is_skipped(self) -> None:
+        """InvalidDataError from parse_artist is reported and the item is skipped."""
         provider = _make_provider()
         collection = Mock()
         collection.artists = [_make_item(1), _make_item(2)]
@@ -107,15 +108,18 @@ class TestGetLibraryArtists:
         provider.client.get_artists = AsyncMock(return_value=[raw_1, raw_2])
 
         parsed_2 = Mock()
+        err = InvalidDataError("bad data")
 
         with patch(
             f"{_PROVIDER_MODULE}.parse_artist",
-            side_effect=[InvalidDataError("bad data"), parsed_2],
+            side_effect=[err, parsed_2],
         ):
             results = [a async for a in provider.get_library_artists()]
 
         assert results == [parsed_2]
-        cast("Mock", provider.logger.debug).assert_called()
+        provider.report_skipped_sync_item.assert_called_once_with(
+            MediaType.ARTIST, str(raw_1.id), err
+        )
 
     @pytest.mark.asyncio
     async def test_large_collection_fetches_multiple_batches(self) -> None:
@@ -176,18 +180,20 @@ class TestGetLibraryAlbums:
 
     @pytest.mark.asyncio
     async def test_invalid_data_error_is_skipped(self) -> None:
-        """InvalidDataError from parse_album causes the item to be skipped."""
+        """InvalidDataError from parse_album is reported and the item is skipped."""
         provider = _make_provider()
         collection = Mock()
         collection.releases = [_make_item(10)]
         provider.client.get_collection = AsyncMock(return_value=collection)
-        provider.client.get_releases = AsyncMock(return_value=[Mock()])
+        raw = Mock()
+        provider.client.get_releases = AsyncMock(return_value=[raw])
 
-        with patch(f"{_PROVIDER_MODULE}.parse_album", side_effect=InvalidDataError("bad release")):
+        err = InvalidDataError("bad release")
+        with patch(f"{_PROVIDER_MODULE}.parse_album", side_effect=err):
             results = [a async for a in provider.get_library_albums()]
 
         assert results == []
-        cast("Mock", provider.logger.debug).assert_called()
+        provider.report_skipped_sync_item.assert_called_once_with(MediaType.ALBUM, str(raw.id), err)
 
 
 # ---------------------------------------------------------------------------
@@ -304,24 +310,28 @@ class TestGetLibraryPlaylists:
 
     @pytest.mark.asyncio
     async def test_synthesis_invalid_data_error_is_skipped(self) -> None:
-        """InvalidDataError from a synthesis playlist parser is skipped."""
+        """InvalidDataError from a synthesis playlist parser is reported and skipped."""
         provider = _make_provider()
         # Need at least one user playlist so the method doesn't return early
         provider.client.get_user_playlists = AsyncMock(return_value=[_make_item(1)])
         provider.client.get_playlists = AsyncMock(return_value=[Mock()])
-        provider.client.get_short_playlists = AsyncMock(return_value=[Mock()])
+        raw_synth = Mock()
+        provider.client.get_short_playlists = AsyncMock(return_value=[raw_synth])
 
         # First call (user playlist) succeeds; second call (synthesis) raises
         good_parsed = Mock()
+        err = InvalidDataError("bad synth")
         with patch(
             f"{_PROVIDER_MODULE}.parse_playlist",
-            side_effect=[good_parsed, InvalidDataError("bad synth")],
+            side_effect=[good_parsed, err],
         ):
             results = [p async for p in provider.get_library_playlists()]
 
         # User playlist is yielded; synthesis item is skipped
         assert results == [good_parsed]
-        cast("Mock", provider.logger.debug).assert_called()
+        provider.report_skipped_sync_item.assert_called_once_with(
+            MediaType.PLAYLIST, str(raw_synth.id), err
+        )
 
     @pytest.mark.asyncio
     async def test_invalid_data_error_in_user_playlist_is_skipped(self) -> None:


### PR DESCRIPTION
# What does this implement/fix?

When a music provider cannot read one item while listing its library, it drops that item
and carries on. The sync then has no way to tell that gap apart from an item the user
deleted at the provider, so the cleanup step removes it from the library - a full removal
for providers like Plex, Jellyfin or Subsonic. The sync task also reported no failures at
all, so nothing pointed at what had happened.

Providers now have a supported way to say "I had to skip this one". The item is reported on
the sync task so it shows up in the UI, and it is kept out of the cleanup step on its own,
so a single unreadable item no longer disables cleanup for the rest of the library.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Providers can report an item they had to skip while listing their library, so it appears
  on the sync task instead of disappearing quietly.
- A reported item is kept out of the cleanup step by itself. An item that can never be read
  no longer switches cleanup off for a whole provider, which is what would happen if the
  whole run were held back.
- Only a provider that cannot tell which item it lost holds the cleanup step back for the
  whole run - digitally_incorporated, where one failure drops a whole network's favourites.
- Applied to the library listings of plex, soundcloud, ibroadcast, qqmusic,
  neteasecloudmusic, yandex_music, kion_music, zvuk_music, deezer, storytel, audible,
  gpodder, overcast, builtin and tunein. Several of those dropped items with no log at all.
- SoundCloud DRM protected tracks stay a filter rather than a failure: they can never be
  imported, so they keep their single "skipped N tracks" log line instead of filling the
  sync with errors.
- qqmusic album/track/playlist id extraction moved into shared helpers, so the parsers and
  the skip reporting cannot drift apart.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
