### PR TITLE
Keep the Spotify session alive when it moves to another player

### DIFF
--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -375,13 +375,23 @@ class SpotifyConnectProvider(PluginProvider):
         # protocol-level player_id. Some protocol players are ephemeral bridges
         # whose ID is invalid for play_media / queue lookups once torn down.
         active_player_id = queue_id
+        prev_player_id = (
+            self._active_player_id if self._active_player_id != active_player_id else None
+        )
 
-        # If there's already a different active player, kick it out. The claim
-        # below replaces the previous queue's claim; the prior stream's
-        # on_source_unselected may fire later, but its session-id guard keeps it
-        # from clobbering the new claim.
-        if self._active_player_id and self._active_player_id != active_player_id:
-            prev_player_id = self._active_player_id
+        # Claim ownership for this queue BEFORE kicking the previous player: the
+        # awaited stop below can complete the old stream's teardown, and only an
+        # already-replaced session id lets on_source_unselected's stale-guard
+        # reject that teardown — otherwise it releases the Spotify session this
+        # handover is about to use.
+        self._in_use_by_queue = queue_id
+        self._active_session_id = stream_session_id
+        self._active_player_id = active_player_id
+        self.logger.debug("Active player set to: %s", active_player_id)
+
+        # If a different player was consuming the source, kick it out (the source
+        # is exclusive).
+        if prev_player_id:
             self.logger.info(
                 "Source selected on player %s, stopping playback on %s",
                 active_player_id,
@@ -391,12 +401,6 @@ class SpotifyConnectProvider(PluginProvider):
                 await self.mass.players.cmd_stop(prev_player_id)
             except Exception as err:
                 self.logger.debug("Failed to stop previous player %s: %s", prev_player_id, err)
-
-        # Claim ownership for this queue.
-        self._in_use_by_queue = queue_id
-        self._active_session_id = stream_session_id
-        self._active_player_id = active_player_id
-        self.logger.debug("Active player set to: %s", active_player_id)
 
         # Push the options the session reported before this claim existed, so the
         # queue mirrors the session's shuffle/repeat state from the start.

--- a/tests/providers/spotify_connect/test_backend_contract.py
+++ b/tests/providers/spotify_connect/test_backend_contract.py
@@ -1012,3 +1012,32 @@ async def test_paused_replaces_pending_pause_stop() -> None:
     for _ in range(3):
         await asyncio.sleep(0)
     assert provider._pending_pause_stop_task is None
+
+
+async def test_handoff_kick_cannot_release_the_session() -> None:
+    """An old stream's teardown during the handoff kick must not deactivate the session."""
+    backend = FakeBackend()
+    provider, mass = _make_provider(
+        backend,
+        playing=True,
+        session_active=True,
+        active_player_id="queue_old",
+        in_use_by_queue="queue_old",
+        active_session_id="sess_old",
+    )
+    _player_with_volume(mass, 25)
+
+    async def _stop_old_player(_player_id: str) -> None:
+        # a fast player: its stream teardown completes within the awaited stop, so
+        # only the already-replaced session id keeps this from releasing the session
+        await provider.on_source_unselected(AUDIO_SOURCE_ID, "queue_old", "sess_old")
+
+    mass.players.cmd_stop = AsyncMock(side_effect=_stop_old_player)
+
+    await provider.on_source_selected(AUDIO_SOURCE_ID, "proto_new", "queue_new", "sess_new")
+
+    assert ("deactivate", None) not in backend.calls
+    assert provider._in_use_by_queue == "queue_new"
+    assert provider._active_session_id == "sess_new"
+    assert provider._active_player_id == "queue_new"
+    mass.players.cmd_stop.assert_awaited_once_with("queue_old")


### PR DESCRIPTION
# What does this implement/fix?

Moving a playing Spotify Connect session from one player to another could kill the session instead of handing it over: playback stopped, the Spotify app dropped the device ("no longer active device" in the log), and the player you just started on stayed silent. Playing again worked, which is what made it look intermittent.

The source is an ordering bug in the plugin's handover. When the source is selected on a new player, the plugin first stopped the previous player and only claimed ownership afterwards. Stopping the old player tears its stream down, and that teardown still carried the *old* stream session id — which, because the new claim had not been written yet, passed the "is this callback stale?" guard and released the Spotify session the new player was about to use.

Claiming ownership before stopping the previous player restores what the code already intended: the teardown is recognised as stale and leaves the live session alone.

- Write the queue claim before kicking the previous player in `on_source_selected`
- Regression test that fails without the fix (the old player's teardown completes inside the awaited stop)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
