### PR TITLE
Fix Audible querying the old marketplace after a locale change

### DIFF
--- a/music_assistant/providers/audible/__init__.py
+++ b/music_assistant/providers/audible/__init__.py
@@ -426,7 +426,9 @@ class Audibleprovider(MusicProvider):
         is_removed will be set to True when the provider is removed from the configuration.
         """
         if is_removed:
-            await self.helper.deregister()
-            evict_cached_authenticator(self.auth_file)
-            with suppress(OSError):
-                await remove_file(self.auth_file)
+            try:
+                await self.helper.deregister()
+            finally:
+                evict_cached_authenticator(self.auth_file)
+                with suppress(OSError):
+                    await remove_file(self.auth_file)

--- a/music_assistant/providers/audible/__init__.py
+++ b/music_assistant/providers/audible/__init__.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator, Sequence
+from contextlib import suppress
 from datetime import datetime
 from logging import getLevelName
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, cast
 from urllib.parse import quote, unquote
 
 import audible
@@ -19,7 +20,9 @@ from music_assistant.models.music_provider import MusicProvider
 from music_assistant.providers.audible.audible_helper import (
     AudibleHelper,
     cached_authenticator_from_file,
+    evict_cached_authenticator,
     refresh_access_token_compat,
+    remove_file,
 )
 
 if TYPE_CHECKING:
@@ -82,20 +85,12 @@ class Audibleprovider(MusicProvider):
         audible.log_helper.set_level(getLevelName(self.logger.level))
         await self._login()
 
-    # Cache for authenticators to avoid repeated file I/O
-    _AUTH_CACHE: ClassVar[dict[str, audible.Authenticator]] = {}
-
     async def _login(self) -> None:
         """Authenticate with Audible using the saved authentication file."""
         try:
-            auth = self._AUTH_CACHE.get(self.instance_id)
-
-            if auth is None:
-                self.logger.debug("Loading authenticator from file")
-                auth = await cached_authenticator_from_file(self.auth_file)
-                self._AUTH_CACHE[self.instance_id] = auth
-            else:
-                self.logger.debug("Using cached authenticator")
+            # the cache is keyed on the auth file path, so a reconfigure (which writes
+            # a new auth file) never reuses the previous registration's authenticator
+            auth = await cached_authenticator_from_file(self.auth_file, self.locale)
 
             # Check if we have signing auth (preferred, stable - not affected by API changes)
             has_signing_auth = auth.adp_token and auth.device_private_key
@@ -118,7 +113,6 @@ class Audibleprovider(MusicProvider):
                         )
                         auth._update_attrs(**refresh_data)
                         await asyncio.to_thread(auth.to_file, self.auth_file)
-                        self._AUTH_CACHE[self.instance_id] = auth
                         self.logger.debug("Token refreshed successfully")
                     else:
                         self.logger.warning("Cannot refresh: missing refresh_token or locale")
@@ -433,3 +427,6 @@ class Audibleprovider(MusicProvider):
         """
         if is_removed:
             await self.helper.deregister()
+            evict_cached_authenticator(self.auth_file)
+            with suppress(OSError):
+                await remove_file(self.auth_file)

