### PR TITLE
Show episode descriptions and artwork for Pocket Casts

### DIFF
--- a/music_assistant/providers/pocketcasts/__init__.py
+++ b/music_assistant/providers/pocketcasts/__init__.py
@@ -640,7 +640,9 @@ class PocketCastsProvider(MusicProvider):
         }
         episode_list = await folder_getters[folder_name]()
 
-        items: list[MediaItemType | BrowseFolder] = []
+        # (episode, podcast uuid, podcast name) per episode, the name empty when the folder
+        # payload does not carry it
+        resolved: list[tuple[dict[str, Any], str, str]] = []
         for episode_data in episode_list:
             # the podcast reference is a string on some endpoints and an object on others
             podcast_field = episode_data.get("podcast")
@@ -654,12 +656,30 @@ class PocketCastsProvider(MusicProvider):
 
             if not podcast_uuid:
                 continue
-            # these folders mix podcasts, so the name is not known up front
-            podcast_name = podcast_field.get("title", "") if isinstance(podcast_field, dict) else ""
-            if not podcast_name:
-                podcast_name = await self._get_podcast_name(podcast_uuid)
+            # these folders mix podcasts, so the name is not known up front. Take it from the
+            # payload where that carries it, in either of the two shapes
+            payload_name = podcast_field.get("title") if isinstance(podcast_field, dict) else None
+            resolved.append(
+                (
+                    episode_data,
+                    podcast_uuid,
+                    payload_name or episode_data.get("podcastTitle") or "",
+                )
+            )
+
+        # every remaining name costs a full-podcast fetch, so look them up once per podcast and
+        # all at once: serialising them would stall the browse for as long as the folder is deep
+        missing = list({uuid for _, uuid, name in resolved if not name})
+        looked_up = await asyncio.gather(*(self._get_podcast_name(uuid) for uuid in missing))
+        names = dict(zip(missing, looked_up, strict=True))
+
+        items: list[MediaItemType | BrowseFolder] = []
+        for episode_data, podcast_uuid, podcast_name in resolved:
             if episode_item := self._convert_episode(
-                episode_data, podcast_uuid, None, podcast_name
+                episode_data,
+                podcast_uuid,
+                show_notes=None,
+                podcast_name=podcast_name or names.get(podcast_uuid, ""),
             ):
                 items.append(episode_item)
         return items

--- a/music_assistant/providers/pocketcasts/__init__.py
+++ b/music_assistant/providers/pocketcasts/__init__.py
@@ -479,11 +479,7 @@ class PocketCastsProvider(MusicProvider):
         )
 
     async def _get_podcast_name(self, prov_podcast_id: str) -> str:
-        """
-        Return a podcast's name, empty when it cannot be looked up.
-
-        :param prov_podcast_id: The provider podcast id.
-        """
+        """Return a podcast's name, empty when it cannot be looked up."""
         # the podcast lookup is cached, so this is one call per podcast per day at most
         try:
             return (await self.get_podcast(prov_podcast_id)).name
@@ -498,11 +494,7 @@ class PocketCastsProvider(MusicProvider):
             return ""
 
     async def _get_show_notes(self, prov_podcast_id: str) -> dict[str, dict[str, Any]]:
-        """
-        Return show notes per episode uuid, empty when they cannot be read.
-
-        :param prov_podcast_id: The provider podcast id.
-        """
+        """Return show notes per episode uuid, empty when they cannot be read."""
         # show notes are supplementary, so a failure here must never break episode
         # resolution. The failure itself is not cached, so the next call tries again.
         try:
@@ -528,17 +520,7 @@ class PocketCastsProvider(MusicProvider):
         show_notes: dict[str, Any] | None = None,
         podcast_name: str = "",
     ) -> PodcastEpisode | None:
-        """
-        Convert Pocket Casts episode data to a PodcastEpisode object.
-
-        Returns None when the data has no episode UUID to key on.
-
-        :param episode_data: Raw episode data dict from the API.
-        :param podcast_uuid: The UUID of the parent podcast.
-        :param show_notes: The episode's show notes entry, or None when not looked up.
-        :param podcast_name: Name of the parent podcast, shown by players alongside the
-            episode title.
-        """
+        """Convert episode data to a PodcastEpisode, or None when it carries no episode uuid."""
         episode_uuid = episode_data.get("uuid")
         if not episode_uuid:
             return None

