### PR TITLE
Track a live external audio source on the player

### DIFF
--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -74,11 +74,12 @@ class AudioSourceSession:
         Record the stream details resolved for this session's source.
 
         Adopts the metadata they carry unless the source has reported something
-        itself, so the placeholder every plugin sets in ``get_stream_details`` is
-        what the session reports until then — for vban_receiver and
-        sendspin_source it is the only metadata there is. A later placeholder
-        replaces an earlier one, so those two still follow a reconnect that
-        changed what they describe.
+        itself: while a source is still selected on a player, what it reported is
+        what the session reports, however long ago it said it. Until it says
+        anything, the placeholder every plugin sets in ``get_stream_details``
+        stands in — for vban_receiver and sendspin_source that is the only
+        metadata there is, and a later placeholder replaces an earlier one so
+        those two still follow a reconnect that changed what they describe.
 
         :param streamdetails: The stream details resolved for this source.
         """

--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -43,18 +43,12 @@ class AudioSourceSession:
 
     player_id: str
     source: AudioSource
-    # instance id of the PluginProvider exposing this source
     provider_instance_id: str
     started_at: float = field(default_factory=time.time)
-    # set once a stream is requested; None during the selection window and again
-    # after a paused source's stream is torn down
     streamdetails: StreamDetails | None = None
-    # what the source is playing, either as the source reported it or as adopted
-    # from the stream details
     stream_metadata: StreamMetadata | None = None
     stream_metadata_last_updated: float | None = None
-    # whether the source reported the metadata itself. An adopted placeholder
-    # stays replaceable by a later one, a report does not.
+    # an adopted placeholder stays replaceable by a later one, a report does not
     stream_metadata_reported: bool = False
     # token of the stream request currently holding the source's claim
     stream_session_id: str | None = None
@@ -143,10 +137,8 @@ class AudioSourceMixin:
         provider = self.mass.get_provider(session.provider_instance_id)
         if not isinstance(provider, PluginProvider):
             return None
-        # A session can only have been started by a provider that declared the
-        # feature, but a flag flipped off at runtime (provider reload, config
-        # change) would leave on_source_control / on_volume_change raising
-        # NotImplementedError. Skip cleanly.
+        # a provider can drop the feature at runtime (reload, config change), which
+        # would leave the control hooks raising NotImplementedError
         if ProviderFeature.AUDIO_SOURCE not in provider.supported_features:
             return None
         return session.source, provider
@@ -180,9 +172,6 @@ class AudioSourceMixin:
             or session.source_id != source_id
             or session.provider_instance_id != provider_instance_id
         ):
-            # Debug level so a misbehaving provider firing constantly stays
-            # diagnosable (the count alone is the signal) without spamming higher
-            # log levels for the legitimate transition cases.
             self.logger.debug(
                 "Rejected source update for player %s from provider %s source %s "
                 "(playing: provider %s source %s)",

--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -49,9 +49,13 @@ class AudioSourceSession:
     # set once a stream is requested; None during the selection window and again
     # after a paused source's stream is torn down
     streamdetails: StreamDetails | None = None
-    # what the source reports it is playing
+    # what the source is playing, either as the source reported it or as adopted
+    # from the stream details
     stream_metadata: StreamMetadata | None = None
     stream_metadata_last_updated: float | None = None
+    # whether the source reported the metadata itself. An adopted placeholder
+    # stays replaceable by a later one, a report does not.
+    stream_metadata_reported: bool = False
     # token of the stream request currently holding the source's claim
     stream_session_id: str | None = None
 
@@ -75,15 +79,17 @@ class AudioSourceSession:
         """
         Record the stream details resolved for this session's source.
 
-        Adopts the metadata they carry unless the source has already reported
-        something itself, so the placeholder every plugin sets in
-        ``get_stream_details`` is what the session reports until then — for
-        vban_receiver and sendspin_source it is the only metadata there is.
+        Adopts the metadata they carry unless the source has reported something
+        itself, so the placeholder every plugin sets in ``get_stream_details`` is
+        what the session reports until then — for vban_receiver and
+        sendspin_source it is the only metadata there is. A later placeholder
+        replaces an earlier one, so those two still follow a reconnect that
+        changed what they describe.
 
         :param streamdetails: The stream details resolved for this source.
         """
         self.streamdetails = streamdetails
-        if streamdetails.stream_metadata is not None and self.stream_metadata is None:
+        if streamdetails.stream_metadata is not None and not self.stream_metadata_reported:
             self.stream_metadata = streamdetails.stream_metadata
             self.stream_metadata_last_updated = time.time()
 
@@ -189,6 +195,7 @@ class AudioSourceMixin:
             return
         session.stream_metadata = stream_metadata
         session.stream_metadata_last_updated = time.time()
+        session.stream_metadata_reported = True
         self.trigger_player_update(player_id)
 
     def _start_audio_source_session(

--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -172,12 +172,29 @@ class AudioSourceMixin:
         self._source_sessions[player_id] = session
         return session
 
-    def _end_audio_source_session(self, player_id: str) -> AudioSourceSession | None:
+    def _end_audio_source_session(
+        self, player_id: str, stream_session_id: str | None = None
+    ) -> AudioSourceSession | None:
         """
         Drop the AudioSource session on the given player and return it.
 
