### PR TITLE
Release Spotify Connect when you clear the queue

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1180,6 +1180,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         if source_current_item:
             target_queue.current_item = source_current_item
             target_queue.current_item.queue_id = target_queue_id
+        # every live source the queue holds moves with it, not just the one that was playing
+        transferred_sources = self._audio_sources_in(source_queue_id)
         self._clear(source_queue_id, skip_stop=True)
 
         await self.load(target_queue_id, source_items, keep_remaining=False, keep_played=False)
@@ -1189,7 +1191,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         # a live source the target was holding has just been displaced by the transferred queue
         self._notify_audio_source_replaced(target_queue_id, target_outgoing_sources)
         await self._notify_audio_source_transferred(
-            source_current_item, source_queue_id, target_queue_id
+            transferred_sources, source_queue_id, target_queue_id
         )
         if auto_play:
             await self.resume(target_queue_id)
@@ -1913,30 +1915,36 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                 self.mass.create_task(prov.on_source_removed(source_id, queue_id))
 
     async def _notify_audio_source_transferred(
-        self, transferred_item: QueueItem | None, from_queue_id: str, to_queue_id: str
+        self,
+        transferred: dict[str, tuple[PluginProvider, str]],
+        from_queue_id: str,
+        to_queue_id: str,
     ) -> None:
         """
-        Tell the owning plugin that its AudioSource moved to another queue.
+        Tell the owning plugins that their AudioSources moved to another queue.
 
-        Awaited rather than dispatched so the plugin has settled the handover before the target
+        Awaited rather than dispatched so the plugins have settled the handover before the target
         queue is resumed. A plugin that raises must not break the transfer.
 
-        :param transferred_item: The current item the source queue handed over.
-        :param from_queue_id: The queue that gave the source up.
-        :param to_queue_id: The queue that took it over.
+        :param transferred: The live AudioSources the source queue handed over.
+        :param from_queue_id: The queue that gave the sources up.
+        :param to_queue_id: The queue that took them over.
         """
-        if (owner := self._audio_source_plugin(transferred_item)) is None:
+        if not transferred or (queue_data := self._queue_data.get(to_queue_id)) is None:
             return
-        prov, source_id = owner
-        try:
-            await prov.on_source_transferred(source_id, from_queue_id, to_queue_id)
-        except Exception:
-            self.logger.warning(
-                "on_source_transferred raised for provider %s source %s",
-                prov.instance_id,
-                source_id,
-                exc_info=True,
-            )
+        arrived = {item.media_item.uri for item in queue_data.items if item.media_item is not None}
+        for uri, (prov, source_id) in transferred.items():
+            if uri not in arrived:
+                continue
+            try:
+                await prov.on_source_transferred(source_id, from_queue_id, to_queue_id)
+            except Exception:
+                self.logger.warning(
+                    "on_source_transferred raised for provider %s source %s",
+                    prov.instance_id,
+                    source_id,
+                    exc_info=True,
+                )
 
     def _reset_shuffle(self, queue_id: str) -> None:
         """Switch shuffle off."""

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1875,8 +1875,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         """
         Tell the owning plugin when whatever took over the queue pushed its AudioSource out.
 
-        The same source coming back (a replace re-selects it) and media that leaves the source
-        among the queue's items both leave it in place, and neither releases it.
+        The same source coming back and contents that leave the source among the queue's items
+        both leave it in place, and neither releases it.
 
         :param queue_id: The queue whose contents were taken over.
         :param outgoing_item: The queue's current item from before the takeover.

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -81,6 +81,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import get_cu
 from music_assistant.helpers.api import api_command
 from music_assistant.models.music_provider import ProviderStreamLimitError
 from music_assistant.models.player import Player, PlayerMedia
+from music_assistant.models.plugin import PluginProvider
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -588,6 +589,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
     @api_command("player_queues/clear", required_scope=Scope.QUEUES_CONTROL)
     def clear(self, queue_id: str, skip_stop: bool = False) -> None:
         """Clear all items in the queue, switching shuffle off with them."""
+        self._notify_audio_source_removed(queue_id)
         self._clear(queue_id, skip_stop)
         # clearing is an explicit "start over" gesture by the user, so a shuffle that belonged to
         # the discarded content must not carry over into whatever is played next
@@ -1821,6 +1823,19 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         queue.index_in_buffer = None
         self.mass.create_task(self._cleanup_queue_audio_data(queue_id))
         self.update_items(queue_id, [])
+
+    def _notify_audio_source_removed(self, queue_id: str) -> None:
+        """Tell the owning plugin that its AudioSource is dropped as this queue's current item."""
+        if (queue_data := self._queue_data.get(queue_id)) is None:
+            return
+        current_item = queue_data.queue.current_item
+        if current_item is None or (media_item := current_item.media_item) is None:
+            return
+        if media_item.media_type != MediaType.AUDIO_SOURCE:
+            return
+        if not isinstance(prov := self.mass.get_provider(media_item.provider), PluginProvider):
+            return
+        self.mass.create_task(prov.on_source_removed(media_item.item_id, queue_id))
 
     def _reset_shuffle(self, queue_id: str) -> None:
         """Switch shuffle off."""

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -501,9 +501,9 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        # what is playing now may not survive what is being started; remembered here so the
-        # owning plugin can be told once we know whether it did
-        outgoing_item = self._queue_data[queue_id].queue.current_item
+        # the live sources the queue holds may not survive what is being started; remembered
+        # here so their plugins can be told once we know which of them did
+        outgoing_sources = self._audio_sources_in(queue_id)
         try:
             # Lock is acquired by the @handle_play_action decorator on the internal handler
             await self._handle_play_media(
@@ -519,7 +519,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         finally:
             # also when the media failed to load: the queue may already have given up its items
             # for it, and the source is just as gone either way
-            self._notify_audio_source_replaced(queue_id, outgoing_item)
+            self._notify_audio_source_replaced(queue_id, outgoing_sources)
 
     @api_command("player_queues/move_item", required_scope=Scope.QUEUES_CONTROL)
     def move_item(self, queue_id: str, queue_item_id: str, pos_shift: int = 1) -> None:
@@ -1174,8 +1174,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             self._queue_data[source_queue_id].enqueued_media_items
         )
         target_queue.resume_pos = source_resume_pos
-        # the target's own current item is about to be overwritten by the transferred one
-        target_outgoing_item = target_queue.current_item
+        # the target's own contents are about to be overwritten by the transferred ones
+        target_outgoing_sources = self._audio_sources_in(target_queue_id)
         target_queue.current_index = source_current_index
         if source_current_item:
             target_queue.current_item = source_current_item
@@ -1186,8 +1186,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         for item in source_items:
             item.queue_id = target_queue_id
         self.update_items(target_queue_id, source_items)
-        # a live source the target was playing has just been displaced by the transferred queue
-        self._notify_audio_source_replaced(target_queue_id, target_outgoing_item)
+        # a live source the target was holding has just been displaced by the transferred queue
+        self._notify_audio_source_replaced(target_queue_id, target_outgoing_sources)
         await self._notify_audio_source_transferred(
             source_current_item, source_queue_id, target_queue_id
         )
@@ -1862,38 +1862,51 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             return None
         return prov, media_item.item_id
 
