### PR TITLE
Refuse Spotify accounts that cannot work during setup

### DIFF
--- a/music_assistant/providers/spotify/constants.py
+++ b/music_assistant/providers/spotify/constants.py
@@ -10,6 +10,7 @@ CONF_REFRESH_TOKEN_DEV = "refresh_token_dev"  # Token authenticated with user's 
 CONF_SYNC_PODCAST_PROGRESS = "sync_podcast_progress"
 CONF_SYNC_AUDIOBOOK_PROGRESS = "sync_audiobook_progress"
 CONF_LIBRESPOT_CREDENTIALS = "librespot_credentials"  # librespot's reusable stored credential
+CONF_ACCOUNT_ID = "account_id"  # Spotify user id this instance serves (one instance per account)
 
 # Librespot playback authorization
 #

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -210,6 +210,11 @@ class SpotifyProvider(MusicProvider):
         return features
 
     @property
+    def account_id(self) -> str | None:
+        """Return the Spotify user id of the logged-in account, if known."""
+        return str(self._sp_user["id"]) if self._sp_user else None
+
+    @property
     def instance_name_postfix(self) -> str | None:
         """Return a (default) instance name postfix for this provider instance."""
         if self._sp_user:

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -61,6 +61,7 @@ from music_assistant.helpers.util import lock
 from music_assistant.models.music_provider import MusicProvider
 
 from .constants import (
+    CONF_ACCOUNT_ID,
     CONF_CLIENT_ID,
     CONF_LIBRESPOT_CREDENTIALS,
     CONF_REFRESH_TOKEN_DEV,
@@ -955,6 +956,10 @@ class SpotifyProvider(MusicProvider):
             )
             if country := userinfo.get("country"):
                 self.mass.metadata.set_default_preferred_language(country)
+            if self.get_setup_value(CONF_ACCOUNT_ID) != userinfo["id"]:
+                # instances configured before the account was recorded fill it in here,
+                # so the setup flow can spot a duplicate account without loading them
+                self._update_setup_data(CONF_ACCOUNT_ID, userinfo["id"])
             self.logger.info("Successfully logged in to Spotify as %s", userinfo["display_name"])
         return auth_info
 

