### PR TITLE
Make next/previous/seek on live audio sources work the same from every API

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -25,7 +25,6 @@ from music_assistant_models.enums import (
     MediaType,
     PlaybackState,
     PlayerType,
-    ProviderFeature,
     QueueOption,
     RepeatMode,
     SourceControl,
@@ -82,6 +81,7 @@ from music_assistant.controllers.player_queues.state import PlayerQueueData
 from music_assistant.controllers.player_queues.stream_feeder import StreamFeederMixin
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.api import api_command
+from music_assistant.helpers.player import get_queue_audio_source
 from music_assistant.models.music_provider import ProviderStreamLimitError
 from music_assistant.models.player import Player, PlayerMedia
 from music_assistant.models.plugin import PluginProvider
@@ -798,12 +798,16 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         self._check_player_permission(queue_id)
         if (queue := self.get(queue_id)) is None or not queue.active:
             raise InvalidCommand(f"Queue {queue_id} is not active")
-        if (delegated := self._get_delegated_source(queue_id)) is not None:
-            audio_source, _caps, provider = delegated
-            if not audio_source.can_next_previous:
+        if (active := self._get_current_audio_source(queue_id)) is not None:
+            audio_source, provider = active
+            # gate on the per-action flag alone so a transport-only source (no
+            # queue_capabilities) also skips within its own session
+            if audio_source.can_next_previous:
+                await provider.on_source_control(audio_source.item_id, SourceControl.NEXT)
+                return
+            if audio_source.queue_capabilities is not None:
                 raise InvalidCommand("Cannot skip: the external session does not support skipping")
-            await provider.on_source_control(audio_source.item_id, SourceControl.NEXT)
-            return
+            # a live source without skip support: fall through to the MA index walk
         self._set_transitioning(queue_id, True)
         idx = self._queue_data[queue_id].queue.current_index
         if idx is None:
@@ -844,12 +848,16 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         self._check_player_permission(queue_id)
         if (queue := self.get(queue_id)) is None or not queue.active:
             raise InvalidCommand(f"Queue {queue_id} is not active")
-        if (delegated := self._get_delegated_source(queue_id)) is not None:
-            audio_source, _caps, provider = delegated
-            if not audio_source.can_next_previous:
+        if (active := self._get_current_audio_source(queue_id)) is not None:
+            audio_source, provider = active
+            # gate on the per-action flag alone so a transport-only source (no
+            # queue_capabilities) also skips within its own session
+            if audio_source.can_next_previous:
+                await provider.on_source_control(audio_source.item_id, SourceControl.PREVIOUS)
+                return
+            if audio_source.queue_capabilities is not None:
                 raise InvalidCommand("Cannot skip: the external session does not support skipping")
-            await provider.on_source_control(audio_source.item_id, SourceControl.PREVIOUS)
-            return
+            # a live source without skip support: fall through to the MA index walk
         self._set_transitioning(queue_id, True)
         current_index = self._queue_data[queue_id].queue.current_index
         if current_index is None:
@@ -900,21 +908,25 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         """
         if (queue := self.get(queue_id)) is None or not queue.active:
             raise InvalidCommand(f"Queue {queue_id} is not active")
-        if (delegated := self._get_delegated_source(queue_id)) is not None:
-            audio_source, _caps, provider = delegated
-            if not audio_source.can_seek:
+        if (active := self._get_current_audio_source(queue_id)) is not None:
+            audio_source, provider = active
+            # gate on the per-action flag alone so a transport-only source (no
+            # queue_capabilities) also seeks within its own session
+            if audio_source.can_seek:
+                position = max(0, int(position))
+                current_item = queue.current_item
+                await provider.on_source_control(audio_source.item_id, SourceControl.SEEK, position)
+                # publish the seek target so the progress bar does not snap back to the
+                # last position report (mirrors the non-delegated path below) — unless a
+                # concurrent play/stop replaced the current item during the forward
+                if queue.current_item is current_item:
+                    queue.elapsed_time = position
+                    queue.elapsed_time_last_updated = time.time()
+                    self.signal_update(queue_id)
+                return
+            if audio_source.queue_capabilities is not None:
                 raise InvalidCommand("Cannot seek: the external session does not support seeking")
-            position = max(0, int(position))
-            current_item = queue.current_item
-            await provider.on_source_control(audio_source.item_id, SourceControl.SEEK, position)
-            # publish the seek target so the progress bar does not snap back to the
-            # last position report (mirrors the non-delegated path below) — unless a
-            # concurrent play/stop replaced the current item during the forward
-            if queue.current_item is current_item:
-                queue.elapsed_time = position
-                queue.elapsed_time_last_updated = time.time()
-                self.signal_update(queue_id)
-            return
+            # a non-seekable live source falls through: the duration guard below rejects it
         queue_player = self.mass.players.get_player(queue_id, True)
         if queue_player is None:
             raise PlayerUnavailableError(f"Player {queue_id} is not available")
@@ -2120,35 +2132,36 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         Return the AudioSource owning the queue's commands, its capabilities and owning plugin.
 
         While the queue's current item is an AudioSource declaring ``queue_capabilities``,
-        the external session owns the queue: commands are forwarded to the owning plugin
-        and the mirrored options event updates the queue state afterwards. This matches
-        the player-layer proxy: no playback-state gate, because a plugin may map a paused
-        session onto a stopped player (Spotify Connect does) — a genuinely dead session
-        is the owning plugin's call, surfaced as its localized not-active error. Returns
-        None — queue commands then apply to the MA queue as usual — when the current item
-        is not such an AudioSource (a transport-only source keeps queue commands with MA)
-        or when the owning plugin provider is no longer available.
+        the external session owns the queue: shuffle/repeat are forwarded to the owning
+        plugin and the mirrored options event updates the queue state afterwards. There is
+        no playback-state gate, because a plugin may map a paused session onto a stopped
+        player (Spotify Connect does) — a genuinely dead session is the owning plugin's
+        call, surfaced as its localized not-active error. Returns None — queue commands
+        then apply to the MA queue as usual — when the current item is not such an
+        AudioSource (a transport-only source keeps ownership of the queue with MA) or
+        when the owning plugin provider is no longer available. Transport commands
+        (next/previous/seek) do not use this gate: see ``_get_current_audio_source``.
+
+        :param queue_id: The queue to inspect.
+        """
+        if (resolved := self._get_current_audio_source(queue_id)) is None:
+            return None
+        audio_source, provider = resolved
+        if (caps := audio_source.queue_capabilities) is None:
+            return None
+        return audio_source, caps, provider
+
+    def _get_current_audio_source(self, queue_id: str) -> tuple[AudioSource, PluginProvider] | None:
+        """
+        Return the AudioSource current on the queue and its owning PluginProvider.
+
+        Unlike ``_get_delegated_source`` this does not require ``queue_capabilities``:
+        transport commands (next/previous/seek) delegate on the per-action capability
+        flags alone, so a transport-only source skips/seeks within its own session
+        via the queue API just like it does via the player-command API.
 
         :param queue_id: The queue to inspect.
         """
         if (queue_data := self._queue_data.get(queue_id)) is None:
             return None
-        current_item = queue_data.queue.current_item
-        if current_item is None or current_item.media_item is None:
-            return None
-        media_item = current_item.media_item
-        if not isinstance(media_item, AudioSource):
-            return None
-        caps = media_item.queue_capabilities
-        if caps is None:
-            return None
-        provider = self.mass.get_provider(media_item.provider)
-        if not isinstance(provider, PluginProvider):
-            return None
-        # Belt-and-suspenders: a queue item carrying media_type=AUDIO_SOURCE
-        # can only have come from a provider that declared the feature, but
-        # a feature flag flipped off at runtime (provider reload, config
-        # change) would leave on_source_control raising NotImplementedError.
-        if ProviderFeature.AUDIO_SOURCE not in provider.supported_features:
-            return None
-        return media_item, caps, provider
+        return get_queue_audio_source(self.mass, queue_data.queue)

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -54,7 +54,6 @@ from music_assistant_models.errors import (
     ProviderUnavailableError,
     UnsupportedFeaturedException,
 )
-from music_assistant_models.media_items import AudioSource
 from music_assistant_models.player import PlayerOptionValueType  # noqa: TC002
 from music_assistant_models.player_control import PlayerControl  # noqa: TC002
 
@@ -104,6 +103,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
 )
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.colors import get_palette_for_url
+from music_assistant.helpers.player import get_queue_audio_source
 from music_assistant.helpers.plugin_engines import create_tts_engine_config_entries
 from music_assistant.helpers.util import (
     TaskManager,
@@ -127,6 +127,7 @@ if TYPE_CHECKING:
         CoreConfig,
         PlayerConfig,
     )
