### PR TITLE
Keep library cleanup running after sync failures

### DIFF
--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -1159,6 +1159,21 @@ class MusicProvider(Provider):
             ):
                 cur_db_ids.add(int(library_item.item_id))
 
+    def _protect_failed_sync_item(
+        self,
+        media_type: MediaType,
+        provider_item_id: str | None,
+        library_item_id: int | None,
+        cur_db_ids: set[int],
+    ) -> None:
+        """Keep a failed item out of this run's deletion pass."""
+        if library_item_id is not None:
+            cur_db_ids.add(library_item_id)
+        elif provider_item_id:
+            sync_run_state().skipped_item_ids.setdefault(media_type, set()).add(provider_item_id)
+        else:
+            sync_run_state().incomplete_media_types.add(media_type)
+
     async def _sync_item_genres(
         self,
         media_type: MediaType,
@@ -1185,10 +1200,12 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_artists():
             item_count += 1
             self._update_sync_task_item_status(MediaType.ARTIST, item_count, prov_item.name)
+            db_id: int | None = None
             try:
                 sync_details = await self.mass.music.artists.get_library_item_sync_details(
                     prov_item.provider_mappings,
                 )
+                db_id = sync_details.item_id if sync_details else None
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
                     if not sync_details:
@@ -1224,8 +1241,10 @@ class MusicProvider(Provider):
                     )
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                sync_run_state().incomplete_media_types.add(MediaType.ARTIST)
                 self._handle_sync_item_failure(MediaType.ARTIST, prov_item.uri, err)
+                self._protect_failed_sync_item(
+                    MediaType.ARTIST, prov_item.item_id, db_id, cur_db_ids
+                )
         return cur_db_ids
 
     def library_sync_album_tracks_enabled(self) -> bool:
@@ -1246,10 +1265,12 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_albums():
             item_count += 1
             self._update_sync_task_item_status(MediaType.ALBUM, item_count, prov_item.name)
+            db_id: int | None = None
             try:
                 sync_details = await self.mass.music.albums.get_library_item_sync_details(
                     prov_item.provider_mappings,
                 )
+                db_id = sync_details.item_id if sync_details else None
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
                     if not sync_details:
@@ -1285,8 +1306,10 @@ class MusicProvider(Provider):
                     )
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                sync_run_state().incomplete_media_types.add(MediaType.ALBUM)
                 self._handle_sync_item_failure(MediaType.ALBUM, prov_item.uri, err)
+                self._protect_failed_sync_item(
+                    MediaType.ALBUM, prov_item.item_id, db_id, cur_db_ids
+                )
                 continue
             # optionally add album tracks to library. the album is already collected here,
             # so failing to import its tracks does not make the album result set incomplete
@@ -1395,6 +1418,7 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_audiobooks():
             item_count += 1
             self._update_sync_task_item_status(MediaType.AUDIOBOOK, item_count, prov_item.name)
+            db_id: int | None = None
             try:
                 sync_details = cast(
                     "AudiobookSyncDetails | None",
@@ -1402,6 +1426,7 @@ class MusicProvider(Provider):
                         prov_item.provider_mappings,
                     ),
                 )
+                db_id = sync_details.item_id if sync_details else None
                 self._validate_audiobook_author_narrator_types(prov_item)
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
@@ -1474,8 +1499,10 @@ class MusicProvider(Provider):
 
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                sync_run_state().incomplete_media_types.add(MediaType.AUDIOBOOK)
                 self._handle_sync_item_failure(MediaType.AUDIOBOOK, prov_item.uri, err)
+                self._protect_failed_sync_item(
+                    MediaType.AUDIOBOOK, prov_item.item_id, db_id, cur_db_ids
+                )
         return cur_db_ids
 
     async def _sync_library_playlists(self) -> set[int]:
@@ -1491,10 +1518,12 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_playlists():
             item_count += 1
             self._update_sync_task_item_status(MediaType.PLAYLIST, item_count, prov_item.name)
+            db_id: int | None = None
             try:
                 library_item = await self.mass.music.playlists.get_library_item_by_prov_mappings(
                     prov_item.provider_mappings,
                 )
+                db_id = int(library_item.item_id) if library_item else None
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
                     if not library_item:
@@ -1529,14 +1558,17 @@ class MusicProvider(Provider):
                         library_item = await self.mass.music.playlists.update_item_in_library(
                             library_item.item_id, prov_item, overwrite=True
                         )
