### PR TITLE
Honor playback speed in the visualizer tap and cancel stale beat hydration

### DIFF
--- a/music_assistant/providers/milkdrop_visualizer/tap.py
+++ b/music_assistant/providers/milkdrop_visualizer/tap.py
@@ -199,10 +199,16 @@ class TrackCursor:
     # Samples left over from the previous chunk, and the media time they start at.
     carry: np.ndarray
     carry_media: float
+    # Media seconds per wall-clock second (atempo, audiobooks/podcasts).
+    speed: float = 1.0
 
     def playhead(self) -> float:
         """Return where the anchor says the audible playhead is now, in media seconds."""
-        return (server_now_us() - self.anchor_us) / 1_000_000
+        return (server_now_us() - self.anchor_us) / 1_000_000 * self.speed
+
+    def media_to_clock_us(self, media_seconds: float) -> int:
+        """Return the clock time at which a media position becomes audible."""
+        return self.anchor_us + int(media_seconds / self.speed * 1_000_000)
 
 
 class Tap:
@@ -260,6 +266,10 @@ class Tap:
 
     def reset(self, message: str) -> None:
         """Drop everything scheduled from a timeline that no longer applies."""
+        # a hydration still in flight would land beats for that dead timeline
+        if self.beats_task is not None:
+            self.beats_task.cancel()
+            self.beats_task = None
         self.ring.clear()
         self.beats.clear()
         self.fan_out(message)
@@ -382,7 +392,9 @@ class TapManager:
             tap.realign_requested = False
             if queue.corrected_elapsed_time >= buffer.first_buffered_chunk:
                 cursor = None
-        cursor = self._align(tap, cursor, item, queue.corrected_elapsed_time, buffer)
+        cursor = self._align(
+            tap, cursor, item, queue.corrected_elapsed_time, buffer, queue.playback_speed
+        )
         # Stay ahead of the listener, but never behind the buffer's retained
         # window: a rolling (radio) buffer discards as playback consumes it, and
         # what it is about to drop is the last chance to read that audio.
@@ -429,23 +441,27 @@ class TapManager:
         item: QueueItem,
         playhead: float,
         buffer: AudioBuffer,
+        speed: float = 1.0,
     ) -> TrackCursor:
         """
         Return a cursor whose timeline still matches what the player is playing.
 
-        A new track, a seek, or a resume re-anchors the media timeline to the
-        relay clock; so does falling behind the buffer's retained window.
+        A new track, a seek, a resume or a speed change re-anchors the media
+        timeline to the relay clock; so does falling behind the buffer's
+        retained window.
 
         :param tap: The tap being fed.
         :param cursor: The cursor in use, if the tap already has one.
         :param item: The queue item now playing.
         :param playhead: Media position the queue reports for it, in seconds.
         :param buffer: The item's PCM buffer.
+        :param speed: Playback speed the queue plays the item at.
         """
         oldest = buffer.first_buffered_chunk
         if (
             cursor is not None
             and cursor.item_id == item.queue_item_id
+            and cursor.speed == speed
             and cursor.next_chunk >= oldest
             and abs(cursor.playhead() - playhead) <= RESYNC_THRESHOLD_SECONDS
         ):
@@ -453,13 +469,14 @@ class TapManager:
         start_chunk = max(int(max(0.0, playhead)), oldest)
         cursor = TrackCursor(
             item_id=item.queue_item_id,
-            anchor_us=server_now_us() - int(playhead * 1_000_000),
+            anchor_us=server_now_us() - int(playhead / speed * 1_000_000),
             next_chunk=start_chunk,
             carry=np.zeros(0, dtype=np.float32),
             carry_media=float(start_chunk),
+            speed=speed,
         )
         tap.reset('{"type": "stream/clear"}')
