### PR TITLE
Keep malformed provider responses from emptying libraries

### DIFF
--- a/music_assistant/providers/emby/__init__.py
+++ b/music_assistant/providers/emby/__init__.py
@@ -16,6 +16,7 @@ from music_assistant_models.enums import (
     StreamType,
 )
 from music_assistant_models.errors import (
+    InvalidDataError,
     LoginFailed,
     MediaNotFoundError,
     ProviderPermissionDenied,
@@ -267,10 +268,17 @@ class EmbyProvider(MusicProvider):
                 params["StartIndex"] = str(page * ITEM_LIMIT)
                 params["Limit"] = ITEM_LIMIT
                 resp = await self._get("Artists", params=params)
-                items = resp.get(ITEMS, [])
+                items = self._get_response_items(resp, "artist")
                 if not items:
                     break
                 for artist in items:
+                    if not isinstance(artist, dict):
+                        self.report_skipped_sync_item(
+                            MediaType.ARTIST,
+                            None,
+                            InvalidDataError("Emby artist listing contains a non-object entry"),
+                        )
+                        continue
                     yield parse_artist(self.instance_id, self, artist)
                 page += 1
 
@@ -290,10 +298,17 @@ class EmbyProvider(MusicProvider):
                 params["StartIndex"] = str(page * ITEM_LIMIT)
                 params["Limit"] = ITEM_LIMIT
                 resp = await self._get(f"Users/{self._user_id}/Items", params=params)
-                items = resp.get(ITEMS, [])
+                items = self._get_response_items(resp, "album")
                 if not items:
                     break
                 for album in items:
+                    if not isinstance(album, dict):
+                        self.report_skipped_sync_item(
+                            MediaType.ALBUM,
+                            None,
+                            InvalidDataError("Emby album listing contains a non-object entry"),
+                        )
+                        continue
                     yield parse_album(self.instance_id, self, album)
                 page += 1
 
@@ -313,11 +328,25 @@ class EmbyProvider(MusicProvider):
                 params["StartIndex"] = str(page * ITEM_LIMIT)
                 params["Limit"] = ITEM_LIMIT
                 resp = await self._get(f"Users/{self._user_id}/Items", params=params)
-                items = resp.get(ITEMS, [])
+                items = self._get_response_items(resp, "track")
                 if not items:
                     break
                 for track in items:
-                    if not len(track.get(ITEM_KEY_MEDIA_STREAMS, [])):
+                    if not isinstance(track, dict):
+                        self.report_skipped_sync_item(
+                            MediaType.TRACK,
+                            None,
+                            InvalidDataError("Emby track listing contains a non-object entry"),
+                        )
+                        continue
+                    media_streams = track.get(ITEM_KEY_MEDIA_STREAMS)
+                    if not isinstance(media_streams, list) or not media_streams:
+                        item_id = track.get(ITEM_KEY_ID)
+                        self.report_skipped_sync_item(
+                            MediaType.TRACK,
+                            str(item_id) if item_id is not None else None,
+                            InvalidDataError("Emby track has no media streams"),
+                        )
                         continue
                     yield parse_track(self.instance_id, self, track)
                 page += 1
@@ -337,10 +366,17 @@ class EmbyProvider(MusicProvider):
                 params["StartIndex"] = str(page * ITEM_LIMIT)
                 params["Limit"] = ITEM_LIMIT
                 resp = await self._get(f"Users/{self._user_id}/Items", params=params)
-                items = resp.get(ITEMS, [])
+                items = self._get_response_items(resp, "playlist")
                 if not items:
                     break
                 for playlist in items:
+                    if not isinstance(playlist, dict):
+                        self.report_skipped_sync_item(
+                            MediaType.PLAYLIST,
+                            None,
+                            InvalidDataError("Emby playlist listing contains a non-object entry"),
+                        )
+                        continue
                     yield parse_playlist(self.instance_id, self, playlist)
                 page += 1
 
@@ -498,14 +534,24 @@ class EmbyProvider(MusicProvider):
 
     async def _get_music_libraries(self) -> list[dict[str, Any]]:
         resp = await self._get("Library/MediaFolders")
-        libs = resp.get(ITEMS, [])
+        libs = self._get_response_items(resp, "music library")
         result = []
         for library in libs:
+            if not isinstance(library, dict):
+                raise InvalidDataError("Emby music-library response contains a non-object entry")
             if ITEM_KEY_COLLECTION_TYPE in library:
                 collection_type = library.get(ITEM_KEY_COLLECTION_TYPE, "").lower()
                 if collection_type == "music":
                     result.append(library)
         return result
+
+    @staticmethod
+    def _get_response_items(response: dict[str, Any], item_type: str) -> list[Any]:
+        """Return the required item list from an Emby listing response."""
+        items = response.get(ITEMS)
+        if not isinstance(items, list):
+            raise InvalidDataError(f"Emby {item_type} response contains no item list")
+        return items
 
     async def on_played(
         self,

--- a/music_assistant/providers/emby/__init__.py
+++ b/music_assistant/providers/emby/__init__.py
@@ -279,7 +279,8 @@ class EmbyProvider(MusicProvider):
                             InvalidDataError("Emby artist listing contains a non-object entry"),
                         )
                         continue
-                    if not str(artist.get(ITEM_KEY_ID) or "").strip():
+                    item_id = artist.get(ITEM_KEY_ID)
+                    if not isinstance(item_id, str) or not item_id.strip():
                         self.report_skipped_sync_item(
                             MediaType.ARTIST,
                             None,
@@ -316,7 +317,8 @@ class EmbyProvider(MusicProvider):
                             InvalidDataError("Emby album listing contains a non-object entry"),
                         )
                         continue
-                    if not str(album.get(ITEM_KEY_ID) or "").strip():
+                    item_id = album.get(ITEM_KEY_ID)
+                    if not isinstance(item_id, str) or not item_id.strip():
                         self.report_skipped_sync_item(
                             MediaType.ALBUM,
                             None,
@@ -353,7 +355,8 @@ class EmbyProvider(MusicProvider):
                             InvalidDataError("Emby track listing contains a non-object entry"),
                         )
                         continue
-                    if not str(track.get(ITEM_KEY_ID) or "").strip():
+                    item_id = track.get(ITEM_KEY_ID)
+                    if not isinstance(item_id, str) or not item_id.strip():
                         self.report_skipped_sync_item(
                             MediaType.TRACK,
                             None,
@@ -362,10 +365,9 @@ class EmbyProvider(MusicProvider):
                         continue
                     media_streams = track.get(ITEM_KEY_MEDIA_STREAMS)
                     if not isinstance(media_streams, list) or not media_streams:
-                        item_id = track.get(ITEM_KEY_ID)
                         self.report_skipped_sync_item(
                             MediaType.TRACK,
-                            str(item_id) if item_id is not None else None,
+                            item_id,
                             InvalidDataError("Emby track has no media streams"),
                         )
                         continue
@@ -398,7 +400,8 @@ class EmbyProvider(MusicProvider):
                             InvalidDataError("Emby playlist listing contains a non-object entry"),
                         )
                         continue
-                    if not str(playlist.get(ITEM_KEY_ID) or "").strip():
+                    item_id = playlist.get(ITEM_KEY_ID)
+                    if not isinstance(item_id, str) or not item_id.strip():
                         self.report_skipped_sync_item(
                             MediaType.PLAYLIST,
                             None,
@@ -573,14 +576,6 @@ class EmbyProvider(MusicProvider):
                     result.append(library)
         return result
 
-    @staticmethod
-    def _get_response_items(response: dict[str, Any], item_type: str) -> list[Any]:
-        """Return the required item list from an Emby listing response."""
-        items = response.get(ITEMS)
-        if not isinstance(items, list):
-            raise InvalidDataError(f"Emby {item_type} response contains no item list")
-        return items
-
     async def on_played(
         self,
         media_type: MediaType,
@@ -602,3 +597,11 @@ class EmbyProvider(MusicProvider):
             )
         if not fully_played and position == 0:
             await self._post(f"/Users/{self._user_id}/PlayedItems/{prov_item_id}/Delete")
+
+    @staticmethod
+    def _get_response_items(response: dict[str, Any], item_type: str) -> list[Any]:
+        """Return the required item list from an Emby listing response."""
+        items = response.get(ITEMS)
+        if not isinstance(items, list):
+            raise InvalidDataError(f"Emby {item_type} response contains no item list")
+        return items

--- a/music_assistant/providers/emby/__init__.py
+++ b/music_assistant/providers/emby/__init__.py
@@ -279,6 +279,13 @@ class EmbyProvider(MusicProvider):
                             InvalidDataError("Emby artist listing contains a non-object entry"),
                         )
                         continue
+                    if not str(artist.get(ITEM_KEY_ID) or "").strip():
+                        self.report_skipped_sync_item(
+                            MediaType.ARTIST,
+                            None,
+                            InvalidDataError("Emby artist listing entry has no id"),
+                        )
+                        continue
                     yield parse_artist(self.instance_id, self, artist)
                 page += 1
 
@@ -309,6 +316,13 @@ class EmbyProvider(MusicProvider):
                             InvalidDataError("Emby album listing contains a non-object entry"),
                         )
                         continue
