### PR TITLE
Stop Cast disconnects from reporting a false error

### DIFF
--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -15,7 +15,7 @@ from pychromecast.const import CAST_TYPE_CHROMECAST
 from pychromecast.socket_client import CONNECTION_STATUS_CONNECTED, CONNECTION_STATUS_LOST
 
 from .constants import MASS_APP_ID
-from .helpers import send_hide_dashboard, send_show_dashboard
+from .helpers import disconnect_no_wait, send_hide_dashboard, send_show_dashboard
 from .player import ChromecastPlayer
 
 if TYPE_CHECKING:
@@ -94,8 +94,7 @@ class ChromecastDashboards:
         if unregister_callback := self._unregister_callbacks.pop(device_id, None):
             unregister_callback()
         if chromecast := self._dashboard_connections.pop(device_id, None):
-            # non-blocking: close the socket, the daemon thread exits on its own
-            chromecast.disconnect(0)
+            disconnect_no_wait(chromecast)
         self._drop_active_cast(device_id)
 
     async def unload(self) -> None:
@@ -112,9 +111,7 @@ class ChromecastDashboards:
         self._dashboard_connections.clear()
         for chromecast in dashboard_connections:
             if self.mass.closing:
-                # Non-blocking disconnect: close socket, don't wait for thread.
-                # Socket threads are daemon threads and die on process exit.
-                chromecast.disconnect(0)
+                disconnect_no_wait(chromecast)
             else:
                 await self.mass.loop.run_in_executor(None, chromecast.disconnect, 10)
 
@@ -228,7 +225,7 @@ class ChromecastDashboards:
             )
             chromecast.wait(timeout=DASHBOARD_CONNECT_TIMEOUT)
             if not chromecast.socket_client.is_connected:
-                chromecast.disconnect(0)
+                disconnect_no_wait(chromecast)
                 msg = f"Timed out connecting to Cast device: {disc_info.friendly_name}"
                 raise PlayerUnavailableError(msg)
             return chromecast
@@ -284,8 +281,7 @@ class ChromecastDashboards:
         self.mass.dashboard.end_session(f"chromecast_{device_id}", reason)
 
         if chromecast := self._dashboard_connections.pop(device_id, None):
-            # non-blocking: close the socket, the daemon thread exits on its own
-            chromecast.disconnect(0)
+            disconnect_no_wait(chromecast)
 
     def _cancel_loss_timer(self, device_id: str) -> None:
         """Cancel the pending connection-loss timer for device_id, if any."""

--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import functools
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
@@ -234,9 +233,14 @@ class ChromecastDashboards:
             chromecast = pychromecast.get_chromecast_from_cast_info(
                 disc_info, self.mass.discovery.aiozc.zeroconf
             )
-            with contextlib.suppress(RequestTimeout):
+            try:
                 chromecast.wait(timeout=DASHBOARD_CONNECT_TIMEOUT)
-            if not chromecast.socket_client.is_connected:
+                # the socket is reported as connected from the handshake onwards, so it
+                # only tells us the device is still reachable now that it has reported in
+                ready = chromecast.socket_client.is_connected
+            except RequestTimeout:
+                ready = False
+            if not ready:
                 disconnect_no_wait(chromecast)
                 msg = f"Timed out connecting to Cast device: {disc_info.friendly_name}"
                 raise PlayerUnavailableError(msg)

--- a/music_assistant/providers/chromecast/dashboard.py
+++ b/music_assistant/providers/chromecast/dashboard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import functools
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
@@ -12,10 +13,16 @@ from music_assistant_models.dashboard import DashboardDevice
 from music_assistant_models.enums import DashboardType
 from music_assistant_models.errors import PlayerUnavailableError
 from pychromecast.const import CAST_TYPE_CHROMECAST
+from pychromecast.error import RequestTimeout
 from pychromecast.socket_client import CONNECTION_STATUS_CONNECTED, CONNECTION_STATUS_LOST
 
 from .constants import MASS_APP_ID
