### PR TITLE
Keep Tidal lists loading past malformed items

### DIFF
--- a/music_assistant/providers/tidal/constants.py
+++ b/music_assistant/providers/tidal/constants.py
@@ -14,6 +14,14 @@ SESSIONS_URL = f"{BASE_URL}/sessions"
 # Official API (JSON:API)
 JSONAPI_CONTENT_TYPE = "application/vnd.api+json"
 
+# Item payload errors that make one resource unusable without invalidating its collection.
+SKIPPABLE_ITEM_ERRORS: Final[tuple[type[Exception], ...]] = (
+    AttributeError,
+    KeyError,
+    TypeError,
+    ValueError,
+)
+
 # Authentication
 AUTH_URL = "https://auth.tidal.com/v1/oauth2"
 # OAuth scopes requested for the device flow (read, write, subscription).

--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -13,7 +13,7 @@ from music_assistant_models.errors import (
 )
 from music_assistant_models.media_items import SearchResults
 
-from .constants import FAVORITE_TRACKS_PLAYLIST_ID, PAGES_MIX, PLAYLISTS
+from .constants import FAVORITE_TRACKS_PLAYLIST_ID, PAGES_MIX, PLAYLISTS, SKIPPABLE_ITEM_ERRORS
 from .parsers import (
     parse_favorite_tracks_playlist,
     parse_playlist,
@@ -352,7 +352,7 @@ class TidalMediaManager:
         """
         try:
             return parser(self.provider, doc, resource)
-        except (AttributeError, KeyError, TypeError, ValueError) as err:
+        except SKIPPABLE_ITEM_ERRORS as err:
             # Tidal sending one item in a shape its parser can not read must not discard
             # the rest of the collection. Log the traceback (on debug) as well, so a
             # parser bug caught here is still traceable to its origin.
@@ -372,7 +372,14 @@ class TidalMediaManager:
                 track = parse_track(self.provider, item)
                 track.position = offset + idx
                 result.append(track)
-            except KeyError, TypeError:
+            except SKIPPABLE_ITEM_ERRORS as err:
+                track_data = item.get("item", item) if isinstance(item, dict) else item
+                self.logger.warning(
+                    "Skipping Tidal track %s: %s",
+                    track_data.get("id", "[no id]") if isinstance(track_data, dict) else "[no id]",
+                    err,
+                    exc_info=err if self.logger.isEnabledFor(logging.DEBUG) else None,
+                )
                 continue
         return result
 

--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -302,7 +302,7 @@ class TidalMediaManager:
             # The mix feed is not itself paginated, so slice MA's page window in memory.
             paged_items = all_items[offset : offset + limit]
             return self._process_tracks(paged_items, offset)
-        except (ClientError, KeyError, ValueError) as err:
+        except (KeyError, ValueError) as err:
             raise MediaNotFoundError(f"Mix {mix_id} not found") from err
 
     async def _get_lyrics(self, prov_track_id: str) -> dict[str, str] | None:

--- a/music_assistant/providers/tidal/parsers.py
+++ b/music_assistant/providers/tidal/parsers.py
@@ -26,7 +26,12 @@ from music_assistant_models.media_items import (
 
 from music_assistant.helpers.util import infer_album_type, parse_title_and_version
 
-from .constants import BROWSE_URL, FAVORITE_TRACKS_PLAYLIST_ID, RESOURCES_URL
+from .constants import (
+    BROWSE_URL,
+    FAVORITE_TRACKS_PLAYLIST_ID,
+    RESOURCES_URL,
+    SKIPPABLE_ITEM_ERRORS,
+)
 
 if TYPE_CHECKING:
     from .provider import TidalProvider
@@ -108,7 +113,7 @@ def parse_album(provider: TidalProvider, album_obj: dict[str, Any]) -> Album:
             if artist_obj.get("name") == "Various Artists":
                 various_artist_album = True
             album.artists.append(parse_artist(provider, artist_obj))
-        except (KeyError, TypeError) as err:
+        except SKIPPABLE_ITEM_ERRORS as err:
             provider.logger.warning("Error parsing artist in album %s: %s", name, err)
 
     # Safely determine album type
@@ -210,7 +215,7 @@ def parse_track(
     for track_artist in track_obj_data.get("artists", []):
         try:
             artist = parse_artist(provider, track_artist)
-        except (KeyError, TypeError) as err:
+        except SKIPPABLE_ITEM_ERRORS as err:
             provider.logger.warning("Error parsing artist in track %s: %s", name, err)
             continue
         track.artists.append(artist)

--- a/music_assistant/providers/tidal/tidal_page_parser.py
+++ b/music_assistant/providers/tidal/tidal_page_parser.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import MediaType
 
-from .constants import CACHE_CATEGORY_RECOMMENDATIONS
+from .constants import CACHE_CATEGORY_RECOMMENDATIONS, SKIPPABLE_ITEM_ERRORS
 from .parsers import parse_album, parse_artist, parse_playlist, parse_track
 
 if TYPE_CHECKING:
@@ -145,7 +145,7 @@ class TidalPageParser:
                     playlist = parse_playlist(self.provider, item, is_mix=is_mix)
                     result.append(playlist)
                     type_counts[MediaType.PLAYLIST] += 1
-                except (KeyError, ValueError, TypeError) as err:
+                except SKIPPABLE_ITEM_ERRORS as err:
                     self.logger.warning("Error parsing playlist: %s", err)
 
     def _process_track_list(
@@ -161,7 +161,7 @@ class TidalPageParser:
                     track = parse_track(self.provider, item)
                     result.append(track)
                     type_counts[MediaType.TRACK] += 1
-                except (KeyError, ValueError, TypeError) as err:
+                except SKIPPABLE_ITEM_ERRORS as err:
                     self.logger.warning("Error parsing track: %s", err)
 
     def _process_album_list(
@@ -177,7 +177,7 @@ class TidalPageParser:
                     album = parse_album(self.provider, item)
                     result.append(album)
                     type_counts[MediaType.ALBUM] += 1
-                except (KeyError, ValueError, TypeError) as err:
+                except SKIPPABLE_ITEM_ERRORS as err:
                     self.logger.warning("Error parsing album: %s", err)
 
     def _process_artist_list(
@@ -193,7 +193,7 @@ class TidalPageParser:
                     artist = parse_artist(self.provider, item)
                     result.append(artist)
                     type_counts[MediaType.ARTIST] += 1
-                except (KeyError, ValueError, TypeError) as err:
+                except SKIPPABLE_ITEM_ERRORS as err:
                     self.logger.warning("Error parsing artist: %s", err)
 
     def _process_mix_list(
@@ -209,7 +209,7 @@ class TidalPageParser:
                     mix = parse_playlist(self.provider, item, is_mix=True)
                     result.append(mix)
                     type_counts[MediaType.PLAYLIST] += 1
-                except (KeyError, ValueError, TypeError) as err:
+                except SKIPPABLE_ITEM_ERRORS as err:
                     self.logger.warning("Error parsing mix: %s", err)
 
     def _process_generic_items(
@@ -226,7 +226,7 @@ class TidalPageParser:
                     parsed_item = self._parse_item(item, type_counts)
                     if parsed_item:
                         result.append(parsed_item)
-                except (KeyError, ValueError, TypeError) as err:
+                except SKIPPABLE_ITEM_ERRORS as err:
                     self.logger.warning("Error parsing generic item: %s", err)
 
     def _log_module_results(
@@ -374,11 +374,8 @@ class TidalPageParser:
             self.logger.warning("Unknown item type, could not parse: %s", item)
             return None
 
-        except (KeyError, ValueError, TypeError) as err:
+        except SKIPPABLE_ITEM_ERRORS as err:
             self.logger.debug("Error parsing %s item: %s", item_type, err)
-            return None
-        except AttributeError as err:
-            self.logger.debug("Attribute error parsing %s item: %s", item_type, err)
             return None
         except (json.JSONDecodeError, UnicodeError) as err:
             self.logger.debug("JSON/Unicode error parsing %s item: %s", item_type, err)

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -2,19 +2,26 @@
 
 import json
 import pathlib
-from typing import Any
+from typing import Any, cast
 from unittest.mock import Mock, patch
 
 import pytest
 from aiohttp.client_exceptions import ClientError
 from music_assistant_models.enums import MediaType
-from music_assistant_models.errors import MediaNotFoundError, RetriesExhausted
+from music_assistant_models.errors import (
+    LoginFailed,
+    MediaNotFoundError,
+    RateLimited,
+    ResourceTemporarilyUnavailable,
+    RetriesExhausted,
+)
 from music_assistant_models.media_items import Playlist
 
 from music_assistant.providers.tidal.jsonapi import JsonApiDocument
 from music_assistant.providers.tidal.media import TidalMediaManager
 
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures" / "v2"
+LEGACY_FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 
 
 def _load_raw(name: str) -> dict[str, Any]:
@@ -35,6 +42,21 @@ def _break_resource(raw: dict[str, Any], resource_id: str) -> dict[str, Any]:
             # artists carry a name where tracks and albums carry a title
             attributes["name" if "name" in attributes else "title"] = None
             return raw
+    raise AssertionError(f"resource {resource_id} not in fixture")
+
+
+def _corrupt_resource(
+    raw: dict[str, Any], resource_id: str, attribute: str | None, value: Any
+) -> dict[str, Any]:
+    """Corrupt one included resource in a fixture."""
+    for resource in raw["included"]:
+        if resource["id"] != resource_id:
+            continue
+        if attribute is None:
+            resource["attributes"] = value
+        else:
+            resource["attributes"][attribute] = value
+        return raw
     raise AssertionError(f"resource {resource_id} not in fixture")
 
 
@@ -213,11 +235,22 @@ async def test_get_album_tracks_skips_videos(
     assert all(track.item_id != "99999" for track in tracks)
 
 
+@pytest.mark.parametrize(
+    ("attribute", "value"),
+    [
+        (None, None),
+        ("copyright", "invalid"),
+        ("externalLinks", ["invalid"]),
+    ],
+    ids=["null-attributes", "string-copyright", "string-external-link"],
+)
 async def test_get_album_tracks_skips_unparsable_track(
-    media_manager: TidalMediaManager, provider_mock: Mock
+    attribute: str | None, value: Any, media_manager: TidalMediaManager, provider_mock: Mock
 ) -> None:
     """Test one unusable track does not take the rest of the album down with it."""
-    doc = JsonApiDocument(_break_resource(_load_raw("album_items.json"), "58756128"))
+    doc = JsonApiDocument(
+        _corrupt_resource(_load_raw("album_items.json"), "58756128", attribute, value)
+    )
 
     async def _pages(*_a: Any, **_k: Any) -> Any:
         yield doc
@@ -229,6 +262,85 @@ async def test_get_album_tracks_skips_unparsable_track(
     assert len(tracks) == 10
     assert all(track.item_id != "58756128" for track in tracks)
     provider_mock.logger.warning.assert_called_once()
+
+
+def test_process_tracks_skips_track_with_invalid_media_metadata(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test a malformed playlist track is skipped without dropping valid siblings."""
+    with open(LEGACY_FIXTURES_DIR / "tracks" / "track.json", encoding="utf-8") as f:
+        malformed = json.load(f)
+    malformed["item"]["mediaMetadata"] = "invalid"
+    valid = {
+        "id": 2,
+        "title": "Valid Track",
+        "duration": 120,
+        "artists": [{"id": 2, "name": "Valid Artist"}],
+    }
+
+    tracks = media_manager._process_tracks([malformed, valid], 0)
+
+    assert [track.item_id for track in tracks] == ["2"]
+    provider_mock.logger.warning.assert_called_once()
+
+
+def test_process_tracks_skips_track_with_invalid_item_wrapper(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test logging a malformed track wrapper does not abort the collection."""
+    valid = {
+        "id": 2,
+        "title": "Valid Track",
+        "duration": 120,
+        "artists": [{"id": 2, "name": "Valid Artist"}],
+    }
+
+    tracks = media_manager._process_tracks([{"item": "invalid"}, valid], 0)
+
+    assert [track.item_id for track in tracks] == ["2"]
+    provider_mock.logger.warning.assert_called_once()
+
+
+def test_process_tracks_skips_non_mapping_item(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test logging a non-mapping track does not abort the collection."""
+    invalid = cast("dict[str, Any]", None)
+    valid = {
+        "id": 2,
+        "title": "Valid Track",
+        "duration": 120,
+        "artists": [{"id": 2, "name": "Valid Artist"}],
+    }
+
+    tracks = media_manager._process_tracks([invalid, valid], 0)
+
+    assert [track.item_id for track in tracks] == ["2"]
+    provider_mock.logger.warning.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ClientError("connection lost"),
+        LoginFailed("login failed"),
+        RateLimited("rate limited", backoff_time=1),
+        ResourceTemporarilyUnavailable("temporarily unavailable"),
+        MediaNotFoundError("not found"),
+    ],
+    ids=lambda error: type(error).__name__,
+)
+@patch("music_assistant.providers.tidal.media.parse_track")
+def test_process_tracks_propagates_fetch_errors(
+    mock_parse_track: Mock,
+    error: Exception,
+    media_manager: TidalMediaManager,
+) -> None:
+    """Test fetch-level errors are never treated as skippable item errors."""
+    mock_parse_track.side_effect = error
+
+    with pytest.raises(type(error)):
+        media_manager._process_tracks([{"id": "1"}], 0)
 
 
 async def test_get_album_tracks_keeps_tracks_from_earlier_pages(

--- a/tests/providers/tidal/test_media_extended.py
+++ b/tests/providers/tidal/test_media_extended.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from aiohttp.client_exceptions import ClientError
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MediaNotFoundError
 
@@ -131,6 +132,16 @@ async def test_get_mix_details_no_rows(
     provider_mock.api.get.return_value = {"rows": []}
 
     with pytest.raises(MediaNotFoundError, match="Mix 123 has no tracks"):
+        await media_manager.get_playlist_tracks("mix_123")
+
+
+async def test_get_mix_tracks_fetch_failure_propagates(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test a mix fetch failure is raised instead of reported as missing."""
+    provider_mock.api.get.side_effect = ClientError("connection lost")
+
+    with pytest.raises(ClientError):
         await media_manager.get_playlist_tracks("mix_123")
 
 

--- a/tests/providers/tidal/test_page_parser.py
+++ b/tests/providers/tidal/test_page_parser.py
@@ -44,3 +44,26 @@ def test_page_parser(example: pathlib.Path, provider_mock: Mock) -> None:
     assert content_type == MediaType.PLAYLIST
     assert len(items) == 1
     assert items[0].name == "My Mix"
+
+
+def test_track_list_skips_unparsable_track(provider_mock: Mock) -> None:
+    """Test a malformed track does not prevent loading the rest of a page module."""
+    with open(FIXTURES_DIR / "tracks" / "track.json") as f:
+        malformed = json.load(f)
+    malformed["item"]["mediaMetadata"] = "invalid"
+    with open(FIXTURES_DIR / "tracks" / "track.json") as f:
+        valid = json.load(f)
+
+    parser = TidalPageParser(provider_mock)
+    module_info = {
+        "raw_data": {
+            "type": "TRACK_LIST",
+            "pagedList": {"items": [malformed, valid]},
+        }
+    }
+
+    items, content_type = parser.get_module_items(module_info)
+
+    assert content_type == MediaType.TRACK
+    assert len(items) == 1
+    provider_mock.logger.warning.assert_called_once()

--- a/tests/providers/tidal/test_parsers.py
+++ b/tests/providers/tidal/test_parsers.py
@@ -90,3 +90,15 @@ def test_parse_track_partial_album(provider_mock: Mock) -> None:
     track_obj["album"] = {"title": "Test Album"}
     track = parse_track(provider_mock, track_obj)
     assert track.album is None
+
+
+def test_parse_track_skips_artist_with_null_name(provider_mock: Mock) -> None:
+    """Test a malformed artist does not prevent parsing the containing track."""
+    with open(TRACK_FIXTURES[0], encoding="utf-8") as f:
+        data = json.load(f)
+    data["item"]["artists"][0]["name"] = None
+
+    track = parse_track(provider_mock, data)
+
+    assert track.artists == []
+    provider_mock.logger.warning.assert_called_once()


### PR DESCRIPTION
# What does this implement/fix?

Tidal used different parser error guards for the same collection behavior, so malformed artists or tracks could still stop an entire list from loading.

- Share one definition for skippable item parsing errors.
- Apply it to official and unofficial Tidal list paths.
- Log skipped playlist and mix tracks while preserving fetch-level errors.
- Cover malformed real-world payload shapes and error propagation.

**Related issue (if applicable):**

- Follow-up to #5859

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.