### PR TITLE
Don't parse playlist items already in the database

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -79,6 +79,7 @@ from music_assistant.helpers.compare import compare_strings
 from music_assistant.helpers.json import SerializableType, json_loads
 from music_assistant.helpers.playlists import parse_m3u, parse_pls
 from music_assistant.helpers.tags import AudioTags, async_parse_tags, clean_mbid, split_items
+from music_assistant.helpers.uri import create_uri
 from music_assistant.helpers.util import (
     TaskManager,
     detect_charset,
@@ -1524,12 +1525,10 @@ class LocalFileSystemProvider(MusicProvider):
                     normalized = posixpath.normpath(f"{playlist_path}/{_line}")
                     with contextlib.suppress(FileNotFoundError, MediaNotFoundError):
                         file_item = await self.resolve(normalized)
-                        tags = await async_parse_tags(file_item.absolute_path, file_item.file_size)
-                        return await self._parse_track(file_item, tags)
+                        return await self._get_playlist_line_track(file_item)
                 with contextlib.suppress(FileNotFoundError, MediaNotFoundError):
                     file_item = await self.resolve(_line)
-                    tags = await async_parse_tags(file_item.absolute_path, file_item.file_size)
-                    return await self._parse_track(file_item, tags)
+                    return await self._get_playlist_line_track(file_item)
             # all attempts failed
             raise MediaNotFoundError("Invalid path/uri")
 
@@ -1537,6 +1536,30 @@ class LocalFileSystemProvider(MusicProvider):
             self.logger.warning("Could not parse %s to track: %s", line, str(err))
 
         return None
+
+    async def _get_playlist_line_track(self, file_item: FileSystemItem) -> Track:
+        """
+        Return the track for a resolved playlist entry.
+
+        :param file_item: The resolved file the playlist entry points at.
+        """
+        # filesystem tracks are synced into the library, so prefer the database over
+        # (expensive) tag parsing - this keeps loading large playlists fast
+        library_track = await self.mass.music.tracks.get_library_item_by_prov_id(
+            file_item.relative_path, self.instance_id
+        )
+        if library_track is not None:
+            # callers expect the provider item identity here (not the library one),
+            # e.g. for duplicate detection when editing the playlist
+            library_track.item_id = file_item.relative_path
+            library_track.provider = self.instance_id
+            library_track.uri = create_uri(
+                MediaType.TRACK, self.instance_id, file_item.relative_path
+            )
+            return library_track
+        # not (yet) in the library: parse the file tags
+        tags = await async_parse_tags(file_item.absolute_path, file_item.file_size)
+        return await self._parse_track(file_item, tags)
 
     @staticmethod
     def _versioned_image_path(relative_path: str, checksum: str | None) -> str:

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -1548,7 +1548,15 @@ class LocalFileSystemProvider(MusicProvider):
         library_track = await self.mass.music.tracks.get_library_item_by_prov_id(
             file_item.relative_path, self.instance_id
         )
-        if library_track is not None:
+        # only trust the library item if its mapping for this file is available: the file
+        # just resolved, so an unavailable mapping is stale (e.g. the file was missing
+        # during the last scan) and would wrongly exclude the track from playback
+        if library_track is not None and any(
+            mapping.provider_instance == self.instance_id
+            and mapping.item_id == file_item.relative_path
+            and mapping.available
+            for mapping in library_track.provider_mappings
+        ):
             # callers expect the provider item identity here (not the library one),
             # e.g. for duplicate detection when editing the playlist
             library_track.item_id = file_item.relative_path

--- a/tests/providers/filesystem/test_parse_playlist_line.py
+++ b/tests/providers/filesystem/test_parse_playlist_line.py
@@ -6,7 +6,9 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from music_assistant_models.enums import MediaType
 
+from music_assistant.helpers.uri import create_uri
 from music_assistant.providers.filesystem_local import LocalFileSystemProvider
 
 if TYPE_CHECKING:
@@ -31,6 +33,9 @@ def provider(
     provider = LocalFileSystemProvider.__new__(LocalFileSystemProvider)
     provider.base_path = str(music_dir)
     provider.logger = MagicMock()
+    provider.config = MagicMock(instance_id="filesystem_local--test")
+    provider.mass = MagicMock()
+    provider.mass.music.tracks.get_library_item_by_prov_id = AsyncMock(return_value=None)
     monkeypatch.setattr(
         "music_assistant.providers.filesystem_local.async_parse_tags",
         AsyncMock(return_value=MagicMock()),
@@ -90,3 +95,34 @@ async def test_missing_file_returns_none(
 
     assert await fs_provider._parse_playlist_line("Missing/nope.mp3", "Playlists") is None
     fs_provider.logger.warning.assert_called_once()  # type: ignore[attr-defined]
+
+
+async def test_library_track_preferred_over_tag_parsing(
+    provider: tuple[LocalFileSystemProvider, MagicMock],
+) -> None:
+    """A line whose file is already in the library resolves from the db, without tag parsing."""
+    fs_provider, _ = provider
+    library_track = MagicMock(name="library_track")
+    db_lookup = AsyncMock(return_value=library_track)
+    fs_provider.mass.music.tracks.get_library_item_by_prov_id = db_lookup  # type: ignore[method-assign]
+
+    result = await fs_provider._parse_playlist_line("../Artist/track.mp3", "Playlists")
+
+    assert result is library_track
+    db_lookup.assert_awaited_once_with("Artist/track.mp3", "filesystem_local--test")
+    # the library track is presented under its provider item identity
+    assert result.item_id == "Artist/track.mp3"
+    assert result.provider == "filesystem_local--test"
+    assert result.uri == create_uri(MediaType.TRACK, "filesystem_local--test", "Artist/track.mp3")
+    fs_provider._parse_track.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+async def test_tag_parsing_fallback_when_not_in_library(
+    provider: tuple[LocalFileSystemProvider, MagicMock],
+) -> None:
+    """A line whose file is not (yet) in the library falls back to parsing the file tags."""
+    fs_provider, track = provider
+
+    assert await fs_provider._parse_playlist_line("../Artist/track.mp3", "Playlists") is track
+    fs_provider.mass.music.tracks.get_library_item_by_prov_id.assert_awaited_once()  # type: ignore[attr-defined]
+    fs_provider._parse_track.assert_awaited_once()  # type: ignore[attr-defined]

--- a/tests/providers/filesystem/test_parse_playlist_line.py
+++ b/tests/providers/filesystem/test_parse_playlist_line.py
@@ -97,12 +97,25 @@ async def test_missing_file_returns_none(
     fs_provider.logger.warning.assert_called_once()  # type: ignore[attr-defined]
 
 
+def _library_track_mock(available: bool) -> MagicMock:
+    """Return a library track mock with a provider mapping for Artist/track.mp3."""
+    library_track = MagicMock(name="library_track")
+    library_track.provider_mappings = {
+        MagicMock(
+            provider_instance="filesystem_local--test",
+            item_id="Artist/track.mp3",
+            available=available,
+        )
+    }
+    return library_track
+
+
 async def test_library_track_preferred_over_tag_parsing(
     provider: tuple[LocalFileSystemProvider, MagicMock],
 ) -> None:
     """A line whose file is already in the library resolves from the db, without tag parsing."""
     fs_provider, _ = provider
-    library_track = MagicMock(name="library_track")
+    library_track = _library_track_mock(available=True)
     db_lookup = AsyncMock(return_value=library_track)
     fs_provider.mass.music.tracks.get_library_item_by_prov_id = db_lookup  # type: ignore[method-assign]
 
@@ -115,6 +128,20 @@ async def test_library_track_preferred_over_tag_parsing(
     assert result.provider == "filesystem_local--test"
     assert result.uri == create_uri(MediaType.TRACK, "filesystem_local--test", "Artist/track.mp3")
     fs_provider._parse_track.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+async def test_stale_unavailable_library_track_falls_back_to_tag_parsing(
+    provider: tuple[LocalFileSystemProvider, MagicMock],
+) -> None:
+    """A library track whose mapping is (stale) unavailable is re-parsed from the file tags."""
+    fs_provider, track = provider
+    library_track = _library_track_mock(available=False)
+    fs_provider.mass.music.tracks.get_library_item_by_prov_id = AsyncMock(  # type: ignore[method-assign]
+        return_value=library_track
+    )
+
+    assert await fs_provider._parse_playlist_line("../Artist/track.mp3", "Playlists") is track
+    fs_provider._parse_track.assert_awaited_once()  # type: ignore[attr-defined]
 
 
 async def test_tag_parsing_fallback_when_not_in_library(

--- a/tests/providers/filesystem_cloud/test_base.py
+++ b/tests/providers/filesystem_cloud/test_base.py
@@ -74,6 +74,7 @@ def _make_provider(tree: dict[str, list[RawItem]] | None = None) -> _StubCloudPr
     provider.config.get_value = MagicMock(return_value=False)
     provider.mass = MagicMock()
     provider.mass.streams.base_url = BASE_URL
+    provider.mass.music.tracks.get_library_item_by_prov_id = AsyncMock(return_value=None)
     provider.tree = TREE if tree is None else tree
     provider.file_data = FILE_DATA
     provider.fail_list = set()


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Loading an m3u/pls playlist ran a full ffprobe tag parse on every referenced file, sequentially, whenever the playlist tracks cache was cold - for a multi-thousand track playlist this delayed playback by many minutes. Nearly all of those files are already synced into the library, so prefer a database lookup per entry (like `get_album_tracks` and `_get_stream_details_for_track` already do) and only fall back to tag parsing for files not (yet) in the library.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6166

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