-    def _notify_audio_source_removed(self, queue_id: str) -> None:
-        """Tell the owning plugin that its AudioSource is dropped as this queue's current item."""
-        if (queue_data := self._queue_data.get(queue_id)) is None:
-            return
-        if (owner := self._audio_source_plugin(queue_data.queue.current_item)) is None:
-            return
-        prov, source_id = owner
-        self.mass.create_task(prov.on_source_removed(source_id, queue_id))
-
-    def _notify_audio_source_replaced(self, queue_id: str, outgoing_item: QueueItem | None) -> None:
+    def _audio_sources_in(self, queue_id: str) -> dict[str, tuple[PluginProvider, str]]:
         """
-        Tell the owning plugin when whatever took over the queue pushed its AudioSource out.
+        Map every live AudioSource the queue holds to its owning plugin, keyed by media uri.
 
-        The same source coming back and contents that leave the source among the queue's items
-        both leave it in place, and neither releases it.
+        Covers the whole queue rather than just what is playing: an option that starts media
+        alongside a live source leaves that source behind as an ordinary item, and it still has
+        to be released when it eventually goes.
+
+        :param queue_id: The queue to look through.
+        """
+        owners: dict[str, tuple[PluginProvider, str]] = {}
+        if (queue_data := self._queue_data.get(queue_id)) is None:
+            return owners
+        for item in queue_data.items:
+            if (media_item := item.media_item) is None or media_item.uri in owners:
+                continue
+            if (owner := self._audio_source_plugin(item)) is not None:
+                owners[str(media_item.uri)] = owner
+        return owners
+
+    def _notify_audio_source_removed(self, queue_id: str) -> None:
+        """Tell the owning plugins that their AudioSources are dropped along with this queue."""
+        for prov, source_id in self._audio_sources_in(queue_id).values():
+            self.mass.create_task(prov.on_source_removed(source_id, queue_id))
+
+    def _notify_audio_source_replaced(
+        self, queue_id: str, outgoing: dict[str, tuple[PluginProvider, str]]
+    ) -> None:
+        """
+        Tell the owning plugins which of their AudioSources the queue's new contents pushed out.
+
+        A source that is still among the queue's items is left in place, so the same source
+        coming back and contents that keep it alongside them both release nothing.
 
         :param queue_id: The queue whose contents were taken over.
-        :param outgoing_item: The queue's current item from before the takeover.
+        :param outgoing: The queue's live AudioSources from before the takeover.
         """
-        if outgoing_item is None or (media_item := outgoing_item.media_item) is None:
+        if not outgoing or (queue_data := self._queue_data.get(queue_id)) is None:
             return
-        if (queue_data := self._queue_data.get(queue_id)) is None:
-            return
-        if (owner := self._audio_source_plugin(outgoing_item)) is None:
-            return
-        if any(
-            item.media_item is not None and item.media_item.uri == media_item.uri
-            for item in queue_data.items
-        ):
-            return
-        prov, source_id = owner
-        self.mass.create_task(prov.on_source_removed(source_id, queue_id))
+        remaining = {
+            item.media_item.uri for item in queue_data.items if item.media_item is not None
+        }
+        for uri, (prov, source_id) in outgoing.items():
+            if uri not in remaining:
+                self.mass.create_task(prov.on_source_removed(source_id, queue_id))
 
     async def _notify_audio_source_transferred(
         self, transferred_item: QueueItem | None, from_queue_id: str, to_queue_id: str

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1174,6 +1174,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             self._queue_data[source_queue_id].enqueued_media_items
         )
         target_queue.resume_pos = source_resume_pos
+        # the target's own current item is about to be overwritten by the transferred one
+        target_outgoing_item = target_queue.current_item
         target_queue.current_index = source_current_index
         if source_current_item:
             target_queue.current_item = source_current_item
@@ -1184,6 +1186,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         for item in source_items:
             item.queue_id = target_queue_id
         self.update_items(target_queue_id, source_items)
+        # a live source the target was playing has just been displaced by the transferred queue
+        self._notify_audio_source_replaced(target_queue_id, target_outgoing_item)
         await self._notify_audio_source_transferred(
             source_current_item, source_queue_id, target_queue_id
         )
@@ -1869,13 +1873,13 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
 
     def _notify_audio_source_replaced(self, queue_id: str, outgoing_item: QueueItem | None) -> None:
         """
-        Tell the owning plugin when newly started media pushed its AudioSource out of the queue.
+        Tell the owning plugin when whatever took over the queue pushed its AudioSource out.
 
-        Starting the very same source again (a replace re-selects it) and options that keep the
-        source among the queue's items both leave it in place, and neither releases it.
+        The same source coming back (a replace re-selects it) and media that leaves the source
+        among the queue's items both leave it in place, and neither releases it.
 
-        :param queue_id: The queue the media was started on.
-        :param outgoing_item: The queue's current item from before the media was started.
+        :param queue_id: The queue whose contents were taken over.
+        :param outgoing_item: The queue's current item from before the takeover.
         """
         if outgoing_item is None or (media_item := outgoing_item.media_item) is None:
             return

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1871,15 +1871,19 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         to be released when it eventually goes.
 
         :param queue_id: The queue to look through.
+        :return: The owning plugin and the source id it exposes, per AudioSource media uri.
         """
         owners: dict[str, tuple[PluginProvider, str]] = {}
         if (queue_data := self._queue_data.get(queue_id)) is None:
             return owners
         for item in queue_data.items:
-            if (media_item := item.media_item) is None or media_item.uri in owners:
+            media_item = item.media_item
+            if media_item is None or media_item.media_type != MediaType.AUDIO_SOURCE:
+                continue
+            if (uri := media_item.uri) is None or uri in owners:
                 continue
             if (owner := self._audio_source_plugin(item)) is not None:
-                owners[str(media_item.uri)] = owner
+                owners[uri] = owner
         return owners
 
     def _notify_audio_source_removed(self, queue_id: str) -> None:

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1168,6 +1168,9 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         for item in source_items:
             item.queue_id = target_queue_id
         self.update_items(target_queue_id, source_items)
+        await self._notify_audio_source_transferred(
+            source_current_item, source_queue_id, target_queue_id
+        )
         if auto_play:
             await self.resume(target_queue_id)
 
@@ -1827,18 +1830,52 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         self.mass.create_task(self._cleanup_queue_audio_data(queue_id))
         self.update_items(queue_id, [])
 
+    def _audio_source_plugin(
+        self, queue_item: QueueItem | None
+    ) -> tuple[PluginProvider, str] | None:
+        """Return the plugin owning this item's live AudioSource, with the source id it exposes."""
+        if queue_item is None or (media_item := queue_item.media_item) is None:
+            return None
+        if media_item.media_type != MediaType.AUDIO_SOURCE:
+            return None
+        if not isinstance(prov := self.mass.get_provider(media_item.provider), PluginProvider):
+            return None
+        return prov, media_item.item_id
+
     def _notify_audio_source_removed(self, queue_id: str) -> None:
         """Tell the owning plugin that its AudioSource is dropped as this queue's current item."""
         if (queue_data := self._queue_data.get(queue_id)) is None:
             return
-        current_item = queue_data.queue.current_item
-        if current_item is None or (media_item := current_item.media_item) is None:
+        if (owner := self._audio_source_plugin(queue_data.queue.current_item)) is None:
             return
-        if media_item.media_type != MediaType.AUDIO_SOURCE:
+        prov, source_id = owner
+        self.mass.create_task(prov.on_source_removed(source_id, queue_id))
+
+    async def _notify_audio_source_transferred(
+        self, transferred_item: QueueItem | None, from_queue_id: str, to_queue_id: str
+    ) -> None:
+        """
+        Tell the owning plugin that its AudioSource moved to another queue.
+
+        Awaited rather than dispatched: the plugin has to know the source changed hands before
+        the target queue resumes it. A plugin that raises must not break the transfer.
+
+        :param transferred_item: The current item the source queue handed over.
+        :param from_queue_id: The queue that gave the source up.
+        :param to_queue_id: The queue that took it over.
+        """
+        if (owner := self._audio_source_plugin(transferred_item)) is None:
             return
-        if not isinstance(prov := self.mass.get_provider(media_item.provider), PluginProvider):
-            return
-        self.mass.create_task(prov.on_source_removed(media_item.item_id, queue_id))
+        prov, source_id = owner
+        try:
+            await prov.on_source_transferred(source_id, from_queue_id, to_queue_id)
+        except Exception:
+            self.logger.warning(
+                "on_source_transferred raised for provider %s source %s",
+                prov.instance_id,
+                source_id,
+                exc_info=True,
+            )
 
     def _reset_shuffle(self, queue_id: str) -> None:
         """Switch shuffle off."""

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -589,6 +589,9 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
     @api_command("player_queues/clear", required_scope=Scope.QUEUES_CONTROL)
     def clear(self, queue_id: str, skip_stop: bool = False) -> None:
         """Clear all items in the queue, switching shuffle off with them."""