+        Pass the ``stream_session_id`` of the stream being torn down to end only
+        the session that stream owns. A reconnect (the player drops and reopens
+        the stream before the first request's teardown runs) leaves the previous
+        request finishing *after* its replacement has started, and an unguarded
+        end would let that late teardown drop the live session — the same hazard
+        ``PluginProvider.on_source_unselected`` requires plugins to guard against.
+        Omit it to end whatever is playing, for a teardown that is not scoped to
+        one stream (an explicit deselect, or the player going away).
+
         :param player_id: The player whose session ended.
+        :param stream_session_id: Only end the session holding this stream token.
+        :return: The session that was ended, or None if none matched.
         """
+        if stream_session_id is not None:
+            session = self._source_sessions.get(player_id)
+            if session is None or session.stream_session_id != stream_session_id:
+                return None
         return self._source_sessions.pop(player_id, None)
 
     def _log_rejected_source_update(
@@ -195,9 +212,11 @@ class AudioSourceMixin:
         the legitimate transition cases.
         """
         self.logger.debug(
-            "Rejected source update for player %s from provider %s source %s (playing: %s)",
+            "Rejected source update for player %s from provider %s source %s "
+            "(playing: provider %s source %s)",
             player_id,
             provider,
             source_id,
-            f"{session.provider_instance_id}/{session.source_id}" if session else "nothing",
+            session.provider_instance_id if session else None,
+            session.source_id if session else None,
         )

--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -35,6 +35,10 @@ class AudioSourceSession:
 
     Carries what the source is, who owns it, and what it reports about itself,
     so none of it has to be read out of a queue item.
+
+    ``streamdetails`` and ``stream_session_id`` are independent of the session's
+    own existence: a paused external source keeps the player while its stream is
+    torn down, so both fall back to None without the session ending.
     """
 
     player_id: str
@@ -42,9 +46,10 @@ class AudioSourceSession:
     # instance id of the PluginProvider exposing this source
     provider_instance_id: str
     started_at: float = field(default_factory=time.time)
-    # resolved once the stream is requested; absent during the selection window
+    # set once a stream is requested; None during the selection window and again
+    # after a paused source's stream is torn down
     streamdetails: StreamDetails | None = None
-    # what the source reports it is playing, pushed by the owning plugin
+    # what the source reports it is playing
     stream_metadata: StreamMetadata | None = None
     stream_metadata_last_updated: float | None = None
     # token of the stream request currently holding the source's claim
@@ -52,8 +57,35 @@ class AudioSourceSession:
 
     @property
     def source_id(self) -> str:
-        """Return the AudioSource.item_id this session plays."""
+        """
+        Return the AudioSource.item_id this session plays.
+
+        Provider-scoped rather than unique: every shipped plugin names its only
+        source "main". Use ``source_uri`` wherever the identifier has to be
+        unique server-wide, such as a player's active source.
+        """
         return self.source.item_id
+
+    @property
+    def source_uri(self) -> str | None:
+        """Return the server-wide unique uri of the AudioSource this session plays."""
+        return self.source.uri
+
+    def attach_streamdetails(self, streamdetails: StreamDetails) -> None:
+        """
+        Record the stream details resolved for this session's source.
+
+        Adopts the metadata they carry unless the source has already reported
+        something itself, so the placeholder every plugin sets in
+        ``get_stream_details`` is what the session reports until then — for
+        vban_receiver and sendspin_source it is the only metadata there is.
+
+        :param streamdetails: The stream details resolved for this source.
+        """
+        self.streamdetails = streamdetails
+        if streamdetails.stream_metadata is not None and self.stream_metadata is None:
+            self.stream_metadata = streamdetails.stream_metadata
+            self.stream_metadata_last_updated = time.time()
 
 
 class AudioSourceMixin:
@@ -68,6 +100,7 @@ class AudioSourceMixin:
     This mixin expects to be mixed with a class that provides:
     - mass: MusicAssistant instance
     - logger: logging.Logger instance
+    - _source_sessions: dict of live sessions, keyed on player_id
     - trigger_player_update(): method to signal a player state change
     """
 
@@ -75,10 +108,9 @@ class AudioSourceMixin:
     if TYPE_CHECKING:
         mass: MusicAssistant
         logger: logging.Logger
+        _source_sessions: dict[str, AudioSourceSession]
 
         def trigger_player_update(self, player_id: str) -> None: ...  # noqa: D102
-
-    _source_sessions: dict[str, AudioSourceSession]
 
     def get_audio_source_session(self, player_id: str) -> AudioSourceSession | None:
         """
@@ -92,8 +124,8 @@ class AudioSourceMixin:
         """
         Return the AudioSource playing on the given player and its owning PluginProvider.
 
-        Named to contrast with ``helpers.player.get_queue_audio_source``, which reads
-        the same pair off a queue's current item and is what this replaces.
+        Resolves the given player alone, so a group member playing its group's
+        source has to be asked for by the group's id.
 
         Returns None when no source is playing on the player, or when the owning
         plugin provider is no longer available.
@@ -117,7 +149,7 @@ class AudioSourceMixin:
         self,
         player_id: str,
         source_id: str,
-        provider: str,
+        provider_instance_id: str,
         stream_metadata: StreamMetadata,
     ) -> None:
         """
@@ -125,24 +157,35 @@ class AudioSourceMixin:
 
         Used by plugin providers exposing an AudioSource (e.g. AirPlay receiver,
         Spotify Connect) to surface live track-change info without restarting the
-        stream. Accepted before the stream details exist, so a provider can
-        replay what it already knows the moment it claims the player.
+        stream. Accepted from the moment the source is selected, so a provider can
+        report what it already knows before any stream exists.
 
-        The update is rejected silently unless the source playing on the player
-        is owned by ``provider`` with ``item_id == source_id``.
+        The update is rejected silently unless the source playing on the player is
+        owned by ``provider_instance_id`` with ``item_id == source_id``.
 
         :param player_id: The player whose session should receive the update.
         :param source_id: The AudioSource.item_id emitting this metadata.
-        :param provider: The provider instance id emitting this metadata.
+        :param provider_instance_id: The provider instance id emitting this metadata.
         :param stream_metadata: The new stream metadata to attach.
         """
         session = self._source_sessions.get(player_id)
         if (
             session is None
             or session.source_id != source_id
-            or session.provider_instance_id != provider
+            or session.provider_instance_id != provider_instance_id
         ):