-        self._schedule_beats(tap, item, cursor.anchor_us)
+        self._schedule_beats(tap, item, cursor.anchor_us, speed)
         return cursor
 
     def _emit_chunk(
@@ -481,9 +498,7 @@ class TapManager:
             quantized = np.rint(np.clip(window, -1.0, 1.0) * 127.0 + 128.0).astype(np.uint8)
             # stamped at the end of the window, the instant it finishes sounding
             end_media = cursor.carry_media + offset / sample_rate
-            frame = pack_wave_frame(
-                cursor.anchor_us + int(end_media * 1_000_000), quantized.tobytes()
-            )
+            frame = pack_wave_frame(cursor.media_to_clock_us(end_media), quantized.tobytes())
             tap.ring.append(frame)
             tap.fan_out(frame)
         cursor.carry = mono[offset:].copy()
@@ -500,7 +515,9 @@ class TapManager:
         if payload != tap.last_color:
             tap.apply_color(payload)
 
-    def _schedule_beats(self, tap: Tap, item: QueueItem, anchor_us: int) -> None:
+    def _schedule_beats(
+        self, tap: Tap, item: QueueItem, anchor_us: int, speed: float = 1.0
+    ) -> None:
         """
         (Re)build a tap's beat schedule for a track.
 
@@ -510,17 +527,20 @@ class TapManager:
         :param tap: The tap to fan the beats out to.
         :param item: The queue item now playing.
         :param anchor_us: Clock time of that item's media time zero.
+        :param speed: Playback speed the queue plays the item at.
         """
         if tap.beats_analysis is not None and tap.beats_analysis[0] == item.queue_item_id:
-            self._fan_out_beats(tap, tap.beats_analysis[1], anchor_us)
+            self._fan_out_beats(tap, tap.beats_analysis[1], anchor_us, speed)
             return
         tap.beats_task = self.mass.create_task(
-            self._hydrate_beats(tap, item, anchor_us),
+            self._hydrate_beats(tap, item, anchor_us, speed),
             task_id=f"milkdrop_beats_{tap.player_id}",
             abort_existing=True,
         )
 
-    async def _hydrate_beats(self, tap: Tap, item: QueueItem, anchor_us: int) -> None:
+    async def _hydrate_beats(
+        self, tap: Tap, item: QueueItem, anchor_us: int, speed: float = 1.0
+    ) -> None:
         """Wait for a track's beat analysis and schedule the beats that are still ahead."""
         streamdetails = item.streamdetails
         if streamdetails is None:
@@ -543,22 +563,25 @@ class TapManager:
             self.logger.debug("No beat analysis for %s", streamdetails.uri)
             return
         tap.beats_analysis = (item.queue_item_id, analysis)
-        self._fan_out_beats(tap, analysis, anchor_us)
+        self._fan_out_beats(tap, analysis, anchor_us, speed)
 
-    def _fan_out_beats(self, tap: Tap, analysis: AudioAnalysisData, anchor_us: int) -> None:
+    def _fan_out_beats(
+        self, tap: Tap, analysis: AudioAnalysisData, anchor_us: int, speed: float = 1.0
+    ) -> None:
         """
         Schedule the analysis beats that are still ahead and fan them out.
 
         :param tap: The tap to fan the beats out to.
         :param analysis: The beat analysis of the item now playing.
         :param anchor_us: Clock time of that item's media time zero.
+        :param speed: Playback speed the queue plays the item at.
         """
         beats = analysis.beats or ()
         downbeats = {float(value) for value in analysis.downbeats or ()}
         now_us = server_now_us()
         scheduled = 0
         for beat in beats:
-            timestamp_us = anchor_us + int(float(beat) * 1_000_000)
+            timestamp_us = anchor_us + int(float(beat) / speed * 1_000_000)
             if timestamp_us <= now_us:
                 continue
             frame = pack_beat_frame(timestamp_us, float(beat) in downbeats)

--- a/music_assistant/providers/milkdrop_visualizer/tap.py
+++ b/music_assistant/providers/milkdrop_visualizer/tap.py
@@ -54,6 +54,8 @@ LEAD_SECONDS = 5.0
 # it that means the audio moved (a seek) rather than the player simply reporting
 # its position coarsely. Well above the ~1s quantization of the coarsest
 # reporters (DLNA), whose jitter would otherwise restart the frame flow.
+# Scaled by playback speed where compared: report jitter lives in wall-clock
+# time and inflates by the speed factor on its way into media time.
 RESYNC_THRESHOLD_SECONDS = 3.0
 # Poll interval while there is nothing to read: idle player, or the tap having
 # read as far ahead as it may.
@@ -463,7 +465,7 @@ class TapManager:
             and cursor.item_id == item.queue_item_id
             and cursor.speed == speed
             and cursor.next_chunk >= oldest
-            and abs(cursor.playhead() - playhead) <= RESYNC_THRESHOLD_SECONDS
+            and abs(cursor.playhead() - playhead) <= RESYNC_THRESHOLD_SECONDS * speed
         ):
             return cursor
         start_chunk = max(int(max(0.0, playhead)), oldest)

