### PR TITLE
Keep capture-only Sendspin devices out of groups

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -3279,7 +3279,8 @@ class Player(ABC):
 
         for member_id in self.can_group_with:
             if player := self.mass.players.get_player(member_id):
-                result.add(player)
+                if not player.private:
+                    result.add(player)
                 continue  # already a player ID
             # Check if member_id is a provider instance ID
             if provider := self.mass.get_provider(member_id):
@@ -3288,7 +3289,8 @@ class Player(ABC):
                     provider_filter=provider.instance_id,
                     return_protocol_players=True,
                 ):
-                    result.add(player)
+                    if not player.private:
+                        result.add(player)
         return result
 
     # The id of the (last) active mass source.

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -3279,7 +3279,7 @@ class Player(ABC):
 
         for member_id in self.can_group_with:
             if player := self.mass.players.get_player(member_id):
-                if not player.private:
+                if player.type != PlayerType.UNKNOWN:
                     result.add(player)
                 continue  # already a player ID
             # Check if member_id is a provider instance ID
@@ -3289,7 +3289,7 @@ class Player(ABC):
                     provider_filter=provider.instance_id,
                     return_protocol_players=True,
                 ):
-                    if not player.private:
+                    if player.type != PlayerType.UNKNOWN:
                         result.add(player)
         return result
 

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -317,7 +317,6 @@ class SendspinBasePlayer(Player):
         self.unsub_event_cb = None
         self.unsub_group_event_cb = None
         self.logger = self.provider.logger.getChild(player_id)
-        self._attr_can_group_with = {provider.instance_id}
         self._attr_power_control = PLAYER_CONTROL_NONE
         self._refresh_client_info(sendspin_client, hello_payload=initial_hello)
         self._subscribe_client_callbacks()
@@ -1119,6 +1118,7 @@ class SendspinPlayer(SendspinBasePlayer):
     ) -> None:
         """Initialize the Player."""
         super().__init__(provider, player_id, initial_hello)
