### PR TITLE
Use the logged-in account for YouTube Music searches

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -216,7 +216,8 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
         if not await self._user_has_ytm_premium():
             raise LoginFailed("User does not have Youtube Music Premium")
 
-    @use_cache(3600 * 24 * 7)  # Cache for 7 days
+    # the checksum invalidates entries cached before search was authenticated
+    @use_cache(3600 * 24 * 7, cache_checksum="authenticated_search_v1")  # Cache for 7 days
     async def search(
         self, search_query: str, media_types: list[MediaType], limit: int = 5
     ) -> SearchResults:

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -245,7 +245,12 @@ class YoutubeMusicProvider(RecommendationPayloadMixin, MusicProvider):
                 # bit of an edge case but still good to handle
                 return parsed_results
         results = await search(
-            query=search_query, ytm_filter=ytm_filter, limit=limit, language=self.language
+            query=search_query,
+            headers=self._headers,
+            ytm_filter=ytm_filter,
+            limit=limit,
+            language=self.language,
+            user=self._yt_user,
         )
         parsed_results = SearchResults()
         artists: list[Artist | ItemMapping] = []

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -327,12 +327,17 @@ async def get_song_radio_tracks(
 
 
 async def search(
-    query: str, ytm_filter: YTMSearchFilter | None = None, limit: int = 20, language: str = "en"
+    query: str,
+    headers: dict[str, str],
+    ytm_filter: YTMSearchFilter | None = None,
+    limit: int = 20,
+    language: str = "en",
+    user: str | None = None,
 ) -> list[dict[str, Any]]:
     """Async wrapper around the ytmusicapi search function."""
 
     def _search() -> list[dict[str, Any]]:
-        ytm = ytmusicapi.YTMusic(language=language)
+        ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
         results = ytm.search(query=query, filter=ytm_filter, limit=limit)
         # Sync result properties with uniformal objects
         for result in results:

--- a/tests/providers/ytmusic/test_helpers.py
+++ b/tests/providers/ytmusic/test_helpers.py
@@ -62,3 +62,13 @@ async def test_get_artist_fallback_still_returns_unknown() -> None:
     with patch.object(ytmusicapi, "YTMusic", return_value=mock_ytm):
         artist = await helpers.get_artist(prov_artist_id="UC123", headers={})
     assert artist == {"channelId": "UC123", "name": "Unknown"}
+
+
+async def test_search_passes_auth_headers_and_user() -> None:
+    """search() must authenticate its YTMusic client so results respect account context."""
+    mock_ytm = MagicMock()
+    mock_ytm.search.return_value = []
+    headers = {"cookie": "abc"}
+    with patch.object(ytmusicapi, "YTMusic", return_value=mock_ytm) as mock_ytmusic:
+        await helpers.search(query="test", headers=headers, user="123")
+    mock_ytmusic.assert_called_once_with(auth=headers, language="en", user="123")


### PR DESCRIPTION
# What does this implement/fix?

YouTube Music searches were performed without the user's credentials, while every other YTM call already authenticates. Because of that, YouTube could not apply the account and region context to search results, so tracks that are not playable for the user were still returned as regular results (and failed with "No playable items found" when played).

- Pass the account headers and (brand account) user to the ytmusicapi search call, like all other YTM helpers already do.
- Add a regression test that verifies search authenticates its client.

Note: the full fix for the linked issue also needs an upstream ytmusicapi change to expose the availability flag on search results (https://github.com/sigma67/ytmusicapi/pull/1001); this PR is the server-side part and is safe on its own.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6154

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.