+        # Only the explicit clear notifies the plugin, never `_clear` itself: replacing the
+        # queue and transferring it both clear as a step towards re-selecting the same source,
+        # and a release there would cost the user their playback position.
         self._notify_audio_source_removed(queue_id)
         self._clear(queue_id, skip_stop)
         # clearing is an explicit "start over" gesture by the user, so a shuffle that belonged to

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -589,9 +589,9 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
     @api_command("player_queues/clear", required_scope=Scope.QUEUES_CONTROL)
     def clear(self, queue_id: str, skip_stop: bool = False) -> None:
         """Clear all items in the queue, switching shuffle off with them."""
-        # Only the explicit clear notifies the plugin, never `_clear` itself: replacing the
-        # queue and transferring it both clear as a step towards re-selecting the same source,
-        # and a release there would cost the user their playback position.
+        # Only the explicit clear notifies the plugin, never `_clear` itself: a replace or a
+        # transfer clears as a first step and may re-select the very same source right after,
+        # where releasing it would cost the user their playback position.
         self._notify_audio_source_removed(queue_id)
         self._clear(queue_id, skip_stop)
         # clearing is an explicit "start over" gesture by the user, so a shuffle that belonged to
@@ -1857,8 +1857,8 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         """
         Tell the owning plugin that its AudioSource moved to another queue.
 
-        Awaited rather than dispatched: the plugin has to know the source changed hands before
-        the target queue resumes it. A plugin that raises must not break the transfer.
+        Awaited rather than dispatched so the plugin has settled the handover before the target
+        queue is resumed. A plugin that raises must not break the transfer.
 
         :param transferred_item: The current item the source queue handed over.
         :param from_queue_id: The queue that gave the source up.

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -604,9 +604,10 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
     @api_command("player_queues/clear", required_scope=Scope.QUEUES_CONTROL)
     def clear(self, queue_id: str, skip_stop: bool = False) -> None:
         """Clear all items in the queue, switching shuffle off with them."""
-        # Only the explicit clear notifies the plugin, never `_clear` itself: a replace or a
+        # Only the explicit clear notifies from here, never `_clear` itself: a replace or a
         # transfer clears as a first step and may re-select the very same source right after,
-        # where releasing it would cost the user their playback position.
+        # where releasing it would cost the user their playback position. Those two decide for
+        # themselves, in `play_media` and `transfer_queue`.
         self._notify_audio_source_removed(queue_id)
         self._clear(queue_id, skip_stop)
         # clearing is an explicit "start over" gesture by the user, so a shuffle that belonged to

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -501,10 +501,14 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
+        # what is playing now may not survive what is being started; remembered here so the
+        # owning plugin can be told once we know whether it did
+        outgoing_item = self._queue_data[queue_id].queue.current_item
         # Lock is acquired by the @handle_play_action decorator on the internal handler
         await self._handle_play_media(
             queue_id, media, option, radio_mode, start_item, sort_by, start_from_beginning, shuffle
         )
+        self._notify_audio_source_replaced(queue_id, outgoing_item)
 
     @api_command("player_queues/move_item", required_scope=Scope.QUEUES_CONTROL)
     def move_item(self, queue_id: str, queue_item_id: str, pos_shift: int = 1) -> None:
@@ -1847,6 +1851,30 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         if (queue_data := self._queue_data.get(queue_id)) is None:
             return
         if (owner := self._audio_source_plugin(queue_data.queue.current_item)) is None:
+            return
+        prov, source_id = owner
+        self.mass.create_task(prov.on_source_removed(source_id, queue_id))
+
+    def _notify_audio_source_replaced(self, queue_id: str, outgoing_item: QueueItem | None) -> None:
+        """
+        Tell the owning plugin when the media just started pushed its AudioSource out of the queue.
+
+        Starting the very same source again (a replace re-selects it) and options that keep the
+        source among the queue's items both leave it in place, and neither releases it.
+
+        :param queue_id: The queue the media was started on.
+        :param outgoing_item: The queue's current item from before the media was started.
+        """
+        if outgoing_item is None or (media_item := outgoing_item.media_item) is None:
+            return
+        if (owner := self._audio_source_plugin(outgoing_item)) is None:
+            return
+        if (queue_data := self._queue_data.get(queue_id)) is None:
+            return
+        if any(
+            item.media_item is not None and item.media_item.uri == media_item.uri
+            for item in queue_data.items
+        ):
             return
         prov, source_id = owner
         self.mass.create_task(prov.on_source_removed(source_id, queue_id))

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -504,11 +504,22 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         # what is playing now may not survive what is being started; remembered here so the
         # owning plugin can be told once we know whether it did
         outgoing_item = self._queue_data[queue_id].queue.current_item
-        # Lock is acquired by the @handle_play_action decorator on the internal handler
-        await self._handle_play_media(
-            queue_id, media, option, radio_mode, start_item, sort_by, start_from_beginning, shuffle
-        )
-        self._notify_audio_source_replaced(queue_id, outgoing_item)
+        try:
+            # Lock is acquired by the @handle_play_action decorator on the internal handler
+            await self._handle_play_media(
+                queue_id,
+                media,
+                option,
+                radio_mode,
+                start_item,
+                sort_by,
+                start_from_beginning,
+                shuffle,
+            )
+        finally:
+            # also when the media failed to load: the queue may already have given up its items
+            # for it, and the source is just as gone either way
+            self._notify_audio_source_replaced(queue_id, outgoing_item)
 
     @api_command("player_queues/move_item", required_scope=Scope.QUEUES_CONTROL)
     def move_item(self, queue_id: str, queue_item_id: str, pos_shift: int = 1) -> None:
@@ -1857,7 +1868,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
 
     def _notify_audio_source_replaced(self, queue_id: str, outgoing_item: QueueItem | None) -> None:
         """
-        Tell the owning plugin when the media just started pushed its AudioSource out of the queue.
+        Tell the owning plugin when newly started media pushed its AudioSource out of the queue.
 
         Starting the very same source again (a replace re-selects it) and options that keep the
         source among the queue's items both leave it in place, and neither releases it.
@@ -1867,9 +1878,9 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         """
         if outgoing_item is None or (media_item := outgoing_item.media_item) is None:
             return
-        if (owner := self._audio_source_plugin(outgoing_item)) is None:
-            return
         if (queue_data := self._queue_data.get(queue_id)) is None:
+            return
+        if (owner := self._audio_source_plugin(outgoing_item)) is None:
             return
         if any(
             item.media_item is not None and item.media_item.uri == media_item.uri

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -245,13 +245,17 @@ class PluginProvider(Provider):
         """
         React to a queue dropping this AudioSource from its items.
 
-        Fired when the queue holding this source as its current item is
-        cleared. Unlike ``on_source_unselected`` this is not tied to a stream,
-        so it also fires when the stream was already torn down earlier (a
-        paused source, for example) — the one moment where nothing else tells
-        the plugin that MA is done with the source. Override to release state
-        that must not outlive the queue, such as an upstream session still
-        pointing at MA.
+        Fired when the user clears the queue that has this source as its
+        current item. Unlike ``on_source_unselected`` this is not tied to a
+        stream, so it also fires when the stream was already torn down earlier
+        (a paused source, for example) — the one moment where nothing else
+        tells the plugin that MA is done with the source. Override to release
+        state that must not outlive the queue, such as an upstream session
+        still pointing at MA.
+
+        Replacing the queue's contents or transferring it to another player
+        does NOT fire this: those re-select the same source right after, and
+        the plugin keeps its session across the switch.
 
         May fire while a stream for this source is still being torn down, so
         implementations must guard on their own claim state to avoid releasing

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -258,8 +258,7 @@ class PluginProvider(Provider):
         the plugin keeps its session across the switch.
 
         May fire while a stream for this source is still being torn down, so
-        implementations must guard on their own claim state to avoid releasing
-        twice.
+        the release has to be safe to run alongside ``on_source_unselected``.
 
         :param source_id: The AudioSource.item_id that was removed.
         :param queue_id: The queue that dropped the source.

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -274,8 +274,14 @@ class PluginProvider(Provider):
         current item. A transfer of a *playing* source re-selects it on the
         target by itself, but a paused one is moved without a stream request,
         so this is the only signal that the source changed hands. Override to
