### PR TITLE
Keep Tidal library sync running after bad items

### DIFF
--- a/music_assistant/providers/tidal/library.py
+++ b/music_assistant/providers/tidal/library.py
@@ -70,7 +70,13 @@ class TidalLibraryManager:
             for item in doc.data_list:
                 if resource := doc.resolve(item):
                     if (
-                        artist := _parse_or_skip(parse_artist_v2, self.provider, doc, resource)
+                        artist := _parse_or_skip(
+                            parse_artist_v2,
+                            self.provider,
+                            doc,
+                            resource,
+                            MediaType.ARTIST,
+                        )
                     ) is None:
                         continue
                     _set_date_added(artist, item)
@@ -86,7 +92,13 @@ class TidalLibraryManager:
             for item in doc.data_list:
                 if resource := doc.resolve(item):
                     if (
-                        album := _parse_or_skip(parse_album_v2, self.provider, doc, resource)
+                        album := _parse_or_skip(
+                            parse_album_v2,
+                            self.provider,
+                            doc,
+                            resource,
+                            MediaType.ALBUM,
+                        )
                     ) is None:
                         continue
                     _set_date_added(album, item)
@@ -102,7 +114,13 @@ class TidalLibraryManager:
             for item in doc.data_list:
                 if resource := doc.resolve(item):
                     if (
-                        track := _parse_or_skip(parse_track_v2, self.provider, doc, resource)
+                        track := _parse_or_skip(
+                            parse_track_v2,
+                            self.provider,
+                            doc,
+                            resource,
+                            MediaType.TRACK,
+                        )
                     ) is None:
                         continue
                     _set_date_added(track, item)
@@ -119,8 +137,20 @@ class TidalLibraryManager:
         ):
             for item in doc.data_list:
                 if resource := doc.resolve(item):
+                    try:
+                        sync_item_id = _playlist_item_id(resource)
+                    except (AttributeError, KeyError, TypeError, ValueError) as err:
+                        self.provider.report_skipped_sync_item(MediaType.PLAYLIST, None, err)
+                        continue
                     if (
-                        playlist := _parse_or_skip(parse_playlist_v2, self.provider, doc, resource)
+                        playlist := _parse_or_skip(
+                            parse_playlist_v2,
+                            self.provider,
+                            doc,
+                            resource,
+                            MediaType.PLAYLIST,
+                            sync_item_id,
+                        )
                     ) is None:
                         continue
                     _set_date_added(playlist, item)
@@ -199,3 +229,11 @@ def _set_date_added(media_item: MediaItemType, item: dict[str, Any]) -> None:
             # the DB only persists whole-second precision, so truncate here to avoid
             # every sync seeing a (sub-second) mismatch and flagging the item as changed
             media_item.date_added = datetime.fromisoformat(added).replace(microsecond=0)
+
+
+def _playlist_item_id(resource: dict[str, Any]) -> str:
+    """Return the provider item ID used for a Tidal playlist resource."""
+    item_id = str(resource["id"])
+    if resource.get("attributes", {}).get("playlistType") == "MIX":
+        return f"mix_{item_id}"
+    return item_id

--- a/music_assistant/providers/tidal/library.py
+++ b/music_assistant/providers/tidal/library.py
@@ -147,7 +147,10 @@ class TidalLibraryManager:
                 ) is None:
                     continue
                 _set_date_added(track, item)
-                self.provider.note_replaced_track(item)
+                try:
+                    self.provider.note_replaced_track(item)
+                except SKIPPABLE_ITEM_ERRORS as err:
+                    self.provider.report_skipped_sync_item(MediaType.TRACK, sync_item_id, err)
                 yield track
 
     async def get_playlists(self) -> AsyncGenerator[Playlist]:

--- a/music_assistant/providers/tidal/library.py
+++ b/music_assistant/providers/tidal/library.py
@@ -11,10 +11,21 @@ from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MediaNotFoundError, ResourceTemporarilyUnavailable
 
 from .parsers import parse_favorite_tracks_playlist
-from .parsers_v2 import parse_album as parse_album_v2
-from .parsers_v2 import parse_artist as parse_artist_v2
-from .parsers_v2 import parse_playlist as parse_playlist_v2
-from .parsers_v2 import parse_track as parse_track_v2
+from .parsers_v2 import (
+    _parse_or_skip,
+)
+from .parsers_v2 import (
+    parse_album as parse_album_v2,
+)
+from .parsers_v2 import (
+    parse_artist as parse_artist_v2,
+)
+from .parsers_v2 import (
+    parse_playlist as parse_playlist_v2,
+)
+from .parsers_v2 import (
+    parse_track as parse_track_v2,
+)
 
 # MediaType -> (official collection resource, JSON:API resource type).
 _COLLECTIONS = {
@@ -58,7 +69,10 @@ class TidalLibraryManager:
         ):
             for item in doc.data_list:
                 if resource := doc.resolve(item):
-                    artist = parse_artist_v2(self.provider, doc, resource)
+                    if (
+                        artist := _parse_or_skip(parse_artist_v2, self.provider, doc, resource)
+                    ) is None:
+                        continue
                     _set_date_added(artist, item)
                     yield artist
 
@@ -71,7 +85,10 @@ class TidalLibraryManager:
         ):
             for item in doc.data_list:
                 if resource := doc.resolve(item):
-                    album = parse_album_v2(self.provider, doc, resource)
+                    if (
+                        album := _parse_or_skip(parse_album_v2, self.provider, doc, resource)
+                    ) is None:
+                        continue
                     _set_date_added(album, item)
                     yield album
 
@@ -84,7 +101,10 @@ class TidalLibraryManager:
         ):
             for item in doc.data_list:
                 if resource := doc.resolve(item):
-                    track = parse_track_v2(self.provider, doc, resource)
+                    if (
+                        track := _parse_or_skip(parse_track_v2, self.provider, doc, resource)
+                    ) is None:
+                        continue
                     _set_date_added(track, item)
                     self.provider.note_replaced_track(item)
                     yield track