+                    if not str(album.get(ITEM_KEY_ID) or "").strip():
+                        self.report_skipped_sync_item(
+                            MediaType.ALBUM,
+                            None,
+                            InvalidDataError("Emby album listing entry has no id"),
+                        )
+                        continue
                     yield parse_album(self.instance_id, self, album)
                 page += 1
 
@@ -337,6 +351,13 @@ class EmbyProvider(MusicProvider):
                             MediaType.TRACK,
                             None,
                             InvalidDataError("Emby track listing contains a non-object entry"),
+                        )
+                        continue
+                    if not str(track.get(ITEM_KEY_ID) or "").strip():
+                        self.report_skipped_sync_item(
+                            MediaType.TRACK,
+                            None,
+                            InvalidDataError("Emby track listing entry has no id"),
                         )
                         continue
                     media_streams = track.get(ITEM_KEY_MEDIA_STREAMS)
@@ -375,6 +396,13 @@ class EmbyProvider(MusicProvider):
                             MediaType.PLAYLIST,
                             None,
                             InvalidDataError("Emby playlist listing contains a non-object entry"),
+                        )
+                        continue
+                    if not str(playlist.get(ITEM_KEY_ID) or "").strip():
+                        self.report_skipped_sync_item(
+                            MediaType.PLAYLIST,
+                            None,
+                            InvalidDataError("Emby playlist listing entry has no id"),
                         )
                         continue
                     yield parse_playlist(self.instance_id, self, playlist)

--- a/music_assistant/providers/neteasecloudmusic/__init__.py
+++ b/music_assistant/providers/neteasecloudmusic/__init__.py
@@ -1396,11 +1396,20 @@ class NeteaseCloudMusicProvider(MusicProvider):
                 cookie=self._cookie,
             )
             data = _extract_data(payload)
-            artists = data.get("data") or data.get("artists")
-            if not isinstance(artists, list) or not artists:
+            artists = data.get("data")
+            if artists is None:
+                artists = data.get("artists")
+            if not isinstance(artists, list):
+                raise InvalidDataError("Netease artist sublist contains no artist list")
+            if not artists:
                 break
             for artist_obj in artists:
                 if not isinstance(artist_obj, dict):
+                    self.report_skipped_sync_item(
+                        MediaType.ARTIST,
+                        None,
+                        InvalidDataError("Netease artist sublist contains a non-object entry"),
+                    )
                     continue
                 try:
                     yield self._parse_artist(artist_obj)
@@ -1422,11 +1431,20 @@ class NeteaseCloudMusicProvider(MusicProvider):
                 cookie=self._cookie,
             )
             data = _extract_data(payload)
-            albums = data.get("data") or data.get("albums")
-            if not isinstance(albums, list) or not albums:
+            albums = data.get("data")
+            if albums is None:
+                albums = data.get("albums")
+            if not isinstance(albums, list):
+                raise InvalidDataError("Netease album sublist contains no album list")
+            if not albums:
                 break
             for album_obj in albums:
                 if not isinstance(album_obj, dict):
+                    self.report_skipped_sync_item(
+                        MediaType.ALBUM,
+                        None,
+                        InvalidDataError("Netease album sublist contains a non-object entry"),
+                    )
                     continue
                 try:
                     yield self._parse_album(album_obj)
