### PR TITLE
Surface Spotify Connect queue and playback options from the Soloist engine

### DIFF
--- a/music_assistant/providers/spotify_connect/README.md
+++ b/music_assistant/providers/spotify_connect/README.md
@@ -73,6 +73,7 @@ as `BackendEvent`s through a single async callback and answers `get_stream_sourc
 | Max quality | Lossless up to 24-bit/44.1 kHz (Premium; actual quality opaque) | Ogg Vorbis 320 kbps |
 | Audio delivery | PulseAudio pipe-sink → FIFO (`NAMED_PIPE`) | Daemon stdout pipe (`CUSTOM` stream) |
 | Pause behavior | Pipe delivers silence → provider stops the player | Stream ends cleanly (EOF) |
+| Queue control | Session-side queue verbs (add-to-queue, shuffle, repeat) + queue/options events | Transport only |
 | Volume | Two modes: pin at 100% (default) or sync with compensation | `external_volume`: MA owns volume |
 | Risk profile | Binary downloaded from Spotify's CDN, 90-day build expiry, ToS grey area | May break when Spotify changes the protocol |
 

--- a/music_assistant/providers/spotify_connect/base.py
+++ b/music_assistant/providers/spotify_connect/base.py
@@ -161,18 +161,24 @@ class SpotifyConnectBackend(ABC):
         """
         Set the repeat mode on the active session.
 
-        Only available on backends with ``supports_queue_control``.
+        Only available on backends with ``supports_queue_control``. May await
+        the engine's acknowledgement, so the call can block and raise — never
+        call it from the backend event callback (the acknowledgement arrives
+        on the same loop and the wait could only time out).
 
         :param repeat: OFF for no repeat, ONE for the current track, ALL for
             the playing context.
         """
         raise NotImplementedError
 
-    async def request_queue(self) -> None:
+    async def request_queue(self, limit: int = 10) -> None:
         """
         Ask the session to (re)emit its queue view.
 
         Only available on backends with ``supports_queue_control``. There is
         no return value: the snapshot arrives as a QUEUE_CHANGED event.
+
+        :param limit: Maximum number of upcoming entries the snapshot should
+            include.
         """
         raise NotImplementedError

--- a/music_assistant/providers/spotify_connect/base.py
+++ b/music_assistant/providers/spotify_connect/base.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from music_assistant_models.enums import RepeatMode
     from music_assistant_models.media_items import AudioFormat
 
     from music_assistant.providers.spotify_connect.models import (
@@ -45,6 +46,17 @@ class SpotifyConnectBackend(ABC):
         stops the player actively on the paused state event.
         """
         return True
+
+    @property
+    def supports_queue_control(self) -> bool:
+        """
+        Whether the backend implements the queue-session verbs.
+
+        A backend returning True implements ``add_to_queue``, ``set_shuffle``,
+        ``set_repeat`` and ``request_queue`` and emits QUEUE_CHANGED /
+        OPTIONS_CHANGED events.
+        """
+        return False
 
     @abstractmethod
     async def start(self) -> None:
@@ -124,3 +136,43 @@ class SpotifyConnectBackend(ABC):
 
         :param volume: Absolute volume as a 0-100 percentage.
         """
+
+    async def add_to_queue(self, uri: str) -> None:
+        """
+        Add a track to the session's play queue.
+
+        Only available on backends with ``supports_queue_control``.
+
+        :param uri: Spotify track URI to queue.
+        """
+        raise NotImplementedError
+
+    async def set_shuffle(self, enabled: bool) -> None:
+        """
+        Enable or disable shuffle on the active session.
+
+        Only available on backends with ``supports_queue_control``.
+
+        :param enabled: True to enable shuffle, False to disable it.
+        """
+        raise NotImplementedError
+
+    async def set_repeat(self, repeat: RepeatMode) -> None:
+        """
+        Set the repeat mode on the active session.
+
+        Only available on backends with ``supports_queue_control``.
+
+        :param repeat: OFF for no repeat, ONE for the current track, ALL for
+            the playing context.
+        """
+        raise NotImplementedError
+
+    async def request_queue(self) -> None:
+        """
+        Ask the session to (re)emit its queue view.
+
+        Only available on backends with ``supports_queue_control``. There is
+        no return value: the snapshot arrives as a QUEUE_CHANGED event.
+        """
+        raise NotImplementedError

--- a/music_assistant/providers/spotify_connect/models.py
+++ b/music_assistant/providers/spotify_connect/models.py
@@ -28,6 +28,10 @@ class BackendEventType(StrEnum):
     POSITION = "position"
     # Spotify-side volume change (normalized to a 0-100 percentage)
     VOLUME = "volume"
+    # queue listing / playback options reported by the session (only emitted
+    # by backends with ``supports_queue_control``)
+    QUEUE_CHANGED = "queue_changed"
+    OPTIONS_CHANGED = "options_changed"
     # the backend lost its Spotify connection (e.g. daemon exit) and will recover
     # on its own; any session/playback state is gone until a new SESSION_ACTIVE
     CONNECTION_LOST = "connection_lost"
@@ -75,6 +79,37 @@ class BackendTrackMetadata:
 
 
 @dataclass(slots=True)
+class BackendQueueEntry:
+    """
+    One entry in the session's queue listing.
+
+    ``source`` tells where the entry comes from: "context" (the playing
+    context), "queue" (explicitly queued) or "autoplay". ``name`` is the
+    display title when the backend reported one.
+    """
+
+    uri: str
+    source: str
+    name: str | None = None
+
+
+@dataclass(slots=True)
+class BackendQueueState:
+    """The session's queue view: recently played and upcoming entries, in play order."""
+
+    previous: list[BackendQueueEntry] = field(default_factory=list)
+    upcoming: list[BackendQueueEntry] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class BackendPlaybackOptions:
+    """Playback options of the session (``repeat`` is one of off/context/track)."""
+
+    shuffle: bool = False
+    repeat: str = "off"
+
+
+@dataclass(slots=True)
 class BackendEvent:
     """
     A single normalized event emitted by a backend to the provider.
@@ -83,8 +118,10 @@ class BackendEvent:
     the latest context/track seen by the backend so the provider can take
     playback back after the user moved the active device away. ``position`` is
     the elapsed time in seconds (POSITION events), ``volume`` a 0-100
-    percentage (VOLUME events) and ``error`` the failure description
-    (ERROR and FATAL_ERROR events).
+    percentage (VOLUME events), ``error`` the failure description (ERROR and
+    FATAL_ERROR events), ``queue`` the session's queue view (QUEUE_CHANGED
+    events) and ``options`` the session's playback options (OPTIONS_CHANGED
+    events, and state events whose payload carried them).
     """
 
     type: BackendEventType
@@ -94,6 +131,8 @@ class BackendEvent:
     position: int | None = None
     volume: int | None = None
     error: str | None = None
+    queue: BackendQueueState | None = None
+    options: BackendPlaybackOptions | None = None
 
 
 # Awaited by the backend for every normalized event, in emit order.

--- a/music_assistant/providers/spotify_connect/models.py
+++ b/music_assistant/providers/spotify_connect/models.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
+from music_assistant_models.enums import RepeatMode
+
 if TYPE_CHECKING:
     from music_assistant_models.enums import StreamType
 
@@ -78,18 +80,36 @@ class BackendTrackMetadata:
     position: int = 0
 
 
+class QueueEntrySource(StrEnum):
+    """Where an entry in the session's queue listing comes from."""
+
+    # part of the playing context (album/playlist/artist)
+    CONTEXT = "context"
+    # explicitly queued by the user
+    QUEUE = "queue"
+    # session autoplay continuation
+    AUTOPLAY = "autoplay"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: object) -> QueueEntrySource:  # noqa: ARG003
+        """Return UNKNOWN if an unknown value is provided."""
+        return cls.UNKNOWN
+
+
 @dataclass(slots=True)
 class BackendQueueEntry:
     """
     One entry in the session's queue listing.
 
-    ``source`` tells where the entry comes from: "context" (the playing
-    context), "queue" (explicitly queued) or "autoplay". ``name`` is the
-    display title when the backend reported one.
+    ``uid`` is the session's stable handle for this entry (two occurrences of
+    the same track carry distinct uids). ``name`` is the display title when
+    the backend reported one.
     """
 
+    uid: str
     uri: str
-    source: str
+    source: QueueEntrySource
     name: str | None = None
 
 
@@ -103,10 +123,10 @@ class BackendQueueState:
 
 @dataclass(slots=True)
 class BackendPlaybackOptions:
-    """Playback options of the session (``repeat`` is one of off/context/track)."""
+    """Playback options of the session."""
 
     shuffle: bool = False
-    repeat: str = "off"
+    repeat: RepeatMode = RepeatMode.OFF
 
 
 @dataclass(slots=True)
@@ -121,7 +141,7 @@ class BackendEvent:
     percentage (VOLUME events), ``error`` the failure description (ERROR and
     FATAL_ERROR events), ``queue`` the session's queue view (QUEUE_CHANGED
     events) and ``options`` the session's playback options (OPTIONS_CHANGED
-    events, and state events whose payload carried them).
+    events).
     """
 
     type: BackendEventType

--- a/music_assistant/providers/spotify_connect/soloist/backend.py
+++ b/music_assistant/providers/spotify_connect/soloist/backend.py
@@ -39,6 +39,7 @@ from music_assistant.providers.spotify_connect.models import (
     BackendQueueState,
     BackendStreamSource,
     BackendTrackMetadata,
+    QueueEntrySource,
 )
 
 from .runtime import (
@@ -198,6 +199,8 @@ class SoloistBackend(SpotifyConnectBackend):
         self._respawn_requested: bool = False
         # serializes all volume handling (sink compensation + event forwarding)
         self._volume_lock = asyncio.Lock()
+        # serializes the two-command repeat sequences of concurrent set_repeat calls
+        self._repeat_lock = asyncio.Lock()
         # last volume reported by the daemon (None until the first event)
         self._spotify_volume: int | None = None
         # guards the player_only 100%-pin so overlapping resets are not issued
@@ -436,24 +439,38 @@ class SoloistBackend(SpotifyConnectBackend):
         """
         Set the repeat mode on the active session.
 
+        Awaits the engine's acknowledgement of both underlying commands, so
+        this call can block and raise; never call it from the backend event
+        callback (the acknowledgements arrive on the same loop and the wait
+        could only time out).
+
         :param repeat: OFF for no repeat, ONE for the current track, ALL for
             the playing context.
         """
         assert self._client is not None
+        if repeat == RepeatMode.UNKNOWN:
+            raise ValueError("cannot apply an unknown repeat mode")
         # soloist models repeat as two independent booleans (track/context) with
-        # both-true undefined; await each ack so the pair cannot race and always
-        # disable one flag before enabling the other
-        if repeat == RepeatMode.ONE:
-            await self._client.set_repeat_context(False, await_result=True)
-            await self._client.set_repeat_track(True, await_result=True)
-            return
-        await self._client.set_repeat_track(False, await_result=True)
-        await self._client.set_repeat_context(repeat == RepeatMode.ALL, await_result=True)
+        # both-true undefined: the lock serializes concurrent callers and the
+        # awaited acks order the pair, so one flag is always cleared before the
+        # other is raised
+        async with self._repeat_lock:
+            if repeat == RepeatMode.ONE:
+                await self._client.set_repeat_context(False, await_result=True)
+                await self._client.set_repeat_track(True, await_result=True)
+                return
+            await self._client.set_repeat_track(False, await_result=True)
+            await self._client.set_repeat_context(repeat == RepeatMode.ALL, await_result=True)
 
-    async def request_queue(self) -> None:
-        """Ask the session to (re)emit its queue view (arrives as a QUEUE_CHANGED event)."""
+    async def request_queue(self, limit: int = 10) -> None:
+        """
+        Ask the session to (re)emit its queue view (arrives as a QUEUE_CHANGED event).
+
+        :param limit: Maximum number of upcoming entries the snapshot should
+            include.
+        """
         assert self._client is not None
-        await self._client.get_queue()
+        await self._client.get_queue(limit)
 
     async def _ensure_fresh_sink(self) -> PipeSink:
         """
@@ -799,6 +816,16 @@ class SoloistBackend(SpotifyConnectBackend):
             await self._event_callback(
                 self._make_event(BackendEventType.METADATA, metadata=_entity_metadata(item))
             )
+        if isinstance(event.data, SoloistPlaybackState) and event.data.options is not None:
+            # a state snapshot/delta carrying the playback options doubles as an
+            # options report; emit a separate OPTIONS_CHANGED so consumers only
+            # ever need to watch one event type for options
+            await self._event_callback(
+                self._make_event(
+                    BackendEventType.OPTIONS_CHANGED,
+                    options=_backend_options(event.data.options),
+                )
+            )
         await self._event_callback(self._translate_event(event))
 
     async def _handle_volume_changed(self, volume: int) -> None:
@@ -878,14 +905,9 @@ class SoloistBackend(SpotifyConnectBackend):
                 else BackendEventType.SESSION_INACTIVE
             )
         if isinstance(data, SoloistPlaybackState):
-            # covers both the playback_state snapshot and the playback_changed
-            # delta; when the payload carries the playback options they ride
-            # along on the normalized event
+            # covers both the playback_state snapshot and the playback_changed delta
             self._cache_uris(track=data.item, context=data.context)
-            options = _backend_options(data.options) if data.options is not None else None
-            return self._make_event(
-                _STATUS_EVENTS.get(data.status, BackendEventType.OTHER), options=options
-            )
+            return self._make_event(_STATUS_EVENTS.get(data.status, BackendEventType.OTHER))
         if isinstance(data, SoloistTrackChanged) and data.item is not None:
             self._cache_uris(track=data.item)
             return self._make_event(BackendEventType.METADATA, metadata=_entity_metadata(data.item))
@@ -943,12 +965,11 @@ def _entity_metadata(item: SoloistEntity) -> BackendTrackMetadata:
     :param item: The soloist entity (track) to extract the metadata from.
     """
     decorations = item.decorations or {}
-    identity = _as_dict(decorations.get("identity"))
     playback = _as_dict(decorations.get("playback"))
     duration_ms = playback.get("duration_ms")
     return BackendTrackMetadata(
         track_uri=item.uri,
-        title=_as_str(identity.get("name")) or _as_str(identity.get("title")),
+        title=_identity_title(decorations),
         artist=_creator_name(decorations.get("creators")),
         album=_nested_entity_name(decorations.get("parent")),
         image_url=_cover_url(decorations),
@@ -960,8 +981,7 @@ def _queue_entries(entries: list[SoloistQueueEntry]) -> list[BackendQueueEntry]:
     """
     Map soloist queue entries onto normalized queue entries.
 
-    Entries without a resolvable uri are skipped; the display name is taken
-    from the (extensible) decorations bag when present.
+    Entries without a resolvable uri are skipped.
 
     :param entries: The soloist queue entries (previous or upcoming listing).
     """
@@ -969,15 +989,31 @@ def _queue_entries(entries: list[SoloistQueueEntry]) -> list[BackendQueueEntry]:
     for entry in entries:
         if entry.item is None or not entry.item.uri:
             continue
-        decorations = entry.item.decorations or {}
-        name = _as_str(_as_dict(decorations.get("identity")).get("name"))
-        result.append(BackendQueueEntry(uri=entry.item.uri, source=entry.source, name=name))
+        result.append(
+            BackendQueueEntry(
+                uid=entry.uid,
+                uri=entry.item.uri,
+                source=QueueEntrySource(entry.source),
+                name=_identity_title(entry.item.decorations or {}),
+            )
+        )
     return result
+
+
+# soloist's repeat vocabulary mapped onto the MA repeat modes
+_REPEAT_MODES: Final = {
+    "off": RepeatMode.OFF,
+    "context": RepeatMode.ALL,
+    "track": RepeatMode.ONE,
+}
 
 
 def _backend_options(options: SoloistPlaybackOptions) -> BackendPlaybackOptions:
     """Map soloist playback options onto the normalized model."""
-    return BackendPlaybackOptions(shuffle=options.shuffle, repeat=options.repeat)
+    return BackendPlaybackOptions(
+        shuffle=options.shuffle,
+        repeat=_REPEAT_MODES.get(options.repeat, RepeatMode.UNKNOWN),
+    )
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
@@ -988,6 +1024,12 @@ def _as_dict(value: Any) -> dict[str, Any]:
 def _as_str(value: Any) -> str | None:
     """Return the value if it is a non-empty string, None otherwise."""
     return value if isinstance(value, str) and value else None
+
+
+def _identity_title(decorations: dict[str, Any]) -> str | None:
+    """Return the display title from a decorations bag's identity."""
+    identity = _as_dict(decorations.get("identity"))
+    return _as_str(identity.get("name")) or _as_str(identity.get("title"))
 
 
 def _entity_name(value: Any) -> str | None:

--- a/music_assistant/providers/spotify_connect/soloist/backend.py
+++ b/music_assistant/providers/spotify_connect/soloist/backend.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
 from aiohttp import ClientError
-from music_assistant_models.enums import ContentType, StreamType
+from music_assistant_models.enums import ContentType, RepeatMode, StreamType
 from music_assistant_models.errors import AudioError
 from music_assistant_models.media_items import AudioFormat
 
@@ -34,6 +34,9 @@ from music_assistant.providers.spotify_connect.base import SpotifyConnectBackend
 from music_assistant.providers.spotify_connect.models import (
     BackendEvent,
     BackendEventType,
+    BackendPlaybackOptions,
+    BackendQueueEntry,
+    BackendQueueState,
     BackendStreamSource,
     BackendTrackMetadata,
 )
@@ -48,8 +51,10 @@ from .runtime import (
     SoloistDeviceChanged,
     SoloistError,
     SoloistErrorMessage,
+    SoloistOptionsChanged,
     SoloistPlaybackState,
     SoloistPositionSync,
+    SoloistQueueChanged,
     SoloistTrackChanged,
     SoloistVolumeChanged,
 )
@@ -64,7 +69,7 @@ if TYPE_CHECKING:
         BackendEventCallback,
     )
 
-    from .runtime import SoloistEntity, SoloistEvent
+    from .runtime import SoloistEntity, SoloistEvent, SoloistPlaybackOptions, SoloistQueueEntry
 
 # How Spotify-side volume changes are handled (see set_volume).
 VOLUME_MODE_PLAYER_ONLY: Final = "player_only"
@@ -231,6 +236,11 @@ class SoloistBackend(SpotifyConnectBackend):
     def stream_ends_on_pause(self) -> bool:
         """The pipe sink delivers silence on pause; the provider stops the player."""
         return False
+
+    @property
+    def supports_queue_control(self) -> bool:
+        """The soloist session implements the queue verbs and queue/options events."""
+        return True
 
     async def start(self) -> None:
         """Start the backend and its supervised soloist daemon."""
@@ -403,6 +413,47 @@ class SoloistBackend(SpotifyConnectBackend):
             if self._spotify_volume == 100:
                 return
             await self._client.set_volume(100)
+
+    async def add_to_queue(self, uri: str) -> None:
+        """
+        Add a track to the session's play queue.
+
+        :param uri: Spotify track URI to queue.
+        """
+        assert self._client is not None
+        await self._client.add_to_queue(uri)
+
+    async def set_shuffle(self, enabled: bool) -> None:
+        """
+        Enable or disable shuffle on the active session.
+
+        :param enabled: True to enable shuffle, False to disable it.
+        """
+        assert self._client is not None
+        await self._client.set_shuffle(enabled)
+
+    async def set_repeat(self, repeat: RepeatMode) -> None:
+        """
+        Set the repeat mode on the active session.
+
+        :param repeat: OFF for no repeat, ONE for the current track, ALL for
+            the playing context.
+        """
+        assert self._client is not None
+        # soloist models repeat as two independent booleans (track/context) with
+        # both-true undefined; await each ack so the pair cannot race and always
+        # disable one flag before enabling the other
+        if repeat == RepeatMode.ONE:
+            await self._client.set_repeat_context(False, await_result=True)
+            await self._client.set_repeat_track(True, await_result=True)
+            return
+        await self._client.set_repeat_track(False, await_result=True)
+        await self._client.set_repeat_context(repeat == RepeatMode.ALL, await_result=True)
+
+    async def request_queue(self) -> None:
+        """Ask the session to (re)emit its queue view (arrives as a QUEUE_CHANGED event)."""
+        assert self._client is not None
+        await self._client.get_queue()
 
     async def _ensure_fresh_sink(self) -> PipeSink:
         """
@@ -827,9 +878,14 @@ class SoloistBackend(SpotifyConnectBackend):
                 else BackendEventType.SESSION_INACTIVE
             )
         if isinstance(data, SoloistPlaybackState):
-            # covers both the playback_state snapshot and the playback_changed delta
+            # covers both the playback_state snapshot and the playback_changed
+            # delta; when the payload carries the playback options they ride
+            # along on the normalized event
             self._cache_uris(track=data.item, context=data.context)
-            return self._make_event(_STATUS_EVENTS.get(data.status, BackendEventType.OTHER))
+            options = _backend_options(data.options) if data.options is not None else None
+            return self._make_event(
+                _STATUS_EVENTS.get(data.status, BackendEventType.OTHER), options=options
+            )
         if isinstance(data, SoloistTrackChanged) and data.item is not None:
             self._cache_uris(track=data.item)
             return self._make_event(BackendEventType.METADATA, metadata=_entity_metadata(data.item))
@@ -839,9 +895,21 @@ class SoloistBackend(SpotifyConnectBackend):
             )
         if isinstance(data, SoloistErrorMessage):
             return self._make_event(BackendEventType.ERROR, error=data.message)
+        if isinstance(data, SoloistQueueChanged):
+            return self._make_event(
+                BackendEventType.QUEUE_CHANGED,
+                queue=BackendQueueState(
+                    previous=_queue_entries(data.previous),
+                    upcoming=_queue_entries(data.upcoming),
+                ),
+            )
+        if isinstance(data, SoloistOptionsChanged):
+            return self._make_event(
+                BackendEventType.OPTIONS_CHANGED, options=_backend_options(data.options)
+            )
         if isinstance(data, SoloistContextChanged):
             self._cache_uris(context=data.context)
-        # queue/options/context changes, command acks and unknown events
+        # context changes, command acks and unknown events
         return self._make_event(BackendEventType.OTHER)
 
     def _make_event(self, event_type: BackendEventType, **fields: Any) -> BackendEvent:
@@ -886,6 +954,30 @@ def _entity_metadata(item: SoloistEntity) -> BackendTrackMetadata:
         image_url=_cover_url(decorations),
         duration=int(duration_ms) // 1000 if isinstance(duration_ms, int | float) else None,
     )
+
+
+def _queue_entries(entries: list[SoloistQueueEntry]) -> list[BackendQueueEntry]:
+    """
+    Map soloist queue entries onto normalized queue entries.
+
+    Entries without a resolvable uri are skipped; the display name is taken
+    from the (extensible) decorations bag when present.
+
+    :param entries: The soloist queue entries (previous or upcoming listing).
+    """
+    result: list[BackendQueueEntry] = []
+    for entry in entries:
+        if entry.item is None or not entry.item.uri:
+            continue
+        decorations = entry.item.decorations or {}
+        name = _as_str(_as_dict(decorations.get("identity")).get("name"))
+        result.append(BackendQueueEntry(uri=entry.item.uri, source=entry.source, name=name))
+    return result
+
+
+def _backend_options(options: SoloistPlaybackOptions) -> BackendPlaybackOptions:
+    """Map soloist playback options onto the normalized model."""
+    return BackendPlaybackOptions(shuffle=options.shuffle, repeat=options.repeat)
 
 
 def _as_dict(value: Any) -> dict[str, Any]:

--- a/tests/providers/spotify_connect/test_backend_contract.py
+++ b/tests/providers/spotify_connect/test_backend_contract.py
@@ -15,7 +15,13 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import ContentType, MediaType, SourceControl, StreamType
+from music_assistant_models.enums import (
+    ContentType,
+    MediaType,
+    RepeatMode,
+    SourceControl,
+    StreamType,
+)
 from music_assistant_models.errors import LoginFailed
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamMetadata
@@ -501,6 +507,21 @@ async def test_on_volume_change_pushes_deduped_volume_to_backend() -> None:
     # unchanged value: deduped, nothing sent
     await provider.on_volume_change(AUDIO_SOURCE_ID, 60)
     assert backend.calls == [("set_volume", 60)]
+
+
+async def test_queue_control_contract_defaults() -> None:
+    """A backend without queue control reports so and refuses the queue-session verbs."""
+    backend = FakeBackend()
+
+    assert backend.supports_queue_control is False
+    with pytest.raises(NotImplementedError):
+        await backend.add_to_queue("spotify:track:t1")
+    with pytest.raises(NotImplementedError):
+        await backend.set_shuffle(True)
+    with pytest.raises(NotImplementedError):
+        await backend.set_repeat(RepeatMode.OFF)
+    with pytest.raises(NotImplementedError):
+        await backend.request_queue()
 
 
 async def test_source_selected_takes_playback_back_via_backend() -> None:

--- a/tests/providers/spotify_connect/test_soloist_backend.py
+++ b/tests/providers/spotify_connect/test_soloist_backend.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import stat
 from contextlib import suppress
+from functools import partial
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
@@ -15,7 +16,11 @@ import pytest
 from music_assistant_models.enums import ContentType, RepeatMode, StreamType
 from music_assistant_models.errors import AudioError
 
-from music_assistant.providers.spotify_connect.models import BackendEvent, BackendEventType
+from music_assistant.providers.spotify_connect.models import (
+    BackendEvent,
+    BackendEventType,
+    QueueEntrySource,
+)
 from music_assistant.providers.spotify_connect.soloist import backend as soloist_backend
 from music_assistant.providers.spotify_connect.soloist.backend import (
     CACHE_SIZE_MB,
@@ -620,7 +625,7 @@ async def test_position_sync_maps_to_seconds() -> None:
 
 
 async def test_queue_changed_maps_entries() -> None:
-    """A queue_changed event maps its entries to normalized uri/source/name triples."""
+    """A queue_changed event maps its entries to normalized uid/uri/source/name entries."""
     backend, events = _make_backend()
     previous = [
         SoloistQueueEntry(
@@ -649,10 +654,20 @@ async def test_queue_changed_maps_entries() -> None:
             source="autoplay",
             item=SoloistEntity(uri="spotify:track:t2", entity_type="track"),
         ),
-        # entries without a resolvable uri are skipped
-        SoloistQueueEntry(uid="u3", source="autoplay", item=None),
+        # the title fallback used for track metadata applies to queue entries too
         SoloistQueueEntry(
-            uid="u4", source="autoplay", item=SoloistEntity(uri="", entity_type="track")
+            uid="u3",
+            source="new_source_kind",
+            item=SoloistEntity(
+                uri="spotify:track:t3",
+                entity_type="track",
+                decorations={"identity": {"title": "Titled Song"}},
+            ),
+        ),
+        # entries without a resolvable uri are skipped
+        SoloistQueueEntry(uid="u4", source="autoplay", item=None),
+        SoloistQueueEntry(
+            uid="u5", source="autoplay", item=SoloistEntity(uri="", entity_type="track")
         ),
     ]
 
@@ -664,12 +679,14 @@ async def test_queue_changed_maps_entries() -> None:
     assert event.type is BackendEventType.QUEUE_CHANGED
     queue = event.queue
     assert queue is not None
-    assert [(e.uri, e.source, e.name) for e in queue.previous] == [
-        ("spotify:track:t0", "context", "Played Song"),
+    assert [(e.uid, e.uri, e.source, e.name) for e in queue.previous] == [
+        ("p1", "spotify:track:t0", QueueEntrySource.CONTEXT, "Played Song"),
     ]
-    assert [(e.uri, e.source, e.name) for e in queue.upcoming] == [
-        ("spotify:track:t1", "queue", "Queued Song"),
-        ("spotify:track:t2", "autoplay", None),
+    assert [(e.uid, e.uri, e.source, e.name) for e in queue.upcoming] == [
+        ("u1", "spotify:track:t1", QueueEntrySource.QUEUE, "Queued Song"),
+        ("u2", "spotify:track:t2", QueueEntrySource.AUTOPLAY, None),
+        # an unrecognized source value degrades to UNKNOWN instead of raising
+        ("u3", "spotify:track:t3", QueueEntrySource.UNKNOWN, "Titled Song"),
     ]
 
 
@@ -688,11 +705,11 @@ async def test_options_changed_maps_shuffle_and_repeat() -> None:
     assert event.type is BackendEventType.OPTIONS_CHANGED
     assert event.options is not None
     assert event.options.shuffle is True
-    assert event.options.repeat == "context"
+    assert event.options.repeat is RepeatMode.ALL
 
 
-async def test_playback_state_options_ride_along() -> None:
-    """A playback_state carrying options attaches them to the normalized state event."""
+async def test_playback_state_options_emit_options_changed_precursor() -> None:
+    """A playback_state carrying options emits OPTIONS_CHANGED before the state event."""
     backend, events = _make_backend()
 
     await backend._handle_event(
@@ -704,11 +721,31 @@ async def test_playback_state_options_ride_along() -> None:
         )
     )
 
-    event = events[0]
-    assert event.type is BackendEventType.PLAYING
-    assert event.options is not None
-    assert event.options.shuffle is True
-    assert event.options.repeat == "track"
+    assert [e.type for e in events] == [
+        BackendEventType.OPTIONS_CHANGED,
+        BackendEventType.PLAYING,
+    ]
+    options = events[0].options
+    assert options is not None
+    assert options.shuffle is True
+    assert options.repeat is RepeatMode.ONE
+    # the state event itself carries no options; OPTIONS_CHANGED is the one channel
+    assert events[1].options is None
+
+
+async def test_unknown_repeat_vocabulary_degrades_to_unknown() -> None:
+    """An unrecognized repeat value from the wire maps to RepeatMode.UNKNOWN."""
+    backend, events = _make_backend()
+
+    await backend._handle_event(
+        _event(
+            "options_changed",
+            SoloistOptionsChanged(options=SoloistPlaybackOptions(repeat="context_repeat")),
+        )
+    )
+
+    assert events[0].options is not None
+    assert events[0].options.repeat is RepeatMode.UNKNOWN
 
 
 async def test_uri_cache_feeds_all_events() -> None:
@@ -1227,8 +1264,8 @@ async def test_queue_commands_map_to_client() -> None:
     client.set_shuffle.assert_awaited_once_with(True)
 
     # the queue snapshot arrives as a queue_changed event, no ack is awaited
-    await backend.request_queue()
-    client.get_queue.assert_awaited_once_with()
+    await backend.request_queue(limit=25)
+    client.get_queue.assert_awaited_once_with(25)
 
 
 @pytest.mark.parametrize(
@@ -1252,6 +1289,41 @@ async def test_set_repeat_sequences_the_two_flags(
     assert [(name, args[0]) for name, args, _kwargs in client.mock_calls] == expected_calls
     # each command waits for its ack so the pair cannot race
     assert all(kwargs == {"await_result": True} for _name, _args, kwargs in client.mock_calls)
+
+
+async def test_set_repeat_rejects_unknown() -> None:
+    """set_repeat refuses RepeatMode.UNKNOWN instead of silently disabling repeat."""
+    backend, _events = _make_backend()
+    client = AsyncMock()
+    backend._client = client
+
+    with pytest.raises(ValueError, match="unknown repeat mode"):
+        await backend.set_repeat(RepeatMode.UNKNOWN)
+    assert client.mock_calls == []
+
+
+async def test_set_repeat_serializes_concurrent_calls() -> None:
+    """Concurrent set_repeat calls cannot interleave their two-command sequences."""
+    backend, _events = _make_backend()
+    call_order: list[tuple[str, bool]] = []
+
+    async def record(name: str, enabled: bool, **_kwargs: Any) -> None:
+        call_order.append((name, enabled))
+        await asyncio.sleep(0)  # yield so an unserialized second call could interleave
+
+    client = AsyncMock()
+    client.set_repeat_track.side_effect = partial(record, "set_repeat_track")
+    client.set_repeat_context.side_effect = partial(record, "set_repeat_context")
+    backend._client = client
+
+    await asyncio.gather(backend.set_repeat(RepeatMode.ALL), backend.set_repeat(RepeatMode.ONE))
+
+    assert call_order == [
+        ("set_repeat_track", False),
+        ("set_repeat_context", True),
+        ("set_repeat_context", False),
+        ("set_repeat_track", True),
+    ]
 
 
 async def test_player_only_pins_spotify_volume_and_suppresses_events() -> None:

--- a/tests/providers/spotify_connect/test_soloist_backend.py
+++ b/tests/providers/spotify_connect/test_soloist_backend.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import ContentType, StreamType
+from music_assistant_models.enums import ContentType, RepeatMode, StreamType
 from music_assistant_models.errors import AudioError
 
 from music_assistant.providers.spotify_connect.models import BackendEvent, BackendEventType
@@ -38,6 +38,7 @@ from music_assistant.providers.spotify_connect.soloist.runtime import (
     SoloistPosition,
     SoloistPositionSync,
     SoloistQueueChanged,
+    SoloistQueueEntry,
     SoloistTrackChanged,
     SoloistVolumeChanged,
 )
@@ -462,10 +463,10 @@ async def test_five_daemon_failures_report_fatal_error(
         ),
         pytest.param(
             SoloistOptionsChanged(options=SoloistPlaybackOptions()),
-            BackendEventType.OTHER,
+            BackendEventType.OPTIONS_CHANGED,
             id="options_changed",
         ),
-        pytest.param(SoloistQueueChanged(), BackendEventType.OTHER, id="queue_changed"),
+        pytest.param(SoloistQueueChanged(), BackendEventType.QUEUE_CHANGED, id="queue_changed"),
         pytest.param(
             SoloistCommandResult(command="pause"), BackendEventType.OTHER, id="command_result"
         ),
@@ -616,6 +617,98 @@ async def test_position_sync_maps_to_seconds() -> None:
 
     assert events[0].type is BackendEventType.POSITION
     assert events[0].position == 45
+
+
+async def test_queue_changed_maps_entries() -> None:
+    """A queue_changed event maps its entries to normalized uri/source/name triples."""
+    backend, events = _make_backend()
+    previous = [
+        SoloistQueueEntry(
+            uid="p1",
+            source="context",
+            item=SoloistEntity(
+                uri="spotify:track:t0",
+                entity_type="track",
+                decorations={"identity": {"name": "Played Song"}},
+            ),
+        ),
+    ]
+    upcoming = [
+        SoloistQueueEntry(
+            uid="u1",
+            source="queue",
+            item=SoloistEntity(
+                uri="spotify:track:t1",
+                entity_type="track",
+                decorations={"identity": {"name": "Queued Song"}},
+            ),
+        ),
+        # a name-less entry is tolerated (decorations is an extensible bag)
+        SoloistQueueEntry(
+            uid="u2",
+            source="autoplay",
+            item=SoloistEntity(uri="spotify:track:t2", entity_type="track"),
+        ),
+        # entries without a resolvable uri are skipped
+        SoloistQueueEntry(uid="u3", source="autoplay", item=None),
+        SoloistQueueEntry(
+            uid="u4", source="autoplay", item=SoloistEntity(uri="", entity_type="track")
+        ),
+    ]
+
+    await backend._handle_event(
+        _event("queue_changed", SoloistQueueChanged(previous=previous, upcoming=upcoming))
+    )
+
+    event = events[0]
+    assert event.type is BackendEventType.QUEUE_CHANGED
+    queue = event.queue
+    assert queue is not None
+    assert [(e.uri, e.source, e.name) for e in queue.previous] == [
+        ("spotify:track:t0", "context", "Played Song"),
+    ]
+    assert [(e.uri, e.source, e.name) for e in queue.upcoming] == [
+        ("spotify:track:t1", "queue", "Queued Song"),
+        ("spotify:track:t2", "autoplay", None),
+    ]
+
+
+async def test_options_changed_maps_shuffle_and_repeat() -> None:
+    """An options_changed event carries the session's shuffle and repeat state."""
+    backend, events = _make_backend()
+
+    await backend._handle_event(
+        _event(
+            "options_changed",
+            SoloistOptionsChanged(options=SoloistPlaybackOptions(shuffle=True, repeat="context")),
+        )
+    )
+
+    event = events[0]
+    assert event.type is BackendEventType.OPTIONS_CHANGED
+    assert event.options is not None
+    assert event.options.shuffle is True
+    assert event.options.repeat == "context"
+
+
+async def test_playback_state_options_ride_along() -> None:
+    """A playback_state carrying options attaches them to the normalized state event."""
+    backend, events = _make_backend()
+
+    await backend._handle_event(
+        _event(
+            "playback_state",
+            SoloistPlaybackState(
+                status="playing", options=SoloistPlaybackOptions(shuffle=True, repeat="track")
+            ),
+        )
+    )
+
+    event = events[0]
+    assert event.type is BackendEventType.PLAYING
+    assert event.options is not None
+    assert event.options.shuffle is True
+    assert event.options.repeat == "track"
 
 
 async def test_uri_cache_feeds_all_events() -> None:
@@ -1117,6 +1210,48 @@ async def test_transport_commands_map_to_client() -> None:
     client.deactivate.assert_awaited_once_with()
     call_names = [name for name, _args, _kwargs in client.mock_calls]
     assert call_names.index("pause") < call_names.index("deactivate")
+
+
+async def test_queue_commands_map_to_client() -> None:
+    """The queue-session verbs pass through to the SoloistClient."""
+    backend, _events = _make_backend()
+    client = AsyncMock()
+    backend._client = client
+
+    assert backend.supports_queue_control is True
+
+    await backend.add_to_queue("spotify:track:t1")
+    client.add_to_queue.assert_awaited_once_with("spotify:track:t1")
+
+    await backend.set_shuffle(True)
+    client.set_shuffle.assert_awaited_once_with(True)
+
+    # the queue snapshot arrives as a queue_changed event, no ack is awaited
+    await backend.request_queue()
+    client.get_queue.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    ("repeat", "expected_calls"),
+    [
+        (RepeatMode.OFF, [("set_repeat_track", False), ("set_repeat_context", False)]),
+        (RepeatMode.ALL, [("set_repeat_track", False), ("set_repeat_context", True)]),
+        (RepeatMode.ONE, [("set_repeat_context", False), ("set_repeat_track", True)]),
+    ],
+)
+async def test_set_repeat_sequences_the_two_flags(
+    repeat: RepeatMode, expected_calls: list[tuple[str, bool]]
+) -> None:
+    """set_repeat disables one repeat flag before enabling the other, awaiting each ack."""
+    backend, _events = _make_backend()
+    client = AsyncMock()
+    backend._client = client
+
+    await backend.set_repeat(repeat)
+
+    assert [(name, args[0]) for name, args, _kwargs in client.mock_calls] == expected_calls
+    # each command waits for its ack so the pair cannot race
+    assert all(kwargs == {"await_result": True} for _name, _args, kwargs in client.mock_calls)
 
 
 async def test_player_only_pins_spotify_volume_and_suppresses_events() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Groundwork for redirecting Spotify playback into a Spotify Connect session (queue delegation): the Soloist engine already reports its queue listing and shuffle/repeat state over its WebSocket API, but the Connect plugin threw those events away. This PR surfaces them and adds the queue-session verbs the engine supports, so upcoming work can let the MA queue delegate to the session.

- New normalized backend events `QUEUE_CHANGED` (previous/upcoming entries with a context/queue/autoplay source tag) and `OPTIONS_CHANGED` (shuffle + repeat), instead of collapsing them to OTHER
- Playback-state events now carry the session's shuffle/repeat options when the payload includes them
- Backend contract gains capability-gated queue verbs: `add_to_queue`, `set_shuffle`, `set_repeat`, `request_queue` (Soloist implements them; go-librespot keeps the defaults)
- `set_repeat` sequences Soloist's two repeat booleans with acks so the pair cannot race

No user-facing behavior change yet; fully covered by unit tests.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
