### PR TITLE
Keep the full details of Spotify episodes when fetched

### DIFF
--- a/music_assistant/providers/spotify/parsers.py
+++ b/music_assistant/providers/spotify/parsers.py
@@ -273,21 +273,10 @@ def parse_podcast_episode(
     episode_obj: dict[str, Any], provider: SpotifyProvider, podcast: Podcast | None = None
 ) -> PodcastEpisode:
     """Parse spotify podcast episode object to generic layout."""
-    # Get or create a basic podcast reference if not provided
+    # The show object embedded in an episode carries the show's description,
+    # artwork and publisher, so parse it in full rather than as a name-only stub.
     if podcast is None and "show" in episode_obj:
-        podcast = Podcast(
-            item_id=episode_obj["show"]["id"],
-            provider=provider.instance_id,
-            name=episode_obj["show"]["name"],
-            provider_mappings={
-                ProviderMapping(
-                    item_id=episode_obj["show"]["id"],
-                    provider_domain=provider.domain,
-                    provider_instance=provider.instance_id,
-                    url=episode_obj["show"]["external_urls"]["spotify"],
-                )
-            },
-        )
+        podcast = parse_podcast(episode_obj["show"], provider)
     elif podcast is None:
         # Create a minimal podcast reference if none available
         podcast = Podcast(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

When a single episode is fetched from Spotify the embedded show object was turned into a name-only Podcast stub, dropping the description, artwork and publisher that the API already returned. Parse it with `parse_podcast` instead so `episode.podcast` carries the same details as a directly fetched show.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