@@ -1445,10 +1463,22 @@ class NeteaseCloudMusicProvider(MusicProvider):
             cookie=self._cookie,
         )
         data = _extract_data(payload)
-        ids = data.get("ids") or payload.get("ids")
+        ids = data.get("ids")
+        if ids is None:
+            ids = payload.get("ids")
         if not isinstance(ids, list):
-            return
-        track_ids = [str(item) for item in ids if str(item).isdigit()]
+            raise InvalidDataError("Netease liked-track response contains no id list")
+        track_ids: list[str] = []
+        for item in ids:
+            item_id = str(item)
+            if item_id.isdigit():
+                track_ids.append(item_id)
+                continue
+            self.report_skipped_sync_item(
+                MediaType.TRACK,
+                None,
+                InvalidDataError("Netease liked-track response contains an invalid id"),
+            )
         chunk_size = 200
         for idx in range(0, len(track_ids), chunk_size):
             chunk_ids = track_ids[idx : idx + chunk_size]
@@ -1480,9 +1510,14 @@ class NeteaseCloudMusicProvider(MusicProvider):
         data = _extract_data(payload)
         playlists = data.get("playlist")
         if not isinstance(playlists, list):
-            return
+            raise InvalidDataError("Netease user-playlist response contains no playlist list")
         for playlist_obj in playlists:
             if not isinstance(playlist_obj, dict):
+                self.report_skipped_sync_item(
+                    MediaType.PLAYLIST,
+                    None,
+                    InvalidDataError("Netease user-playlist response contains a non-object entry"),
+                )
                 continue
             try:
                 yield self._parse_playlist(playlist_obj)