--- a/music_assistant/providers/spotify/setup_flow.py
+++ b/music_assistant/providers/spotify/setup_flow.py
@@ -23,6 +23,7 @@ from music_assistant.helpers.oauth import (
 from music_assistant.models.setup_flow import AbortFlow, SetupFlowError, StepExpiredError
 
 from .constants import (
+    CONF_ACCOUNT_ID,
     CONF_CLIENT_ID,
     CONF_LIBRESPOT_CREDENTIALS,
     CONF_REFRESH_TOKEN_DEV,
@@ -105,7 +106,7 @@ async def run_setup(session: SetupSession) -> None:
     )
     setup_data[CONF_REFRESH_TOKEN_GLOBAL] = str(token_result["refresh_token"])
     # an account that cannot work is turned away before the playback authorization
-    await _verify_account(session, str(token_result["access_token"]))
+    setup_data[CONF_ACCOUNT_ID] = await _verify_account(session, str(token_result["access_token"]))
     # playback needs its own credential, minted with Spotify's keymaster client id
     setup_data[CONF_LIBRESPOT_CREDENTIALS] = await _authorize_playback(session)
     # everything needed is collected by now; the developer key is a purely optional extra,
@@ -173,14 +174,14 @@ async def _authorize_developer_key(
     return client_id, None
 
 
-async def _verify_account(session: SetupSession, access_token: str) -> None:
+async def _verify_account(session: SetupSession, access_token: str) -> str | None:
     """
-    Check the just-authenticated Spotify account before the setup continues.
+    Check the just-authenticated Spotify account and return its id.
 
     Turns the user away when the account has no Spotify Premium (librespot, which
     streams this provider's audio, refuses to play for a free account) or when it is
     already set up on another provider instance. A lookup Spotify does not answer is
-    not held against the user: the setup simply continues.
+    not held against the user: the setup simply continues and None is returned.
 
     :param session: The setup session driving the flow.
     :param access_token: The access token from the just-completed sign-in. Reusing
@@ -195,35 +196,46 @@ async def _verify_account(session: SetupSession, access_token: str) -> None:
             timeout=ClientTimeout(total=ACCOUNT_LOOKUP_TIMEOUT),
         ) as response:
             if response.status != 200:
-                return
+                return None
+            # a malformed body raises ValueError, which is not a ClientError
             userinfo = await response.json()
-    except ClientError, TimeoutError:
-        return
+    except ClientError, TimeoutError, ValueError:
+        return None
     product = str(userinfo.get("product") or "")
     if product and product != "premium":
         raise AbortFlow("premium_required")
-    account_id = str(userinfo.get("id") or "")
-    if account_id and _account_in_use(session, account_id):
+    if not (account_id := str(userinfo.get("id") or "")):
+        return None
+    if await _account_in_use(session, account_id):
         raise AbortFlow("account_already_configured")
+    return account_id
 
 
-def _account_in_use(session: SetupSession, account_id: str) -> bool:
+async def _account_in_use(session: SetupSession, account_id: str) -> bool:
     """
-    Return whether another Spotify provider instance already serves this account.
+    Return whether another Spotify provider instance is already set up for this account.
 
-    Only running instances can be compared (the account is not part of the stored
-    config), and the instance being reconfigured is of course allowed to keep its
-    own account.
+    Compares the account id stored with each instance's configuration, so an instance
+    that is disabled or failed to load still holds its account. Configurations
+    predating that stored value fall back to the running instance, which fills the
+    value in on its next successful load. The instance being reconfigured is of
+    course allowed to keep its own account.
 
     :param session: The setup session driving the flow.
     :param account_id: The Spotify user id that just signed in.
     """
-    return any(
-        isinstance(prov, SpotifyProvider)
-        and prov.instance_id != session.context.instance_id
-        and prov.account_id == account_id
-        for prov in session.mass.providers
-    )
+    mass = session.mass
+    for config in await mass.config.get_provider_configs(provider_domain="spotify"):
+        if config.instance_id == session.context.instance_id:
+            continue
+        if stored := mass.config.get_provider_setup_value(config.instance_id, CONF_ACCOUNT_ID):
+            if str(stored) == account_id:
+                return True
+            continue
+        provider = mass.get_provider(config.instance_id, return_unavailable=True)
+        if isinstance(provider, SpotifyProvider) and provider.account_id == account_id:
+            return True
+    return False
 
 
 async def _authorize_playback(session: SetupSession) -> str:

--- a/music_assistant/providers/spotify/setup_flow.py
+++ b/music_assistant/providers/spotify/setup_flow.py
@@ -6,9 +6,8 @@ from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 
-import aiohttp
 import pkce
-from aiohttp import ClientError
+from aiohttp import ClientError, ClientTimeout
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType
 from music_assistant_models.errors import LoginFailed
@@ -48,6 +47,9 @@ from .provider import SpotifyProvider
 
 if TYPE_CHECKING:
     from music_assistant.models.setup_flow import SetupSession
+
+# seconds to wait for the account lookup that gates the setup
+ACCOUNT_LOOKUP_TIMEOUT = 30
 
 AUTHORIZE_URL = "https://accounts.spotify.com/authorize"
 TOKEN_URL = "https://accounts.spotify.com/api/token"
@@ -175,10 +177,10 @@ async def _verify_account(session: SetupSession, access_token: str) -> None:
     """
     Check the just-authenticated Spotify account before the setup continues.
 
-    Turns the user away when the account has no Spotify Premium (Music Assistant
-    cannot play audio from a free account) or when it is already set up on another
-    provider instance. A lookup Spotify does not answer is not held against the
-    user: the setup simply continues.
+    Turns the user away when the account has no Spotify Premium (librespot, which
+    streams this provider's audio, refuses to play for a free account) or when it is
+    already set up on another provider instance. A lookup Spotify does not answer is
+    not held against the user: the setup simply continues.
 
     :param session: The setup session driving the flow.
     :param access_token: The access token from the just-completed sign-in. Reusing
@@ -190,12 +192,12 @@ async def _verify_account(session: SetupSession, access_token: str) -> None:
         async with session.mass.http_session.get(
             "https://api.spotify.com/v1/me",
             headers={"Authorization": f"Bearer {access_token}"},
-            timeout=aiohttp.ClientTimeout(total=30),
+            timeout=ClientTimeout(total=ACCOUNT_LOOKUP_TIMEOUT),
         ) as response:
             if response.status != 200:
                 return
             userinfo = await response.json()
-    except aiohttp.ClientError, TimeoutError:
+    except ClientError, TimeoutError:
         return
     product = str(userinfo.get("product") or "")
     if product and product != "premium":

--- a/music_assistant/providers/spotify/setup_flow.py
+++ b/music_assistant/providers/spotify/setup_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
@@ -13,6 +14,7 @@ from music_assistant_models.enums import ConfigEntryType
 from music_assistant_models.errors import LoginFailed
 
 from music_assistant.helpers.app_vars import app_var
+from music_assistant.helpers.json import json_loads
 from music_assistant.helpers.oauth import (
     HOSTED_CALLBACK_URL,
     OAUTH_STEP_TIMEOUT,
@@ -48,6 +50,8 @@ from .provider import SpotifyProvider
 
 if TYPE_CHECKING:
     from music_assistant.models.setup_flow import SetupSession
+
+LOGGER = logging.getLogger(__name__)
 
 # seconds to wait for the account lookup that gates the setup
 ACCOUNT_LOOKUP_TIMEOUT = 30
@@ -106,9 +110,10 @@ async def run_setup(session: SetupSession) -> None:
     )
     setup_data[CONF_REFRESH_TOKEN_GLOBAL] = str(token_result["refresh_token"])
     # an account that cannot work is turned away before the playback authorization
-    setup_data[CONF_ACCOUNT_ID] = await _verify_account(session, str(token_result["access_token"]))
+    account_id = await _verify_account(session, str(token_result["access_token"]))
+    setup_data[CONF_ACCOUNT_ID] = account_id
     # playback needs its own credential, minted with Spotify's keymaster client id
-    setup_data[CONF_LIBRESPOT_CREDENTIALS] = await _authorize_playback(session)
+    setup_data[CONF_LIBRESPOT_CREDENTIALS] = await _authorize_playback(session, account_id)
     # everything needed is collected by now; the developer key is a purely optional extra,
     # so it is offered as an opt-in rather than a field the user has to reason about
     client_id_default = str(session.context.setup_data.get(CONF_CLIENT_ID) or "")
@@ -196,12 +201,15 @@ async def _verify_account(session: SetupSession, access_token: str) -> str | Non
             timeout=ClientTimeout(total=ACCOUNT_LOOKUP_TIMEOUT),
         ) as response:
             if response.status != 200:
+                LOGGER.warning("Account check skipped: Spotify replied HTTP %s", response.status)
                 return None
             # a malformed body raises ValueError, which is not a ClientError
             userinfo = await response.json()
-    except ClientError, TimeoutError, ValueError:
+    except (ClientError, TimeoutError, ValueError) as err:
+        LOGGER.warning("Account check skipped: %s", err)
         return None
     if not isinstance(userinfo, dict):
+        LOGGER.warning("Account check skipped: Spotify returned an unexpected profile")
         return None
     product = str(userinfo.get("product") or "")
     if product and product != "premium":
@@ -240,14 +248,19 @@ async def _account_in_use(session: SetupSession, account_id: str) -> bool:
     return False
 
 
-async def _authorize_playback(session: SetupSession) -> str:
+async def _authorize_playback(session: SetupSession, account_id: str | None) -> str:
     """
     Obtain librespot's playback credential and return it as stored-credential JSON.
 
     Offers pairing through the Spotify app first and falls back to a browser sign-in for
-    setups where the Spotify app cannot discover Music Assistant.
+    setups where the Spotify app cannot discover Music Assistant. The credential has to
+    belong to the account that signed in: authorizing playback from a Spotify app that
+    is logged in as someone else would leave the library and the audio on different
+    accounts.
 
     :param session: The setup session driving the flow.
+    :param account_id: The signed-in Spotify user id to match the credential against;
+        the check is skipped when it (or the credential's own account) is unknown.
     """
     try:
         librespot_bin = await get_librespot_binary()
@@ -265,13 +278,18 @@ async def _authorize_playback(session: SetupSession) -> str:
         # aborting the flow would throw that away over a retryable mistake
         try:
             if method == PLAYBACK_AUTH_APP:
-                return await session.progress_until(
+                credentials = await session.progress_until(
                     librespot_credentials_via_pairing(librespot_bin, PAIRING_DEVICE_NAME),
                     step_id="playback_pairing",
                     text="pairing_instructions",
                     expires_in=PAIRING_TIMEOUT,
                 )
-            return await _authorize_playback_via_browser(session, librespot_bin)
+            else:
+                credentials = await _authorize_playback_via_browser(session, librespot_bin)
+            if _credential_account_differs(credentials, account_id):
+                errors = {"base": "playback_account_mismatch"}
+                continue
+            return credentials
         except StepExpiredError:
             errors = {
                 "base": "pairing_not_completed"
@@ -284,6 +302,28 @@ async def _authorize_playback(session: SetupSession) -> str:
             # librespot refusing the token, a transport failure, or a token response without a
             # token; LoginFailed's own default key is too generic to show here
             errors = {"base": "playback_auth_failed"}
+
+
+def _credential_account_differs(credentials: str, account_id: str | None) -> bool:
+    """
+    Return whether a playback credential belongs to a different account than the sign-in.
+
+    Answers False whenever either side is unknown, so an unreadable credential never
+    blocks a setup that is otherwise fine.
+
+    :param credentials: librespot's stored-credential JSON.
+    :param account_id: The signed-in Spotify user id, when known.
+    """
+    if not account_id:
+        return False
+    try:
+        stored = json_loads(credentials)
+    except ValueError:
+        return False
+    if not isinstance(stored, dict):
+        return False
+    username = str(stored.get("username") or "")
+    return bool(username) and username != account_id
 
 
 async def _authorize_playback_via_browser(session: SetupSession, librespot_bin: str) -> str:

--- a/music_assistant/providers/spotify/setup_flow.py
+++ b/music_assistant/providers/spotify/setup_flow.py
@@ -206,7 +206,8 @@ async def _verify_account(session: SetupSession, access_token: str) -> str | Non
             # a malformed body raises ValueError, which is not a ClientError
             userinfo = await response.json()
     except (ClientError, TimeoutError, ValueError) as err:
-        LOGGER.warning("Account check skipped: %s", err)
+        # a bare TimeoutError stringifies to nothing, so log the type too
+        LOGGER.warning("Account check skipped: %s %s", type(err).__name__, err)
         return None
     if not isinstance(userinfo, dict):
         LOGGER.warning("Account check skipped: Spotify returned an unexpected profile")
@@ -322,8 +323,12 @@ def _credential_account_differs(credentials: str, account_id: str | None) -> boo
         return False
     if not isinstance(stored, dict):
         return False
+    # librespot stores Spotify's canonical username, which is the signed-in id lowercased
     username = str(stored.get("username") or "")
-    return bool(username) and username != account_id
+    if not username or username.casefold() == account_id.casefold():
+        return False
+    LOGGER.warning("Playback was authorized for %s instead of %s", username, account_id)
+    return True
 
 
 async def _authorize_playback_via_browser(session: SetupSession, librespot_bin: str) -> str:

--- a/music_assistant/providers/spotify/setup_flow.py
+++ b/music_assistant/providers/spotify/setup_flow.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 
+import aiohttp
 import pkce
 from aiohttp import ClientError
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
@@ -20,7 +21,7 @@ from music_assistant.helpers.oauth import (
     authorization_code_from_url,
     hosted_bounce_redirect,
 )
-from music_assistant.models.setup_flow import SetupFlowError, StepExpiredError
+from music_assistant.models.setup_flow import AbortFlow, SetupFlowError, StepExpiredError
 
 from .constants import (
     CONF_CLIENT_ID,
@@ -43,6 +44,7 @@ from .helpers import (
     librespot_credentials_via_pairing,
     librespot_credentials_via_token,
 )
+from .provider import SpotifyProvider
 
 if TYPE_CHECKING:
     from music_assistant.models.setup_flow import SetupSession
@@ -96,9 +98,12 @@ async def run_setup(session: SetupSession) -> None:
     setup_data = dict(session.context.setup_data)
     # the global session always (re)authenticates: a refresh token cannot be reused across a
     # re-auth and secure values are never prefilled back into the flow
-    setup_data[CONF_REFRESH_TOKEN_GLOBAL] = await _pkce_authenticate(
+    token_result = await _pkce_authenticate(
         session, app_var("spotify_client_id"), step_id="authenticate"
     )
+    setup_data[CONF_REFRESH_TOKEN_GLOBAL] = str(token_result["refresh_token"])
+    # an account that cannot work is turned away before the playback authorization
+    await _verify_account(session, str(token_result["access_token"]))
     # playback needs its own credential, minted with Spotify's keymaster client id
     setup_data[CONF_LIBRESPOT_CREDENTIALS] = await _authorize_playback(session)
     # everything needed is collected by now; the developer key is a purely optional extra,
@@ -152,9 +157,10 @@ async def _authorize_developer_key(
     try:
         if client_id:
             setup_data[CONF_CLIENT_ID] = client_id
-            setup_data[CONF_REFRESH_TOKEN_DEV] = await _pkce_authenticate(
+            dev_token_result = await _pkce_authenticate(
                 session, client_id, step_id="authenticate_dev"
             )
+            setup_data[CONF_REFRESH_TOKEN_DEV] = str(dev_token_result["refresh_token"])
         else:
             # opted in but left the field empty: keep using the shared key
             setup_data[CONF_CLIENT_ID] = None
@@ -163,6 +169,59 @@ async def _authorize_developer_key(
     except SetupFlowError as err:
         return client_id, {"base": err.translation_key or str(err)}
     return client_id, None
+
+
+async def _verify_account(session: SetupSession, access_token: str) -> None:
+    """
+    Check the just-authenticated Spotify account before the setup continues.
+
+    Turns the user away when the account has no Spotify Premium (Music Assistant
+    cannot play audio from a free account) or when it is already set up on another
+    provider instance. A lookup Spotify does not answer is not held against the
+    user: the setup simply continues.
+
+    :param session: The setup session driving the flow.
+    :param access_token: The access token from the just-completed sign-in. Reusing
+        it is deliberate — minting a fresh one rotates the refresh token, which
+        revokes the one just stored as setup data.
+    :raises AbortFlow: When the account is non-Premium or already configured.
+    """
+    try:
+        async with session.mass.http_session.get(
+            "https://api.spotify.com/v1/me",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as response:
+            if response.status != 200:
+                return
+            userinfo = await response.json()
+    except aiohttp.ClientError, TimeoutError:
+        return
+    product = str(userinfo.get("product") or "")
+    if product and product != "premium":
+        raise AbortFlow("premium_required")
+    account_id = str(userinfo.get("id") or "")
+    if account_id and _account_in_use(session, account_id):
+        raise AbortFlow("account_already_configured")
+
+
+def _account_in_use(session: SetupSession, account_id: str) -> bool:
+    """
+    Return whether another Spotify provider instance already serves this account.
+
+    Only running instances can be compared (the account is not part of the stored
+    config), and the instance being reconfigured is of course allowed to keep its
+    own account.
+
+    :param session: The setup session driving the flow.
+    :param account_id: The Spotify user id that just signed in.
+    """
+    return any(
+        isinstance(prov, SpotifyProvider)
+        and prov.instance_id != session.context.instance_id
+        and prov.account_id == account_id
+        for prov in session.mass.providers
+    )
 
 
 async def _authorize_playback(session: SetupSession) -> str:
@@ -266,9 +325,9 @@ async def _authorize_playback_via_browser(session: SetupSession, librespot_bin: 
     return await librespot_credentials_via_token(librespot_bin, token_result["access_token"])
 
 
-async def _pkce_authenticate(session: SetupSession, client_id: str, step_id: str) -> str:
+async def _pkce_authenticate(session: SetupSession, client_id: str, step_id: str) -> dict[str, Any]:
     """
-    Run the Spotify PKCE auth flow via the setup session and return a refresh token.
+    Run the Spotify PKCE auth flow and return the token result (refresh + access token).
 
     :param session: The setup session driving the flow.
     :param client_id: The Spotify client id to authenticate with.
@@ -299,7 +358,7 @@ async def _pkce_authenticate(session: SetupSession, client_id: str, step_id: str
     async with session.mass.http_session.post(TOKEN_URL, data=token_params) as response:
         if response.status != 200:
             raise SetupFlowError(f"Failed to get access token: {await response.text()}")
-        token_result = await response.json()
-    if not (refresh_token := token_result.get("refresh_token")):
+        token_result: dict[str, Any] = await response.json()
+    if not token_result.get("refresh_token"):
         raise SetupFlowError("No refresh token in the token response")
-    return str(refresh_token)
+    return token_result

--- a/music_assistant/providers/spotify/setup_flow.py
+++ b/music_assistant/providers/spotify/setup_flow.py
@@ -201,6 +201,8 @@ async def _verify_account(session: SetupSession, access_token: str) -> str | Non
             userinfo = await response.json()
     except ClientError, TimeoutError, ValueError:
         return None
+    if not isinstance(userinfo, dict):
+        return None
     product = str(userinfo.get("product") or "")
     if product and product != "premium":
         raise AbortFlow("premium_required")

--- a/music_assistant/providers/spotify/strings.json
+++ b/music_assistant/providers/spotify/strings.json
@@ -44,6 +44,10 @@
     }
   },
   "setup_flow": {
+    "abort": {
+      "account_already_configured": "This Spotify account is already set up in Music Assistant. Each account can only be added once — sign in with a different account, or reconfigure the existing one instead.",
+      "premium_required": "A Spotify Premium account is required to use Spotify within Music Assistant. Sign in with a Premium account, or upgrade this one, and try again."
+    },
     "authenticate": {
       "title": "Connect your Spotify account",
       "description": "A browser window will open so you can sign in to Spotify and authorize Music Assistant. Come back here once you're done."

--- a/music_assistant/providers/spotify/strings.json
+++ b/music_assistant/providers/spotify/strings.json
@@ -111,6 +111,7 @@
     "playback_auth_required": "Spotify needs you to approve audio playback again. Open the Spotify provider settings and run through the setup once more to restore playback.",
     "playback_not_completed": "Playback wasn't approved in time. Open the link again and paste the address of the page your browser ends up on.",
     "playback_auth_failed": "Approving playback didn't work. Please try again.",
+    "playback_account_mismatch": "Playback was approved with a different Spotify account than the one you signed in with. Use the same account for both, so your music library and the audio come from the same place.",
     "librespot_unavailable": "Music Assistant has no Spotify playback support for this system, so Spotify audio cannot be played here."
   },
   "manifest": {

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -2292,6 +2292,7 @@
   "provider.spotify.config_entries.use_developer_key.label": "Use my own Spotify developer key (advanced, optional)",
   "provider.spotify.errors.librespot_unavailable": "Music Assistant has no Spotify playback support for this system, so Spotify audio cannot be played here.",
   "provider.spotify.errors.pairing_not_completed": "Music Assistant Pairing wasn't selected in the Spotify app in time. Try again, or use the web browser option if Music Assistant Pairing doesn't appear in your Spotify app.",
+  "provider.spotify.errors.playback_account_mismatch": "Playback was approved with a different Spotify account than the one you signed in with. Use the same account for both, so your music library and the audio come from the same place.",
   "provider.spotify.errors.playback_auth_failed": "Approving playback didn't work. Please try again.",
   "provider.spotify.errors.playback_auth_required": "Spotify needs you to approve audio playback again. Open the Spotify provider settings and run through the setup once more to restore playback.",
   "provider.spotify.errors.playback_code_invalid": "That address could not be used. Make sure you copied the complete address of the error page, and note that each attempt can only be used once — start over to get a new link.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -2302,6 +2302,8 @@
   "provider.spotify.media.folder.new_releases.name": "New Releases",
   "provider.spotify.media.playlist.liked_songs.name": "Liked Songs {0}",
   "provider.spotify.media.podcast.unknown_podcast.name": "Unknown Podcast",
+  "provider.spotify.setup_flow.abort.account_already_configured": "This Spotify account is already set up in Music Assistant. Each account can only be added once — sign in with a different account, or reconfigure the existing one instead.",
+  "provider.spotify.setup_flow.abort.premium_required": "A Spotify Premium account is required to use Spotify within Music Assistant. Sign in with a Premium account, or upgrade this one, and try again.",
   "provider.spotify.setup_flow.authenticate.description": "A browser window will open so you can sign in to Spotify and authorize Music Assistant. Come back here once you're done.",
   "provider.spotify.setup_flow.authenticate.title": "Connect your Spotify account",
   "provider.spotify.setup_flow.authenticate_dev.description": "A browser window will open to authorize Music Assistant against your own Spotify app.",

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -2151,7 +2151,7 @@ async def test_spotify_flow_rejects_playback_authorized_by_another_account(
             step.flow_id,
             {CONF_PLAYBACK_CALLBACK_URL: "http://127.0.0.1:5588/login?code=playback_code"},
         )
-        # back at the method step, telling the user which account it has to be
+        # back at the method step, carrying the reason it was refused
         retry = await _wait_for(
             lambda: (
                 session.current_step

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -149,8 +149,14 @@ def _abort_events(events: list[MassEvent]) -> list[SetupFlowStep]:
     return [event.data for event in events if event.data.type == FlowStepType.ABORT]
 
 
-def _fake_json_session(payload: dict[str, Any]) -> Any:
-    """Return a stub http_session whose .post() yields a 200 JSON response (token exchange)."""
+def _fake_json_session(payload: dict[str, Any], get_payload: dict[str, Any] | None = None) -> Any:
+    """
+    Return a stub http_session yielding 200 JSON responses.
+
+    :param payload: Body for .post() (the token exchange).
+    :param get_payload: Body for .get() (e.g. the Spotify account lookup); when omitted
+        .get() is left unstubbed.
+    """
     response = SimpleNamespace(
         status=200,
         json=AsyncMock(return_value=payload),
@@ -161,6 +167,16 @@ def _fake_json_session(payload: dict[str, Any]) -> Any:
     post_cm.__aexit__ = AsyncMock(return_value=False)
     session = MagicMock()
     session.post = MagicMock(return_value=post_cm)
+    if get_payload is not None:
+        get_response = SimpleNamespace(
+            status=200,
+            json=AsyncMock(return_value=get_payload),
+            text=AsyncMock(return_value=""),
+        )
+        get_cm = MagicMock()
+        get_cm.__aenter__ = AsyncMock(return_value=get_response)
+        get_cm.__aexit__ = AsyncMock(return_value=False)
+        session.get = MagicMock(return_value=get_cm)
     return session
 
 
@@ -1596,7 +1612,12 @@ async def test_spotify_flow_hosted_bounce_roundtrip(
     monkeypatch.setattr(
         flow_mass,
         "_http_session",
-        _fake_json_session({"refresh_token": "rt_global", "access_token": "at_keymaster"}),
+        _fake_json_session(
+            {"refresh_token": "rt_global", "access_token": "at_keymaster"},
+            # the account lookup must answer, so the flow really traverses the
+            # premium/duplicate gate instead of skipping it on an unstubbed call
+            get_payload={"id": "u1", "product": "premium"},
+        ),
     )
     # the playback steps shell out to librespot; stub the binary lookup and the exchange
     monkeypatch.setattr(
@@ -2030,3 +2051,40 @@ async def test_tidal_flow_device_login_remints_on_expiry(
         await _wait_for(lambda: session.finished)
     # the first (expired) attempt is followed by a re-minted second that succeeds
     assert polls["n"] == 2
+
+
+async def test_spotify_flow_aborts_on_a_non_premium_account(
+    flow_mass: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Spotify flow stops right after the sign-in when the account has no Premium."""
+    from music_assistant.providers.spotify.setup_flow import run_setup  # noqa: PLC0415
+
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.setup_flow.app_var", lambda _key: "ma_client_id"
+    )
+    monkeypatch.setattr(
+        flow_mass,
+        "_http_session",
+        _fake_json_session(
+            {"refresh_token": "rt_global", "access_token": "at_keymaster"},
+            get_payload={"id": "u1", "product": "free"},
+        ),
+    )
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        session = flow_mass.config._setup_flows[step.flow_id].session
+        await _fire_callback(flow_mass, step.flow_id, "code=auth_code&state=xyz")
+        aborted = await _wait_for(
+            lambda: (
+                session.current_step
+                if session.current_step is not None
+                and session.current_step.type == FlowStepType.ABORT
+                else None
+            )
+        )
+        # the flow never reaches the playback authorization, and nothing is persisted
+        assert aborted.reason == "premium_required"
+        assert flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}") is None

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -1624,7 +1624,8 @@ async def test_spotify_flow_hosted_bounce_roundtrip(
         "music_assistant.providers.spotify.setup_flow.get_librespot_binary",
         AsyncMock(return_value="/bin/librespot"),
     )
-    credentials_via_token = AsyncMock(return_value='{"username": "u", "auth_data": "d"}')
+    # librespot stores the account it was authorized for, and it is the one that signed in
+    credentials_via_token = AsyncMock(return_value='{"username": "u1", "auth_data": "d"}')
     monkeypatch.setattr(
         "music_assistant.providers.spotify.setup_flow.librespot_credentials_via_token",
         credentials_via_token,
@@ -1697,7 +1698,7 @@ async def test_spotify_flow_hosted_bounce_roundtrip(
     )
     assert (
         flow_mass.config.decrypt_string(raw_conf["setup_data"][CONF_LIBRESPOT_CREDENTIALS])
-        == '{"username": "u", "auth_data": "d"}'
+        == '{"username": "u1", "auth_data": "d"}'
     )
 
 
@@ -2088,3 +2089,78 @@ async def test_spotify_flow_aborts_on_a_non_premium_account(
         # the flow never reaches the playback authorization, and nothing is persisted
         assert aborted.reason == "premium_required"
         assert flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}") is None
+
+
+async def test_spotify_flow_rejects_playback_authorized_by_another_account(
+    flow_mass: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Authorizing playback as a different Spotify account re-asks instead of storing it."""
+    from music_assistant.providers.spotify.setup_flow import (  # noqa: PLC0415
+        CONF_PLAYBACK_AUTH_METHOD,
+        CONF_PLAYBACK_CALLBACK_URL,
+        PLAYBACK_AUTH_BROWSER,
+        run_setup,
+    )
+
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.setup_flow.app_var", lambda _key: "ma_client_id"
+    )
+    monkeypatch.setattr(
+        flow_mass,
+        "_http_session",
+        _fake_json_session(
+            {"refresh_token": "rt_global", "access_token": "at_keymaster"},
+            get_payload={"id": "u1", "product": "premium"},
+        ),
+    )
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.setup_flow.get_librespot_binary",
+        AsyncMock(return_value="/bin/librespot"),
+    )
+    # the browser sign-in lands on a Spotify account other than the one that just signed in
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.setup_flow.librespot_credentials_via_token",
+        AsyncMock(return_value='{"username": "someone_else", "auth_data": "d"}'),
+    )
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.setup_flow.await_loopback_authorization",
+        MagicMock(side_effect=OSError),
+    )
+    with (
+        _use_flow(flow_mass, run_setup),
+        patch.object(flow_mass, "load_provider_config", AsyncMock()),
+    ):
+        step = await flow_mass.config.setup_provider(FAKE_DOMAIN)
+        session = flow_mass.config._setup_flows[step.flow_id].session
+        await _fire_callback(flow_mass, step.flow_id, "code=auth_code&state=xyz")
+        await _wait_for(
+            lambda: (
+                session.current_step is not None and session.current_step.step_id == "playback_auth"
+            )
+        )
+        await flow_mass.config.submit_setup_flow(
+            step.flow_id, {CONF_PLAYBACK_AUTH_METHOD: PLAYBACK_AUTH_BROWSER}
+        )
+        await _wait_for(
+            lambda: (
+                session.current_step is not None
+                and session.current_step.step_id == "playback_browser"
+            )
+        )
+        await flow_mass.config.submit_setup_flow(
+            step.flow_id,
+            {CONF_PLAYBACK_CALLBACK_URL: "http://127.0.0.1:5588/login?code=playback_code"},
+        )
+        # back at the method step, telling the user which account it has to be
+        retry = await _wait_for(
+            lambda: (
+                session.current_step
+                if session.current_step is not None
+                and session.current_step.step_id == "playback_auth"
+                and session.current_step.errors
+                else None
+            )
+        )
+        assert retry.errors == {"base": "playback_account_mismatch"}
+    # the mismatching credential is never persisted
+    assert flow_mass.config.get(f"{CONF_PROVIDERS}/{FAKE_DOMAIN}") is None

--- a/tests/providers/spotify/test_account_gating.py
+++ b/tests/providers/spotify/test_account_gating.py
@@ -23,6 +23,9 @@ def _make_session(*, instance_id: str | None = None) -> SetupSession:
     """Return a setup session for a fresh setup (or a reconfigure of the given instance)."""
     mass = mock.Mock()
     mass.providers = []
+    mass.config.get_provider_configs = mock.AsyncMock(return_value=[])
+    mass.config.get_provider_setup_value = mock.Mock(return_value=None)
+    mass.get_provider = mock.Mock(return_value=None)
 
     async def finish(_session: SetupSession, _submitted: dict[str, Any]) -> dict[str, str]:
         return {"instance_id": "spotify--test"}
@@ -34,6 +37,16 @@ def _make_session(*, instance_id: str | None = None) -> SetupSession:
         instance_id=instance_id,
     )
     return SetupSession(mass, "flow-test", context, finish)
+
+
+def _stub_configs(session: SetupSession, accounts: dict[str, str | None]) -> None:
+    """Point the session at the given configured Spotify instances and their stored accounts."""
+    session.mass.config.get_provider_configs = mock.AsyncMock(  # type: ignore[method-assign]
+        return_value=[mock.Mock(instance_id=instance_id) for instance_id in accounts]
+    )
+    session.mass.config.get_provider_setup_value = mock.Mock(  # type: ignore[method-assign]
+        side_effect=lambda instance_id, _key: accounts.get(instance_id)
+    )
 
 
 def _stub_me(session: SetupSession, *, status: int = 200, payload: Any = None) -> None:
@@ -99,14 +112,44 @@ async def test_an_already_configured_account_is_refused(
 ) -> None:
     """An account another instance already serves is refused; a reconfigure keeps its own."""
     session = _make_session(instance_id=setup_instance_id)
-    existing = mock.MagicMock(spec=SpotifyProvider)
-    existing.instance_id = other_instance_id
-    existing.account_id = "u1"
-    session.mass.providers = [existing]  # type: ignore[misc]
+    _stub_configs(session, {other_instance_id: "u1"})
     _stub_me(session, payload={"id": "u1", "product": "premium"})
 
     if aborts:
         with pytest.raises(AbortFlow, match="account_already_configured"):
             await spotify_flow._verify_account(session, "at-test")
     else:
+        assert await spotify_flow._verify_account(session, "at-test") == "u1"
+
+
+async def test_a_disabled_instance_still_holds_its_account() -> None:
+    """An instance that is not running is still found through its stored account id."""
+    session = _make_session()
+    # configured but absent from mass.providers, as a disabled or failed instance is
+    _stub_configs(session, {"spotify--disabled": "u1"})
+    _stub_me(session, payload={"id": "u1", "product": "premium"})
+
+    with pytest.raises(AbortFlow, match="account_already_configured"):
         await spotify_flow._verify_account(session, "at-test")
+
+
+async def test_a_config_without_a_stored_account_falls_back_to_the_instance() -> None:
+    """A configuration predating the stored account id is compared via its running instance."""
+    session = _make_session()
+    _stub_configs(session, {"spotify--legacy": None})
+    legacy = mock.MagicMock(spec=SpotifyProvider)
+    legacy.account_id = "u1"
+    session.mass.get_provider = mock.Mock(return_value=legacy)  # type: ignore[method-assign]
+    _stub_me(session, payload={"id": "u1", "product": "premium"})
+
+    with pytest.raises(AbortFlow, match="account_already_configured"):
+        await spotify_flow._verify_account(session, "at-test")
+
+
+async def test_a_different_account_is_accepted() -> None:
+    """A second account alongside an existing instance is allowed and returned."""
+    session = _make_session()
+    _stub_configs(session, {"spotify--other": "u1"})
+    _stub_me(session, payload={"id": "u2", "product": "premium"})
+
+    assert await spotify_flow._verify_account(session, "at-test") == "u2"

--- a/tests/providers/spotify/test_account_gating.py
+++ b/tests/providers/spotify/test_account_gating.py
@@ -1,0 +1,94 @@
+"""
+Tests for the Spotify setup flow's account checks.
+
+Right after the sign-in the flow refuses accounts that cannot work: one without
+Spotify Premium (no backend can play audio from a free account) and one that is
+already set up on another provider instance.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from music_assistant.models.setup_flow import AbortFlow, SetupFlowContext, SetupSession
+from music_assistant.providers.spotify import setup_flow as spotify_flow
+from music_assistant.providers.spotify.provider import SpotifyProvider
+
+
+def _make_session(*, instance_id: str | None = None) -> SetupSession:
+    """Return a setup session for a fresh setup (or a reconfigure of the given instance)."""
+    mass = mock.Mock()
+    mass.providers = []
+
+    async def finish(_session: SetupSession, _submitted: dict[str, Any]) -> dict[str, str]:
+        return {"instance_id": "spotify--test"}
+
+    context = SetupFlowContext(
+        kind="reconfigure" if instance_id else "setup",
+        reason="user",
+        domain="spotify",
+        instance_id=instance_id,
+    )
+    return SetupSession(mass, "flow-test", context, finish)
+
+
+def _stub_me(session: SetupSession, *, status: int = 200, payload: Any = None) -> None:
+    """Point the session's http_session at a canned GET /me response."""
+    response = mock.MagicMock()
+    response.status = status
+    response.json = mock.AsyncMock(return_value=payload)
+    session.mass.http_session.get = mock.MagicMock(  # type: ignore[method-assign]
+        return_value=mock.MagicMock(
+            __aenter__=mock.AsyncMock(return_value=response), __aexit__=mock.AsyncMock()
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("product", "aborts"),
+    [("premium", False), ("free", True), ("open", True), ("", False), (None, False)],
+)
+async def test_non_premium_accounts_are_turned_away(product: str | None, aborts: bool) -> None:
+    """Only a non-Premium answer aborts; an absent product field is not held against the user."""
+    session = _make_session()
+    payload = {"id": "u1"} if product is None else {"id": "u1", "product": product}
+    _stub_me(session, payload=payload)
+
+    if aborts:
+        with pytest.raises(AbortFlow, match="premium_required"):
+            await spotify_flow._verify_account(session, "at-test")
+    else:
+        await spotify_flow._verify_account(session, "at-test")
+
+
+async def test_a_failing_lookup_does_not_block_the_setup() -> None:
+    """A lookup Spotify does not answer must not stop the user from setting up."""
+    session = _make_session()
+    _stub_me(session, status=503)
+
+    await spotify_flow._verify_account(session, "at-test")
+
+
+@pytest.mark.parametrize(
+    ("other_instance_id", "aborts"),
+    [("spotify--other", True), ("spotify--test", False)],
+)
+async def test_an_already_configured_account_is_refused(
+    other_instance_id: str, aborts: bool
+) -> None:
+    """An account another instance already serves is refused; a reconfigure keeps its own."""
+    session = _make_session(instance_id="spotify--test")
+    existing = mock.MagicMock(spec=SpotifyProvider)
+    existing.instance_id = other_instance_id
+    existing.account_id = "u1"
+    session.mass.providers = [existing]  # type: ignore[misc]
+    _stub_me(session, payload={"id": "u1", "product": "premium"})
+
+    if aborts:
+        with pytest.raises(AbortFlow, match="account_already_configured"):
+            await spotify_flow._verify_account(session, "at-test")
+    else:
+        await spotify_flow._verify_account(session, "at-test")

--- a/tests/providers/spotify/test_account_gating.py
+++ b/tests/providers/spotify/test_account_gating.py
@@ -2,7 +2,7 @@
 Tests for the Spotify setup flow's account checks.
 
 Right after the sign-in the flow refuses accounts that cannot work: one without
-Spotify Premium (no backend can play audio from a free account) and one that is
+Spotify Premium (librespot refuses to stream for a free account) and one that is
 already set up on another provider instance.
 """
 
@@ -12,6 +12,7 @@ from typing import Any
 from unittest import mock
 
 import pytest
+from aiohttp import ClientError
 
 from music_assistant.models.setup_flow import AbortFlow, SetupFlowContext, SetupSession
 from music_assistant.providers.spotify import setup_flow as spotify_flow
@@ -65,22 +66,39 @@ async def test_non_premium_accounts_are_turned_away(product: str | None, aborts:
 
 
 async def test_a_failing_lookup_does_not_block_the_setup() -> None:
-    """A lookup Spotify does not answer must not stop the user from setting up."""
+    """A lookup Spotify answers with an error must not stop the user from setting up."""
     session = _make_session()
     _stub_me(session, status=503)
 
     await spotify_flow._verify_account(session, "at-test")
 
 
+async def test_an_unreachable_lookup_does_not_block_the_setup() -> None:
+    """A lookup that never completes (transport error/timeout) must not stop the setup."""
+    session = _make_session()
+    session.mass.http_session.get = mock.MagicMock(  # type: ignore[method-assign]
+        side_effect=ClientError("boom")
+    )
+
+    await spotify_flow._verify_account(session, "at-test")
+
+
 @pytest.mark.parametrize(
-    ("other_instance_id", "aborts"),
-    [("spotify--other", True), ("spotify--test", False)],
+    ("setup_instance_id", "other_instance_id", "aborts"),
+    [
+        # a fresh setup adding an account another instance already serves
+        (None, "spotify--other", True),
+        # a reconfigure of a different instance
+        ("spotify--test", "spotify--other", True),
+        # a reconfigure of the very instance that owns the account
+        ("spotify--test", "spotify--test", False),
+    ],
 )
 async def test_an_already_configured_account_is_refused(
-    other_instance_id: str, aborts: bool
+    setup_instance_id: str | None, other_instance_id: str, aborts: bool
 ) -> None:
     """An account another instance already serves is refused; a reconfigure keeps its own."""
-    session = _make_session(instance_id="spotify--test")
+    session = _make_session(instance_id=setup_instance_id)
     existing = mock.MagicMock(spec=SpotifyProvider)
     existing.instance_id = other_instance_id
     existing.account_id = "u1"

--- a/tests/providers/spotify/test_account_gating.py
+++ b/tests/providers/spotify/test_account_gating.py
@@ -153,3 +153,12 @@ async def test_a_different_account_is_accepted() -> None:
     _stub_me(session, payload={"id": "u2", "product": "premium"})
 
     assert await spotify_flow._verify_account(session, "at-test") == "u2"
+
+
+@pytest.mark.parametrize("payload", [None, [], "nope"])
+async def test_a_malformed_account_response_does_not_block_the_setup(payload: Any) -> None:
+    """A 200 whose body is not an object must fail open like any other bad lookup."""
+    session = _make_session()
+    _stub_me(session, payload=payload)
+
+    assert await spotify_flow._verify_account(session, "at-test") is None

--- a/tests/providers/spotify/test_auth.py
+++ b/tests/providers/spotify/test_auth.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from music_assistant_models.errors import LoginFailed
 
-from music_assistant.providers.spotify.constants import CONF_REFRESH_TOKEN_GLOBAL
+from music_assistant.providers.spotify.constants import CONF_ACCOUNT_ID, CONF_REFRESH_TOKEN_GLOBAL
 from music_assistant.providers.spotify.provider import SpotifyProvider
 
 USED_TOKEN = "token_a"
@@ -207,3 +207,59 @@ async def test_login_debounces_save_when_token_unchanged(monkeypatch: pytest.Mon
     update_setup_data.assert_called_once_with(
         CONF_REFRESH_TOKEN_GLOBAL, USED_TOKEN, immediate=False
     )
+
+
+async def test_login_records_the_account_on_a_legacy_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A config predating the stored account id gets it filled in on the next login."""
+    prov = _make_provider(stored_token="fresh_token")
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.provider.get_spotify_token",
+        AsyncMock(
+            return_value={
+                "access_token": "access",
+                "refresh_token": "fresh_token",
+                "expires_at": 9999999999,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        prov, "_get_data", AsyncMock(return_value={"id": "u1", "display_name": "tester"})
+    )
+    update = MagicMock()
+    monkeypatch.setattr(prov, "_update_setup_data", update)
+    prov.mass.metadata = MagicMock()
+
+    await prov.login()
+
+    # the setup flow can now spot a duplicate account without loading this instance
+    assert (CONF_ACCOUNT_ID, "u1") in [call.args[:2] for call in update.call_args_list]
+
+
+async def test_login_leaves_a_recorded_account_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An account id that is already stored is not rewritten on every login."""
+    prov = _make_provider(stored_token="fresh_token")
+    prov.mass.config.get = MagicMock(  # type: ignore[method-assign]
+        return_value={CONF_REFRESH_TOKEN_GLOBAL: "fresh_token", CONF_ACCOUNT_ID: "u1"}
+    )
+    monkeypatch.setattr(
+        "music_assistant.providers.spotify.provider.get_spotify_token",
+        AsyncMock(
+            return_value={
+                "access_token": "access",
+                "refresh_token": "fresh_token",
+                "expires_at": 9999999999,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        prov, "_get_data", AsyncMock(return_value={"id": "u1", "display_name": "tester"})
+    )
+    update = MagicMock()
+    monkeypatch.setattr(prov, "_update_setup_data", update)
+    prov.mass.metadata = MagicMock()
+
+    await prov.login()
+
+    assert CONF_ACCOUNT_ID not in [call.args[0] for call in update.call_args_list]

--- a/tests/providers/spotify/test_playback_auth.py
+++ b/tests/providers/spotify/test_playback_auth.py
@@ -207,9 +207,14 @@ def test_authorization_code_from_url_rejects_unusable(url: str) -> None:
         ('{"username": "u1", "auth_data": "blob"}', "u1", False),
         # a Spotify app logged in as someone else
         ('{"username": "u2", "auth_data": "blob"}', "u1", True),
+        # a near miss is still another account
+        ('{"username": "u10", "auth_data": "blob"}', "u1", True),
+        # the canonical username Spotify hands librespot is the lowercased account id
+        ('{"username": "u1", "auth_data": "blob"}', "U1", False),
         # either side unknown, or an unreadable credential: never block the setup
         ('{"username": "u2", "auth_data": "blob"}', None, False),
         ('{"auth_data": "blob"}', "u1", False),
+        ('{"username": null, "auth_data": "blob"}', "u1", False),
         ('{"username": "", "auth_data": "blob"}', "u1", False),
         ("not json", "u1", False),
         ("[]", "u1", False),

--- a/tests/providers/spotify/test_playback_auth.py
+++ b/tests/providers/spotify/test_playback_auth.py
@@ -106,7 +106,7 @@ async def test_failed_attempt_loops_back_to_the_choice(monkeypatch: pytest.Monke
     session.form = AsyncMock(return_value={setup_flow.CONF_PLAYBACK_AUTH_METHOD: "spotify_app"})
     session.progress_until = AsyncMock(side_effect=_run_awaitable)
 
-    assert await setup_flow._authorize_playback(session) == STORED_CREDENTIALS
+    assert await setup_flow._authorize_playback(session, None) == STORED_CREDENTIALS
     # the form was re-shown, carrying the failure reason rather than aborting the flow
     assert session.form.await_count == 2
     assert session.form.await_args_list[1].kwargs["errors"] == {"base": "playback_auth_failed"}
@@ -198,3 +198,58 @@ def test_authorization_code_from_url_rejects_unusable(url: str) -> None:
     """A denied, empty or malformed paste is reported instead of silently proceeding."""
     with pytest.raises(SetupFlowError):
         authorization_code_from_url(url)
+
+
+@pytest.mark.parametrize(
+    ("credentials", "account_id", "differs"),
+    [
+        # the same account: the credential is accepted
+        ('{"username": "u1", "auth_data": "blob"}', "u1", False),
+        # a Spotify app logged in as someone else
+        ('{"username": "u2", "auth_data": "blob"}', "u1", True),
+        # either side unknown, or an unreadable credential: never block the setup
+        ('{"username": "u2", "auth_data": "blob"}', None, False),
+        ('{"auth_data": "blob"}', "u1", False),
+        ('{"username": "", "auth_data": "blob"}', "u1", False),
+        ("not json", "u1", False),
+        ("[]", "u1", False),
+    ],
+)
+def test_credential_account_comparison(
+    credentials: str, account_id: str | None, differs: bool
+) -> None:
+    """A playback credential from another Spotify account is spotted, and only that."""
+    from music_assistant.providers.spotify.setup_flow import (  # noqa: PLC0415
+        _credential_account_differs,
+    )
+
+    assert _credential_account_differs(credentials, account_id) is differs
+
+
+async def test_playback_authorized_with_another_account_loops_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pairing with the wrong Spotify account re-shows the step instead of storing it."""
+    from music_assistant.providers.spotify import setup_flow  # noqa: PLC0415
+
+    monkeypatch.setattr(
+        setup_flow, "get_librespot_binary", AsyncMock(return_value="/bin/librespot")
+    )
+    # first attempt pairs the wrong account, second one gets it right
+    pairing_mock = MagicMock(
+        side_effect=[
+            _returning('{"username": "someone_else", "auth_data": "blob"}'),
+            _returning('{"username": "u1", "auth_data": "blob"}'),
+        ]
+    )
+    monkeypatch.setattr(setup_flow, "librespot_credentials_via_pairing", pairing_mock)
+    session = MagicMock()
+    session.form = AsyncMock(return_value={setup_flow.CONF_PLAYBACK_AUTH_METHOD: "spotify_app"})
+    session.progress_until = AsyncMock(side_effect=_run_awaitable)
+
+    result = await setup_flow._authorize_playback(session, "u1")
+
+    assert result == '{"username": "u1", "auth_data": "blob"}'
+    # the mismatch re-showed the method step carrying the reason
+    assert session.form.await_count == 2
+    assert session.form.await_args_list[1].kwargs["errors"] == {"base": "playback_account_mismatch"}


### PR DESCRIPTION
# What does this implement/fix?

Setting up Spotify with an account that can never play audio used to fail late and unhelpfully: you signed in, approved playback, finished the whole flow, and only discovered the problem when playback did not work. Adding the same account twice was possible too, which just produces two provider instances fighting over one account.

The setup flow now checks the account and stops with a clear message instead of letting you finish:

- **No Spotify Premium** — librespot, which plays this provider's audio, refuses to stream for a free account, so the flow says so right after the sign-in.
- **Account already set up** — each Spotify account can only be added once; reconfiguring the instance that already owns the account is of course still fine.
- **Playback approved with a different account** — the sign-in and the playback approval are two separate steps that could land on two different Spotify accounts. If they do, the flow asks again rather than storing a credential that does not match your library.

An account lookup that Spotify does not answer is not held against the user: the setup simply continues.

The first two checks share the single `GET /me` call that the flow makes anyway.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
