### PR TITLE
Start the next track's crossfade audio while the current one is still playing

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -274,6 +274,7 @@ class _IncomingFadePrefetcher:
         self._chunks: deque[bytes] = deque()
         self._target = 0
         self._failed = False
+        self._collected_at_handover = 0
         self._task: asyncio.Task[None] | None = None
 
     def ensure_started(
@@ -371,8 +372,14 @@ class _IncomingFadePrefetcher:
             return None
         chunks, stream = self._chunks, self._stream
         assert stream is not None
+        self._collected_at_handover = sum(len(chunk) for chunk in chunks)
         self._reset()
         return self._replay(chunks, stream)
+
+    @property
+    def collected_at_handover(self) -> int:
+        """Return how many bytes the last handover already had in hand."""
+        return self._collected_at_handover
 
     async def close(self) -> None:
         """Abandon a pending prefetch and release the incoming track's stream."""
@@ -2333,6 +2340,7 @@ class StreamsAudio:
                 collect_resident = 0.0
                 incoming_crossfade_size = crossfade_buffer_size
                 incoming_audio_buffer: AudioBuffer | None = None
+                build_seconds = 0.0
                 transition_mode = CrossfadeMode.DISABLED
                 applied_mode = CrossfadeMode.DISABLED
                 outgoing_queue_track = last_queue_track
@@ -2370,6 +2378,7 @@ class StreamsAudio:
                         collect_started = asyncio.get_event_loop().time()
                         collect_resident = incoming_audio_buffer.duration_available
                         applied_mode = transition_mode
+                        build_started = asyncio.get_event_loop().time()
                         crossfade_smart_fade = await self.smart_fades_mixer.build(
                             fade_in_streamdetails=queue_track.streamdetails,
                             fade_out_streamdetails=last_streamdetails,
@@ -2379,6 +2388,7 @@ class StreamsAudio:
                             fade_out_data=last_fadeout_part,
                             fade_in_bytes_len=incoming_crossfade_size,
                         )
+                        build_seconds = asyncio.get_event_loop().time() - build_started
                         timing_info = crossfade_smart_fade.timing_info
                         if isinstance(crossfade_smart_fade, StandardCrossFade):
                             # the mixer degrades to a standard fade when the smart one
@@ -2422,6 +2432,7 @@ class StreamsAudio:
                 holdback_armed = False
 
                 item_stream = await incoming_prefetcher.take(queue_track, int(raw_seek_position))
+                prefetched_size = incoming_prefetcher.collected_at_handover if item_stream else 0
                 if item_stream is None:
                     item_stream = self.get_queue_item_stream(
                         queue_track,
@@ -2515,11 +2526,14 @@ class StreamsAudio:
                             and last_play_log_entry is not None
                         ):
                             self.logger.debug(
-                                "Collected %.1fs of incoming audio for the transition into %s in %.1fs"
-                                " (%.1fs was resident when it started)",
+                                "Collected %.1fs of incoming audio for the transition into %s"
+                                " in %.1fs (%.1fs prefetched, %.1fs build,"
+                                " %.1fs was resident when it started)",
                                 len(crossfade_buffer) / pcm_sample_size,
                                 queue_track.name,
                                 asyncio.get_event_loop().time() - collect_started,
+                                prefetched_size / pcm_sample_size,
+                                build_seconds,
                                 collect_resident,
                             )
                             fadein_part = bytes(crossfade_buffer[:incoming_crossfade_size])

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -306,6 +306,8 @@ class _IncomingFadePrefetcher:
             or next_item.media_type != MediaType.TRACK
             or (streamdetails := next_item.streamdetails) is None
             or streamdetails.is_realtime
+            # without a duration the read below cannot be kept clear of the track's end
+            or not streamdetails.duration
             or (audio_buffer := cast("AudioBuffer | None", streamdetails.buffer)) is None
             or audio_buffer.has_error
             or not audio_buffer.is_valid()
@@ -316,10 +318,10 @@ class _IncomingFadePrefetcher:
             if crossfade_mode == CrossfadeMode.SMART_CROSSFADE
             else standard_crossfade_duration
         )
-        if streamdetails.duration:
-            # never read a track to its end in the background: that would report it to its
-            # provider as streamed before a single second of it has reached the player
-            overlap = min(overlap, streamdetails.duration / 2)
+        # never read a track to its end in the background: that would report it to its
+        # provider as streamed before a single second of it has reached the player.
+        # A track always plays at its own pace, so its duration is also its stream length.
+        overlap = min(overlap, streamdetails.duration / 2)
         if overlap <= 0:
             return
         self._target = int(self._pcm_format.pcm_sample_size * overlap)

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -310,11 +310,15 @@ class _IncomingFadePrefetcher:
             or not audio_buffer.is_valid()
         ):
             return
-        overlap = (
+        overlap: float = (
             SMART_CROSSFADE_DURATION
             if crossfade_mode == CrossfadeMode.SMART_CROSSFADE
             else standard_crossfade_duration
         )
+        if streamdetails.duration:
+            # never read a track to its end in the background: that would report it to its
+            # provider as streamed before a single second of it has reached the player
+            overlap = min(overlap, streamdetails.duration / 2)
         if overlap <= 0:
             return
         self._target = int(self._pcm_format.pcm_sample_size * overlap)
@@ -333,7 +337,7 @@ class _IncomingFadePrefetcher:
         )
         self._task = asyncio.create_task(self._collect(self._stream, self._chunks))
         self._audio.logger.debug(
-            "Prefetching %s seconds of %s while the tail of %s is held back",
+            "Prefetching %.0f seconds of %s while the tail of %s is held back",
             overlap,
             next_item.name,
             queue_item.name,
@@ -2431,165 +2435,171 @@ class StreamsAudio:
                         prepared_buffer=incoming_audio_buffer,
                     )
 
-                async for chunk in item_stream:
-                    # if a newer producer has taken over this queue, stop sending
-                    # audio and exit cleanly before the outer-loop end-of-track
-                    # bookkeeping mutates seconds_streamed / duration on the log
-                    if _superseded():
-                        self.logger.debug(
-                            "Flow stream for queue %s superseded - stopping chunk yield",
-                            queue.display_name,
-                        )
-                        return
-                    total_chunks_received += 1
-                    if not first_chunk_received:
-                        first_chunk_received = True
-                        # inform the queue that the track is now loaded in the buffer
-                        # so the next track can be preloaded
-                        self.mass.player_queues.track_loaded_in_buffer(
-                            queue.queue_id, queue_track.queue_item_id
-                        )
+                # closing here releases the decoders on an early exit,
+                # instead of leaving them to the garbage collector
+                async with aclosing(item_stream):
+                    async for chunk in item_stream:
+                        # if a newer producer has taken over this queue, stop sending
+                        # audio and exit cleanly before the outer-loop end-of-track
+                        # bookkeeping mutates seconds_streamed / duration on the log
+                        if _superseded():
+                            self.logger.debug(
+                                "Flow stream for queue %s superseded - stopping chunk yield",
+                                queue.display_name,
+                            )
+                            return
+                        total_chunks_received += 1
+                        if not first_chunk_received:
+                            first_chunk_received = True
+                            # inform the queue that the track is now loaded in the buffer
+                            # so the next track can be preloaded
+                            self.mass.player_queues.track_loaded_in_buffer(
+                                queue.queue_id, queue_track.queue_item_id
+                            )
 
-                    if item_crossfade_mode == CrossfadeMode.DISABLED:
-                        # no cross/smart fade: yield chunks directly without intermediate buffer
-                        yield chunk
-                        bytes_written += len(chunk)
-                        del chunk
-                        continue
-
-                    # Warmup: yield chunks directly until we have streamed WARMUP_DURATION
-                    # worth of audio, so playback starts immediately. Skip warmup when
-                    # crossfade data from the previous track is pending — we need a full
-                    # buffer for the mix.
-                    if warmup_bytes < warmup_size and not last_fadeout_part:
-                        yield chunk
-                        warmup_bytes += len(chunk)
-                        bytes_written += len(chunk)
-                        del chunk
-                        continue
-
-                    if not last_fadeout_part and not holdback_armed:
-                        holdback_armed = self._crossfade_holdback_allowed(
-                            queue_track.streamdetails,
-                            crossfade_buffer_duration,
-                            track_playback_speed,
-                        )
-                        if not holdback_armed:
-                            # holding audio back now would only shrink the player's lead
+                        if item_crossfade_mode == CrossfadeMode.DISABLED:
+                            # no cross/smart fade: yield chunks directly without intermediate buffer
                             yield chunk
                             bytes_written += len(chunk)
                             del chunk
                             continue
 
-                    if not last_fadeout_part:
-                        # the tail is being held back, so the audio the next transition
-                        # blends in can be gathered alongside it instead of after it
-                        incoming_prefetcher.ensure_started(
-                            queue,
-                            queue_track,
-                            item_crossfade_mode,
-                            standard_crossfade_duration,
-                        )
+                        # Warmup: yield chunks directly until we have streamed WARMUP_DURATION
+                        # worth of audio, so playback starts immediately. Skip warmup when
+                        # crossfade data from the previous track is pending — we need a full
+                        # buffer for the mix.
+                        if warmup_bytes < warmup_size and not last_fadeout_part:
+                            yield chunk
+                            warmup_bytes += len(chunk)
+                            bytes_written += len(chunk)
+                            del chunk
+                            continue
 