--- a/tests/providers/milkdrop_visualizer/test_tap.py
+++ b/tests/providers/milkdrop_visualizer/test_tap.py
@@ -187,6 +187,38 @@ def test_align_starts_inside_the_retained_window() -> None:
     assert cursor.next_chunk == 90
 
 
+def test_playhead_tracks_playback_speed() -> None:
+    """At 2x, media time advances two seconds per wall-clock second from the anchor."""
+    cursor = _cursor(anchor_us=server_now_us() - 10_000_000)
+    cursor.speed = 2.0
+    assert abs(cursor.playhead() - 20.0) < 0.1
+    # and the inverse mapping stamps media second 20 at (roughly) now
+    assert abs(cursor.media_to_clock_us(20.0) - server_now_us()) < 100_000
+
+
+def test_align_keeps_a_speed_aware_cursor_in_step() -> None:
+    """A cursor anchored at 2x stays matched against a queue advancing in media-time."""
+    manager = _manager()
+    tap = Tap("player-1")
+    item = Mock(queue_item_id="item-1")
+    buffer = Mock(first_buffered_chunk=0)
+    cursor = manager._align(tap, None, item, 10.0, buffer, 2.0)
+    assert cursor.speed == 2.0
+    assert manager._align(tap, cursor, item, 10.0, buffer, 2.0) is cursor
+
+
+def test_align_re_anchors_on_a_speed_change() -> None:
+    """A playback speed change remaps media time to the clock, so the cursor restarts."""
+    manager = _manager()
+    tap = Tap("player-1")
+    item = Mock(queue_item_id="item-1")
+    buffer = Mock(first_buffered_chunk=0)
+    cursor = manager._align(tap, None, item, 10.0, buffer)
+    new_cursor = manager._align(tap, cursor, item, 10.0, buffer, 1.5)
+    assert new_cursor is not cursor
+    assert new_cursor.speed == 1.5
+
+
 def _beats_manager() -> TapManager:
     """Return a tap manager with the real beat scheduling in place."""
     provider = Mock()
@@ -209,6 +241,25 @@ def test_schedule_beats_rebuilds_from_cached_analysis() -> None:
     # the downbeat flag survives the rebuild
     assert tap.beats[0][1][9] == 1
     assert tap.beats[1][1][9] == 0
+
+
+def test_fan_out_beats_scales_media_time_by_speed() -> None:
+    """At 2x a beat at media second 2 sounds one wall-clock second after the anchor."""
+    manager = _beats_manager()
+    tap = Tap("player-1")
+    anchor_us = server_now_us()
+    manager._fan_out_beats(tap, AudioAnalysisData(beats=[2.0]), anchor_us, 2.0)
+    assert [timestamp_us for timestamp_us, _ in tap.beats] == [anchor_us + 1_000_000]
+
+
+def test_reset_cancels_an_in_flight_beat_hydration() -> None:
+    """A timeline reset stops a pending hydration from landing beats for a dead track."""
+    tap = Tap("player-1")
+    task = Mock()
+    tap.beats_task = task
+    tap.reset('{"type": "stream/end"}')
+    task.cancel.assert_called_once()
+    assert tap.beats_task is None
 
 
 def test_schedule_beats_does_not_serve_another_item_from_cache() -> None:
@@ -250,7 +301,7 @@ async def test_read_once_realigns_when_requested() -> None:
     manager = _manager()
     manager.provider.config.get_value.return_value = False  # type: ignore[attr-defined]
     tap = Tap("player-1")
-    queue = Mock(corrected_elapsed_time=100.0)
+    queue = Mock(corrected_elapsed_time=100.0, playback_speed=1.0)
     item = Mock(queue_item_id="item-1")
     buffer = Mock(first_buffered_chunk=0, pcm_format=PCM_FORMAT)
     buffer.read_chunk_for_analysis = AsyncMock(return_value=_stereo_pcm([0] * 44100))
@@ -271,7 +322,7 @@ async def test_read_once_ignores_realign_when_playhead_chunk_is_evicted() -> Non
     manager.provider.config.get_value.return_value = False  # type: ignore[attr-defined]
     tap = Tap("player-1")
     tap.ring.append(b"frame")
-    queue = Mock(corrected_elapsed_time=100.0)
+    queue = Mock(corrected_elapsed_time=100.0, playback_speed=1.0)
     item = Mock(queue_item_id="item-1")
     buffer = Mock(first_buffered_chunk=200, pcm_format=PCM_FORMAT)
     buffer.read_chunk_for_analysis = AsyncMock(return_value=_stereo_pcm([0] * 44100))

--- a/tests/providers/milkdrop_visualizer/test_tap.py
+++ b/tests/providers/milkdrop_visualizer/test_tap.py
@@ -207,6 +207,19 @@ def test_align_keeps_a_speed_aware_cursor_in_step() -> None:
     assert manager._align(tap, cursor, item, 10.0, buffer, 2.0) is cursor
 
 
+def test_align_scales_the_resync_threshold_by_speed() -> None:
+    """At 2x, report jitter inflates by the speed factor, so the threshold grows with it."""
+    manager = _manager()
+    tap = Tap("player-1")
+    item = Mock(queue_item_id="item-1")
+    buffer = Mock(first_buffered_chunk=0)
+    cursor = manager._align(tap, None, item, 10.0, buffer, 2.0)
+    # a 5s media-time gap is within the scaled 6s threshold, not a seek
+    assert manager._align(tap, cursor, item, 15.0, buffer, 2.0) is cursor
+    # beyond the scaled threshold it is a seek and re-anchors
+    assert manager._align(tap, cursor, item, 17.0, buffer, 2.0) is not cursor
+
+
 def test_align_re_anchors_on_a_speed_change() -> None:
     """A playback speed change remaps media time to the clock, so the cursor restarts."""
     manager = _manager()


### PR DESCRIPTION
# What does this implement/fix?

Fixes two issues in the MilkDrop visualizer tap, flagged by Copilot on the post-merge review of #5864:

**Playback speed.** The tap mapped media time to the relay clock at a fixed 1x, but queues advance `corrected_elapsed_time` at `playback_speed` media-seconds per wall second (audiobooks/podcasts, 0.5x to 3x via atempo). At 2x the drift crossed the 3s resync threshold every ~3 seconds, fanning `stream/clear` to every viewer on that cadence, with frame and beat stamps progressively off in between. The cursor now carries the queue's speed: the anchor, `playhead()`, waveform frame stamps and beat stamps all map through it, and a speed change re-anchors. Chunk indexing needed no changes: the analysis buffer stores raw pre-atempo PCM, so chunk N is still media second N.

**Stale beats.** `Tap.reset()` did not cancel an in-flight beat hydration, so a track stopped during the retry window (up to ~90s) could still land beats for the dead timeline and replay them to newly attaching viewers. The reset now cancels the task; `_align` reschedules right after, so resume behavior is unchanged apart from the hydration restarting (a DB read, and the `beats_analysis` cache still short-circuits it).

At 1x every changed expression reduces exactly to the previous arithmetic, so music playback is untouched. Not present on `stable`, so no backport label.

**Related issue (if applicable):**

- n/a (found in post-merge review of #5864)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a)