+    from music_assistant_models.media_items import AudioSource
     from music_assistant_models.player import OutputProtocol
     from music_assistant_models.player_queue import PlayerQueue
 
@@ -705,15 +706,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         - position: position in seconds to seek to in the current playing item.
         """
         player = self._get_player_with_redirect(player_id)
-        # If an AudioSource is the active queue item, proxy the seek to the plugin
-        if active := self._get_active_audio_source(player):
-            audio_source, plugin_prov = active
-            if audio_source.can_seek:
-                await plugin_prov.on_source_control(
-                    audio_source.item_id, SourceControl.SEEK, position
-                )
-                return
         # Redirect to queue controller if it is active
+        # (it delegates an active seekable AudioSource item to the owning plugin)
         if active_queue := self.get_active_queue(player):
             await self.mass.player_queues.seek(active_queue.queue_id, position)
             return
@@ -737,13 +731,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         """Handle NEXT TRACK command for given player."""
         player = self._get_player_with_redirect(player_id)
         active_source_id = player.state.active_source or player.player_id
-        # If an AudioSource is the active queue item, proxy next to the plugin
-        if active := self._get_active_audio_source(player):
-            audio_source, plugin_prov = active
-            if audio_source.can_next_previous:
-                await plugin_prov.on_source_control(audio_source.item_id, SourceControl.NEXT)
-                return
         # Redirect to queue controller if it is active
+        # (it delegates an active skippable AudioSource item to the owning plugin)
         if active_queue := self.get_active_queue(player):
             await self.mass.player_queues.next(active_queue.queue_id)
             return
@@ -767,13 +756,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         """Handle PREVIOUS TRACK command for given player."""
         player = self._get_player_with_redirect(player_id)
         active_source_id = player.state.active_source or player.player_id
-        # If an AudioSource is the active queue item, proxy previous to the plugin
-        if active := self._get_active_audio_source(player):
-            audio_source, plugin_prov = active
-            if audio_source.can_next_previous:
-                await plugin_prov.on_source_control(audio_source.item_id, SourceControl.PREVIOUS)
-                return
         # Redirect to queue controller if it is active
+        # (it delegates an active skippable AudioSource item to the owning plugin)
         if active_queue := self.get_active_queue(player):
             await self.mass.player_queues.previous(active_queue.queue_id)
             return
@@ -2845,29 +2829,7 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
 
         :param player: The player whose active queue to inspect.
         """