@@ -99,7 +119,10 @@ class TidalLibraryManager:
         ):
             for item in doc.data_list:
                 if resource := doc.resolve(item):
-                    playlist = parse_playlist_v2(self.provider, doc, resource)
+                    if (
+                        playlist := _parse_or_skip(parse_playlist_v2, self.provider, doc, resource)
+                    ) is None:
+                        continue
                     _set_date_added(playlist, item)
                     yield playlist
 

--- a/music_assistant/providers/tidal/library.py
+++ b/music_assistant/providers/tidal/library.py
@@ -10,6 +10,7 @@ from aiohttp.client_exceptions import ClientError
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MediaNotFoundError, ResourceTemporarilyUnavailable
 
+from .constants import SKIPPABLE_ITEM_ERRORS
 from .parsers import parse_favorite_tracks_playlist
 from .parsers_v2 import (
     _parse_or_skip,
@@ -76,6 +77,7 @@ class TidalLibraryManager:
                             doc,
                             resource,
                             MediaType.ARTIST,
+                            resource.get("id"),
                         )
                     ) is None:
                         continue
@@ -98,6 +100,7 @@ class TidalLibraryManager:
                             doc,
                             resource,
                             MediaType.ALBUM,
+                            resource.get("id"),
                         )
                     ) is None:
                         continue
@@ -113,6 +116,11 @@ class TidalLibraryManager:
         ):
             for item in doc.data_list:
                 if resource := doc.resolve(item):
+                    try:
+                        sync_item_id = _track_item_id(item, resource)
+                    except SKIPPABLE_ITEM_ERRORS as err:
+                        self.provider.report_skipped_sync_item(MediaType.TRACK, None, err)
+                        continue
                     if (
                         track := _parse_or_skip(
                             parse_track_v2,
@@ -120,6 +128,7 @@ class TidalLibraryManager:
                             doc,
                             resource,
                             MediaType.TRACK,
+                            sync_item_id,
                         )
                     ) is None:
                         continue
@@ -139,7 +148,7 @@ class TidalLibraryManager:
                 if resource := doc.resolve(item):
                     try:
                         sync_item_id = _playlist_item_id(resource)
-                    except (AttributeError, KeyError, TypeError, ValueError) as err:
+                    except SKIPPABLE_ITEM_ERRORS as err:
                         self.provider.report_skipped_sync_item(MediaType.PLAYLIST, None, err)
                         continue
                     if (
@@ -237,3 +246,12 @@ def _playlist_item_id(resource: dict[str, Any]) -> str:
     if resource.get("attributes", {}).get("playlistType") == "MIX":
         return f"mix_{item_id}"
     return item_id
+
+
+def _track_item_id(item: dict[str, Any], resource: dict[str, Any]) -> str | None:
+    """Return the provider item ID that can be protected during track sync."""
+    replacement = (item.get("meta") or {}).get("replacement") or {}
+    if replacement.get("status") == "REPLACED":
+        return None
+    item_id = resource.get("id")
+    return str(item_id) if item_id is not None else None

--- a/music_assistant/providers/tidal/library.py
+++ b/music_assistant/providers/tidal/library.py
@@ -248,8 +248,8 @@ class TidalLibraryManager:
 
 def _set_date_added(media_item: MediaItemType, item: dict[str, Any]) -> None:
     """Set date_added from a userCollection linkage item's addedAt meta."""
-    if added := (item.get("meta") or {}).get("addedAt"):
-        with suppress(ValueError):
+    with suppress(AttributeError, TypeError, ValueError):
+        if added := (item.get("meta") or {}).get("addedAt"):
             # the DB only persists whole-second precision, so truncate here to avoid
             # every sync seeing a (sub-second) mismatch and flagging the item as changed
             media_item.date_added = datetime.fromisoformat(added).replace(microsecond=0)
@@ -257,7 +257,8 @@ def _set_date_added(media_item: MediaItemType, item: dict[str, Any]) -> None:
 
 def _playlist_item_id(resource: dict[str, Any]) -> str:
     """Return the provider item ID used for a Tidal playlist resource."""
-    item_id = str(resource["id"])
+    if not isinstance(item_id := resource["id"], str):
+        raise TypeError("Tidal playlist resource ID is not a string")
     if resource.get("attributes", {}).get("playlistType") == "MIX":
         return f"mix_{item_id}"
     return item_id
@@ -274,7 +275,7 @@ def _track_item_id(item: dict[str, Any]) -> str | None:
 def _resource_id(resource: dict[str, Any]) -> str | None:
     """Return a JSON:API resource identifier as text."""
     item_id = resource.get("id")
-    return str(item_id) if item_id is not None else None
+    return item_id if isinstance(item_id, str) else None
 
 
 def _resolve_resource(doc: JsonApiDocument, item: dict[str, Any]) -> dict[str, Any]:

--- a/music_assistant/providers/tidal/library.py
+++ b/music_assistant/providers/tidal/library.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
         Track,
     )
 
+    from .jsonapi import JsonApiDocument
     from .provider import TidalProvider
 
 
@@ -69,20 +70,26 @@ class TidalLibraryManager:
             "userCollectionArtists/me/relationships/items", include=["items.profileArt"]
         ):
             for item in doc.data_list:
-                if resource := doc.resolve(item):
-                    if (
-                        artist := _parse_or_skip(
-                            parse_artist_v2,
-                            self.provider,
-                            doc,
-                            resource,
-                            MediaType.ARTIST,
-                            resource.get("id"),
-                        )
-                    ) is None:
-                        continue
-                    _set_date_added(artist, item)
-                    yield artist
+                sync_item_id: str | None = None
+                try:
+                    sync_item_id = _resource_id(item)
+                    resource = _resolve_resource(doc, item)
+                except SKIPPABLE_ITEM_ERRORS as err:
+                    self.provider.report_skipped_sync_item(MediaType.ARTIST, sync_item_id, err)
+                    continue
+                if (
+                    artist := _parse_or_skip(
+                        parse_artist_v2,
+                        self.provider,
+                        doc,
+                        resource,
+                        MediaType.ARTIST,
+                        sync_item_id,
+                    )
+                ) is None:
+                    continue
+                _set_date_added(artist, item)
+                yield artist
 
     async def get_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums."""
@@ -92,20 +99,26 @@ class TidalLibraryManager:
             replace_media="items",
         ):
             for item in doc.data_list:
-                if resource := doc.resolve(item):
-                    if (
-                        album := _parse_or_skip(
-                            parse_album_v2,
-                            self.provider,
-                            doc,
-                            resource,
-                            MediaType.ALBUM,
-                            resource.get("id"),
-                        )
-                    ) is None:
-                        continue
-                    _set_date_added(album, item)
-                    yield album
+                sync_item_id = None
+                try:
+                    sync_item_id = _resource_id(item)
+                    resource = _resolve_resource(doc, item)
+                except SKIPPABLE_ITEM_ERRORS as err:
+                    self.provider.report_skipped_sync_item(MediaType.ALBUM, sync_item_id, err)
+                    continue
+                if (
+                    album := _parse_or_skip(
+                        parse_album_v2,
+                        self.provider,
+                        doc,
+                        resource,
+                        MediaType.ALBUM,
+                        sync_item_id,
+                    )
+                ) is None:
+                    continue
+                _set_date_added(album, item)
+                yield album
 
     async def get_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks."""
@@ -115,26 +128,27 @@ class TidalLibraryManager:
             replace_media="items",
         ):
             for item in doc.data_list:
-                if resource := doc.resolve(item):
-                    try:
-                        sync_item_id = _track_item_id(item, resource)
-                    except SKIPPABLE_ITEM_ERRORS as err:
-                        self.provider.report_skipped_sync_item(MediaType.TRACK, None, err)
-                        continue
-                    if (
-                        track := _parse_or_skip(
-                            parse_track_v2,
-                            self.provider,
-                            doc,
-                            resource,
-                            MediaType.TRACK,
-                            sync_item_id,
-                        )
-                    ) is None:
-                        continue
-                    _set_date_added(track, item)
-                    self.provider.note_replaced_track(item)
-                    yield track
+                sync_item_id = None
+                try:
+                    sync_item_id = _track_item_id(item)
+                    resource = _resolve_resource(doc, item)
+                except SKIPPABLE_ITEM_ERRORS as err:
+                    self.provider.report_skipped_sync_item(MediaType.TRACK, sync_item_id, err)
+                    continue
+                if (
+                    track := _parse_or_skip(
+                        parse_track_v2,
+                        self.provider,
+                        doc,
+                        resource,
+                        MediaType.TRACK,
+                        sync_item_id,
+                    )
+                ) is None:
+                    continue
+                _set_date_added(track, item)
+                self.provider.note_replaced_track(item)
+                yield track
 
     async def get_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library playlists."""
@@ -145,25 +159,26 @@ class TidalLibraryManager:
             include=["items.coverArt", "items.owners"],
         ):
             for item in doc.data_list:
-                if resource := doc.resolve(item):
-                    try:
-                        sync_item_id = _playlist_item_id(resource)
-                    except SKIPPABLE_ITEM_ERRORS as err:
-                        self.provider.report_skipped_sync_item(MediaType.PLAYLIST, None, err)
-                        continue
-                    if (
-                        playlist := _parse_or_skip(
-                            parse_playlist_v2,
-                            self.provider,
-                            doc,
-                            resource,
-                            MediaType.PLAYLIST,
-                            sync_item_id,
-                        )
-                    ) is None:
-                        continue
-                    _set_date_added(playlist, item)
-                    yield playlist
+                sync_item_id = None
+                try:
+                    resource = _resolve_resource(doc, item)
+                    sync_item_id = _playlist_item_id(resource)
+                except SKIPPABLE_ITEM_ERRORS as err:
+                    self.provider.report_skipped_sync_item(MediaType.PLAYLIST, sync_item_id, err)
+                    continue
+                if (
+                    playlist := _parse_or_skip(
+                        parse_playlist_v2,
+                        self.provider,
+                        doc,
+                        resource,
+                        MediaType.PLAYLIST,
+                        sync_item_id,
+                    )
+                ) is None:
+                    continue
+                _set_date_added(playlist, item)
+                yield playlist
 
         # The virtual "favorite tracks" playlist is a Music Assistant construct.
         yield parse_favorite_tracks_playlist(self.provider)
@@ -248,10 +263,22 @@ def _playlist_item_id(resource: dict[str, Any]) -> str:
     return item_id
 
 
-def _track_item_id(item: dict[str, Any], resource: dict[str, Any]) -> str | None:
+def _track_item_id(item: dict[str, Any]) -> str | None:
     """Return the provider item ID that can be protected during track sync."""
     replacement = (item.get("meta") or {}).get("replacement") or {}
     if replacement.get("status") == "REPLACED":
         return None
+    return _resource_id(item)
+
+
+def _resource_id(resource: dict[str, Any]) -> str | None:
+    """Return a JSON:API resource identifier as text."""
     item_id = resource.get("id")
     return str(item_id) if item_id is not None else None
+
+
+def _resolve_resource(doc: JsonApiDocument, item: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a library linkage item to its included resource."""
+    if resource := doc.resolve(item):
+        return resource
+    raise ValueError(f"Tidal library item {_resource_id(item) or '[no id]'} has no resource")

--- a/music_assistant/providers/tidal/library.py
+++ b/music_assistant/providers/tidal/library.py
@@ -275,7 +275,9 @@ def _track_item_id(item: dict[str, Any]) -> str | None:
 def _resource_id(resource: dict[str, Any]) -> str | None:
     """Return a JSON:API resource identifier as text."""
     item_id = resource.get("id")
