### PR TITLE
Restore missing provider mapping warnings

### DIFF
--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -657,6 +657,12 @@ class AlbumsController(MediaControllerBase[Album]):
             db_id, update.external_ids if overwrite else cur_item.external_ids
         )
         # update/set provider_mappings table
+        if overwrite and cur_item.provider_mappings and not update.provider_mappings:
+            self.logger.warning(
+                "Ignoring request to clear all provider mappings of %s item id %s",
+                self.media_type.value,
+                db_id,
+            )
         provider_mappings = provider_mappings_for_update(
             cur_item.provider_mappings, update.provider_mappings, overwrite
         )

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -1148,6 +1148,12 @@ class ArtistsController(MediaControllerBase[Artist]):
             db_id, update.external_ids if overwrite else cur_item.external_ids
         )
         # update/set provider_mappings table
+        if overwrite and cur_item.provider_mappings and not update.provider_mappings:
+            self.logger.warning(
+                "Ignoring request to clear all provider mappings of %s item id %s",
+                self.media_type.value,
+                db_id,
+            )
         provider_mappings = provider_mappings_for_update(
             cur_item.provider_mappings, update.provider_mappings, overwrite
         )

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -776,6 +776,12 @@ class TracksController(MediaControllerBase[Track]):
             db_id, update.external_ids if overwrite else cur_item.external_ids
         )
         # update/set provider_mappings table
+        if overwrite and cur_item.provider_mappings and not update.provider_mappings:
+            self.logger.warning(
+                "Ignoring request to clear all provider mappings of %s item id %s",
+                self.media_type.value,
+                db_id,
+            )
         provider_mappings = provider_mappings_for_update(
             cur_item.provider_mappings, update.provider_mappings, overwrite
         )

--- a/tests/controllers/music/test_albums.py
+++ b/tests/controllers/music/test_albums.py
@@ -56,6 +56,24 @@ async def test_overwrite_update_keeps_artists_when_none_are_given(
     assert "Ignoring request to clear all artists" in caplog.text
 
 
+async def test_overwrite_update_warns_when_no_provider_mappings_are_given(
+    mass: MusicAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An overwrite update carrying no provider mappings must emit a warning."""
+    db_album = await mass.music.albums.add_item_to_library(create_album("spotify_1", "album1"))
+
+    update = create_album("spotify_1", "album1")
+    update.provider_mappings = set()
+    await mass.music.albums.update_item_in_library(db_album.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.albums.get_library_item(db_album.item_id)
+    assert refreshed.provider_mappings == db_album.provider_mappings
+    assert (
+        f"Ignoring request to clear all provider mappings of album item id {db_album.item_id}"
+        in caplog.text
+    )
+
+
 async def test_overwrite_update_replaces_artists(mass: MusicAssistant) -> None:
     """An overwrite update carrying artists still replaces the stored ones."""
     db_album = await mass.music.albums.add_item_to_library(create_album("spotify_1", "album1"))

--- a/tests/controllers/music/test_artists.py
+++ b/tests/controllers/music/test_artists.py
@@ -15,6 +15,8 @@ from music_assistant_models.media_items import (
 from .helpers import create_track
 
 if TYPE_CHECKING:
+    import pytest
+
     from music_assistant.mass import MusicAssistant
 
 ARTIST_MBID = "aa1b2c3d-1c99-4c1b-b0f1-9f2c1b2a3d44"
@@ -47,6 +49,24 @@ def _detailed_artist() -> Artist:
         [MediaItemImage(type=ImageType.THUMB, path=ARTIST_IMAGE, provider="spotify_1")]
     )
     return artist
+
+
+async def test_overwrite_update_warns_when_no_provider_mappings_are_given(
+    mass: MusicAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An overwrite update carrying no provider mappings must emit a warning."""
+    db_artist = await mass.music.artists.add_item_to_library(_artist_stub())
+
+    update = _artist_stub()
+    update.provider_mappings = set()
+    await mass.music.artists.update_item_in_library(db_artist.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.artists.get_library_item(db_artist.item_id)
+    assert refreshed.provider_mappings == db_artist.provider_mappings
+    assert (
+        f"Ignoring request to clear all provider mappings of artist item id {db_artist.item_id}"
+        in caplog.text
+    )
 
 
 async def test_track_overwrite_keeps_artist_details(mass: MusicAssistant) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -176,6 +176,24 @@ async def test_overwrite_update_keeps_artists_when_none_are_given(
     assert "Ignoring request to clear all artists" in caplog.text
 
 
+async def test_overwrite_update_warns_when_no_provider_mappings_are_given(
+    mass: MusicAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An overwrite update carrying no provider mappings must emit a warning."""
+    db_track = await mass.music.tracks.add_item_to_library(create_track("spotify_1", "track1"))
+
+    update = create_track("spotify_1", "track1")
+    update.provider_mappings = set()
+    await mass.music.tracks.update_item_in_library(db_track.item_id, update, overwrite=True)
+
+    refreshed = await mass.music.tracks.get_library_item(db_track.item_id)
+    assert refreshed.provider_mappings == db_track.provider_mappings
+    assert (
+        f"Ignoring request to clear all provider mappings of track item id {db_track.item_id}"
+        in caplog.text
+    )
+
+
 async def test_overwrite_update_replaces_artists(mass: MusicAssistant) -> None:
     """An overwrite update carrying artists still replaces the stored ones."""
     db_track = await mass.music.tracks.add_item_to_library(create_track("spotify_1", "track1"))


### PR DESCRIPTION
# What does this implement/fix?

Restore the warning emitted when an album, artist, or track update arrives without provider mappings.

- Keep the existing provider mapping data behavior unchanged.
- Add regression coverage for all three media types.

**Related issue (if applicable):**

- Follow-up to #5855

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.