-        active_queue = self.get_active_queue(player)
-        if active_queue is None:
-            return None
-        current_item = active_queue.current_item
-        if current_item is None or current_item.media_item is None:
-            return None
-        media_item = current_item.media_item
-        # isinstance check defends against a non-AudioSource subclass that
-        # somehow has media_type=AUDIO_SOURCE set (mutated or constructed wrong)
-        # — the media_type guard alone would let it through and crash later.
-        if not isinstance(media_item, AudioSource):
-            return None
-        provider = self.mass.get_provider(media_item.provider)
-        if not isinstance(provider, PluginProvider):
-            return None
-        # Belt-and-suspenders: a queue item carrying media_type=AUDIO_SOURCE
-        # can only have come from a provider that declared the feature, but
-        # a feature flag flipped off at runtime (provider reload, config
-        # change) would leave on_source_control / on_volume_change raising
-        # NotImplementedError out of cmd_play / cmd_pause. Skip cleanly.
-        if ProviderFeature.AUDIO_SOURCE not in provider.supported_features:
-            return None
-        return media_item, provider
+        return get_queue_audio_source(self.mass, self.get_active_queue(player))
 
     def _get_player_groups(self, player: Player) -> Iterator[Player]:
         """

--- a/music_assistant/helpers/player.py
+++ b/music_assistant/helpers/player.py
@@ -1,6 +1,16 @@
 """Helpers for player behavior."""
 
-from music_assistant_models.enums import PlayerType
+from typing import TYPE_CHECKING
+
+from music_assistant_models.enums import PlayerType, ProviderFeature
+from music_assistant_models.media_items import AudioSource
+
+from music_assistant.models.plugin import PluginProvider
+
+if TYPE_CHECKING:
+    from music_assistant_models.player_queue import PlayerQueue
+
+    from music_assistant.mass import MusicAssistant
 
 _DEFAULT_ICONS_BY_PROVIDER = {
     "airplay": "airplay",
@@ -74,3 +84,39 @@ def get_default_player_icon(
     if provider_icon := _DEFAULT_ICONS_BY_PROVIDER.get(provider_domain):
         return provider_icon
     return "speaker"
+
+
+def get_queue_audio_source(
+    mass: MusicAssistant, queue: PlayerQueue | None
+) -> tuple[AudioSource, PluginProvider] | None:
+    """
+    Return the AudioSource current on the given queue and its owning PluginProvider.
+
+    Returns None when the queue's current item is not a MediaType.AUDIO_SOURCE
+    or when the owning plugin provider is no longer available.
+
+    :param mass: The MusicAssistant instance.
+    :param queue: The queue whose current item to inspect (None allowed).
+    """
+    if queue is None:
+        return None
+    current_item = queue.current_item
+    if current_item is None or current_item.media_item is None:
+        return None
+    media_item = current_item.media_item
+    # isinstance check defends against a non-AudioSource subclass that
+    # somehow has media_type=AUDIO_SOURCE set (mutated or constructed wrong)
+    # — the media_type guard alone would let it through and crash later.
+    if not isinstance(media_item, AudioSource):
+        return None
+    provider = mass.get_provider(media_item.provider)
+    if not isinstance(provider, PluginProvider):
+        return None
+    # Belt-and-suspenders: a queue item carrying media_type=AUDIO_SOURCE
+    # can only have come from a provider that declared the feature, but
+    # a feature flag flipped off at runtime (provider reload, config
+    # change) would leave on_source_control / on_volume_change raising
+    # NotImplementedError. Skip cleanly.
+    if ProviderFeature.AUDIO_SOURCE not in provider.supported_features:
+        return None
+    return media_item, provider

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -171,11 +171,12 @@ class PluginProvider(Provider):
         """
         Handle a playback control command for an active AudioSource.
 