-from .helpers import disconnect_no_wait, send_hide_dashboard, send_show_dashboard
+from .helpers import (
+    disconnect_and_wait,
+    disconnect_no_wait,
+    send_hide_dashboard,
+    send_show_dashboard,
+)
 from .player import ChromecastPlayer
 
 if TYPE_CHECKING:
@@ -113,7 +120,9 @@ class ChromecastDashboards:
             if self.mass.closing:
                 disconnect_no_wait(chromecast)
             else:
-                await self.mass.loop.run_in_executor(None, chromecast.disconnect, 10)
+                await self.mass.loop.run_in_executor(
+                    None, disconnect_and_wait, chromecast, self.logger, 10
+                )
 
     def _register_device(self, device_id: str, cast_info: CastInfo) -> None:
         """Build a DashboardDevice for device_id and (re-)register it with the controller."""
@@ -198,7 +207,9 @@ class ChromecastDashboards:
         # only tear down a connection we opened on-demand; never an active player's own cc
         on_demand = self._dashboard_connections.pop(device_id, None)
         if on_demand is not None:
-            await self.mass.loop.run_in_executor(None, on_demand.disconnect, 10)
+            await self.mass.loop.run_in_executor(
+                None, disconnect_and_wait, on_demand, self.logger, 10
+            )
 
     async def _get_or_create_chromecast(self, device_id: str) -> pychromecast.Chromecast:
         """Resolve a device_id to a connected Chromecast, reusing an existing connection."""
@@ -223,7 +234,8 @@ class ChromecastDashboards:
             chromecast = pychromecast.get_chromecast_from_cast_info(
                 disc_info, self.mass.discovery.aiozc.zeroconf
             )
-            chromecast.wait(timeout=DASHBOARD_CONNECT_TIMEOUT)
+            with contextlib.suppress(RequestTimeout):
+                chromecast.wait(timeout=DASHBOARD_CONNECT_TIMEOUT)
             if not chromecast.socket_client.is_connected:
                 disconnect_no_wait(chromecast)
                 msg = f"Timed out connecting to Cast device: {disc_info.friendly_name}"

--- a/music_assistant/providers/chromecast/helpers.py
+++ b/music_assistant/providers/chromecast/helpers.py
@@ -20,6 +20,8 @@ from music_assistant.constants import VERBOSE_LOG_LEVEL
 from .constants import DASHBOARD_NAMESPACE, MASS_APP_ID
 
 if TYPE_CHECKING:
+    from logging import Logger
+
     from pychromecast import Chromecast
     from pychromecast.controllers.media import MediaStatus, MediaStatusListener
     from pychromecast.controllers.multizone import MultizoneManager, MultiZoneManagerListener
@@ -46,6 +48,23 @@ def disconnect_no_wait(chromecast: Chromecast) -> None:
     # to report.
     with contextlib.suppress(TimeoutError):
         chromecast.disconnect(0)