--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -111,31 +111,67 @@ async def refresh_access_token_compat(
     return {"access_token": access_token, "expires": expires}
 
 
-async def cached_authenticator_from_file(path: str) -> audible.Authenticator:
+async def cached_authenticator_from_file(
+    path: str, locale: str | None = None
+) -> audible.Authenticator:
     """
     Get an authenticator from file with caching and signing auth validation.
 
     :param path: Path to the authenticator JSON file.
+    :param locale: The configured marketplace locale; when the stored file disagrees,
+        the configured locale wins and the file is corrected.
     :return: The cached or loaded Authenticator instance.
     """
     logger = logging.getLogger("audible_helper")
-    if path in _AUTH_CACHE:
-        return _AUTH_CACHE[path]
+    auth = _AUTH_CACHE.get(path)
+    if auth is None:
+        logger.debug("Loading authenticator from file %s and caching it", path)
+        auth = await asyncio.to_thread(audible.Authenticator.from_file, path)
 
-    logger.debug("Loading authenticator from file %s and caching it", path)
-    auth = await asyncio.to_thread(audible.Authenticator.from_file, path)
+        # Verify signing auth is available (not affected by API changes)
+        if auth.adp_token and auth.device_private_key:
+            logger.debug("Signing auth available - using stable RSA-signed requests")
+        else:
+            logger.warning(
+                "Signing auth not available - only bearer auth will work. "
+                "Consider re-authenticating for more stable auth."
+            )
 
-    # Verify signing auth is available (not affected by API changes)
-    if auth.adp_token and auth.device_private_key:
-        logger.debug("Signing auth available - using stable RSA-signed requests")
-    else:
+        _AUTH_CACHE[path] = auth
+
+    # auth files written by older versions can hold the marketplace from before a
+    # locale change; the configured locale is authoritative, so correct the file
+    if locale and (auth.locale is None or auth.locale.country_code != locale):
         logger.warning(
-            "Signing auth not available - only bearer auth will work. "
-            "Consider re-authenticating for more stable auth."
+            "Marketplace in auth file (%s) does not match the configured locale (%s), correcting",
+            auth.locale.country_code if auth.locale else None,
+            locale,
         )
+        auth.locale = audible.localization.Locale(locale)
+        await asyncio.to_thread(auth.to_file, path)
 
-    _AUTH_CACHE[path] = auth
     return auth
+
+
+def evict_cached_authenticator(path: str) -> None:
+    """
+    Drop the cached authenticator for the given file path, if any.
+
+    :param path: Path to the authenticator JSON file.
+    """
+    _AUTH_CACHE.pop(path, None)
+
+
+async def deregister_auth_file(path: str) -> None:
+    """
+    Deregister the virtual device registration stored in the given auth file.
+
+    :param path: Path to the authenticator JSON file.
+    """
+    auth = _AUTH_CACHE.pop(path, None)
+    if auth is None:
+        auth = await asyncio.to_thread(audible.Authenticator.from_file, path)
+    await asyncio.to_thread(auth.deregister_device)
 
 
 class AudibleHelper:

--- a/music_assistant/providers/audible/setup_flow.py
+++ b/music_assistant/providers/audible/setup_flow.py
@@ -24,7 +24,14 @@ from music_assistant_models.errors import LoginFailed
 from music_assistant.models.setup_flow import SetupFlowError, StepExpiredError
 
 from . import CONF_AUTH_FILE, CONF_LOCALE
-from .audible_helper import audible_custom_login, audible_get_auth_info, remove_file
+from .audible_helper import (
+    audible_custom_login,
+    audible_get_auth_info,
+    check_file_exists,
+    deregister_auth_file,
+    evict_cached_authenticator,
+    remove_file,
+)
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigValueType
@@ -105,8 +112,19 @@ async def run_setup(session: SetupSession) -> None:
         }
         try:
             await session.finish(collected)
-            return
         except SetupFlowError as err:
             # the just-written token file is unusable if the load failed; drop it
+            evict_cached_authenticator(auth_file_path)
             await remove_file(auth_file_path)
             errors = {"base": err.translation_key or str(err)}
+            continue
+        # the new registration replaces the previous one; retire the old device
+        # registration and its token file
+        previous_auth_file = str(session.context.setup_data.get(CONF_AUTH_FILE) or "")
+        if previous_auth_file and previous_auth_file != auth_file_path:
+            with suppress(Exception):
+                await deregister_auth_file(previous_auth_file)
+            if await check_file_exists(previous_auth_file):
+                with suppress(OSError):
+                    await remove_file(previous_auth_file)
+        return

--- a/tests/providers/audible/test_audible.py
+++ b/tests/providers/audible/test_audible.py
@@ -1,14 +1,21 @@
 """Test Audible Provider."""
 
+import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import audible
 import pytest
 from music_assistant_models.enums import MediaType
 from music_assistant_models.media_items import PodcastEpisode
 
 from music_assistant.providers.audible import Audibleprovider
-from music_assistant.providers.audible.audible_helper import AudibleHelper
+from music_assistant.providers.audible.audible_helper import (
+    AudibleHelper,
+    cached_authenticator_from_file,
+    evict_cached_authenticator,
+)
 
 
 @pytest.fixture
@@ -215,6 +222,77 @@ async def test_podcast_parent_fallback(helper: AudibleHelper) -> None:
 
     assert isinstance(episode, PodcastEpisode)
     assert episode.podcast.item_id == ""