-        Called by the player controller when the user (or an automation) issues
-        a control command and the active queue item is an AudioSource whose
-        capability flag for the action is True (e.g. ``can_next_previous`` for
-        NEXT/PREVIOUS), and by the queue controller when the queue's current
-        item is an AudioSource declaring ``queue_capabilities`` (SHUFFLE/REPEAT).
+        Called when the user (or an automation) issues a control command while
+        the active queue item is an AudioSource that supports the action:
+        PLAY/PAUSE dispatch from the player controller (gated on
+        ``can_play_pause``), NEXT/PREVIOUS/SEEK from the queue controller
+        (gated on ``can_next_previous`` / ``can_seek``) and SHUFFLE/REPEAT
+        from the queue controller for sources declaring ``queue_capabilities``.
 
         :param source_id: The AudioSource.item_id the command applies to.
         :param action: The control action to perform.

--- a/music_assistant/providers/_demo_plugin_provider/__init__.py
+++ b/music_assistant/providers/_demo_plugin_provider/__init__.py
@@ -182,8 +182,8 @@ class MyDemoPluginprovider(PluginProvider):
         # "Live Inputs" browse node and can be played on any player via
         # the standard play_media flow. Capability flags (can_play_pause,
         # can_seek, can_next_previous) drive which control buttons the UI