-                    cur_db_ids.add(int(library_item.item_id))
+                    db_id = int(library_item.item_id)
+                    cur_db_ids.add(db_id)
                     if not library_item.favorite and prov_item.favorite:
                         # existing library item not favorite but should be
                         await self.mass.music.playlists.set_favorite(library_item.item_id, True)
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                sync_run_state().incomplete_media_types.add(MediaType.PLAYLIST)
                 self._handle_sync_item_failure(MediaType.PLAYLIST, prov_item.uri, err)
+                self._protect_failed_sync_item(
+                    MediaType.PLAYLIST, prov_item.item_id, db_id, cur_db_ids
+                )
                 continue
             # optionally sync playlist tracks. the playlist is already collected here, so
             # failing on its tracks does not make the playlist result set incomplete
@@ -1609,6 +1641,7 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_tracks():
             item_count += 1
             self._update_sync_task_item_status(MediaType.TRACK, item_count, prov_item.name)
+            db_id: int | None = None
             try:
                 sync_details = cast(
                     "TrackSyncDetails | None",
@@ -1616,6 +1649,7 @@ class MusicProvider(Provider):
                         prov_item.provider_mappings,
                     ),
                 )
+                db_id = sync_details.item_id if sync_details else None
                 if not sync_details and not prov_item.available:
                     # skip unavailable tracks
                     # TODO: do we want to search for substitutes at this point ?
@@ -1665,8 +1699,10 @@ class MusicProvider(Provider):
                     )
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                sync_run_state().incomplete_media_types.add(MediaType.TRACK)
                 self._handle_sync_item_failure(MediaType.TRACK, prov_item.uri, err)
+                self._protect_failed_sync_item(
+                    MediaType.TRACK, prov_item.item_id, db_id, cur_db_ids
+                )
         return cur_db_ids
 
     async def _sync_library_podcasts(self) -> set[int]:
@@ -1677,10 +1713,12 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_podcasts():
             item_count += 1
             self._update_sync_task_item_status(MediaType.PODCAST, item_count, prov_item.name)
+            db_id: int | None = None
             try:
                 sync_details = await self.mass.music.podcasts.get_library_item_sync_details(
                     prov_item.provider_mappings,
                 )
+                db_id = sync_details.item_id if sync_details else None
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
                     if not sync_details:
@@ -1716,8 +1754,10 @@ class MusicProvider(Provider):
                     )
                 await asyncio.sleep(0)  # yield to eventloop
             except Exception as err:
-                sync_run_state().incomplete_media_types.add(MediaType.PODCAST)
                 self._handle_sync_item_failure(MediaType.PODCAST, prov_item.uri, err)
+                self._protect_failed_sync_item(
+                    MediaType.PODCAST, prov_item.item_id, db_id, cur_db_ids
+                )
                 continue
             # the podcast is already collected here, so a feed that fails to deliver its
             # episodes does not make the podcast result set incomplete
@@ -1737,10 +1777,12 @@ class MusicProvider(Provider):
         async for prov_item in self.get_library_radios():
             item_count += 1
             self._update_sync_task_item_status(MediaType.RADIO, item_count, prov_item.name)
+            db_id: int | None = None
             try:
                 library_item = await self.mass.music.radio.get_library_item_by_prov_mappings(
                     prov_item.provider_mappings,
                 )
+                db_id = int(library_item.item_id) if library_item else None
                 # batch all writes for this item into a single commit
                 async with self.mass.music.database.deferred_commit():
                     if not library_item:
@@ -1766,15 +1808,18 @@ class MusicProvider(Provider):
                         library_item = await self.mass.music.radio.update_item_in_library(
                             library_item.item_id, prov_item
                         )
-                    cur_db_ids.add(int(library_item.item_id))
+                    db_id = int(library_item.item_id)
+                    cur_db_ids.add(db_id)
                     if not library_item.favorite and prov_item.favorite:
                         # existing library item not favorite but should be
                         await self.mass.music.radio.set_favorite(library_item.item_id, True)
                 await asyncio.sleep(0)  # yield to eventloop
 
             except Exception as err:
-                sync_run_state().incomplete_media_types.add(MediaType.RADIO)
                 self._handle_sync_item_failure(MediaType.RADIO, prov_item.uri, err)
+                self._protect_failed_sync_item(
+                    MediaType.RADIO, prov_item.item_id, db_id, cur_db_ids
+                )
         return cur_db_ids
 
     # DO NOT OVERRIDE BELOW

--- a/tests/controllers/music/test_sync_resilience.py
+++ b/tests/controllers/music/test_sync_resilience.py
@@ -154,19 +154,18 @@ async def test_unexpected_error_from_provider_album_tracks_does_not_abort_sync()
     mass.music.get_controller.return_value.get_library_item.assert_awaited_once_with(99)
 
 