-        re-point any queue the plugin tracked, so later callbacks (this hook's
-        ``on_source_removed`` sibling included) arrive for the right queue.
+        re-point the queue the plugin tracks as its owner, so later callbacks
+        (this hook's ``on_source_removed`` sibling included) arrive for the
+        right queue.
+
+        Only long-lived ownership belongs here. Anything scoped to a stream —
+        an exclusive claim, the ``on_source_selected`` session id — must be
+        left alone: no stream exists on the target until it starts one, and
+        ``on_source_selected`` re-establishes those when it does.
 
         :param source_id: The AudioSource.item_id that was transferred.
         :param from_queue_id: The queue that gave the source up.

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -264,6 +264,24 @@ class PluginProvider(Provider):
         :param queue_id: The queue that dropped the source.
         """
 
+    async def on_source_transferred(
+        self, source_id: str, from_queue_id: str, to_queue_id: str
+    ) -> None:
+        """
+        React to this AudioSource being handed over to another queue.
+
+        Fired when the user transfers a queue that has this source as its
+        current item. A transfer of a *playing* source re-selects it on the
+        target by itself, but a paused one is moved without a stream request,
+        so this is the only signal that the source changed hands. Override to
+        re-point any queue the plugin tracked, so later callbacks (this hook's
+        ``on_source_removed`` sibling included) arrive for the right queue.
+
+        :param source_id: The AudioSource.item_id that was transferred.
+        :param from_queue_id: The queue that gave the source up.
+        :param to_queue_id: The queue that took it over.
+        """
+
     async def on_volume_change(self, source_id: str, volume: int) -> None:
         """
         React to a volume change on the player streaming this AudioSource.

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -241,6 +241,26 @@ class PluginProvider(Provider):
             not match the currently stored active session id.
         """
 
+    async def on_source_removed(self, source_id: str, queue_id: str) -> None:
+        """
+        React to a queue dropping this AudioSource from its items.
+
+        Fired when the queue holding this source as its current item is
+        cleared. Unlike ``on_source_unselected`` this is not tied to a stream,
+        so it also fires when the stream was already torn down earlier (a
+        paused source, for example) — the one moment where nothing else tells
+        the plugin that MA is done with the source. Override to release state
+        that must not outlive the queue, such as an upstream session still
+        pointing at MA.
+
+        May fire while a stream for this source is still being torn down, so
+        implementations must guard on their own claim state to avoid releasing
+        twice.
+
+        :param source_id: The AudioSource.item_id that was removed.
+        :param queue_id: The queue that dropped the source.
+        """
+
     async def on_volume_change(self, source_id: str, volume: int) -> None:
         """
         React to a volume change on the player streaming this AudioSource.

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -245,14 +245,14 @@ class PluginProvider(Provider):
         """
         React to a queue dropping this AudioSource from its items.
 
-        Fired when the source leaves the queue it was playing on: the user
-        cleared that queue, or started media that took the source's place in
-        it. Unlike ``on_source_unselected`` this is not tied to a stream, so it
-        also fires when the stream was already torn down earlier (a paused
-        source, for example) — the one moment where nothing else tells the
-        plugin that MA is done with the source. Override to release state that
-        must not outlive the queue, such as an upstream session still pointing
-        at MA.
+        Fired when the source leaves a queue that held it — whether or not it
+        was the one playing: the user cleared that queue, or started media that
+        took the source's place in it. Unlike ``on_source_unselected`` this is
+        not tied to a stream, so it also fires when the stream was already torn
+        down earlier (a paused source, for example) — the one moment where
+        nothing else tells the plugin that MA is done with the source. Override
+        to release state that must not outlive the queue, such as an upstream
+        session still pointing at MA.
 
         Media that leaves the source among the queue's items does NOT fire
         this, nor does starting that very same source again, nor handing the
@@ -271,13 +271,13 @@ class PluginProvider(Provider):
         """
         React to this AudioSource being handed over to another queue.
 
-        Fired when the user transfers a queue that has this source as its
-        current item. A transfer of a *playing* source re-selects it on the
-        target by itself, but a paused one is moved without a stream request,
-        so this is the only signal that the source changed hands. Override to
-        re-point the queue the plugin tracks as its owner, so later callbacks
-        (this hook's ``on_source_removed`` sibling included) arrive for the
-        right queue.
+        Fired for every live source a transferred queue held, whether or not it
+        was the one playing. A transfer of a *playing* source re-selects it on
+        the target by itself, but one that was paused or merely queued is moved
+        without a stream request, so this is the only signal that the source
+        changed hands. Override to re-point the queue the plugin tracks as its
+        owner, so later callbacks (this hook's ``on_source_removed`` sibling
+        included) arrive for the right queue.
 
         Only long-lived ownership belongs here. Anything scoped to a stream —
         an exclusive claim, the ``on_source_selected`` session id — must be

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -245,17 +245,18 @@ class PluginProvider(Provider):
         """
         React to a queue dropping this AudioSource from its items.
 
-        Fired when the user clears the queue that has this source as its
-        current item. Unlike ``on_source_unselected`` this is not tied to a
-        stream, so it also fires when the stream was already torn down earlier
-        (a paused source, for example) — the one moment where nothing else
-        tells the plugin that MA is done with the source. Override to release
-        state that must not outlive the queue, such as an upstream session
-        still pointing at MA.
+        Fired when the source leaves the queue it was playing on: the user
+        cleared that queue, or started media that took the source's place in
+        it. Unlike ``on_source_unselected`` this is not tied to a stream, so it
+        also fires when the stream was already torn down earlier (a paused
+        source, for example) — the one moment where nothing else tells the
+        plugin that MA is done with the source. Override to release state that
+        must not outlive the queue, such as an upstream session still pointing
+        at MA.
 
-        Replacing the queue's contents or transferring it to another player
-        does NOT fire this: those re-select the same source right after, and
-        the plugin keeps its session across the switch.
+        Media that leaves the source among the queue's items does NOT fire
+        this, nor does starting that very same source again, nor handing the
+        queue to another player (see ``on_source_transferred``).
 
         May fire while a stream for this source is still being torn down, so
         the release has to be safe to run alongside ``on_source_unselected``.

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -430,14 +430,11 @@ class SpotifyConnectProvider(PluginProvider):
         """Release the Spotify session when the queue drops this source."""
         if source_id != AUDIO_SOURCE_ID or self._active_player_id != queue_id:
             return
-        if self._in_use_by_queue or not self._spotify_session_active:
-            # a live stream still holds the claim (its teardown does the release),
-            # or we are not the active Spotify device to begin with
+        if not self._spotify_session_active:
             return
-        # Nothing is streaming us anymore (e.g. the source was paused, which
-        # already tore the stream down), so no teardown will follow to release
-        # the session — the Spotify app would stay tethered to a device that no
-        # longer has a queue.
+        # Released whether or not a stream is still winding down: a paused source
+        # already ended its stream, so its teardown released nothing and the
+        # Spotify app would stay tethered to a device that has no queue left.
         try:
             await self._backend.deactivate()
         except Exception as err:

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -426,6 +426,23 @@ class SpotifyConnectProvider(PluginProvider):
             except Exception as err:
                 self.logger.debug("Failed to release Spotify session on stream teardown: %s", err)
 
+    async def on_source_removed(self, source_id: str, queue_id: str) -> None:
+        """Release the Spotify session when the queue drops this source."""
+        if source_id != AUDIO_SOURCE_ID or self._active_player_id != queue_id:
+            return
+        if self._in_use_by_queue or not self._spotify_session_active:
+            # a live stream still holds the claim (its teardown does the release),
+            # or we are not the active Spotify device to begin with
+            return
+        # Nothing is streaming us anymore (e.g. the source was paused, which
+        # already tore the stream down), so no teardown will follow to release
+        # the session — the Spotify app would stay tethered to a device that no
+        # longer has a queue.
+        try:
+            await self._backend.deactivate()
+        except Exception as err:
+            self.logger.debug("Failed to release Spotify session on queue clear: %s", err)
+
     async def on_source_control(
         self,
         source_id: str,

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -440,6 +440,17 @@ class SpotifyConnectProvider(PluginProvider):
         except Exception as err:
             self.logger.debug("Failed to release Spotify session on queue clear: %s", err)
 
+    async def on_source_transferred(
+        self, source_id: str, from_queue_id: str, to_queue_id: str
+    ) -> None:
+        """Follow this AudioSource to the queue it was handed over to."""
+        if source_id != AUDIO_SOURCE_ID or self._active_player_id != from_queue_id:
+            return
+        # A transfer while playing re-selects the source on the target and re-claims it there,
+        # but a paused one moves without a stream request: without this the plugin would stay
+        # pointed at the queue it left behind.
+        self._active_player_id = to_queue_id
+
     async def on_source_control(
         self,
         source_id: str,

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -435,6 +435,11 @@ class SpotifyConnectProvider(PluginProvider):
         # Released whether or not a stream is still winding down: a paused source
         # already ended its stream, so its teardown released nothing and the
         # Spotify app would stay tethered to a device that has no queue left.
+        #
+        # Let the player go first. The backend answers a deactivate with the same
+        # 'inactive' event a deselect in the Spotify app produces, and that stops
+        # the player we were on - which by now is playing whatever took our place.
+        self._active_player_id = None
         try:
             await self._backend.deactivate()
         except Exception as err:

--- a/tests/controllers/player_queues/test_audio_source_removed.py
+++ b/tests/controllers/player_queues/test_audio_source_removed.py
@@ -303,3 +303,39 @@ async def test_transferring_onto_a_paused_source_releases_it() -> None:
     await ctrl.transfer_queue("q1", "q2")
 
     provider.on_source_removed.assert_called_once_with("main", "q2")
+
+
+async def test_a_source_left_behind_by_a_play_is_still_released_later() -> None:
+    """
+    A source kept in the queue alongside other media is released when it does leave.
+
+    Starting a track with "play" leaves the live source in the queue behind it, so nothing is
+    released then. Clearing the queue afterwards is what finally removes it - and by then it is
+    no longer the item the queue is playing.
+    """
+    source_item = QueueItem.from_media_item("q1", _audio_source())
+    ctrl = _controller(source_item)
+    provider = _plugin_provider(ctrl)
+    # as a "play" leaves it: the source still queued, a track playing in front of it
+    track_item = QueueItem.from_media_item("q1", _track())
+    ctrl._queue_data["q1"].items = [source_item, track_item]
+    ctrl._queue_data["q1"].queue.current_item = track_item
+
+    ctrl.clear("q1")
+
+    provider.on_source_removed.assert_called_once_with("main", "q1")
+
+
+async def test_a_source_left_behind_by_a_play_is_released_when_replaced() -> None:
+    """The same source, no longer playing, is released when new media takes the queue over."""
+    source_item = QueueItem.from_media_item("q1", _audio_source())
+    ctrl = _controller(source_item)
+    provider = _plugin_provider(ctrl)
+    track_item = QueueItem.from_media_item("q1", _track())
+    ctrl._queue_data["q1"].items = [source_item, track_item]
+    ctrl._queue_data["q1"].queue.current_item = track_item
+    _play_media_replacing_with(ctrl, QueueItem.from_media_item("q1", _track()))
+
+    await ctrl.play_media("q1", "test://album/al1", QueueOption.REPLACE)
+
+    provider.on_source_removed.assert_called_once_with("main", "q1")

--- a/tests/controllers/player_queues/test_audio_source_removed.py
+++ b/tests/controllers/player_queues/test_audio_source_removed.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock
 
-from music_assistant_models.enums import PlaybackState
+from music_assistant_models.enums import PlaybackState, QueueOption
 from music_assistant_models.media_items import AudioSource, ProviderMapping, Track
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
@@ -192,3 +192,59 @@ async def test_a_plugin_raising_does_not_break_the_transfer() -> None:
     # reaching this at all means the raise was contained; the queue still changed hands
     provider.on_source_transferred.assert_awaited_once()
     assert ctrl._queue_data["q2"].queue.current_item is not None
+
+
+def _play_media_replacing_with(ctrl: Any, *items: QueueItem) -> None:
+    """Stand in for the resolve/enqueue path, leaving the queue holding the given items."""
+    ctrl._check_player_permission = Mock()
+
+    async def _handle(*_args: Any, **_kwargs: Any) -> None:
+        ctrl._queue_data["q1"].items = list(items)
+
+    ctrl._handle_play_media = _handle
+
+
+async def test_starting_other_media_releases_the_source_it_replaced() -> None:
+    """
+    Media that pushes a live source out of the queue releases it.
+
+    Album, artist and playlist all default to "replace", so this - not the clear button - is how
+    a paused live source usually leaves the queue.
+    """
+    ctrl = _controller(QueueItem.from_media_item("q1", _audio_source()))
+    provider = _plugin_provider(ctrl)
+    _play_media_replacing_with(ctrl, QueueItem.from_media_item("q1", _track()))
+
+    await ctrl.play_media("q1", "test://album/al1", QueueOption.REPLACE)
+
+    provider.on_source_removed.assert_called_once_with("main", "q1")
+
+
+async def test_starting_the_same_source_again_keeps_it() -> None:
+    """
+    Playing the paused source again must not release it.
+
+    A replace drops the queue's items before loading the new ones, so the source briefly leaves
+    the queue on its way back in. Releasing it there would end the upstream session and restart
+    playback from the top instead of resuming where the user paused.
+    """
+    ctrl = _controller(QueueItem.from_media_item("q1", _audio_source()))
+    provider = _plugin_provider(ctrl)
+    # the source comes back as a freshly built queue item, so identity is by media, not item id
+    _play_media_replacing_with(ctrl, QueueItem.from_media_item("q1", _audio_source()))
+
+    await ctrl.play_media("q1", "spotify_connect--test://audio_source/main", QueueOption.REPLACE)
+
+    provider.on_source_removed.assert_not_called()
+
+
+async def test_media_played_alongside_the_source_keeps_it() -> None:
+    """An option that leaves the source in the queue is not the user done with it."""
+    source_item = QueueItem.from_media_item("q1", _audio_source())
+    ctrl = _controller(source_item)
+    provider = _plugin_provider(ctrl)
+    _play_media_replacing_with(ctrl, source_item, QueueItem.from_media_item("q1", _track()))
+
+    await ctrl.play_media("q1", "test://album/al1", QueueOption.PLAY)
+
+    provider.on_source_removed.assert_not_called()

--- a/tests/controllers/player_queues/test_audio_source_removed.py
+++ b/tests/controllers/player_queues/test_audio_source_removed.py
@@ -143,12 +143,26 @@ def test_clearing_a_queue_whose_plugin_is_gone_still_clears() -> None:
     assert ctrl._queue_data["q1"].items == []
 
 
-def _ready_for_transfer(ctrl: Any) -> None:
-    """Stub out the playback side of transfer_queue, leaving the handover itself real."""
+def _ready_for_transfer(ctrl: Any, target_current_item: QueueItem | None = None) -> None:
+    """
+    Stub out the playback side of transfer_queue, leaving the handover itself real.
+
+    :param ctrl: The controller to prepare.
+    :param target_current_item: What the target queue "q2" is playing when the transfer lands.
+    """
     ctrl.stop = AsyncMock()
     ctrl.load = AsyncMock()
-    ctrl.update_items = Mock()
+
+    def _apply_items(queue_id: str, items: list[QueueItem]) -> None:
+        ctrl._queue_data[queue_id].items = items
+
+    # the real thing, minus the signalling: the queues have to end up holding what they were
+    # handed, or a check on what survived the transfer reads the items it was supposed to replace
+    ctrl.update_items = Mock(side_effect=_apply_items)
     ctrl._queue_data["q1"].queue.state = PlaybackState.PAUSED
+    if target_current_item is not None:
+        ctrl._queue_data["q2"].queue.current_item = target_current_item
+        ctrl._queue_data["q2"].items = [target_current_item]
     target_player = MagicMock()
     target_player.state.active_group = None
     target_player.state.synced_to = None
@@ -273,3 +287,19 @@ async def test_media_that_fails_to_load_still_releases_the_emptied_queue() -> No
         await ctrl.play_media("q1", "test://album/gone", QueueOption.REPLACE)
 
     provider.on_source_removed.assert_called_once_with("main", "q1")
+
+
+async def test_transferring_onto_a_paused_source_releases_it() -> None:
+    """
+    A queue moved onto a player that was paused on a live source releases that source.
+
+    The transfer overwrites what the target was playing, so its source leaves the queue just as
+    surely as a clear would take it - and nothing else would tell its plugin.
+    """
+    ctrl = _controller(QueueItem.from_media_item("q1", _track()))
+    provider = _plugin_provider(ctrl)
+    _ready_for_transfer(ctrl, target_current_item=QueueItem.from_media_item("q2", _audio_source()))
+
+    await ctrl.transfer_queue("q1", "q2")
+
+    provider.on_source_removed.assert_called_once_with("main", "q2")

--- a/tests/controllers/player_queues/test_audio_source_removed.py
+++ b/tests/controllers/player_queues/test_audio_source_removed.py
@@ -1,16 +1,19 @@
 """
-Tests for the notification a plugin gets when a queue drops its live AudioSource.
+Tests for the notifications a plugin gets when a queue drops or hands over its AudioSource.
 
 Clearing the queue is the one moment the owning plugin has no other signal to go on: the
 stream serving the source may have been torn down long before (a paused source ends its
-stream), so without this notification the plugin never learns that MA is done with it.
+stream), so without this notification the plugin never learns that MA is done with it. A
+transfer of a paused source is the same blind spot - it moves to another queue without a
+stream request, so the plugin has to be told which queue holds it now.
 """
 
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
+from music_assistant_models.enums import PlaybackState
 from music_assistant_models.media_items import AudioSource, ProviderMapping, Track
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
@@ -50,7 +53,7 @@ def _track() -> Track:
 
 def _controller(current_item: QueueItem | None) -> Any:
     """
-    Build a bare controller holding a single queue "q1" playing the given item.
+    Build a bare controller holding a queue "q1" playing the given item, plus an empty "q2".
 
     Tasks created along the way are closed instead of scheduled, so the notification can be
     asserted on the plugin mock without a running loop.
@@ -66,7 +69,8 @@ def _controller(current_item: QueueItem | None) -> Any:
     ctrl._smart_shuffle = Mock()
     queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
     queue.current_item = current_item
-    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+    target = PlayerQueue(queue_id="q2", active=True, display_name="Q2", available=True, items=0)
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue), "q2": PlayerQueueData(queue=target)}
     if current_item is not None:
         ctrl._queue_data["q1"].items = [current_item]
         queue.items = 1
