### PR TITLE
Fix Audible podcast sync skipping Periodical series

### DIFF
--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -56,7 +56,9 @@ CACHE_CATEGORY_PODCAST_EPISODES = 4
 
 # Content delivery types
 AUDIOBOOK_CONTENT_TYPES = ("SinglePartBook", "MultiPartBook")
-PODCAST_CONTENT_TYPES = ("PodcastParent",)
+# Podcasts are normally reported as "PodcastParent", but (older) Audible Original
+# series are still reported with the legacy "Periodical" delivery type.
+PODCAST_CONTENT_TYPES = ("PodcastParent", "Periodical")
 
 _AUTH_CACHE: dict[str, audible.Authenticator] = {}
 

--- a/tests/providers/audible/test_audible.py
+++ b/tests/providers/audible/test_audible.py
@@ -233,3 +233,34 @@ async def test_browse_decoding(provider: Audibleprovider) -> None:
     # Test Genre with slash (encoded)
     await provider.browse("audible://genres/Sci-Fi%2FFantasy")
     provider.helper.get_audiobooks_by_genre.assert_called_with("Sci-Fi/Fantasy")
+
+
+async def test_get_library_podcasts_includes_legacy_periodicals(helper: AudibleHelper) -> None:
+    """Test podcast sync also picks up series with the legacy Periodical delivery type."""
+    library_items = [
+        {
+            "asin": "P1",
+            "title": "Modern Podcast",
+            "content_delivery_type": "PodcastParent",
+        },
+        {
+            "asin": "P2",
+            "title": "Audible Original Show",
+            "content_delivery_type": "Periodical",
+        },
+        {
+            "asin": "B1",
+            "title": "Some Book",
+            "content_delivery_type": "SinglePartBook",
+        },
+    ]
+
+    async def side_effect(_: str, **kwargs: Any) -> dict[str, Any]:
+        if kwargs.get("page") == 1:
+            return {"items": library_items}
+        return {"items": []}
+
+    with patch.object(helper, "_call_api", side_effect=side_effect):
+        podcasts = [podcast async for podcast in helper.get_library_podcasts()]
+
+    assert [podcast.item_id for podcast in podcasts] == ["P1", "P2"]


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The library sync filters items by `content_delivery_type` and only accepted `PodcastParent`. Older Audible Original series report `Periodical` instead, so they were dropped before the podcast import ran and never appeared in the library. Nothing was logged, so the sync looked like it had finished cleanly.

`Periodical` parents hold their episodes the same way `PodcastParent` ones do, so no other changes were needed.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6077

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