-    return item_id if isinstance(item_id, str) else None
+    if item_id is not None and not isinstance(item_id, str):
+        raise TypeError("Tidal resource ID is not a string")
+    return item_id
 
 
 def _resolve_resource(doc: JsonApiDocument, item: dict[str, Any]) -> dict[str, Any]:

--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp.client_exceptions import ClientError
@@ -19,17 +18,26 @@ from .parsers import (
     parse_playlist,
     parse_track,
 )
-from .parsers_v2 import parse_album as parse_album_v2
-from .parsers_v2 import parse_artist as parse_artist_v2
-from .parsers_v2 import parse_playlist as parse_playlist_v2
-from .parsers_v2 import parse_track as parse_track_v2
+from .parsers_v2 import (
+    _parse_items,
+    _parse_or_skip,
+)
+from .parsers_v2 import (
+    parse_album as parse_album_v2,
+)
+from .parsers_v2 import (
+    parse_artist as parse_artist_v2,
+)
+from .parsers_v2 import (
+    parse_playlist as parse_playlist_v2,
+)
+from .parsers_v2 import (
+    parse_track as parse_track_v2,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from music_assistant_models.media_items import Album, Artist, Playlist, Track
 
-    from .jsonapi import JsonApiDocument
     from .provider import TidalProvider
 
 
@@ -80,25 +88,26 @@ class TidalMediaManager:
             results.tracks = [
                 track
                 for res in doc.related(data, "tracks")[:limit]
-                if (track := self._parse_or_skip(parse_track_v2, doc, res)) is not None
+                if (track := _parse_or_skip(parse_track_v2, self.provider, doc, res)) is not None
             ]
         if MediaType.ALBUM in wanted:
             results.albums = [
                 album
                 for res in doc.related(data, "albums")[:limit]
-                if (album := self._parse_or_skip(parse_album_v2, doc, res)) is not None
+                if (album := _parse_or_skip(parse_album_v2, self.provider, doc, res)) is not None
             ]
         if MediaType.ARTIST in wanted:
             results.artists = [
                 artist
                 for res in doc.related(data, "artists")[:limit]
-                if (artist := self._parse_or_skip(parse_artist_v2, doc, res)) is not None
+                if (artist := _parse_or_skip(parse_artist_v2, self.provider, doc, res)) is not None
             ]
         if MediaType.PLAYLIST in wanted:
             results.playlists = [
                 playlist
                 for res in doc.related(data, "playlists")[:limit]
-                if (playlist := self._parse_or_skip(parse_playlist_v2, doc, res)) is not None
+                if (playlist := _parse_or_skip(parse_playlist_v2, self.provider, doc, res))
+                is not None
             ]
         return results
 
@@ -177,7 +186,7 @@ class TidalMediaManager:
                     continue
                 if not (resource := doc.resolve(item)):
                     continue
-                if (track := self._parse_or_skip(parse_track_v2, doc, resource)) is None:
+                if (track := _parse_or_skip(parse_track_v2, self.provider, doc, resource)) is None:
                     continue
                 item_meta = item.get("meta") or {}
                 track.track_number = item_meta.get("trackNumber", 0) or 0
@@ -193,7 +202,7 @@ class TidalMediaManager:
             include=["albums.artists", "albums.coverArt"],
             replace_media="albums",
         ):
-            albums.extend(self._parse_items(parse_album_v2, doc))
+            albums.extend(_parse_items(parse_album_v2, self.provider, doc))
         return albums
 
     async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
@@ -205,7 +214,7 @@ class TidalMediaManager:
             include=["tracks.artists", "tracks.albums.coverArt"],
             replace_media="tracks",
         )
-        return self._parse_items(parse_track_v2, doc)
+        return _parse_items(parse_track_v2, self.provider, doc)
 
     async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
         """Get similar tracks."""
@@ -215,7 +224,7 @@ class TidalMediaManager:
             include=["similarTracks.artists", "similarTracks.albums.coverArt"],
             replace_media="similarTracks",
         )
-        return self._parse_items(parse_track_v2, doc)[:limit]
+        return _parse_items(parse_track_v2, self.provider, doc)[:limit]
 
     async def get_similar_artists(self, prov_artist_id: str, limit: int = 25) -> list[Artist]:
         """Get similar artists."""
@@ -224,7 +233,7 @@ class TidalMediaManager:
             f"artists/{prov_artist_id}/relationships/similarArtists",
             include=["similarArtists.profileArt"],
         )
-        return self._parse_items(parse_artist_v2, doc)[:limit]
+        return _parse_items(parse_artist_v2, self.provider, doc)[:limit]
 
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
         """Get playlist tracks."""
@@ -282,7 +291,7 @@ class TidalMediaManager:
             for item in doc.data_list:
                 if not (resource := doc.resolve(item)):
                     continue
-                if (track := self._parse_or_skip(parse_track_v2, doc, resource)) is None:
+                if (track := _parse_or_skip(parse_track_v2, self.provider, doc, resource)) is None:
                     continue
                 track.position = len(tracks) + 1
                 tracks.append(track)
@@ -313,56 +322,6 @@ class TidalMediaManager:
             return await self.api.get(f"tracks/{prov_track_id}/lyrics")
         except (ClientError, MusicAssistantError) as err:
             self.logger.debug("Failed to fetch lyrics for track %s: %s", prov_track_id, err)