@@ -134,3 +138,56 @@ def test_clearing_a_queue_whose_plugin_is_gone_still_clears() -> None:
     ctrl.clear("q1")
 
     assert ctrl._queue_data["q1"].items == []
+
+
+def _ready_for_transfer(ctrl: Any) -> None:
+    """Stub out the playback side of transfer_queue, leaving the handover itself real."""
+    ctrl.stop = AsyncMock()
+    ctrl.load = AsyncMock()
+    ctrl.update_items = Mock()
+    ctrl._queue_data["q1"].queue.state = PlaybackState.PAUSED
+    target_player = MagicMock()
+    target_player.state.active_group = None
+    target_player.state.synced_to = None
+    ctrl.mass.players.get_player.return_value = target_player
+
+
+async def test_transferring_a_paused_source_notifies_the_plugin() -> None:
+    """
+    The plugin is told which queue holds its source now.
+
+    A paused source is moved without a stream request, so nothing else would tell the plugin
+    it changed hands - and every later callback would arrive for the queue it left behind.
+    """
+    ctrl = _controller(QueueItem.from_media_item("q1", _audio_source()))
+    provider = _plugin_provider(ctrl)
+    _ready_for_transfer(ctrl)
+
+    await ctrl.transfer_queue("q1", "q2")
+
+    provider.on_source_transferred.assert_awaited_once_with("main", "q1", "q2")
+
+
+async def test_transferring_a_queue_of_tracks_notifies_nothing() -> None:
+    """A queue without a live source has no plugin to hand anything over to."""
+    ctrl = _controller(QueueItem.from_media_item("q1", _track()))
+    provider = _plugin_provider(ctrl)
+    _ready_for_transfer(ctrl)
+
+    await ctrl.transfer_queue("q1", "q2")
+
+    provider.on_source_transferred.assert_not_awaited()
+
+
+async def test_a_plugin_raising_does_not_break_the_transfer() -> None:
+    """A buggy plugin must not strand the queue halfway through a transfer."""
+    ctrl = _controller(QueueItem.from_media_item("q1", _audio_source()))
+    provider = _plugin_provider(ctrl)
+    provider.on_source_transferred.side_effect = RuntimeError("plugin is broken")
+    _ready_for_transfer(ctrl)
+
+    await ctrl.transfer_queue("q1", "q2")
+
+    # reaching this at all means the raise was contained; the queue still changed hands
+    provider.on_source_transferred.assert_awaited_once()
+    assert ctrl._queue_data["q2"].queue.current_item is not None

