### PR TITLE
Restore setup values that were dropped before they could be migrated

### DIFF
--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -459,14 +459,17 @@ PROVIDER_SETUP_FLOW_KEYS: dict[str, tuple[str, ...]] = {
 # default had nothing in `values` for the migration below to move and now reads back as
 # None. These are the defaults those keys carried as config entries before the setup
 # flows landed. Only keys whose read site has no fallback of its own are listed; the
-# others already resolve their default at runtime.
+# others already resolve their default at runtime. This runs on every startup, so only
+# keys their setup flow persists unconditionally belong here - a key a flow may
+# legitimately omit would be re-injected forever.
 # TODO: remove after 2.13 release
 PROVIDER_SETUP_FLOW_DEFAULTS: dict[str, dict[str, ConfigValueType]] = {
     "alexa": {"url": "amazon.com", "api_url": "http://localhost:5000"},
     "audiobookshelf": {"verify_ssl": True},
     "filesystem_local": {"path": "/media"},
-    "filesystem_smb": {"subfolder": ""},
+    "filesystem_smb": {"subfolder": "", "smb_version": "3.0"},
     "jellyfin": {"verify_ssl": True},
+    "lastfm_scrobble": {"_provider": "lastfm"},
     "plex": {
         "local_server_port": 32400,
         "local_server_ssl": False,

--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -39,6 +39,8 @@ from music_assistant.controllers.player_queues.constants import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from music_assistant_models.config_entries import ConfigValueType
+
 LOGGER = logging.getLogger(__name__)
 
 # removed player config key, only referenced by its migration
@@ -452,6 +454,28 @@ PROVIDER_SETUP_FLOW_KEYS: dict[str, tuple[str, ...]] = {
 }
 
 
+# Fallback defaults for setup-flow keys that were never stored in the first place.
+# A config value that matches its entry default is not persisted, so a key left at its
+# default had nothing in `values` for the migration below to move and now reads back as
+# None. These are the defaults those keys carried as config entries before the setup
+# flows landed. Only keys whose read site has no fallback of its own are listed; the
+# others already resolve their default at runtime.
+# TODO: remove after 2.13 release
+PROVIDER_SETUP_FLOW_DEFAULTS: dict[str, dict[str, ConfigValueType]] = {
+    "alexa": {"url": "amazon.com", "api_url": "http://localhost:5000"},
+    "audiobookshelf": {"verify_ssl": True},
+    "filesystem_local": {"path": "/media"},
+    "filesystem_smb": {"subfolder": ""},
+    "jellyfin": {"verify_ssl": True},
+    "plex": {
+        "local_server_port": 32400,
+        "local_server_ssl": False,
+        "local_server_verify_cert": True,
+    },
+    "siriusxm": {"sxm_region": "US"},
+}
+
+
 async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
     """Migrate the persistent settings data in-place; return True if anything changed."""
     changed = False
@@ -636,6 +660,10 @@ def migrate_provider_setup_data(data: dict[str, Any], encrypt: Callable[[str], s
     """
     Move each provider's setup-flow-owned keys from `values` to `setup_data` in-place.
 
+    Also restores the keys listed in PROVIDER_SETUP_FLOW_DEFAULTS that are absent from
+    `setup_data`, which covers the installs whose values were already moved by an
+    earlier run of this step.
+
     Runs after encryption is initialized (unlike migrate()), so string values are
     encrypted at rest with the given callback - matching how the setup flows persist
     collected values. Returns True if anything changed.
@@ -651,28 +679,38 @@ def migrate_provider_setup_data(data: dict[str, Any], encrypt: Callable[[str], s
     for provider_cfg in all_provider_configs.values():
         if not isinstance(provider_cfg, dict):
             continue
-        owned_keys = PROVIDER_SETUP_FLOW_KEYS.get(provider_cfg.get("domain", ""))
+        domain = provider_cfg.get("domain", "")
+        owned_keys = PROVIDER_SETUP_FLOW_KEYS.get(domain)
         if not owned_keys:
             continue
         values = provider_cfg.get("values")
         if not isinstance(values, dict):
-            continue
+            # a config without stored values has nothing to move, but may still
+            # be missing a default
+            values = {}
         movable_keys = [key for key in owned_keys if key in values]
         setup_data = provider_cfg.get("setup_data")
-        needs_airplay_default = provider_cfg.get("domain") == "airplay_receiver" and (
-            not isinstance(setup_data, dict) or "airplay_name" not in setup_data
-        )
-        if not movable_keys and not needs_airplay_default:
-            continue
         if not isinstance(setup_data, dict):
             setup_data = {}
-            provider_cfg["setup_data"] = setup_data
+        # a key that is about to be moved carries the user's own value and is left alone
+        missing_defaults = {
+            key: value
+            for key, value in PROVIDER_SETUP_FLOW_DEFAULTS.get(domain, {}).items()
+            if key not in setup_data and key not in movable_keys
+        }
+        needs_airplay_default = domain == "airplay_receiver" and "airplay_name" not in setup_data
+        if not movable_keys and not missing_defaults and not needs_airplay_default:
+            continue
+        provider_cfg["setup_data"] = setup_data
         for key in movable_keys:
             # a value already collected into setup_data wins; only drop the stale copy
             if key not in setup_data:
                 value = values[key]
                 setup_data[key] = encrypt(value) if isinstance(value, str) else value
             del values[key]
+        for key, value in missing_defaults.items():
+            setup_data[key] = encrypt(value) if isinstance(value, str) else value
+        # re-checked after the move: airplay_name may have just arrived from values
         if needs_airplay_default and "airplay_name" not in setup_data:
             setup_data["airplay_name"] = encrypt("Music Assistant")
         changed = True

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -16,6 +16,7 @@ from music_assistant.constants import (
 )
 from music_assistant.controllers.config.controller import ConfigController
 from music_assistant.controllers.config.migrations import (
+    PROVIDER_SETUP_FLOW_DEFAULTS,
     PROVIDER_SETUP_FLOW_KEYS,
     _migrate_airplay_apple_power_control,
     _migrate_airplay_receiver_ghost_players,
@@ -366,6 +367,81 @@ def test_migrate_provider_setup_data_moves_and_encrypts(monkeypatch: pytest.Monk
     assert cfg["setup_data"]["username"] == ENCRYPT_SUFFIX + "bob"
     assert cfg["setup_data"]["password"] == ENCRYPT_SUFFIX + "sekret"
     assert cfg["setup_data"]["port"] == 8096
+
+
+def test_setup_flow_defaults_are_owned_keys() -> None:
+    """Every key with a fallback default is also a key the migration owns."""
+    for domain, defaults in PROVIDER_SETUP_FLOW_DEFAULTS.items():
+        owned = PROVIDER_SETUP_FLOW_KEYS[domain]
+        assert set(defaults).issubset(owned), f"{domain}: {set(defaults) - set(owned)}"
+
+
+def test_migrate_provider_setup_data_restores_dropped_defaults() -> None:
+    """
+    A plex instance left on the default port gets that port back.
+
+    Regression: a config value that matches its entry default is not persisted, so an
+    instance on port 32400 had nothing in values to migrate and its server URL became
+    'https://<host>:None'.
+    """
+    data: dict[str, Any] = {
+        "providers": {
+            "plex--abc": {
+                "domain": "plex",
+                "values": {"local_server_ip": "local.abc.plex.direct", "local_server_ssl": True},
+            }
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is True
+    setup_data = data["providers"]["plex--abc"]["setup_data"]
+    assert setup_data["local_server_port"] == 32400
+    assert setup_data["local_server_verify_cert"] is True
+    # the user's own value is migrated, not replaced by the default
+    assert setup_data["local_server_ssl"] is True
+
+
+def test_migrate_provider_setup_data_restores_defaults_after_earlier_run() -> None:
+    """An install whose values were already moved by an earlier run is still repaired."""
+    data: dict[str, Any] = {
+        "providers": {
+            "plex--abc": {
+                "domain": "plex",
+                "values": {},
+                "setup_data": {
+                    "local_server_ip": ENCRYPT_SUFFIX + "local.abc.plex.direct",
+                    "local_server_ssl": True,
+                },
+            }
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is True
+    assert data["providers"]["plex--abc"]["setup_data"]["local_server_port"] == 32400
+
+
+def test_migrate_provider_setup_data_keeps_explicit_values() -> None:
+    """A stored choice is never overwritten by a fallback default."""
+    data: dict[str, Any] = {
+        "providers": {
+            "jellyfin": {
+                "domain": "jellyfin",
+                "values": {},
+                "setup_data": {"verify_ssl": False},
+            }
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is False
+    assert data["providers"]["jellyfin"]["setup_data"]["verify_ssl"] is False
+
+
+def test_migrate_provider_setup_data_encrypts_restored_strings() -> None:
+    """A restored string default is encrypted at rest like a migrated one."""
+    data: dict[str, Any] = {
+        "providers": {
+            "filesystem_local": {"domain": "filesystem_local", "values": {}},
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is True
+    assert data["providers"]["filesystem_local"]["setup_data"]["path"] == ENCRYPT_SUFFIX + "/media"
 
 
 def test_migrate_receiver_and_connect_setup_values() -> None:

--- a/tests/controllers/config/test_migrations.py
+++ b/tests/controllers/config/test_migrations.py
@@ -444,6 +444,66 @@ def test_migrate_provider_setup_data_encrypts_restored_strings() -> None:
     assert data["providers"]["filesystem_local"]["setup_data"]["path"] == ENCRYPT_SUFFIX + "/media"
 
 
+def test_migrate_provider_setup_data_restores_lastfm_network() -> None:
+    """
+    A Last.fm scrobbler that never stored its network choice gets it back.
+
+    Regression: `_provider` defaulted to 'lastfm' so it was never persisted, and the
+    None read back from setup_data made get_network raise on _NetworkType('None').
+    """
+    data: dict[str, Any] = {
+        "providers": {
+            "lastfm_scrobble": {
+                "domain": "lastfm_scrobble",
+                "values": {"_api_session_key": "abc123"},
+            }
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is True
+    setup_data = data["providers"]["lastfm_scrobble"]["setup_data"]
+    assert setup_data["_provider"] == ENCRYPT_SUFFIX + "lastfm"
+    # an explicit librefm choice differed from the default and was persisted, so it
+    # arrives via the move and is never overwritten by the fallback
+    data = {
+        "providers": {
+            "lastfm_scrobble": {
+                "domain": "lastfm_scrobble",
+                "values": {"_provider": "librefm"},
+            }
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is True
+    assert (
+        data["providers"]["lastfm_scrobble"]["setup_data"]["_provider"]
+        == ENCRYPT_SUFFIX + "librefm"
+    )
+
+
+def test_migrate_provider_setup_data_restores_smb_version() -> None:
+    """
+    An SMB share left on the default protocol version keeps its 3.0 pin.
+
+    Regression: the dropped default made both mount paths read '' and skip the
+    vers=3.0 mount option, silently changing protocol negotiation.
+    """
+    data: dict[str, Any] = {
+        "providers": {
+            "filesystem_smb": {"domain": "filesystem_smb", "values": {}},
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is True
+    setup_data = data["providers"]["filesystem_smb"]["setup_data"]
+    assert setup_data["smb_version"] == ENCRYPT_SUFFIX + "3.0"
+    # an explicit '' (auto-negotiate) choice was persisted and must win over the pin
+    data = {
+        "providers": {
+            "filesystem_smb": {"domain": "filesystem_smb", "values": {"smb_version": ""}},
+        }
+    }
+    assert migrate_provider_setup_data(data, _fake_encrypt) is True
+    assert data["providers"]["filesystem_smb"]["setup_data"]["smb_version"] == ENCRYPT_SUFFIX
+
+
 def test_migrate_receiver_and_connect_setup_values() -> None:
     """New setup-flow fields move to setup_data without losing typed values."""
     data: dict[str, Any] = {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

A config value that matches its entry default is not persisted, so a setting left at its default had nothing in `values` for the setup_data migration to move. Before the setup flows landed those keys were declared as config entries carrying the default, so reads resolved it even with nothing stored. The entries moved into the setup flow modules, which only run during setup, so the same reads now return None.

For Plex this made the server URL "https://<host>:None" for every instance on the default port, which no HTTP client can parse, so the provider failed to load. A provider that is not loaded has no resolvable options either, which is why its config screen came up without any fields. Six other providers lost a value the same way: filesystem_local `path`, filesystem_smb `subfolder`, jellyfin and audiobookshelf `verify_ssl`, siriusxm `sxm_region` and alexa `url`/`api_url`. The two verify_ssl ones read back as False, silently dropping certificate verification.

The migration now restores those keys from a table of the defaults they used to carry. It fills a key only when it is absent, so an explicit choice is never overwritten, and it no longer requires something in `values` to move, so an install that was already migrated by an earlier run is repaired as well.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6156

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