+        self._attr_can_group_with = {provider.instance_id}
         hello_payload = initial_hello or self.api.info
         self.playback_session = SendspinPlaybackSession(self)
         self._attr_supported_features = {
@@ -2179,6 +2179,7 @@ class SendspinVisualizerPlayer(SendspinBasePlayer):
         :param initial_hello: Optional hello payload from the client.
         """
         super().__init__(provider, player_id, initial_hello)
+        self._attr_can_group_with = {provider.instance_id}
         self._attr_supported_features = {PlayerFeature.SET_MEMBERS}
 
     async def set_members(

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -338,8 +338,8 @@ class TestProviderInstanceIdExpansion:
         assert "player_b" in can_group
         assert "player_c" in can_group
 
-    def test_provider_instance_id_excludes_private_players(self, mock_mass: MagicMock) -> None:
-        """Test that private players are not offered as grouping targets."""
+    def test_provider_instance_id_excludes_unknown_players(self, mock_mass: MagicMock) -> None:
+        """Test that players without an output type are not offered as grouping targets."""
         controller = PlayerController(mock_mass)
         provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
         mock_mass.get_provider = MagicMock(return_value=provider)
@@ -352,12 +352,16 @@ class TestProviderInstanceIdExpansion:
         )
         leader._attr_can_group_with = {"test"}
         public_player = MockPlayer(provider, "public", "Public Player")
-        private_player = MockPlayer(provider, "private", "Private Player")
-        private_player._attr_private = True
+        unknown_player = MockPlayer(
+            provider,
+            "unknown",
+            "Unknown Player",
+            player_type=PlayerType.UNKNOWN,
+        )
         controller._players = {
             "leader": leader,
             "public": public_player,
-            "private": private_player,
+            "unknown": unknown_player,
         }
         mock_mass.players = controller
 
@@ -367,9 +371,9 @@ class TestProviderInstanceIdExpansion:
             player.update_state(signal_event=False)
 
         assert "public" in leader.state.can_group_with
-        assert "private" not in leader.state.can_group_with
+        assert "unknown" not in leader.state.can_group_with
 
-        leader._attr_can_group_with = {"private"}
+        leader._attr_can_group_with = {"unknown"}
         leader.update_state(signal_event=False, force_update=True)
 
         assert leader.state.can_group_with == set()

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -338,6 +338,42 @@ class TestProviderInstanceIdExpansion:
         assert "player_b" in can_group
         assert "player_c" in can_group
 
+    def test_provider_instance_id_excludes_private_players(self, mock_mass: MagicMock) -> None:
+        """Test that private players are not offered as grouping targets."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        mock_mass.get_provider = MagicMock(return_value=provider)
+
+        leader = MockPlayer(
+            provider,
+            "leader",
+            "Leader",
+            player_type=PlayerType.PROTOCOL,
+        )
+        leader._attr_can_group_with = {"test"}
+        public_player = MockPlayer(provider, "public", "Public Player")
+        private_player = MockPlayer(provider, "private", "Private Player")
+        private_player._attr_private = True
+        controller._players = {
+            "leader": leader,
+            "public": public_player,
+            "private": private_player,
+        }
+        mock_mass.players = controller
+
+        for player in controller._players.values():
+            player.set_initialized()
+        for player in controller._players.values():
+            player.update_state(signal_event=False)
+
+        assert "public" in leader.state.can_group_with
+        assert "private" not in leader.state.can_group_with
+
+        leader._attr_can_group_with = {"private"}
+        leader.update_state(signal_event=False, force_update=True)
+
+        assert leader.state.can_group_with == set()
+
 
 class TestFinalActiveGroupNewModel:
     """

--- a/tests/providers/sendspin/test_refresh_player.py
+++ b/tests/providers/sendspin/test_refresh_player.py
@@ -9,9 +9,12 @@ from unittest.mock import Mock
 import pytest
 from music_assistant_models.enums import PlayerType
 
+import music_assistant.providers.sendspin.player as player_module
 import music_assistant.providers.sendspin.provider as provider_module
+from music_assistant.models.player import Player
 from music_assistant.providers.sendspin.player import (
     SendspinBasePlayer,
+    SendspinPlayer,
     SendspinSourcePlayer,
     SendspinVisualizerPlayer,
 )
@@ -21,6 +24,7 @@ if TYPE_CHECKING:
     from aiosendspin.server.client import SendspinClient
 
     from music_assistant.mass import MusicAssistant
+    from music_assistant.models.player_provider import PlayerProvider
 
 
 def _make_provider(player: SendspinBasePlayer | None) -> SendspinProvider:
@@ -148,3 +152,36 @@ def test_player_classes_declare_their_privacy() -> None:
     assert SendspinVisualizerPlayer._attr_hidden_by_default is True
     assert SendspinVisualizerPlayer._attr_private is False
     assert SendspinSourcePlayer._attr_private is True
+
+
+def test_player_classes_advertise_grouping_by_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only Sendspin clients with an output role advertise grouping capability."""
+
+    def _init_player(self: Player, provider: PlayerProvider, player_id: str) -> None:
+        self._provider = provider
+        self._player_id = player_id
+        self._attr_can_group_with = set()
+
+    client = SimpleNamespace(info=SimpleNamespace(player_support=None))
+    provider = cast(
+        "SendspinProvider",
+        SimpleNamespace(
+            instance_id="sendspin--test",
+            logger=Mock(),
+            server_api=SimpleNamespace(get_client=Mock(return_value=client)),
+        ),
+    )
+    monkeypatch.setattr(Player, "__init__", _init_player)
+    monkeypatch.setattr(SendspinBasePlayer, "_refresh_client_info", Mock())
+    monkeypatch.setattr(SendspinBasePlayer, "_subscribe_client_callbacks", Mock())
+    monkeypatch.setattr(SendspinPlayer, "_refresh_client_info", Mock())
+    monkeypatch.setattr(SendspinPlayer, "_subscribe_client_callbacks", Mock())
+    monkeypatch.setattr(player_module, "SendspinPlaybackSession", Mock())
+
+    audio_player = SendspinPlayer(provider, "audio")
+    visualizer_player = SendspinVisualizerPlayer(provider, "visualizer")
+    source_player = SendspinSourcePlayer(provider, "source")
+
+    assert audio_player.can_group_with == {provider.instance_id}
+    assert visualizer_player.can_group_with == {provider.instance_id}
+    assert source_player.can_group_with == set()


### PR DESCRIPTION
# What does this implement/fix?

Capture-only Sendspin devices were advertised as grouping targets even though they cannot play audio.

- Advertise grouping only from Sendspin playback and visualizer roles.
- Exclude capture-only players from group-target expansion and direct grouping requests.
- Add regression coverage for provider-wide and explicit grouping targets.

**Related issue (if applicable):**

- Frontend workaround: https://github.com/music-assistant/frontend/pull/2591

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