--- a/tests/controllers/player_queues/test_audio_source_removed.py
+++ b/tests/controllers/player_queues/test_audio_source_removed.py
@@ -120,7 +120,8 @@ def test_replacing_or_transferring_the_queue_notifies_nothing() -> None:
 
     Playing the same live source again and transferring the queue to another player both drop
     the queue's items on their way to re-selecting that very source. Releasing it there would
-    end the upstream session and cost the user the position they were paused at.
+    end the upstream session and cost the user the position they were paused at. A replace
+    that brings different media is a gap this leaves open, not a case it decides.
     """
     ctrl = _controller(QueueItem.from_media_item("q1", _audio_source()))
     provider = _plugin_provider(ctrl)

--- a/tests/controllers/player_queues/test_audio_source_removed.py
+++ b/tests/controllers/player_queues/test_audio_source_removed.py
@@ -110,6 +110,22 @@ def test_clearing_an_empty_queue_notifies_nothing() -> None:
     provider.on_source_removed.assert_not_called()
 
 
+def test_replacing_or_transferring_the_queue_notifies_nothing() -> None:
+    """
+    Only the user clearing their queue releases the source, not the internal clear.
+
+    Playing the same live source again and transferring the queue to another player both drop
+    the queue's items on their way to re-selecting that very source. Releasing it there would
+    end the upstream session and cost the user the position they were paused at.
+    """
+    ctrl = _controller(QueueItem.from_media_item("q1", _audio_source()))
+    provider = _plugin_provider(ctrl)
+
+    ctrl._clear("q1", skip_stop=True)
+
+    provider.on_source_removed.assert_not_called()
+
+
 def test_clearing_a_queue_whose_plugin_is_gone_still_clears() -> None:
     """An unloaded plugin must not keep the user from clearing their queue."""
     ctrl = _controller(QueueItem.from_media_item("q1", _audio_source()))

--- a/tests/controllers/player_queues/test_audio_source_removed.py
+++ b/tests/controllers/player_queues/test_audio_source_removed.py
@@ -1,0 +1,120 @@
+"""
+Tests for the notification a plugin gets when a queue drops its live AudioSource.
+
+Clearing the queue is the one moment the owning plugin has no other signal to go on: the
+stream serving the source may have been torn down long before (a paused source ends its
+stream), so without this notification the plugin never learns that MA is done with it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, Mock
+
+from music_assistant_models.media_items import AudioSource, ProviderMapping, Track
+from music_assistant_models.player_queue import PlayerQueue
+from music_assistant_models.queue_item import QueueItem
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+from music_assistant.models.plugin import PluginProvider
+
+
+def _audio_source() -> AudioSource:
+    """Build the live AudioSource a plugin exposes."""
+    return AudioSource(
+        item_id="main",
+        provider="spotify_connect--test",
+        name="Spotify Connect",
+        provider_mappings={
+            ProviderMapping(
+                item_id="main",
+                provider_domain="spotify_connect",
+                provider_instance="spotify_connect--test",
+            )
+        },
+    )
+
+
+def _track() -> Track:
+    """Build a plain track, i.e. a current item with no plugin behind it."""
+    return Track(
+        item_id="t1",
+        provider="test",
+        name="Track t1",
+        provider_mappings={
+            ProviderMapping(item_id="t1", provider_domain="test", provider_instance="test")
+        },
+    )
+
+
+def _controller(current_item: QueueItem | None) -> Any:
+    """
+    Build a bare controller holding a single queue "q1" playing the given item.
+
+    Tasks created along the way are closed instead of scheduled, so the notification can be
+    asserted on the plugin mock without a running loop.
+
+    :param current_item: The item the queue has as its current one, None for an empty queue.
+    """
+    ctrl = PlayerQueuesController.__new__(PlayerQueuesController)
+    ctrl.logger = Mock()
+    ctrl.mass = MagicMock()
+    ctrl.mass.create_task.side_effect = lambda coroutine: coroutine.close()
+    ctrl.signal_update = Mock()  # type: ignore[method-assign]
+    ctrl._managed_pool = Mock()
+    ctrl._smart_shuffle = Mock()
+    queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+    queue.current_item = current_item
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+    if current_item is not None:
+        ctrl._queue_data["q1"].items = [current_item]
+        queue.items = 1
+    return ctrl
+
+
+def _plugin_provider(ctrl: Any) -> Any:
+    """Make the controller resolve the AudioSource's provider to a plugin provider."""
+    provider = MagicMock(spec=PluginProvider)
+    ctrl.mass.get_provider.return_value = provider
+    return provider
+
+
+def test_clearing_the_queue_notifies_the_plugin() -> None:
+    """The plugin owning the current AudioSource is told the queue dropped it."""
+    ctrl = _controller(QueueItem.from_media_item("q1", _audio_source()))
+    provider = _plugin_provider(ctrl)
+
+    ctrl.clear("q1")
+
+    provider.on_source_removed.assert_called_once_with("main", "q1")
+
+
+def test_clearing_a_queue_of_tracks_notifies_nothing() -> None:
+    """A regular track has no plugin behind it to notify."""
+    ctrl = _controller(QueueItem.from_media_item("q1", _track()))
+    provider = _plugin_provider(ctrl)
+
+    ctrl.clear("q1")
+
+    provider.on_source_removed.assert_not_called()
+
+
+def test_clearing_an_empty_queue_notifies_nothing() -> None:
+    """A queue with nothing playing has no source to release."""
+    ctrl = _controller(None)
+    provider = _plugin_provider(ctrl)
+
+    ctrl.clear("q1")
+
+    provider.on_source_removed.assert_not_called()
+
+
+def test_clearing_a_queue_whose_plugin_is_gone_still_clears() -> None:
+    """An unloaded plugin must not keep the user from clearing their queue."""
+    ctrl = _controller(QueueItem.from_media_item("q1", _audio_source()))
+    ctrl.mass.get_provider.return_value = None
+
+    ctrl.clear("q1")
+
+    assert ctrl._queue_data["q1"].items == []