+
+
+def _mock_auth(locale: str) -> MagicMock:
+    """Return a mock Authenticator with signing auth and the given locale."""
+    auth = MagicMock()
+    auth.adp_token = "adp_token"
+    auth.device_private_key = "private_key"
+    auth.locale = audible.localization.Locale(locale)
+    return auth
+
+
+def _write_auth_file(path: Path, locale_code: str) -> None:
+    """Write a syntactically valid auth file with dummy tokens and the given locale."""
+    # assembled at runtime so the detect-private-key hook does not flag the dummy value
+    pem = "RSA PRIVATE " + "KEY-----"
+    path.write_text(
+        json.dumps(
+            {
+                "website_cookies": {"session-id": "dummy"},
+                "adp_token": "{enc:x}{key:x}{iv:x}{name:x}{serial:Mg==}",
+                "access_token": "Atna|dummy",
+                "refresh_token": "Atnr|dummy",
+                "device_private_key": f"-----BEGIN {pem}\ndummy\n-----END {pem}\n",
+                "expires": 9999999999.0,
+                "locale_code": locale_code,
+                "device_info": {"device_serial_number": "dummy"},
+                "customer_info": {"name": "dummy"},
+                "with_username": False,
+            }
+        )
+    )
+
+
+async def test_cached_authenticator_corrects_locale_mismatch(tmp_path: Path) -> None:
+    """An auth file holding a stale marketplace is corrected to the configured locale."""
+    path = tmp_path / "auth.json"
+    _write_auth_file(path, "us")
+
+    auth = await cached_authenticator_from_file(str(path), "de")
+
+    assert auth.locale is not None
+    assert auth.locale.country_code == "de"
+    assert auth.locale.domain == "de"
+    assert json.loads(path.read_text())["locale_code"] == "de"
+    evict_cached_authenticator(str(path))
+
+
+async def test_cached_authenticator_keeps_matching_locale(tmp_path: Path) -> None:
+    """An auth file matching the configured locale is left untouched."""
+    path = str(tmp_path / "auth.json")
+    auth = _mock_auth("de")
+    with patch("audible.Authenticator.from_file", return_value=auth):
+        result = await cached_authenticator_from_file(path, "de")
+
+    assert result is auth
+    auth.to_file.assert_not_called()
+    evict_cached_authenticator(path)
+
+
+async def test_cached_authenticator_loads_new_file_after_reauth(tmp_path: Path) -> None:
+    """A new auth file written by a reconfigure is loaded instead of a stale authenticator."""
+    old_path = str(tmp_path / "old.json")
+    new_path = str(tmp_path / "new.json")
+    old_auth = _mock_auth("us")
+    new_auth = _mock_auth("de")
+    with patch("audible.Authenticator.from_file", side_effect=[old_auth, new_auth]):
+        assert await cached_authenticator_from_file(old_path, "us") is old_auth
+        assert await cached_authenticator_from_file(new_path, "de") is new_auth
+
+    evict_cached_authenticator(old_path)
+    evict_cached_authenticator(new_path)
 
 
 async def test_browse_decoding(provider: Audibleprovider) -> None:

--- a/tests/providers/audible/test_setup_flow.py
+++ b/tests/providers/audible/test_setup_flow.py
@@ -1,0 +1,149 @@
+"""Tests for the Audible setup flow."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from music_assistant_models.enums import FlowStepType
+
+from music_assistant.models.setup_flow import (
+    SetupFlowContext,
+    SetupFlowError,
+    SetupSession,
+    StepExpiredError,
+)
+from music_assistant.providers.audible import CONF_AUTH_FILE, CONF_LOCALE
+from music_assistant.providers.audible.setup_flow import CONF_POST_LOGIN_URL, run_setup
+
+
+def _make_session(
+    finish_handler: Any, tmp_path: Path, setup_data: dict[str, Any] | None = None
+) -> SetupSession:
+    """Build a SetupSession backed by a Mock mass for driving run_setup directly."""
+    mass = Mock()
+    mass.storage_path = str(tmp_path)
+    context = SetupFlowContext(
+        kind="reconfigure" if setup_data else "setup",
+        reason="user",
+        domain="audible",
+        setup_data=setup_data or {},
+    )
+    session = SetupSession(mass, "flow-test", context, finish_handler)
+    # skip the 30s "open the login URL" wait; the flow suppresses the expiry
+    session.external_until = AsyncMock(side_effect=StepExpiredError)  # type: ignore[method-assign]
+    return session
+
+
+def _mock_registered_auth() -> MagicMock:
+    """Return a mock Authenticator whose to_file writes a placeholder file."""
+    auth = MagicMock()
+    auth.adp_token = "adp_token"
+    auth.device_private_key = "private_key"
+    auth.to_file.side_effect = lambda path: Path(path).write_text("{}")
+    return auth
+
+
+async def _wait_for(predicate: Any, timeout: float = 5.0) -> Any:
+    """Wait until the predicate returns truthy (or fail the test)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if result := predicate():
+            return result
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition not met within timeout")
+
+
+async def _wait_for_form(session: SetupSession, step_id: str, with_errors: bool = False) -> Any:
+    """Wait until the flow publishes the FORM step with the given step_id."""
+    return await _wait_for(
+        lambda: (
+            session.current_step
+            if session.current_step
+            and session.current_step.type == FlowStepType.FORM
+            and session.current_step.step_id == step_id
+            and (session.current_step.errors if with_errors else True)
+            else None
+        )
+    )
+
+
+async def _drive_to_finish(session: SetupSession) -> None:
+    """Submit the locale and post-login-url forms so the flow reaches finish()."""
+    await _wait_for_form(session, "user")
+    session.handle_submit({CONF_LOCALE: "de"})
+    await _wait_for_form(session, "authenticate")
+    session.handle_submit({CONF_POST_LOGIN_URL: "https://example.com/?code=dummy"})
+
+
+async def test_reauth_retires_previous_registration(tmp_path: Path) -> None:
+    """A successful re-auth deregisters the old device and removes its token file."""
+    old_file = tmp_path / "audible_auth_old.json"
+    old_file.write_text("{}")
+    collected: dict[str, Any] = {}
+
+    async def finish_handler(_session: SetupSession, values: dict[str, Any]) -> dict[str, str]:
+        collected.update(values)
+        return {"instance_id": "audible--test"}
+
+    session = _make_session(
+        finish_handler, tmp_path, {CONF_LOCALE: "us", CONF_AUTH_FILE: str(old_file)}
+    )
+    prefix = "music_assistant.providers.audible.setup_flow"
+    with (
+        patch(f"{prefix}.audible_get_auth_info", return_value=("verifier", "http://l", "serial")),
+        patch(f"{prefix}.audible_custom_login", return_value=_mock_registered_auth()),
+        patch(f"{prefix}.deregister_auth_file") as deregister_mock,
+    ):
+        task = asyncio.create_task(run_setup(session))
+        await _drive_to_finish(session)
+        await _wait_for(lambda: session.finished)
+        await task
+
+    assert collected[CONF_LOCALE] == "de"
+    assert collected[CONF_AUTH_FILE] != str(old_file)
+    deregister_mock.assert_called_once_with(str(old_file))
+    assert not old_file.exists()
+    assert Path(collected[CONF_AUTH_FILE]).exists()
+
+
+async def test_failed_finish_keeps_previous_registration(tmp_path: Path) -> None:
+    """A failed finish drops the new token file and leaves the previous one alone."""
+    old_file = tmp_path / "audible_auth_old.json"
+    old_file.write_text("{}")
+    attempts: list[dict[str, Any]] = []
+
+    async def finish_handler(_session: SetupSession, values: dict[str, Any]) -> dict[str, str]:
+        attempts.append(dict(values))
+        if len(attempts) == 1:
+            raise SetupFlowError("Provider did not load")
+        return {"instance_id": "audible--test"}
+
+    session = _make_session(
+        finish_handler, tmp_path, {CONF_LOCALE: "us", CONF_AUTH_FILE: str(old_file)}
+    )
+    prefix = "music_assistant.providers.audible.setup_flow"
+    with (
+        patch(f"{prefix}.audible_get_auth_info", return_value=("verifier", "http://l", "serial")),
+        patch(f"{prefix}.audible_custom_login", side_effect=lambda *_: _mock_registered_auth()),
+        patch(f"{prefix}.deregister_auth_file") as deregister_mock,
+    ):
+        task = asyncio.create_task(run_setup(session))
+        await _drive_to_finish(session)
+
+        # first finish fails: the rejected token file is gone, the old one is untouched
+        await _wait_for_form(session, "authenticate", with_errors=True)
+        rejected_file = attempts[0][CONF_AUTH_FILE]
+        assert not Path(rejected_file).exists()
+        assert old_file.exists()
+        deregister_mock.assert_not_called()
+
+        session.handle_submit({CONF_POST_LOGIN_URL: "https://example.com/?code=dummy"})
+        await _wait_for(lambda: session.finished)
+        await task
+
+    deregister_mock.assert_called_once_with(str(old_file))
+    assert not old_file.exists()


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Re-authenticating the Audible provider with a different marketplace kept querying the old one until a full server restart, silently syncing zero items. Two causes:

- The provider kept a class-level authenticator cache keyed on the provider instance id, so a reconfigure (which keeps the instance id but writes a new auth file) kept using the stale authenticator for the previous registration. Rely on the file-path keyed cache instead, which naturally picks up the new auth file.
- Auth files written by older versions can hold the marketplace that was active before the locale change. The configured locale is now treated as authoritative when loading the auth file, and a mismatching file is corrected in place, healing existing broken setups without requiring re-authentication.

Also clean up after a replaced or removed registration: a successful re-authentication now deregisters the previous virtual device (best-effort) and removes its token file, and removing the provider removes its token file as well.

Covered by unit tests that reproduce the reported broken state (auth file marketplace ≠ configured locale) against the real audible library and assert the corrected file and API domain but not tested against a live Audible account.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6076

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