-        # surfaces and which commands the player controller proxies through
-        # to on_source_control.
+        # surfaces and which commands the server proxies through to
+        # on_source_control.
         #
         # Most plugins expose a single source; for those, build it once in
         # __init__ and return the cached instance here. Plugins that expose

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -457,6 +457,12 @@ class AriaCastReceiver(PluginProvider):
         key = "command" if "command" in payload else "action" if "action" in payload else None
         if key is None:
             return
+        # A payload carrying "success" is a reply/ack (the shape this server
+        # sends itself), not a command — dispatching it would relay a client's
+        # ack of a broadcast action as a fresh command (and loop on a client
+        # that acks our own ack).
+        if "success" in payload:
+            return
         command = str(payload.get(key) or "").lower()
         if not command:
             return
@@ -478,14 +484,15 @@ class AriaCastReceiver(PluginProvider):
                 await self._cmd_play()
         elif command == "stop":
             await self._cmd_pause()
-        elif command == "next":
+        elif command in ("next", "previous"):
+            # Relay to the other control clients so the streaming sender skips
+            # within its own playlist (the MA queue holds no track boundaries for
+            # a live cast stream). Never routed through player_queues.next: the
+            # queue delegates transport commands for an active AudioSource back
+            # to this plugin, which would echo the command to its originator
+            # (and loop forever on a client that echoes actions back).
             if self._in_use_by_queue:
-                with suppress(Exception):
-                    await self.mass.player_queues.next(self._in_use_by_queue)
-        elif command == "previous":
-            if self._in_use_by_queue:
-                with suppress(Exception):
-                    await self.mass.player_queues.previous(self._in_use_by_queue)
+                await self._forward_action(command, exclude=ws)
         elif command == "seek":
             # The live AriaCast source has no seekable timeline on the MA side
             # (audio_source.can_seek is False); accept and ack per spec, no-op.
@@ -818,11 +825,20 @@ class AriaCastReceiver(PluginProvider):
         await self._forward_action("pause")
         await self._broadcast_meta()
 
-    async def _forward_action(self, action: str) -> None:
-        """Send an action to all connected /control WebSocket senders."""
+    async def _forward_action(
+        self, action: str, exclude: web.WebSocketResponse | None = None
+    ) -> None:
+        """
+        Send an action to all connected /control WebSocket senders.
+
+        :param action: The action to broadcast.
+        :param exclude: Optional sender to skip (the originator of a relayed command).
+        """
         msg = {"action": action}
         dead: set[web.WebSocketResponse] = set()
         for ws in list(self._control_senders):
+            if ws is exclude:
+                continue
             try:
                 await ws.send_json(msg)
             except Exception:

--- a/tests/controllers/player_queues/test_delegated_queue.py
+++ b/tests/controllers/player_queues/test_delegated_queue.py
@@ -5,9 +5,11 @@ While the queue's current item is a live (playing/paused) AudioSource declaring
 ``queue_capabilities``, the external session owns the queue: shuffle/repeat/next/previous/
 seek are forwarded to the owning plugin (the mirrored options event updates the queue
 state afterwards) and ``queue_owner`` tells clients who owns the ordering. MA-owned tail