-async def test_deletions_skipped_when_an_item_failed() -> None:
-    """A skipped item must not be read as removed from the provider."""
-    mass = _build_mass(prev_library_ids=[1, 2, 3])
+async def test_failed_item_is_protected_without_holding_back_deletions() -> None:
+    """A failed item must survive while unrelated deletions still run."""
+    mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
     provider = _build_provider(mass)
-
+    _library_holds(mass, {"album_2": 2})
     _fail_add_for(mass, "album_2")
 
     await provider.sync_library(MediaType.ALBUM)
 
     controller = mass.music.get_controller.return_value
-    controller.get_library_item.assert_not_called()
-    controller.set_provider_mappings.assert_not_called()
-    controller.remove_item_from_library.assert_not_called()
+    controller.get_library_item.assert_awaited_once_with(99)
+    assert sorted(mass.cache.set.await_args.kwargs["data"]) == [1, 2, 3]
 
 
 async def test_deletions_run_on_a_clean_sync() -> None:
@@ -214,32 +213,54 @@ async def test_library_generator_error_still_propagates() -> None:
     mass.music.get_controller.return_value.set_provider_mappings.assert_not_called()
 
 
-async def test_expected_error_also_holds_back_deletions() -> None:
-    """A MusicAssistantError leaves the same gap in the result set as any other error."""
+async def test_expected_error_also_protects_only_failed_items() -> None:
+    """A MusicAssistantError protects its items without freezing unrelated cleanup."""
     mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
     provider = _build_provider(mass)
+    _library_holds(mass, DB_IDS)
     mass.music.albums.add_item_to_library = AsyncMock(side_effect=MediaNotFoundError("gone"))
 
     await provider.sync_library(MediaType.ALBUM)
 
-    mass.music.get_controller.return_value.get_library_item.assert_not_called()
+    mass.music.get_controller.return_value.get_library_item.assert_awaited_once_with(99)
+    assert sorted(mass.cache.set.await_args.kwargs["data"]) == [1, 2, 3]
 
 
-async def test_incomplete_run_keeps_the_previous_id_snapshot() -> None:
+async def test_failed_item_snapshot_drops_unrelated_deletions() -> None:
     """
-    A run that skipped items merges into the cached id's instead of replacing them.
+    A run with an identifiable failure replaces the cached id's with its surgical result.
 
-    Those id's are what a later run compares against; replacing them with an incomplete
-    set would drop the deletions this run could not process.
+    The failed item's id is retained, while an unrelated provider deletion must not survive
+    into the next snapshot.
     """
     mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
     provider = _build_provider(mass)
+    _library_holds(mass, {"album_2": 2})
     _fail_add_for(mass, "album_2")
 
     await provider.sync_library(MediaType.ALBUM)
 
-    # 99 (gone from the provider) and 2 (failed this run) both survive for the next run
-    assert sorted(mass.cache.set.await_args.kwargs["data"]) == [1, 2, 3, 99]
+    assert sorted(mass.cache.set.await_args.kwargs["data"]) == [1, 2, 3]
+
+
+async def test_resolved_failed_item_does_not_need_provider_id_lookup() -> None:
+    """A known db id is protected directly when later item processing fails."""
+    mass = _build_mass(prev_library_ids=[1, 2, 3, 99])
+    provider = _build_provider(mass)
+    sync_details = MagicMock(item_id=2, favorite=False)
+    mass.music.albums.get_library_item_sync_details = AsyncMock(
+        side_effect=[None, sync_details, None]
+    )
+    provider._library_item_needs_update = MagicMock(  # type: ignore[method-assign]
+        side_effect=KeyError("release_date")
+    )
+
+    await provider.sync_library(MediaType.ALBUM)
+
+    controller = mass.music.get_controller.return_value
+    controller.get_library_items_by_prov_id.assert_not_awaited()
+    controller.get_library_item.assert_awaited_once_with(99)
+    assert sorted(mass.cache.set.await_args.kwargs["data"]) == [1, 2, 3]
 
 
 async def test_deletions_not_reported_when_disabled() -> None:


### PR DESCRIPTION
# What does this implement/fix?

A failed item during library sync could block cleanup for every item of that media type on every run.

- Protect only the failed item when its library or provider ID is known.
- Keep deletion cleanup working for unrelated items.
- Update the sync resilience tests for the surgical cleanup behavior.

**Related issue (if applicable):**

- Follow-up to #5861.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project’s [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.