-            self._log_rejected_source_update(player_id, source_id, provider, session)
+            # Debug level so a misbehaving provider firing constantly stays
+            # diagnosable (the count alone is the signal) without spamming higher
+            # log levels for the legitimate transition cases.
+            self.logger.debug(
+                "Rejected source update for player %s from provider %s source %s "
+                "(playing: provider %s source %s)",
+                player_id,
+                provider_instance_id,
+                source_id,
+                session.provider_instance_id if session else None,
+                session.source_id if session else None,
+            )
             return
         session.stream_metadata = stream_metadata
         session.stream_metadata_last_updated = time.time()
@@ -153,21 +196,35 @@ class AudioSourceMixin:
         player_id: str,
         source: AudioSource,
         provider_instance_id: str,
+        stream_session_id: str | None = None,
     ) -> AudioSourceSession:
         """
         Record that an AudioSource is now playing on the given player.
 
-        Replaces any session already on the player: a player outputs one source
-        at a time, and the previous one is released by its own stream teardown.
+        Re-selecting the source already playing keeps its session and re-stamps
+        the stream token, so a player that drops and reconnects keeps the metadata
+        and stream details it had. Selecting a different source replaces the
+        session: a player outputs one source at a time.
 
         :param player_id: The player the source plays on.
         :param source: The AudioSource that was selected.
         :param provider_instance_id: Instance id of the plugin exposing it.
+        :param stream_session_id: Token of the stream claiming the source, when one
+            has been requested; pass it so the matching release is recognised.
         """
+        session = self._source_sessions.get(player_id)
+        if (
+            session is not None
+            and session.source_id == source.item_id
+            and session.provider_instance_id == provider_instance_id
+        ):
+            session.stream_session_id = stream_session_id
+            return session
         session = AudioSourceSession(
             player_id=player_id,
             source=source,
             provider_instance_id=provider_instance_id,
+            stream_session_id=stream_session_id,
         )
         self._source_sessions[player_id] = session
         return session
@@ -196,27 +253,3 @@ class AudioSourceMixin:
             if session is None or session.stream_session_id != stream_session_id:
                 return None
         return self._source_sessions.pop(player_id, None)
-
-    def _log_rejected_source_update(
-        self,
-        player_id: str,
-        source_id: str,
-        provider: str,
-        session: AudioSourceSession | None,
-    ) -> None:
-        """
-        Log an update that did not match the player's session.
-
-        Debug level so a misbehaving provider firing constantly stays diagnosable
-        (the count alone is the signal) without spamming higher log levels for
-        the legitimate transition cases.
-        """
-        self.logger.debug(
-            "Rejected source update for player %s from provider %s source %s "
-            "(playing: provider %s source %s)",
-            player_id,
-            provider,
-            source_id,
-            session.provider_instance_id if session else None,
-            session.source_id if session else None,
-        )

--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -203,8 +203,10 @@ class AudioSourceMixin:
 
         Re-selecting the source already playing keeps its session and re-stamps
         the stream token, so a player that drops and reconnects keeps the metadata
-        and stream details it had. Selecting a different source replaces the
-        session: a player outputs one source at a time.
+        and stream details it had. The source object itself is always taken from
+        this call: a plugin rebuilds it whenever its capability flags change, and
+        the session has to report the current ones. Selecting a different source
+        replaces the session: a player outputs one source at a time.
 
         :param player_id: The player the source plays on.
         :param source: The AudioSource that was selected.
@@ -218,6 +220,7 @@ class AudioSourceMixin:
             and session.source_id == source.item_id
             and session.provider_instance_id == provider_instance_id
         ):