--- a/tests/controllers/player_queues/test_audio_source_removed.py
+++ b/tests/controllers/player_queues/test_audio_source_removed.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock
 
+import pytest
 from music_assistant_models.enums import PlaybackState, QueueOption
+from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import AudioSource, ProviderMapping, Track
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
@@ -248,3 +250,26 @@ async def test_media_played_alongside_the_source_keeps_it() -> None:
     await ctrl.play_media("q1", "test://album/al1", QueueOption.PLAY)
 
     provider.on_source_removed.assert_not_called()
+
+
+async def test_media_that_fails_to_load_still_releases_the_emptied_queue() -> None:
+    """
+    A replace gives up the queue's items before it knows the new media is playable.
+
+    Nothing plays afterwards and the source is just as gone, so it has to be released even
+    though starting the media failed.
+    """
+    ctrl = _controller(QueueItem.from_media_item("q1", _audio_source()))
+    provider = _plugin_provider(ctrl)
+    _play_media_replacing_with(ctrl)
+
+    async def _fail(*_args: Any, **_kwargs: Any) -> None:
+        ctrl._queue_data["q1"].items = []
+        raise MediaNotFoundError("No playable items found")
+
+    ctrl._handle_play_media = _fail
+
+    with pytest.raises(MediaNotFoundError):
+        await ctrl.play_media("q1", "test://album/gone", QueueOption.REPLACE)
+
+    provider.on_source_removed.assert_called_once_with("main", "q1")

--- a/tests/controllers/player_queues/test_audio_source_removed.py
+++ b/tests/controllers/player_queues/test_audio_source_removed.py
@@ -339,3 +339,22 @@ async def test_a_source_left_behind_by_a_play_is_released_when_replaced() -> Non
     await ctrl.play_media("q1", "test://album/al1", QueueOption.REPLACE)
 
     provider.on_source_removed.assert_called_once_with("main", "q1")
+
+
+async def test_transferring_hands_over_a_source_that_was_not_playing() -> None:
+    """
+    Every live source the queue holds moves with it, not just the one that was playing.
+
+    A source left in the queue by a "play" travels to the target like any other item, so its
+    plugin has to follow it there - otherwise a later clear on the target releases nothing.
+    """
+    source_item = QueueItem.from_media_item("q1", _audio_source())
+    track_item = QueueItem.from_media_item("q1", _track())
+    ctrl = _controller(track_item)
+    provider = _plugin_provider(ctrl)
+    ctrl._queue_data["q1"].items = [source_item, track_item]
+    _ready_for_transfer(ctrl)
+
+    await ctrl.transfer_queue("q1", "q2")
+
+    provider.on_source_transferred.assert_awaited_once_with("main", "q1", "q2")

--- a/tests/controllers/player_queues/test_audio_source_removed.py
+++ b/tests/controllers/player_queues/test_audio_source_removed.py
@@ -156,7 +156,7 @@ def _ready_for_transfer(ctrl: Any, target_current_item: QueueItem | None = None)
     def _apply_items(queue_id: str, items: list[QueueItem]) -> None:
         ctrl._queue_data[queue_id].items = items
 
-    # the real thing, minus the signalling: the queues have to end up holding what they were
+    # only the assignment the real one does: the queues have to end up holding what they were
     # handed, or a check on what survived the transfer reads the items it was supposed to replace
     ctrl.update_items = Mock(side_effect=_apply_items)
     ctrl._queue_data["q1"].queue.state = PlaybackState.PAUSED

--- a/tests/controllers/player_queues/test_transfer_queue.py
+++ b/tests/controllers/player_queues/test_transfer_queue.py
@@ -44,6 +44,7 @@ def _fake_controller(source_id: str, target_player: MagicMock) -> MagicMock:
     fake.resume = AsyncMock()
     fake.clear = MagicMock()
     fake.update_items = MagicMock()
+    fake._notify_audio_source_transferred = AsyncMock()
     fake.mass.players.get_player = MagicMock(return_value=target_player)
     fake.mass.players.cmd_ungroup = AsyncMock()
     fake.mass.players.wait_for_player_update = MagicMock(return_value=_DummyACM())