-            return None
-
-    def _parse_items[ItemT](
-        self,
-        parser: Callable[[TidalProvider, JsonApiDocument, dict[str, Any]], ItemT],
-        doc: JsonApiDocument,
-    ) -> list[ItemT]:
-        """
-        Parse the document's primary collection, leaving out the items that cannot be parsed.
-
-        Only for a collection of a single resource type: every resource is handed to the
-        same parser, so a mixed-type relationship has to be filtered by the caller.
-
-        :param parser: The parser to apply to each resolved resource.
-        :param doc: The JSON:API document holding the collection.
-        """
-        items: list[ItemT] = []
-        for identifier in doc.data_list:
-            if not (resource := doc.resolve(identifier)):
-                continue
-            if (item := self._parse_or_skip(parser, doc, resource)) is not None:
-                items.append(item)
-        return items
-
-    def _parse_or_skip[ItemT](
-        self,
-        parser: Callable[[TidalProvider, JsonApiDocument, dict[str, Any]], ItemT],
-        doc: JsonApiDocument,
-        resource: dict[str, Any],
-    ) -> ItemT | None:
-        """
-        Parse a resource into a media item, or return None if it cannot be parsed.
-
-        :param parser: The parser to apply to the resource.
-        :param doc: The JSON:API document holding the resource.
-        :param resource: The resource object to parse.
-        """
-        try:
-            return parser(self.provider, doc, resource)
-        except SKIPPABLE_ITEM_ERRORS as err:
-            # Tidal sending one item in a shape its parser can not read must not discard
-            # the rest of the collection. Log the traceback (on debug) as well, so a
-            # parser bug caught here is still traceable to its origin.
-            self.logger.warning(
-                "Skipping Tidal %s %s: %s",
-                resource.get("type", "item"),
-                resource.get("id", "[no id]"),
-                err,
-                exc_info=err if self.logger.isEnabledFor(logging.DEBUG) else None,
-            )
             return None
 
     def _process_tracks(self, items: list[dict[str, Any]], offset: int) -> list[Track]:

--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp.client_exceptions import ClientError

--- a/music_assistant/providers/tidal/parsers_v2.py
+++ b/music_assistant/providers/tidal/parsers_v2.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Mapping
 from contextlib import suppress