+            session.source = source
             session.stream_session_id = stream_session_id
             return session
         session = AudioSourceSession(

--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -1,0 +1,203 @@
+"""
+Audio Source Mixin for the Player Controller.
+
+Holds the live external AudioSource playing on a player, independently of that
+player's queue. A queue is Music Assistant's or it is not a queue: while an
+external source plays, the player's queue keeps its own items and goes inactive,
+exactly as it does for a line-in or TV input.
+
+This module provides the AudioSourceMixin class which is inherited by
+PlayerController to add per-player audio source sessions.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from music_assistant_models.enums import ProviderFeature
+
+from music_assistant.models.plugin import PluginProvider
+
+if TYPE_CHECKING:
+    from music_assistant_models.media_items import AudioSource
+    from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
+
+    from music_assistant.mass import MusicAssistant
+
+
+@dataclass
+class AudioSourceSession:
+    """
+    A live external AudioSource playing on a player.
+
+    Carries what the source is, who owns it, and what it reports about itself,
+    so none of it has to be read out of a queue item.
+    """
+
+    player_id: str
+    source: AudioSource
+    # instance id of the PluginProvider exposing this source
+    provider_instance_id: str
+    started_at: float = field(default_factory=time.time)
+    # resolved once the stream is requested; absent during the selection window
+    streamdetails: StreamDetails | None = None
+    # what the source reports it is playing, pushed by the owning plugin
+    stream_metadata: StreamMetadata | None = None
+    stream_metadata_last_updated: float | None = None
+    # token of the stream request currently holding the source's claim
+    stream_session_id: str | None = None
+
+    @property
+    def source_id(self) -> str:
+        """Return the AudioSource.item_id this session plays."""
+        return self.source.item_id
+
+
+class AudioSourceMixin:
+    """
+    Mixin class providing live audio source sessions for PlayerController.
+
+    Handles:
+    - Tracking which external AudioSource is playing on which player
+    - Resolving that source (and its owning plugin) for command proxying
+    - Receiving the live metadata the owning plugin pushes about the source
+
+    This mixin expects to be mixed with a class that provides:
+    - mass: MusicAssistant instance
+    - logger: logging.Logger instance
+    - trigger_player_update(): method to signal a player state change
+    """
+
+    # Type hints for attributes provided by the class this mixin is used with
+    if TYPE_CHECKING:
+        mass: MusicAssistant
+        logger: logging.Logger
+
+        def trigger_player_update(self, player_id: str) -> None: ...  # noqa: D102
+
+    _source_sessions: dict[str, AudioSourceSession]
+
+    def get_audio_source_session(self, player_id: str) -> AudioSourceSession | None:
+        """
+        Return the live AudioSource session on the given player, if any.
+
+        :param player_id: The player to inspect.
+        """
+        return self._source_sessions.get(player_id)
+
+    def get_player_audio_source(self, player_id: str) -> tuple[AudioSource, PluginProvider] | None:
+        """
+        Return the AudioSource playing on the given player and its owning PluginProvider.
+
+        Named to contrast with ``helpers.player.get_queue_audio_source``, which reads
+        the same pair off a queue's current item and is what this replaces.
+
+        Returns None when no source is playing on the player, or when the owning
+        plugin provider is no longer available.
+
+        :param player_id: The player whose source to resolve.
+        """
+        if (session := self._source_sessions.get(player_id)) is None:
+            return None
+        provider = self.mass.get_provider(session.provider_instance_id)
+        if not isinstance(provider, PluginProvider):
+            return None
+        # A session can only have been started by a provider that declared the
+        # feature, but a flag flipped off at runtime (provider reload, config
+        # change) would leave on_source_control / on_volume_change raising
+        # NotImplementedError. Skip cleanly.
+        if ProviderFeature.AUDIO_SOURCE not in provider.supported_features:
+            return None
+        return session.source, provider
+
+    def update_source_metadata(
+        self,
+        player_id: str,
+        source_id: str,
+        provider: str,
+        stream_metadata: StreamMetadata,
+    ) -> None:
+        """
+        Push a live metadata update for the AudioSource playing on a player.
+
+        Used by plugin providers exposing an AudioSource (e.g. AirPlay receiver,
+        Spotify Connect) to surface live track-change info without restarting the
+        stream. Accepted before the stream details exist, so a provider can
+        replay what it already knows the moment it claims the player.
+
+        The update is rejected silently unless the source playing on the player
+        is owned by ``provider`` with ``item_id == source_id``.
+
+        :param player_id: The player whose session should receive the update.
+        :param source_id: The AudioSource.item_id emitting this metadata.
+        :param provider: The provider instance id emitting this metadata.
+        :param stream_metadata: The new stream metadata to attach.
+        """
+        session = self._source_sessions.get(player_id)
+        if (
+            session is None
+            or session.source_id != source_id
+            or session.provider_instance_id != provider
+        ):
+            self._log_rejected_source_update(player_id, source_id, provider, session)
+            return
+        session.stream_metadata = stream_metadata
+        session.stream_metadata_last_updated = time.time()
+        self.trigger_player_update(player_id)
+
+    def _start_audio_source_session(
+        self,
+        player_id: str,
+        source: AudioSource,
+        provider_instance_id: str,
+    ) -> AudioSourceSession:
+        """
+        Record that an AudioSource is now playing on the given player.
+
+        Replaces any session already on the player: a player outputs one source
+        at a time, and the previous one is released by its own stream teardown.
+
+        :param player_id: The player the source plays on.
+        :param source: The AudioSource that was selected.
+        :param provider_instance_id: Instance id of the plugin exposing it.
+        """
+        session = AudioSourceSession(
+            player_id=player_id,
+            source=source,
+            provider_instance_id=provider_instance_id,
+        )
+        self._source_sessions[player_id] = session
+        return session
+
+    def _end_audio_source_session(self, player_id: str) -> AudioSourceSession | None:
+        """
+        Drop the AudioSource session on the given player and return it.
+
+        :param player_id: The player whose session ended.
+        """
+        return self._source_sessions.pop(player_id, None)
+
+    def _log_rejected_source_update(
+        self,
+        player_id: str,
+        source_id: str,
+        provider: str,
+        session: AudioSourceSession | None,
+    ) -> None:
+        """
+        Log an update that did not match the player's session.
+
+        Debug level so a misbehaving provider firing constantly stays diagnosable
+        (the count alone is the signal) without spamming higher log levels for
+        the legitimate transition cases.
+        """
+        self.logger.debug(
+            "Rejected source update for player %s from provider %s source %s (playing: %s)",
+            player_id,
+            provider,
+            source_id,
+            f"{session.provider_instance_id}/{session.source_id}" if session else "nothing",
+        )

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -116,6 +116,7 @@ from music_assistant.models.player_provider import PlayerProvider
 from music_assistant.models.plugin import PluginProvider
 
 from .announcements import AnnouncementsMixin
+from .audio_sources import AudioSourceMixin, AudioSourceSession
 from .constants import PlayerLockPurpose
 from .helpers import handle_player_command, wait_for_power_on
 from .protocol_linking import ProtocolLinkingMixin
@@ -154,7 +155,7 @@ VOLUME_TARGET_EXPIRY = 2.0
 _SENTINEL: Any = object()
 
 
-class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController):
+class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixin, CoreController):
     """Controller holding all logic to control registered players."""
 
     domain: str = "players"
@@ -182,6 +183,8 @@ class PlayerController(AnnouncementsMixin, ProtocolLinkingMixin, CoreController)
         self._pending_protocol_evaluations: dict[str, asyncio.TimerHandle] = {}
         # Serialize delayed evaluations to prevent race conditions
         self._delayed_evaluation_lock = asyncio.Lock()
+        # Live external AudioSource playing on a player, keyed on player_id
+        self._source_sessions: dict[str, AudioSourceSession] = {}
         # Subscribers for player state updates (called with player + changed_values)
         self._state_update_subscribers: list[
             Callable[[Player, dict[str, tuple[Any, Any]]], None]

--- a/tests/controllers/players/test_audio_source_session.py
+++ b/tests/controllers/players/test_audio_source_session.py
@@ -8,15 +8,17 @@ these tests drive the mixin directly.
 
 from unittest.mock import MagicMock
 
-from music_assistant_models.enums import ProviderFeature
-from music_assistant_models.media_items import AudioSource
+from music_assistant_models.enums import ContentType, MediaType, ProviderFeature, StreamType
+from music_assistant_models.media_items import AudioFormat, AudioSource
 from music_assistant_models.media_items.provider_mapping import ProviderMapping
-from music_assistant_models.streamdetails import StreamMetadata
+from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 
+from music_assistant.controllers.players import PlayerController
 from music_assistant.controllers.players.audio_sources import (
     AudioSourceMixin,
     AudioSourceSession,
 )
+from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.plugin import PluginProvider
 
 PLAYER_ID = "player-1"
@@ -55,6 +57,17 @@ class _Controller(AudioSourceMixin):
     def trigger_player_update(self, player_id: str) -> None:
         """Record that a player update was signalled."""
         self.updated_players.append(player_id)
+
+
+def _streamdetails(metadata: StreamMetadata) -> StreamDetails:
+    return StreamDetails(
+        provider=PROVIDER_INSTANCE,
+        item_id=SOURCE_ID,
+        audio_format=AudioFormat(content_type=ContentType.PCM_S16LE),
+        media_type=MediaType.AUDIO_SOURCE,
+        stream_type=StreamType.CUSTOM,
+        stream_metadata=metadata,
+    )
 
 
 def _plugin_provider(*, with_feature: bool = True) -> MagicMock:
@@ -182,8 +195,15 @@ def test_source_unresolvable_when_the_feature_was_turned_off() -> None:
 
 
 def test_source_unresolvable_when_the_provider_is_not_a_plugin() -> None:
-    """A non-PluginProvider behind the instance id is skipped."""
-    ctrl = _Controller(MagicMock())
+    """
+    A non-PluginProvider behind the instance id is skipped.
+
+    It declares the AUDIO_SOURCE feature so the feature guard cannot be what
+    rejects it — only the isinstance check can.
+    """
+    not_a_plugin = MagicMock(spec=MusicProvider)
+    not_a_plugin.supported_features = {ProviderFeature.AUDIO_SOURCE}
+    ctrl = _Controller(not_a_plugin)
     ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
 
     assert ctrl.get_player_audio_source(PLAYER_ID) is None
@@ -242,3 +262,90 @@ def test_metadata_update_rejected_when_nothing_is_playing() -> None:
     assert ctrl.get_audio_source_session(PLAYER_ID) is None
     assert ctrl.updated_players == []
     assert ctrl.log_mock.debug.called
+
+
+def test_reconnecting_the_same_source_keeps_its_metadata() -> None:
+    """
+    A drop and reconnect re-stamps the stream token without losing what was known.
+
+    The queue-borne path reuses the cached streamdetails on a reconnect, so the
+    reported track survives one; a fresh session per stream request would blank it
+    until the plugin happened to push again.
+    """
+    ctrl = _Controller(_plugin_provider())
+    source = _audio_source()
+    first = ctrl._start_audio_source_session(PLAYER_ID, source, PROVIDER_INSTANCE, "stream-a")
+    ctrl.update_source_metadata(
+        PLAYER_ID, SOURCE_ID, PROVIDER_INSTANCE, StreamMetadata(title="Take Five")
+    )
+
+    again = ctrl._start_audio_source_session(PLAYER_ID, source, PROVIDER_INSTANCE, "stream-b")
+
+    assert again is first
+    assert again.stream_session_id == "stream-b"
+    assert again.stream_metadata is not None
+    assert again.stream_metadata.title == "Take Five"
+    assert again.started_at == first.started_at
+
+
+def test_selecting_a_different_source_does_not_keep_the_old_metadata() -> None:
+    """A different source is a new session, so nothing carries over."""
+    ctrl = _Controller(_plugin_provider())
+    ctrl._start_audio_source_session(PLAYER_ID, _audio_source("first"), PROVIDER_INSTANCE)
+    ctrl.update_source_metadata(
+        PLAYER_ID, "first", PROVIDER_INSTANCE, StreamMetadata(title="Take Five")
+    )
+
+    second = ctrl._start_audio_source_session(PLAYER_ID, _audio_source("second"), PROVIDER_INSTANCE)
+
+    assert second.source_id == "second"
+    assert second.stream_metadata is None
+
+
+def test_attaching_streamdetails_adopts_their_metadata() -> None:
+    """The placeholder a plugin sets in get_stream_details is what the session reports."""
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+
+    session.attach_streamdetails(_streamdetails(StreamMetadata(title="VBAN | Studio")))
+
+    assert session.streamdetails is not None
+    assert session.stream_metadata is not None
+    assert session.stream_metadata.title == "VBAN | Studio"
+    assert session.stream_metadata_last_updated is not None
+
+
+def test_attaching_streamdetails_does_not_overwrite_a_reported_track() -> None:
+    """A source that already reported something keeps it: the placeholder is only a fallback."""
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+    ctrl.update_source_metadata(
+        PLAYER_ID, SOURCE_ID, PROVIDER_INSTANCE, StreamMetadata(title="Take Five")
+    )
+
+    session.attach_streamdetails(_streamdetails(StreamMetadata(title="Spotify Connect | Kitchen")))
+
+    assert session.stream_metadata is not None
+    assert session.stream_metadata.title == "Take Five"
+
+
+def test_source_id_is_provider_scoped_and_uri_is_unique() -> None:
+    """Every shipped plugin names its only source "main", so the uri is the unique handle."""
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+
+    assert session.source_id == "main"
+    assert session.source_uri != session.source_id
+    assert session.source_uri is not None
+    assert PROVIDER_INSTANCE in session.source_uri
+
+
+def test_mixin_is_attached_to_the_real_player_controller() -> None:
+    """The carrier is wired into PlayerController and its store is initialised."""
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value.return_value = "INFO"
+    controller = PlayerController(mass)
+
+    assert isinstance(controller, AudioSourceMixin)
+    assert controller._source_sessions == {}
+    assert controller.get_audio_source_session("no-such-player") is None

--- a/tests/controllers/players/test_audio_source_session.py
+++ b/tests/controllers/players/test_audio_source_session.py
@@ -111,6 +111,50 @@ def test_ending_a_session_drops_and_returns_it() -> None:
     assert ctrl._end_audio_source_session(PLAYER_ID) is None
 
 
+def test_ending_a_session_by_stream_token_requires_a_match() -> None:
+    """A teardown scoped to a stream only ends the session holding that stream."""
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+    session.stream_session_id = "stream-a"
+
+    assert ctrl._end_audio_source_session(PLAYER_ID, "stream-b") is None
+    assert ctrl.get_audio_source_session(PLAYER_ID) is session
+
+    assert ctrl._end_audio_source_session(PLAYER_ID, "stream-a") is session
+    assert ctrl.get_audio_source_session(PLAYER_ID) is None
+
+
+def test_a_superseded_teardown_does_not_end_its_replacement() -> None:
+    """
+    A reconnect's late teardown must not drop the session that replaced it.
+
+    Replays the ordering the plugin contract calls out: the player drops and
+    reopens the stream, so the first request's teardown runs after the second
+    request has already claimed the player.
+    """
+    ctrl = _Controller(_plugin_provider())
+    first = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+    first.stream_session_id = "stream-a"
+
+    # the player reconnects: a new stream claims the player before the old one tears down
+    second = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+    second.stream_session_id = "stream-b"
+
+    # ...and only now does the first request's finally block run
+    assert ctrl._end_audio_source_session(PLAYER_ID, "stream-a") is None
+    assert ctrl.get_audio_source_session(PLAYER_ID) is second
+
+
+def test_ending_a_session_without_a_token_is_unconditional() -> None:
+    """A deselect that is not scoped to a stream ends whatever is playing."""
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+    session.stream_session_id = "stream-a"
+
+    assert ctrl._end_audio_source_session(PLAYER_ID) is session
+    assert ctrl.get_audio_source_session(PLAYER_ID) is None
+
+
 def test_sessions_are_isolated_per_player() -> None:
     """A session on one player is invisible to another."""
     ctrl = _Controller(_plugin_provider())

--- a/tests/controllers/players/test_audio_source_session.py
+++ b/tests/controllers/players/test_audio_source_session.py
@@ -1,0 +1,200 @@
+"""
+Tests for the per-player AudioSource session record.
+
+The session holds what an external source is, who owns it and what it reports,
+without any of it living in a queue item. Nothing produces a session yet, so
+these tests drive the mixin directly.
+"""
+
+from unittest.mock import MagicMock
+
+from music_assistant_models.enums import ProviderFeature
+from music_assistant_models.media_items import AudioSource
+from music_assistant_models.media_items.provider_mapping import ProviderMapping
+from music_assistant_models.streamdetails import StreamMetadata
+
+from music_assistant.controllers.players.audio_sources import (
+    AudioSourceMixin,
+    AudioSourceSession,
+)
+from music_assistant.models.plugin import PluginProvider
+
+PLAYER_ID = "player-1"
+PROVIDER_INSTANCE = "spotify_connect--abc"
+SOURCE_ID = "main"
+
+
+def _audio_source(item_id: str = SOURCE_ID) -> AudioSource:
+    return AudioSource(
+        item_id=item_id,
+        provider=PROVIDER_INSTANCE,
+        name="Spotify Connect",
+        provider_mappings={
+            ProviderMapping(
+                item_id=item_id,
+                provider_domain="spotify_connect",
+                provider_instance=PROVIDER_INSTANCE,
+            )
+        },
+        can_play_pause=True,
+    )
+
+
+class _Controller(AudioSourceMixin):
+    """Minimal stand-in for the parts of PlayerController the mixin relies on."""
+
+    def __init__(self, provider: object | None) -> None:
+        self._source_sessions: dict[str, AudioSourceSession] = {}
+        self.mass = MagicMock()
+        self.mass.get_provider.return_value = provider
+        # kept under its own name so assertions can read the mock's call record
+        self.log_mock = MagicMock()
+        self.logger = self.log_mock
+        self.updated_players: list[str] = []
+
+    def trigger_player_update(self, player_id: str) -> None:
+        """Record that a player update was signalled."""
+        self.updated_players.append(player_id)
+
+
+def _plugin_provider(*, with_feature: bool = True) -> MagicMock:
+    provider = MagicMock(spec=PluginProvider)
+    provider.instance_id = PROVIDER_INSTANCE
+    provider.supported_features = {ProviderFeature.AUDIO_SOURCE} if with_feature else set()
+    return provider
+
+
+def test_no_session_by_default() -> None:
+    """A player with nothing playing on it has no session and no source."""
+    ctrl = _Controller(_plugin_provider())
+    assert ctrl.get_audio_source_session(PLAYER_ID) is None
+    assert ctrl.get_player_audio_source(PLAYER_ID) is None
+
+
+def test_started_session_resolves_source_and_provider() -> None:
+    """A started session resolves to its AudioSource and owning plugin."""
+    provider = _plugin_provider()
+    ctrl = _Controller(provider)
+    source = _audio_source()
+    session = ctrl._start_audio_source_session(PLAYER_ID, source, PROVIDER_INSTANCE)
+
+    assert session.player_id == PLAYER_ID
+    assert session.source_id == SOURCE_ID
+    assert session.streamdetails is None
+    assert session.stream_metadata is None
+    assert session.stream_session_id is None
+    assert session.started_at > 0
+
+    assert ctrl.get_audio_source_session(PLAYER_ID) is session
+    assert ctrl.get_player_audio_source(PLAYER_ID) == (source, provider)
+
+
+def test_starting_a_second_session_replaces_the_first() -> None:
+    """A player outputs one source at a time, so a new session replaces the old."""
+    ctrl = _Controller(_plugin_provider())
+    ctrl._start_audio_source_session(PLAYER_ID, _audio_source("first"), PROVIDER_INSTANCE)
+    second = ctrl._start_audio_source_session(PLAYER_ID, _audio_source("second"), PROVIDER_INSTANCE)
+
+    current = ctrl.get_audio_source_session(PLAYER_ID)
+    assert current is second
+    assert current.source_id == "second"
+
+
+def test_ending_a_session_drops_and_returns_it() -> None:
+    """Ending a session removes it from the player and hands it back."""
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+
+    assert ctrl._end_audio_source_session(PLAYER_ID) is session
+    assert ctrl.get_audio_source_session(PLAYER_ID) is None
+    # ending twice is harmless
+    assert ctrl._end_audio_source_session(PLAYER_ID) is None
+
+
+def test_sessions_are_isolated_per_player() -> None:
+    """A session on one player is invisible to another."""
+    ctrl = _Controller(_plugin_provider())
+    ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+
+    assert ctrl.get_audio_source_session("player-2") is None
+    assert ctrl.get_player_audio_source("player-2") is None
+
+
+def test_source_unresolvable_when_provider_is_gone() -> None:
+    """A session whose plugin has unloaded resolves to nothing."""
+    ctrl = _Controller(None)
+    ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+
+    assert ctrl.get_audio_source_session(PLAYER_ID) is not None
+    assert ctrl.get_player_audio_source(PLAYER_ID) is None
+
+
+def test_source_unresolvable_when_the_feature_was_turned_off() -> None:
+    """A provider that dropped the AUDIO_SOURCE feature at runtime is skipped."""
+    ctrl = _Controller(_plugin_provider(with_feature=False))
+    ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+
+    assert ctrl.get_player_audio_source(PLAYER_ID) is None
+
+
+def test_source_unresolvable_when_the_provider_is_not_a_plugin() -> None:
+    """A non-PluginProvider behind the instance id is skipped."""
+    ctrl = _Controller(MagicMock())
+    ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+
+    assert ctrl.get_player_audio_source(PLAYER_ID) is None
+
+
+def test_metadata_update_is_accepted_before_streamdetails_exist() -> None:
+    """The owning plugin can replay what it knows the moment it claims the player."""
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+    metadata = StreamMetadata(title="Take Five", artist="Dave Brubeck")
+
+    ctrl.update_source_metadata(PLAYER_ID, SOURCE_ID, PROVIDER_INSTANCE, metadata)
+
+    assert session.streamdetails is None
+    assert session.stream_metadata is metadata
+    assert session.stream_metadata_last_updated is not None
+    assert ctrl.updated_players == [PLAYER_ID]
+
+
+def test_metadata_update_rejected_for_another_source() -> None:
+    """Metadata for a source that is not the one playing is dropped."""
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+
+    ctrl.update_source_metadata(
+        PLAYER_ID, "some-other-source", PROVIDER_INSTANCE, StreamMetadata(title="Nope")
+    )
+
+    assert session.stream_metadata is None
+    assert ctrl.updated_players == []
+    assert ctrl.log_mock.debug.called
+
+
+def test_metadata_update_rejected_for_another_provider() -> None:
+    """Metadata from a provider that does not own the session is dropped."""
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+
+    ctrl.update_source_metadata(
+        PLAYER_ID, SOURCE_ID, "airplay_receiver--xyz", StreamMetadata(title="Nope")
+    )
+
+    assert session.stream_metadata is None
+    assert ctrl.updated_players == []
+    assert ctrl.log_mock.debug.called
+
+
+def test_metadata_update_rejected_when_nothing_is_playing() -> None:
+    """Metadata for a player with no session is dropped without raising."""
+    ctrl = _Controller(_plugin_provider())
+
+    ctrl.update_source_metadata(
+        PLAYER_ID, SOURCE_ID, PROVIDER_INSTANCE, StreamMetadata(title="Nope")
+    )
+
+    assert ctrl.get_audio_source_session(PLAYER_ID) is None
+    assert ctrl.updated_players == []
+    assert ctrl.log_mock.debug.called

--- a/tests/controllers/players/test_audio_source_session.py
+++ b/tests/controllers/players/test_audio_source_session.py
@@ -378,3 +378,41 @@ def test_reselecting_adopts_a_rebuilt_source() -> None:
     # the reported track still survives the reselect
     assert again.stream_metadata is not None
     assert again.stream_metadata.title == "Take Five"
+
+
+def test_a_fallback_only_source_follows_a_changed_placeholder() -> None:
+    """
+    A source that never reports keeps taking its placeholder from the stream details.
+
+    vban_receiver and sendspin_source never call update_stream_metadata, so the
+    placeholder is all they have. Adopting one must not stop a later one landing:
+    a VBAN reconnect from a different sender describes something else.
+    """
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+
+    session.attach_streamdetails(_streamdetails(StreamMetadata(title="VBAN | Studio")))
+    assert session.stream_metadata is not None
+    assert session.stream_metadata.title == "VBAN | Studio"
+
+    session.attach_streamdetails(_streamdetails(StreamMetadata(title="VBAN | Booth")))
+    assert session.stream_metadata.title == "VBAN | Booth"
+    assert session.stream_metadata_reported is False
+
+
+def test_a_reported_track_is_not_replaced_by_a_later_placeholder() -> None:
+    """Once the source has reported, stream details stop overriding it."""
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+    session.attach_streamdetails(_streamdetails(StreamMetadata(title="Spotify Connect | Kitchen")))
+
+    ctrl.update_source_metadata(
+        PLAYER_ID, SOURCE_ID, PROVIDER_INSTANCE, StreamMetadata(title="Take Five")
+    )
+    assert session.stream_metadata_reported is True
+
+    # a reconnect brings fresh stream details carrying only the placeholder again
+    session.attach_streamdetails(_streamdetails(StreamMetadata(title="Spotify Connect | Kitchen")))
+
+    assert session.stream_metadata is not None
+    assert session.stream_metadata.title == "Take Five"

--- a/tests/controllers/players/test_audio_source_session.py
+++ b/tests/controllers/players/test_audio_source_session.py
@@ -26,7 +26,7 @@ PROVIDER_INSTANCE = "spotify_connect--abc"
 SOURCE_ID = "main"
 
 
-def _audio_source(item_id: str = SOURCE_ID) -> AudioSource:
+def _audio_source(item_id: str = SOURCE_ID, *, can_seek: bool = False) -> AudioSource:
     return AudioSource(
         item_id=item_id,
         provider=PROVIDER_INSTANCE,
@@ -39,6 +39,7 @@ def _audio_source(item_id: str = SOURCE_ID) -> AudioSource:
             )
         },
         can_play_pause=True,
+        can_seek=can_seek,
     )
 
 
@@ -349,3 +350,31 @@ def test_mixin_is_attached_to_the_real_player_controller() -> None:
     assert isinstance(controller, AudioSourceMixin)
     assert controller._source_sessions == {}
     assert controller.get_audio_source_session("no-such-player") is None
+
+
+def test_reselecting_adopts_a_rebuilt_source() -> None:
+    """
+    A plugin that rebuilds its source with new capabilities gets those reported.
+
+    spotify_connect and yandex_ynison rebuild the AudioSource whenever a
+    capability flag changes; ynison's _update_source_capabilities even overwrites
+    the queue item's snapshot so the new flags reach the UI without waiting for
+    the next play. A session that kept the first object would report stale flags.
+    """
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(
+        PLAYER_ID, _audio_source(can_seek=False), PROVIDER_INSTANCE
+    )
+    ctrl.update_source_metadata(
+        PLAYER_ID, SOURCE_ID, PROVIDER_INSTANCE, StreamMetadata(title="Take Five")
+    )
+
+    rebuilt = _audio_source(can_seek=True)
+    again = ctrl._start_audio_source_session(PLAYER_ID, rebuilt, PROVIDER_INSTANCE)
+
+    assert again is session
+    assert again.source is rebuilt
+    assert again.source.can_seek is True
+    # the reported track still survives the reselect
+    assert again.stream_metadata is not None
+    assert again.stream_metadata.title == "Take Five"


### PR DESCRIPTION
# What does this implement/fix?

Groundwork for moving live external sources (Spotify Connect, AirPlay receiver, VBAN, Ynison, AriaCast) off the queue and onto the player they actually play on. A queue is Music Assistant's or it is not a queue — while an external source plays, the player's queue should keep its own items and go inactive, exactly as it already does for a line-in or TV input.

This adds the thing that has to exist first: a per-player record of the live source. It holds what the source is, which plugin owns it, and the live metadata that plugin pushes about it — none of which then has to be read out of a queue item.

**Deliberately inert: nothing creates a session yet, so there is no behaviour change.** It lands on its own on purpose. Before this model existed there was no wire-level place to say what a live source is playing, and the result was that several providers each arrived at their own way of faking a queue so the UI would render it — which is what motivated #3938 in the first place. Having one carrier in core, merged before any provider moves onto it, is what stops that happening again.

### Two deliberate differences from the queue-borne path

- **Metadata is accepted from the moment the source is selected**, not only once stream details exist. Today `update_stream_metadata` → `_resolve_live_source_streamdetails` rejects a push while `current_item.streamdetails is None`, so this is a widening rather than preserved behaviour — worth calling out explicitly. It matters because a plugin knows what its session is playing before MA asks for a stream.
- **A session adopts the metadata its stream details carry** unless the source has already reported something itself. Every plugin sets a placeholder in `get_stream_details`, and for `vban_receiver` and `sendspin_source` that is the *only* metadata they ever provide — neither calls `update_stream_metadata` at all.

Re-selecting the source already playing keeps its session rather than replacing it, so a player that drops and reconnects does not lose either of the above. That mirrors the queue path, which reuses cached stream details across a reconnect.

The design investigation behind this (why the representation moves, what it costs, and the six-step sequence) is not in the repo — this project keeps its design docs on working branches rather than in a `docs/` tree, and there is no such directory on `dev` to put it in. Ask if you want it linked; the summary above is meant to stand on its own for reviewing this PR.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