-items behind the source stay editable. A transport-only AudioSource (no
-``queue_capabilities``) keeps the exact pre-delegation behavior; playback state is
-deliberately not gated (a paused session may read as a stopped player).
+items behind the source stay editable. Transport commands (next/previous/seek) delegate
+on the per-action capability flags alone, so a transport-only AudioSource (no
+``queue_capabilities``) also skips/seeks within its own session — matching the
+player-command API — while queue ownership (shuffle/repeat/items) stays with MA.
+Playback state is deliberately not gated (a paused session may read as a stopped player).
 """
 
 from __future__ import annotations
@@ -396,13 +398,12 @@ async def test_signal_update_refreshes_the_derived_shuffle_flag() -> None:
     assert queue.smart_shuffle_active is True
 
 
-async def test_transport_only_source_keeps_normal_queue_behavior() -> None:
-    """Regression: without queue_capabilities nothing is forwarded to the plugin."""
+async def test_transport_only_source_keeps_queue_ownership_with_ma() -> None:
+    """Regression: without queue_capabilities no ownership command reaches the plugin."""
     ctrl, provider = _controller(_audio_source(None))
 
     await ctrl.set_shuffle(QUEUE_ID, True)
     await ctrl.set_repeat(QUEUE_ID, RepeatMode.ALL)
-    await ctrl.next(QUEUE_ID)
     ctrl.delete_item(QUEUE_ID, 0)
 
     provider.on_source_control.assert_not_awaited()
@@ -410,6 +411,58 @@ async def test_transport_only_source_keeps_normal_queue_behavior() -> None:
     assert _queue(ctrl).shuffle_enabled is True
     assert _queue(ctrl).repeat_mode == RepeatMode.ALL
     assert ctrl._queue_data[QUEUE_ID].items == []
+
+
+async def test_transport_only_next_and_previous_forward_to_the_session() -> None:
+    """
+    A transport-only source (yandex_ynison/ariacast shape) skips within its session.
+
+    The per-action flag gates the delegation, not queue_capabilities — so the queue
+    API behaves the same as the player-command API for next/previous.
+    """
+    ctrl, provider = _controller(_audio_source(None))
+
+    await ctrl.next(QUEUE_ID)
+    await ctrl.previous(QUEUE_ID)
+
+    assert provider.on_source_control.await_count == 2
+    provider.on_source_control.assert_any_await(SOURCE_ID, SourceControl.NEXT)
+    provider.on_source_control.assert_any_await(SOURCE_ID, SourceControl.PREVIOUS)
+    # no MA index walk: the source stays current
+    assert _queue(ctrl).current_index == 0
+    ctrl.play_index.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+async def test_transport_only_seek_forwards_and_publishes_the_target() -> None:
+    """A transport-only seekable source seeks within its session, with progress published."""
+    ctrl, provider = _controller(_audio_source(None))
+
+    await ctrl.seek(QUEUE_ID, 42)
+
+    provider.on_source_control.assert_awaited_once_with(SOURCE_ID, SourceControl.SEEK, 42)
+    assert _queue(ctrl).elapsed_time == 42
+    ctrl.play_index.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+async def test_transport_incapable_source_walks_the_ma_index() -> None:
+    """A live source without skip support (sendspin/vban shape) keeps the MA index walk."""
+    ctrl, provider = _controller(_audio_source(None, can_seek=False, can_next_previous=False))
+    _add_tail_items(ctrl, "t1")
+
+    await ctrl.next(QUEUE_ID)
+
+    provider.on_source_control.assert_not_awaited()
+    assert _queue(ctrl).current_index == 1
+
+
+async def test_transport_incapable_seek_hits_the_duration_guard() -> None:
+    """Seek on a non-seekable live source falls through and fails on the missing duration."""
+    ctrl, provider = _controller(_audio_source(None, can_seek=False, can_next_previous=False))
+
+    with pytest.raises(InvalidCommand):
+        await ctrl.seek(QUEUE_ID, 42)
+
+    provider.on_source_control.assert_not_awaited()
 
 
 async def test_ordered_play_reorders_the_tail_locally_while_delegated() -> None:

--- a/tests/controllers/streams/test_audio_sources.py
+++ b/tests/controllers/streams/test_audio_sources.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncGenerator
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -536,6 +537,68 @@ class TestGetActiveAudioSource:
         # Don't dispatch on_source_control / on_volume_change to a provider
         # that didn't opt in to the feature.
         assert controller._get_active_audio_source(player) is None
+
+
+# ------------------------------------------------------------ transport redirect
+
+
+class TestTransportCommandsRedirectToQueue:
+    """
+    players/cmd next/previous/seek always hand off to the queue controller.
+
+    The queue controller owns AudioSource transport delegation (gated on the
+    per-action capability flags), so the player layer carries no proxy of its
+    own — the redirect below is what routes an active AudioSource to its plugin.
+    """
+
+    def _wire_active_queue(self, mock_mass: MagicMock) -> None:
+        """Point the mocked queue registry at the player's own (active) queue."""
+        mock_mass.player_queues.get = MagicMock(return_value=SimpleNamespace(queue_id="player_1"))
+
+    @pytest.mark.asyncio
+    async def test_cmd_next_redirects_to_the_queue_controller(
+        self,
+        controller: PlayerController,
+        player: MockPlayer,
+        mock_mass: MagicMock,
+    ) -> None:
+        """players/cmd/next reaches player_queues.next for the active queue."""
+        self._wire_active_queue(mock_mass)
+        mock_mass.player_queues.next = AsyncMock()
+
+        await controller.cmd_next_track("player_1")
+
+        mock_mass.player_queues.next.assert_awaited_once_with("player_1")
+
+    @pytest.mark.asyncio
+    async def test_cmd_previous_redirects_to_the_queue_controller(
+        self,
+        controller: PlayerController,
+        player: MockPlayer,
+        mock_mass: MagicMock,
+    ) -> None:
+        """players/cmd/previous reaches player_queues.previous for the active queue."""
+        self._wire_active_queue(mock_mass)
+        mock_mass.player_queues.previous = AsyncMock()
+
+        await controller.cmd_previous_track("player_1")
+
+        mock_mass.player_queues.previous.assert_awaited_once_with("player_1")
+
+    @pytest.mark.asyncio
+    async def test_cmd_seek_redirects_to_the_queue_controller(
+        self,
+        controller: PlayerController,
+        player: MockPlayer,
+        mock_mass: MagicMock,
+    ) -> None:
+        """players/cmd/seek reaches player_queues.seek for the active queue."""
+        self._wire_active_queue(mock_mass)
+        mock_mass.player_queues.seek = AsyncMock()
+
+        await controller.cmd_seek("player_1", 42)
+
+        mock_mass.player_queues.seek.assert_awaited_once_with("player_1", 42)
 
 
 # ------------------------------------------------------------- update_stream_metadata

