### PR TITLE
Fix WiiM players not reporting state after a restart

### DIFF
--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -470,13 +470,13 @@ class WiimPlayer(Player):
         if play_mode and play_mode != SOURCE_NETWORK and play_mode in INPUT_MODE_SOURCES:
             self._attr_active_source = INPUT_MODE_SOURCES[play_mode].id
         elif play_mode == SOURCE_NETWORK:
+            # the queue is registered just after the player, so an early poll can precede it
             ma_queue = self.mass.player_queues.get(self.player_id)
-            assert ma_queue is not None
             if device_uri == "wiimu_airplay":
                 self._attr_active_source = SOURCE_AIRPLAY
             elif device_uri.startswith("spotify:"):
                 self._attr_active_source = SOURCE_SPOTIFY
-            elif ma_queue.current_item:
+            elif ma_queue and ma_queue.current_item:
                 self._attr_active_source = self.player_id
             else:
                 self._attr_active_source = SOURCE_UNKNOWN

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -16,6 +16,7 @@ from music_assistant.models.player import PlayerMedia
 from music_assistant.providers.wiim.constants import (
     PLAYER_ID_PREFIX,
     SOURCE_NETWORK,
+    SOURCE_UNKNOWN,
 )
 from music_assistant.providers.wiim.grouping import NativeGroupRole
 from music_assistant.providers.wiim.player import SDK_TO_MA_STATE, WiimPlayer
@@ -252,6 +253,56 @@ class TestFalsePlayingFilter:
         player._update_ma_state_from_sdk_cache()
 
         assert player._attr_playback_state == PlaybackState.IDLE
+
+
+class TestActiveSourceMapping:
+    """Network mode must resolve an active source with or without a registered queue."""
+
+    def test_state_completes_before_the_queue_exists(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """
+        A poll landing before the PlayerQueue is registered must still publish state.
+
+        The player is initialised a moment before its queue, so the first poll after
+        a restart finds no queue; aborting there left the player with no active
+        source and no state update at all.
+        """
+        mock_provider.mass.player_queues.get.return_value = None
+        mock_wiim_device.play_mode = SOURCE_NETWORK
+        player = WiimPlayer(provider=mock_provider, player_id="uuid:test", device=mock_wiim_device)
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player._attr_active_source == SOURCE_UNKNOWN
+        player.update_state.assert_called_once()
+
+    def test_queue_with_current_item_is_the_active_source(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """A queue that holds a current item makes the player itself the source."""
+        mock_provider.mass.player_queues.get.return_value.current_item = MagicMock()
+        mock_wiim_device.play_mode = SOURCE_NETWORK
+        player = WiimPlayer(provider=mock_provider, player_id="uuid:test", device=mock_wiim_device)
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player._attr_active_source == player.player_id
+
+    def test_idle_queue_falls_back_to_unknown(
+        self, mock_provider: MagicMock, mock_wiim_device: MagicMock
+    ) -> None:
+        """A registered queue with nothing loaded is not the active source."""
+        mock_provider.mass.player_queues.get.return_value.current_item = None
+        mock_wiim_device.play_mode = SOURCE_NETWORK
+        player = WiimPlayer(provider=mock_provider, player_id="uuid:test", device=mock_wiim_device)
+        player.update_state = MagicMock()  # type: ignore[misc,method-assign]
+
+        player._update_ma_state_from_sdk_cache()
+
+        assert player._attr_active_source == SOURCE_UNKNOWN
 
 
 class TestSupportedFeatures:


### PR DESCRIPTION
# What does this implement/fix?

WiiM players could come up after a Music Assistant restart without reporting anything: no source, no track, no playback state, until something else nudged them.

The first poll of a player can land in the short window before its queue is registered. The WiiM state update asserted the queue was already there, so it aborted halfway and never published the state it had just collected. The queue simply not existing yet is a normal startup condition, so it now falls back to the unknown source and finishes the update.

Found while going through the nightly logs, where it showed up as an empty `Error while requesting latest state from player WiiM ...` warning on every restart.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