-                    # smart fades enabled: accumulate chunks in crossfade buffer
-                    crossfade_buffer.extend(chunk)
-                    del chunk
-                    required_buffer_size = (
-                        incoming_crossfade_size if last_fadeout_part else crossfade_buffer_size
-                    )
-                    if len(crossfade_buffer) < required_buffer_size:
-                        await asyncio.sleep(0)
-                        continue
-                    # handle crossfade of previous track and new track
-                    if (
-                        last_fadeout_part
-                        and last_streamdetails
-                        and crossfade_smart_fade is not None
-                        and last_play_log_entry is not None
-                    ):
-                        self.logger.debug(
-                            "Collected %.1fs of incoming audio for the transition into %s in %.1fs"
-                            " (%.1fs was resident when it started)",
-                            len(crossfade_buffer) / pcm_sample_size,
-                            queue_track.name,
-                            asyncio.get_event_loop().time() - collect_started,
-                            collect_resident,
+                        if not last_fadeout_part and not holdback_armed:
+                            holdback_armed = self._crossfade_holdback_allowed(
+                                queue_track.streamdetails,
+                                crossfade_buffer_duration,
+                                track_playback_speed,
+                            )
+                            if not holdback_armed:
+                                # holding audio back now would only shrink the player's lead
+                                yield chunk
+                                bytes_written += len(chunk)
+                                del chunk
+                                continue
+
+                        if not last_fadeout_part:
+                            # the tail is being held back, so the audio the next transition
+                            # blends in can be gathered alongside it instead of after it
+                            incoming_prefetcher.ensure_started(
+                                queue,
+                                queue_track,
+                                item_crossfade_mode,
+                                standard_crossfade_duration,
+                            )
+
+                        # smart fades enabled: accumulate chunks in crossfade buffer
+                        crossfade_buffer.extend(chunk)
+                        del chunk
+                        required_buffer_size = (
+                            incoming_crossfade_size if last_fadeout_part else crossfade_buffer_size
                         )
-                        fadein_part = bytes(crossfade_buffer[:incoming_crossfade_size])
-                        remaining_bytes = bytes(crossfade_buffer[incoming_crossfade_size:])
-                        try:
-                            crossfade_bytes_written = 0
-                            async for mix_chunk in self.smart_fades_mixer.mix(
-                                crossfade_smart_fade,
-                                fade_in_part=fadein_part,
-                                fade_out_part=last_fadeout_part,
-                                pcm_format=pcm_format,
-                            ):
-                                yield mix_chunk
-                                crossfade_bytes_written += len(mix_chunk)
-                        except Exception as mix_err:
-                            if crossfade_bytes_written:
-                                # partial mix already played — concat'd tail would duplicate audio
-                                raise
-                            self.logger.warning(
-                                "Crossfade mixer failed for %s, falling back to simple concat: %s",
+                        if len(crossfade_buffer) < required_buffer_size:
+                            await asyncio.sleep(0)
+                            continue
+                        # handle crossfade of previous track and new track
+                        if (
+                            last_fadeout_part
+                            and last_streamdetails
+                            and crossfade_smart_fade is not None
+                            and last_play_log_entry is not None
+                        ):
+                            self.logger.debug(
+                                "Collected %.1fs of incoming audio for the transition into %s in %.1fs"
+                                " (%.1fs was resident when it started)",
+                                len(crossfade_buffer) / pcm_sample_size,
                                 queue_track.name,
-                                mix_err,
+                                asyncio.get_event_loop().time() - collect_started,
+                                collect_resident,
                             )
-                            for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
-                                yield pcm_slice
-                                await asyncio.sleep(0)
-                            # full tail was pre-counted and is now yielded as-is
-                            crossfade_bytes_written = 0
-                            remaining_bytes = bytes(crossfade_buffer)
-                            # mix failed — undo the eager seek_position
-                            queue_track.streamdetails.seek_position = raw_seek_position
-                        if crossfade_bytes_written:
-                            # the blend really played, so credit both of its sides with it
-                            for faded_item in (queue_track, outgoing_queue_track):
-                                if faded_item is None:
-                                    continue
-                                self._report_crossfade_mode(
-                                    queue.queue_id,
-                                    faded_item,
-                                    pcm_format,
-                                    applied_mode,
-                                    flow_session_id,
-                                    overlay_enabled=overlay_active(queue),
+                            fadein_part = bytes(crossfade_buffer[:incoming_crossfade_size])
+                            remaining_bytes = bytes(crossfade_buffer[incoming_crossfade_size:])
+                            try:
+                                crossfade_bytes_written = 0
+                                async for mix_chunk in self.smart_fades_mixer.mix(
+                                    crossfade_smart_fade,
+                                    fade_in_part=fadein_part,
+                                    fade_out_part=last_fadeout_part,
+                                    pcm_format=pcm_format,
+                                ):
+                                    yield mix_chunk
+                                    crossfade_bytes_written += len(mix_chunk)
+                            except Exception as mix_err:
+                                if crossfade_bytes_written:
+                                    # partial mix already played — concat'd tail would duplicate audio
+                                    raise
+                                self.logger.warning(
+                                    "Crossfade mixer failed for %s, falling back to simple concat: %s",
+                                    queue_track.name,
+                                    mix_err,
                                 )
-                            # Split mix output at end-of-overlap: PRE+CF to A, POST to B.
-                            fadeout_share_seconds = (
-                                timing_info.pre_crossfade_duration + timing_info.crossfade_duration
-                            )
-                            fadeout_share = int(fadeout_share_seconds * pcm_sample_size)
-                            fadeout_share = (fadeout_share // frame_size) * frame_size
-                            fadeout_share = min(fadeout_share, crossfade_bytes_written)
-                            fadein_share = crossfade_bytes_written - fadeout_share
-                            bytes_written += fadein_share
-                            if last_play_log_entry:
-                                assert last_play_log_entry.seconds_streamed is not None
-                                # correct pre-counted full tail to the timing-based share
-                                last_play_log_entry.seconds_streamed += (
-                                    fadeout_share - len(last_fadeout_part)
-                                ) / pcm_sample_size
-                        if remaining_bytes:
-                            for pcm_slice in iter_pcm_slices(remaining_bytes, pcm_format, 1000):
-                                yield pcm_slice
-                                await asyncio.sleep(0)
-                            bytes_written += len(remaining_bytes)
-                            del remaining_bytes
-                        last_fadeout_part = b""
-                        last_streamdetails = None
-                        last_queue_track = None
-                        crossfade_buffer = bytearray()
-                        warmup_bytes = 0
+                                for pcm_slice in iter_pcm_slices(
+                                    last_fadeout_part, pcm_format, 1000
+                                ):
+                                    yield pcm_slice
+                                    await asyncio.sleep(0)
+                                # full tail was pre-counted and is now yielded as-is
+                                crossfade_bytes_written = 0
+                                remaining_bytes = bytes(crossfade_buffer)
+                                # mix failed — undo the eager seek_position
+                                queue_track.streamdetails.seek_position = raw_seek_position
+                            if crossfade_bytes_written:
+                                # the blend really played, so credit both of its sides with it
+                                for faded_item in (queue_track, outgoing_queue_track):
+                                    if faded_item is None:
+                                        continue
+                                    self._report_crossfade_mode(
+                                        queue.queue_id,
+                                        faded_item,
+                                        pcm_format,
+                                        applied_mode,
+                                        flow_session_id,
+                                        overlay_enabled=overlay_active(queue),
+                                    )
+                                # Split mix output at end-of-overlap: PRE+CF to A, POST to B.
+                                fadeout_share_seconds = (
+                                    timing_info.pre_crossfade_duration
+                                    + timing_info.crossfade_duration
+                                )
+                                fadeout_share = int(fadeout_share_seconds * pcm_sample_size)
+                                fadeout_share = (fadeout_share // frame_size) * frame_size
+                                fadeout_share = min(fadeout_share, crossfade_bytes_written)
+                                fadein_share = crossfade_bytes_written - fadeout_share
+                                bytes_written += fadein_share
+                                if last_play_log_entry:
+                                    assert last_play_log_entry.seconds_streamed is not None
+                                    # correct pre-counted full tail to the timing-based share
+                                    last_play_log_entry.seconds_streamed += (
+                                        fadeout_share - len(last_fadeout_part)
+                                    ) / pcm_sample_size
+                            if remaining_bytes:
+                                for pcm_slice in iter_pcm_slices(remaining_bytes, pcm_format, 1000):
+                                    yield pcm_slice
+                                    await asyncio.sleep(0)
+                                bytes_written += len(remaining_bytes)
+                                del remaining_bytes
+                            last_fadeout_part = b""
+                            last_streamdetails = None
+                            last_queue_track = None
+                            crossfade_buffer = bytearray()
+                            warmup_bytes = 0
 
-                    # yield everything above the crossfade buffer size
-                    while len(crossfade_buffer) > crossfade_buffer_size:
-                        yield bytes(crossfade_buffer[:pcm_sample_size])
-                        bytes_written += pcm_sample_size
-                        del crossfade_buffer[:pcm_sample_size]
-                        await asyncio.sleep(0)
+                        # yield everything above the crossfade buffer size
+                        while len(crossfade_buffer) > crossfade_buffer_size:
+                            yield bytes(crossfade_buffer[:pcm_sample_size])
+                            bytes_written += pcm_sample_size
+                            del crossfade_buffer[:pcm_sample_size]
+                            await asyncio.sleep(0)
 
                 # A source error after partial audio must not look like a completed item.
                 # Progress reporting skips items with stream_error, so the item is not

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -320,19 +320,21 @@ class _IncomingFadePrefetcher:
         )
         # never read a track to its end in the background: that would report it to its
         # provider as streamed before a single second of it has reached the player.
-        # A track always plays at its own pace, so its duration is also its stream length.
-        overlap = min(overlap, streamdetails.duration / 2)
+        # A track always plays at its own pace, so what is left of it after the seek is
+        # also what is left of the stream.
+        seek_position = int(streamdetails.seek_position)
+        overlap = min(overlap, (streamdetails.duration - seek_position) / 2)
         if overlap <= 0:
             return
         self._target = int(self._pcm_format.pcm_sample_size * overlap)
         self._queue_item_id = next_item.queue_item_id
         self._streamdetails = streamdetails
-        self._seek_position = int(streamdetails.seek_position)
+        self._seek_position = seek_position
         self._chunks = deque()
         self._stream = self._audio.get_queue_item_stream(
             next_item,
             pcm_format=self._pcm_format,
-            seek_position=self._seek_position,
+            seek_position=seek_position,
             playback_speed=cast("float", next_item.extra_attributes.get("playback_speed", 1.0)),
             raise_on_error=False,
             session_id=self._session_id,
@@ -421,7 +423,10 @@ class _IncomingFadePrefetcher:
                 collected += len(chunk)
                 # re-read the target every chunk: it drops to zero on handover
                 if collected >= self._target:
-                    break
+                    return
+            # the target is kept clear of the track's end, so running out here means the
+            # source gave up early and the flow stream is better off opening it again
+            self._failed = True
         except Exception as err:
             # the flow stream opens the track itself rather than inheriting a dead stream
             self._failed = True

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -268,9 +268,12 @@ class _IncomingFadePrefetcher:
         self._pcm_format = pcm_format
         self._session_id = session_id
         self._queue_item_id: str | None = None
+        self._streamdetails: StreamDetails | None = None
+        self._seek_position = 0
         self._stream: AsyncGenerator[bytes] | None = None
         self._chunks: deque[bytes] = deque()
         self._target = 0
+        self._failed = False
         self._task: asyncio.Task[None] | None = None
 
     def ensure_started(
@@ -316,11 +319,13 @@ class _IncomingFadePrefetcher:
             return
         self._target = int(self._pcm_format.pcm_sample_size * overlap)
         self._queue_item_id = next_item.queue_item_id
+        self._streamdetails = streamdetails
+        self._seek_position = int(streamdetails.seek_position)
         self._chunks = deque()
         self._stream = self._audio.get_queue_item_stream(
             next_item,
             pcm_format=self._pcm_format,
-            seek_position=int(streamdetails.seek_position),
+            seek_position=self._seek_position,
             playback_speed=cast("float", next_item.extra_attributes.get("playback_speed", 1.0)),
             raise_on_error=False,
             session_id=self._session_id,
@@ -334,23 +339,32 @@ class _IncomingFadePrefetcher:
             queue_item.name,
         )
 
-    async def take(self, queue_item: QueueItem) -> AsyncGenerator[bytes] | None:
+    async def take(self, queue_item: QueueItem, seek_position: int) -> AsyncGenerator[bytes] | None:
         """
         Hand over the prefetched stream for the given queue item.
 
-        Returns None when nothing was prefetched for this item, in which case the caller
-        opens the stream itself.
+        Returns None unless the prefetch is for exactly the track and position the flow
+        stream is about to play and is still usable; the caller then opens the stream
+        itself, which also gives a broken source its chance to be re-resolved.
 
         :param queue_item: Queue item the flow stream is about to play.
+        :param seek_position: Position in seconds the item is to be streamed from.
         """
         if self._task is None:
             return None
-        if self._queue_item_id != queue_item.queue_item_id:
+        if (
+            self._queue_item_id != queue_item.queue_item_id
+            or self._streamdetails is not queue_item.streamdetails
+            or self._seek_position != seek_position
+        ):
             await self.close()
             return None
         # stop collecting: from here the flow stream reads the same generator itself
         self._target = 0
         await self._task
+        if self._failed or (self._streamdetails is not None and self._streamdetails.stream_error):
+            await self.close()
+            return None
         chunks, stream = self._chunks, self._stream
         assert stream is not None
         self._reset()
@@ -359,13 +373,18 @@ class _IncomingFadePrefetcher:
     async def close(self) -> None:
         """Abandon a pending prefetch and release the incoming track's stream."""
         task, stream = self._task, self._stream
-        self._reset()
+        # stop the collector before dropping the handles, so a task still running
+        # cannot write into the state a next prefetch starts from
+        self._target = 0
         if task is not None:
             task.cancel()
             with suppress(asyncio.CancelledError):
                 await task
-        if stream is not None:
+        # an outer cancellation can land on the await above, leaving the collector inside
+        # the generator; closing it from here would be a second concurrent entry
+        if stream is not None and (task is None or task.done()):
             await stream.aclose()
+        self._reset()
 
     # --- Private methods ---
 
@@ -374,8 +393,11 @@ class _IncomingFadePrefetcher:
         self._task = None
         self._stream = None
         self._queue_item_id = None
+        self._streamdetails = None
+        self._seek_position = 0
         self._chunks = deque()
         self._target = 0
+        self._failed = False
 
     async def _collect(self, stream: AsyncGenerator[bytes], chunks: deque[bytes]) -> None:
         """Read the incoming track until the fade-in target is reached."""
@@ -388,7 +410,8 @@ class _IncomingFadePrefetcher:
                 if collected >= self._target:
                     break
         except Exception as err:
-            # whatever was collected is still handed over, the rest is read by the flow stream
+            # the flow stream opens the track itself rather than inheriting a dead stream
+            self._failed = True
             self._audio.logger.warning("Failed to prefetch the incoming fade-in: %s", err)
 
     async def _replay(
@@ -1945,16 +1968,6 @@ class StreamsAudio:
                     fade_in_playback_speed,
                 )
                 crossfade_allowed = transition_mode != CrossfadeMode.DISABLED
-        if transition_mode != CrossfadeMode.DISABLED:
-            # the fade leaving this item is settled, so report what it really is
-            self._report_crossfade_mode(
-                queue.queue_id,
-                queue_item,
-                pcm_format,
-                transition_mode,
-                session_id,
-                overlay_enabled=False,
-            )
         if not crossfade_allowed:
             # no crossfade enabled/allowed, just yield the buffer last part
             bytes_written += len(buffer)
@@ -2011,6 +2024,12 @@ class StreamsAudio:
                     fade_out_data=fade_out_data,
                     fade_in_bytes_len=fade_in_buffer_size,
                 )
+                # the mixer degrades to a standard fade when the smart one cannot be planned
+                applied_mode = (
+                    CrossfadeMode.STANDARD_CROSSFADE
+                    if isinstance(smart_fade, StandardCrossFade)
+                    else transition_mode
+                )
                 crossfade_timing = smart_fade.timing_info
                 # Split mix output at end-of-overlap: PRE+CF to A, POST to B's intro.
                 fadeout_share_bytes = int(
@@ -2040,13 +2059,21 @@ class StreamsAudio:
                         second_part_buf.extend(mix_chunk)
                 # tail consumed by the mix but not credited to bytes_written
                 uncredited_tail_bytes = len(fade_out_data) - first_part_written
+                self._report_crossfade_mode(
+                    queue.queue_id,
+                    queue_item,
+                    pcm_format,
+                    applied_mode,
+                    session_id,
+                    overlay_enabled=False,
+                )
                 self._crossfade_data[queue_item.queue_id] = CrossfadeData(
                     data=bytes(second_part_buf),
                     fade_in_media_duration=(fade_in_bytes_consumed / pcm_format.pcm_sample_size)
                     * fade_in_playback_speed,
                     pcm_format=pcm_format,
                     queue_item_id=next_queue_item.queue_item_id,
-                    crossfade_mode=transition_mode,
+                    crossfade_mode=applied_mode,
                     elapsed_time_offset=(
                         crossfade_timing.fadein_trimmed_duration
                         + crossfade_timing.crossfade_duration
@@ -2303,6 +2330,7 @@ class StreamsAudio:
                 incoming_crossfade_size = crossfade_buffer_size
                 incoming_audio_buffer: AudioBuffer | None = None
                 transition_mode = CrossfadeMode.DISABLED
+                applied_mode = CrossfadeMode.DISABLED
                 outgoing_queue_track = last_queue_track
                 if last_fadeout_part and last_streamdetails:
                     incoming_duration = 0.0
@@ -2337,6 +2365,7 @@ class StreamsAudio:
                         # slow collection here is heard as a gap at the transition
                         collect_started = asyncio.get_event_loop().time()
                         collect_resident = incoming_audio_buffer.duration_available
+                        applied_mode = transition_mode
                         crossfade_smart_fade = await self.smart_fades_mixer.build(
                             fade_in_streamdetails=queue_track.streamdetails,
                             fade_out_streamdetails=last_streamdetails,
@@ -2348,6 +2377,9 @@ class StreamsAudio:
                         )
                         timing_info = crossfade_smart_fade.timing_info
                         if isinstance(crossfade_smart_fade, StandardCrossFade):
+                            # the mixer degrades to a standard fade when the smart one
+                            # cannot be planned, so that is what will really be applied
+                            applied_mode = CrossfadeMode.STANDARD_CROSSFADE
                             # A standard fade blends its overlap and passes everything after it
                             # through untouched, so only the overlap has to be in hand before
                             # the transition can start. Holding back the rest buys nothing and
@@ -2366,25 +2398,15 @@ class StreamsAudio:
                             + (timing_info.fadein_trimmed_duration + timing_info.crossfade_duration)
                             * track_playback_speed
                         )
-                # the boundary has decided, so the fade can now be reported for real:
-                # this track's fade-in, and - when it happens - the outgoing track's fade-out
+                # no fade is credited to this track until one is really rendered below
                 self._report_crossfade_mode(
                     queue.queue_id,
                     queue_track,
                     pcm_format,
-                    transition_mode,
+                    CrossfadeMode.DISABLED,
                     flow_session_id,
                     overlay_enabled=overlay_active(queue),
                 )
-                if transition_mode != CrossfadeMode.DISABLED and outgoing_queue_track is not None:
-                    self._report_crossfade_mode(
-                        queue.queue_id,
-                        outgoing_queue_track,
-                        pcm_format,
-                        transition_mode,
-                        flow_session_id,
-                        overlay_enabled=overlay_active(queue),
-                    )
                 # append to play log so the queue controller can work out which track is playing
                 play_log_entry = PlayLogEntry(queue_track.queue_item_id)
                 flow_log.append(play_log_entry)
@@ -2395,7 +2417,7 @@ class StreamsAudio:
                 first_chunk_received = False
                 holdback_armed = False
 
-                item_stream = await incoming_prefetcher.take(queue_track)
+                item_stream = await incoming_prefetcher.take(queue_track, int(raw_seek_position))
                 if item_stream is None:
                     item_stream = self.get_queue_item_stream(
                         queue_track,
@@ -2523,6 +2545,18 @@ class StreamsAudio:
                             # mix failed — undo the eager seek_position
                             queue_track.streamdetails.seek_position = raw_seek_position
                         if crossfade_bytes_written:
+                            # the blend really played, so credit both of its sides with it
+                            for faded_item in (queue_track, outgoing_queue_track):
+                                if faded_item is None:
+                                    continue
+                                self._report_crossfade_mode(
+                                    queue.queue_id,
+                                    faded_item,
+                                    pcm_format,
+                                    applied_mode,
+                                    flow_session_id,
+                                    overlay_enabled=overlay_active(queue),
+                                )
                             # Split mix output at end-of-overlap: PRE+CF to A, POST to B.
                             fadeout_share_seconds = (
                                 timing_info.pre_crossfade_duration + timing_info.crossfade_duration

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -15,7 +15,7 @@ import re
 import time
 from collections import deque
 from collections.abc import AsyncGenerator, Iterable
-from contextlib import aclosing, asynccontextmanager, nullcontext, suppress
+from contextlib import aclosing, asynccontextmanager, nullcontext
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, cast
@@ -393,11 +393,10 @@ class _IncomingFadePrefetcher:
         self._target = 0
         if task is not None:
             task.cancel()
-            with suppress(asyncio.CancelledError):
-                await task
-        # an outer cancellation can land on the await above, leaving the collector inside
-        # the generator; closing it from here would be a second concurrent entry
-        if stream is not None and (task is None or task.done()):
+            # gather consumes the collector's own cancellation but still lets a
+            # cancellation of this task through, so a stopped flow really stops
+            await asyncio.gather(task, return_exceptions=True)
+        if stream is not None:
             await stream.aclose()
         self._reset()
 

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -13,8 +13,9 @@ import logging
 import os
 import re
 import time
+from collections import deque
 from collections.abc import AsyncGenerator, Iterable
-from contextlib import aclosing, asynccontextmanager, nullcontext
+from contextlib import aclosing, asynccontextmanager, nullcontext, suppress
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, cast
@@ -200,6 +201,8 @@ class CrossfadeData:
     fade_in_media_duration: float
     pcm_format: AudioFormat  # Format of the 'data' bytes (current/previous track's format)
     queue_item_id: str
+    # Mode of the fade the 'data' bytes were blended with
+    crossfade_mode: CrossfadeMode = CrossfadeMode.DISABLED
     # Offset for the fade_in track's elapsed time calculation, to account for crossfade duration and trim
     elapsed_time_offset: float = 0.0
     # Normalization mode the intro PCM was baked with, used to pin the next track's body to the same mode
@@ -238,6 +241,165 @@ def _pcm_formats_match(a: AudioFormat, b: AudioFormat) -> bool:
 def overlay_active(queue: PlayerQueue) -> bool:
     """Return True if the given queue has an audio overlay enabled and a source selected."""
     return queue.overlay_enabled and queue.overlay_source is not None
+
+
+class _IncomingFadePrefetcher:
+    """
+    Collect the incoming track's fade-in while the outgoing track's tail is held back.
+
+    A flow stream emits nothing while it gathers the audio a transition blends in, so the
+    player hears that wait as lost lead. Gathering it alongside the held-back tail instead
+    of after it keeps audio flowing right up to the transition. The collected audio and the
+    still-open stream are handed over together, so the track is decoded exactly once and the
+    seam is a plain continuation.
+    """
+
+    def __init__(
+        self, audio: StreamsAudio, pcm_format: AudioFormat, session_id: str | None
+    ) -> None:
+        """
+        Initialize the prefetcher for one flow stream.
+
+        :param audio: Audio sub-controller used to open the incoming track's stream.
+        :param pcm_format: Shared PCM format of the flow stream.
+        :param session_id: Queue session that owns the flow stream.
+        """
+        self._audio = audio
+        self._pcm_format = pcm_format
+        self._session_id = session_id
+        self._queue_item_id: str | None = None
+        self._stream: AsyncGenerator[bytes] | None = None
+        self._chunks: deque[bytes] = deque()
+        self._target = 0
+        self._task: asyncio.Task[None] | None = None
+
+    def ensure_started(
+        self,
+        queue: PlayerQueue,
+        queue_item: QueueItem,
+        crossfade_mode: CrossfadeMode,
+        standard_crossfade_duration: int,
+    ) -> None:
+        """
+        Start collecting the next track's fade-in when it can be served from its buffer.
+
+        Does nothing when a prefetch is already running or the next track is not prepared
+        yet, so this is safe (and cheap) to call for every chunk of the outgoing track.
+
+        :param queue: Queue being streamed.
+        :param queue_item: Queue item whose tail is currently held back.
+        :param crossfade_mode: Crossfade mode selected for this queue item.
+        :param standard_crossfade_duration: Configured standard overlap in seconds.
+        """
+        if self._task is not None or crossfade_mode == CrossfadeMode.DISABLED:
+            return
+        next_item = self._audio.mass.player_queues.get_next_item(
+            queue.queue_id, queue_item.queue_item_id
+        )
+        if (
+            next_item is None
+            or next_item.queue_item_id == queue_item.queue_item_id
+            or next_item.media_type != MediaType.TRACK
+            or (streamdetails := next_item.streamdetails) is None
+            or streamdetails.is_realtime
+            or (audio_buffer := cast("AudioBuffer | None", streamdetails.buffer)) is None
+            or audio_buffer.has_error
+            or not audio_buffer.is_valid()
+        ):
+            return
+        overlap = (
+            SMART_CROSSFADE_DURATION
+            if crossfade_mode == CrossfadeMode.SMART_CROSSFADE
+            else standard_crossfade_duration
+        )
+        if overlap <= 0:
+            return
+        self._target = int(self._pcm_format.pcm_sample_size * overlap)
+        self._queue_item_id = next_item.queue_item_id
+        self._chunks = deque()
+        self._stream = self._audio.get_queue_item_stream(
+            next_item,
+            pcm_format=self._pcm_format,
+            seek_position=int(streamdetails.seek_position),
+            playback_speed=cast("float", next_item.extra_attributes.get("playback_speed", 1.0)),
+            raise_on_error=False,
+            session_id=self._session_id,
+            prepared_buffer=audio_buffer,
+        )
+        self._task = asyncio.create_task(self._collect(self._stream, self._chunks))
+        self._audio.logger.debug(
+            "Prefetching %s seconds of %s while the tail of %s is held back",
+            overlap,
+            next_item.name,
+            queue_item.name,
+        )
+
+    async def take(self, queue_item: QueueItem) -> AsyncGenerator[bytes] | None:
+        """
+        Hand over the prefetched stream for the given queue item.
+
+        Returns None when nothing was prefetched for this item, in which case the caller
+        opens the stream itself.
+
+        :param queue_item: Queue item the flow stream is about to play.
+        """
+        if self._task is None:
+            return None
+        if self._queue_item_id != queue_item.queue_item_id:
+            await self.close()
+            return None
+        # stop collecting: from here the flow stream reads the same generator itself
+        self._target = 0
+        await self._task
+        chunks, stream = self._chunks, self._stream
+        assert stream is not None
+        self._reset()
+        return self._replay(chunks, stream)
+
+    async def close(self) -> None:
+        """Abandon a pending prefetch and release the incoming track's stream."""
+        task, stream = self._task, self._stream
+        self._reset()
+        if task is not None:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        if stream is not None:
+            await stream.aclose()
+
+    # --- Private methods ---
+
+    def _reset(self) -> None:
+        """Drop the handles of the current prefetch so a next one can start."""
+        self._task = None
+        self._stream = None
+        self._queue_item_id = None
+        self._chunks = deque()
+        self._target = 0
+
+    async def _collect(self, stream: AsyncGenerator[bytes], chunks: deque[bytes]) -> None:
+        """Read the incoming track until the fade-in target is reached."""
+        collected = 0
+        try:
+            async for chunk in stream:
+                chunks.append(chunk)
+                collected += len(chunk)
+                # re-read the target every chunk: it drops to zero on handover
+                if collected >= self._target:
+                    break
+        except Exception as err:
+            # whatever was collected is still handed over, the rest is read by the flow stream
+            self._audio.logger.warning("Failed to prefetch the incoming fade-in: %s", err)
+
+    async def _replay(
+        self, chunks: deque[bytes], stream: AsyncGenerator[bytes]
+    ) -> AsyncGenerator[bytes]:
+        """Yield the collected audio, then continue from the same stream."""
+        async with aclosing(stream):
+            while chunks:
+                yield chunks.popleft()
+            async for chunk in stream:
+                yield chunk
 
 
 class StreamsAudio:
@@ -1607,6 +1769,17 @@ class StreamsAudio:
             crossfade_mode,
             "true" if crossfade_data else "false",
         )
+        # report the fade this item was actually faded into; the fade leaving it is
+        # only known once the next item's overlap has been selected further down
+        self._report_crossfade_mode(
+            queue.queue_id,
+            queue_item,
+            pcm_format,
+            crossfade_data.crossfade_mode if crossfade_data else CrossfadeMode.DISABLED,
+            session_id,
+            # only radio carries an overlay outside flow mode, and this path is tracks-only
+            overlay_enabled=False,
+        )
 
         buffer = bytearray()
         bytes_written = 0
@@ -1772,6 +1945,16 @@ class StreamsAudio:
                     fade_in_playback_speed,
                 )
                 crossfade_allowed = transition_mode != CrossfadeMode.DISABLED
+        if transition_mode != CrossfadeMode.DISABLED:
+            # the fade leaving this item is settled, so report what it really is
+            self._report_crossfade_mode(
+                queue.queue_id,
+                queue_item,
+                pcm_format,
+                transition_mode,
+                session_id,
+                overlay_enabled=False,
+            )
         if not crossfade_allowed:
             # no crossfade enabled/allowed, just yield the buffer last part
             bytes_written += len(buffer)
@@ -1863,6 +2046,7 @@ class StreamsAudio:
                     * fade_in_playback_speed,
                     pcm_format=pcm_format,
                     queue_item_id=next_queue_item.queue_item_id,
+                    crossfade_mode=transition_mode,
                     elapsed_time_offset=(
                         crossfade_timing.fadein_trimmed_duration
                         + crossfade_timing.crossfade_duration
@@ -1956,6 +2140,7 @@ class StreamsAudio:
         queue_track = None
         last_fadeout_part: bytes = b""
         last_streamdetails: StreamDetails | None = None
+        last_queue_track: QueueItem | None = None
         last_play_log_entry: PlayLogEntry | None = None
         # Snapshot the queue's current session_id. PlayerQueues rotates this on
         # every new stream session, so if a newer producer takes over the queue
@@ -2016,435 +2201,467 @@ class StreamsAudio:
             return pq_data.session_id != flow_session_id
 
         queue_exhausted = False
-        while True:
-            # bail out early if a newer producer has taken over this queue,
-            # so we don't append another entry to a stream log we no longer own
-            if _superseded():
-                self.logger.debug(
-                    "Flow stream for queue %s superseded (session %s -> %s) "
-                    "- exiting before next track",
-                    queue.display_name,
-                    flow_session_id,
-                    pq_data.session_id,
-                )
-                return
-            # get (next) queue item to stream
-            if queue_track is None:
-                queue_track = start_queue_item
-            else:
-                try:
-                    queue_track = await self.mass.player_queues.load_next_queue_item(
-                        queue.queue_id, queue_track.queue_item_id
+        incoming_prefetcher = _IncomingFadePrefetcher(self, pcm_format, flow_session_id)
+        try:
+            while True:
+                # bail out early if a newer producer has taken over this queue,
+                # so we don't append another entry to a stream log we no longer own
+                if _superseded():
+                    self.logger.debug(
+                        "Flow stream for queue %s superseded (session %s -> %s) "
+                        "- exiting before next track",
+                        queue.display_name,
+                        flow_session_id,
+                        pq_data.session_id,
                     )
-                except QueueEmpty:
-                    queue_exhausted = True
+                    return
+                # get (next) queue item to stream
+                if queue_track is None:
+                    queue_track = start_queue_item
+                else:
+                    try:
+                        queue_track = await self.mass.player_queues.load_next_queue_item(
+                            queue.queue_id, queue_track.queue_item_id
+                        )
+                    except QueueEmpty:
+                        queue_exhausted = True
+                        break
+
+                if self._flow_stream_needs_restart(
+                    queue_track,
+                    pcm_format,
+                    flow_supported_sample_rates,
+                    flow_mode_sample_rate_conf,
+                    is_first_track=queue_track is start_queue_item,
+                ):
                     break
 
-            if self._flow_stream_needs_restart(
-                queue_track,
-                pcm_format,
-                flow_supported_sample_rates,
-                flow_mode_sample_rate_conf,
-                is_first_track=queue_track is start_queue_item,
-            ):
-                break
-
-            if queue_track.streamdetails is None:
-                self.logger.error(
-                    "No StreamDetails for queue item %s (%s) on queue %s - skipping track",
-                    queue_track.queue_item_id,
+                if queue_track.streamdetails is None:
+                    self.logger.error(
+                        "No StreamDetails for queue item %s (%s) on queue %s - skipping track",
+                        queue_track.queue_item_id,
+                        queue_track.name,
+                        queue.display_name,
+                    )
+                    continue
+                # a realtime source delivers at playback pace, so it has no audio to spare
+                # for an overlap in either direction
+                item_crossfade_mode = (
+                    CrossfadeMode.DISABLED
+                    if queue_track.streamdetails.is_realtime
+                    else crossfade_mode
+                )
+                self.logger.debug(
+                    "Start Streaming queue track: %s (%s) for queue %s",
+                    queue_track.streamdetails.uri,
                     queue_track.name,
                     queue.display_name,
                 )
-                continue
-            # a realtime source delivers at playback pace, so it has no audio to spare
-            # for an overlap in either direction
-            item_crossfade_mode = (
-                CrossfadeMode.DISABLED if queue_track.streamdetails.is_realtime else crossfade_mode
-            )
-            if flow_session_id is not None:
-                self.mass.streams.audio_processing.update_item_context(
-                    queue_id=queue.queue_id,
-                    session_id=flow_session_id,
-                    queue_item_id=queue_track.queue_item_id,
-                    queue_processing=AudioQueueProcessing(
-                        pcm_format=pcm_format,
-                        playback_speed=cast(
-                            "float",
-                            queue_track.extra_attributes.get("playback_speed", 1.0),
-                        ),
-                        crossfade_mode=item_crossfade_mode,
-                        overlay_active=overlay_active(queue),
-                    ),
-                    alters_audio=queue_track.streamdetails.fade_in,
-                )
-
-            self.logger.debug(
-                "Start Streaming queue track: %s (%s) for queue %s",
-                queue_track.streamdetails.uri,
-                queue_track.name,
-                queue.display_name,
-            )
-            # last chance to bail before mutating the stream log: a newer producer
-            # may have taken over while we were awaiting load_next_queue_item
-            if _superseded():
-                self.logger.debug(
-                    "Flow stream for queue %s superseded - exiting before playlog append",
-                    queue.display_name,
-                )
-                return
-            track_playback_speed = cast(
-                "float", queue_track.extra_attributes.get("playback_speed", 1.0)
-            )
-            # calculate crossfade buffer size
-            crossfade_buffer_duration = (
-                SMART_CROSSFADE_DURATION
-                if item_crossfade_mode == CrossfadeMode.SMART_CROSSFADE
-                else standard_crossfade_duration
-            )
-            crossfade_buffer_duration = min(
-                crossfade_buffer_duration,
-                int(queue_track.streamdetails.duration / 2)
-                if queue_track.streamdetails.duration
-                else crossfade_buffer_duration,
-            )
-            # skip crossfade if buffer would be too small to be meaningful
-            if crossfade_buffer_duration < MIN_CROSSFADE_FALLBACK_DURATION:
-                crossfade_buffer_duration = 0
-            # Ensure crossfade buffer size is aligned to frame boundaries
-            # Frame size = bytes_per_sample * channels
-            bytes_per_sample = pcm_format.bit_depth // 8
-            frame_size = bytes_per_sample * pcm_format.channels
-            crossfade_buffer_size = int(pcm_format.pcm_sample_size * crossfade_buffer_duration)
-            # Round down to nearest frame boundary
-            crossfade_buffer_size = (crossfade_buffer_size // frame_size) * frame_size
-            warmup_size = int(pcm_format.pcm_sample_size * WARMUP_DURATION)
-
-            # raw_seek_position feeds the PCM buffer; streamdetails.seek_position
-            # (overwritten below) only drives reported elapsed time.
-            raw_seek_position = queue_track.streamdetails.seek_position
-            # Build eagerly so seek_position is set before PlayLogEntry is appended —
-            # consumer-paced mix() would otherwise let the queue briefly report 0.
-            crossfade_smart_fade: SmartFade | None = None
-            collect_started = 0.0
-            collect_resident = 0.0
-            incoming_crossfade_size = crossfade_buffer_size
-            incoming_audio_buffer: AudioBuffer | None = None
-            if last_fadeout_part and last_streamdetails:
-                transition_mode = CrossfadeMode.DISABLED
-                incoming_duration = 0.0
-                if crossfade_buffer_size > 0 and item_crossfade_mode != CrossfadeMode.DISABLED:
-                    transition_mode, incoming_duration = self._select_buffered_crossfade(
-                        queue_track.streamdetails,
-                        item_crossfade_mode,
-                        standard_crossfade_duration,
-                        track_playback_speed,
-                    )
-                if transition_mode == CrossfadeMode.DISABLED:
-                    # nothing to fade into: flush the held-back tail of the previous track
-                    for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
-                        yield pcm_slice
-                        await asyncio.sleep(0)
-                    last_fadeout_part = b""
-                    last_streamdetails = None
-                    last_play_log_entry = None
-                else:
-                    assert queue_track.streamdetails.buffer is not None
-                    incoming_audio_buffer = cast("AudioBuffer", queue_track.streamdetails.buffer)
-                    incoming_crossfade_size = int(pcm_format.pcm_sample_size * incoming_duration)
-                    incoming_crossfade_size = (incoming_crossfade_size // frame_size) * frame_size
-                    # no audio is emitted while the incoming overlap is collected, so a
-                    # slow collection here is heard as a gap at the transition
-                    collect_started = asyncio.get_event_loop().time()
-                    collect_resident = incoming_audio_buffer.duration_available
-                    crossfade_smart_fade = await self.smart_fades_mixer.build(
-                        fade_in_streamdetails=queue_track.streamdetails,
-                        fade_out_streamdetails=last_streamdetails,
-                        pcm_format=pcm_format,
-                        standard_crossfade_duration=standard_crossfade_duration,
-                        mode=transition_mode,
-                        fade_out_data=last_fadeout_part,
-                        fade_in_bytes_len=incoming_crossfade_size,
-                    )
-                    timing_info = crossfade_smart_fade.timing_info
-                    if isinstance(crossfade_smart_fade, StandardCrossFade):
-                        # A standard fade blends its overlap and passes everything after it
-                        # through untouched, so only the overlap has to be in hand before
-                        # the transition can start. Holding back the rest buys nothing and
-                        # keeps the player waiting - a smart fade does need its full window,
-                        # which is only chosen when the analysis it needs is already there.
-                        blended_seconds = (
-                            timing_info.fadein_trimmed_duration + timing_info.crossfade_duration
-                        )
-                        blended_size = int(pcm_format.pcm_sample_size * blended_seconds)
-                        incoming_crossfade_size = min(
-                            incoming_crossfade_size,
-                            (blended_size // frame_size) * frame_size,
-                        )
-                    queue_track.streamdetails.seek_position = (
-                        raw_seek_position
-                        + (timing_info.fadein_trimmed_duration + timing_info.crossfade_duration)
-                        * track_playback_speed
-                    )
-            # append to play log so the queue controller can work out which track is playing
-            play_log_entry = PlayLogEntry(queue_track.queue_item_id)
-            flow_log.append(play_log_entry)
-
-            bytes_written = 0
-            crossfade_buffer = bytearray()
-            warmup_bytes = 0
-            first_chunk_received = False
-            holdback_armed = False
-
-            async for chunk in self.get_queue_item_stream(
-                queue_track,
-                pcm_format=pcm_format,
-                seek_position=int(raw_seek_position),
-                playback_speed=cast(
-                    "float", queue_track.extra_attributes.get("playback_speed", 1.0)
-                ),
-                raise_on_error=False,
-                session_id=flow_session_id,
-                prepared_buffer=incoming_audio_buffer,
-            ):
-                # if a newer producer has taken over this queue, stop sending
-                # audio and exit cleanly before the outer-loop end-of-track
-                # bookkeeping mutates seconds_streamed / duration on the log
+                # last chance to bail before mutating the stream log: a newer producer
+                # may have taken over while we were awaiting load_next_queue_item
                 if _superseded():
                     self.logger.debug(
-                        "Flow stream for queue %s superseded - stopping chunk yield",
+                        "Flow stream for queue %s superseded - exiting before playlog append",
                         queue.display_name,
                     )
                     return
-                total_chunks_received += 1
-                if not first_chunk_received:
-                    first_chunk_received = True
-                    # inform the queue that the track is now loaded in the buffer
-                    # so the next track can be preloaded
-                    self.mass.player_queues.track_loaded_in_buffer(
-                        queue.queue_id, queue_track.queue_item_id
+                track_playback_speed = cast(
+                    "float", queue_track.extra_attributes.get("playback_speed", 1.0)
+                )
+                # calculate crossfade buffer size
+                crossfade_buffer_duration = (
+                    SMART_CROSSFADE_DURATION
+                    if item_crossfade_mode == CrossfadeMode.SMART_CROSSFADE
+                    else standard_crossfade_duration
+                )
+                crossfade_buffer_duration = min(
+                    crossfade_buffer_duration,
+                    int(queue_track.streamdetails.duration / 2)
+                    if queue_track.streamdetails.duration
+                    else crossfade_buffer_duration,
+                )
+                # skip crossfade if buffer would be too small to be meaningful
+                if crossfade_buffer_duration < MIN_CROSSFADE_FALLBACK_DURATION:
+                    crossfade_buffer_duration = 0
+                # Ensure crossfade buffer size is aligned to frame boundaries
+                # Frame size = bytes_per_sample * channels
+                bytes_per_sample = pcm_format.bit_depth // 8
+                frame_size = bytes_per_sample * pcm_format.channels
+                crossfade_buffer_size = int(pcm_format.pcm_sample_size * crossfade_buffer_duration)
+                # Round down to nearest frame boundary
+                crossfade_buffer_size = (crossfade_buffer_size // frame_size) * frame_size
+                warmup_size = int(pcm_format.pcm_sample_size * WARMUP_DURATION)
+
+                # raw_seek_position feeds the PCM buffer; streamdetails.seek_position
+                # (overwritten below) only drives reported elapsed time.
+                raw_seek_position = queue_track.streamdetails.seek_position
+                # Build eagerly so seek_position is set before PlayLogEntry is appended —
+                # consumer-paced mix() would otherwise let the queue briefly report 0.
+                crossfade_smart_fade: SmartFade | None = None
+                collect_started = 0.0
+                collect_resident = 0.0
+                incoming_crossfade_size = crossfade_buffer_size
+                incoming_audio_buffer: AudioBuffer | None = None
+                transition_mode = CrossfadeMode.DISABLED
+                outgoing_queue_track = last_queue_track
+                if last_fadeout_part and last_streamdetails:
+                    incoming_duration = 0.0
+                    if crossfade_buffer_size > 0 and item_crossfade_mode != CrossfadeMode.DISABLED:
+                        transition_mode, incoming_duration = self._select_buffered_crossfade(
+                            queue_track.streamdetails,
+                            item_crossfade_mode,
+                            standard_crossfade_duration,
+                            track_playback_speed,
+                        )
+                    if transition_mode == CrossfadeMode.DISABLED:
+                        # nothing to fade into: flush the held-back tail of the previous track
+                        for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
+                            yield pcm_slice
+                            await asyncio.sleep(0)
+                        last_fadeout_part = b""
+                        last_streamdetails = None
+                        last_play_log_entry = None
+                        last_queue_track = None
+                    else:
+                        assert queue_track.streamdetails.buffer is not None
+                        incoming_audio_buffer = cast(
+                            "AudioBuffer", queue_track.streamdetails.buffer
+                        )
+                        incoming_crossfade_size = int(
+                            pcm_format.pcm_sample_size * incoming_duration
+                        )
+                        incoming_crossfade_size = (
+                            incoming_crossfade_size // frame_size
+                        ) * frame_size
+                        # no audio is emitted while the incoming overlap is collected, so a
+                        # slow collection here is heard as a gap at the transition
+                        collect_started = asyncio.get_event_loop().time()
+                        collect_resident = incoming_audio_buffer.duration_available
+                        crossfade_smart_fade = await self.smart_fades_mixer.build(
+                            fade_in_streamdetails=queue_track.streamdetails,
+                            fade_out_streamdetails=last_streamdetails,
+                            pcm_format=pcm_format,
+                            standard_crossfade_duration=standard_crossfade_duration,
+                            mode=transition_mode,
+                            fade_out_data=last_fadeout_part,
+                            fade_in_bytes_len=incoming_crossfade_size,
+                        )
+                        timing_info = crossfade_smart_fade.timing_info
+                        if isinstance(crossfade_smart_fade, StandardCrossFade):
+                            # A standard fade blends its overlap and passes everything after it
+                            # through untouched, so only the overlap has to be in hand before
+                            # the transition can start. Holding back the rest buys nothing and
+                            # keeps the player waiting - a smart fade does need its full window,
+                            # which is only chosen when the analysis it needs is already there.
+                            blended_seconds = (
+                                timing_info.fadein_trimmed_duration + timing_info.crossfade_duration
+                            )
+                            blended_size = int(pcm_format.pcm_sample_size * blended_seconds)
+                            incoming_crossfade_size = min(
+                                incoming_crossfade_size,
+                                (blended_size // frame_size) * frame_size,
+                            )
+                        queue_track.streamdetails.seek_position = (
+                            raw_seek_position
+                            + (timing_info.fadein_trimmed_duration + timing_info.crossfade_duration)
+                            * track_playback_speed
+                        )
+                # the boundary has decided, so the fade can now be reported for real:
+                # this track's fade-in, and - when it happens - the outgoing track's fade-out
+                self._report_crossfade_mode(
+                    queue.queue_id,
+                    queue_track,
+                    pcm_format,
+                    transition_mode,
+                    flow_session_id,
+                    overlay_enabled=overlay_active(queue),
+                )
+                if transition_mode != CrossfadeMode.DISABLED and outgoing_queue_track is not None:
+                    self._report_crossfade_mode(
+                        queue.queue_id,
+                        outgoing_queue_track,
+                        pcm_format,
+                        transition_mode,
+                        flow_session_id,
+                        overlay_enabled=overlay_active(queue),
+                    )
+                # append to play log so the queue controller can work out which track is playing
+                play_log_entry = PlayLogEntry(queue_track.queue_item_id)
+                flow_log.append(play_log_entry)
+
+                bytes_written = 0
+                crossfade_buffer = bytearray()
+                warmup_bytes = 0
+                first_chunk_received = False
+                holdback_armed = False
+
+                item_stream = await incoming_prefetcher.take(queue_track)
+                if item_stream is None:
+                    item_stream = self.get_queue_item_stream(
+                        queue_track,
+                        pcm_format=pcm_format,
+                        seek_position=int(raw_seek_position),
+                        playback_speed=cast(
+                            "float", queue_track.extra_attributes.get("playback_speed", 1.0)
+                        ),
+                        raise_on_error=False,
+                        session_id=flow_session_id,
+                        prepared_buffer=incoming_audio_buffer,
                     )
 
-                if item_crossfade_mode == CrossfadeMode.DISABLED:
-                    # no cross/smart fade: yield chunks directly without intermediate buffer
-                    yield chunk
-                    bytes_written += len(chunk)
-                    del chunk
-                    continue
+                async for chunk in item_stream:
+                    # if a newer producer has taken over this queue, stop sending
+                    # audio and exit cleanly before the outer-loop end-of-track
+                    # bookkeeping mutates seconds_streamed / duration on the log
+                    if _superseded():
+                        self.logger.debug(
+                            "Flow stream for queue %s superseded - stopping chunk yield",
+                            queue.display_name,
+                        )
+                        return
+                    total_chunks_received += 1
+                    if not first_chunk_received:
+                        first_chunk_received = True
+                        # inform the queue that the track is now loaded in the buffer
+                        # so the next track can be preloaded
+                        self.mass.player_queues.track_loaded_in_buffer(
+                            queue.queue_id, queue_track.queue_item_id
+                        )
 
-                # Warmup: yield chunks directly until we have streamed WARMUP_DURATION
-                # worth of audio, so playback starts immediately. Skip warmup when
-                # crossfade data from the previous track is pending — we need a full
-                # buffer for the mix.
-                if warmup_bytes < warmup_size and not last_fadeout_part:
-                    yield chunk
-                    warmup_bytes += len(chunk)
-                    bytes_written += len(chunk)
-                    del chunk
-                    continue
-
-                if not last_fadeout_part and not holdback_armed:
-                    holdback_armed = self._crossfade_holdback_allowed(
-                        queue_track.streamdetails,
-                        crossfade_buffer_duration,
-                        track_playback_speed,
-                    )
-                    if not holdback_armed:
-                        # holding audio back now would only shrink the player's lead
+                    if item_crossfade_mode == CrossfadeMode.DISABLED:
+                        # no cross/smart fade: yield chunks directly without intermediate buffer
                         yield chunk
                         bytes_written += len(chunk)
                         del chunk
                         continue
 
-                # smart fades enabled: accumulate chunks in crossfade buffer
-                crossfade_buffer.extend(chunk)
-                del chunk
-                required_buffer_size = (
-                    incoming_crossfade_size if last_fadeout_part else crossfade_buffer_size
-                )
-                if len(crossfade_buffer) < required_buffer_size:
-                    await asyncio.sleep(0)
-                    continue
-                # handle crossfade of previous track and new track
-                if (
-                    last_fadeout_part
-                    and last_streamdetails
-                    and crossfade_smart_fade is not None
-                    and last_play_log_entry is not None
-                ):
-                    self.logger.debug(
-                        "Collected %.1fs of incoming audio for the transition into %s in %.1fs"
-                        " (%.1fs was resident when it started)",
-                        len(crossfade_buffer) / pcm_sample_size,
-                        queue_track.name,
-                        asyncio.get_event_loop().time() - collect_started,
-                        collect_resident,
+                    # Warmup: yield chunks directly until we have streamed WARMUP_DURATION
+                    # worth of audio, so playback starts immediately. Skip warmup when
+                    # crossfade data from the previous track is pending — we need a full
+                    # buffer for the mix.
+                    if warmup_bytes < warmup_size and not last_fadeout_part:
+                        yield chunk
+                        warmup_bytes += len(chunk)
+                        bytes_written += len(chunk)
+                        del chunk
+                        continue
+
+                    if not last_fadeout_part and not holdback_armed:
+                        holdback_armed = self._crossfade_holdback_allowed(
+                            queue_track.streamdetails,
+                            crossfade_buffer_duration,
+                            track_playback_speed,
+                        )
+                        if not holdback_armed:
+                            # holding audio back now would only shrink the player's lead
+                            yield chunk
+                            bytes_written += len(chunk)
+                            del chunk
+                            continue
+
+                    if not last_fadeout_part:
+                        # the tail is being held back, so the audio the next transition
+                        # blends in can be gathered alongside it instead of after it
+                        incoming_prefetcher.ensure_started(
+                            queue,
+                            queue_track,
+                            item_crossfade_mode,
+                            standard_crossfade_duration,
+                        )
+
+                    # smart fades enabled: accumulate chunks in crossfade buffer
+                    crossfade_buffer.extend(chunk)
+                    del chunk
+                    required_buffer_size = (
+                        incoming_crossfade_size if last_fadeout_part else crossfade_buffer_size
                     )
-                    fadein_part = bytes(crossfade_buffer[:incoming_crossfade_size])
-                    remaining_bytes = bytes(crossfade_buffer[incoming_crossfade_size:])
-                    try:
-                        crossfade_bytes_written = 0
-                        async for mix_chunk in self.smart_fades_mixer.mix(
-                            crossfade_smart_fade,
-                            fade_in_part=fadein_part,
-                            fade_out_part=last_fadeout_part,
-                            pcm_format=pcm_format,
-                        ):
-                            yield mix_chunk
-                            crossfade_bytes_written += len(mix_chunk)
-                    except Exception as mix_err:
-                        if crossfade_bytes_written:
-                            # partial mix already played — concat'd tail would duplicate audio
-                            raise
-                        self.logger.warning(
-                            "Crossfade mixer failed for %s, falling back to simple concat: %s",
+                    if len(crossfade_buffer) < required_buffer_size:
+                        await asyncio.sleep(0)
+                        continue
+                    # handle crossfade of previous track and new track
+                    if (
+                        last_fadeout_part
+                        and last_streamdetails
+                        and crossfade_smart_fade is not None
+                        and last_play_log_entry is not None
+                    ):
+                        self.logger.debug(
+                            "Collected %.1fs of incoming audio for the transition into %s in %.1fs"
+                            " (%.1fs was resident when it started)",
+                            len(crossfade_buffer) / pcm_sample_size,
                             queue_track.name,
-                            mix_err,
+                            asyncio.get_event_loop().time() - collect_started,
+                            collect_resident,
                         )
-                        for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
-                            yield pcm_slice
-                            await asyncio.sleep(0)
-                        # full tail was pre-counted and is now yielded as-is
-                        crossfade_bytes_written = 0
-                        remaining_bytes = bytes(crossfade_buffer)
-                        # mix failed — undo the eager seek_position
+                        fadein_part = bytes(crossfade_buffer[:incoming_crossfade_size])
+                        remaining_bytes = bytes(crossfade_buffer[incoming_crossfade_size:])
+                        try:
+                            crossfade_bytes_written = 0
+                            async for mix_chunk in self.smart_fades_mixer.mix(
+                                crossfade_smart_fade,
+                                fade_in_part=fadein_part,
+                                fade_out_part=last_fadeout_part,
+                                pcm_format=pcm_format,
+                            ):
+                                yield mix_chunk
+                                crossfade_bytes_written += len(mix_chunk)
+                        except Exception as mix_err:
+                            if crossfade_bytes_written:
+                                # partial mix already played — concat'd tail would duplicate audio
+                                raise
+                            self.logger.warning(
+                                "Crossfade mixer failed for %s, falling back to simple concat: %s",
+                                queue_track.name,
+                                mix_err,
+                            )
+                            for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
+                                yield pcm_slice
+                                await asyncio.sleep(0)
+                            # full tail was pre-counted and is now yielded as-is
+                            crossfade_bytes_written = 0
+                            remaining_bytes = bytes(crossfade_buffer)
+                            # mix failed — undo the eager seek_position
+                            queue_track.streamdetails.seek_position = raw_seek_position
+                        if crossfade_bytes_written:
+                            # Split mix output at end-of-overlap: PRE+CF to A, POST to B.
+                            fadeout_share_seconds = (
+                                timing_info.pre_crossfade_duration + timing_info.crossfade_duration
+                            )
+                            fadeout_share = int(fadeout_share_seconds * pcm_sample_size)
+                            fadeout_share = (fadeout_share // frame_size) * frame_size
+                            fadeout_share = min(fadeout_share, crossfade_bytes_written)
+                            fadein_share = crossfade_bytes_written - fadeout_share
+                            bytes_written += fadein_share
+                            if last_play_log_entry:
+                                assert last_play_log_entry.seconds_streamed is not None
+                                # correct pre-counted full tail to the timing-based share
+                                last_play_log_entry.seconds_streamed += (
+                                    fadeout_share - len(last_fadeout_part)
+                                ) / pcm_sample_size
+                        if remaining_bytes:
+                            for pcm_slice in iter_pcm_slices(remaining_bytes, pcm_format, 1000):
+                                yield pcm_slice
+                                await asyncio.sleep(0)
+                            bytes_written += len(remaining_bytes)
+                            del remaining_bytes
+                        last_fadeout_part = b""
+                        last_streamdetails = None
+                        last_queue_track = None
+                        crossfade_buffer = bytearray()
+                        warmup_bytes = 0
+
+                    # yield everything above the crossfade buffer size
+                    while len(crossfade_buffer) > crossfade_buffer_size:
+                        yield bytes(crossfade_buffer[:pcm_sample_size])
+                        bytes_written += pcm_sample_size
+                        del crossfade_buffer[:pcm_sample_size]
+                        await asyncio.sleep(0)
+
+                # A source error after partial audio must not look like a completed item.
+                # Progress reporting skips items with stream_error, so the item is not
+                # marked played; move on to the next queue item like the zero-audio path.
+                if first_chunk_received and queue_track.streamdetails.stream_error:
+                    if _superseded():
+                        return
+                    self.logger.warning(
+                        "Track %s (%s) on queue %s aborted by a stream error - skipping",
+                        queue_track.name,
+                        queue_track.streamdetails.uri,
+                        queue.display_name,
+                    )
+                    # the audio sent so far will still play out; keep the play log entry
+                    # honest about how much of this item was actually streamed
+                    play_log_entry.seconds_streamed = bytes_written / pcm_sample_size
+                    if last_fadeout_part:
+                        # crossfade into this item never happened — undo the eager seek_position
                         queue_track.streamdetails.seek_position = raw_seek_position
-                    if crossfade_bytes_written:
-                        # Split mix output at end-of-overlap: PRE+CF to A, POST to B.
-                        fadeout_share_seconds = (
-                            timing_info.pre_crossfade_duration + timing_info.crossfade_duration
-                        )
-                        fadeout_share = int(fadeout_share_seconds * pcm_sample_size)
-                        fadeout_share = (fadeout_share // frame_size) * frame_size
-                        fadeout_share = min(fadeout_share, crossfade_bytes_written)
-                        fadein_share = crossfade_bytes_written - fadeout_share
-                        bytes_written += fadein_share
-                        if last_play_log_entry:
-                            assert last_play_log_entry.seconds_streamed is not None
-                            # correct pre-counted full tail to the timing-based share
-                            last_play_log_entry.seconds_streamed += (
-                                fadeout_share - len(last_fadeout_part)
-                            ) / pcm_sample_size
+                    continue
+
+                #### HANDLE END OF TRACK
+                if not first_chunk_received:
+                    self.logger.warning(
+                        "Track %s (%s) on queue %s produced no audio data - skipping",
+                        queue_track.name,
+                        queue_track.streamdetails.uri if queue_track.streamdetails else "unknown",
+                        queue.display_name,
+                    )
+                    queue_track.streamdetails.stream_error = True
+                    play_log_entry.seconds_streamed = 0
+                    if last_fadeout_part:
+                        queue_track.streamdetails.seek_position = raw_seek_position
+                    continue
+                if last_fadeout_part:
+                    # edge case: we did not get enough data to make the crossfade
+                    # attribute these bytes to the previous track (they are its tail)
+                    for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
+                        yield pcm_slice
+                        await asyncio.sleep(0)
+                    # no crossfade happened — undo the eager seek_position
+                    queue_track.streamdetails.seek_position = raw_seek_position
+                    # full tail was pre-counted and is now yielded as-is
+                    last_fadeout_part = b""
+                # a fade needs enough of the outgoing track to overlap with; a holdback that
+                # armed late (or not at all) leaves less than that
+                min_fade_out_size = int(pcm_sample_size * MIN_CROSSFADE_FALLBACK_DURATION)
+                if len(crossfade_buffer) >= min_fade_out_size and self.crossfade_allowed(
+                    queue_track,
+                    crossfade_mode=item_crossfade_mode,
+                    player_id=queue.queue_id,
+                    flow_mode=True,
+                ):
+                    last_fadeout_part = bytes(crossfade_buffer[-crossfade_buffer_size:])
+                    last_streamdetails = queue_track.streamdetails
+                    last_queue_track = queue_track
+                    last_play_log_entry = play_log_entry
+                    remaining_bytes = bytes(crossfade_buffer[:-crossfade_buffer_size])
                     if remaining_bytes:
                         for pcm_slice in iter_pcm_slices(remaining_bytes, pcm_format, 1000):
                             yield pcm_slice
                             await asyncio.sleep(0)
                         bytes_written += len(remaining_bytes)
-                        del remaining_bytes
-                    last_fadeout_part = b""
-                    last_streamdetails = None
-                    crossfade_buffer = bytearray()
-                    warmup_bytes = 0
-
-                # yield everything above the crossfade buffer size
-                while len(crossfade_buffer) > crossfade_buffer_size:
-                    yield bytes(crossfade_buffer[:pcm_sample_size])
-                    bytes_written += pcm_sample_size
-                    del crossfade_buffer[:pcm_sample_size]
-                    await asyncio.sleep(0)
-
-            # A source error after partial audio must not look like a completed item.
-            # Progress reporting skips items with stream_error, so the item is not
-            # marked played; move on to the next queue item like the zero-audio path.
-            if first_chunk_received and queue_track.streamdetails.stream_error:
-                if _superseded():
-                    return
-                self.logger.warning(
-                    "Track %s (%s) on queue %s aborted by a stream error - skipping",
-                    queue_track.name,
-                    queue_track.streamdetails.uri,
-                    queue.display_name,
-                )
-                # the audio sent so far will still play out; keep the play log entry
-                # honest about how much of this item was actually streamed
-                play_log_entry.seconds_streamed = bytes_written / pcm_sample_size
-                if last_fadeout_part:
-                    # crossfade into this item never happened — undo the eager seek_position
-                    queue_track.streamdetails.seek_position = raw_seek_position
-                continue
-
-            #### HANDLE END OF TRACK
-            if not first_chunk_received:
-                self.logger.warning(
-                    "Track %s (%s) on queue %s produced no audio data - skipping",
-                    queue_track.name,
-                    queue_track.streamdetails.uri if queue_track.streamdetails else "unknown",
-                    queue.display_name,
-                )
-                queue_track.streamdetails.stream_error = True
-                play_log_entry.seconds_streamed = 0
-                if last_fadeout_part:
-                    queue_track.streamdetails.seek_position = raw_seek_position
-                continue
-            if last_fadeout_part:
-                # edge case: we did not get enough data to make the crossfade
-                # attribute these bytes to the previous track (they are its tail)
-                for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
-                    yield pcm_slice
-                    await asyncio.sleep(0)
-                # no crossfade happened — undo the eager seek_position
-                queue_track.streamdetails.seek_position = raw_seek_position
-                # full tail was pre-counted and is now yielded as-is
-                last_fadeout_part = b""
-            # a fade needs enough of the outgoing track to overlap with; a holdback that
-            # armed late (or not at all) leaves less than that
-            min_fade_out_size = int(pcm_sample_size * MIN_CROSSFADE_FALLBACK_DURATION)
-            if len(crossfade_buffer) >= min_fade_out_size and self.crossfade_allowed(
-                queue_track,
-                crossfade_mode=item_crossfade_mode,
-                player_id=queue.queue_id,
-                flow_mode=True,
-            ):
-                last_fadeout_part = bytes(crossfade_buffer[-crossfade_buffer_size:])
-                last_streamdetails = queue_track.streamdetails
-                last_play_log_entry = play_log_entry
-                remaining_bytes = bytes(crossfade_buffer[:-crossfade_buffer_size])
-                if remaining_bytes:
-                    for pcm_slice in iter_pcm_slices(remaining_bytes, pcm_format, 1000):
+                    del remaining_bytes
+                elif item_crossfade_mode != CrossfadeMode.DISABLED and crossfade_buffer:
+                    bytes_written += len(crossfade_buffer)
+                    for pcm_slice in iter_pcm_slices(bytes(crossfade_buffer), pcm_format, 1000):
                         yield pcm_slice
                         await asyncio.sleep(0)
-                    bytes_written += len(remaining_bytes)
-                del remaining_bytes
-            elif item_crossfade_mode != CrossfadeMode.DISABLED and crossfade_buffer:
-                bytes_written += len(crossfade_buffer)
-                for pcm_slice in iter_pcm_slices(bytes(crossfade_buffer), pcm_format, 1000):
-                    yield pcm_slice
-                    await asyncio.sleep(0)
-            crossfade_buffer = bytearray()
+                crossfade_buffer = bytearray()
 
-            # update duration details based on the actual pcm data we sent
-            # this also accounts for crossfade and silence stripping
-            seconds_streamed = bytes_written / pcm_sample_size
-            queue_track.streamdetails.seconds_streamed = seconds_streamed
-            play_log_entry.seconds_streamed = seconds_streamed
-            # an externally aborted source ends in a clean EOF mid-track, so the
-            # streamed length must not be written back as the item's duration
-            source_buffer = queue_track.streamdetails.buffer
-            source_aborted = source_buffer is not None and source_buffer.cancelled
-            if not source_aborted:
-                # the held-back crossfade tail still counts as this track's media-time
-                tail_seconds = len(last_fadeout_part) / pcm_sample_size
-                # streamdetails.duration is in media-time; seconds_streamed is stream-time
-                # (post-atempo), so we scale by the track's playback_speed to recover media-time.
-                queue_track.streamdetails.duration = int(
-                    queue_track.streamdetails.seek_position
-                    + (seconds_streamed + tail_seconds) * track_playback_speed
+                # update duration details based on the actual pcm data we sent
+                # this also accounts for crossfade and silence stripping
+                seconds_streamed = bytes_written / pcm_sample_size
+                queue_track.streamdetails.seconds_streamed = seconds_streamed
+                play_log_entry.seconds_streamed = seconds_streamed
+                # an externally aborted source ends in a clean EOF mid-track, so the
+                # streamed length must not be written back as the item's duration
+                source_buffer = queue_track.streamdetails.buffer
+                source_aborted = source_buffer is not None and source_buffer.cancelled
+                if not source_aborted:
+                    # the held-back crossfade tail still counts as this track's media-time
+                    tail_seconds = len(last_fadeout_part) / pcm_sample_size
+                    # streamdetails.duration is in media-time; seconds_streamed is stream-time
+                    # (post-atempo), so we scale by the track's playback_speed to recover media-time.
+                    queue_track.streamdetails.duration = int(
+                        queue_track.streamdetails.seek_position
+                        + (seconds_streamed + tail_seconds) * track_playback_speed
+                    )
+                    # propagate accurate duration to queue_item so UI displays it
+                    queue_track.duration = queue_track.streamdetails.duration
+                    play_log_entry.duration = queue_track.streamdetails.duration
+                if last_play_log_entry is play_log_entry and last_fadeout_part:
+                    # Pre-count the full crossfade tail so the queue index calculation
+                    # doesn't undercount while waiting for the next track's crossfade mix.
+                    # This will be corrected to crossfade_total/2 once the mix completes.
+                    assert play_log_entry.seconds_streamed is not None
+                    play_log_entry.seconds_streamed += len(last_fadeout_part) / pcm_sample_size
+                self.logger.debug(
+                    "Finished Streaming queue track: %s (%s) on queue %s",
+                    queue_track.streamdetails.uri,
+                    queue_track.name,
+                    queue.display_name,
                 )
-                # propagate accurate duration to queue_item so UI displays it
-                queue_track.duration = queue_track.streamdetails.duration
-                play_log_entry.duration = queue_track.streamdetails.duration
-            if last_play_log_entry is play_log_entry and last_fadeout_part:
-                # Pre-count the full crossfade tail so the queue index calculation
-                # doesn't undercount while waiting for the next track's crossfade mix.
-                # This will be corrected to crossfade_total/2 once the mix completes.
-                assert play_log_entry.seconds_streamed is not None
-                play_log_entry.seconds_streamed += len(last_fadeout_part) / pcm_sample_size
-            self.logger.debug(
-                "Finished Streaming queue track: %s (%s) on queue %s",
-                queue_track.streamdetails.uri,
-                queue_track.name,
-                queue.display_name,
-            )
+        finally:
+            await incoming_prefetcher.close()
         #### HANDLE END OF QUEUE FLOW STREAM
         # skip end-of-queue bookkeeping if a newer producer has superseded us;
         # the new producer owns queue_buffer_completed and the play log now
@@ -3372,6 +3589,43 @@ class StreamsAudio:
         # is too small to ever hold the tail is the exception - waiting for the source
         # there would only lose the fade.
         return audio_buffer.eof or audio_buffer.max_size_seconds / playback_speed < tail_seconds
+
+    def _report_crossfade_mode(
+        self,
+        queue_id: str,
+        queue_item: QueueItem,
+        pcm_format: AudioFormat,
+        crossfade_mode: CrossfadeMode,
+        session_id: str | None,
+        *,
+        overlay_enabled: bool,
+    ) -> None:
+        """
+        Publish the crossfade that is actually applied to a queue item's audio.
+
+        :param queue_id: Queue the item is streamed from.
+        :param queue_item: Queue item the fade touches.
+        :param pcm_format: Shared PCM format leaving queue processing.
+        :param crossfade_mode: Mode of the applied fade, or DISABLED when none is applied.
+        :param session_id: Queue session that owns processing-detail updates.
+        :param overlay_enabled: Whether an overlay is mixed into this stream.
+        """
+        if session_id is None or queue_item.streamdetails is None:
+            return
+        self.mass.streams.audio_processing.update_item_context(
+            queue_id=queue_id,
+            session_id=session_id,
+            queue_item_id=queue_item.queue_item_id,
+            queue_processing=AudioQueueProcessing(
+                pcm_format=pcm_format,
+                playback_speed=cast(
+                    "float", queue_item.extra_attributes.get("playback_speed", 1.0)
+                ),
+                crossfade_mode=crossfade_mode,
+                overlay_active=overlay_enabled,
+            ),
+            alters_audio=queue_item.streamdetails.fade_in,
+        )
 
     def _select_buffered_crossfade(
         self,

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -101,7 +101,6 @@ from music_assistant.helpers.audio import (
     get_mime_type,
     store_content_length_in_cache,
 )
-from music_assistant.helpers.buffered_generator import buffered
 from music_assistant.helpers.ffmpeg import (
     CACHE_ATTR_FFMPEG_VERSION,
     CACHE_ATTR_LIBSOXR_PRESENT,
@@ -838,7 +837,6 @@ class StreamsController(CoreController):
                 queue=queue,
                 queue_item=queue_item,
                 pcm_format=pcm_format,
-                crossfade_mode=crossfade_mode,
                 overlay_enabled=(
                     queue_item.media_type == MediaType.RADIO and overlay_active(queue)
                 ),
@@ -1100,7 +1098,6 @@ class StreamsController(CoreController):
             queue=queue,
             queue_item=start_queue_item,
             pcm_format=flow_pcm_format,
-            crossfade_mode=crossfade_mode,
             overlay_enabled=overlay_active(queue),
             session_id=session_id,
         )
@@ -1315,7 +1312,6 @@ class StreamsController(CoreController):
         pcm_format: AudioFormat,
         player_id: str | None = None,
         force_flow_mode: bool = False,
-        use_flow_stream_buffering: bool = False,
     ) -> AsyncGenerator[bytes]:
         """
         Get a stream of the given media as raw PCM audio.
@@ -1329,9 +1325,6 @@ class StreamsController(CoreController):
             if flow mode should be used based on the player's capabilities.
         :param force_flow_mode: Force flow mode regardless of player capabilities.
             Used for multi-client streaming scenarios that require continuous streams.
-        :param use_flow_stream_buffering: Buffer the flow stream to provide headroom
-            during smart fades transitions. Use for consumers that read directly
-            (e.g. AirPlay, Snapcast) and can't tolerate stalls.
         """
         # select audio source
         if media.media_type == MediaType.ANNOUNCEMENT:
@@ -1388,16 +1381,10 @@ class StreamsController(CoreController):
                     media.source_id, media.queue_item_id
                 )
                 assert start_queue_item
-                crossfade_mode = (
-                    self.get_crossfade_mode(queue)
-                    if start_queue_item.media_type == MediaType.TRACK
-                    else CrossfadeMode.DISABLED
-                )
                 self._update_audio_processing_context(
                     queue=queue,
                     queue_item=start_queue_item,
                     pcm_format=pcm_format,
-                    crossfade_mode=crossfade_mode,
                     overlay_enabled=overlay_active(queue),
                     session_id=queue_session_id,
                 )
@@ -1412,8 +1399,6 @@ class StreamsController(CoreController):
                     flow_stream = self.audio.get_overlay_mixed_stream(
                         queue, flow_stream, pcm_format
                     )
-                if use_flow_stream_buffering:
-                    return buffered(flow_stream, buffer_size=30, min_buffer_before_yield=1)
                 return flow_stream
             # single item stream (e.g. radio or non-flow mode)
             queue_item = self.mass.player_queues.get_item(media.source_id, media.queue_item_id)
@@ -1423,13 +1408,6 @@ class StreamsController(CoreController):
                     queue=queue,
                     queue_item=queue_item,
                     pcm_format=pcm_format,
-                    crossfade_mode=(
-                        self.get_crossfade_mode(queue)
-                        # a realtime source is never faded, in either direction
-                        if queue_item.media_type == MediaType.TRACK
-                        and not (queue_item.streamdetails and queue_item.streamdetails.is_realtime)
-                        else CrossfadeMode.DISABLED
-                    ),
                     overlay_enabled=(
                         queue_item.media_type == MediaType.RADIO and overlay_active(queue)
                     ),
@@ -1622,17 +1600,18 @@ class StreamsController(CoreController):
         queue: PlayerQueue,
         queue_item: QueueItem,
         pcm_format: AudioFormat,
-        crossfade_mode: CrossfadeMode,
         overlay_enabled: bool,
         session_id: str | None = None,
     ) -> None:
         """
         Store the shared processing context selected for a queue item.
 
+        The crossfade is left out on purpose: only the audio layer knows whether one
+        really happens, and it reports that itself once the boundary has decided.
+
         :param queue: Active player queue.
         :param queue_item: Queue item being prepared.
         :param pcm_format: Shared PCM format leaving queue processing.
-        :param crossfade_mode: Effective crossfade mode for the item.
         :param overlay_enabled: Whether an overlay is mixed into this stream.
         :param session_id: Queue session that owns processing-detail updates.
         """
@@ -1656,7 +1635,6 @@ class StreamsController(CoreController):
                     "float",
                     queue_item.extra_attributes.get("playback_speed", 1.0),
                 ),
-                crossfade_mode=crossfade_mode,
                 overlay_active=overlay_enabled,
             ),
             alters_audio=queue_item.streamdetails.fade_in,

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -559,7 +559,7 @@ class AirPlayPlayer(Player):
             ):
                 self._transitioning = True
                 audio_source = self.mass.streams.get_stream(
-                    media, session_pcm_format, self.player_id, use_flow_stream_buffering=True
+                    media, session_pcm_format, self.player_id
                 )
                 if await self.stream.session.replace(audio_source, media):
                     self._transitioning = False
@@ -584,9 +584,7 @@ class AirPlayPlayer(Player):
                 self.stream = None
 
             # select audio source
-            audio_source = self.mass.streams.get_stream(
-                media, session_pcm_format, self.player_id, use_flow_stream_buffering=True
-            )
+            audio_source = self.mass.streams.get_stream(media, session_pcm_format, self.player_id)
 
             # setup StreamSession for player (and its sync childs if any)
             provider = cast("AirPlayProvider", self.provider)

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncGenerator, Coroutine
-from contextlib import suppress
+from contextlib import aclosing, suppress
 from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import ContentType, PlaybackState
@@ -867,14 +867,19 @@ class AirPlayStreamSession:
         """Stream audio to all players."""
         stream_error: BaseException | None = None
         try:
-            async for chunk in audio_source:
-                if not self.sync_clients:
-                    break
+            # the loop below leaves early once the clients are gone; closing the source
+            # from here releases its decoders instead of waiting on the garbage collector
+            async with aclosing(audio_source):
+                async for chunk in audio_source:
+                    if not self.sync_clients:
+                        break
 
-                has_running_clients = await self._write_chunk_to_all_players(chunk)
-                if not has_running_clients:
-                    self.prov.logger.debug("No running clients remaining, stopping audio streamer")
-                    break
+                    has_running_clients = await self._write_chunk_to_all_players(chunk)
+                    if not has_running_clients:
+                        self.prov.logger.debug(
+                            "No running clients remaining, stopping audio streamer"
+                        )
+                        break
         except asyncio.CancelledError:
             self.prov.logger.debug("Audio streamer cancelled after %.1fs", self.seconds_streamed)
             raise

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -25,6 +25,7 @@ from music_assistant.controllers.streams.audio_processing import (
     AudioOutputPlan,
     get_media_session_id,
 )
+from music_assistant.helpers.buffered_generator import buffered
 from music_assistant.helpers.ffmpeg import FFMpeg
 from music_assistant.providers.snapcast.socket_server import SnapcastSocketServer
 
@@ -328,11 +329,16 @@ class SnapcastMAStream:
             self._register_output_plan()
             self._filter_settings = self._output_plan.filter_params
         stream_format = self._provider.stream_audio_format
-        audio_source = self._mass.streams.get_stream(
-            self.media,
-            stream_format,
-            self._filter_settings_owner,
-            use_flow_stream_buffering=True,
+        # ffmpeg reads this pipeline at 1x (-re) and snapserver only holds ~1 second,
+        # so buffer here to give the source room to hiccup without starving the server
+        audio_source = buffered(
+            self._mass.streams.get_stream(
+                self.media,
+                stream_format,
+                self._filter_settings_owner,
+            ),
+            buffer_size=30,
+            min_buffer_before_yield=1,
         )
         try:
             async with FFMpeg(

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -1178,7 +1178,8 @@ async def test_flow_zero_audio_skip_restores_seek_position(
         pass
 
     build.assert_awaited_once()
-    assert eager_seek_positions == [32]
+    # a source that hands over nothing is reopened, and both opens see the eager position
+    assert eager_seek_positions == [32, 32]
     assert skipped_streamdetails.seek_position == raw_seek_position
 
 

--- a/tests/controllers/streams/test_crossfade_transition.py
+++ b/tests/controllers/streams/test_crossfade_transition.py
@@ -14,6 +14,7 @@ from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.controllers.streams.audio import StreamsAudio
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
+from music_assistant.controllers.streams.smart_fades.fades import StandardCrossFade
 
 if TYPE_CHECKING:
     import pytest
@@ -74,9 +75,10 @@ def _flow_audio(
     monkeypatch: pytest.MonkeyPatch,
     *,
     next_item: SimpleNamespace | None,
-    load_next: list[Any],
+    load_next: Any,
     crossfade_mode: CrossfadeMode = CrossfadeMode.STANDARD_CROSSFADE,
     crossfade_allowed: bool = True,
+    build_result: object | None = None,
 ) -> tuple[StreamsAudio, SimpleNamespace, MagicMock]:
     """Build a StreamsAudio wired for a two-track flow stream."""
     queue = SimpleNamespace(
@@ -108,7 +110,8 @@ def _flow_audio(
         audio.smart_fades_mixer,
         "build",
         AsyncMock(
-            return_value=SimpleNamespace(
+            return_value=build_result
+            or SimpleNamespace(
                 timing_info=SimpleNamespace(
                     fadein_trimmed_duration=0.0,
                     crossfade_duration=float(STANDARD_CROSSFADE_DURATION),
@@ -254,10 +257,11 @@ async def test_flow_reports_the_crossfade_that_actually_happens(
     await _drain(stream)
 
     assert _reported(mass) == [
-        # nothing faded into the first track
+        # each track starts out crediting no fade
         ("item-1", CrossfadeMode.DISABLED),
+        ("item-2", CrossfadeMode.DISABLED),
+        # both sides are only credited once the blend has really been rendered
         ("item-2", CrossfadeMode.STANDARD_CROSSFADE),
-        # the first track is only credited with a fade once its tail is really blended
         ("item-1", CrossfadeMode.STANDARD_CROSSFADE),
     ]
 
@@ -286,3 +290,106 @@ async def test_flow_reports_no_crossfade_when_the_transition_is_denied(
         ("item-1", CrossfadeMode.DISABLED),
         ("item-2", CrossfadeMode.DISABLED),
     ]
+
+
+async def test_flow_reports_a_smart_fade_that_degraded_to_standard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A smart fade the mixer could not plan is reported as the standard one it became."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second")
+    degraded = StandardCrossFade(logger=MagicMock(), crossfade_duration=STANDARD_CROSSFADE_DURATION)
+    overlap_size = TEST_PCM_FORMAT.pcm_sample_size * STANDARD_CROSSFADE_DURATION
+    degraded.build(overlap_size, overlap_size, TEST_PCM_FORMAT)
+    audio, queue, mass = _flow_audio(
+        monkeypatch,
+        next_item=second_item,
+        load_next=[second_item, QueueEmpty],
+        crossfade_mode=CrossfadeMode.SMART_CROSSFADE,
+        build_result=degraded,
+    )
+    _install_item_streams(monkeypatch, audio, {"item-1": 60, "item-2": 60})
+
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    await _drain(stream)
+
+    assert _reported(mass) == [
+        ("item-1", CrossfadeMode.DISABLED),
+        ("item-2", CrossfadeMode.DISABLED),
+        ("item-2", CrossfadeMode.STANDARD_CROSSFADE),
+        ("item-1", CrossfadeMode.STANDARD_CROSSFADE),
+    ]
+
+
+async def test_flow_reopens_the_incoming_track_when_the_prefetch_broke(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A prefetch whose source failed is dropped so the track gets a fresh attempt."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second")
+    audio, queue, _mass = _flow_audio(
+        monkeypatch, next_item=second_item, load_next=[second_item, QueueEmpty]
+    )
+    opened: list[str] = []
+
+    async def _item_stream(
+        queue_item: SimpleNamespace, *_args: object, **_kwargs: object
+    ) -> AsyncGenerator[bytes]:
+        queue_item.streamdetails.stream_error = False
+        opened.append(queue_item.queue_item_id)
+        if queue_item is second_item and opened.count("item-2") == 1:
+            # the source dies before handing over any audio
+            queue_item.streamdetails.stream_error = True
+            return
+        total = TEST_PCM_FORMAT.pcm_sample_size * 40
+        sent = 0
+        while sent < total:
+            size = min(CHUNK_SIZE, total - sent)
+            sent += size
+            yield bytes(size)
+            await asyncio.sleep(0)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    emitted = await _drain(stream)
+
+    assert opened == ["item-1", "item-2", "item-2"]
+    # the retry serves the whole track, so nothing is lost to the failed prefetch
+    assert emitted == TEST_PCM_FORMAT.pcm_sample_size * 80
+
+
+async def test_flow_drops_a_prefetch_opened_at_another_position(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A prefetch started at a stale seek position is not adopted."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second")
+    # a leftover from an earlier crossfade into this track
+    second_item.streamdetails.seek_position = 8
+
+    loads = {"count": 0}
+
+    async def _load_next(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        loads["count"] += 1
+        if loads["count"] > 1:
+            raise QueueEmpty
+        # loading the item resolves its stream details again, back to the track start
+        second_item.streamdetails.seek_position = 0
+        return second_item
+
+    audio, queue, _mass = _flow_audio(monkeypatch, next_item=second_item, load_next=_load_next)
+    opened, _consumed, _exhausted_at = _install_item_streams(
+        monkeypatch, audio, {"item-1": 40, "item-2": 20}
+    )
+
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    emitted = await _drain(stream)
+
+    assert opened == ["item-1", "item-2", "item-2"]
+    assert emitted == TEST_PCM_FORMAT.pcm_sample_size * 60

--- a/tests/controllers/streams/test_crossfade_transition.py
+++ b/tests/controllers/streams/test_crossfade_transition.py
@@ -443,3 +443,64 @@ async def test_flow_skips_the_prefetch_without_a_known_duration(
     # opened once, at the transition, with nothing read while the tail was held back
     assert opened == ["item-1", "item-2"]
     assert exhausted_at["item-1"]["item-2"] == 0
+
+
+async def test_flow_reopens_a_track_whose_prefetch_ran_out_early(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A source that stops short of the clamp is not trusted to serve the track."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second")
+    audio, queue, _mass = _flow_audio(
+        monkeypatch, next_item=second_item, load_next=[second_item, QueueEmpty]
+    )
+    opened: list[str] = []
+
+    async def _item_stream(
+        queue_item: SimpleNamespace, *_args: object, **_kwargs: object
+    ) -> AsyncGenerator[bytes]:
+        opened.append(queue_item.queue_item_id)
+        # the incoming source ends cleanly long before the prefetch target
+        seconds = 2 if queue_item is second_item and opened.count("item-2") == 1 else 40
+        total = TEST_PCM_FORMAT.pcm_sample_size * seconds
+        sent = 0
+        while sent < total:
+            size = min(CHUNK_SIZE, total - sent)
+            sent += size
+            yield bytes(size)
+            await asyncio.sleep(0)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    emitted = await _drain(stream)
+
+    assert opened == ["item-1", "item-2", "item-2"]
+    # the truncated prefetch is discarded rather than played as the whole track
+    assert emitted == TEST_PCM_FORMAT.pcm_sample_size * 80
+
+
+async def test_flow_keeps_the_prefetch_clear_of_the_end_after_a_seek(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The clamp follows the seek position, so a near-the-end start is not read to EOF."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second")
+    # resuming with only 10 seconds of the track left
+    second_item.streamdetails.seek_position = 290
+    audio, queue, _mass = _flow_audio(
+        monkeypatch, next_item=second_item, load_next=[second_item, QueueEmpty]
+    )
+    opened, _consumed, exhausted_at = _install_item_streams(
+        monkeypatch, audio, {"item-1": 40, "item-2": 10}
+    )
+
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    await _drain(stream)
+
+    # half of the 10s that remain, so the source is never read to its end in the background
+    assert exhausted_at["item-1"]["item-2"] <= TEST_PCM_FORMAT.pcm_sample_size * 5 + CHUNK_SIZE
+    assert opened.count("item-2") == 1

--- a/tests/controllers/streams/test_crossfade_transition.py
+++ b/tests/controllers/streams/test_crossfade_transition.py
@@ -45,7 +45,7 @@ def _buffer(*, duration_available: float = 45.0, eof: bool = True) -> AudioBuffe
     return audio_buffer
 
 
-def _queue_item(item_id: str, name: str) -> SimpleNamespace:
+def _queue_item(item_id: str, name: str, duration: int = 300) -> SimpleNamespace:
     """Build a flow-streamable track with a prepared buffer."""
     streamdetails = SimpleNamespace(
         audio_format=TEST_PCM_FORMAT,
@@ -59,6 +59,7 @@ def _queue_item(item_id: str, name: str) -> SimpleNamespace:
         is_realtime=False,
         volume_normalization_mode=None,
     )
+    streamdetails.duration = duration
     return SimpleNamespace(
         queue_id="queue-1",
         queue_item_id=item_id,
@@ -66,7 +67,7 @@ def _queue_item(item_id: str, name: str) -> SimpleNamespace:
         media_type=MediaType.TRACK,
         media_item=None,
         streamdetails=streamdetails,
-        duration=300,
+        duration=duration,
         extra_attributes={},
     )
 
@@ -393,3 +394,28 @@ async def test_flow_drops_a_prefetch_opened_at_another_position(
 
     assert opened == ["item-1", "item-2", "item-2"]
     assert emitted == TEST_PCM_FORMAT.pcm_sample_size * 60
+
+
+async def test_flow_never_prefetches_a_short_track_to_its_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The prefetch stops short of the end, so the track is not reported as streamed."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second", duration=20)
+    audio, queue, _mass = _flow_audio(
+        monkeypatch,
+        next_item=second_item,
+        load_next=[second_item, QueueEmpty],
+        crossfade_mode=CrossfadeMode.SMART_CROSSFADE,
+    )
+    _opened, _consumed, exhausted_at = _install_item_streams(
+        monkeypatch, audio, {"item-1": 40, "item-2": 20}
+    )
+
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    await _drain(stream)
+
+    # the requested 45s window is clamped to half the incoming track
+    assert exhausted_at["item-1"]["item-2"] <= TEST_PCM_FORMAT.pcm_sample_size * 10 + CHUNK_SIZE

--- a/tests/controllers/streams/test_crossfade_transition.py
+++ b/tests/controllers/streams/test_crossfade_transition.py
@@ -1,0 +1,288 @@
+"""Tests for the flow stream's transition: incoming prefetch and crossfade reporting."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import ContentType, CrossfadeMode, MediaType
+from music_assistant_models.errors import QueueEmpty
+from music_assistant_models.media_items import AudioFormat
+
+from music_assistant.controllers.streams.audio import StreamsAudio
+from music_assistant.controllers.streams.audio_buffer import AudioBuffer
+
+if TYPE_CHECKING:
+    import pytest
+
+TEST_PCM_FORMAT = AudioFormat(
+    content_type=ContentType.PCM_S16LE,
+    sample_rate=8000,
+    bit_depth=16,
+    channels=2,
+)
+# deliberately not a whole second and not frame-aligned, so any assumption about
+# chunk boundaries in the transition path shows up as wrong audio
+CHUNK_SIZE = TEST_PCM_FORMAT.pcm_sample_size // 3 + 2
+STANDARD_CROSSFADE_DURATION = 8
+
+
+def _buffer(*, duration_available: float = 45.0, eof: bool = True) -> AudioBuffer:
+    """Build a valid, fully resident buffer."""
+    audio_buffer = MagicMock(spec=AudioBuffer)
+    audio_buffer.has_error = False
+    audio_buffer.cancelled = False
+    audio_buffer.eof = eof
+    audio_buffer.max_size_seconds = 300
+    audio_buffer.is_valid.return_value = True
+    audio_buffer.duration_available = duration_available
+    audio_buffer.ready = MagicMock()
+    audio_buffer.ready.is_set.return_value = True
+    return audio_buffer
+
+
+def _queue_item(item_id: str, name: str) -> SimpleNamespace:
+    """Build a flow-streamable track with a prepared buffer."""
+    streamdetails = SimpleNamespace(
+        audio_format=TEST_PCM_FORMAT,
+        buffer=_buffer(),
+        fade_in=False,
+        stream_error=False,
+        uri=f"test://{item_id}",
+        seek_position=0,
+        seconds_streamed=0,
+        duration=300,
+        is_realtime=False,
+        volume_normalization_mode=None,
+    )
+    return SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id=item_id,
+        name=name,
+        media_type=MediaType.TRACK,
+        media_item=None,
+        streamdetails=streamdetails,
+        duration=300,
+        extra_attributes={},
+    )
+
+
+def _flow_audio(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    next_item: SimpleNamespace | None,
+    load_next: list[Any],
+    crossfade_mode: CrossfadeMode = CrossfadeMode.STANDARD_CROSSFADE,
+    crossfade_allowed: bool = True,
+) -> tuple[StreamsAudio, SimpleNamespace, MagicMock]:
+    """Build a StreamsAudio wired for a two-track flow stream."""
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        flow_mode=False,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
+    mass = MagicMock()
+    mass.player_queues.queue_data.return_value = SimpleNamespace(
+        session_id="session-1", flow_mode_stream_log=[]
+    )
+    mass.player_queues.load_next_queue_item = AsyncMock(side_effect=load_next)
+    mass.player_queues.get.return_value = queue
+    mass.player_queues.get_next_item.return_value = next_item
+    mass.streams.get_crossfade_mode.return_value = crossfade_mode
+    mass.config.get_raw_core_config_value.return_value = STANDARD_CROSSFADE_DURATION
+    mass.streams.audio_processing.update_item_context = MagicMock()
+    player = MagicMock()
+    player.config.get_value.return_value = "fixed_48000"
+    player.get_supported_sample_rates.return_value = []
+    mass.players.get_player.return_value = player
+
+    audio = StreamsAudio(cast("Any", mass))
+    audio.setup()
+    audio.crossfade_allowed = MagicMock(return_value=crossfade_allowed)  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        audio.smart_fades_mixer,
+        "build",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                timing_info=SimpleNamespace(
+                    fadein_trimmed_duration=0.0,
+                    crossfade_duration=float(STANDARD_CROSSFADE_DURATION),
+                    pre_crossfade_duration=0.0,
+                )
+            )
+        ),
+    )
+
+    async def _concat_mix(
+        _smart_fade: object,
+        *,
+        fade_in_part: bytes,
+        fade_out_part: bytes,
+        **_kwargs: object,
+    ) -> AsyncGenerator[bytes]:
+        # a lossless stand-in for the mixer, so the emitted total stays checkable
+        yield fade_out_part
+        yield fade_in_part
+
+    monkeypatch.setattr(audio.smart_fades_mixer, "mix", _concat_mix)
+    return audio, queue, mass
+
+
+def _install_item_streams(
+    monkeypatch: pytest.MonkeyPatch,
+    audio: StreamsAudio,
+    seconds_per_item: dict[str, int],
+) -> tuple[list[str], dict[str, int], dict[str, dict[str, int]]]:
+    """
+    Serve each queue item unaligned chunks.
+
+    Returns the order in which streams were opened, how much of each item was read, and
+    a snapshot of that reading taken the moment each item's stream ran out.
+    """
+    opened: list[str] = []
+    consumed: dict[str, int] = dict.fromkeys(seconds_per_item, 0)
+    exhausted_at: dict[str, dict[str, int]] = {}
+
+    async def _item_stream(
+        queue_item: SimpleNamespace, *_args: object, **_kwargs: object
+    ) -> AsyncGenerator[bytes]:
+        item_id = queue_item.queue_item_id
+        opened.append(item_id)
+        total = TEST_PCM_FORMAT.pcm_sample_size * seconds_per_item[item_id]
+        sent = 0
+        while sent < total:
+            size = min(CHUNK_SIZE, total - sent)
+            sent += size
+            consumed[item_id] += size
+            yield bytes(size)
+            await asyncio.sleep(0)
+        exhausted_at[item_id] = dict(consumed)
+
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
+    return opened, consumed, exhausted_at
+
+
+def _reported(mass: MagicMock) -> list[tuple[str, CrossfadeMode]]:
+    """Return the crossfade modes published for each queue item, in order."""
+    return [
+        (call.kwargs["queue_item_id"], call.kwargs["queue_processing"].crossfade_mode)
+        for call in mass.streams.audio_processing.update_item_context.call_args_list
+    ]
+
+
+async def _drain(stream: AsyncGenerator[bytes]) -> int:
+    """Consume a flow stream, yielding to the loop like a real consumer does."""
+    total = 0
+    async for chunk in stream:
+        total += len(chunk)
+        await asyncio.sleep(0)
+    return total
+
+
+async def test_flow_prefetches_the_incoming_fade_in_during_the_holdback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The incoming overlap is gathered while the outgoing tail is still being held back."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second")
+    audio, queue, _mass = _flow_audio(
+        monkeypatch, next_item=second_item, load_next=[second_item, QueueEmpty]
+    )
+    opened, _consumed, exhausted_at = _install_item_streams(
+        monkeypatch, audio, {"item-1": 40, "item-2": 20}
+    )
+
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    emitted = await _drain(stream)
+
+    # the whole overlap was already in hand when the outgoing track ran out
+    overlap_size = TEST_PCM_FORMAT.pcm_sample_size * STANDARD_CROSSFADE_DURATION
+    assert exhausted_at["item-1"]["item-2"] >= overlap_size
+    # the prefetched stream is adopted, so the incoming track is only ever opened once
+    assert opened == ["item-1", "item-2"]
+    assert emitted == TEST_PCM_FORMAT.pcm_sample_size * 60
+
+
+async def test_flow_falls_back_when_the_next_item_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A prefetch for another item is dropped and the real next item is streamed."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second")
+    other_item = _queue_item("item-3", "Other")
+    audio, queue, _mass = _flow_audio(
+        monkeypatch, next_item=other_item, load_next=[second_item, QueueEmpty]
+    )
+    opened, consumed, _exhausted_at = _install_item_streams(
+        monkeypatch, audio, {"item-1": 40, "item-2": 20, "item-3": 20}
+    )
+
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    emitted = await _drain(stream)
+
+    # the stale prefetch is dropped and the real next item is opened once
+    assert opened[:3] == ["item-1", "item-3", "item-2"]
+    assert opened.count("item-2") == 1
+    # the discarded prefetch never reaches the listener
+    assert emitted == TEST_PCM_FORMAT.pcm_sample_size * 60
+    assert consumed["item-2"] == TEST_PCM_FORMAT.pcm_sample_size * 20
+
+
+async def test_flow_reports_the_crossfade_that_actually_happens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fade is reported on both of its sides, once the boundary has decided."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second")
+    audio, queue, mass = _flow_audio(
+        monkeypatch, next_item=second_item, load_next=[second_item, QueueEmpty]
+    )
+    _install_item_streams(monkeypatch, audio, {"item-1": 40, "item-2": 20})
+
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    await _drain(stream)
+
+    assert _reported(mass) == [
+        # nothing faded into the first track
+        ("item-1", CrossfadeMode.DISABLED),
+        ("item-2", CrossfadeMode.STANDARD_CROSSFADE),
+        # the first track is only credited with a fade once its tail is really blended
+        ("item-1", CrossfadeMode.STANDARD_CROSSFADE),
+    ]
+
+
+async def test_flow_reports_no_crossfade_when_the_transition_is_denied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transition that never happens is not reported as a crossfade."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second")
+    audio, queue, mass = _flow_audio(
+        monkeypatch,
+        next_item=second_item,
+        load_next=[second_item, QueueEmpty],
+        crossfade_mode=CrossfadeMode.SMART_CROSSFADE,
+        crossfade_allowed=False,
+    )
+    _install_item_streams(monkeypatch, audio, {"item-1": 40, "item-2": 20})
+
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    await _drain(stream)
+
+    assert _reported(mass) == [
+        ("item-1", CrossfadeMode.DISABLED),
+        ("item-2", CrossfadeMode.DISABLED),
+    ]

--- a/tests/controllers/streams/test_crossfade_transition.py
+++ b/tests/controllers/streams/test_crossfade_transition.py
@@ -419,3 +419,27 @@ async def test_flow_never_prefetches_a_short_track_to_its_end(
 
     # the requested 45s window is clamped to half the incoming track
     assert exhausted_at["item-1"]["item-2"] <= TEST_PCM_FORMAT.pcm_sample_size * 10 + CHUNK_SIZE
+
+
+async def test_flow_skips_the_prefetch_without_a_known_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A track of unknown length is not prefetched, since its end cannot be avoided."""
+    first_item = _queue_item("item-1", "First")
+    second_item = _queue_item("item-2", "Second")
+    second_item.streamdetails.duration = None
+    audio, queue, _mass = _flow_audio(
+        monkeypatch, next_item=second_item, load_next=[second_item, QueueEmpty]
+    )
+    opened, _consumed, exhausted_at = _install_item_streams(
+        monkeypatch, audio, {"item-1": 40, "item-2": 20}
+    )
+
+    stream = audio.get_queue_flow_stream(
+        cast("Any", queue), cast("Any", first_item), TEST_PCM_FORMAT, session_id="session-1"
+    )
+    await _drain(stream)
+
+    # opened once, at the transition, with nothing read while the tail was held back
+    assert opened == ["item-1", "item-2"]
+    assert exhausted_at["item-1"]["item-2"] == 0


### PR DESCRIPTION
# What does this implement/fix?

When one track crossfades into the next, the flow stream used to fetch the incoming
track's audio only after the outgoing track had finished - and it sent nothing to the
player while it did. That pause ate into the player's buffer and, on a smart fade
(which needs a 45 second window), could be heard as a gap. The incoming audio is now
collected in the background while the outgoing track is still playing, so the fade
starts the moment the tracks meet.

The audio-processing panel also claimed a crossfade in cases where none happens
(consecutive tracks from the same album, last track of the queue, next track not ready
yet, mismatched sample rates). It now reports the fade that was really applied.

- Collect the incoming track's fade-in in the background during the outgoing track's
  holdback, and continue from that same stream at the transition, so the track is only
  decoded once
- Report the crossfade after the transition has been decided instead of when the stream
  starts, on both tracks a fade touches
- Only credit a track with a crossfade once the blend has really been rendered, and report
  the fade the mixer actually built (it quietly degrades a smart fade to a standard one when
  the analysis it needs is missing)
- Drop the extra flow-stream buffering for AirPlay, which already has ~10 seconds of its
  own buffering downstream; Snapcast keeps it, now applied in the provider itself (which
  also covers its radio streams, where it is a no-op since those are delivered at 1x)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
