### PR TITLE
Fix static on hi-res AirPlay speakers in compatibility mode

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -208,6 +208,8 @@ class AirPlayPlayer(Player):
         return (
             bool(self.advertised_audio_formats & AIRPLAY_HIRES_AUDIO_FORMATS)
             and self.protocol == StreamingProtocol.AIRPLAY2
+            # the compat lane is 16-bit only, so hi-res stands down while the pin is active
+            and self.streaming_mode != STREAMING_MODE_AP2_COMPAT
         )
 
     @property

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -31,6 +31,7 @@ from music_assistant.providers.airplay.constants import (
     CONF_RAOP_CREDENTIALS,
     CONF_STORED_VOLUME,
     CONF_STREAMING_MODE,
+    STREAMING_MODE_AP2_COMPAT,
     STREAMING_MODE_AP2_NTP,
     STREAMING_MODE_AUTO,
     STREAMING_MODE_RAOP,
@@ -530,6 +531,8 @@ def _configure_player(player: AirPlayPlayer, values: dict[str, object]) -> None:
         (ALAC_48000_24, STREAMING_MODE_AUTO, True, [(44100, 24), (48000, 24)]),
         # the RAOP mode cannot do 24-bit: falls back to the 16-bit base
         (ALAC_44100_24, STREAMING_MODE_RAOP, True, [(44100, 16)]),
+        # the compatibility mode streams through the 16-bit RAOP flow
+        (ALAC_44100_24, STREAMING_MODE_AP2_COMPAT, True, [(44100, 16)]),
         # a receiver that streams RAOP never gets 24-bit, whatever it advertises
         (ALAC_44100_24, STREAMING_MODE_AUTO, False, [(44100, 16)]),
         # only 16-bit advertised: the 16-bit default
@@ -555,6 +558,23 @@ def test_hires_supported_sample_rates(
     airplay_player.advertised_audio_formats = advertised_audio_formats
     _configure_player(airplay_player, {CONF_STREAMING_MODE: streaming_mode})
     assert airplay_player.supported_sample_rates == expected
+
+
+def test_hires_disabled_in_compatibility_mode(airplay_player: AirPlayPlayer) -> None:
+    """A hi-res device pinned to compatibility mode drops back to the 16-bit base."""
+    _set_discovery_info(airplay_player, raop=True, airplay=True, airplay_features=AP2_FEATURES)
+    airplay_player.advertised_audio_formats = ALAC_44100_24
+    _configure_player(airplay_player, {CONF_STREAMING_MODE: STREAMING_MODE_AP2_COMPAT})
+
+    # the compat lanes keep reporting AirPlay 2, so the protocol alone cannot gate hi-res
+    assert airplay_player.protocol == StreamingProtocol.AIRPLAY2
+    assert airplay_player.hires_playback_enabled is False
+    assert airplay_player.supported_sample_rates == [(44100, 16)]
+
+    session_format = AudioFormat(
+        content_type=ContentType.PCM_F32LE, sample_rate=48000, bit_depth=32
+    )
+    assert airplay_player.get_stream_pcm_format(session_format) == AIRPLAY_PCM_FORMAT
 
 
 def test_get_stream_pcm_format_hires(airplay_player: AirPlayPlayer) -> None:


### PR DESCRIPTION
# What does this implement/fix?

AirPlay players that support hi-res audio play nothing but static when they are set to "AirPlay 2 - compatibility mode". That mode streams through the 16-bit RAOP flow, but the player still reported itself as AirPlay 2, so Music Assistant kept 24-bit playback switched on and sent the speaker 24-bit audio it cannot decode.

This also hits people who never touched the setting: when a HomePod or Apple TV stops answering the AirPlay 2 control channel, Music Assistant switches that player to compatibility mode by itself for the next playback. One user with eight HomePod Pros had every speaker switched over after network trouble and got static on all of them. He [confirmed](https://github.com/orgs/music-assistant/discussions/5982#discussioncomment-18093762) that the audio returned to normal when he set the streaming mode back to automatic.

The fix makes hi-res playback stand down while compatibility mode is in use. Everything else follows from that one switch: the offered sample rates, the audio format we produce and the bit depth we hand to the streaming binary.

Not changed here: whether Music Assistant should switch players to compatibility mode on its own. That is a separate discussion.

- Hi-res playback is now off while a player is in AirPlay 2 compatibility mode
- Those players stay on the 16-bit 44.1 kHz format the mode actually supports
- Tests added for a hi-res speaker pinned to compatibility mode

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.