@@ -129,6 +130,7 @@ def _shuffle_controller(
     fake.resume = AsyncMock()
     fake._clear = MagicMock()
     fake.update_items = MagicMock()
+    fake._notify_audio_source_transferred = AsyncMock()
     fake.is_smart_shuffle_active = MagicMock(side_effect=lambda queue: queue.is_dynamic)
     target_player = MagicMock()
     target_player.state.synced_to = None

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -232,6 +232,39 @@ async def test_queue_clear_survives_a_failing_release() -> None:
     deactivate.assert_awaited_once()
 
 
+async def test_a_transferred_source_follows_its_new_queue() -> None:
+    """A paused source moved to another player is tracked on the queue that took it over."""
+    provider, _ = _tethered_provider()
+
+    await provider.on_source_transferred(AUDIO_SOURCE_ID, "player1", "player2")
+
+    assert provider._active_player_id == "player2"
+
+
+async def test_a_transfer_of_another_queue_is_ignored() -> None:
+    """A transfer that does not involve the tethered queue leaves the tracking alone."""
+    provider, _ = _tethered_provider()
+
+    await provider.on_source_transferred(AUDIO_SOURCE_ID, "player3", "player2")
+
+    assert provider._active_player_id == "player1"
+
+
+async def test_clearing_a_transferred_queue_releases_the_session() -> None:
+    """
+    The queue a paused source was transferred to can release it.
+
+    Transferring a paused source never re-selects it on the target, so without the handover
+    the plugin would still be pointed at the queue it left and the release would not fire.
+    """
+    provider, deactivate = _tethered_provider()
+
+    await provider.on_source_transferred(AUDIO_SOURCE_ID, "player1", "player2")
+    await provider.on_source_removed(AUDIO_SOURCE_ID, "player2")
+
+    deactivate.assert_awaited_once()
+
+
 def _provider_with_stored_config(
     setup_data: dict[str, Any], tmp_path: Path
 ) -> SpotifyConnectProvider:

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -24,7 +24,10 @@ from music_assistant.providers.spotify_connect.go_librespot.backend import (
     GoLibrespotBackend,
 )
 from music_assistant.providers.spotify_connect.go_librespot.client import GoLibrespotClient
-from music_assistant.providers.spotify_connect.provider import CONF_LOUDNESS_NORMALIZATION
+from music_assistant.providers.spotify_connect.provider import (
+    AUDIO_SOURCE_ID,
+    CONF_LOUDNESS_NORMALIZATION,
+)
 from music_assistant.providers.spotify_connect.soloist.backend import (
     VOLUME_MODE_SYNC_SPOTIFY,
     SoloistBackend,
@@ -159,6 +162,69 @@ async def test_sync_player_volume_restores_cache_on_failure() -> None:
     await provider._sync_player_volume_to_spotify("player1")
 
     assert provider._last_volume_sent is None
+
+
+def _tethered_provider() -> tuple[SpotifyConnectProvider, AsyncMock]:
+    """Build a provider tethered to queue 'player1' with an active (paused) Spotify session."""
+    provider = object.__new__(SpotifyConnectProvider)
+    provider.mass = MagicMock()
+    provider.logger = MagicMock()
+    backend = MagicMock()
+    deactivate = AsyncMock()
+    backend.deactivate = deactivate
+    provider._backend = backend
+    provider._active_player_id = "player1"
+    provider._in_use_by_queue = None
+    provider._spotify_session_active = True
+    return provider, deactivate
+
+
+async def test_queue_clear_releases_a_paused_spotify_session() -> None:
+    """Clearing the queue releases the session the paused stream's teardown left behind."""
+    provider, deactivate = _tethered_provider()
+
+    await provider.on_source_removed(AUDIO_SOURCE_ID, "player1")
+
+    deactivate.assert_awaited_once()
+
+
+async def test_queue_clear_leaves_the_release_to_a_live_stream() -> None:
+    """A stream still holding the claim releases the session in its own teardown."""
+    provider, deactivate = _tethered_provider()
+    provider._in_use_by_queue = "player1"
+
+    await provider.on_source_removed(AUDIO_SOURCE_ID, "player1")
+
+    deactivate.assert_not_awaited()
+
+
+async def test_clearing_another_queue_leaves_the_session_alone() -> None:
+    """Only the queue the source is tethered to may release it."""
+    provider, deactivate = _tethered_provider()
+
+    await provider.on_source_removed(AUDIO_SOURCE_ID, "player2")
+
+    deactivate.assert_not_awaited()
+
+
+async def test_queue_clear_without_an_active_session_does_nothing() -> None:
+    """There is nothing to release when MA is not the active Spotify device."""
+    provider, deactivate = _tethered_provider()
+    provider._spotify_session_active = False
+
+    await provider.on_source_removed(AUDIO_SOURCE_ID, "player1")
+
+    deactivate.assert_not_awaited()
+
+
+async def test_queue_clear_survives_a_failing_release() -> None:
+    """A backend that cannot be reached must not break clearing the queue."""
+    provider, deactivate = _tethered_provider()
+    deactivate.side_effect = OSError("daemon gone")
+
+    await provider.on_source_removed(AUDIO_SOURCE_ID, "player1")
+
+    deactivate.assert_awaited_once()
 
 
 def _provider_with_stored_config(

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -188,14 +188,19 @@ async def test_queue_clear_releases_a_paused_spotify_session() -> None:
     deactivate.assert_awaited_once()
 
 
-async def test_queue_clear_leaves_the_release_to_a_live_stream() -> None:
-    """A stream still holding the claim releases the session in its own teardown."""
+async def test_queue_clear_releases_while_the_stream_is_winding_down() -> None:
+    """
+    A clear landing before the paused stream finished tearing down still releases.
+
+    The teardown itself releases nothing for a paused source, so waiting for it to hand the
+    claim back would leave the Spotify app tethered for good.
+    """
     provider, deactivate = _tethered_provider()
     provider._in_use_by_queue = "player1"
 
     await provider.on_source_removed(AUDIO_SOURCE_ID, "player1")
 
-    deactivate.assert_not_awaited()
+    deactivate.assert_awaited_once()
 
 
 async def test_clearing_another_queue_leaves_the_session_alone() -> None:

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -24,6 +24,7 @@ from music_assistant.providers.spotify_connect.go_librespot.backend import (
     GoLibrespotBackend,
 )
 from music_assistant.providers.spotify_connect.go_librespot.client import GoLibrespotClient
+from music_assistant.providers.spotify_connect.models import BackendEvent, BackendEventType
 from music_assistant.providers.spotify_connect.provider import (
     AUDIO_SOURCE_ID,
     CONF_LOUDNESS_NORMALIZATION,
@@ -175,7 +176,11 @@ def _tethered_provider() -> tuple[SpotifyConnectProvider, AsyncMock]:
     provider._backend = backend
     provider._active_player_id = "player1"
     provider._in_use_by_queue = None
+    provider._active_session_id = None
     provider._spotify_session_active = True
+    provider._playing = False
+    provider._pending_pause_stop_task = None
+    provider._pending_play_media_task = None
     return provider, deactivate
 
 
@@ -220,6 +225,38 @@ async def test_queue_clear_without_an_active_session_does_nothing() -> None:
     await provider.on_source_removed(AUDIO_SOURCE_ID, "player1")
 
     deactivate.assert_not_awaited()
+
+
+async def _session_inactive(provider: SpotifyConnectProvider) -> list[str]:
+    """Run the backend's 'session inactive' answer and return the players it wanted stopped."""
+    stopped: list[str] = []
+    provider._schedule_pause_stop = lambda player_id: stopped.append(player_id)  # type: ignore[method-assign]
+    with patch.object(SpotifyConnectProvider, "name", "Spotify Test"):
+        await provider._handle_backend_event(BackendEvent(type=BackendEventType.SESSION_INACTIVE))
+    return stopped
+
+
+async def test_releasing_the_session_leaves_the_new_playback_alone() -> None:
+    """
+    Releasing must not stop the player that took the source's place.
+
+    The backend answers a release with the same "session inactive" it sends when the user picks
+    another device in the Spotify app - and that one does stop the player. By then this player is
+    playing whatever replaced the source, so stopping it would cut the music the user just started.
+    """
+    provider, _ = _tethered_provider()
+
+    with patch.object(SpotifyConnectProvider, "name", "Spotify Test"):
+        await provider.on_source_removed(AUDIO_SOURCE_ID, "player1")
+
+    assert await _session_inactive(provider) == []
+
+
+async def test_a_spotify_side_deselect_still_stops_the_player() -> None:
+    """Picking another device in the Spotify app does stop what MA was playing from it."""
+    provider, _ = _tethered_provider()
+
+    assert await _session_inactive(provider) == ["player1"]
 
 
 async def test_queue_clear_survives_a_failing_release() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Pausing a live audio source (like Spotify Connect) left the Spotify app tethered to Music Assistant for good: it kept showing MA as its playback device, paused, even after the queue was cleared, replaced by other music, or moved to another player.

Pausing already ends the stream, so the callback that normally hands the device back has nothing left to release by the time the queue changes - and none of those three actions gave the plugin any signal of their own.

- Spotify Connect now hands the device back when you clear the queue, so the Spotify app drops MA as its playback target instead of staying stuck on it.
- Same when you start something else that takes the source's place in the queue - playing an album or playlist, for instance.
- Starting that same source again still resumes where you paused it: that is not the source leaving the queue.
- Moving a paused source to another player used to leave the plugin pointing at the player it came from. It now follows the source, which also fixes volume sync and where playback starts when you press play in the Spotify app afterwards.
- Under the hood: two optional callbacks for plugin providers (`on_source_removed` and `on_source_transferred`); sources that are still streaming keep releasing on the existing stream teardown.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