+
+
+def disconnect_and_wait(chromecast: Chromecast, logger: Logger, timeout: float) -> None:
+    """
+    Close the socket connection to a Cast device and wait for its thread to exit.
+
+    :param chromecast: Cast connection to close.
+    :param logger: Logger to report a socket thread that outlives the wait.
+    :param timeout: Seconds to wait for the socket thread to exit.
+    """
+    try:
+        chromecast.disconnect(timeout)
+    except TimeoutError:
+        # a lingering daemon thread blocks nothing, so this must not fail the teardown
+        logger.warning(
+            "Socket thread for %s did not exit within %s seconds", chromecast.name, timeout
+        )
 
 
 def send_show_dashboard(

--- a/music_assistant/providers/chromecast/helpers.py
+++ b/music_assistant/providers/chromecast/helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import threading
 import time
 import urllib.error
@@ -32,6 +33,19 @@ if TYPE_CHECKING:
 
 DEFAULT_PORT = 8009
 DASHBOARD_NAMESPACE_POLL_INTERVAL = 0.1
+
+
+def disconnect_no_wait(chromecast: Chromecast) -> None:
+    """
+    Close the socket connection to a Cast device without waiting for its thread to exit.
+
+    :param chromecast: Cast connection to close.
+    """
+    # pychromecast closes the socket and then reports the skipped wait as a TimeoutError.
+    # The socket thread is a daemon thread that winds down on its own, so there is nothing
+    # to report.
+    with contextlib.suppress(TimeoutError):
+        chromecast.disconnect(0)
 
 
 def send_show_dashboard(

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -45,7 +45,7 @@ from .constants import (
     MASS_APP_ID,
     SENDSPIN_CAST_APP_ID,
 )
-from .helpers import CastStatusListener, ChromecastInfo
+from .helpers import CastStatusListener, ChromecastInfo, disconnect_no_wait
 
 if TYPE_CHECKING:
     from pychromecast import Chromecast
@@ -291,10 +291,8 @@ class ChromecastPlayer(Player):
         self.status_listener = None
         self.logger.debug("Disconnecting from chromecast socket %s", self.display_name)
         if self.mass.closing:
-            # Non-blocking disconnect: close socket, don't wait for thread.
-            # Socket threads are daemon threads and die on process exit.
             # Blocking disconnect can stall shutdown if threads are slow to exit.
-            self.cc.disconnect(0)
+            disconnect_no_wait(self.cc)
         else:
             await asyncio.to_thread(self.cc.disconnect, 10)
 

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -45,7 +45,7 @@ from .constants import (
     MASS_APP_ID,
     SENDSPIN_CAST_APP_ID,
 )
-from .helpers import CastStatusListener, ChromecastInfo, disconnect_no_wait
+from .helpers import CastStatusListener, ChromecastInfo, disconnect_and_wait, disconnect_no_wait
 
 if TYPE_CHECKING:
     from pychromecast import Chromecast
@@ -294,7 +294,7 @@ class ChromecastPlayer(Player):
             # Blocking disconnect can stall shutdown if threads are slow to exit.
             disconnect_no_wait(self.cc)
         else:
-            await asyncio.to_thread(self.cc.disconnect, 10)
+            await asyncio.to_thread(disconnect_and_wait, self.cc, self.logger, 10)
 
     ### Callbacks from Chromecast Statuslistener
 

--- a/tests/providers/chromecast/conftest.py
+++ b/tests/providers/chromecast/conftest.py
@@ -1,0 +1,62 @@
+"""Shared fixtures for the chromecast provider tests."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Iterator
+
+import pychromecast
+import pytest
+
+
+class FakeSocketClient(threading.Thread):
+    """A Cast socket client thread that stays alive, as a real one does right after disconnect()."""
+
+    def __init__(self, released: threading.Event) -> None:
+        """Initialize with the event that lets the thread finish."""
+        super().__init__(daemon=True)
+        self._released = released
+        self.is_connected = False
+        self.disconnect_called = False
+
+    def run(self) -> None:
+        """Stay alive until the test releases the thread."""
+        self._released.wait(10)
+
+    def disconnect(self) -> None:
+        """Signal the socket thread to stop, as the real client does."""
+        self.disconnect_called = True
+
+
+class FakeChromecast:
+    """Cast connection running pychromecast's real disconnect/join over a live socket thread."""
+
+    disconnect = pychromecast.Chromecast.disconnect
+    join = pychromecast.Chromecast.join
+
+    def __init__(self, socket_client: FakeSocketClient) -> None:
+        """Initialize with the socket client this connection runs on."""
+        self.socket_client = socket_client
+
+    def wait(self, timeout: float | None = None) -> None:
+        """Stand in for the blocking wait on the device's first status."""
+
+
+@pytest.fixture(name="live_chromecast_factory")
+def live_chromecast_factory_fixture() -> Iterator[Callable[[], FakeChromecast]]:
+    """Yield a factory for Cast connections whose socket thread is running."""
+    released = threading.Event()
+    socket_clients: list[FakeSocketClient] = []
+
+    def _create() -> FakeChromecast:
+        socket_client = FakeSocketClient(released)
+        socket_client.start()
+        socket_clients.append(socket_client)
+        return FakeChromecast(socket_client)
+
+    try:
+        yield _create
+    finally:
+        released.set()
+        for socket_client in socket_clients:
+            socket_client.join(5)

--- a/tests/providers/chromecast/conftest.py
+++ b/tests/providers/chromecast/conftest.py
@@ -31,28 +31,35 @@ class FakeSocketClient(threading.Thread):
 class FakeChromecast:
     """Cast connection running pychromecast's real disconnect/join over a live socket thread."""
 
+    # borrowed from the real class on purpose: the tests pin pychromecast's actual
+    # disconnect/join behaviour, not a stand-in for it.
     disconnect = pychromecast.Chromecast.disconnect
     join = pychromecast.Chromecast.join
 
-    def __init__(self, socket_client: FakeSocketClient) -> None:
+    def __init__(
+        self, socket_client: FakeSocketClient, wait_error: Exception | None = None
+    ) -> None:
         """Initialize with the socket client this connection runs on."""
         self.socket_client = socket_client
+        self._wait_error = wait_error
 
     def wait(self, timeout: float | None = None) -> None:
-        """Stand in for the blocking wait on the device's first status."""
+        """Stand in for the blocking wait on the device's first status, or raise wait_error."""
+        if self._wait_error is not None:
+            raise self._wait_error
 
 
 @pytest.fixture(name="live_chromecast_factory")
-def live_chromecast_factory_fixture() -> Iterator[Callable[[], FakeChromecast]]:
+def live_chromecast_factory_fixture() -> Iterator[Callable[..., FakeChromecast]]:
     """Yield a factory for Cast connections whose socket thread is running."""
     released = threading.Event()
     socket_clients: list[FakeSocketClient] = []
 
-    def _create() -> FakeChromecast:
+    def _create(wait_error: Exception | None = None) -> FakeChromecast:
         socket_client = FakeSocketClient(released)
         socket_client.start()
         socket_clients.append(socket_client)
-        return FakeChromecast(socket_client)
+        return FakeChromecast(socket_client, wait_error=wait_error)
 
     try:
         yield _create

--- a/tests/providers/chromecast/test_dashboard_commands.py
+++ b/tests/providers/chromecast/test_dashboard_commands.py
@@ -12,6 +12,7 @@ from music_assistant_models.dashboard import DashboardDevice
 from music_assistant_models.enums import DashboardType
 from music_assistant_models.errors import PlayerUnavailableError
 from pychromecast.const import CAST_TYPE_CHROMECAST
+from pychromecast.error import RequestTimeout
 
 from music_assistant.providers.chromecast.dashboard import ChromecastDashboards
 from music_assistant.providers.chromecast.player import ChromecastPlayer
@@ -276,9 +277,9 @@ async def test_on_show_wraps_timeout_error() -> None:
 
 
 async def test_on_show_reports_a_connect_timeout_as_player_unavailable(
-    live_chromecast_factory: Callable[[], FakeChromecast],
+    live_chromecast_factory: Callable[..., FakeChromecast],
 ) -> None:
-    """A Cast device that never comes up is reported as unavailable, naming the device."""
+    """A connection that drops right after its first status is reported as unavailable."""
     dashboards = _make_dashboards()
     device_uuid = uuid4()
     disc_info = _cast_info(name="Living Room TV")
@@ -298,6 +299,32 @@ async def test_on_show_reports_a_connect_timeout_as_player_unavailable(
         await dashboards._on_show(str(device_uuid), DashboardType.PARTY, None)
 
     assert str(exc_info.value) == "Timed out connecting to Cast device: Living Room TV"
+
+
+async def test_on_show_reports_an_unreachable_device_as_player_unavailable(
+    live_chromecast_factory: Callable[..., FakeChromecast],
+) -> None:
+    """A Cast device that never reports a status is reported as unavailable, not left leaking."""
+    dashboards = _make_dashboards()
+    device_uuid = uuid4()
+    disc_info = _cast_info(name="Living Room TV")
+    dashboards.provider.browser = MagicMock(devices={device_uuid: disc_info})
+    dashboards.mass.dashboard.resolve_dashboard_url = AsyncMock(  # type: ignore[method-assign]
+        return_value="https://mass.example.com?path=%2Fparty"
+    )
+    chromecast = live_chromecast_factory(wait_error=RequestTimeout("wait", 10.0))
+
+    with (
+        patch(
+            "music_assistant.providers.chromecast.dashboard.pychromecast.get_chromecast_from_cast_info",
+            return_value=chromecast,
+        ),
+        pytest.raises(PlayerUnavailableError) as exc_info,
+    ):
+        await dashboards._on_show(str(device_uuid), DashboardType.PARTY, None)
+
+    assert str(exc_info.value) == "Timed out connecting to Cast device: Living Room TV"
+    assert chromecast.socket_client.disconnect_called is True
 
 
 ### on_hide: no-op / eviction behavior
@@ -329,6 +356,21 @@ async def test_on_hide_evicts_on_demand_connection() -> None:
 
     connected_chromecast.disconnect.assert_called_once_with(10)
     assert str(device_uuid) not in dashboards._dashboard_connections
+
+
+async def test_on_hide_succeeds_when_the_disconnect_times_out() -> None:
+    """A disconnect that times out waiting for the socket thread must not fail the hide."""
+    dashboards = _make_dashboards()
+    device_uuid = uuid4()
+    connected_chromecast = MagicMock()
+    connected_chromecast.socket_client.is_connected = True
+    connected_chromecast.disconnect.side_effect = TimeoutError("join", 10)
+    dashboards._dashboard_connections[str(device_uuid)] = connected_chromecast
+
+    with patch("music_assistant.providers.chromecast.dashboard.send_hide_dashboard"):
+        await dashboards._on_hide(str(device_uuid))
+
+    connected_chromecast.disconnect.assert_called_once_with(10)
 
 
 async def test_on_hide_keeps_registered_player_connection() -> None:
@@ -403,6 +445,22 @@ async def test_unload_unregisters_all_and_disconnects_via_executor() -> None:
     assert dashboards._dashboard_connections == {}
 
 
+async def test_unload_keeps_going_when_a_disconnect_times_out() -> None:
+    """A disconnect that times out waiting for its socket thread must not stop the cleanup."""
+    dashboards = _make_dashboards()
+    timing_out = MagicMock()
+    timing_out.disconnect.side_effect = TimeoutError("join", 10)
+    other = MagicMock()
+    dashboards._dashboard_connections["device-1"] = timing_out
+    dashboards._dashboard_connections["device-2"] = other
+
+    await dashboards.unload()
+
+    timing_out.disconnect.assert_called_once_with(10)
+    other.disconnect.assert_called_once_with(10)
+    assert dashboards._dashboard_connections == {}
+
+
 async def test_unload_disconnects_without_executor_when_closing() -> None:
     """During shutdown, disconnects happen synchronously instead of via the executor."""
     dashboards = _make_dashboards()
@@ -416,7 +474,7 @@ async def test_unload_disconnects_without_executor_when_closing() -> None:
 
 
 async def test_unload_disconnects_every_connection_while_closing(
-    live_chromecast_factory: Callable[[], FakeChromecast],
+    live_chromecast_factory: Callable[..., FakeChromecast],
 ) -> None:
     """Every cached connection is closed, also the ones behind a skipped socket wait."""
     dashboards = _make_dashboards()

--- a/tests/providers/chromecast/test_dashboard_commands.py
+++ b/tests/providers/chromecast/test_dashboard_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -15,6 +16,8 @@ from pychromecast.const import CAST_TYPE_CHROMECAST
 from music_assistant.providers.chromecast.dashboard import ChromecastDashboards
 from music_assistant.providers.chromecast.player import ChromecastPlayer
 from music_assistant.providers.chromecast.provider import ChromecastProvider
+
+from .conftest import FakeChromecast
 
 
 def _make_dashboards() -> ChromecastDashboards:
@@ -272,6 +275,31 @@ async def test_on_show_wraps_timeout_error() -> None:
     assert exc_info.value.translation_owner == "provider.chromecast"
 
 
+async def test_on_show_reports_a_connect_timeout_as_player_unavailable(
+    live_chromecast_factory: Callable[[], FakeChromecast],
+) -> None:
+    """A Cast device that never comes up is reported as unavailable, naming the device."""
+    dashboards = _make_dashboards()
+    device_uuid = uuid4()
+    disc_info = _cast_info(name="Living Room TV")
+    dashboards.provider.browser = MagicMock(devices={device_uuid: disc_info})
+    dashboards.mass.dashboard.resolve_dashboard_url = AsyncMock(  # type: ignore[method-assign]
+        return_value="https://mass.example.com?path=%2Fparty"
+    )
+    chromecast = live_chromecast_factory()
+
+    with (
+        patch(
+            "music_assistant.providers.chromecast.dashboard.pychromecast.get_chromecast_from_cast_info",
+            return_value=chromecast,
+        ),
+        pytest.raises(PlayerUnavailableError) as exc_info,
+    ):
+        await dashboards._on_show(str(device_uuid), DashboardType.PARTY, None)
+
+    assert str(exc_info.value) == "Timed out connecting to Cast device: Living Room TV"
+
+
 ### on_hide: no-op / eviction behavior
 
 
@@ -385,6 +413,23 @@ async def test_unload_disconnects_without_executor_when_closing() -> None:
     await dashboards.unload()
 
     chromecast.disconnect.assert_called_once_with(0)
+
+
+async def test_unload_disconnects_every_connection_while_closing(
+    live_chromecast_factory: Callable[[], FakeChromecast],
+) -> None:
+    """Every cached connection is closed, also the ones behind a skipped socket wait."""
+    dashboards = _make_dashboards()
+    dashboards.mass.closing = True  # type: ignore[misc]
+    first = live_chromecast_factory()
+    second = live_chromecast_factory()
+    dashboards._dashboard_connections["device-1"] = first  # type: ignore[assignment]
+    dashboards._dashboard_connections["device-2"] = second  # type: ignore[assignment]
+
+    await dashboards.unload()
+
+    assert first.socket_client.disconnect_called is True
+    assert second.socket_client.disconnect_called is True
 
 
 async def test_register_after_unload_is_noop() -> None:

--- a/tests/providers/chromecast/test_dashboard_commands.py
+++ b/tests/providers/chromecast/test_dashboard_commands.py
@@ -313,6 +313,8 @@ async def test_on_show_reports_an_unreachable_device_as_player_unavailable(
         return_value="https://mass.example.com?path=%2Fparty"
     )
     chromecast = live_chromecast_factory(wait_error=RequestTimeout("wait", 10.0))
+    # a device that answers the handshake but never reports in is the realistic shape here
+    chromecast.socket_client.is_connected = True
 
     with (
         patch(

--- a/tests/providers/chromecast/test_socket_disconnect.py
+++ b/tests/providers/chromecast/test_socket_disconnect.py
@@ -1,0 +1,64 @@
+"""
+Tests for how ChromecastPlayer closes its Cast socket when it is unloaded.
+
+During shutdown the socket thread is deliberately not waited for: it is a daemon thread
+that dies with the process, and waiting on it stalls the shutdown. pychromecast reports
+that skipped wait as a TimeoutError, which must not escape the unload.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+from music_assistant.providers.chromecast.player import ChromecastPlayer
+
+from .conftest import FakeChromecast
+
+
+def _fake_player(chromecast: Any, *, closing: bool) -> Any:
+    """
+    Build a Cast player on mocked collaborators, so it disconnects a real Cast connection.
+
+    :param chromecast: Cast connection the player's on_unload should disconnect.
+    :param closing: Whether Music Assistant is shutting down.
+    """
+    # __init__ is skipped: it needs a provider, cast info and a live Chromecast connection.
+    # Typed as Any because the collaborators below are read back as the mocks they are.
+    fake = cast("Any", ChromecastPlayer.__new__(ChromecastPlayer))
+    fake.mass = MagicMock()
+    fake.mass.closing = closing
+    fake.logger = MagicMock()
+    fake.cc = chromecast
+    fake.mz_controller = None
+    fake.status_listener = MagicMock()
+    fake._app_quit_task_id = "cast_quit_app_test"
+    # display_name is a cached property, normally built from the config in __init__
+    fake._cache = {"display_name": "Test Cast"}
+    # used by the base Player.on_unload
+    fake._on_unload_callbacks = []
+    return fake
+
+
+async def test_unload_while_closing_closes_socket_without_waiting(
+    live_chromecast_factory: Callable[[], FakeChromecast],
+) -> None:
+    """A shutdown closes the socket but does not wait for the daemon thread to exit."""
+    chromecast = live_chromecast_factory()
+    player = _fake_player(chromecast, closing=True)
+
+    await player.on_unload()
+
+    assert chromecast.socket_client.disconnect_called is True
+    assert chromecast.socket_client.is_alive() is True
+
+
+async def test_unload_while_running_waits_for_the_socket_thread() -> None:
+    """Outside of shutdown, disconnecting still blocks for the socket thread to exit."""
+    chromecast = MagicMock()
+    player = _fake_player(chromecast, closing=False)
+
+    await player.on_unload()
+
+    chromecast.disconnect.assert_called_once_with(10)

--- a/tests/providers/chromecast/test_socket_disconnect.py
+++ b/tests/providers/chromecast/test_socket_disconnect.py
@@ -18,12 +18,7 @@ from .conftest import FakeChromecast
 
 
 def _fake_player(chromecast: Any, *, closing: bool) -> Any:
-    """
-    Build a Cast player on mocked collaborators, so it disconnects a real Cast connection.
-
-    :param chromecast: Cast connection the player's on_unload should disconnect.
-    :param closing: Whether Music Assistant is shutting down.
-    """
+    """Build a Cast player on mocked collaborators, so it disconnects a real Cast connection."""
     # __init__ is skipped: it needs a provider, cast info and a live Chromecast connection.
     # Typed as Any because the collaborators below are read back as the mocks they are.
     fake = cast("Any", ChromecastPlayer.__new__(ChromecastPlayer))
@@ -42,7 +37,7 @@ def _fake_player(chromecast: Any, *, closing: bool) -> Any:
 
 
 async def test_unload_while_closing_closes_socket_without_waiting(
-    live_chromecast_factory: Callable[[], FakeChromecast],
+    live_chromecast_factory: Callable[..., FakeChromecast],
 ) -> None:
     """A shutdown closes the socket but does not wait for the daemon thread to exit."""
     chromecast = live_chromecast_factory()
@@ -62,3 +57,16 @@ async def test_unload_while_running_waits_for_the_socket_thread() -> None:
     await player.on_unload()
 
     chromecast.disconnect.assert_called_once_with(10)
+
+
+async def test_unload_survives_a_disconnect_that_times_out() -> None:
+    """A disconnect that times out waiting for the socket thread must not fail the unload."""
+    # a MagicMock keeps this fast: what is under test is that MA swallows the timeout,
+    # not the real 10s join a live thread would need to reproduce it.
+    chromecast = MagicMock()
+    chromecast.disconnect.side_effect = TimeoutError("join", 10)
+    player = _fake_player(chromecast, closing=False)
+
+    await player.on_unload()
+
+    player.logger.warning.assert_called_once()


### PR DESCRIPTION
# What does this implement/fix?

Closing the socket to a Cast device deliberately does not always wait for that device's background thread, and pychromecast reports a wait it did not do as a timeout error. So every shutdown logged an error with a stack trace for each Cast player.

In the Cast dashboard code that same error did more than fill the log, it stopped the cleanup halfway. Connections were left open, a removed device kept a stale dashboard session, and a device that could not be reached reported `[Errno join] 0` instead of a readable message. A socket thread that really is stuck had the same effect: it aborted the provider teardown before discovery was stopped, so a provider reload left the discovery threads running, and it reported a dashboard that was already hidden as failing to hide.

Separately, a Cast device that never answers made the dashboard connect give up with an untranslated error and leave the connection open, leaking a socket thread on every attempt.

- Added helpers that close a Cast socket, with or without waiting for its thread, and never fail the teardown over it
- Used them for the player unload, and for the dashboard register, unload, hide, connect and session-lost paths
- A socket thread that outlives the wait is now a warning instead of an error with a stack trace
- A Cast device that never reports a status now gives the readable "timed out connecting" message, and its connection is closed
- Added tests that run pychromecast's own disconnect against a live socket thread, since a mocked connection cannot reproduce this

**Related issue (if applicable):**

- n/a, found while going through the nightly add-on logs

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