--- a/tests/providers/ariacast_receiver/test_control.py
+++ b/tests/providers/ariacast_receiver/test_control.py
@@ -1,0 +1,102 @@
+"""Tests for the inbound /control command handling of the AriaCast receiver."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant.providers.ariacast_receiver import AriaCastReceiver
+
+
+def _receiver(in_use_by_queue: str | None = "queue_1") -> SimpleNamespace:
+    """Build a bare receiver namespace for driving _handle_inbound_control."""
+    return SimpleNamespace(
+        _in_use_by_queue=in_use_by_queue,
+        _forward_action=AsyncMock(),
+        _cmd_play=AsyncMock(),
+        _cmd_pause=AsyncMock(),
+        mass=MagicMock(),
+        logger=MagicMock(),
+    )
+
+
+async def _handle(receiver: SimpleNamespace, ws: Any, payload: dict[str, Any]) -> None:
+    """Run the inbound control handler on the bare receiver."""
+    await AriaCastReceiver._handle_inbound_control(cast("AriaCastReceiver", receiver), ws, payload)
+
+
+async def test_inbound_next_relays_to_the_other_senders() -> None:
+    """
+    A control client's next/previous is relayed to the other control clients.
+
+    It must never be routed through player_queues: the queue delegates transport
+    commands for an active AudioSource back to this plugin, which would echo the
+    command straight back to its originator.
+    """
+    receiver = _receiver()
+    ws = AsyncMock()
+
+    await _handle(receiver, ws, {"command": "next"})
+    await _handle(receiver, ws, {"action": "previous"})
+
+    assert receiver._forward_action.await_args_list == [
+        (("next",), {"exclude": ws}),
+        (("previous",), {"exclude": ws}),
+    ]
+    receiver.mass.player_queues.next.assert_not_called()
+    receiver.mass.player_queues.previous.assert_not_called()
+
+
+async def test_ack_shaped_payloads_are_not_dispatched_as_commands() -> None:
+    """
+    A reply/ack payload (carrying "success") is ignored, not relayed as a command.
+
+    A client acking a broadcast action with the server's own ack shape would
+    otherwise trigger a fresh relay — and loop on a client that acks the ack.
+    """
+    receiver = _receiver()
+    ws = AsyncMock()
+
+    await _handle(receiver, ws, {"action": "next", "success": True})
+    await _handle(receiver, ws, {"command": "play", "success": False})
+
+    receiver._forward_action.assert_not_awaited()
+    receiver._cmd_play.assert_not_awaited()
+    ws.send_json.assert_not_awaited()
+
+
+async def test_inbound_next_is_ignored_while_the_source_is_not_in_use() -> None:
+    """Next/previous do nothing while no MA queue is playing the source."""
+    receiver = _receiver(in_use_by_queue=None)
+    ws = AsyncMock()
+
+    await _handle(receiver, ws, {"command": "next"})
+
+    receiver._forward_action.assert_not_awaited()
+
+
+async def test_forward_action_excludes_the_originating_sender() -> None:
+    """The relayed action reaches every control client except the one that sent it."""
+    originator = AsyncMock()
+    other = AsyncMock()
+    receiver = SimpleNamespace(_control_senders={originator, other})
+
+    await AriaCastReceiver._forward_action(
+        cast("AriaCastReceiver", receiver), "next", exclude=originator
+    )
+
+    other.send_json.assert_awaited_once_with({"action": "next"})
+    originator.send_json.assert_not_awaited()
+
+
+async def test_forward_action_without_exclusion_reaches_all_senders() -> None:
+    """An MA-initiated action (no originator) is broadcast to every control client."""
+    ws1 = AsyncMock()
+    ws2 = AsyncMock()
+    receiver = SimpleNamespace(_control_senders={ws1, ws2})
+
+    await AriaCastReceiver._forward_action(cast("AriaCastReceiver", receiver), "next")
+
+    ws1.send_json.assert_awaited_once_with({"action": "next"})
+    ws2.send_json.assert_awaited_once_with({"action": "next"})


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5880. Skipping/seeking a live audio source behaved differently depending on which API a client used: the player commands (`players/cmd/next` etc.) forwarded next/previous/seek to the owning plugin, while the queue commands (`player_queues/next` etc.) only did so for sources that own the whole queue (Spotify Connect) and otherwise walked the MA queue index. So pressing next on e.g. a Yandex Ynison session worked from one API and did nothing useful from the other.

The queue controller now delegates next/previous/seek based on the source's own capability flags, so both APIs behave the same, and the duplicated player-layer proxy is removed.

- `player_queues` next/previous/seek now forward to the owning plugin for any live source that supports them (not only queue-owning sessions); shuffle/repeat delegation is unchanged
- removed the duplicated AudioSource proxy blocks from the player commands — they always hand off to the queue controller
- extracted the duplicated source-resolution logic from both controllers into a shared helper
- AriaCast: a remote's next/previous is now relayed directly to the casting sender (excluding the client that sent it) instead of going through the queue controller, which would bounce the command back into the plugin after this change; reply/ack payloads are no longer parsed as commands
- updated the `on_source_control` provider contract docs to match the new dispatch split
- added tests for the transport delegation matrix and the AriaCast relay

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
