### PR TITLE
Prevent server shutdown from hanging

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -399,6 +399,10 @@ class WebserverController(CoreController):
         # Setup remote access after webserver is running
         await self.remote_access.setup()
 
+    async def stop_accepting_connections(self) -> None:
+        """Stop accepting new webserver connections."""
+        await self._server.stop_accepting_connections()
+
     async def close(self) -> None:
         """Cleanup on exit."""
         await self.remote_access.close()

--- a/music_assistant/helpers/webserver.py
+++ b/music_assistant/helpers/webserver.py
@@ -163,13 +163,18 @@ class Webserver:
             )
             await self._ingress_tcp_site.start()
 
-    async def close(self) -> None:
-        """Cleanup on exit."""
-        # stop/clean webserver
+    async def stop_accepting_connections(self) -> None:
+        """Stop accepting new connections."""
         if self._tcp_site:
             await self._tcp_site.stop()
+            self._tcp_site = None
         if self._ingress_tcp_site:
             await self._ingress_tcp_site.stop()
+            self._ingress_tcp_site = None
+
+    async def close(self) -> None:
+        """Cleanup on exit."""
+        await self.stop_accepting_connections()
         if self._apprunner:
             await self._apprunner.cleanup()
         if self._webapp:

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -117,6 +117,9 @@ PROVIDER_SETUP_TIMEOUT = 120
 # provider fails to load instead of holding up startup forever.
 PROVIDER_ASYNC_INIT_TIMEOUT = 300
 PROVIDER_LOAD_CONCURRENCY = 8
+# Provider teardown may involve third-party network clients or subprocesses. Keep shutdown
+# bounded without changing the timeout behavior of normal provider reloads and removals.
+PROVIDER_SHUTDOWN_TIMEOUT = 30
 
 _R = TypeVar("_R")
 _ProviderT = TypeVar("_ProviderT", bound=ProviderInstanceType)
@@ -333,12 +336,36 @@ class MusicAssistant:
         LOGGER.info("Stop called, cleaning up...")
         # set state to stopping to signal we're shutting down
         self._set_state(CoreState.STOPPING)
+        # stop accepting new API/frontend connections before provider teardown starts
+        if webserver := getattr(self, "webserver", None):
+            try:
+                await webserver.stop_accepting_connections()
+            except Exception:
+                LOGGER.exception("Error while stopping the webserver listeners")
         # cancel all running tasks
         for task in list(self._tracked_tasks.values()):
             task.cancel()
-        # cleanup all providers
+
+        async def unload_provider_bounded(instance_id: str) -> None:
+            provider = self._providers.get(instance_id)
+            provider_name = provider.name if provider else instance_id
+            timeout: asyncio.Timeout | None = None
+            try:
+                async with asyncio.timeout(PROVIDER_SHUTDOWN_TIMEOUT) as timeout:
+                    await self.unload_provider(instance_id)
+            except TimeoutError:
+                if timeout is None or not timeout.expired():
+                    raise
+                LOGGER.warning(
+                    "Provider %s (%s) did not unload within %s seconds; continuing shutdown",
+                    provider_name,
+                    instance_id,
+                    PROVIDER_SHUTDOWN_TIMEOUT,
+                )
+
+        # cleanup all providers concurrently, without allowing one to block shutdown
         await asyncio.gather(
-            *[self.unload_provider(prov_id) for prov_id in list(self._providers.keys())],
+            *[unload_provider_bounded(prov_id) for prov_id in list(self._providers.keys())],
             return_exceptions=True,
         )
         # stop core controllers, cache and config last because the others rely on them.

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -340,7 +340,7 @@ class MusicAssistant:
         if webserver := getattr(self, "webserver", None):
             try:
                 await webserver.stop_accepting_connections()
-            except Exception:
+            except OSError, RuntimeError:
                 LOGGER.exception("Error while stopping the webserver listeners")
         # cancel all running tasks
         for task in list(self._tracked_tasks.values()):

