### PR TITLE
Ensure gapless playback in MusicCast after security hardening

### DIFF
--- a/music_assistant/controllers/streams/constants.py
+++ b/music_assistant/controllers/streams/constants.py
@@ -49,8 +49,8 @@ RADIO_BUFFER_SIZE: Final[int] = 15
 # as listening to it would. These are the fastest we go, not a target - a player that needs
 # feeding more gently (Chromecast is the known case) can be paced slower than this.
 # Do not remove this to "fix" slow buffering; raise the burst instead. See the usage policy.
-SINGLE_ITEM_READRATE: Final[str] = "2"
-SINGLE_ITEM_READRATE_INITIAL_BURST: Final[str] = "30"
+SINGLE_ITEM_READRATE: Final[str] = "1.2"
+SINGLE_ITEM_READRATE_INITIAL_BURST: Final[str] = "60"
 
 # Time to keep the flow stream response open after the last audio byte of a queue.
 # Players buffer a few seconds ahead of what they actually render; some of them drop


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Adjust the single item's initial burst and read rate to make them work in gapless playback with MusicCast.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
