### PR TITLE
Hide capture-only devices from universal groups

### DIFF
--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -207,7 +207,7 @@ class UniversalGroupPlayer(Player):
                 options=[
                     ConfigValueOption(x.player_id, title=x.display_name)
                     for x in self.mass.players.all_players(True, False)
-                    if x.type != PlayerType.GROUP
+                    if x.type not in (PlayerType.GROUP, PlayerType.UNKNOWN)
                 ],
             ),
             ConfigEntry(

--- a/tests/providers/universal_group/test_universal_group.py
+++ b/tests/providers/universal_group/test_universal_group.py
@@ -19,8 +19,9 @@ from music_assistant_models.constants import (
     PLAYER_CONTROL_NATIVE,
     PLAYER_CONTROL_NONE,
 )
-from music_assistant_models.enums import PlaybackState, PlayerFeature
+from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
 
+from music_assistant.constants import CONF_GROUP_MEMBERS
 from music_assistant.providers.universal_group.player import UniversalGroupPlayer
 
 
@@ -98,11 +99,13 @@ def _make_mock_player(
     active_group: str | None = None,
     synced_to: str | None = None,
     playback_state: PlaybackState = PlaybackState.IDLE,
+    player_type: PlayerType = PlayerType.PLAYER,
 ) -> MagicMock:
     """Create a mock child player."""
     player = MagicMock()
     player.player_id = player_id
     player.display_name = player_id
+    player.type = player_type
     player.available = available
     player.enabled = enabled
     player.powered = powered
@@ -123,6 +126,34 @@ def _make_mock_player(
     player.state.elapsed_time_last_updated = None
     player.ungroup = AsyncMock()
     return player
+
+
+async def test_config_members_exclude_groups_and_unknown_players() -> None:
+    """Only known non-group player types should be offered as universal group members."""
+    mass = _make_mock_mass()
+    players = [
+        _make_mock_player("speaker"),
+        _make_mock_player("light", player_type=PlayerType.LIGHT),
+        _make_mock_player("visualizer", player_type=PlayerType.VISUALIZER),
+        _make_mock_player("display", player_type=PlayerType.DISPLAY),
+        _make_mock_player("group", player_type=PlayerType.GROUP),
+        _make_mock_player("capture-only", player_type=PlayerType.UNKNOWN),
+    ]
+    players[1].state.supported_features = set()
+    players[2].state.supported_features = set()
+    players[2].hide_in_ui = True
+    players[3].state.supported_features = set()
+    mass.players.all_players.return_value = players
+
+    entries = await _make_ugp(mass).get_config_entries()
+    members_entry = next(entry for entry in entries if entry.key == CONF_GROUP_MEMBERS)
+
+    assert {option.value for option in members_entry.options} == {
+        "speaker",
+        "light",
+        "visualizer",
+        "display",
+    }
 
 
 class TestIsActiveSession:


### PR DESCRIPTION
# What does this implement/fix?

Capture-only devices were offered as members when editing a universal group, even though they cannot render group output.

- Exclude players with an unknown type from universal group member options.
- Keep supported lights, visualizers, displays, and hidden players available.
- Add regression coverage for the member filter.

Related frontend change: https://github.com/music-assistant/frontend/pull/2591

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.