### PR TITLE
Keep autoplay running when a provider fails

### DIFF
--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Never, cast
 
+from aiohttp import ClientError
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import (
     ExternalID,
@@ -17,6 +18,7 @@ from music_assistant_models.enums import (
 from music_assistant_models.errors import (
     InvalidDataError,
     MusicAssistantError,
+    ProviderUnavailableError,
     UnsupportedFeaturedException,
 )
 from music_assistant_models.helpers import create_safe_string
@@ -453,6 +455,7 @@ class TracksController(MediaControllerBase[Track]):
         :param allow_lookup: Allow lookup on other providers if not found.
         :param preferred_provider_instances: List of preferred provider instance IDs to use.
             When provided, these providers will be tried first before falling back to others.
+        :raises MusicAssistantError: When no provider can complete the request.
         """
         ref_item = await self.get(item_id, provider_instance_id_or_domain)
 
@@ -470,45 +473,52 @@ class TracksController(MediaControllerBase[Track]):
             return (preferred, quality)
 
         sorted_mappings = sorted(ref_item.provider_mappings, key=sort_key)
+        last_provider_error: MusicAssistantError | ClientError | OSError | TimeoutError | None = (
+            None
+        )
+        provider_responded = False
 
         # Try preferred providers first, then fall back to others
-        for allow_other_provider in (False, True):
-            for prov_mapping in sorted_mappings:
-                if (
-                    not allow_other_provider
-                    and preferred_provider_instances
-                    and prov_mapping.provider_instance not in preferred_provider_instances
-                ):
-                    continue
-                prov = self.mass.get_provider(prov_mapping.provider_instance)
-                if prov is None:
-                    continue
-                if not isinstance(prov, MusicProvider):
-                    continue
-                if ProviderFeature.SIMILAR_TRACKS not in prov.supported_features:
-                    continue
-                # Grab similar tracks from the music provider
-                try:
-                    if result := await prov.get_similar_tracks(
-                        prov_track_id=prov_mapping.item_id, limit=limit
-                    ):
-                        return result
-                except NotImplementedError:
-                    continue
+        for prov_mapping in sorted_mappings:
+            prov = self.mass.get_provider(prov_mapping.provider_instance)
+            if (
+                not isinstance(prov, MusicProvider)
+                or ProviderFeature.SIMILAR_TRACKS not in prov.supported_features
+            ):
+                continue
+            result, error = await self._get_similar_tracks_from_provider(
+                prov, ref_item, limit, provider_track_id=prov_mapping.item_id
+            )
+            if error is not None:
+                last_provider_error = error
+                continue
+            if result is None:
+                continue
+            provider_responded = True
+            if result:
+                return result
 
         # Fallback: consult metadata/plugin providers that claim SIMILAR_TRACKS
         for prov in self.mass.get_providers_supporting_feature(
             ProviderFeature.SIMILAR_TRACKS,
             priority=(ProviderType.METADATA, ProviderType.PLUGIN),
         ):
-            try:
-                cross_prov = cast("MetadataProvider | PluginProvider", prov)
-                if result := await cross_prov.get_similar_tracks(ref_item, limit=limit):
-                    return result
-            except NotImplementedError:
+            cross_prov = cast("MetadataProvider | PluginProvider", prov)
+            result, error = await self._get_similar_tracks_from_provider(
+                cross_prov, ref_item, limit
+            )
+            if error is not None:
+                last_provider_error = error
                 continue
+            if result is None:
+                continue
+            provider_responded = True
+            if result:
+                return result
 
         if not allow_lookup:
+            if not provider_responded and last_provider_error is not None:
+                self._raise_similar_tracks_provider_error(ref_item, last_provider_error)
             return []
 
         music_prov: MusicProvider | None = None
@@ -525,10 +535,17 @@ class TracksController(MediaControllerBase[Track]):
                 # update database with new provider mappings
                 await self.add_provider_mappings(ref_item.item_id, mappings)
             ref_item.provider_mappings.update(mappings)
-            return await music_prov.get_similar_tracks(
-                prov_track_id=mappings[0].item_id, limit=limit
+            result, error = await self._get_similar_tracks_from_provider(
+                music_prov, ref_item, limit, provider_track_id=mappings[0].item_id
             )
+            if error is not None:
+                if not provider_responded:
+                    self._raise_similar_tracks_provider_error(ref_item, error)
+                return []
+            return result or []
 
+        if not provider_responded and last_provider_error is not None:
+            self._raise_similar_tracks_provider_error(ref_item, last_provider_error)
         return []
 
     async def remove_item_from_library(self, item_id: str | int, recursive: bool = True) -> None:
@@ -972,3 +989,58 @@ class TracksController(MediaControllerBase[Track]):
                 # always prefer album image over track image
                 item.metadata.images = UniqueList([album_thumb])
         return item
+
+    async def _get_similar_tracks_from_provider(
+        self,
+        provider: MusicProvider | MetadataProvider | PluginProvider,
+        ref_item: Track,
+        limit: int,
+        provider_track_id: str | None = None,
+    ) -> tuple[
+        list[Track] | None,
+        MusicAssistantError | ClientError | OSError | TimeoutError | None,
+    ]:
+        """
+        Request similar tracks from a provider.
+
+        :param provider: Provider to request similar tracks from.
+        :param ref_item: Full track supplied to metadata and plugin providers.
+        :param limit: Maximum number of tracks to return.
+        :param provider_track_id: Provider track ID supplied to music providers.
+        """
+        if isinstance(provider, MusicProvider):
+            if provider_track_id is None:
+                raise InvalidDataError("Music provider track ID is required")
+            request = provider.get_similar_tracks(provider_track_id, limit=limit)
+        else:
+            request = provider.get_similar_tracks(ref_item, limit=limit)
+        try:
+            result = await request
+        except NotImplementedError:
+            return None, None
+        except (MusicAssistantError, ClientError, OSError, TimeoutError) as err:
+            self.logger.warning(
+                "Failed to fetch similar tracks for %s from provider %s: %s",
+                ref_item.name,
+                provider.name,
+                err,
+            )
+            return None, err
+        return result, None
+
+    @staticmethod
+    def _raise_similar_tracks_provider_error(
+        ref_item: Track,
+        err: MusicAssistantError | ClientError | OSError | TimeoutError,
+    ) -> Never:
+        """
+        Raise a provider error from a similar-tracks lookup using MA's typed error hierarchy.
+
+        :param ref_item: The track whose similar tracks were requested.
+        :param err: The provider error to raise or normalize.
+        """
+        if isinstance(err, MusicAssistantError):
+            raise err
+        raise ProviderUnavailableError(
+            f"Failed to fetch similar tracks for {ref_item.name}"
+        ) from err

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1049,14 +1049,18 @@ class TracksController(MediaControllerBase[Track]):
         :param limit: Maximum number of tracks to return.
         :raises UnsupportedFeaturedException: When no music provider supports similar tracks.
         """
-        providers = [
+        supported_providers = [
             prov
             for prov in self.mass.music.providers
             if ProviderFeature.SIMILAR_TRACKS in prov.supported_features
         ]
-        if not providers:
+        if not supported_providers:
             msg = "No Music Provider found that supports requesting similar tracks."
             raise UnsupportedFeaturedException(msg)
+        mapped_instances = {mapping.provider_instance for mapping in ref_item.provider_mappings}
+        providers = [
+            prov for prov in supported_providers if prov.instance_id not in mapped_instances
+        ]
 
         last_error: MusicAssistantError | ClientError | OSError | TimeoutError | None = None
         provider_responded = False

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -521,7 +521,14 @@ class TracksController(MediaControllerBase[Track]):
                 self._raise_similar_tracks_provider_error(ref_item, last_provider_error)
             return []
 
-        result, error = await self._lookup_similar_tracks_provider(ref_item, limit)
+        try:
+            result, error = await self._lookup_similar_tracks_provider(ref_item, limit)
+        except UnsupportedFeaturedException:
+            if provider_responded:
+                return []
+            if last_provider_error is not None:
+                self._raise_similar_tracks_provider_error(ref_item, last_provider_error)
+            raise
         if error is not None:
             last_provider_error = error
         if result is not None:

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -521,28 +521,13 @@ class TracksController(MediaControllerBase[Track]):
                 self._raise_similar_tracks_provider_error(ref_item, last_provider_error)
             return []
 
-        music_prov: MusicProvider | None = None
-        for prov in self.mass.music.providers:
-            if ProviderFeature.SIMILAR_TRACKS in prov.supported_features:
-                music_prov = prov
-                break
-        if music_prov is None:
-            msg = "No Music Provider found that supports requesting similar tracks."
-            raise UnsupportedFeaturedException(msg)
-
-        if mappings := await self.match_provider(ref_item, music_prov):
-            if ref_item.provider == "library":
-                # update database with new provider mappings
-                await self.add_provider_mappings(ref_item.item_id, mappings)
-            ref_item.provider_mappings.update(mappings)
-            result, error = await self._get_similar_tracks_from_provider(
-                music_prov, ref_item, limit, provider_track_id=mappings[0].item_id
-            )
-            if error is not None:
-                if not provider_responded:
-                    self._raise_similar_tracks_provider_error(ref_item, error)
-                return []
-            return result or []
+        result, error = await self._lookup_similar_tracks_provider(ref_item, limit)
+        if error is not None:
+            last_provider_error = error
+        if result is not None:
+            provider_responded = True
+            if result:
+                return result
 
         if not provider_responded and last_provider_error is not None:
             self._raise_similar_tracks_provider_error(ref_item, last_provider_error)
@@ -1027,6 +1012,76 @@ class TracksController(MediaControllerBase[Track]):
             )
             return None, err
         return result, None
+
+    async def _match_similar_tracks_provider(
+        self, ref_item: Track, provider: MusicProvider
+    ) -> tuple[
+        list[ProviderMapping] | None,
+        MusicAssistantError | ClientError | OSError | TimeoutError | None,
+    ]:
+        """
+        Find a matching track on a provider for a similar-tracks lookup.
+
+        :param ref_item: Track to match.
+        :param provider: Provider to search for a matching track.
+        """
+        try:
+            return await self.match_provider(ref_item, provider), None
+        except (MusicAssistantError, ClientError, OSError, TimeoutError) as err:
+            self.logger.warning(
+                "Failed to match %s on provider %s for similar tracks: %s",
+                ref_item.name,
+                provider.name,
+                err,
+            )
+            return None, err
+
+    async def _lookup_similar_tracks_provider(
+        self, ref_item: Track, limit: int
+    ) -> tuple[
+        list[Track] | None,
+        MusicAssistantError | ClientError | OSError | TimeoutError | None,
+    ]:
+        """
+        Find a provider match and request similar tracks from it.
+
+        :param ref_item: Track to match.
+        :param limit: Maximum number of tracks to return.
+        :raises UnsupportedFeaturedException: When no music provider supports similar tracks.
+        """
+        providers = [
+            prov
+            for prov in self.mass.music.providers
+            if ProviderFeature.SIMILAR_TRACKS in prov.supported_features
+        ]
+        if not providers:
+            msg = "No Music Provider found that supports requesting similar tracks."
+            raise UnsupportedFeaturedException(msg)
+
+        last_error: MusicAssistantError | ClientError | OSError | TimeoutError | None = None
+        provider_responded = False
+        for provider in providers:
+            mappings, error = await self._match_similar_tracks_provider(ref_item, provider)
+            if error is not None:
+                last_error = error
+                continue
+            if not mappings:
+                continue
+            if ref_item.provider == "library":
+                await self.add_provider_mappings(ref_item.item_id, mappings)
+            ref_item.provider_mappings.update(mappings)
+            result, error = await self._get_similar_tracks_from_provider(
+                provider, ref_item, limit, provider_track_id=mappings[0].item_id
+            )
+            if error is not None:
+                last_error = error
+                continue
+            if result is None:
+                continue
+            provider_responded = True
+            if result:
+                return result, None
+        return ([] if provider_responded else None), last_error
 
     @staticmethod
     def _raise_similar_tracks_provider_error(

--- a/tests/controllers/player_queues/test_autoplay_dispatch.py
+++ b/tests/controllers/player_queues/test_autoplay_dispatch.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.enums import MediaType, PlaybackState
+from music_assistant_models.errors import ProviderUnavailableError
 from music_assistant_models.media_items import (
     Audiobook,
     MediaCollection,
@@ -25,6 +26,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.media_items.metadata import MediaItemCollection, MediaItemMetadata
 from music_assistant_models.media_items.provider_mapping import ProviderMapping
 
+from music_assistant.controllers.player_queues.autoplay import AutoplayMode
 from music_assistant.controllers.player_queues.media_resolver import MediaResolver
 from music_assistant.controllers.player_queues.playback_tracker import PlaybackTrackerMixin
 from music_assistant.controllers.player_queues.queue_loader import QueueLoaderMixin
@@ -345,6 +347,22 @@ async def test_music_refill_without_seeds_appends_nothing() -> None:
     await QueueLoaderMixin._fill_autoplay_music_tracks(loader, "q1")
 
     loader.load.assert_not_awaited()
+
+
+async def test_auto_music_refill_falls_back_to_library_after_provider_failure() -> None:
+    """AUTO mode falls back to library tracks when similar-track providers fail."""
+    loader = _loader(_queue_item(_track()), seeds=[_track()])
+    loader._autoplay.resolve_mode.return_value = AutoplayMode.AUTO
+    loader._autoplay.get_library_tracks = AsyncMock(return_value=[])
+    loader._get_similar_tracks = AsyncMock(side_effect=ProviderUnavailableError("offline"))
+    loader.mass.music.recency.snapshot = AsyncMock(return_value=MagicMock())
+
+    with patch(
+        "music_assistant.controllers.player_queues.queue_loader.gate_tracks", return_value=[]
+    ):
+        await QueueLoaderMixin._fill_autoplay_music_tracks(loader, "q1")
+
+    loader._autoplay.get_library_tracks.assert_awaited_once()
 
 
 # --- appending the resolved successor ---

--- a/tests/test_cross_type_features.py
+++ b/tests/test_cross_type_features.py
@@ -268,6 +268,79 @@ async def test_similar_tracks_lookup_failure_after_empty_response_returns_empty(
     lookup_provider.get_similar_tracks.assert_awaited_once_with("lookup_track", limit=25)
 
 
+async def test_similar_tracks_normalizes_provider_matching_failure() -> None:
+    """A transport failure while matching a lookup provider is normalized."""
+    mass = Mock()
+    lookup_provider = Mock(spec=MusicProvider)
+    lookup_provider.name = "Lookup"
+    lookup_provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
+    mass.get_providers_supporting_feature.return_value = []
+    mass.music.providers = [lookup_provider]
+
+    ref_item = Mock()
+    ref_item.name = "Seed"
+    ref_item.provider_mappings = set()
+    controller = TracksController.__new__(TracksController)
+    controller.mass = mass
+    controller.logger = Mock()
+    controller.get = AsyncMock(return_value=ref_item)  # type: ignore[method-assign]
+    client_error = ClientConnectionError("offline")
+    controller.match_provider = AsyncMock(  # type: ignore[method-assign]
+        side_effect=client_error
+    )
+
+    with pytest.raises(ProviderUnavailableError) as raised:
+        await controller.similar_tracks("seed", "library", allow_lookup=True)
+
+    assert raised.value.__cause__ is client_error
+
+
+async def test_similar_tracks_preserves_failure_when_lookup_is_not_implemented() -> None:
+    """An unsupported matched lookup does not discard an earlier provider failure."""
+    mass = Mock()
+    mapped_provider = Mock(spec=MusicProvider)
+    mapped_provider.name = "Mapped"
+    mapped_provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
+    client_error = ClientConnectionError("offline")
+    mapped_provider.get_similar_tracks = AsyncMock(side_effect=client_error)
+    lookup_provider = Mock(spec=MusicProvider)
+    lookup_provider.name = "Lookup"
+    lookup_provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
+    lookup_provider.get_similar_tracks = AsyncMock(side_effect=NotImplementedError)
+    mass.get_provider.return_value = mapped_provider
+    mass.get_providers_supporting_feature.return_value = []
+    mass.music.providers = [lookup_provider]
+
+    ref_item = Mock()
+    ref_item.name = "Seed"
+    ref_item.provider = "mapped"
+    ref_item.provider_mappings = {
+        ProviderMapping(
+            item_id="mapped_track",
+            provider_domain="mapped",
+            provider_instance="mapped",
+        )
+    }
+    controller = TracksController.__new__(TracksController)
+    controller.mass = mass
+    controller.logger = Mock()
+    controller.get = AsyncMock(return_value=ref_item)  # type: ignore[method-assign]
+    controller.match_provider = AsyncMock(  # type: ignore[method-assign]
+        return_value=[
+            ProviderMapping(
+                item_id="lookup_track",
+                provider_domain="lookup",
+                provider_instance="lookup",
+            )
+        ]
+    )
+
+    with pytest.raises(ProviderUnavailableError) as raised:
+        await controller.similar_tracks("seed", "mapped", allow_lookup=True)
+
+    assert raised.value.__cause__ is client_error
+
+
 def _artist(item_id: str, name: str, instance: str) -> Artist:
     """Build a minimal Artist for the given provider instance."""
     return Artist(

--- a/tests/test_cross_type_features.py
+++ b/tests/test_cross_type_features.py
@@ -232,6 +232,7 @@ async def test_similar_tracks_lookup_failure_after_empty_response_returns_empty(
     mapped_provider.get_similar_tracks = AsyncMock(return_value=[])
     lookup_provider = Mock(spec=MusicProvider)
     lookup_provider.name = "Lookup"
+    lookup_provider.instance_id = "lookup"
     lookup_provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
     lookup_provider.get_similar_tracks = AsyncMock(side_effect=ClientConnectionError("offline"))
     mass.get_provider.return_value = mapped_provider
@@ -273,6 +274,7 @@ async def test_similar_tracks_normalizes_provider_matching_failure() -> None:
     mass = Mock()
     lookup_provider = Mock(spec=MusicProvider)
     lookup_provider.name = "Lookup"
+    lookup_provider.instance_id = "lookup"
     lookup_provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
     mass.get_providers_supporting_feature.return_value = []
     mass.music.providers = [lookup_provider]
@@ -305,6 +307,7 @@ async def test_similar_tracks_preserves_failure_when_lookup_is_not_implemented()
     mapped_provider.get_similar_tracks = AsyncMock(side_effect=client_error)
     lookup_provider = Mock(spec=MusicProvider)
     lookup_provider.name = "Lookup"
+    lookup_provider.instance_id = "lookup"
     lookup_provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
     lookup_provider.get_similar_tracks = AsyncMock(side_effect=NotImplementedError)
     mass.get_provider.return_value = mapped_provider
@@ -339,6 +342,39 @@ async def test_similar_tracks_preserves_failure_when_lookup_is_not_implemented()
         await controller.similar_tracks("seed", "mapped", allow_lookup=True)
 
     assert raised.value.__cause__ is client_error
+
+
+async def test_similar_tracks_lookup_skips_mapped_provider() -> None:
+    """Cross-provider lookup does not retry an instance already mapped to the track."""
+    mass = Mock()
+    mapped_provider = Mock(spec=MusicProvider)
+    mapped_provider.name = "Mapped"
+    mapped_provider.instance_id = "mapped"
+    mapped_provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
+    mapped_provider.get_similar_tracks = AsyncMock(return_value=[])
+    mass.get_provider.return_value = mapped_provider
+    mass.get_providers_supporting_feature.return_value = []
+    mass.music.providers = [mapped_provider]
+
+    ref_item = Mock()
+    ref_item.name = "Seed"
+    ref_item.provider_mappings = {
+        ProviderMapping(
+            item_id="mapped_track",
+            provider_domain="mapped",
+            provider_instance="mapped",
+        )
+    }
+    controller = TracksController.__new__(TracksController)
+    controller.mass = mass
+    controller.logger = Mock()
+    controller.get = AsyncMock(return_value=ref_item)  # type: ignore[method-assign]
+    controller.match_provider = AsyncMock()  # type: ignore[method-assign]
+
+    result = await controller.similar_tracks("seed", "mapped", allow_lookup=True)
+
+    assert result == []
+    controller.match_provider.assert_not_awaited()
 
 
 def _artist(item_id: str, name: str, instance: str) -> Artist:

--- a/tests/test_cross_type_features.py
+++ b/tests/test_cross_type_features.py
@@ -377,6 +377,68 @@ async def test_similar_tracks_lookup_skips_mapped_provider() -> None:
     controller.match_provider.assert_not_awaited()
 
 
+async def test_similar_tracks_empty_response_wins_without_lookup_provider() -> None:
+    """A valid empty response is preserved when no lookup provider is available."""
+    mass = Mock()
+    mapped_provider = Mock(spec=MusicProvider)
+    mapped_provider.name = "Mapped"
+    mapped_provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
+    mapped_provider.get_similar_tracks = AsyncMock(return_value=[])
+    mass.get_provider.return_value = mapped_provider
+    mass.get_providers_supporting_feature.return_value = []
+    mass.music.providers = []
+
+    ref_item = Mock()
+    ref_item.name = "Seed"
+    ref_item.provider_mappings = {
+        ProviderMapping(
+            item_id="mapped_track",
+            provider_domain="mapped",
+            provider_instance="mapped",
+        )
+    }
+    controller = TracksController.__new__(TracksController)
+    controller.mass = mass
+    controller.logger = Mock()
+    controller.get = AsyncMock(return_value=ref_item)  # type: ignore[method-assign]
+
+    result = await controller.similar_tracks("seed", "mapped", allow_lookup=True)
+
+    assert result == []
+
+
+async def test_similar_tracks_failure_wins_without_lookup_provider() -> None:
+    """A provider failure is preserved when no lookup provider is available."""
+    mass = Mock()
+    mapped_provider = Mock(spec=MusicProvider)
+    mapped_provider.name = "Mapped"
+    mapped_provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
+    client_error = ClientConnectionError("offline")
+    mapped_provider.get_similar_tracks = AsyncMock(side_effect=client_error)
+    mass.get_provider.return_value = mapped_provider
+    mass.get_providers_supporting_feature.return_value = []
+    mass.music.providers = []
+
+    ref_item = Mock()
+    ref_item.name = "Seed"
+    ref_item.provider_mappings = {
+        ProviderMapping(
+            item_id="mapped_track",
+            provider_domain="mapped",
+            provider_instance="mapped",
+        )
+    }
+    controller = TracksController.__new__(TracksController)
+    controller.mass = mass
+    controller.logger = Mock()
+    controller.get = AsyncMock(return_value=ref_item)  # type: ignore[method-assign]
+
+    with pytest.raises(ProviderUnavailableError) as raised:
+        await controller.similar_tracks("seed", "mapped", allow_lookup=True)
+
+    assert raised.value.__cause__ is client_error
+
+
 def _artist(item_id: str, name: str, instance: str) -> Artist:
     """Build a minimal Artist for the given provider instance."""
     return Artist(

--- a/tests/test_cross_type_features.py
+++ b/tests/test_cross_type_features.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
+from aiohttp import ClientConnectionError
 from music_assistant_models.enums import MediaType, ProviderFeature, ProviderType
+from music_assistant_models.errors import InvalidDataError, ProviderUnavailableError
 from music_assistant_models.media_items import Artist, ProviderMapping, SearchResults
 
 from music_assistant.controllers.music import MusicController
@@ -113,6 +116,156 @@ async def test_similar_tracks_falls_back_to_metadata_provider() -> None:
     metadata_prov.get_similar_tracks.assert_awaited_once()
     call_kwargs = metadata_prov.get_similar_tracks.await_args.kwargs
     assert call_kwargs.get("limit") == 5
+
+
+async def test_similar_tracks_skips_failed_provider_mapping() -> None:
+    """A transport failure from one mapping does not prevent trying the next provider."""
+    mass = Mock()
+    failed_prov = Mock(spec=MusicProvider)
+    failed_prov.name = "Failed"
+    failed_prov.supported_features = {ProviderFeature.SIMILAR_TRACKS}
+    failed_prov.get_similar_tracks = AsyncMock(side_effect=ClientConnectionError("offline"))
+    working_prov = Mock(spec=MusicProvider)
+    working_prov.name = "Working"
+    working_prov.supported_features = {ProviderFeature.SIMILAR_TRACKS}
+    working_prov.get_similar_tracks = AsyncMock(return_value=["t1", "t2"])
+    mass.get_provider.side_effect = lambda instance_id: {
+        "failed": failed_prov,
+        "working": working_prov,
+    }.get(instance_id)
+    mass.get_providers_supporting_feature.return_value = []
+
+    ref_item = Mock()
+    ref_item.name = "Seed"
+    ref_item.provider_mappings = [
+        ProviderMapping(
+            item_id="failed_track",
+            provider_domain="failed",
+            provider_instance="failed",
+        ),
+        ProviderMapping(
+            item_id="working_track",
+            provider_domain="working",
+            provider_instance="working",
+        ),
+    ]
+    controller = TracksController.__new__(TracksController)
+    controller.mass = mass
+    controller.logger = Mock()
+    controller.get = AsyncMock(return_value=ref_item)  # type: ignore[method-assign]
+
+    result = await controller.similar_tracks("seed", "library")
+
+    assert result == ["t1", "t2"]
+    failed_prov.get_similar_tracks.assert_awaited_once()
+    working_prov.get_similar_tracks.assert_awaited_once()
+
+
+async def test_similar_tracks_normalizes_provider_transport_failure() -> None:
+    """An all-provider transport failure is exposed as a typed MA provider error."""
+    mass = Mock()
+    provider = Mock(spec=MusicProvider)
+    provider.name = "Failed"
+    provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
+    client_error = ClientConnectionError("offline")
+    provider.get_similar_tracks = AsyncMock(side_effect=client_error)
+    mass.get_provider.return_value = provider
+    mass.get_providers_supporting_feature.return_value = []
+
+    ref_item = Mock()
+    ref_item.name = "Seed"
+    ref_item.provider_mappings = [
+        ProviderMapping(
+            item_id="failed_track",
+            provider_domain="failed",
+            provider_instance="failed",
+        )
+    ]
+    controller = TracksController.__new__(TracksController)
+    controller.mass = mass
+    controller.logger = Mock()
+    controller.get = AsyncMock(return_value=ref_item)  # type: ignore[method-assign]
+
+    with pytest.raises(ProviderUnavailableError) as raised:
+        await controller.similar_tracks("seed", "library")
+
+    assert raised.value.__cause__ is client_error
+
+
+async def test_similar_tracks_preserves_typed_provider_error() -> None:
+    """A typed provider failure is re-raised unchanged when no provider responds."""
+    mass = Mock()
+    provider = Mock(spec=MusicProvider)
+    provider.name = "Failed"
+    provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
+    provider_error = InvalidDataError("invalid response")
+    provider.get_similar_tracks = AsyncMock(side_effect=provider_error)
+    mass.get_provider.return_value = provider
+    mass.get_providers_supporting_feature.return_value = []
+
+    ref_item = Mock()
+    ref_item.name = "Seed"
+    ref_item.provider_mappings = [
+        ProviderMapping(
+            item_id="failed_track",
+            provider_domain="failed",
+            provider_instance="failed",
+        )
+    ]
+    controller = TracksController.__new__(TracksController)
+    controller.mass = mass
+    controller.logger = Mock()
+    controller.get = AsyncMock(return_value=ref_item)  # type: ignore[method-assign]
+
+    with pytest.raises(InvalidDataError) as raised:
+        await controller.similar_tracks("seed", "library")
+
+    assert raised.value is provider_error
+
+
+async def test_similar_tracks_lookup_failure_after_empty_response_returns_empty() -> None:
+    """A failed cross-provider lookup does not override an earlier valid empty response."""
+    mass = Mock()
+    mapped_provider = Mock(spec=MusicProvider)
+    mapped_provider.name = "Mapped"
+    mapped_provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
+    mapped_provider.get_similar_tracks = AsyncMock(return_value=[])
+    lookup_provider = Mock(spec=MusicProvider)
+    lookup_provider.name = "Lookup"
+    lookup_provider.supported_features = {ProviderFeature.SIMILAR_TRACKS}
+    lookup_provider.get_similar_tracks = AsyncMock(side_effect=ClientConnectionError("offline"))
+    mass.get_provider.return_value = mapped_provider
+    mass.get_providers_supporting_feature.return_value = []
+    mass.music.providers = [lookup_provider]
+
+    ref_item = Mock()
+    ref_item.name = "Seed"
+    ref_item.provider = "mapped"
+    ref_item.provider_mappings = {
+        ProviderMapping(
+            item_id="mapped_track",
+            provider_domain="mapped",
+            provider_instance="mapped",
+        )
+    }
+    controller = TracksController.__new__(TracksController)
+    controller.mass = mass
+    controller.logger = Mock()
+    controller.get = AsyncMock(return_value=ref_item)  # type: ignore[method-assign]
+    controller.match_provider = AsyncMock(  # type: ignore[method-assign]
+        return_value=[
+            ProviderMapping(
+                item_id="lookup_track",
+                provider_domain="lookup",
+                provider_instance="lookup",
+            )
+        ]
+    )
+
+    result = await controller.similar_tracks("seed", "mapped", allow_lookup=True)
+
+    assert result == []
+    lookup_provider.get_similar_tracks.assert_awaited_once_with("lookup_track", limit=25)
 
 
 def _artist(item_id: str, name: str, instance: str) -> Artist:


### PR DESCRIPTION
# What does this implement/fix?

A provider connection error could stop autoplay refill before another provider or the library fallback was tried.

- Continue through available similar-track providers when one fails.
- Convert raw transport failures into Music Assistant provider errors when every provider fails.
- Cover provider fallback and AUTO mode library fallback with regression tests.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.