--- a/music_assistant/providers/neteasecloudmusic/__init__.py
+++ b/music_assistant/providers/neteasecloudmusic/__init__.py
@@ -271,6 +271,18 @@ def _extract_data(payload: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def _extract_item_id(item: dict[str, Any], *keys: str) -> str:
+    """Return a provider item id from the first populated key."""
+    for key in keys:
+        value = item.get(key)
+        if value is None:
+            continue
+        if isinstance(value, bool) or not isinstance(value, str | int):
+            return ""
+        return str(value).strip()
+    return ""
+
+
 def _extract_cookie(payload: dict[str, Any]) -> str:
     """Extract login cookie string from payload."""
     data = _extract_data(payload)
@@ -692,7 +704,7 @@ class NeteaseCloudMusicProvider(MusicProvider):
 
     def _parse_artist(self, artist_obj: dict[str, Any]) -> Artist:
         """Parse artist object."""
-        artist_id = str(artist_obj.get("id") or artist_obj.get("artistId") or "").strip()
+        artist_id = _extract_item_id(artist_obj, "id", "artistId")
         if not artist_id:
             raise InvalidDataError("Artist object missing id")
         name = str(artist_obj.get("name") or "Unknown Artist").strip()
@@ -721,7 +733,7 @@ class NeteaseCloudMusicProvider(MusicProvider):
 
     def _parse_album(self, album_obj: dict[str, Any]) -> Album:
         """Parse album object."""
-        album_id = str(album_obj.get("id") or album_obj.get("albumId") or "").strip()
+        album_id = _extract_item_id(album_obj, "id", "albumId")
         if not album_id:
             raise InvalidDataError("Album object missing id")
         name = str(album_obj.get("name") or "Unknown Album").strip()
@@ -766,7 +778,7 @@ class NeteaseCloudMusicProvider(MusicProvider):
 
     def _parse_track(self, song_obj: dict[str, Any]) -> Track:
         """Parse song object."""
-        track_id = str(song_obj.get("id") or song_obj.get("songId") or "").strip()
+        track_id = _extract_item_id(song_obj, "id", "songId")
         if not track_id:
             raise InvalidDataError("Track object missing id")
         name = str(song_obj.get("name") or "Unknown Track").strip()
@@ -825,7 +837,7 @@ class NeteaseCloudMusicProvider(MusicProvider):
 
     def _parse_playlist(self, playlist_obj: dict[str, Any]) -> Playlist:
         """Parse playlist object."""
-        playlist_id = str(playlist_obj.get("id") or playlist_obj.get("playlistId") or "").strip()
+        playlist_id = _extract_item_id(playlist_obj, "id", "playlistId")
         if not playlist_id:
             raise InvalidDataError("Playlist object missing id")
         name = str(playlist_obj.get("name") or "Unknown Playlist").strip()

--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -175,10 +175,15 @@ class TuneInProvider(MusicProvider):
     async def get_library_radios(self) -> AsyncGenerator[Radio]:
         """Retrieve library/subscribed radio stations from the provider."""
 
-        async def parse_items(
-            items: list[dict[str, Any]], folder: str | None = None
-        ) -> AsyncGenerator[Radio]:
+        async def parse_items(items: list[Any], folder: str | None = None) -> AsyncGenerator[Radio]:
             for item in items:
+                if not isinstance(item, dict):
+                    self.report_skipped_sync_item(
+                        MediaType.RADIO,
+                        None,
+                        InvalidDataError("TuneIn preset listing contains a non-object entry"),
+                    )
+                    continue
                 item_type = item.get("type", "")
                 if "unavailable" in item.get("key", ""):
                     continue
@@ -199,18 +204,26 @@ class TuneInProvider(MusicProvider):
                         self.report_skipped_sync_item(MediaType.RADIO, item["URL"], err)
                 elif item_type == "link":
                     # stations are in sublevel (new style)
-                    if sublevel := await self.__get_data(item["URL"], render="json"):
-                        async for subitem in parse_items(sublevel["body"], item["text"]):
-                            yield subitem
+                    sublevel = await self.__get_data(item["URL"], render="json")
+                    if sublevel is None or not isinstance(sublevel.get("body"), list):
+                        self.report_skipped_sync_item(
+                            MediaType.RADIO,
+                            None,
+                            InvalidDataError("TuneIn preset folder contains no item list"),
+                        )
+                        continue
+                    async for subitem in parse_items(sublevel["body"], item["text"]):
+                        yield subitem
                 elif item.get("children"):
                     # stations are in sublevel (old style ?)
                     async for subitem in parse_items(item["children"], item["text"]):
                         yield subitem
 
         data = await self.__get_data("Browse.ashx", c="presets")
-        if data and "body" in data:
-            async for item in parse_items(data["body"]):
-                yield item
+        if data is None or not isinstance(data.get("body"), list):
+            raise InvalidDataError("TuneIn preset response contains no item list")
+        async for item in parse_items(data["body"]):
+            yield item
 
     @use_cache(3600 * 24 * 30)  # Cache for 30 days
     async def get_radio(self, prov_radio_id: str) -> Radio:

--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -237,14 +237,19 @@ class TuneInProvider(MusicProvider):
                 elif "children" in item:
                     # stations are in sublevel (old style ?)
                     children = item["children"]
-                    if not isinstance(children, list):
+                    item_text = item.get("text")
+                    if (
+                        not isinstance(children, list)
+                        or not isinstance(item_text, str)
+                        or not item_text
+                    ):
                         self.report_skipped_sync_item(
                             MediaType.RADIO,
                             None,
-                            InvalidDataError("TuneIn preset folder contains no item list"),
+                            InvalidDataError("TuneIn preset folder contains no item list or name"),
                         )
                         continue
-                    async for subitem in parse_items(children, item["text"]):
+                    async for subitem in parse_items(children, item_text):
                         yield subitem
 
         data = await self.__get_data("Browse.ashx", c="presets")

--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -200,16 +200,31 @@ class TuneInProvider(MusicProvider):
                     # each radio station can have multiple streams add each one as different quality
                     stream_info = await self._get_stream_info(item["preset_id"])
                     yield self._parse_radio(item, stream_info, folder)
-                elif item_type == "link" and item.get("item") == "url":
-                    # custom url
-                    try:
-                        yield self._parse_radio(item)
-                    except InvalidDataError as err:
-                        # there may be invalid custom urls, ignore those
-                        self.report_skipped_sync_item(MediaType.RADIO, item["URL"], err)
                 elif item_type == "link":
+                    item_url = item.get("URL")
+                    item_text = item.get("text")
+                    if (
+                        not isinstance(item_url, str)
+                        or not item_url
+                        or not isinstance(item_text, str)
+                        or not item_text
+                    ):
+                        self.report_skipped_sync_item(
+                            MediaType.RADIO,
+                            None,
+                            InvalidDataError("TuneIn link preset has no URL or name"),
+                        )
+                        continue
+                    if item.get("item") == "url":
+                        # custom url
+                        try:
+                            yield self._parse_radio(item)
+                        except InvalidDataError as err:
+                            # there may be invalid custom urls, ignore those
+                            self.report_skipped_sync_item(MediaType.RADIO, item_url, err)
+                        continue
                     # stations are in sublevel (new style)
-                    sublevel = await self.__get_data(item["URL"], render="json")
+                    sublevel = await self.__get_data(item_url, render="json")
                     if sublevel is None or not isinstance(sublevel.get("body"), list):
                         self.report_skipped_sync_item(
                             MediaType.RADIO,
@@ -217,7 +232,7 @@ class TuneInProvider(MusicProvider):
                             InvalidDataError("TuneIn preset folder contains no item list"),
                         )
                         continue
-                    async for subitem in parse_items(sublevel["body"], item["text"]):
+                    async for subitem in parse_items(sublevel["body"], item_text):
                         yield subitem
                 elif "children" in item:
                     # stations are in sublevel (old style ?)

--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -191,6 +191,11 @@ class TuneInProvider(MusicProvider):
                     continue
                 if item_type == "audio":
                     if "preset_id" not in item:
+                        self.report_skipped_sync_item(
+                            MediaType.RADIO,
+                            None,
+                            InvalidDataError("TuneIn audio preset has no id"),
+                        )
                         continue
                     # each radio station can have multiple streams add each one as different quality
                     stream_info = await self._get_stream_info(item["preset_id"])
@@ -214,9 +219,17 @@ class TuneInProvider(MusicProvider):
                         continue
                     async for subitem in parse_items(sublevel["body"], item["text"]):
                         yield subitem
-                elif item.get("children"):
+                elif "children" in item:
                     # stations are in sublevel (old style ?)
-                    async for subitem in parse_items(item["children"], item["text"]):
+                    children = item["children"]
+                    if not isinstance(children, list):
+                        self.report_skipped_sync_item(
+                            MediaType.RADIO,
+                            None,
+                            InvalidDataError("TuneIn preset folder contains no item list"),
+                        )
+                        continue
+                    async for subitem in parse_items(children, item["text"]):
                         yield subitem
 
         data = await self.__get_data("Browse.ashx", c="presets")

--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -190,7 +190,8 @@ class TuneInProvider(MusicProvider):
                 if not item.get("is_available", True):
                     continue
                 if item_type == "audio":
-                    if "preset_id" not in item:
+                    preset_id = item.get("preset_id")
+                    if not isinstance(preset_id, str) or not preset_id:
                         self.report_skipped_sync_item(
                             MediaType.RADIO,
                             None,
@@ -198,7 +199,7 @@ class TuneInProvider(MusicProvider):
                         )
                         continue
                     # each radio station can have multiple streams add each one as different quality
-                    stream_info = await self._get_stream_info(item["preset_id"])
+                    stream_info = await self._get_stream_info(preset_id)
                     yield self._parse_radio(item, stream_info, folder)
                 elif item_type == "link":
                     item_url = item.get("URL")

--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -174,89 +174,10 @@ class TuneInProvider(MusicProvider):
 
     async def get_library_radios(self) -> AsyncGenerator[Radio]:
         """Retrieve library/subscribed radio stations from the provider."""
-
-        async def parse_items(items: list[Any], folder: str | None = None) -> AsyncGenerator[Radio]:
-            for item in items:
-                if not isinstance(item, dict):
-                    self.report_skipped_sync_item(
-                        MediaType.RADIO,
-                        None,
-                        InvalidDataError("TuneIn preset listing contains a non-object entry"),
-                    )
-                    continue
-                item_type = item.get("type", "")
-                if "unavailable" in item.get("key", ""):
-                    continue
-                if not item.get("is_available", True):
-                    continue
-                if item_type == "audio":
-                    preset_id = item.get("preset_id")
-                    if not isinstance(preset_id, str) or not preset_id:
-                        self.report_skipped_sync_item(
-                            MediaType.RADIO,
-                            None,
-                            InvalidDataError("TuneIn audio preset has no id"),
-                        )
-                        continue
-                    # each radio station can have multiple streams add each one as different quality
-                    stream_info = await self._get_stream_info(preset_id)
-                    yield self._parse_radio(item, stream_info, folder)
-                elif item_type == "link":
-                    item_url = item.get("URL")
-                    item_text = item.get("text")
-                    if (
-                        not isinstance(item_url, str)
-                        or not item_url
-                        or not isinstance(item_text, str)
-                        or not item_text
-                    ):
-                        self.report_skipped_sync_item(
-                            MediaType.RADIO,
-                            None,
-                            InvalidDataError("TuneIn link preset has no URL or name"),
-                        )
-                        continue
-                    if item.get("item") == "url":
-                        # custom url
-                        try:
-                            yield self._parse_radio(item)
-                        except InvalidDataError as err:
-                            # there may be invalid custom urls, ignore those
-                            self.report_skipped_sync_item(MediaType.RADIO, item_url, err)
-                        continue
-                    # stations are in sublevel (new style)
-                    sublevel = await self.__get_data(item_url, render="json")
-                    if sublevel is None or not isinstance(sublevel.get("body"), list):
-                        self.report_skipped_sync_item(
-                            MediaType.RADIO,
-                            None,
-                            InvalidDataError("TuneIn preset folder contains no item list"),
-                        )
-                        continue
-                    async for subitem in parse_items(sublevel["body"], item_text):
-                        yield subitem
-                elif "children" in item:
-                    # stations are in sublevel (old style ?)
-                    children = item["children"]
-                    item_text = item.get("text")
-                    if (
-                        not isinstance(children, list)
-                        or not isinstance(item_text, str)
-                        or not item_text
-                    ):
-                        self.report_skipped_sync_item(
-                            MediaType.RADIO,
-                            None,
-                            InvalidDataError("TuneIn preset folder contains no item list or name"),
-                        )
-                        continue
-                    async for subitem in parse_items(children, item_text):
-                        yield subitem
-
         data = await self.__get_data("Browse.ashx", c="presets")
         if data is None or not isinstance(data.get("body"), list):
             raise InvalidDataError("TuneIn preset response contains no item list")
-        async for item in parse_items(data["body"]):
+        async for item in self._parse_library_radio_items(data["body"]):
             yield item
 
     @use_cache(3600 * 24 * 30)  # Cache for 30 days
@@ -381,6 +302,102 @@ class TuneInProvider(MusicProvider):
                         break
         result.radio = radios
         return result
+
+    async def _parse_library_radio_items(
+        self, items: list[Any], folder: str | None = None
+    ) -> AsyncGenerator[Radio]:
+        """Parse playable radios from a TuneIn preset list."""
+        for item in items:
+            if not isinstance(item, dict):
+                self.report_skipped_sync_item(
+                    MediaType.RADIO,
+                    None,
+                    InvalidDataError("TuneIn preset listing contains a non-object entry"),
+                )
+                continue
+            item_type = item.get("type", "")
+            if "unavailable" in item.get("key", ""):
+                continue
+            if not item.get("is_available", True):
+                continue
+            if item_type == "audio":
+                preset_id = item.get("preset_id")
+                if not isinstance(preset_id, str) or not preset_id:
+                    self.report_skipped_sync_item(
+                        MediaType.RADIO,
+                        None,
+                        InvalidDataError("TuneIn audio preset has no id"),
+                    )
+                    continue
+                item_text = item.get("text")
+                if not isinstance(item_text, str) or not item_text:
+                    self.report_skipped_sync_item(
+                        MediaType.RADIO,
+                        preset_id,
+                        InvalidDataError("TuneIn audio preset has no name"),
+                    )
+                    continue
+                # each radio station can have multiple streams add each one as different quality
+                stream_info = await self._get_stream_info(preset_id)
+                if not stream_info:
+                    self.report_skipped_sync_item(
+                        MediaType.RADIO,
+                        preset_id,
+                        InvalidDataError("TuneIn audio preset has no streams"),
+                    )
+                    continue
+                yield self._parse_radio(item, stream_info, folder)
+            elif item_type == "link":
+                item_url = item.get("URL")
+                item_text = item.get("text")
+                if (
+                    not isinstance(item_url, str)
+                    or not item_url
+                    or not isinstance(item_text, str)
+                    or not item_text
+                ):
+                    self.report_skipped_sync_item(
+                        MediaType.RADIO,
+                        None,
+                        InvalidDataError("TuneIn link preset has no URL or name"),
+                    )
+                    continue
+                if item.get("item") == "url":
+                    # custom url
+                    try:
+                        yield self._parse_radio(item)
+                    except InvalidDataError as err:
+                        # there may be invalid custom urls, ignore those
+                        self.report_skipped_sync_item(MediaType.RADIO, item_url, err)
+                    continue
+                # stations are in sublevel (new style)
+                sublevel = await self.__get_data(item_url, render="json")
+                if sublevel is None or not isinstance(sublevel.get("body"), list):
+                    self.report_skipped_sync_item(
+                        MediaType.RADIO,
+                        None,
+                        InvalidDataError("TuneIn preset folder contains no item list"),
+                    )
+                    continue
+                async for subitem in self._parse_library_radio_items(sublevel["body"], item_text):
+                    yield subitem
+            elif "children" in item:
+                # stations are in sublevel (old style ?)
+                children = item["children"]
+                item_text = item.get("text")
+                if (
+                    not isinstance(children, list)
+                    or not isinstance(item_text, str)
+                    or not item_text
+                ):
+                    self.report_skipped_sync_item(
+                        MediaType.RADIO,
+                        None,
+                        InvalidDataError("TuneIn preset folder contains no item list or name"),
+                    )
+                    continue
+                async for subitem in self._parse_library_radio_items(children, item_text):
+                    yield subitem
 
     @staticmethod
     def _browse_path_key(text: str) -> str:

--- a/tests/providers/emby/__init__.py
+++ b/tests/providers/emby/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Emby provider."""

--- a/tests/providers/emby/test_library_listings.py
+++ b/tests/providers/emby/test_library_listings.py
@@ -75,7 +75,7 @@ async def test_empty_item_list_is_a_valid_empty_library(provider: EmbyProvider) 
         ("get_library_playlists", MediaType.PLAYLIST),
     ],
 )
-@pytest.mark.parametrize("entry", [None, {}])
+@pytest.mark.parametrize("entry", [None, {}, {ITEM_KEY_ID: {}}])
 async def test_non_object_entry_is_reported(
     provider: EmbyProvider,
     method_name: str,

--- a/tests/providers/emby/test_library_listings.py
+++ b/tests/providers/emby/test_library_listings.py
@@ -1,0 +1,140 @@
+"""Tests for Emby library listing validation."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Callable
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.providers.emby import SUPPORTED_FEATURES, EmbyProvider
+from music_assistant.providers.emby.const import ITEM_KEY_ID, ITEM_KEY_MEDIA_STREAMS, ITEMS
+
+
+@pytest.fixture
+def provider() -> EmbyProvider:
+    """Create an Emby provider with mocked dependencies."""
+    mass = Mock()
+    manifest = Mock()
+    manifest.domain = "emby"
+    config = Mock()
+    config.instance_id = "emby--test123"
+    config.name = "Emby Test"
+    config.enabled = True
+    config.get_value.return_value = "GLOBAL"
+    result = EmbyProvider(mass, manifest, config, SUPPORTED_FEATURES)
+    result._user_id = "user"
+    return result
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "get_library_artists",
+        "get_library_albums",
+        "get_library_tracks",
+        "get_library_playlists",
+    ],
+)
+@pytest.mark.parametrize("response", [{}, {ITEMS: None}, {ITEMS: {}}])
+async def test_malformed_item_list_raises(
+    provider: EmbyProvider,
+    method_name: str,
+    response: dict[str, Any],
+) -> None:
+    """A missing or wrong-typed Items field must abort the library sync."""
+    provider._get_music_libraries = AsyncMock(  # type: ignore[method-assign]
+        return_value=[{ITEM_KEY_ID: "library"}]
+    )
+    provider._get = AsyncMock(return_value=response)  # type: ignore[method-assign]
+
+    listing: Callable[[], AsyncGenerator[Any]] = getattr(provider, method_name)
+    with pytest.raises(InvalidDataError):
+        _ = [item async for item in listing()]
+
+
+async def test_empty_item_list_is_a_valid_empty_library(provider: EmbyProvider) -> None:
+    """An explicit empty Items list remains a valid empty library."""
+    provider._get_music_libraries = AsyncMock(  # type: ignore[method-assign]
+        return_value=[{ITEM_KEY_ID: "library"}]
+    )
+    provider._get = AsyncMock(return_value={ITEMS: []})  # type: ignore[method-assign]
+
+    assert [track async for track in provider.get_library_tracks()] == []
+
+
+@pytest.mark.parametrize(
+    ("method_name", "media_type"),
+    [
+        ("get_library_artists", MediaType.ARTIST),
+        ("get_library_albums", MediaType.ALBUM),
+        ("get_library_tracks", MediaType.TRACK),
+        ("get_library_playlists", MediaType.PLAYLIST),
+    ],
+)
+async def test_non_object_entry_is_reported(
+    provider: EmbyProvider, method_name: str, media_type: MediaType
+) -> None:
+    """An unidentifiable malformed entry must hold back deletions for its listing."""
+    provider._get_music_libraries = AsyncMock(  # type: ignore[method-assign]
+        return_value=[{ITEM_KEY_ID: "library"}]
+    )
+    provider._get = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[{ITEMS: [None]}, {ITEMS: []}]
+    )
+    provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
+
+    listing: Callable[[], AsyncGenerator[Any]] = getattr(provider, method_name)
+    assert [item async for item in listing()] == []
+
+    provider.report_skipped_sync_item.assert_called_once()
+    args = provider.report_skipped_sync_item.call_args.args
+    assert args[:2] == (media_type, None)
+    assert isinstance(args[2], InvalidDataError)
+
+
+@pytest.mark.parametrize("media_streams", [None, {}, []])
+async def test_streamless_track_is_reported(provider: EmbyProvider, media_streams: Any) -> None:
+    """A track without media streams must be reported instead of silently disappearing."""
+    provider._get_music_libraries = AsyncMock(  # type: ignore[method-assign]
+        return_value=[{ITEM_KEY_ID: "library"}]
+    )
+    provider._get = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            {
+                ITEMS: [
+                    {
+                        ITEM_KEY_ID: "track-1",
+                        ITEM_KEY_MEDIA_STREAMS: media_streams,
+                    }
+                ]
+            },
+            {ITEMS: []},
+        ]
+    )
+    provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
+
+    assert [track async for track in provider.get_library_tracks()] == []
+
+    args = provider.report_skipped_sync_item.call_args.args
+    assert args[:2] == (MediaType.TRACK, "track-1")
+    assert isinstance(args[2], InvalidDataError)
+
+
+async def test_malformed_music_library_list_raises(provider: EmbyProvider) -> None:
+    """A malformed media-folder response must not make every listing look empty."""
+    provider._get = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+    with pytest.raises(InvalidDataError):
+        await provider._get_music_libraries()
+
+
+async def test_malformed_music_library_entry_raises(provider: EmbyProvider) -> None:
+    """A non-object media folder must abort every listing that depends on it."""
+    provider._get = AsyncMock(return_value={ITEMS: [None]})  # type: ignore[method-assign]
+
+    with pytest.raises(InvalidDataError):
+        await provider._get_music_libraries()