@@ -31,7 +32,11 @@ from music_assistant_models.media_items import (
 
 from music_assistant.helpers.util import infer_album_type, parse_title_and_version
 
+from .constants import SKIPPABLE_ITEM_ERRORS
+
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ._openapi_models import (
         AlbumsAttributes,
         ArtistsAttributes,
@@ -291,6 +296,56 @@ def parse_playlist(
     if image := _resolve_image(provider, doc, resource, "coverArt"):
         playlist.metadata.images = UniqueList([image])
     return playlist
+
+
+def _parse_items[ItemT](
+    parser: Callable[[TidalProvider, JsonApiDocument, dict[str, Any]], ItemT],
+    provider: TidalProvider,
+    doc: JsonApiDocument,
+) -> list[ItemT]:
+    """
+    Parse the document's primary collection, leaving out items that cannot be parsed.
+
+    Only use this for a collection of a single resource type.
+
+    :param parser: The parser to apply to each resolved resource.
+    :param provider: The Tidal provider instance.
+    :param doc: The JSON:API document holding the collection.
+    """
+    items: list[ItemT] = []
+    for identifier in doc.data_list:
+        if not (resource := doc.resolve(identifier)):
+            continue
+        if (item := _parse_or_skip(parser, provider, doc, resource)) is not None:
+            items.append(item)
+    return items
+
+
+def _parse_or_skip[ItemT](
+    parser: Callable[[TidalProvider, JsonApiDocument, dict[str, Any]], ItemT],
+    provider: TidalProvider,
+    doc: JsonApiDocument,
+    resource: dict[str, Any],
+) -> ItemT | None:
+    """
+    Parse a resource into a media item, or return None if it cannot be parsed.
+
+    :param parser: The parser to apply to the resource.
+    :param provider: The Tidal provider instance.
+    :param doc: The JSON:API document holding the resource.
+    :param resource: The resource object to parse.
+    """
+    try:
+        return parser(provider, doc, resource)
+    except SKIPPABLE_ITEM_ERRORS as err:
+        provider.logger.warning(
+            "Skipping Tidal %s %s: %s",
+            resource.get("type", "item"),
+            resource.get("id", "[no id]"),
+            err,
+            exc_info=err if provider.logger.isEnabledFor(logging.DEBUG) else None,
+        )
+        return None
 
 
 def _split_title_version(title: str, version: str | None) -> tuple[str, str]:

--- a/music_assistant/providers/tidal/parsers_v2.py
+++ b/music_assistant/providers/tidal/parsers_v2.py
@@ -345,7 +345,7 @@ def _parse_or_skip[ItemT](
         if sync_media_type is not None:
             provider.report_skipped_sync_item(
                 sync_media_type,
-                sync_item_id if sync_item_id is not None else resource.get("id"),
+                sync_item_id,
                 err,
             )
         else:

--- a/music_assistant/providers/tidal/parsers_v2.py
+++ b/music_assistant/providers/tidal/parsers_v2.py
@@ -326,6 +326,8 @@ def _parse_or_skip[ItemT](
     provider: TidalProvider,
     doc: JsonApiDocument,
     resource: dict[str, Any],
+    sync_media_type: MediaType | None = None,
+    sync_item_id: str | None = None,
 ) -> ItemT | None:
     """
     Parse a resource into a media item, or return None if it cannot be parsed.
@@ -334,17 +336,26 @@ def _parse_or_skip[ItemT](
     :param provider: The Tidal provider instance.
     :param doc: The JSON:API document holding the resource.
     :param resource: The resource object to parse.
+    :param sync_media_type: The library media type to protect from sync cleanup.
+    :param sync_item_id: The provider item ID to protect from sync cleanup.
     """
     try:
         return parser(provider, doc, resource)
     except SKIPPABLE_ITEM_ERRORS as err:
-        provider.logger.warning(
-            "Skipping Tidal %s %s: %s",
-            resource.get("type", "item"),
-            resource.get("id", "[no id]"),
-            err,
-            exc_info=err if provider.logger.isEnabledFor(logging.DEBUG) else None,
-        )
+        if sync_media_type is not None:
+            provider.report_skipped_sync_item(
+                sync_media_type,
+                sync_item_id if sync_item_id is not None else resource.get("id"),
+                err,
+            )
+        else:
+            provider.logger.warning(
+                "Skipping Tidal %s %s: %s",
+                resource.get("type", "item"),
+                resource.get("id", "[no id]"),
+                err,
+                exc_info=err if provider.logger.isEnabledFor(logging.DEBUG) else None,
+            )
         return None
 
 

--- a/tests/providers/tidal/test_library.py
+++ b/tests/providers/tidal/test_library.py
@@ -141,7 +141,11 @@ async def test_library_listing_skips_unparsable_item(
     assert len(items) == expected_count
     assert all(item.item_id != broken_id for item in items)
     provider_mock.logger.warning.assert_not_called()
-    skipped_media_type, skipped_id, err = provider_mock.report_skipped_sync_item.call_args.args
+    skipped_media_type, skipped_id, err = next(
+        call.args
+        for call in provider_mock.report_skipped_sync_item.call_args_list
+        if call.args[1] == broken_id
+    )
     assert skipped_media_type == media_type
     assert skipped_id == broken_id
     assert isinstance(err, (AttributeError, KeyError, TypeError, ValueError))
@@ -224,6 +228,48 @@ async def test_library_tracks_hold_cleanup_for_unparsable_replacement(
 
 
 @pytest.mark.parametrize(
+    ("method_name", "fixture_name", "media_type", "expected_count", "protect_exact_id"),
+    [
+        ("get_artists", "lib_artists.json", MediaType.ARTIST, 19, True),
+        ("get_albums", "lib_albums.json", MediaType.ALBUM, 19, True),
+        ("get_tracks", "lib_tracks.json", MediaType.TRACK, 19, True),
+        ("get_playlists", "lib_playlists.json", MediaType.PLAYLIST, 19, False),
+    ],
+)
+async def test_library_listing_reports_missing_resource(
+    method_name: str,
+    fixture_name: str,
+    media_type: MediaType,
+    expected_count: int,
+    protect_exact_id: bool,
+    library_manager: TidalLibraryManager,
+    provider_mock: Mock,
+) -> None:
+    """Test a missing included resource does not look like a library deletion."""
+    raw = _load_raw(fixture_name)
+    broken_id = raw["data"][0]["id"]
+    raw["included"] = [
+        resource
+        for resource in raw["included"]
+        if not (resource["type"] == raw["data"][0]["type"] and resource["id"] == broken_id)
+    ]
+    doc = JsonApiDocument(raw)
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    items = [item async for item in getattr(library_manager, method_name)()]
+
+    assert len(items) == expected_count
+    skipped_media_type, skipped_id, err = provider_mock.report_skipped_sync_item.call_args.args
+    assert skipped_media_type == media_type
+    assert skipped_id == (broken_id if protect_exact_id else None)
+    assert isinstance(err, ValueError)
+
+
+@pytest.mark.parametrize(
     ("method_name", "fixture_name", "_media_type", "_expected_count"), _LIBRARY_READ_CASES
 )
 async def test_library_listing_fetch_failure_propagates(
@@ -244,7 +290,10 @@ async def test_library_listing_fetch_failure_propagates(
 
     with pytest.raises(ClientError):
         [item async for item in getattr(library_manager, method_name)()]
-    provider_mock.report_skipped_sync_item.assert_not_called()
+    assert all(
+        not isinstance(call.args[2], ClientError)
+        for call in provider_mock.report_skipped_sync_item.call_args_list
+    )
 
 
 _COLLECTION_CASES = [

--- a/tests/providers/tidal/test_library.py
+++ b/tests/providers/tidal/test_library.py
@@ -227,6 +227,35 @@ async def test_library_tracks_hold_cleanup_for_unparsable_replacement(
     assert isinstance(err, (AttributeError, KeyError, TypeError, ValueError))
 
 
+async def test_library_tracks_hold_cleanup_for_invalid_replacement_metadata(
+    library_manager: TidalLibraryManager, provider_mock: Mock
+) -> None:
+    """Test invalid replacement metadata cannot abort a track listing."""
+    raw = _load_raw("lib_tracks.json")
+    raw["data"][0]["meta"]["replacement"] = {
+        "status": "REPLACED",
+        "original": "invalid",
+    }
+    doc = JsonApiDocument(raw)
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+    provider_mock.note_replaced_track.side_effect = [
+        AttributeError("invalid replacement"),
+        *([None] * 19),
+    ]
+
+    tracks = [track async for track in library_manager.get_tracks()]
+
+    assert len(tracks) == 20
+    skipped_media_type, skipped_id, err = provider_mock.report_skipped_sync_item.call_args.args
+    assert skipped_media_type == MediaType.TRACK
+    assert skipped_id is None
+    assert isinstance(err, AttributeError)
+
+
 @pytest.mark.parametrize(
     ("method_name", "fixture_name", "media_type", "expected_count", "protect_exact_id"),
     [

--- a/tests/providers/tidal/test_library.py
+++ b/tests/providers/tidal/test_library.py
@@ -20,6 +20,22 @@ def _load_doc(name: str) -> JsonApiDocument:
         return JsonApiDocument(json.load(f))
 
 
+def _load_raw(name: str) -> dict[str, Any]:
+    with open(FIXTURES_DIR / name) as f:
+        data: dict[str, Any] = json.load(f)
+        return data
+
+
+def _break_resource(raw: dict[str, Any], resource_id: str) -> dict[str, Any]:
+    """Blank the name or title of one included resource so its parser rejects it."""
+    for resource in raw["included"]:
+        if resource["id"] == resource_id:
+            attributes = resource["attributes"]
+            attributes["name" if "name" in attributes else "title"] = None
+            return raw
+    raise AssertionError(f"resource {resource_id} not in fixture")
+
+
 @pytest.fixture
 def library_manager(provider_mock: Mock) -> TidalLibraryManager:
     """Return a TidalLibraryManager instance."""
@@ -89,6 +105,59 @@ async def test_get_playlists(library_manager: TidalLibraryManager, provider_mock
     # mixes come through the same collection with the "mix_" item id prefix
     assert any(p.item_id.startswith("mix_") for p in playlists)
     assert any(not p.item_id.startswith("mix_") for p in playlists[:-1])
+
+
+_LIBRARY_READ_CASES = [
+    ("get_artists", "lib_artists.json", 19),
+    ("get_albums", "lib_albums.json", 19),
+    ("get_tracks", "lib_tracks.json", 19),
+    ("get_playlists", "lib_playlists.json", 19),
+]
+
+
+@pytest.mark.parametrize(("method_name", "fixture_name", "expected_count"), _LIBRARY_READ_CASES)
+async def test_library_listing_skips_unparsable_item(
+    method_name: str,
+    fixture_name: str,
+    expected_count: int,
+    library_manager: TidalLibraryManager,
+    provider_mock: Mock,
+) -> None:
+    """Test one unusable item does not prevent later library items from being yielded."""
+    raw = _load_raw(fixture_name)
+    broken_id = raw["data"][0]["id"]
+    doc = JsonApiDocument(_break_resource(raw, broken_id))
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    items = [item async for item in getattr(library_manager, method_name)()]
+
+    assert len(items) == expected_count
+    assert all(item.item_id != broken_id for item in items)
+    provider_mock.logger.warning.assert_called_once()
+
+
+@pytest.mark.parametrize(("method_name", "fixture_name", "_expected_count"), _LIBRARY_READ_CASES)
+async def test_library_listing_fetch_failure_propagates(
+    method_name: str,
+    fixture_name: str,
+    _expected_count: int,
+    library_manager: TidalLibraryManager,
+    provider_mock: Mock,
+) -> None:
+    """Test a later page failure aborts the listing instead of returning partial results."""
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield _load_doc(fixture_name)
+        raise ClientError("connection lost")
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    with pytest.raises(ClientError):
+        [item async for item in getattr(library_manager, method_name)()]
 
 
 _COLLECTION_CASES = [

--- a/tests/providers/tidal/test_library.py
+++ b/tests/providers/tidal/test_library.py
@@ -108,17 +108,20 @@ async def test_get_playlists(library_manager: TidalLibraryManager, provider_mock
 
 
 _LIBRARY_READ_CASES = [
-    ("get_artists", "lib_artists.json", 19),
-    ("get_albums", "lib_albums.json", 19),
-    ("get_tracks", "lib_tracks.json", 19),
-    ("get_playlists", "lib_playlists.json", 19),
+    ("get_artists", "lib_artists.json", MediaType.ARTIST, 19),
+    ("get_albums", "lib_albums.json", MediaType.ALBUM, 19),
+    ("get_tracks", "lib_tracks.json", MediaType.TRACK, 19),
+    ("get_playlists", "lib_playlists.json", MediaType.PLAYLIST, 19),
 ]
 
 
-@pytest.mark.parametrize(("method_name", "fixture_name", "expected_count"), _LIBRARY_READ_CASES)
+@pytest.mark.parametrize(
+    ("method_name", "fixture_name", "media_type", "expected_count"), _LIBRARY_READ_CASES
+)
 async def test_library_listing_skips_unparsable_item(
     method_name: str,
     fixture_name: str,
+    media_type: MediaType,
     expected_count: int,
     library_manager: TidalLibraryManager,
     provider_mock: Mock,
@@ -137,13 +140,70 @@ async def test_library_listing_skips_unparsable_item(
 
     assert len(items) == expected_count
     assert all(item.item_id != broken_id for item in items)
-    provider_mock.logger.warning.assert_called_once()
+    provider_mock.logger.warning.assert_not_called()
+    skipped_media_type, skipped_id, err = provider_mock.report_skipped_sync_item.call_args.args
+    assert skipped_media_type == media_type
+    assert skipped_id == broken_id
+    assert isinstance(err, (AttributeError, KeyError, TypeError, ValueError))
 
 
-@pytest.mark.parametrize(("method_name", "fixture_name", "_expected_count"), _LIBRARY_READ_CASES)
+async def test_library_playlists_report_unparsable_mix_id(
+    library_manager: TidalLibraryManager, provider_mock: Mock
+) -> None:
+    """Test an unusable mix is protected under its prefixed library item ID."""
+    raw = _load_raw("lib_playlists.json")
+    mix = next(
+        resource
+        for resource in raw["included"]
+        if resource["type"] == "playlists" and resource["attributes"].get("playlistType") == "MIX"
+    )
+    broken_id = mix["id"]
+    doc = JsonApiDocument(_break_resource(raw, broken_id))
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    playlists = [item async for item in library_manager.get_playlists()]
+
+    assert all(item.item_id != f"mix_{broken_id}" for item in playlists)
+    skipped_media_type, skipped_id, err = provider_mock.report_skipped_sync_item.call_args.args
+    assert skipped_media_type == MediaType.PLAYLIST
+    assert skipped_id == f"mix_{broken_id}"
+    assert isinstance(err, (AttributeError, KeyError, TypeError, ValueError))
+
+
+async def test_library_playlists_hold_cleanup_when_item_type_is_unreadable(
+    library_manager: TidalLibraryManager, provider_mock: Mock
+) -> None:
+    """Test an unidentifiable playlist item holds cleanup without ending the listing."""
+    raw = _load_raw("lib_playlists.json")
+    playlist = next(resource for resource in raw["included"] if resource["type"] == "playlists")
+    playlist["attributes"] = None
+    doc = JsonApiDocument(raw)
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    playlists = [item async for item in library_manager.get_playlists()]
+
+    assert len(playlists) == 19
+    skipped_media_type, skipped_id, err = provider_mock.report_skipped_sync_item.call_args.args
+    assert skipped_media_type == MediaType.PLAYLIST
+    assert skipped_id is None
+    assert isinstance(err, AttributeError)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "fixture_name", "_media_type", "_expected_count"), _LIBRARY_READ_CASES
+)
 async def test_library_listing_fetch_failure_propagates(
     method_name: str,
     fixture_name: str,
+    _media_type: MediaType,
     _expected_count: int,
     library_manager: TidalLibraryManager,
     provider_mock: Mock,
@@ -158,6 +218,7 @@ async def test_library_listing_fetch_failure_propagates(
 
     with pytest.raises(ClientError):
         [item async for item in getattr(library_manager, method_name)()]
+    provider_mock.report_skipped_sync_item.assert_not_called()
 
 
 _COLLECTION_CASES = [

--- a/tests/providers/tidal/test_library.py
+++ b/tests/providers/tidal/test_library.py
@@ -197,6 +197,32 @@ async def test_library_playlists_hold_cleanup_when_item_type_is_unreadable(
     assert isinstance(err, AttributeError)
 
 
+async def test_library_tracks_hold_cleanup_for_unparsable_replacement(
+    library_manager: TidalLibraryManager, provider_mock: Mock
+) -> None:
+    """Test an unusable replacement track holds cleanup when its stored ID is ambiguous."""
+    raw = _load_raw("lib_tracks.json")
+    broken_id = raw["data"][0]["id"]
+    raw["data"][0]["meta"]["replacement"] = {
+        "status": "REPLACED",
+        "original": {"type": "tracks", "id": "stale_track_id"},
+    }
+    doc = JsonApiDocument(_break_resource(raw, broken_id))
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    tracks = [item async for item in library_manager.get_tracks()]
+
+    assert len(tracks) == 19
+    skipped_media_type, skipped_id, err = provider_mock.report_skipped_sync_item.call_args.args
+    assert skipped_media_type == MediaType.TRACK
+    assert skipped_id is None
+    assert isinstance(err, (AttributeError, KeyError, TypeError, ValueError))
+
+
 @pytest.mark.parametrize(
     ("method_name", "fixture_name", "_media_type", "_expected_count"), _LIBRARY_READ_CASES
 )

--- a/tests/providers/tidal/test_library.py
+++ b/tests/providers/tidal/test_library.py
@@ -270,6 +270,92 @@ async def test_library_listing_reports_missing_resource(
 
 
 @pytest.mark.parametrize(
+    ("method_name", "fixture_name", "media_type", "expected_count"), _LIBRARY_READ_CASES[:3]
+)
+async def test_library_listing_holds_cleanup_for_invalid_resource_id(
+    method_name: str,
+    fixture_name: str,
+    media_type: MediaType,
+    expected_count: int,
+    library_manager: TidalLibraryManager,
+    provider_mock: Mock,
+) -> None:
+    """Test an invalid resource ID holds cleanup when its identity is unknown."""
+    raw = _load_raw(fixture_name)
+    raw["data"][0]["id"] = ["invalid"]
+    doc = JsonApiDocument(raw)
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    items = [item async for item in getattr(library_manager, method_name)()]
+
+    assert len(items) == expected_count
+    skipped_media_type, skipped_id, err = provider_mock.report_skipped_sync_item.call_args.args
+    assert skipped_media_type == media_type
+    assert skipped_id is None
+    assert isinstance(err, (TypeError, ValueError))
+
+
+async def test_library_playlists_hold_cleanup_for_invalid_resource_id(
+    library_manager: TidalLibraryManager,
+    provider_mock: Mock,
+) -> None:
+    """Test an invalid resolved playlist ID holds cleanup."""
+    raw = _load_raw("lib_playlists.json")
+    original_id = raw["data"][0]["id"]
+    raw["data"][0]["id"] = 123
+    next(resource for resource in raw["included"] if resource["id"] == original_id)["id"] = 123
+    doc = JsonApiDocument(raw)
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    items = [item async for item in library_manager.get_playlists()]
+
+    assert len(items) == 19
+    skipped_media_type, skipped_id, err = next(
+        call.args
+        for call in provider_mock.report_skipped_sync_item.call_args_list
+        if isinstance(call.args[2], TypeError)
+    )
+    assert skipped_media_type == MediaType.PLAYLIST
+    assert skipped_id is None
+    assert isinstance(err, TypeError)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "fixture_name", "_media_type", "_expected_count"), _LIBRARY_READ_CASES
+)
+async def test_library_listing_ignores_invalid_date_added(
+    method_name: str,
+    fixture_name: str,
+    _media_type: MediaType,
+    _expected_count: int,
+    library_manager: TidalLibraryManager,
+    provider_mock: Mock,
+) -> None:
+    """Test invalid optional date metadata does not abort a library listing."""
+    raw = _load_raw(fixture_name)
+    raw["data"][0]["meta"]["addedAt"] = ["invalid"]
+    doc = JsonApiDocument(raw)
+
+    async def _pages(*_a: Any, **_k: Any) -> Any:
+        yield doc
+
+    provider_mock.api.paginate_jsonapi = _pages
+
+    items = [item async for item in getattr(library_manager, method_name)()]
+
+    assert len(items) == 20
+    assert items[0].date_added is None
+
+
+@pytest.mark.parametrize(
     ("method_name", "fixture_name", "_media_type", "_expected_count"), _LIBRARY_READ_CASES
 )
 async def test_library_listing_fetch_failure_propagates(

--- a/tests/providers/tidal/test_library.py
+++ b/tests/providers/tidal/test_library.py
@@ -282,7 +282,9 @@ async def test_library_listing_holds_cleanup_for_invalid_resource_id(
 ) -> None:
     """Test an invalid resource ID holds cleanup when its identity is unknown."""
     raw = _load_raw(fixture_name)
-    raw["data"][0]["id"] = ["invalid"]
+    original_id = raw["data"][0]["id"]
+    raw["data"][0]["id"] = 123
+    next(resource for resource in raw["included"] if resource["id"] == original_id)["id"] = 123
     doc = JsonApiDocument(raw)
 
     async def _pages(*_a: Any, **_k: Any) -> Any:


### PR DESCRIPTION
# What does this implement/fix?

A malformed item returned by Tidal could stop the entire library sync for that media type, leaving every later item unseen.

- Skip and log only individual items that cannot be parsed.
- Keep pagination and fetch errors propagating so incomplete syncs cannot trigger library cleanup.
- Share the existing guarded Tidal parser used by other media listings.

**Related issue (if applicable):**

- Follow-up to #5859

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