--- a/tests/controllers/webserver/test_bind_fallback.py
+++ b/tests/controllers/webserver/test_bind_fallback.py
@@ -96,6 +96,27 @@ async def test_wildcard_bind_ip_is_reported_as_all_interfaces(server: Webserver)
     assert server.bind_ip is None
 
 
+async def test_stop_accepting_connections_releases_listener(server: Webserver) -> None:
+    """Stopping listeners refuses new connections while allowing later cleanup."""
+    await server.setup(bind_ip="127.0.0.1", bind_port=0)
+    port = server.port
+    assert port is not None
+
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(f"http://127.0.0.1:{port}/info") as response,
+    ):
+        assert response.status == 404
+
+    await server.stop_accepting_connections()
+    await server.stop_accepting_connections()
+
+    timeout = aiohttp.ClientTimeout(total=1)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        with pytest.raises(aiohttp.ClientConnectorError):
+            await session.get(f"http://127.0.0.1:{port}/info")
+
+
 def test_fallback_publishes_only_dialable_addresses(controller: WebserverController) -> None:
     """After a fallback, the un-bindable address is neither advertised nor dialed."""
     # what setup() resolves from the configured address, before the bind is attempted

--- a/tests/core/test_server_base.py
+++ b/tests/core/test_server_base.py
@@ -3,9 +3,11 @@
 import asyncio
 import logging
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
 
-from music_assistant_models.enums import EventType
+from music_assistant_models.enums import CoreState, EventType
 
+import music_assistant.mass as mass_module
 from music_assistant.constants import MASS_LOGGER_NAME
 from music_assistant.mass import MusicAssistant
 
@@ -30,6 +32,56 @@ async def test_start_and_stop_server(mass: MusicAssistant) -> None:
         )
     )
     assert domains.issuperset(core_providers)
+
+
+async def test_stop_bounds_provider_unload_after_stopping_webserver(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A stuck provider cannot keep the server listening or block shutdown."""
+    mass = object.__new__(MusicAssistant)
+    mass._state = CoreState.RUNNING
+    mass._tracked_tasks = {}
+    mass._http_session = None
+    mass._http_session_no_ssl = None
+
+    provider = MagicMock()
+    provider.name = "Stuck provider"
+    mass._providers = {"stuck--instance": provider}
+
+    order: list[str] = []
+    webserver = MagicMock()
+    webserver.stop_accepting_connections = AsyncMock(
+        side_effect=lambda: order.append("listeners_stopped")
+    )
+    webserver.close = AsyncMock(side_effect=lambda: order.append("webserver_closed"))
+    mass.webserver = webserver
+
+    def set_state(state: CoreState) -> None:
+        mass._state = state
+
+    async def unload_provider(_instance_id: str) -> None:
+        order.append("provider_unload_started")
+        try:
+            await asyncio.Event().wait()
+        finally:
+            order.append("provider_unload_cancelled")
+
+    monkeypatch.setattr(mass, "_set_state", set_state)
+    monkeypatch.setattr(mass, "unload_provider", unload_provider)
+    monkeypatch.setattr(mass_module, "PROVIDER_SHUTDOWN_TIMEOUT", 0.01)
+
+    with caplog.at_level(logging.WARNING, logger=MASS_LOGGER_NAME):
+        await asyncio.wait_for(mass.stop(), timeout=1)
+
+    assert order == [
+        "listeners_stopped",
+        "provider_unload_started",
+        "provider_unload_cancelled",
+        "webserver_closed",
+    ]
+    assert mass.state == CoreState.STOPPED
+    assert "Stuck provider (stuck--instance) did not unload" in caplog.text
 
 
 async def test_events(mass: MusicAssistant) -> None:


### PR DESCRIPTION
# What does this implement/fix?

A provider that did not finish unloading could leave the server stuck after SIGTERM or SIGINT, while the webserver continued accepting requests.

- Stop webserver listeners as soon as shutdown starts.
- Bound provider teardown so one provider cannot block process exit indefinitely.
- Add regression coverage for shutdown ordering, cancellation, and listener cleanup.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature change that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.