--- a/tests/providers/emby/test_library_listings.py
+++ b/tests/providers/emby/test_library_listings.py
@@ -75,15 +75,19 @@ async def test_empty_item_list_is_a_valid_empty_library(provider: EmbyProvider) 
         ("get_library_playlists", MediaType.PLAYLIST),
     ],
 )
+@pytest.mark.parametrize("entry", [None, {}])
 async def test_non_object_entry_is_reported(
-    provider: EmbyProvider, method_name: str, media_type: MediaType
+    provider: EmbyProvider,
+    method_name: str,
+    media_type: MediaType,
+    entry: Any,
 ) -> None:
     """An unidentifiable malformed entry must hold back deletions for its listing."""
     provider._get_music_libraries = AsyncMock(  # type: ignore[method-assign]
         return_value=[{ITEM_KEY_ID: "library"}]
     )
     provider._get = AsyncMock(  # type: ignore[method-assign]
-        side_effect=[{ITEMS: [None]}, {ITEMS: []}]
+        side_effect=[{ITEMS: [entry]}, {ITEMS: []}]
     )
     provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
 

--- a/tests/providers/neteasecloudmusic/test_library_listing_validation.py
+++ b/tests/providers/neteasecloudmusic/test_library_listing_validation.py
@@ -42,6 +42,9 @@ async def test_malformed_listing_field_raises(
         ("get_library_artists", {"artists": [None]}, MediaType.ARTIST),
         ("get_library_albums", {"albums": [None]}, MediaType.ALBUM),
         ("get_library_playlists", {"playlist": [None]}, MediaType.PLAYLIST),
+        ("get_library_artists", {"artists": [{"id": {}}]}, MediaType.ARTIST),
+        ("get_library_albums", {"albums": [{"id": {}}]}, MediaType.ALBUM),
+        ("get_library_playlists", {"playlist": [{"id": {}}]}, MediaType.PLAYLIST),
     ],
 )
 async def test_malformed_listing_entry_is_reported(

--- a/tests/providers/neteasecloudmusic/test_library_listing_validation.py
+++ b/tests/providers/neteasecloudmusic/test_library_listing_validation.py
@@ -1,0 +1,80 @@
+"""Tests for malformed NetEase library listing responses."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Callable
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.providers.neteasecloudmusic import NeteaseCloudMusicProvider
+
+
+@pytest.mark.parametrize(
+    ("method_name", "response"),
+    [
+        ("get_library_artists", {"data": {"unexpected": []}}),
+        ("get_library_albums", {"data": {"unexpected": []}}),
+        ("get_library_tracks", {"unexpected": []}),
+        ("get_library_playlists", {"unexpected": []}),
+    ],
+)
+async def test_malformed_listing_field_raises(
+    provider: NeteaseCloudMusicProvider,
+    method_name: str,
+    response: dict[str, Any],
+) -> None:
+    """A missing item list must abort the sync instead of looking empty."""
+    provider._client = AsyncMock()
+    provider._client.get.return_value = response
+
+    listing: Callable[[], AsyncGenerator[Any]] = getattr(provider, method_name)
+    with pytest.raises(InvalidDataError):
+        _ = [item async for item in listing()]
+
+
+@pytest.mark.parametrize(
+    ("method_name", "response", "media_type"),
+    [
+        ("get_library_artists", {"artists": [None]}, MediaType.ARTIST),
+        ("get_library_albums", {"albums": [None]}, MediaType.ALBUM),
+        ("get_library_playlists", {"playlist": [None]}, MediaType.PLAYLIST),
+    ],
+)
+async def test_malformed_listing_entry_is_reported(
+    provider: NeteaseCloudMusicProvider,
+    method_name: str,
+    response: dict[str, Any],
+    media_type: MediaType,
+) -> None:
+    """An unidentifiable malformed entry must hold back deletions for the listing."""
+    provider._client = AsyncMock()
+    provider._client.get.return_value = response
+    provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
+
+    listing: Callable[[], AsyncGenerator[Any]] = getattr(provider, method_name)
+    assert [item async for item in listing()] == []
+
+    provider.report_skipped_sync_item.assert_called_once()
+    args = provider.report_skipped_sync_item.call_args.args
+    assert args[:2] == (media_type, None)
+    assert isinstance(args[2], InvalidDataError)
+
+
+async def test_malformed_liked_track_id_is_reported(
+    provider: NeteaseCloudMusicProvider,
+) -> None:
+    """An invalid liked-track id must not silently disappear from the authoritative list."""
+    provider._client = AsyncMock()
+    provider._client.get.return_value = {"ids": [None]}
+    provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
+
+    assert [track async for track in provider.get_library_tracks()] == []
+
+    provider.report_skipped_sync_item.assert_called_once()
+    args = provider.report_skipped_sync_item.call_args.args
+    assert args[:2] == (MediaType.TRACK, None)
+    assert isinstance(args[2], InvalidDataError)

--- a/tests/providers/tunein/test_library_listings.py
+++ b/tests/providers/tunein/test_library_listings.py
@@ -77,3 +77,28 @@ async def test_old_style_folder_without_item_list_is_reported(provider: TuneInPr
     args = provider.report_skipped_sync_item.call_args.args
     assert args[:2] == (MediaType.RADIO, None)
     assert isinstance(args[2], InvalidDataError)
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        {"type": "link"},
+        {"type": "link", "URL": "https://example.com"},
+        {"type": "link", "item": "url", "text": "Custom station"},
+    ],
+)
+async def test_link_without_url_or_name_is_reported(
+    provider: TuneInProvider, item: dict[str, Any]
+) -> None:
+    """A link without its required fields must hold back radio deletions."""
+    provider._TuneInProvider__get_data = AsyncMock(  # type: ignore[attr-defined]
+        return_value={"body": [item]}
+    )
+    provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
+
+    assert [radio async for radio in provider.get_library_radios()] == []
+
+    provider.report_skipped_sync_item.assert_called_once()
+    args = provider.report_skipped_sync_item.call_args.args
+    assert args[:2] == (MediaType.RADIO, None)
+    assert isinstance(args[2], InvalidDataError)

--- a/tests/providers/tunein/test_library_listings.py
+++ b/tests/providers/tunein/test_library_listings.py
@@ -1,0 +1,49 @@
+"""Tests for TuneIn library listing validation."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.providers.tunein import TuneInProvider
+
+
+@pytest.mark.parametrize("response", [None, {}, {"body": None}, {"body": {}}])
+async def test_malformed_preset_list_raises(
+    provider: TuneInProvider, response: dict[str, Any] | None
+) -> None:
+    """A malformed top-level preset response must abort the radio sync."""
+    provider._TuneInProvider__get_data = AsyncMock(  # type: ignore[attr-defined]
+        return_value=response
+    )
+
+    with pytest.raises(InvalidDataError):
+        _ = [radio async for radio in provider.get_library_radios()]
+
+
+async def test_empty_preset_list_is_valid(provider: TuneInProvider) -> None:
+    """An explicit empty preset list remains a valid empty library."""
+    provider._TuneInProvider__get_data = AsyncMock(  # type: ignore[attr-defined]
+        return_value={"body": []}
+    )
+
+    assert [radio async for radio in provider.get_library_radios()] == []
+
+
+async def test_malformed_preset_entry_is_reported(provider: TuneInProvider) -> None:
+    """An unidentifiable malformed preset must hold back radio deletions."""
+    provider._TuneInProvider__get_data = AsyncMock(  # type: ignore[attr-defined]
+        return_value={"body": [None]}
+    )
+    provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
+
+    assert [radio async for radio in provider.get_library_radios()] == []
+
+    provider.report_skipped_sync_item.assert_called_once()
+    args = provider.report_skipped_sync_item.call_args.args
+    assert args[:2] == (MediaType.RADIO, None)
+    assert isinstance(args[2], InvalidDataError)

--- a/tests/providers/tunein/test_library_listings.py
+++ b/tests/providers/tunein/test_library_listings.py
@@ -47,3 +47,33 @@ async def test_malformed_preset_entry_is_reported(provider: TuneInProvider) -> N
     args = provider.report_skipped_sync_item.call_args.args
     assert args[:2] == (MediaType.RADIO, None)
     assert isinstance(args[2], InvalidDataError)
+
+
+async def test_audio_preset_without_id_is_reported(provider: TuneInProvider) -> None:
+    """An audio preset without an id must hold back radio deletions."""
+    provider._TuneInProvider__get_data = AsyncMock(  # type: ignore[attr-defined]
+        return_value={"body": [{"type": "audio"}]}
+    )
+    provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
+
+    assert [radio async for radio in provider.get_library_radios()] == []
+
+    provider.report_skipped_sync_item.assert_called_once()
+    args = provider.report_skipped_sync_item.call_args.args
+    assert args[:2] == (MediaType.RADIO, None)
+    assert isinstance(args[2], InvalidDataError)
+
+
+async def test_old_style_folder_without_item_list_is_reported(provider: TuneInProvider) -> None:
+    """An old-style folder without an item list must hold back radio deletions."""
+    provider._TuneInProvider__get_data = AsyncMock(  # type: ignore[attr-defined]
+        return_value={"body": [{"children": None}]}
+    )
+    provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
+
+    assert [radio async for radio in provider.get_library_radios()] == []
+
+    provider.report_skipped_sync_item.assert_called_once()
+    args = provider.report_skipped_sync_item.call_args.args
+    assert args[:2] == (MediaType.RADIO, None)
+    assert isinstance(args[2], InvalidDataError)

--- a/tests/providers/tunein/test_library_listings.py
+++ b/tests/providers/tunein/test_library_listings.py
@@ -67,6 +67,37 @@ async def test_audio_preset_without_id_is_reported(
     assert isinstance(args[2], InvalidDataError)
 
 
+async def test_audio_preset_without_name_is_reported(provider: TuneInProvider) -> None:
+    """An audio preset without a name must be reported with its known id."""
+    provider._TuneInProvider__get_data = AsyncMock(  # type: ignore[attr-defined]
+        return_value={"body": [{"type": "audio", "preset_id": "station-1"}]}
+    )
+    provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
+
+    assert [radio async for radio in provider.get_library_radios()] == []
+
+    provider.report_skipped_sync_item.assert_called_once()
+    args = provider.report_skipped_sync_item.call_args.args
+    assert args[:2] == (MediaType.RADIO, "station-1")
+    assert isinstance(args[2], InvalidDataError)
+
+
+async def test_audio_preset_without_streams_is_reported(provider: TuneInProvider) -> None:
+    """An audio preset without streams must be reported with its known id."""
+    provider._TuneInProvider__get_data = AsyncMock(  # type: ignore[attr-defined]
+        return_value={"body": [{"type": "audio", "preset_id": "station-1", "text": "Station"}]}
+    )
+    provider._get_stream_info = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
+
+    assert [radio async for radio in provider.get_library_radios()] == []
+
+    provider.report_skipped_sync_item.assert_called_once()
+    args = provider.report_skipped_sync_item.call_args.args
+    assert args[:2] == (MediaType.RADIO, "station-1")
+    assert isinstance(args[2], InvalidDataError)
+
+
 @pytest.mark.parametrize(
     "folder",
     [

--- a/tests/providers/tunein/test_library_listings.py
+++ b/tests/providers/tunein/test_library_listings.py
@@ -64,10 +64,20 @@ async def test_audio_preset_without_id_is_reported(provider: TuneInProvider) -> 
     assert isinstance(args[2], InvalidDataError)
 
 
-async def test_old_style_folder_without_item_list_is_reported(provider: TuneInProvider) -> None:
-    """An old-style folder without an item list must hold back radio deletions."""
+@pytest.mark.parametrize(
+    "folder",
+    [
+        {"children": None, "text": "Folder"},
+        {"children": [], "text": None},
+        {"children": []},
+    ],
+)
+async def test_malformed_old_style_folder_is_reported(
+    provider: TuneInProvider, folder: dict[str, Any]
+) -> None:
+    """A malformed old-style folder must hold back radio deletions."""
     provider._TuneInProvider__get_data = AsyncMock(  # type: ignore[attr-defined]
-        return_value={"body": [{"children": None}]}
+        return_value={"body": [folder]}
     )
     provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
 

--- a/tests/providers/tunein/test_library_listings.py
+++ b/tests/providers/tunein/test_library_listings.py
@@ -49,10 +49,13 @@ async def test_malformed_preset_entry_is_reported(provider: TuneInProvider) -> N
     assert isinstance(args[2], InvalidDataError)
 
 
-async def test_audio_preset_without_id_is_reported(provider: TuneInProvider) -> None:
+@pytest.mark.parametrize("preset_id", [None, "", {}])
+async def test_audio_preset_without_id_is_reported(
+    provider: TuneInProvider, preset_id: Any
+) -> None:
     """An audio preset without an id must hold back radio deletions."""
     provider._TuneInProvider__get_data = AsyncMock(  # type: ignore[attr-defined]
-        return_value={"body": [{"type": "audio"}]}
+        return_value={"body": [{"type": "audio", "preset_id": preset_id}]}
     )
     provider.report_skipped_sync_item = Mock()  # type: ignore[method-assign]
 


### PR DESCRIPTION
# What does this implement/fix?

Malformed library-listing responses could look like an empty provider library, allowing the sync cleanup pass to remove items that still exist.

- Abort Netease, Emby, and TuneIn syncs when required listing data is malformed.
- Report individual malformed entries so affected items are protected from deletion.
- Keep explicit empty listings working normally.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.