### PR TITLE
Fix nugs.net playback for promo and trial subscriptions

### DIFF
--- a/music_assistant/providers/nugs/__init__.py
+++ b/music_assistant/providers/nugs/__init__.py
@@ -16,10 +16,10 @@ from music_assistant_models.enums import (
     StreamType,
 )
 from music_assistant_models.errors import (
+    AudioError,
     InvalidDataError,
     LoginFailed,
     MediaNotFoundError,
-    ProviderPermissionDenied,
     ResourceTemporarilyUnavailable,
 )
 from music_assistant_models.media_items import (
@@ -430,7 +430,7 @@ class NugsProvider(MusicProvider):
         plan = subscription_info.get("plan") or (subscription_info.get("promo") or {}).get("plan")
         if not plan:
             msg = "No active nugs.net subscription found for this account"
-            raise ProviderPermissionDenied(msg)
+            raise AudioError(msg)
         dt_start = datetime.strptime(subscription_info["startedAt"], "%m/%d/%Y %H:%M:%S").replace(
             tzinfo=UTC
         )

--- a/music_assistant/providers/nugs/__init__.py
+++ b/music_assistant/providers/nugs/__init__.py
@@ -19,6 +19,7 @@ from music_assistant_models.errors import (
     InvalidDataError,
     LoginFailed,
     MediaNotFoundError,
+    ProviderPermissionDenied,
     ResourceTemporarilyUnavailable,
 )
 from music_assistant_models.media_items import (
@@ -425,6 +426,11 @@ class NugsProvider(MusicProvider):
 
     async def _get_stream_url(self, item_id: str) -> Any:
         subscription_info = await self._get_data("subscription", "")
+        # trial and promo accounts have no regular plan: their plan sits on the promo object
+        plan = subscription_info.get("plan") or (subscription_info.get("promo") or {}).get("plan")
+        if not plan:
+            msg = "No active nugs.net subscription found for this account"
+            raise ProviderPermissionDenied(msg)
         dt_start = datetime.strptime(subscription_info["startedAt"], "%m/%d/%Y %H:%M:%S").replace(
             tzinfo=UTC
         )
@@ -441,7 +447,7 @@ class NugsProvider(MusicProvider):
             "orgn": "websdk",
             "method": "subPlayer",
             "trackId": item_id,
-            "subCostplanIDAccessList": subscription_info["plan"]["id"],
+            "subCostplanIDAccessList": plan["id"],
             "startDateStamp": int(dt_start.timestamp()),
             "endDateStamp": int(dt_end.timestamp()),
             "nn_userID": user_info["userId"],

--- a/tests/providers/nugs/test_stream_url.py
+++ b/tests/providers/nugs/test_stream_url.py
@@ -6,7 +6,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.errors import ProviderPermissionDenied
+from music_assistant_models.errors import AudioError
 
 from music_assistant.providers.nugs import NugsProvider
 
@@ -68,8 +68,8 @@ async def test_stream_url_falls_back_to_promo_plan(provider: NugsProvider) -> No
 
 @pytest.mark.asyncio
 async def test_stream_url_without_any_plan_raises(provider: NugsProvider) -> None:
-    """Without a regular or promo plan a clear permission error is raised."""
+    """Without a regular or promo plan a clear audio error is raised."""
     _stub_get_data(provider, {**SUBSCRIPTION_BASE, "plan": None, "promo": None})
 
-    with pytest.raises(ProviderPermissionDenied):
+    with pytest.raises(AudioError):
         await provider._get_stream_url("123")

--- a/tests/providers/nugs/test_stream_url.py
+++ b/tests/providers/nugs/test_stream_url.py
@@ -1,0 +1,79 @@
+"""Test Nugs.net stream url building for regular, promo/trial and inactive subscriptions."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from music_assistant_models.errors import ProviderPermissionDenied
+
+from music_assistant.providers.nugs import NugsProvider
+
+USER_DATA = {"userId": "user-1"}
+SUBSCRIPTION_BASE = {
+    "startedAt": "08/01/2026 00:00:00",
+    "endsAt": "09/01/2026 00:00:00",
+    "legacySubscriptionId": "legacy-1",
+}
+
+
+def _stub_get_data(provider: NugsProvider, subscription: dict[str, Any]) -> None:
+    """Attach a _get_data stub returning the given subscription payload."""
+
+    async def _fake(nugs_api: str, _endpoint: str, **_kwargs: Any) -> Any:
+        if nugs_api == "subscription":
+            return subscription
+        return USER_DATA
+
+    provider._get_data = AsyncMock(side_effect=_fake)  # type: ignore[method-assign]
+
+
+def _stub_http_session(provider: NugsProvider, captured: dict[str, Any]) -> None:
+    """Stub the http session so the subplayer call returns a fixed stream link."""
+    response = AsyncMock()
+    response.raise_for_status = lambda: None
+    response.text = AsyncMock(return_value='{"streamLink": "https://stream.test/track.m3u8"}')
+    get_ctx = AsyncMock()
+    get_ctx.__aenter__ = AsyncMock(return_value=response)
+    get_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    def _get(_url: str, **kwargs: Any) -> Any:
+        captured.update(kwargs["params"])
+        return get_ctx
+
+    provider.mass.http_session.get = _get
+
+
+@pytest.mark.asyncio
+async def test_stream_url_uses_regular_plan(provider: NugsProvider) -> None:
+    """A regular subscription passes its own plan id as the cost plan access list."""
+    captured: dict[str, Any] = {}
+    _stub_get_data(provider, {**SUBSCRIPTION_BASE, "plan": {"id": "plan-42"}})
+    _stub_http_session(provider, captured)
+
+    assert await provider._get_stream_url("123") == "https://stream.test/track.m3u8"
+    assert captured["subCostplanIDAccessList"] == "plan-42"
+
+
+@pytest.mark.asyncio
+async def test_stream_url_falls_back_to_promo_plan(provider: NugsProvider) -> None:
+    """A trial/promo subscription has plan set to None and its plan id under promo."""
+    captured: dict[str, Any] = {}
+    _stub_get_data(
+        provider,
+        {**SUBSCRIPTION_BASE, "plan": None, "promo": {"plan": {"id": "promo-7"}}},
+    )
+    _stub_http_session(provider, captured)
+
+    assert await provider._get_stream_url("123") == "https://stream.test/track.m3u8"
+    assert captured["subCostplanIDAccessList"] == "promo-7"
+
+
+@pytest.mark.asyncio
+async def test_stream_url_without_any_plan_raises(provider: NugsProvider) -> None:
+    """Without a regular or promo plan a clear permission error is raised."""
+    _stub_get_data(provider, {**SUBSCRIPTION_BASE, "plan": None, "promo": None})
+
+    with pytest.raises(ProviderPermissionDenied):
+        await provider._get_stream_url("123")

--- a/tests/providers/nugs/test_stream_url.py
+++ b/tests/providers/nugs/test_stream_url.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.errors import ProviderPermissionDenied
@@ -29,7 +29,7 @@ def _stub_get_data(provider: NugsProvider, subscription: dict[str, Any]) -> None
     provider._get_data = AsyncMock(side_effect=_fake)  # type: ignore[method-assign]
 
 
-def _stub_http_session(provider: NugsProvider, captured: dict[str, Any]) -> None:
+def _stub_http_session(provider: NugsProvider) -> MagicMock:
     """Stub the http session so the subplayer call returns a fixed stream link."""
     response = AsyncMock()
     response.raise_for_status = lambda: None
@@ -37,37 +37,33 @@ def _stub_http_session(provider: NugsProvider, captured: dict[str, Any]) -> None
     get_ctx = AsyncMock()
     get_ctx.__aenter__ = AsyncMock(return_value=response)
     get_ctx.__aexit__ = AsyncMock(return_value=False)
-
-    def _get(_url: str, **kwargs: Any) -> Any:
-        captured.update(kwargs["params"])
-        return get_ctx
-
-    provider.mass.http_session.get = _get
+    session_get = MagicMock(return_value=get_ctx)
+    mass: Any = provider.mass
+    mass.http_session.get = session_get
+    return session_get
 
 
 @pytest.mark.asyncio
 async def test_stream_url_uses_regular_plan(provider: NugsProvider) -> None:
     """A regular subscription passes its own plan id as the cost plan access list."""
-    captured: dict[str, Any] = {}
     _stub_get_data(provider, {**SUBSCRIPTION_BASE, "plan": {"id": "plan-42"}})
-    _stub_http_session(provider, captured)
+    session_get = _stub_http_session(provider)
 
     assert await provider._get_stream_url("123") == "https://stream.test/track.m3u8"
-    assert captured["subCostplanIDAccessList"] == "plan-42"
+    assert session_get.call_args.kwargs["params"]["subCostplanIDAccessList"] == "plan-42"
 
 
 @pytest.mark.asyncio
 async def test_stream_url_falls_back_to_promo_plan(provider: NugsProvider) -> None:
     """A trial/promo subscription has plan set to None and its plan id under promo."""
-    captured: dict[str, Any] = {}
     _stub_get_data(
         provider,
         {**SUBSCRIPTION_BASE, "plan": None, "promo": {"plan": {"id": "promo-7"}}},
     )
-    _stub_http_session(provider, captured)
+    session_get = _stub_http_session(provider)
 
     assert await provider._get_stream_url("123") == "https://stream.test/track.m3u8"
-    assert captured["subCostplanIDAccessList"] == "promo-7"
+    assert session_get.call_args.kwargs["params"]["subCostplanIDAccessList"] == "promo-7"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

nugs returns the cost plan under `promo.plan` instead of the top-level `plan` field for promotional and trial subscriptions, so building the subplayer params raised `TypeError: 'NoneType' object is not subscriptable` for those accounts, even though login, browsing and the account page work.

Prefer the regular plan, fall back to the promo plan, and raise a clear `ProviderPermissionDenied` when the account has neither instead of letting a raw TypeError surface from the websocket handler.

I couldn't actually test this as nugs has no trial plans anymore. The original path remains so there will no regression for existing users but it means in future if they do reinstate any promo plans that this will now work.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