--- a/music_assistant/providers/pocketcasts/__init__.py
+++ b/music_assistant/providers/pocketcasts/__init__.py
@@ -236,17 +236,23 @@ class PocketCastsProvider(MusicProvider):
 
         :param prov_podcast_id: The provider podcast id.
         """
-        # fetch episode metadata and user status in parallel
-        episodes, in_progress, history = await asyncio.gather(
+        # fetch episode metadata, user status and show notes in parallel
+        (podcast_name, episodes), in_progress, history, show_notes = await asyncio.gather(
             self._client.get_podcast_episodes(prov_podcast_id),
             self._client.get_in_progress_episodes(),
             self._client.get_history(),
+            self._get_show_notes(prov_podcast_id),
         )
         in_progress_map = {ep.get("uuid"): ep for ep in in_progress}
         history_map = {ep.get("uuid"): ep for ep in history}
 
         for episode_data in episodes:
-            episode_item = self._convert_episode(episode_data, prov_podcast_id)
+            episode_item = self._convert_episode(
+                episode_data,
+                prov_podcast_id,
+                show_notes.get(episode_data.get("uuid", "")),
+                podcast_name,
+            )
             if episode_item:
                 self._enrich_episode_with_status(
                     episode_item, episode_data, in_progress_map, history_map
@@ -327,8 +333,14 @@ class PocketCastsProvider(MusicProvider):
         :param prov_item_id: The episode item id (format: podcast_uuid:episode_uuid).
         """
         podcast_uuid, episode_uuid = prov_item_id.split(":", 1)
-        episode_data = await self._client.get_episode_details(episode_uuid)
-        episode_item = self._convert_episode(episode_data, podcast_uuid)
+        episode_data, show_notes, podcast_name = await asyncio.gather(
+            self._client.get_episode_details(episode_uuid),
+            self._get_show_notes(podcast_uuid),
+            self._get_podcast_name(podcast_uuid),
+        )
+        episode_item = self._convert_episode(
+            episode_data, podcast_uuid, show_notes.get(episode_uuid), podcast_name
+        )
         if episode_item is None:
             raise MediaNotFoundError(f"Episode {episode_uuid} not found in podcast {podcast_uuid}")
 
@@ -443,6 +455,7 @@ class PocketCastsProvider(MusicProvider):
             item_id=uuid,
             provider=self.instance_id,
             name=podcast_data.get("title", ""),
+            publisher=podcast_data.get("author"),
             provider_mappings={
                 ProviderMapping(
                     item_id=uuid,
@@ -465,8 +478,55 @@ class PocketCastsProvider(MusicProvider):
             ),
         )
 
+    async def _get_podcast_name(self, prov_podcast_id: str) -> str:
+        """
+        Return a podcast's name, empty when it cannot be looked up.
+
+        :param prov_podcast_id: The provider podcast id.
+        """
+        # the podcast lookup is cached, so this is one call per podcast per day at most
+        try:
+            return (await self.get_podcast(prov_podcast_id)).name
+        except (
+            MediaNotFoundError,
+            LoginFailed,
+            ProviderUnavailableError,
+            ResourceTemporarilyUnavailable,
+            RetriesExhausted,
+        ) as err:
+            self.logger.debug("Could not retrieve podcast name for %s: %s", prov_podcast_id, err)
+            return ""
+
+    async def _get_show_notes(self, prov_podcast_id: str) -> dict[str, dict[str, Any]]:
+        """
+        Return show notes per episode uuid, empty when they cannot be read.
+
+        :param prov_podcast_id: The provider podcast id.
+        """
+        # show notes are supplementary, so a failure here must never break episode
+        # resolution. The failure itself is not cached, so the next call tries again.
+        try:
+            return await self._fetch_show_notes(prov_podcast_id)
+        except (
+            LoginFailed,
+            ProviderUnavailableError,
+            ResourceTemporarilyUnavailable,
+            RetriesExhausted,
+        ) as err:
+            self.logger.debug("Could not retrieve show notes for %s: %s", prov_podcast_id, err)
+            return {}
+
+    @use_cache(3600 * 24)
+    async def _fetch_show_notes(self, prov_podcast_id: str) -> dict[str, dict[str, Any]]:
+        """Return show notes per episode uuid for the given podcast."""
+        return await self._client.get_show_notes(prov_podcast_id)
+
     def _convert_episode(
-        self, episode_data: dict[str, Any], podcast_uuid: str
+        self,
+        episode_data: dict[str, Any],
+        podcast_uuid: str,
+        show_notes: dict[str, Any] | None = None,
+        podcast_name: str = "",
     ) -> PodcastEpisode | None:
         """
         Convert Pocket Casts episode data to a PodcastEpisode object.
@@ -475,6 +535,9 @@ class PocketCastsProvider(MusicProvider):
 
         :param episode_data: Raw episode data dict from the API.
         :param podcast_uuid: The UUID of the parent podcast.
+        :param show_notes: The episode's show notes entry, or None when not looked up.
+        :param podcast_name: Name of the parent podcast, shown by players alongside the
+            episode title.
         """
         episode_uuid = episode_data.get("uuid")
         if not episode_uuid:
@@ -482,8 +545,8 @@ class PocketCastsProvider(MusicProvider):
 
         # this is fed by two endpoints with different field schemas: the full-podcast JSON
         # uses snake_case (file_type) while /user/episode uses camelCase (fileType,
-        # episodeNumber). Neither carries show notes or episode artwork, so the description is
-        # left empty and the parent podcast image is used for every episode.
+        # episodeNumber). Neither carries the description or artwork, which is what the
+        # separate show notes lookup is for.
         item_id = f"{podcast_uuid}:{episode_uuid}"
         file_type = episode_data.get("fileType") or episode_data.get("file_type", "audio/mpeg")
         episode_item = PodcastEpisode(
@@ -494,7 +557,7 @@ class PocketCastsProvider(MusicProvider):
                 media_type=MediaType.PODCAST,
                 item_id=podcast_uuid,
                 provider=self.instance_id,
-                name="",
+                name=podcast_name,
             ),
             position=episode_data.get("episodeNumber", 0),
             provider_mappings={
@@ -511,11 +574,18 @@ class PocketCastsProvider(MusicProvider):
             episode_item.duration = int(episode_data["duration"])
         if title := episode_data.get("title"):
             episode_item.metadata.label = title
+        details = show_notes or {}
+        if description := details.get("description"):
+            episode_item.metadata.description = description
+        # only about half the episodes have their own artwork, the rest keep the podcast cover
+        image_url = details.get("image") or (
+            f"https://static.pocketcasts.com/discover/images/280/{podcast_uuid}.jpg"
+        )
         episode_item.metadata.images = UniqueList(
             [
                 MediaItemImage(
                     type=ImageType.THUMB,
-                    path=f"https://static.pocketcasts.com/discover/images/280/{podcast_uuid}.jpg",
+                    path=image_url,
                     provider=self.instance_id,
                     remotely_accessible=True,
                 )
@@ -582,7 +652,15 @@ class PocketCastsProvider(MusicProvider):
             else:
                 podcast_uuid = episode_data.get("podcastUuid")
 
-            if podcast_uuid and (episode_item := self._convert_episode(episode_data, podcast_uuid)):
+            if not podcast_uuid:
+                continue
+            # these folders mix podcasts, so the name is not known up front
+            podcast_name = podcast_field.get("title", "") if isinstance(podcast_field, dict) else ""
+            if not podcast_name:
+                podcast_name = await self._get_podcast_name(podcast_uuid)
+            if episode_item := self._convert_episode(
+                episode_data, podcast_uuid, None, podcast_name
+            ):
                 items.append(episode_item)
         return items
 

--- a/music_assistant/providers/pocketcasts/api_client.py
+++ b/music_assistant/providers/pocketcasts/api_client.py
@@ -81,9 +81,9 @@ class PocketCastsClient:
         podcast: dict[str, Any] = data.get("podcast", {})
         return podcast
 
-    async def get_podcast_episodes(self, podcast_uuid: str) -> list[dict[str, Any]]:
+    async def get_podcast_episodes(self, podcast_uuid: str) -> tuple[str, list[dict[str, Any]]]:
         """
-        Return all episodes for a podcast.
+        Return a podcast's title and all of its episodes.
 
         :param podcast_uuid: The podcast UUID.
         """
@@ -94,7 +94,39 @@ class PocketCastsClient:
         # episode number, show notes or artwork.
         episodes: list[dict[str, Any]] = podcast.get("episodes", [])
         self.logger.debug("Retrieved %d episodes for podcast %s", len(episodes), podcast_uuid)
-        return episodes
+        return str(podcast.get("title", "")), episodes
+
+    async def get_show_notes(self, podcast_uuid: str) -> dict[str, dict[str, Any]]:
+        """
+        Return the show notes and artwork, keyed by episode UUID, for a podcast.
+
+        Episodes carrying neither are left out.
+
+        :param podcast_uuid: The podcast UUID.
+        """
+        data = await self._request(
+            "GET",
+            f"{PODCAST_API_URL}/mobile/show_notes/full/{podcast_uuid}",
+            auth=False,
+            allow_redirects=True,
+        )
+        # one call covers every episode, and no other endpoint carries these two fields. The
+        # rest of the response is dropped here to keep the cached entry small.
+        show_notes: dict[str, dict[str, Any]] = {}
+        for episode in data.get("podcast", {}).get("episodes", []):
+            if not (uuid := episode.get("uuid")):
+                continue
+            details: dict[str, Any] = {}
+            if description := episode.get("show_notes"):
+                details["description"] = description
+            if image := episode.get("image"):
+                details["image"] = image
+            if details:
+                show_notes[uuid] = details
+        self.logger.debug(
+            "Retrieved show notes for %d episodes of podcast %s", len(show_notes), podcast_uuid
+        )
+        return show_notes
 
     async def get_in_progress_episodes(self) -> list[dict[str, Any]]:
         """Return episodes currently in progress."""

--- a/tests/providers/pocketcasts/test_pocketcasts.py
+++ b/tests/providers/pocketcasts/test_pocketcasts.py
@@ -287,3 +287,45 @@ async def test_special_folder_episodes_name_their_podcast(
 
     episodes = [item for item in items if isinstance(item, PodcastEpisode)]
     assert [episode.podcast.name for episode in episodes] == ["Podcast One"]
+
+
+async def test_special_folder_episodes_use_the_name_from_the_payload(
+    provider: PocketCastsProvider, client: AsyncMock
+) -> None:
+    """A podcast title carried by the folder payload is used without a podcast lookup."""
+    client.get_history.return_value = [
+        {
+            "uuid": "episode-1",
+            "title": "Episode 1",
+            "url": "https://example.com/ep1.mp3",
+            "podcastUuid": "podcast-1",
+            "podcastTitle": "Podcast One",
+        }
+    ]
+
+    items = await provider.browse("pocketcasts://history")
+
+    episodes = [item for item in items if isinstance(item, PodcastEpisode)]
+    assert [episode.podcast.name for episode in episodes] == ["Podcast One"]
+    client.get_podcast.assert_not_called()
+
+
+async def test_special_folder_looks_each_podcast_up_once(
+    provider: PocketCastsProvider, client: AsyncMock
+) -> None:
+    """Episodes of the same podcast share a single name lookup for the whole folder."""
+    client.get_history.return_value = [
+        {
+            "uuid": f"episode-{index}",
+            "title": f"Episode {index}",
+            "url": f"https://example.com/ep{index}.mp3",
+            "podcast": "podcast-1",
+        }
+        for index in (1, 2, 3)
+    ]
+
+    items = await provider.browse("pocketcasts://history")
+
+    episodes = [item for item in items if isinstance(item, PodcastEpisode)]
+    assert [episode.podcast.name for episode in episodes] == ["Podcast One"] * 3
+    assert client.get_podcast.await_count == 1

--- a/tests/providers/pocketcasts/test_pocketcasts.py
+++ b/tests/providers/pocketcasts/test_pocketcasts.py
@@ -7,25 +7,35 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import RetriesExhausted
+from music_assistant_models.media_items import PodcastEpisode
 
 from music_assistant.providers.pocketcasts import PocketCastsProvider
+from tests.common import use_real_create_task
 
 
 @pytest.fixture
 def client() -> AsyncMock:
-    """Return a mocked Pocket Casts API client."""
-    return AsyncMock()
+    """Return a mocked Pocket Casts API client with no show notes on offer."""
+    client = AsyncMock()
+    client.get_show_notes.return_value = {}
+    client.get_podcast.return_value = {"uuid": "podcast-1", "title": "Podcast One"}
+    return client
 
 
 @pytest.fixture
 def provider(client: AsyncMock) -> PocketCastsProvider:
-    """Return a PocketCastsProvider backed by the mocked API client."""
+    """Return a PocketCastsProvider backed by the mocked API client and a cold cache."""
+    mass = AsyncMock()
+    # force a cache miss so the wrapped fetches always run
+    mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
+    use_real_create_task(mass)
     manifest = MagicMock()
     manifest.domain = "pocketcasts"
     config = MagicMock()
     config.instance_id = "pocketcasts"
     config.get_value.return_value = None
-    prov = PocketCastsProvider(MagicMock(), manifest, config)
+    prov = PocketCastsProvider(mass, manifest, config)
     prov._client = client
     return prov
 
@@ -46,10 +56,13 @@ async def test_sync_survives_episode_without_duration(
     provider: PocketCastsProvider, client: AsyncMock
 ) -> None:
     """A feed episode with a null duration must not abort the episode listing."""
-    client.get_podcast_episodes.return_value = [
-        _feed_episode(uuid="episode-1", duration=None),
-        _feed_episode(uuid="episode-2", duration=1800),
-    ]
+    client.get_podcast_episodes.return_value = (
+        "Podcast One",
+        [
+            _feed_episode(uuid="episode-1", duration=None),
+            _feed_episode(uuid="episode-2", duration=1800),
+        ],
+    )
     client.get_in_progress_episodes.return_value = []
     client.get_history.return_value = []
 
@@ -68,7 +81,10 @@ async def test_sync_survives_null_status_fields(
     provider: PocketCastsProvider, client: AsyncMock
 ) -> None:
     """Null playedUpTo/duration on an in-progress entry must not abort the listing."""
-    client.get_podcast_episodes.return_value = [_feed_episode(uuid="episode-1", duration=None)]
+    client.get_podcast_episodes.return_value = (
+        "Podcast One",
+        [_feed_episode(uuid="episode-1", duration=None)],
+    )
     client.get_in_progress_episodes.return_value = [
         {"uuid": "episode-1", "playedUpTo": None, "duration": None}
     ]
@@ -85,7 +101,7 @@ async def test_sync_still_marks_played_episodes(
     provider: PocketCastsProvider, client: AsyncMock
 ) -> None:
     """An episode played past the threshold is still reported as fully played."""
-    client.get_podcast_episodes.return_value = [_feed_episode(duration=1000)]
+    client.get_podcast_episodes.return_value = ("Podcast One", [_feed_episode(duration=1000)])
     client.get_in_progress_episodes.return_value = [
         {"uuid": "episode-1", "playedUpTo": 950, "duration": 1000}
     ]
@@ -101,7 +117,7 @@ async def test_sync_reports_resume_position(
     provider: PocketCastsProvider, client: AsyncMock
 ) -> None:
     """A partially played episode keeps its resume position."""
-    client.get_podcast_episodes.return_value = [_feed_episode(duration=1000)]
+    client.get_podcast_episodes.return_value = ("Podcast One", [_feed_episode(duration=1000)])
     client.get_in_progress_episodes.return_value = [
         {"uuid": "episode-1", "playedUpTo": 300, "duration": 1000}
     ]
@@ -148,3 +164,126 @@ async def test_get_resume_position_handles_null_fields(
         0,
         None,
     )
+
+
+async def test_episodes_get_their_own_description_and_artwork(
+    provider: PocketCastsProvider, client: AsyncMock
+) -> None:
+    """An episode uses its own show notes and artwork when the podcast supplies them."""
+    client.get_podcast_episodes.return_value = (
+        "Podcast One",
+        [
+            _feed_episode(uuid="episode-1"),
+            _feed_episode(uuid="episode-2"),
+        ],
+    )
+    client.get_in_progress_episodes.return_value = []
+    client.get_history.return_value = []
+    client.get_show_notes.return_value = {
+        "episode-1": {
+            "description": "<p>All about episode one.</p>",
+            "image": "https://example.com/ep1.jpg",
+        }
+    }
+
+    episodes = [episode async for episode in provider.get_podcast_episodes("podcast-1")]
+
+    assert episodes[0].metadata.description == "<p>All about episode one.</p>"
+    assert episodes[0].metadata.images is not None
+    assert episodes[0].metadata.images[0].path == "https://example.com/ep1.jpg"
+
+
+async def test_episodes_without_artwork_keep_the_podcast_cover(
+    provider: PocketCastsProvider, client: AsyncMock
+) -> None:
+    """Only some episodes have their own artwork, the rest fall back to the podcast cover."""
+    client.get_podcast_episodes.return_value = ("Podcast One", [_feed_episode(uuid="episode-2")])
+    client.get_in_progress_episodes.return_value = []
+    client.get_history.return_value = []
+    client.get_show_notes.return_value = {"episode-2": {"description": "Just notes."}}
+
+    episodes = [episode async for episode in provider.get_podcast_episodes("podcast-1")]
+
+    assert episodes[0].metadata.description == "Just notes."
+    assert episodes[0].metadata.images is not None
+    assert episodes[0].metadata.images[0].path.endswith("/podcast-1.jpg")
+
+
+async def test_sync_survives_unavailable_show_notes(
+    provider: PocketCastsProvider, client: AsyncMock
+) -> None:
+    """A failing show notes lookup must not abort the episode listing."""
+    client.get_podcast_episodes.return_value = ("Podcast One", [_feed_episode(uuid="episode-1")])
+    client.get_in_progress_episodes.return_value = []
+    client.get_history.return_value = []
+    client.get_show_notes.side_effect = RetriesExhausted("gave up")
+
+    episodes = [episode async for episode in provider.get_podcast_episodes("podcast-1")]
+
+    assert [episode.item_id for episode in episodes] == ["podcast-1:episode-1"]
+    assert episodes[0].metadata.description is None
+
+
+async def test_single_episode_gets_its_description(
+    provider: PocketCastsProvider, client: AsyncMock
+) -> None:
+    """Fetching one episode also fills in its description."""
+    client.get_episode_details.return_value = {
+        "uuid": "episode-1",
+        "title": "Episode 1",
+        "url": "https://example.com/ep1.mp3",
+        "duration": 1800,
+    }
+    client.get_show_notes.return_value = {"episode-1": {"description": "All about it."}}
+
+    episode = await provider.get_podcast_episode("podcast-1:episode-1")
+
+    assert episode.metadata.description == "All about it."
+
+
+async def test_episodes_name_their_podcast(
+    provider: PocketCastsProvider, client: AsyncMock
+) -> None:
+    """An episode carries its podcast's name, which players show next to the title."""
+    client.get_podcast_episodes.return_value = ("Podcast One", [_feed_episode(uuid="episode-1")])
+    client.get_in_progress_episodes.return_value = []
+    client.get_history.return_value = []
+
+    episodes = [episode async for episode in provider.get_podcast_episodes("podcast-1")]
+
+    assert episodes[0].podcast.name == "Podcast One"
+
+
+async def test_single_episode_names_its_podcast(
+    provider: PocketCastsProvider, client: AsyncMock
+) -> None:
+    """Fetching one episode also names its podcast."""
+    client.get_episode_details.return_value = {
+        "uuid": "episode-1",
+        "title": "Episode 1",
+        "url": "https://example.com/ep1.mp3",
+        "duration": 1800,
+    }
+
+    episode = await provider.get_podcast_episode("podcast-1:episode-1")
+
+    assert episode.podcast.name == "Podcast One"
+
+
+async def test_special_folder_episodes_name_their_podcast(
+    provider: PocketCastsProvider, client: AsyncMock
+) -> None:
+    """Episodes in the mixed folders name the podcast they came from."""
+    client.get_starred_episodes.return_value = [
+        {
+            "uuid": "episode-1",
+            "title": "Episode 1",
+            "url": "https://example.com/ep1.mp3",
+            "podcast": {"uuid": "podcast-1", "title": "Podcast One"},
+        }
+    ]
+
+    items = await provider.browse("pocketcasts://starred")
+
+    episodes = [item for item in items if isinstance(item, PodcastEpisode)]
+    assert [episode.podcast.name for episode in episodes] == ["Podcast One"]


### PR DESCRIPTION
# What does this implement/fix?

Pocket Casts episodes came through with no description, the podcast cover as their picture, and no mention of which podcast they belong to. The endpoints the provider was using carry none of that, so it was never being asked for.

- Episodes now show their own description
- Episodes show their own artwork where the podcast provides one, and keep the podcast cover where it does not
- The now playing view names the podcast an episode came from, which was blank before
- Podcasts show who publishes them, something every other podcast provider was already doing

Tested against a real Pocket Casts account. Descriptions came back for every episode of the podcasts checked, artwork for about half, and the publisher now reads Vox, Goalhanger and Spotify Studios where those rows were empty before.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
