### PR TITLE
Fix misleading errors when Home Assistant TTS fails

### DIFF
--- a/music_assistant/helpers/tts.py
+++ b/music_assistant/helpers/tts.py
@@ -89,7 +89,7 @@ async def query_tts_engine_with_language_fallback(
     try:
         return await query_tts_engine(engine, message, language, timeout, options)
     except TTSLanguageNotSupportedError as err:
-        if language is None:
+        if not language:
             raise
         # the error message carries the classifier's certainty, so it is logged as-is
         (logger or LOGGER).warning("%s, retrying with the engine's default voice", err)

--- a/music_assistant/helpers/tts.py
+++ b/music_assistant/helpers/tts.py
@@ -28,6 +28,10 @@ TTS_QUERY_TIMEOUT_SECONDS = 180
 REMOTE_STREAM_SCHEMES = ("http://", "https://", "rtsp://", "rtmp://")
 
 
+class TTSLanguageNotSupportedError(MusicAssistantError):
+    """The TTS engine rejected (or likely rejected) the requested language."""
+
+
 async def query_tts_engine(
     engine: TTSEngine,
     message: str,
@@ -71,7 +75,7 @@ async def query_tts_engine_with_language_fallback(
     options: dict[str, Any] | None = None,
 ) -> StreamDetails:
     """
-    Render a message through a TTS engine, retrying without the language if it is rejected.
+    Render a message through a TTS engine, retrying without the language if the engine rejects it.
 
     :param engine: The TTS engine to speak the message.
     :param message: The text to speak.
@@ -84,21 +88,11 @@ async def query_tts_engine_with_language_fallback(
     """
     try:
         return await query_tts_engine(engine, message, language, timeout, options)
-    except TimeoutError, MusicAssistantError:
-        # a timeout or our own structured failure is not a language rejection, so a
-        # language-less retry would not help and would only double the wait
-        raise
-    except Exception as err:
+    except TTSLanguageNotSupportedError as err:
         if language is None:
             raise
-        # some engines reject a language they don't support; fall back to the engine's
-        # own default voice rather than losing the audio entirely
-        (logger or LOGGER).warning(
-            "TTS engine '%s' rejected language '%s' (%s), retrying with its default voice",
-            engine.uid,
-            language,
-            err,
-        )
+        # the error message carries the classifier's certainty, so it is logged as-is
+        (logger or LOGGER).warning("%s, retrying with the engine's default voice", err)
         return await query_tts_engine(engine, message, None, timeout, options)
 
 

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -458,8 +458,9 @@ class AIRadioRenderMixin:
                 # the engine reports no reason of its own (Home Assistant answers a failed
                 # render with an empty 500), so the probe's message is the only clue there is
                 raise MusicAssistantError(
-                    f"{err}. Does your TTS provider have enough credit? "
-                    "Check the logs of your TTS provider for the reason."
+                    f"{err}. The TTS engine failed to generate the audio and Home Assistant "
+                    "does not pass on the reason. Check the Home Assistant core log and your "
+                    "TTS integration (a cloud engine may be out of credit or having an outage)."
                 ) from err
             self.logger.warning("Could not determine AI Radio clip duration: %s", err)
             return None

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -458,9 +458,10 @@ class AIRadioRenderMixin:
                 # the engine reports no reason of its own (Home Assistant answers a failed
                 # render with an empty 500), so the probe's message is the only clue there is
                 raise MusicAssistantError(
-                    f"{err}. The TTS engine failed to generate the audio and Home Assistant "
-                    "does not pass on the reason. Check the Home Assistant core log and your "
-                    "TTS integration (a cloud engine may be out of credit or having an outage)."
+                    f"{err}. The TTS engine failed to generate the audio it handed out. "
+                    "Check the logs of the TTS engine for the reason (for a Home Assistant "
+                    "engine that is the Home Assistant core log). A cloud engine may be "
+                    "out of credit or having an outage."
                 ) from err
             self.logger.warning("Could not determine AI Radio clip duration: %s", err)
             return None

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -44,6 +44,7 @@ from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.datetime import iso_from_utc_timestamp
 from music_assistant.helpers.json import SerializableType
+from music_assistant.helpers.tts import TTSLanguageNotSupportedError
 from music_assistant.helpers.util import lock, try_parse_int
 from music_assistant.models.plugin import AIEngine, PluginProvider, TTSEngine
 
@@ -686,7 +687,7 @@ class HomeAssistantProvider(PluginProvider):
         async with http_session.post(
             f"{ha_url}/api/tts_get_url", headers=headers, json=payload
         ) as response:
-            await self._raise_for_tts_error(response)
+            await self._raise_for_tts_error(response, entity_id, language)
             data = await response.json()
         url = str(data["url"])
         return StreamDetails(
@@ -955,8 +956,10 @@ class HomeAssistantProvider(PluginProvider):
         http_session = self.mass.http_session if ssl else self.mass.http_session_no_ssl
         return ha_url, headers, http_session
 
-    async def _raise_for_tts_error(self, response: ClientResponse) -> None:
-        """Raise for a failed tts_get_url response without masking a language rejection."""
+    async def _raise_for_tts_error(
+        self, response: ClientResponse, entity_id: str, language: str | None
+    ) -> None:
+        """Raise a classified error for a failed tts_get_url response."""
         if response.ok:
             return
         try:
@@ -965,10 +968,24 @@ class HomeAssistantProvider(PluginProvider):
         except ValueError:
             body = None
         error_message = body.get("error") if isinstance(body, dict) else None
-        # HA returns the same 400 for a rejected option and an unsupported language
-        if isinstance(error_message, str) and "Invalid options found" in error_message:
+        if isinstance(error_message, str):
+            if error_message.startswith("Language '") and error_message.endswith("' not supported"):
+                raise TTSLanguageNotSupportedError(
+                    f"TTS engine '{entity_id}' does not support language '{language}'"
+                )
             raise MusicAssistantError(error_message)
-        response.raise_for_status()
+        if response.status >= 500 and language:
+            # HA masks tts_get_url validation errors as a bare 500 (the error body fails
+            # to serialize), so a rejected language is the one recoverable cause left
+            raise TTSLanguageNotSupportedError(
+                f"TTS request to engine '{entity_id}' for language '{language}' failed "
+                f"(HTTP {response.status} from Home Assistant, which hides the reason, "
+                "possibly an unsupported language)"
+            )
+        raise MusicAssistantError(
+            f"Home Assistant tts_get_url failed with HTTP {response.status}. "
+            "Check the Home Assistant core log for the reason."
+        )
 
     async def _disconnect_hass(self) -> None:
         """Stop listening for Home Assistant events and disconnect the client."""

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -980,10 +980,15 @@ class HomeAssistantProvider(PluginProvider):
                 f"(HTTP {response.status} from Home Assistant, which hides the reason, "
                 "possibly an unsupported language)"
             )
-        raise MusicAssistantError(
-            f"Home Assistant tts_get_url failed with HTTP {response.status}. "
-            "Check the Home Assistant core log for the reason."
+        failure = (
+            f"TTS request to engine '{entity_id}' failed: Home Assistant returned "
+            f"HTTP {response.status} ({response.reason}) on tts_get_url."
         )
+        if response.status in (401, 403):
+            raise MusicAssistantError(
+                f"{failure} Check your Home Assistant connection settings and access token."
+            )
+        raise MusicAssistantError(f"{failure} Check the Home Assistant core log for the reason.")
 
     async def _disconnect_hass(self) -> None:
         """Stop listening for Home Assistant events and disconnect the client."""

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -970,11 +970,9 @@ class HomeAssistantProvider(PluginProvider):
         error_message = body.get("error") if isinstance(body, dict) else None
         if isinstance(error_message, str):
             if error_message.startswith("Language '") and error_message.endswith("' not supported"):
-                raise TTSLanguageNotSupportedError(
-                    f"TTS engine '{entity_id}' does not support language '{language}'"
-                )
+                raise TTSLanguageNotSupportedError(f"TTS engine '{entity_id}': {error_message}")
             raise MusicAssistantError(error_message)
-        if response.status >= 500 and language:
+        if response.status == 500 and language:
             # HA masks tts_get_url validation errors as a bare 500 (the error body fails
             # to serialize), so a rejected language is the one recoverable cause left
             raise TTSLanguageNotSupportedError(

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -65,7 +65,7 @@ from music_assistant.controllers.players import PlayerController
 from music_assistant.controllers.players import controller as players_controller
 from music_assistant.controllers.players.announcements import ANNOUNCEMENT_TTS_TIMEOUT
 from music_assistant.controllers.webserver.helpers.auth_middleware import current_user
-from music_assistant.helpers.tts import TTS_QUERY_TIMEOUT_SECONDS
+from music_assistant.helpers.tts import TTS_QUERY_TIMEOUT_SECONDS, TTSLanguageNotSupportedError
 from music_assistant.models.player import LinkedOutputProtocol, Player
 from music_assistant.models.player_provider import PlayerProvider
 from music_assistant.providers.universal_player.player import UniversalPlayer
@@ -4542,7 +4542,9 @@ class TestPlayAnnouncementMessage:
         engine = self._make_engine()
         engine.provider.get_tts_message = AsyncMock(
             side_effect=[
-                RuntimeError("unsupported language"),
+                TTSLanguageNotSupportedError(
+                    "TTS engine 'voice' does not support language 'en-US'"
+                ),
                 SimpleNamespace(path="http://speech/spoken.mp3"),
             ]
         )

--- a/tests/helpers/test_tts.py
+++ b/tests/helpers/test_tts.py
@@ -1,0 +1,78 @@
+"""Tests for the TTS engine query helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.errors import MusicAssistantError
+
+from music_assistant.helpers.tts import (
+    TTSLanguageNotSupportedError,
+    query_tts_engine_with_language_fallback,
+)
+from music_assistant.models.plugin import PluginProvider, TTSEngine
+
+
+def _create_engine() -> tuple[TTSEngine, AsyncMock]:
+    """Create a TTS engine and the mock that renders its speech."""
+    provider = MagicMock(spec=PluginProvider)
+    provider.instance_id = "hass"
+    provider.get_tts_message = AsyncMock()
+    return TTSEngine(id="tts.x", name="X", provider=provider), provider.get_tts_message
+
+
+async def test_language_rejection_retries_without_language(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A rejected language is retried once with the engine's default voice."""
+    engine, get_tts_message = _create_engine()
+    sentinel = MagicMock()
+    get_tts_message.side_effect = [
+        TTSLanguageNotSupportedError("TTS engine 'tts.x' does not support language 'en-US'"),
+        sentinel,
+    ]
+
+    with caplog.at_level("WARNING"):
+        result = await query_tts_engine_with_language_fallback(engine, "Hello", "en-US")
+
+    assert result is sentinel
+    assert get_tts_message.call_count == 2
+    second_call = get_tts_message.call_args_list[1]
+    assert second_call.kwargs["language"] is None
+    assert "retrying with the engine's default voice" in caplog.text
+
+
+async def test_generic_errors_do_not_retry() -> None:
+    """A generic exception from the engine propagates without a retry."""
+    engine, get_tts_message = _create_engine()
+    get_tts_message.side_effect = RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        await query_tts_engine_with_language_fallback(engine, "Hello", "en-US")
+
+    assert get_tts_message.call_count == 1
+
+
+async def test_music_assistant_error_does_not_retry() -> None:
+    """A structured MusicAssistantError propagates without a retry."""
+    engine, get_tts_message = _create_engine()
+    get_tts_message.side_effect = MusicAssistantError("nope")
+
+    with pytest.raises(MusicAssistantError):
+        await query_tts_engine_with_language_fallback(engine, "Hello", "en-US")
+
+    assert get_tts_message.call_count == 1
+
+
+async def test_rejection_without_language_does_not_retry() -> None:
+    """A language rejection raised while no language was requested is not retried."""
+    engine, get_tts_message = _create_engine()
+    get_tts_message.side_effect = TTSLanguageNotSupportedError(
+        "TTS engine 'tts.x' does not support language 'en-US'"
+    )
+
+    with pytest.raises(TTSLanguageNotSupportedError):
+        await query_tts_engine_with_language_fallback(engine, "Hello", None)
+
+    assert get_tts_message.call_count == 1

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -603,7 +603,7 @@ async def test_tts_server_error_fails_the_clip_with_an_actionable_message(
 
     session = renderer._sessions["sess"]
     assert session.skipped_sections == 1
-    assert "Check the Home Assistant core log" in session.last_render_error
+    assert "Check the logs of the TTS engine" in session.last_render_error
     # the hint is a guess, so the whole probe message travels with it - the url included,
     # since that is what tells a failing engine apart from a failing tts server behind it
     assert "http://ha.invalid/api/tts_proxy/1.mp3" in session.last_render_error

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -33,6 +33,7 @@ from music_assistant.constants import (
     CONF_VOLUME_NORMALIZATION_TRACKS,
 )
 from music_assistant.helpers.tags import AudioTags
+from music_assistant.helpers.tts import TTSLanguageNotSupportedError
 from music_assistant.models.plugin import PluginProvider, TTSEngine
 from music_assistant.providers.ai_radio.constants import (
     ATTR_HOST_ID,
@@ -368,7 +369,9 @@ async def test_render_tts_media_falls_back_without_language_on_rejection() -> No
     engine = cast("Any", renderer)._get_tts_engine.return_value
     engine.provider.get_tts_message = AsyncMock(
         side_effect=[
-            Exception("unsupported language"),
+            TTSLanguageNotSupportedError(
+                "TTS engine 'tts.cloud' does not support language 'en-US'"
+            ),
             SimpleNamespace(
                 path="http://example.test/api/tts_proxy/abc123.mp3",
                 audio_format=AudioFormat(content_type=ContentType.MP3),
@@ -600,7 +603,7 @@ async def test_tts_server_error_fails_the_clip_with_an_actionable_message(
 
     session = renderer._sessions["sess"]
     assert session.skipped_sections == 1
-    assert "enough credit" in session.last_render_error
+    assert "Check the Home Assistant core log" in session.last_render_error
     # the hint is a guess, so the whole probe message travels with it - the url included,
     # since that is what tells a failing engine apart from a failing tts server behind it
     assert "http://ha.invalid/api/tts_proxy/1.mp3" in session.last_render_error

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -790,6 +790,18 @@ async def test_tts_bare_500_with_language_is_classified_as_possible_language_rej
         assert "possibly" in str(excinfo.value)
 
 
+async def test_tts_bare_503_with_language_raises_generic_error() -> None:
+    """A bodyless 5xx other than 500 is an outage, not a masked validation error."""
+    async with _start_provider([_state("tts.first", "First")]) as (provider, _):
+        _mock_tts_error_response(provider, None, status=503)
+
+        with pytest.raises(MusicAssistantError) as excinfo:
+            await provider.get_tts_message("Hello", language="en-US")
+
+        assert not isinstance(excinfo.value, TTSLanguageNotSupportedError)
+        assert "503" in str(excinfo.value)
+
+
 async def test_tts_bare_500_without_language_raises_generic_error() -> None:
     """A bare 500 with no language requested has nothing to blame on a rejection."""
     async with _start_provider([_state("tts.first", "First")]) as (provider, _):

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
+from http import HTTPStatus
 from math import ceil
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -676,6 +677,7 @@ def _mock_tts_error_response(
     response = AsyncMock()
     response.ok = False
     response.status = status
+    response.reason = HTTPStatus(status).phrase
     if error_message is None:
         response.json.side_effect = ValueError("not json")
     else:
@@ -788,6 +790,19 @@ async def test_tts_bare_500_with_language_is_classified_as_possible_language_rej
 
         assert "500" in str(excinfo.value)
         assert "possibly" in str(excinfo.value)
+
+
+async def test_tts_401_points_at_the_access_token() -> None:
+    """An auth failure points at the connection settings instead of the core log."""
+    async with _start_provider([_state("tts.first", "First")]) as (provider, _):
+        _mock_tts_error_response(provider, None, status=401)
+
+        with pytest.raises(MusicAssistantError) as excinfo:
+            await provider.get_tts_message("Hello", language="en-US")
+
+        assert not isinstance(excinfo.value, TTSLanguageNotSupportedError)
+        assert "401 (Unauthorized)" in str(excinfo.value)
+        assert "access token" in str(excinfo.value)
 
 
 async def test_tts_bare_503_with_language_raises_generic_error() -> None:

--- a/tests/providers/hass/test_provider.py
+++ b/tests/providers/hass/test_provider.py
@@ -11,7 +11,6 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aiohttp import ClientResponseError
 from hass_client.exceptions import BaseHassClientError
 from music_assistant_models.enums import EventType, ProviderFeature
 from music_assistant_models.errors import (
@@ -21,6 +20,7 @@ from music_assistant_models.errors import (
 )
 
 from music_assistant.constants import CONF_LOG_LEVEL
+from music_assistant.helpers.tts import TTSLanguageNotSupportedError
 from music_assistant.providers.hass import (
     CONF_AUTH_TOKEN,
     CONF_URL,
@@ -669,14 +669,17 @@ def _mock_tts_response(provider: HomeAssistantProvider) -> MagicMock:
     return post
 
 
-def _mock_tts_error_response(provider: HomeAssistantProvider, error_message: str) -> MagicMock:
-    """Let the tts_get_url endpoint fail with a 400 carrying the given HA error body."""
+def _mock_tts_error_response(
+    provider: HomeAssistantProvider, error_message: str | None, status: int = 400
+) -> MagicMock:
+    """Let the tts_get_url endpoint fail with the given status and HA error body."""
     response = AsyncMock()
     response.ok = False
-    response.json.return_value = {"error": error_message}
-    response.raise_for_status = MagicMock(
-        side_effect=ClientResponseError(MagicMock(), (), status=400, message=error_message)
-    )
+    response.status = status
+    if error_message is None:
+        response.json.side_effect = ValueError("not json")
+    else:
+        response.json.return_value = {"error": error_message}
     post = cast("MagicMock", provider.mass.http_session.post)
     post.return_value.__aenter__.return_value = response
     return post
@@ -756,23 +759,48 @@ async def test_tts_invalid_option_raises_music_assistant_error() -> None:
 
 
 async def test_tts_error_body_that_is_not_json_still_raises_the_generic_way() -> None:
-    """An unparsable error body leaves the status error to speak for itself."""
+    """An unparsable error body raises the generic error naming the endpoint and status."""
     async with _start_provider([_state("tts.first", "First")]) as (provider, _):
-        post = _mock_tts_error_response(provider, "Invalid options found: ['x']")
-        response = post.return_value.__aenter__.return_value
-        response.json.side_effect = ValueError("not json")
+        _mock_tts_error_response(provider, None, status=400)
 
-        with pytest.raises(ClientResponseError):
+        with pytest.raises(MusicAssistantError, match=r"tts_get_url") as excinfo:
             await provider.get_tts_message("Hello", options={"x": 1})
 
+        assert "400" in str(excinfo.value)
 
-async def test_tts_unsupported_language_still_raises_the_generic_way() -> None:
-    """An unsupported-language 400 keeps raising as before, so the caller's retry still fires."""
+
+async def test_tts_unsupported_language_raises_typed_error() -> None:
+    """An unsupported-language 400 raises the typed error naming the language."""
     async with _start_provider([_state("tts.first", "First")]) as (provider, _):
         _mock_tts_error_response(provider, "Language 'xx' not supported")
 
-        with pytest.raises(ClientResponseError):
+        with pytest.raises(TTSLanguageNotSupportedError, match=r"'xx'"):
             await provider.get_tts_message("Hello", language="xx")
+
+
+async def test_tts_bare_500_with_language_is_classified_as_possible_language_rejection() -> None:
+    """A bare 500 (HA's masked validation failure) with a language is a possible rejection."""
+    async with _start_provider([_state("tts.first", "First")]) as (provider, _):
+        _mock_tts_error_response(provider, None, status=500)
+
+        with pytest.raises(TTSLanguageNotSupportedError) as excinfo:
+            await provider.get_tts_message("Hello", language="en-US")
+
+        assert "500" in str(excinfo.value)
+        assert "possibly" in str(excinfo.value)
+
+
+async def test_tts_bare_500_without_language_raises_generic_error() -> None:
+    """A bare 500 with no language requested has nothing to blame on a rejection."""
+    async with _start_provider([_state("tts.first", "First")]) as (provider, _):
+        _mock_tts_error_response(provider, None, status=500)
+
+        with pytest.raises(MusicAssistantError) as excinfo:
+            await provider.get_tts_message("Hello")
+
+        assert not isinstance(excinfo.value, TTSLanguageNotSupportedError)
+        assert "tts_get_url" in str(excinfo.value)
+        assert "500" in str(excinfo.value)
 
 
 async def test_registry_update_refreshes_the_engines() -> None:


### PR DESCRIPTION
# What does this implement/fix?

AI Radio DJ clips were dropped from the queue with misleading errors when Home Assistant's TTS failed. MA treated any TTS failure as a rejected language, logging "TTS engine rejected language 'en-US'" even for a plain server error, and the final message guessed "Does your TTS provider have enough credit?" as the diagnosis.

Background: HA's `tts_get_url` endpoint currently answers every validation failure (unsupported language, invalid options) with a bare HTTP 500 instead of the intended 400 with an error body, so MA cannot always know the real reason. The errors are now classified where the response is inspected and the messages say honestly what is known.

- Retry with the engine's default voice only when the language was (possibly) rejected, instead of on any error
- Classify `tts_get_url` responses in the Home Assistant provider: a real "language not supported" body, a masked bare 500, and other failures each get their own error and wording
- Reword the failed-render message: point at the Home Assistant core log instead of presenting the credit guess as the diagnosis
- Add regression tests for the fallback helper and the new classification

**Related issue (if applicable):**

- related issue N/A (found via triage of nightly logs)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
