### PR TITLE
Migrate playlists between providers

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 56
+API_SCHEMA_VERSION: Final[int] = 57
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -662,16 +662,29 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param limit: Maximum results per media type.
         :param allowed_provider_instances: Explicit provider scope for deferred work.
         """
-        provider = self.mass.get_provider(
-            provider_instance_id_or_domain,
-            provider_type=MusicProvider,
-        )
-        if not provider:
-            return SearchResults()
         if allowed_provider_instances is not None:
-            if provider.instance_id not in allowed_provider_instances:
-                return SearchResults()
-        elif not self._apply_user_provider_filter([provider]):
+            available_providers = [
+                provider
+                for provider_instance_id in sorted(allowed_provider_instances)
+                if isinstance(
+                    provider := self.mass.get_provider(provider_instance_id),
+                    MusicProvider,
+                )
+            ]
+        else:
+            available_providers = self.providers
+        provider = next(
+            (
+                item
+                for item in available_providers
+                if item.instance_id == provider_instance_id_or_domain
+            ),
+            None,
+        ) or next(
+            (item for item in available_providers if item.domain == provider_instance_id_or_domain),
+            None,
+        )
+        if provider is None:
             return SearchResults()
         return (
             await self._search_provider(

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -651,6 +651,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         provider_instance_id_or_domain: str,
         media_types: list[MediaType],
         limit: int = 10,
+        allowed_provider_instances: set[str] | None = None,
     ) -> SearchResults:
         """
         Search one available provider through the cached, timeout-bounded path.
@@ -659,12 +660,18 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param provider_instance_id_or_domain: Provider instance ID or domain.
         :param media_types: Media types to include.
         :param limit: Maximum results per media type.
+        :param allowed_provider_instances: Explicit provider scope for deferred work.
         """
         provider = self.mass.get_provider(
             provider_instance_id_or_domain,
             provider_type=MusicProvider,
         )
-        if not provider or not self._apply_user_provider_filter([provider]):
+        if not provider:
+            return SearchResults()
+        if allowed_provider_instances is not None:
+            if provider.instance_id not in allowed_provider_instances:
+                return SearchResults()
+        elif not self._apply_user_provider_filter([provider]):
             return SearchResults()
         return (
             await self._search_provider(

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -32,6 +32,7 @@ from music_assistant_models.errors import (
     InvalidProviderURI,
     MediaNotFoundError,
     MusicAssistantError,
+    ResourceTemporarilyUnavailable,
     UnsupportedFeaturedException,
 )
 from music_assistant_models.helpers import get_global_cache_value
@@ -686,15 +687,17 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         )
         if provider is None:
             return SearchResults()
-        return (
-            await self._search_provider(
-                search_query,
-                provider.instance_id,
-                media_types,
-                limit=limit,
-            )
-            or SearchResults()
+        result = await self._search_provider(
+            search_query,
+            provider.instance_id,
+            media_types,
+            limit=limit,
         )
+        if result is None:
+            raise ResourceTemporarilyUnavailable(
+                f"Search on provider {provider.name} failed or timed out"
+            )
+        return result
 
     async def search_library(
         self,

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -668,9 +668,14 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 provider
                 for provider_instance_id in sorted(allowed_provider_instances)
                 if isinstance(
-                    provider := self.mass.get_provider(provider_instance_id),
+                    provider := self.mass.get_provider(
+                        provider_instance_id,
+                        return_unavailable=True,
+                    ),
                     MusicProvider,
                 )
+                and provider.instance_id == provider_instance_id
+                and provider.available
             ]
         else:
             available_providers = self.providers
@@ -692,6 +697,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             provider.instance_id,
             media_types,
             limit=limit,
+            strict_provider_instance=True,
         )
         if result is None:
             raise ResourceTemporarilyUnavailable(
@@ -2504,6 +2510,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         media_types: list[MediaType],
         limit: int = 10,
         skip_item_ids: set[tuple[MediaType, str, str]] | None = None,
+        strict_provider_instance: bool = False,
     ) -> SearchResults | None:
         """
         Perform search on given provider, returns None if the search failed or timed out.
@@ -2515,9 +2522,17 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param limit: number of items to return in the search (per type).
         :param skip_item_ids: Optional set of (media_type, provider_domain, item_id)
                               tuples to filter out of the results.
+        :param strict_provider_instance: Do not fall back to another provider instance.
         """
-        prov = self.mass.get_provider(provider_instance_id_or_domain, provider_type=MusicProvider)
-        if not prov:
+        prov = self.mass.get_provider(
+            provider_instance_id_or_domain,
+            return_unavailable=strict_provider_instance,
+            provider_type=MusicProvider,
+        )
+        if not prov or (
+            strict_provider_instance
+            and (prov.instance_id != provider_instance_id_or_domain or not prov.available)
+        ):
             return SearchResults()
         if ProviderFeature.SEARCH not in prov.supported_features:
             return SearchResults()

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -691,6 +691,13 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             None,
         )
         if provider is None:
+            if (
+                allowed_provider_instances is not None
+                and provider_instance_id_or_domain in allowed_provider_instances
+            ):
+                raise ResourceTemporarilyUnavailable(
+                    f"Provider {provider_instance_id_or_domain} is unavailable"
+                )
             return SearchResults()
         result = await self._search_provider(
             search_query,
@@ -2533,7 +2540,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             strict_provider_instance
             and (prov.instance_id != provider_instance_id_or_domain or not prov.available)
         ):
-            return SearchResults()
+            return None if strict_provider_instance else SearchResults()
         if ProviderFeature.SEARCH not in prov.supported_features:
             return SearchResults()
 

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -645,6 +645,37 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             )
         return result
 
+    async def search_provider(
+        self,
+        search_query: str,
+        provider_instance_id_or_domain: str,
+        media_types: list[MediaType],
+        limit: int = 10,
+    ) -> SearchResults:
+        """
+        Search one available provider through the cached, timeout-bounded path.
+
+        :param search_query: Search query.
+        :param provider_instance_id_or_domain: Provider instance ID or domain.
+        :param media_types: Media types to include.
+        :param limit: Maximum results per media type.
+        """
+        provider = self.mass.get_provider(
+            provider_instance_id_or_domain,
+            provider_type=MusicProvider,
+        )
+        if not provider or not self._apply_user_provider_filter([provider]):
+            return SearchResults()
+        return (
+            await self._search_provider(
+                search_query,
+                provider.instance_id,
+                media_types,
+                limit=limit,
+            )
+            or SearchResults()
+        )
+
     async def search_library(
         self,
         search_query: str,

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -994,6 +994,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         force_refresh: bool = False,
         fallback: ItemMapping | ItemCls | None = None,
         allow_fallback: bool = True,
+        strict_provider_instance: bool = False,
     ) -> ItemCls:
         """
         Return item details for the given provider item ID.
@@ -1003,30 +1004,37 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         :param force_refresh: Bypass cached provider details.
         :param fallback: Preferred fallback when the provider no longer resolves the ID.
         :param allow_fallback: Return supplied or stored fallback details after a provider miss.
+        :param strict_provider_instance: Do not fall back to another provider instance.
         """
         if provider_instance_id_or_domain == "library":
             return await self.get_library_item(item_id)
-        if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
+        provider = self.mass.get_provider(
+            provider_instance_id_or_domain,
+            return_unavailable=strict_provider_instance,
+        )
+        if provider is None or (
+            strict_provider_instance
+            and (provider.instance_id != provider_instance_id_or_domain or not provider.available)
+        ):
             raise ProviderUnavailableError(f"{provider_instance_id_or_domain} is not available")
-        if provider := self.mass.get_provider(provider_instance_id_or_domain):
-            provider = cast("MusicProvider | PluginProvider", provider)
-            with suppress(MediaNotFoundError):
-                async with self.mass.cache.handle_refresh(force_refresh):
-                    if self.media_type == MediaType.PLAYLIST:
-                        return cast("ItemCls", await provider.get_playlist(item_id))
-                    music_prov = cast("MusicProvider", provider)
-                    if self.media_type == MediaType.ARTIST:
-                        return cast("ItemCls", await music_prov.get_artist(item_id))
-                    if self.media_type == MediaType.ALBUM:
-                        return cast("ItemCls", await music_prov.get_album(item_id))
-                    if self.media_type == MediaType.TRACK:
-                        return cast("ItemCls", await music_prov.get_track(item_id))
-                    if self.media_type == MediaType.RADIO:
-                        return cast("ItemCls", await music_prov.get_radio(item_id))
-                    if self.media_type == MediaType.AUDIOBOOK:
-                        return cast("ItemCls", await music_prov.get_audiobook(item_id))
-                    if self.media_type == MediaType.PODCAST:
-                        return cast("ItemCls", await music_prov.get_podcast(item_id))
+        provider = cast("MusicProvider | PluginProvider", provider)
+        with suppress(MediaNotFoundError):
+            async with self.mass.cache.handle_refresh(force_refresh):
+                if self.media_type == MediaType.PLAYLIST:
+                    return cast("ItemCls", await provider.get_playlist(item_id))
+                music_prov = cast("MusicProvider", provider)
+                if self.media_type == MediaType.ARTIST:
+                    return cast("ItemCls", await music_prov.get_artist(item_id))
+                if self.media_type == MediaType.ALBUM:
+                    return cast("ItemCls", await music_prov.get_album(item_id))
+                if self.media_type == MediaType.TRACK:
+                    return cast("ItemCls", await music_prov.get_track(item_id))
+                if self.media_type == MediaType.RADIO:
+                    return cast("ItemCls", await music_prov.get_radio(item_id))
+                if self.media_type == MediaType.AUDIOBOOK:
+                    return cast("ItemCls", await music_prov.get_audiobook(item_id))
+                if self.media_type == MediaType.PODCAST:
+                    return cast("ItemCls", await music_prov.get_podcast(item_id))
         # if we reach this point all possibilities failed and the item could not be found.
         if not allow_fallback:
             msg = (

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -993,8 +993,17 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         provider_instance_id_or_domain: str,
         force_refresh: bool = False,
         fallback: ItemMapping | ItemCls | None = None,
+        allow_fallback: bool = True,
     ) -> ItemCls:
-        """Return item details for the given provider item id."""
+        """
+        Return item details for the given provider item ID.
+
+        :param item_id: Provider item ID.
+        :param provider_instance_id_or_domain: Provider instance ID or domain.
+        :param force_refresh: Bypass cached provider details.
+        :param fallback: Preferred fallback when the provider no longer resolves the ID.
+        :param allow_fallback: Return supplied or stored fallback details after a provider miss.
+        """
         if provider_instance_id_or_domain == "library":
             return await self.get_library_item(item_id)
         if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
@@ -1019,6 +1028,12 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                     if self.media_type == MediaType.PODCAST:
                         return cast("ItemCls", await music_prov.get_podcast(item_id))
         # if we reach this point all possibilities failed and the item could not be found.
+        if not allow_fallback:
+            msg = (
+                f"{self.media_type.value}://{item_id} not "
+                f"found on provider {provider_instance_id_or_domain}"
+            )
+            raise MediaNotFoundError(msg)
         # There is a possibility that the (streaming) provider changed the id of the item
         # so we return the previous details (if we have any) marked as unavailable, so
         # at least we have the possibility to sort out the new id through matching logic.

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -523,7 +523,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
         trust_source_mappings = source_provider_obj.domain != "builtin"
         update_current_task_progress(0, "Loading source playlist")
         source_tracks: list[Track] = []
-        async for item in self.tracks(source_playlist_item_id, source_provider):
+        async for item in self.tracks(
+            source_playlist_item_id,
+            source_provider,
+            force_refresh=True,
+        ):
             if isinstance(item, Track):
                 source_tracks.append(item)
                 continue
@@ -748,7 +752,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     trust_track_mappings=trust_source_mappings,
                 )
                 return _PlaylistMigrationTrackResult(
-                    track=enrichment.track,
+                    track=enrichment.track if enrichment.track.provider_mappings else None,
                     provider_matches=enrichment.matches,
                     ambiguous_providers=enrichment.ambiguous_providers,
                     failed_providers=enrichment.failed_providers,

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -459,17 +459,21 @@ class PlaylistController(MediaControllerBase[Playlist]):
             raise InvalidDataError(f"{destination_name} is not a valid Playlist name")
 
         user = get_current_user()
+        source_provider, source_item_id = self._select_provider_id(source_playlist)
+        allowed_provider_instances = {item.instance_id for item in self.mass.music.providers}
+        allowed_provider_instances.update(
+            (source_provider, provider.instance_id),
+        )
         return self.mass.tasks.run_background_task(
-            task_id=(
-                f"playlist_migration.{source_playlist.item_id}."
-                f"{provider.instance_id}.{match_policy.value}"
-            ),
             name=f"Migrate playlist {source_playlist.name}",
             handler=lambda: self._handle_migrate_playlist(
                 source_playlist.item_id,
+                source_item_id,
+                source_provider,
                 provider.instance_id,
                 destination_name,
                 match_policy,
+                tuple(sorted(allowed_provider_instances)),
             ),
             user_id=user.user_id if user else None,
             metadata={
@@ -487,9 +491,12 @@ class PlaylistController(MediaControllerBase[Playlist]):
     async def _handle_migrate_playlist(
         self,
         source_playlist_id: str,
+        source_playlist_item_id: str,
+        source_provider: str,
         destination_provider: str,
         destination_name: str,
         match_policy: PlaylistMigrationMatchPolicy,
+        allowed_provider_instances: tuple[str, ...],
     ) -> None:
         """Resolve and copy a playlist inside a managed task."""
         source_playlist = await self.get_library_item(source_playlist_id)
@@ -498,7 +505,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
             raise ProviderUnavailableError(f"Provider {destination_provider} is not available")
         update_current_task_progress(0, "Loading source playlist")
         source_tracks: list[Track] = []
-        async for item in self.tracks(source_playlist.item_id, "library"):
+        async for item in self.tracks(source_playlist_item_id, source_provider):
             if isinstance(item, Track):
                 source_tracks.append(item)
                 continue
@@ -522,6 +529,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     track,
                     provider,
                     minimum_confidence,
+                    set(allowed_provider_instances),
                 )
             completed += 1
             _update_stage_progress(
@@ -695,6 +703,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         track: Track,
         provider: MusicProvider,
         minimum_confidence: TrackMatchConfidence,
+        allowed_provider_instances: set[str],
     ) -> _PlaylistMigrationTrackResult:
         """Resolve one source track for a migration destination."""
         try:
@@ -702,6 +711,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 enrichment = await self.mass.music.tracks.enrich_provider_mappings(
                     track,
                     minimum_confidence=minimum_confidence,
+                    provider_instance_ids=allowed_provider_instances,
                 )
                 return _PlaylistMigrationTrackResult(
                     track=enrichment.track,
@@ -711,11 +721,12 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     used_library_item=enrichment.used_library_item,
                 )
             library_track = await self.mass.music.tracks.get_library_match(track)
-            base_track = library_track or track
             result = await self.mass.music.tracks.find_provider_match(
-                base_track,
+                track,
                 provider,
                 minimum_confidence=minimum_confidence,
+                mapping_source=library_track,
+                allowed_provider_instances=allowed_provider_instances,
             )
             if not result.match:
                 return _PlaylistMigrationTrackResult(

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -602,6 +602,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
             report_current_task_failure(f"{track_label}: {reason}")
             skipped_tracks.append((track_label, reason.capitalize()))
 
+        seen_target_ids: set[str] = set()
         for track in source_tracks:
             result = resolved_tracks[self._migration_track_key(track)]
             if provider.domain == "builtin" and result.track:
@@ -612,6 +613,18 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 if result.ambiguous:
                     counts["ambiguous"] += 1
                 continue
+            if (
+                not provider.playlist_duplicates_supported
+                and result.mapping.item_id in seen_target_ids
+            ):
+                reason = f"{provider.name} does not support duplicate playlist entries"
+                counts["skipped"] += 1
+                report_current_task_failure(
+                    f"{self._migration_track_label(track)}: {reason.lower()}"
+                )
+                skipped_tracks.append((self._migration_track_label(track), reason))
+                continue
+            seen_target_ids.add(result.mapping.item_id)
             target_ids.append(result.mapping.item_id)
             if result.confidence == TrackMatchConfidence.EXACT:
                 counts["exact"] += 1

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -26,6 +26,7 @@ from music_assistant.constants import DB_TABLE_PLAYLISTS, PLAYLIST_MEDIA_TYPES, 
 from music_assistant.controllers.tasks.context import (
     get_current_task,
     report_current_task_failure,
+    set_current_task_report,
     update_current_task_progress,
     update_current_task_progress_text,
 )
@@ -546,31 +547,49 @@ class PlaylistController(MediaControllerBase[Playlist]):
             "library_matches": 0,
             "provider_matches": 0,
         }
+        substitutions: list[tuple[str, str, str]] = []
+        skipped_tracks: list[tuple[str, str]] = []
+        provider_issues: list[tuple[str, str]] = []
         for key, result in resolved_tracks.items():
             track = unique_tracks[key]
+            track_label = self._migration_track_label(track)
             if result.used_library_item:
                 counts["library_matches"] += 1
             counts["provider_matches"] += len(result.provider_matches)
             if result.error:
-                report_current_task_failure(f"{track.artist_str} - {track.name}: {result.error}")
+                report_current_task_failure(f"{track_label}: {result.error}")
+                if provider.domain == "builtin":
+                    provider_issues.append((track_label, result.error))
             for provider_name in result.failed_providers:
-                report_current_task_failure(
-                    f"{track.artist_str} - {track.name}: matching failed on {provider_name}"
-                )
+                issue = f"Matching failed on {provider_name}"
+                report_current_task_failure(f"{track_label}: {issue.lower()}")
+                provider_issues.append((track_label, issue))
             for provider_name in result.ambiguous_providers:
-                report_current_task_failure(
-                    f"{track.artist_str} - {track.name}: ambiguous match on {provider_name}"
-                )
+                issue = f"Ambiguous match on {provider_name}"
+                report_current_task_failure(f"{track_label}: {issue.lower()}")
+                provider_issues.append((track_label, issue))
             if provider.domain == "builtin" and result.track:
                 continue
             if result.mapping:
+                if result.track and result.confidence != TrackMatchConfidence.EXACT:
+                    substitutions.append(
+                        (
+                            track_label,
+                            self._migration_track_label(result.track),
+                            "Same recording"
+                            if result.confidence == TrackMatchConfidence.LIKELY
+                            else "Best effort",
+                        )
+                    )
                 continue
             if result.error:
+                skipped_tracks.append((track_label, result.error))
                 continue
             reason = (
                 "multiple equally likely matches" if result.ambiguous else "no acceptable match"
             )
-            report_current_task_failure(f"{track.artist_str} - {track.name}: {reason}")
+            report_current_task_failure(f"{track_label}: {reason}")
+            skipped_tracks.append((track_label, reason.capitalize()))
 
         for track in source_tracks:
             result = resolved_tracks[self._migration_track_key(track)]
@@ -591,6 +610,20 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 counts["best_effort"] += 1
 
         migrated_count = len(builtin_entries) if provider.domain == "builtin" else len(target_ids)
+        set_current_task_report(
+            self._build_migration_report(
+                source_playlist.name,
+                destination_name,
+                provider.name,
+                migrated_count,
+                counts,
+                substitutions,
+                skipped_tracks,
+                provider_issues,
+                completed=False,
+                builtin_destination=provider.domain == "builtin",
+            )
+        )
         if not migrated_count:
             raise InvalidDataError("No tracks could be migrated")
         update_current_task_progress(85, "Creating destination playlist")
@@ -631,6 +664,20 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     **counts,
                 }
             )
+        set_current_task_report(
+            self._build_migration_report(
+                source_playlist.name,
+                destination_playlist.name,
+                provider.name,
+                migrated_count,
+                counts,
+                substitutions,
+                skipped_tracks,
+                provider_issues,
+                completed=True,
+                builtin_destination=provider.domain == "builtin",
+            )
+        )
         update_current_task_progress(
             100,
             f"Migrated {migrated_count} of {len(source_tracks)} tracks",
@@ -711,6 +758,112 @@ class PlaylistController(MediaControllerBase[Playlist]):
     def _migration_track_key(track: Track) -> str:
         """Return a stable key for reusing duplicate track resolutions."""
         return track.uri or f"{track.provider}://track/{track.item_id}"
+
+    @classmethod
+    def _build_migration_report(
+        cls,
+        source_name: str,
+        destination_name: str,
+        destination_provider: str,
+        migrated_count: int,
+        counts: Mapping[str, int],
+        substitutions: list[tuple[str, str, str]],
+        skipped_tracks: list[tuple[str, str]],
+        provider_issues: list[tuple[str, str]],
+        *,
+        completed: bool,
+        builtin_destination: bool,
+    ) -> str:
+        """Build the human-readable Markdown report for a migration task."""
+        source = cls._escape_markdown(source_name)
+        destination = cls._escape_markdown(destination_name)
+        provider = cls._escape_markdown(destination_provider)
+        action = "Migrated" if completed else "Prepared"
+        lines = [
+            f"## Playlist migration {'complete' if completed else 'analysis'}",
+            "",
+            f"{action} **{migrated_count}** of **{counts['total']}** tracks "
+            f"from **{source}** for **{destination}** on **{provider}**.",
+            "",
+            "| Result | Tracks |",
+            "| --- | ---: |",
+        ]
+        if builtin_destination:
+            lines.extend(
+                (
+                    f"| Included | {migrated_count} |",
+                    f"| Existing library matches used | {counts['library_matches']} |",
+                    f"| Additional provider mappings found | {counts['provider_matches']} |",
+                    f"| Skipped | {counts['skipped']} |",
+                )
+            )
+        else:
+            lines.extend(
+                (
+                    f"| Exact release | {counts['exact']} |",
+                    f"| Same recording | {counts['same_recording']} |",
+                    f"| Best effort | {counts['best_effort']} |",
+                    f"| Skipped | {counts['skipped']} |",
+                    f"| Ambiguous | {counts['ambiguous']} |",
+                )
+            )
+        cls._add_report_table(
+            lines,
+            "Substitutions",
+            ("Source", "Destination", "Match"),
+            substitutions,
+        )
+        cls._add_report_table(
+            lines,
+            "Skipped tracks",
+            ("Track", "Reason"),
+            skipped_tracks,
+        )
+        cls._add_report_table(
+            lines,
+            "Provider lookup issues",
+            ("Track", "Issue"),
+            provider_issues,
+        )
+        return "\n".join(lines)
+
+    @classmethod
+    def _add_report_table(
+        cls,
+        lines: list[str],
+        title: str,
+        headers: tuple[str, ...],
+        rows: Sequence[tuple[str, ...]],
+    ) -> None:
+        """Append a Markdown report table when it has rows."""
+        if not rows:
+            return
+        lines.extend(
+            (
+                "",
+                f"### {title}",
+                "",
+                f"| {' | '.join(headers)} |",
+                f"| {' | '.join('---' for _ in headers)} |",
+            )
+        )
+        lines.extend(
+            f"| {' | '.join(cls._escape_markdown(value, table=True) for value in row)} |"
+            for row in rows
+        )
+
+    @staticmethod
+    def _migration_track_label(track: Track) -> str:
+        """Return a readable artist and title label."""
+        return f"{track.artist_str} - {track.name}" if track.artist_str else track.name
+
+    @staticmethod
+    def _escape_markdown(value: str, table: bool = False) -> str:
+        """Escape provider text before adding it to a Markdown report."""
+        value = value.replace("\\", "\\\\").replace("\n", " ")
+        for character in ("`", "*", "_", "[", "]", "<", ">"):
+            value = value.replace(character, f"\\{character}")
+        return value.replace("|", "\\|") if table else value
 
     def _verify_update_allowed(self, current_item: Playlist, update: Playlist) -> None:
         """

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -468,10 +468,16 @@ class PlaylistController(MediaControllerBase[Playlist]):
 
         user = get_current_user()
         source_provider, source_item_id = self._select_provider_id(source_playlist)
-        allowed_provider_instances = {item.instance_id for item in self.mass.music.providers}
-        allowed_provider_instances.update(
-            (source_provider, provider.instance_id),
-        )
+        allowed_provider_instances = {item.instance_id for item in available_providers}
+        if source_provider not in allowed_provider_instances:
+            source_provider_obj = self.mass.get_provider(
+                source_provider,
+                provider_type=MusicProvider,
+            )
+            if not source_provider_obj or source_provider_obj.domain != "builtin":
+                raise ProviderUnavailableError(f"Provider {source_provider} is not available")
+            allowed_provider_instances.add(source_provider)
+        allowed_provider_instances.add(provider.instance_id)
         return self.mass.tasks.run_background_task(
             name=f"Migrate playlist {source_playlist.name}",
             handler=lambda: self._handle_migrate_playlist(

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -54,6 +54,7 @@ from .tracks import TrackProviderMatch, TracksController
 
 _PROVIDER_PLAYLIST_ADD_BATCH_SIZE = 100
 _MIGRATION_REPORT_DETAIL_LIMIT = 200
+_MIGRATION_RESOLVE_BATCH_SIZE = 5
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -542,7 +543,6 @@ class PlaylistController(MediaControllerBase[Playlist]):
 
         minimum_confidence = self._minimum_match_confidence(match_policy)
         unique_tracks = {self._migration_track_key(track): track for track in source_tracks}
-        semaphore = asyncio.Semaphore(5)
         allowed_provider_instance_set = set(allowed_provider_instances)
         failed_provider_instances: set[str] = set()
         completed = 0
@@ -551,15 +551,14 @@ class PlaylistController(MediaControllerBase[Playlist]):
             key: str, track: Track
         ) -> tuple[str, _PlaylistMigrationTrackResult]:
             nonlocal completed
-            async with semaphore:
-                result = await self._resolve_migration_track(
-                    track,
-                    provider,
-                    minimum_confidence,
-                    allowed_provider_instance_set,
-                    trust_source_mappings,
-                    failed_provider_instances,
-                )
+            result = await self._resolve_migration_track(
+                track,
+                provider,
+                minimum_confidence,
+                allowed_provider_instance_set,
+                trust_source_mappings,
+                failed_provider_instances,
+            )
             completed += 1
             _update_stage_progress(
                 completed,
@@ -570,11 +569,16 @@ class PlaylistController(MediaControllerBase[Playlist]):
             )
             return key, result
 
-        resolved_tracks = dict(
-            await asyncio.gather(
-                *(resolve_track(key, track) for key, track in unique_tracks.items())
+        resolved_items: list[tuple[str, _PlaylistMigrationTrackResult]] = []
+        for track_batch in batched(
+            unique_tracks.items(),
+            _MIGRATION_RESOLVE_BATCH_SIZE,
+            strict=False,
+        ):
+            resolved_items.extend(
+                await asyncio.gather(*(resolve_track(key, track) for key, track in track_batch))
             )
-        )
+        resolved_tracks = dict(resolved_items)
         target_ids: list[str] = []
         target_results: list[tuple[Track, _PlaylistMigrationTrackResult]] = []
         builtin_entries: list[PlaylistItem] = []

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -518,6 +518,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
     ) -> None:
         """Resolve and copy a playlist inside a managed task."""
         source_playlist = await self.get_library_item(source_playlist_id)
+        if source_playlist.is_dynamic:
+            raise InvalidDataError("Dynamic playlists can not be migrated")
         provider = self.mass.get_provider(destination_provider)
         if not provider or not isinstance(provider, MusicProvider):
             raise ProviderUnavailableError(f"Provider {destination_provider} is not available")
@@ -527,6 +529,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         trust_source_mappings = source_provider_obj.domain != "builtin"
         update_current_task_progress(0, "Loading source playlist")
         source_tracks: list[Track] = []
+        unsupported_items: list[tuple[str, str]] = []
         async for item in self.tracks(
             source_playlist_item_id,
             source_provider,
@@ -535,9 +538,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
             if isinstance(item, Track):
                 source_tracks.append(item)
                 continue
-            report_current_task_failure(
-                f"{item.name}: {item.media_type.value} items are not supported"
+            reason = (
+                f"{item.media_type.value.replace('_', ' ').capitalize()} entries are not supported"
             )
+            report_current_task_failure(f"{item.name}: {reason.lower()}")
+            unsupported_items.append((item.name, reason))
         if not source_tracks:
             raise InvalidDataError("The source playlist has no tracks to migrate")
 
@@ -583,17 +588,17 @@ class PlaylistController(MediaControllerBase[Playlist]):
         target_results: list[tuple[Track, _PlaylistMigrationTrackResult]] = []
         builtin_entries: list[PlaylistItem] = []
         counts = {
-            "total": len(source_tracks),
+            "total": len(source_tracks) + len(unsupported_items),
             "exact": 0,
             "same_recording": 0,
             "best_effort": 0,
-            "skipped": 0,
+            "skipped": len(unsupported_items),
             "ambiguous": 0,
             "library_matches": 0,
             "provider_matches": 0,
         }
         substitutions_by_track: dict[str, tuple[str, str, str]] = {}
-        skipped_tracks: list[tuple[str, str]] = []
+        skipped_items = unsupported_items.copy()
         provider_issues: list[tuple[str, str]] = []
         for key, result in resolved_tracks.items():
             track = unique_tracks[key]
@@ -626,13 +631,13 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     )
                 continue
             if result.error:
-                skipped_tracks.append((track_label, result.error))
+                skipped_items.append((track_label, result.error))
                 continue
             reason = (
                 "multiple equally likely matches" if result.ambiguous else "no acceptable match"
             )
             report_current_task_failure(f"{track_label}: {reason}")
-            skipped_tracks.append((track_label, reason.capitalize()))
+            skipped_items.append((track_label, reason.capitalize()))
 
         seen_target_ids: set[str] = set()
         for track in source_tracks:
@@ -654,7 +659,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 report_current_task_failure(
                     f"{self._migration_track_label(track)}: {reason.lower()}"
                 )
-                skipped_tracks.append((self._migration_track_label(track), reason))
+                skipped_items.append((self._migration_track_label(track), reason))
                 continue
             seen_target_ids.add(result.mapping.item_id)
             target_ids.append(result.mapping.item_id)
@@ -676,7 +681,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 prepared_count,
                 counts,
                 list(substitutions_by_track.values()),
-                skipped_tracks,
+                skipped_items,
                 provider_issues,
                 completed=False,
                 builtin_destination=provider.domain == "builtin",
@@ -758,7 +763,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     report_current_task_failure(
                         f"{self._migration_track_label(track)}: {reason.lower()}"
                     )
-                    skipped_tracks.append((self._migration_track_label(track), reason))
+                    skipped_items.append((self._migration_track_label(track), reason))
                 if destination_mismatch:
                     issue = "Destination playlist contains unexpected or reordered tracks"
                     report_current_task_failure(issue)
@@ -795,7 +800,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 migrated_count,
                 counts,
                 list(substitutions_by_track.values()),
-                skipped_tracks,
+                skipped_items,
                 provider_issues,
                 completed=True,
                 builtin_destination=provider.domain == "builtin",
@@ -805,7 +810,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
             raise InvalidDataError("The destination provider did not add any tracks")
         update_current_task_progress(
             100,
-            f"Migrated {migrated_count} of {len(source_tracks)} tracks",
+            f"Migrated {migrated_count} of {counts['total']} playlist items",
         )
 
     async def _resolve_migration_track(
@@ -990,7 +995,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         migrated_count: int,
         counts: Mapping[str, int],
         substitutions: list[tuple[str, str, str]],
-        skipped_tracks: list[tuple[str, str]],
+        skipped_items: list[tuple[str, str]],
         provider_issues: list[tuple[str, str]],
         *,
         completed: bool,
@@ -1004,10 +1009,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
         lines = [
             f"## Playlist migration {'complete' if completed else 'analysis'}",
             "",
-            f"{action} **{migrated_count}** of **{counts['total']}** tracks "
+            f"{action} **{migrated_count}** of **{counts['total']}** playlist items "
             f"from **{source}** for **{destination}** on **{provider}**.",
             "",
-            "| Result | Tracks |",
+            "| Result | Items |",
             "| --- | ---: |",
         ]
         if builtin_destination:
@@ -1037,9 +1042,9 @@ class PlaylistController(MediaControllerBase[Playlist]):
         )
         cls._add_report_table(
             lines,
-            "Skipped tracks",
-            ("Track", "Reason"),
-            skipped_tracks,
+            "Skipped items",
+            ("Item", "Reason"),
+            skipped_items,
         )
         cls._add_report_table(
             lines,

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -54,6 +54,7 @@ from .tracks import TrackProviderMatch, TracksController
 _PROVIDER_PLAYLIST_ADD_BATCH_SIZE = 100
 _MIGRATION_REPORT_DETAIL_LIMIT = 200
 _MIGRATION_RESOLVE_BATCH_SIZE = 5
+_MIGRATION_VERIFY_RETRY_DELAYS = (1, 2, 4)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -713,14 +714,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
             )
             update_current_task_progress(95, "Verifying destination playlist")
             try:
-                actual_target_ids = [
-                    item.item_id
-                    async for item in self.tracks(
-                        playlist_item_id,
-                        provider.instance_id,
-                        force_refresh=True,
-                    )
-                ]
+                confirmed_indexes, destination_mismatch = await self._verify_migration_results(
+                    playlist_item_id,
+                    provider.instance_id,
+                    target_results,
+                )
             except (
                 ResourceTemporarilyUnavailable,
                 ProviderUnavailableError,
@@ -743,10 +741,6 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 report_current_task_failure(issue)
                 provider_issues.append(("Destination playlist", issue))
             else:
-                confirmed_indexes, destination_mismatch = self._reconcile_migration_results(
-                    actual_target_ids,
-                    target_results,
-                )
                 missing_results = [
                     target_result
                     for index, target_result in enumerate(target_results)
@@ -901,6 +895,34 @@ class PlaylistController(MediaControllerBase[Playlist]):
         for mapping in playlist.provider_mappings:
             mapping.in_library = True
         return await self.add_item_to_library(playlist, False)
+
+    async def _verify_migration_results(
+        self,
+        playlist_item_id: str,
+        provider_instance_id: str,
+        target_results: Sequence[tuple[Track, _PlaylistMigrationTrackResult]],
+    ) -> tuple[set[int], bool]:
+        """Verify which requested tracks appear in the destination playlist."""
+        confirmed_indexes: set[int] = set()
+        destination_mismatch = False
+        for retry_delay in (0, *_MIGRATION_VERIFY_RETRY_DELAYS):
+            if retry_delay:
+                await asyncio.sleep(retry_delay)
+            actual_target_ids = [
+                item.item_id
+                async for item in self.tracks(
+                    playlist_item_id,
+                    provider_instance_id,
+                    force_refresh=True,
+                )
+            ]
+            confirmed_indexes, destination_mismatch = self._reconcile_migration_results(
+                actual_target_ids,
+                target_results,
+            )
+            if len(confirmed_indexes) == len(target_results) and not destination_mismatch:
+                break
+        return confirmed_indexes, destination_mismatch
 
     @staticmethod
     def _reconcile_migration_results(

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections import Counter
+from bisect import bisect_right
 from collections.abc import AsyncGenerator, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
@@ -591,7 +591,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
             "library_matches": 0,
             "provider_matches": 0,
         }
-        substitutions: list[tuple[str, str, str]] = []
+        substitutions_by_track: dict[str, tuple[str, str, str]] = {}
         skipped_tracks: list[tuple[str, str]] = []
         provider_issues: list[tuple[str, str]] = []
         for key, result in resolved_tracks.items():
@@ -616,14 +616,12 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 continue
             if result.mapping:
                 if result.track and result.confidence != TrackMatchConfidence.EXACT:
-                    substitutions.append(
-                        (
-                            track_label,
-                            self._migration_track_label(result.track),
-                            "Same recording"
-                            if result.confidence == TrackMatchConfidence.LIKELY
-                            else "Best effort",
-                        )
+                    substitutions_by_track[key] = (
+                        track_label,
+                        self._migration_track_label(result.track),
+                        "Same recording"
+                        if result.confidence == TrackMatchConfidence.LIKELY
+                        else "Best effort",
                     )
                 continue
             if result.error:
@@ -676,7 +674,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 provider.name,
                 prepared_count,
                 counts,
-                substitutions,
+                list(substitutions_by_track.values()),
                 skipped_tracks,
                 provider_issues,
                 completed=False,
@@ -745,13 +743,18 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 report_current_task_failure(issue)
                 provider_issues.append(("Destination playlist", issue))
             else:
-                missing_results = self._reconcile_migration_results(
+                confirmed_indexes, destination_mismatch = self._reconcile_migration_results(
                     actual_target_ids,
                     target_results,
                 )
-                migrated_count = len(target_results) - len(missing_results)
+                missing_results = [
+                    target_result
+                    for index, target_result in enumerate(target_results)
+                    if index not in confirmed_indexes
+                ]
+                migrated_count = len(confirmed_indexes)
                 for track, result in missing_results:
-                    reason = f"{provider.name} did not add this track"
+                    reason = f"{provider.name} did not add this track in the expected order"
                     counts["skipped"] += 1
                     self._adjust_migration_match_count(
                         counts,
@@ -762,6 +765,19 @@ class PlaylistController(MediaControllerBase[Playlist]):
                         f"{self._migration_track_label(track)}: {reason.lower()}"
                     )
                     skipped_tracks.append((self._migration_track_label(track), reason))
+                if destination_mismatch:
+                    issue = "Destination playlist contains unexpected or reordered tracks"
+                    report_current_task_failure(issue)
+                    provider_issues.append(("Destination playlist", issue))
+                confirmed_track_keys = {
+                    self._migration_track_key(target_results[index][0])
+                    for index in confirmed_indexes
+                }
+                substitutions_by_track = {
+                    key: substitution
+                    for key, substitution in substitutions_by_track.items()
+                    if key in confirmed_track_keys
+                }
             destination_playlist.metadata.last_refresh = None
             await self.update_item_in_library(
                 destination_playlist.item_id,
@@ -784,7 +800,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 provider.name,
                 migrated_count,
                 counts,
-                substitutions,
+                list(substitutions_by_track.values()),
                 skipped_tracks,
                 provider_issues,
                 completed=True,
@@ -890,18 +906,28 @@ class PlaylistController(MediaControllerBase[Playlist]):
     def _reconcile_migration_results(
         actual_target_ids: list[str],
         target_results: Sequence[tuple[Track, _PlaylistMigrationTrackResult]],
-    ) -> list[tuple[Track, _PlaylistMigrationTrackResult]]:
-        """Return requested tracks missing from the destination playlist."""
-        actual_id_counts = Counter(actual_target_ids)
-        missing_results: list[tuple[Track, _PlaylistMigrationTrackResult]] = []
-        for track, result in target_results:
+    ) -> tuple[set[int], bool]:
+        """Return confirmed result indexes and whether destination content is unexpected."""
+        expected_positions: dict[str, list[int]] = {}
+        for index, (_track, result) in enumerate(target_results):
             assert result.mapping is not None
-            if actual_id_counts[result.mapping.item_id]:
-                actual_id_counts[result.mapping.item_id] -= 1
+            expected_positions.setdefault(result.mapping.item_id, []).append(index)
+
+        confirmed_indexes: set[int] = set()
+        last_confirmed_index = -1
+        destination_mismatch = False
+        for actual_target_id in actual_target_ids:
+            positions = expected_positions.get(actual_target_id)
+            if not positions:
+                destination_mismatch = True
                 continue
-            missing_results.append((track, result))
-        redirected_count = min(sum(actual_id_counts.values()), len(missing_results))
-        return missing_results[redirected_count:]
+            position_index = bisect_right(positions, last_confirmed_index)
+            if position_index == len(positions):
+                destination_mismatch = True
+                continue
+            last_confirmed_index = positions[position_index]
+            confirmed_indexes.add(last_confirmed_index)
+        return confirmed_indexes, destination_mismatch
 
     @staticmethod
     def _adjust_migration_match_count(

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import Counter
 from collections.abc import AsyncGenerator, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
@@ -19,6 +20,7 @@ from music_assistant_models.errors import (
     MediaNotFoundError,
     MusicAssistantError,
     ProviderUnavailableError,
+    ResourceTemporarilyUnavailable,
 )
 from music_assistant_models.helpers import create_safe_string
 from music_assistant_models.media_items import Playlist, PlaylistSummary, ProviderMapping, Track
@@ -51,6 +53,7 @@ from .radio import RadioController
 from .tracks import TrackProviderMatch, TracksController
 
 _PROVIDER_PLAYLIST_ADD_BATCH_SIZE = 100
+_MIGRATION_REPORT_DETAIL_LIMIT = 200
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -540,6 +543,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
         minimum_confidence = self._minimum_match_confidence(match_policy)
         unique_tracks = {self._migration_track_key(track): track for track in source_tracks}
         semaphore = asyncio.Semaphore(5)
+        allowed_provider_instance_set = set(allowed_provider_instances)
+        failed_provider_instances: set[str] = set()
         completed = 0
 
         async def resolve_track(
@@ -551,8 +556,9 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     track,
                     provider,
                     minimum_confidence,
-                    set(allowed_provider_instances),
+                    allowed_provider_instance_set,
                     trust_source_mappings,
+                    failed_provider_instances,
                 )
             completed += 1
             _update_stage_progress(
@@ -570,6 +576,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
             )
         )
         target_ids: list[str] = []
+        target_results: list[tuple[Track, _PlaylistMigrationTrackResult]] = []
         builtin_entries: list[PlaylistItem] = []
         counts = {
             "total": len(source_tracks),
@@ -649,20 +656,22 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 continue
             seen_target_ids.add(result.mapping.item_id)
             target_ids.append(result.mapping.item_id)
-            if result.confidence == TrackMatchConfidence.EXACT:
-                counts["exact"] += 1
-            elif result.confidence == TrackMatchConfidence.LIKELY:
-                counts["same_recording"] += 1
-            else:
-                counts["best_effort"] += 1
+            target_results.append((track, result))
+            self._adjust_migration_match_count(
+                counts,
+                result.confidence,
+                1,
+            )
 
-        migrated_count = len(builtin_entries) if provider.domain == "builtin" else len(target_ids)
+        prepared_count = (
+            len(builtin_entries) if provider.domain == "builtin" else len(target_results)
+        )
         set_current_task_report(
             self._build_migration_report(
                 source_playlist.name,
                 destination_name,
                 provider.name,
-                migrated_count,
+                prepared_count,
                 counts,
                 substitutions,
                 skipped_tracks,
@@ -671,7 +680,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 builtin_destination=provider.domain == "builtin",
             )
         )
-        if not migrated_count:
+        if not prepared_count:
             raise InvalidDataError("No tracks could be migrated")
         update_current_task_progress(85, "Creating destination playlist")
         if provider.domain == "builtin":
@@ -680,6 +689,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 builtin_entries,
                 source_playlist.image.path if source_playlist.image else None,
             )
+            migrated_count = prepared_count
         else:
             destination_playlist = await self.create_playlist(
                 destination_name,
@@ -700,6 +710,32 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 playlist_item_id,
                 target_ids,
             )
+            update_current_task_progress(95, "Verifying destination playlist")
+            actual_target_ids = [
+                item.item_id
+                async for item in self.tracks(
+                    playlist_item_id,
+                    provider.instance_id,
+                    force_refresh=True,
+                )
+            ]
+            missing_results = self._reconcile_migration_results(
+                actual_target_ids,
+                target_results,
+            )
+            migrated_count = len(target_results) - len(missing_results)
+            for track, result in missing_results:
+                reason = f"{provider.name} did not add this track"
+                counts["skipped"] += 1
+                self._adjust_migration_match_count(
+                    counts,
+                    result.confidence,
+                    -1,
+                )
+                report_current_task_failure(
+                    f"{self._migration_track_label(track)}: {reason.lower()}"
+                )
+                skipped_tracks.append((self._migration_track_label(track), reason))
             destination_playlist.metadata.last_refresh = None
             await self.update_item_in_library(
                 destination_playlist.item_id,
@@ -729,6 +765,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 builtin_destination=provider.domain == "builtin",
             )
         )
+        if not migrated_count:
+            raise InvalidDataError("The destination provider did not add any tracks")
         update_current_task_progress(
             100,
             f"Migrated {migrated_count} of {len(source_tracks)} tracks",
@@ -741,8 +779,13 @@ class PlaylistController(MediaControllerBase[Playlist]):
         minimum_confidence: TrackMatchConfidence,
         allowed_provider_instances: set[str],
         trust_source_mappings: bool,
+        failed_provider_instances: set[str],
     ) -> _PlaylistMigrationTrackResult:
         """Resolve one source track for a migration destination."""
+        if provider.domain != "builtin" and provider.instance_id in failed_provider_instances:
+            return _PlaylistMigrationTrackResult(
+                error=f"Matching unavailable on {provider.name} after an earlier failure"
+            )
         try:
             if provider.domain == "builtin":
                 enrichment = await self.mass.music.tracks.enrich_provider_mappings(
@@ -750,6 +793,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     minimum_confidence=minimum_confidence,
                     provider_instance_ids=allowed_provider_instances,
                     trust_track_mappings=trust_source_mappings,
+                    failed_provider_instances=failed_provider_instances,
                 )
                 return _PlaylistMigrationTrackResult(
                     track=enrichment.track if enrichment.track.provider_mappings else None,
@@ -778,9 +822,17 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 confidence=result.match.confidence,
                 used_library_item=library_track is not None,
             )
-        except (MusicAssistantError, ClientError, OSError, TimeoutError) as err:
+        except (
+            ResourceTemporarilyUnavailable,
+            ProviderUnavailableError,
+            ClientError,
+            OSError,
+            TimeoutError,
+        ) as err:
+            failed_provider_instances.add(provider.instance_id)
+            return _PlaylistMigrationTrackResult(error=str(err))
+        except MusicAssistantError as err:
             return _PlaylistMigrationTrackResult(
-                track=track if provider.domain == "builtin" else None,
                 error=str(err),
             )
 
@@ -799,6 +851,37 @@ class PlaylistController(MediaControllerBase[Playlist]):
         for mapping in playlist.provider_mappings:
             mapping.in_library = True
         return await self.add_item_to_library(playlist, False)
+
+    @staticmethod
+    def _reconcile_migration_results(
+        actual_target_ids: list[str],
+        target_results: Sequence[tuple[Track, _PlaylistMigrationTrackResult]],
+    ) -> list[tuple[Track, _PlaylistMigrationTrackResult]]:
+        """Return requested tracks missing from the destination playlist."""
+        actual_id_counts = Counter(actual_target_ids)
+        missing_results: list[tuple[Track, _PlaylistMigrationTrackResult]] = []
+        for track, result in target_results:
+            assert result.mapping is not None
+            if actual_id_counts[result.mapping.item_id]:
+                actual_id_counts[result.mapping.item_id] -= 1
+                continue
+            missing_results.append((track, result))
+        redirected_count = min(sum(actual_id_counts.values()), len(missing_results))
+        return missing_results[redirected_count:]
+
+    @staticmethod
+    def _adjust_migration_match_count(
+        counts: dict[str, int],
+        confidence: TrackMatchConfidence,
+        amount: int,
+    ) -> None:
+        """Adjust the aggregate count for a migration match confidence."""
+        count_key = {
+            TrackMatchConfidence.EXACT: "exact",
+            TrackMatchConfidence.LIKELY: "same_recording",
+            TrackMatchConfidence.LOOSE: "best_effort",
+        }[confidence]
+        counts[count_key] += amount
 
     @staticmethod
     def _minimum_match_confidence(
@@ -895,6 +978,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         """Append a Markdown report table when it has rows."""
         if not rows:
             return
+        visible_rows = rows[:_MIGRATION_REPORT_DETAIL_LIMIT]
         lines.extend(
             (
                 "",
@@ -906,8 +990,15 @@ class PlaylistController(MediaControllerBase[Playlist]):
         )
         lines.extend(
             f"| {' | '.join(cls._escape_markdown(value, table=True) for value in row)} |"
-            for row in rows
+            for row in visible_rows
         )
+        if omitted_count := len(rows) - len(visible_rows):
+            lines.extend(
+                (
+                    "",
+                    f"_{omitted_count} additional rows omitted._",
+                )
+            )
 
     @staticmethod
     def _migration_track_label(track: Track) -> str:

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -18,7 +18,6 @@ from music_assistant_models.errors import (
     InvalidDataError,
     InvalidProviderURI,
     MediaNotFoundError,
-    MusicAssistantError,
     ProviderUnavailableError,
     ResourceTemporarilyUnavailable,
 )
@@ -724,7 +723,14 @@ class PlaylistController(MediaControllerBase[Playlist]):
                         force_refresh=True,
                     )
                 ]
-            except (MusicAssistantError, ClientError, OSError, TimeoutError) as err:
+            except (
+                ResourceTemporarilyUnavailable,
+                ProviderUnavailableError,
+                MediaNotFoundError,
+                ClientError,
+                OSError,
+                TimeoutError,
+            ) as err:
                 migrated_count = len(target_results)
                 issue = (
                     "Could not verify destination playlist: "
@@ -856,7 +862,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     f"Matching failed on {provider.name}",
                 )
             )
-        except MusicAssistantError as err:
+        except (InvalidDataError, MediaNotFoundError) as err:
             return _PlaylistMigrationTrackResult(
                 error=self._migration_error_message(
                     err,

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -722,7 +722,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 ]
             except (MusicAssistantError, ClientError, OSError, TimeoutError) as err:
                 migrated_count = len(target_results)
-                issue = f"Could not verify destination playlist: {err}"
+                issue = (
+                    "Could not verify destination playlist: "
+                    f"{self._migration_error_message(err, 'Verification failed')}"
+                )
                 self.logger.warning(
                     "Could not verify migrated playlist %s on provider %s: %s",
                     destination_playlist.name,
@@ -843,10 +846,18 @@ class PlaylistController(MediaControllerBase[Playlist]):
             TimeoutError,
         ) as err:
             failed_provider_instances.add(provider.instance_id)
-            return _PlaylistMigrationTrackResult(error=str(err))
+            return _PlaylistMigrationTrackResult(
+                error=self._migration_error_message(
+                    err,
+                    f"Matching failed on {provider.name}",
+                )
+            )
         except MusicAssistantError as err:
             return _PlaylistMigrationTrackResult(
-                error=str(err),
+                error=self._migration_error_message(
+                    err,
+                    f"Matching failed on {provider.name}",
+                ),
             )
 
     async def _create_builtin_migration_playlist(
@@ -1017,6 +1028,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
     def _migration_track_label(track: Track) -> str:
         """Return a readable artist and title label."""
         return f"{track.artist_str} - {track.name}" if track.artist_str else track.name
+
+    @staticmethod
+    def _migration_error_message(error: BaseException, fallback: str) -> str:
+        """Return a non-empty error message for a migration report."""
+        return str(error).strip() or f"{fallback} ({type(error).__name__})"
 
     @staticmethod
     def _escape_markdown(value: str, table: bool = False) -> str:

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -45,6 +45,7 @@ from music_assistant.helpers.security import is_safe_name
 from music_assistant.helpers.uri import create_uri, parse_uri
 from music_assistant.helpers.util import guard_single_request
 from music_assistant.models.music_provider import MusicProvider
+from music_assistant.models.plugin import PluginProvider
 
 from .audiobooks import AudiobooksController
 from .base import MediaControllerBase
@@ -173,8 +174,17 @@ class PlaylistController(MediaControllerBase[Playlist]):
         provider_instance_id_or_domain: str,
         force_refresh: bool = False,
         allow_dynamic_tracks: bool = False,
+        strict_provider_instance: bool = False,
     ) -> AsyncGenerator[PlaylistPlayableItem]:
-        """Return playlist tracks for the given provider playlist id."""
+        """
+        Return playlist items for a provider playlist.
+
+        :param item_id: Provider playlist ID.
+        :param provider_instance_id_or_domain: Provider instance ID or domain.
+        :param force_refresh: Bypass cached playlist contents.
+        :param allow_dynamic_tracks: Request a fresh sample from dynamic playlists.
+        :param strict_provider_instance: Do not fall back to another provider instance.
+        """
         if provider_instance_id_or_domain == "library":
             library_item = await self.get_library_item(item_id)
             provider_instance_id_or_domain, item_id = self._select_provider_id(library_item)
@@ -194,6 +204,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 provider_instance_id_or_domain,
                 page=page,
                 force_refresh=force_refresh,
+                strict_provider_instance=strict_provider_instance,
             )
             if not tracks:
                 break
@@ -206,12 +217,26 @@ class PlaylistController(MediaControllerBase[Playlist]):
         name: str,
         media_types: list[MediaType] | None = None,
         provider_instance_or_domain: str | None = None,
+        strict_provider_instance: bool = False,
     ) -> Playlist:
-        """Create new playlist."""
+        """
+        Create a playlist on an available provider.
+
+        :param name: Playlist name.
+        :param media_types: Media types the playlist must support.
+        :param provider_instance_or_domain: Destination provider instance ID or domain.
+        :param strict_provider_instance: Do not fall back to another provider instance.
+        """
         # if provider is omitted, just pick builtin provider
         if provider_instance_or_domain:
-            provider = self.mass.get_provider(provider_instance_or_domain)
-            if provider is None:
+            provider = self.mass.get_provider(
+                provider_instance_or_domain,
+                return_unavailable=strict_provider_instance,
+            )
+            if provider is None or (
+                strict_provider_instance
+                and (provider.instance_id != provider_instance_or_domain or not provider.available)
+            ):
                 raise ProviderUnavailableError
         else:
             provider = self.mass.get_provider("builtin")
@@ -473,12 +498,21 @@ class PlaylistController(MediaControllerBase[Playlist]):
         user = get_current_user()
         source_provider, source_item_id = self._select_provider_id(source_playlist)
         allowed_provider_instances = {item.instance_id for item in available_providers}
-        if source_provider not in allowed_provider_instances:
-            source_provider_obj = self.mass.get_provider(
-                source_provider,
-                provider_type=MusicProvider,
-            )
-            if not source_provider_obj or source_provider_obj.domain != "builtin":
+        source_provider_obj = self.mass.get_provider(
+            source_provider,
+            return_unavailable=True,
+        )
+        if (
+            not isinstance(source_provider_obj, MusicProvider | PluginProvider)
+            or source_provider_obj.instance_id != source_provider
+            or not source_provider_obj.available
+        ):
+            raise ProviderUnavailableError(f"Provider {source_provider} is not available")
+        if isinstance(source_provider_obj, MusicProvider):
+            if (
+                source_provider not in allowed_provider_instances
+                and source_provider_obj.domain != "builtin"
+            ):
                 raise ProviderUnavailableError(f"Provider {source_provider} is not available")
             allowed_provider_instances.add(source_provider)
         allowed_provider_instances.add(provider.instance_id)
@@ -520,13 +554,30 @@ class PlaylistController(MediaControllerBase[Playlist]):
         source_playlist = await self.get_library_item(source_playlist_id)
         if source_playlist.is_dynamic:
             raise InvalidDataError("Dynamic playlists can not be migrated")
-        provider = self.mass.get_provider(destination_provider)
-        if not provider or not isinstance(provider, MusicProvider):
+        provider = self.mass.get_provider(
+            destination_provider,
+            return_unavailable=True,
+        )
+        if (
+            not isinstance(provider, MusicProvider)
+            or provider.instance_id != destination_provider
+            or not provider.available
+        ):
             raise ProviderUnavailableError(f"Provider {destination_provider} is not available")
-        source_provider_obj = self.mass.get_provider(source_provider)
-        if not source_provider_obj or not isinstance(source_provider_obj, MusicProvider):
+        source_provider_obj = self.mass.get_provider(
+            source_provider,
+            return_unavailable=True,
+        )
+        if (
+            not isinstance(source_provider_obj, MusicProvider | PluginProvider)
+            or source_provider_obj.instance_id != source_provider
+            or not source_provider_obj.available
+        ):
             raise ProviderUnavailableError(f"Provider {source_provider} is not available")
-        trust_source_mappings = source_provider_obj.domain != "builtin"
+        trust_source_mappings = (
+            isinstance(source_provider_obj, MusicProvider)
+            and source_provider_obj.domain != "builtin"
+        )
         update_current_task_progress(0, "Loading source playlist")
         source_tracks: list[Track] = []
         unsupported_items: list[tuple[str, str]] = []
@@ -534,6 +585,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
             source_playlist_item_id,
             source_provider,
             force_refresh=True,
+            strict_provider_instance=True,
         ):
             if isinstance(item, Track):
                 source_tracks.append(item)
@@ -702,6 +754,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 destination_name,
                 media_types=[MediaType.TRACK],
                 provider_instance_or_domain=provider.instance_id,
+                strict_provider_instance=True,
             )
             playlist_provider, playlist_item_id = self._select_provider_id(destination_playlist)
             if playlist_provider != provider.instance_id:
@@ -919,6 +972,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     playlist_item_id,
                     provider_instance_id,
                     force_refresh=True,
+                    strict_provider_instance=True,
                 )
             ]
             confirmed_indexes, destination_mismatch = self._reconcile_migration_results(
@@ -1228,12 +1282,24 @@ class PlaylistController(MediaControllerBase[Playlist]):
         provider_instance_id_or_domain: str,
         page: int = 0,
         force_refresh: bool = False,
+        strict_provider_instance: bool = False,
     ) -> Sequence[PlaylistPlayableItem]:
         """Return playlist tracks for the given provider playlist id."""
         assert provider_instance_id_or_domain != "library"
-        if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
+        provider = self.mass.get_provider(
+            provider_instance_id_or_domain,
+            return_unavailable=strict_provider_instance,
+        )
+        if strict_provider_instance and (
+            provider is None
+            or provider.instance_id != provider_instance_id_or_domain
+            or not provider.available
+        ):
+            raise ProviderUnavailableError(
+                f"Provider {provider_instance_id_or_domain} is not available"
+            )
+        if not isinstance(provider, MusicProvider | PluginProvider):
             return []
-        provider = cast("MusicProvider", provider)
         async with self.mass.cache.handle_refresh(force_refresh):
             return await provider.get_playlist_tracks(item_id, page=page)
 

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -429,12 +429,20 @@ class PlaylistController(MediaControllerBase[Playlist]):
         source_playlist = await self.get_library_item(int(db_playlist_id))
         if source_playlist.is_dynamic:
             raise InvalidDataError("Dynamic playlists can not be migrated")
-        provider = self.mass.get_provider(destination_provider)
+        available_providers = self.mass.music.providers
+        provider = next(
+            (item for item in available_providers if item.instance_id == destination_provider),
+            None,
+        ) or next(
+            (item for item in available_providers if item.domain == destination_provider),
+            None,
+        )
+        if provider is None and destination_provider == "builtin":
+            provider = self.mass.get_provider(
+                "builtin",
+                provider_type=MusicProvider,
+            )
         if not provider or not isinstance(provider, MusicProvider):
-            raise ProviderUnavailableError(f"Provider {destination_provider} is not available")
-        if provider.domain != "builtin" and provider.instance_id not in {
-            item.instance_id for item in self.mass.music.providers
-        }:
             raise ProviderUnavailableError(f"Provider {destination_provider} is not available")
         if provider.domain != "builtin" and not provider.is_streaming_provider:
             raise InvalidDataError(
@@ -503,6 +511,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
         provider = self.mass.get_provider(destination_provider)
         if not provider or not isinstance(provider, MusicProvider):
             raise ProviderUnavailableError(f"Provider {destination_provider} is not available")
+        source_provider_obj = self.mass.get_provider(source_provider)
+        if not source_provider_obj or not isinstance(source_provider_obj, MusicProvider):
+            raise ProviderUnavailableError(f"Provider {source_provider} is not available")
+        trust_source_mappings = source_provider_obj.domain != "builtin"
         update_current_task_progress(0, "Loading source playlist")
         source_tracks: list[Track] = []
         async for item in self.tracks(source_playlist_item_id, source_provider):
@@ -530,6 +542,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     provider,
                     minimum_confidence,
                     set(allowed_provider_instances),
+                    trust_source_mappings,
                 )
             completed += 1
             _update_stage_progress(
@@ -717,6 +730,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         provider: MusicProvider,
         minimum_confidence: TrackMatchConfidence,
         allowed_provider_instances: set[str],
+        trust_source_mappings: bool,
     ) -> _PlaylistMigrationTrackResult:
         """Resolve one source track for a migration destination."""
         try:
@@ -725,6 +739,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     track,
                     minimum_confidence=minimum_confidence,
                     provider_instance_ids=allowed_provider_instances,
+                    trust_track_mappings=trust_source_mappings,
                 )
                 return _PlaylistMigrationTrackResult(
                     track=enrichment.track,
@@ -740,6 +755,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 minimum_confidence=minimum_confidence,
                 mapping_source=library_track,
                 allowed_provider_instances=allowed_provider_instances,
+                trust_base_mapping=trust_source_mappings,
             )
             if not result.match:
                 return _PlaylistMigrationTrackResult(

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -2,27 +2,35 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator, Sequence
 from contextlib import suppress
+from dataclasses import dataclass
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, cast
 
+from aiohttp import ClientError
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import (
     InvalidDataError,
     InvalidProviderURI,
     MediaNotFoundError,
+    MusicAssistantError,
     ProviderUnavailableError,
 )
 from music_assistant_models.helpers import create_safe_string
-from music_assistant_models.media_items import Playlist, PlaylistSummary
+from music_assistant_models.media_items import Playlist, PlaylistSummary, ProviderMapping, Track
 
 from music_assistant.constants import DB_TABLE_PLAYLISTS, PLAYLIST_MEDIA_TYPES, PlaylistPlayableItem
 from music_assistant.controllers.tasks.context import (
+    get_current_task,
+    report_current_task_failure,
     update_current_task_progress,
     update_current_task_progress_text,
 )
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
+from music_assistant.helpers.compare import TrackMatchConfidence
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.helpers.playlists import (
@@ -38,7 +46,7 @@ from music_assistant.models.music_provider import MusicProvider
 from .audiobooks import AudiobooksController
 from .base import MediaControllerBase
 from .radio import RadioController
-from .tracks import TracksController
+from .tracks import TrackProviderMatch, TracksController
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -62,6 +70,29 @@ def _update_stage_progress(
         return
     progress = start + int((current * (end - start)) / total)
     update_current_task_progress(min(progress, end), text)
+
+
+class PlaylistMigrationMatchPolicy(StrEnum):
+    """Allowed fallback depth for playlist track matching."""
+
+    EXACT = "exact"
+    SAME_RECORDING = "same_recording"
+    BEST_EFFORT = "best_effort"
+
+
+@dataclass(frozen=True, slots=True)
+class _PlaylistMigrationTrackResult:
+    """Resolved destination details for one source track."""
+
+    track: Track | None = None
+    mapping: ProviderMapping | None = None
+    confidence: TrackMatchConfidence = TrackMatchConfidence.NO_MATCH
+    provider_matches: tuple[TrackProviderMatch, ...] = ()
+    ambiguous_providers: tuple[str, ...] = ()
+    failed_providers: tuple[str, ...] = ()
+    used_library_item: bool = False
+    ambiguous: bool = False
+    error: str | None = None
 
 
 class PlaylistController(MediaControllerBase[Playlist]):
@@ -103,6 +134,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
         self.mass.register_api_command(
             "music/playlists/import_playlist",
             self.import_playlist,
+            required_scope=Scope.LIBRARY_WRITE,
+        )
+        self.mass.register_api_command(
+            "music/playlists/migrate_playlist",
+            self.migrate_playlist,
             required_scope=Scope.LIBRARY_WRITE,
         )
 
@@ -369,6 +405,312 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 priority=True,
             )
         return db_playlist
+
+    async def migrate_playlist(
+        self,
+        db_playlist_id: str | int,
+        destination_provider: str = "builtin",
+        name: str | None = None,
+        match_policy: PlaylistMigrationMatchPolicy = PlaylistMigrationMatchPolicy.SAME_RECORDING,
+    ) -> BackgroundTask:
+        """
+        Queue copying a playlist to another provider or Music Assistant.
+
+        :param db_playlist_id: Library database ID of the source playlist.
+        :param destination_provider: Destination provider instance ID or domain.
+        :param name: Optional destination playlist name.
+        :param match_policy: Lowest track-match confidence that may be accepted.
+        :return: Managed background task performing the migration.
+        """
+        source_playlist = await self.get_library_item(int(db_playlist_id))
+        if source_playlist.is_dynamic:
+            raise InvalidDataError("Dynamic playlists can not be migrated")
+        provider = self.mass.get_provider(destination_provider)
+        if not provider or not isinstance(provider, MusicProvider):
+            raise ProviderUnavailableError(f"Provider {destination_provider} is not available")
+        if provider.domain != "builtin" and provider.instance_id not in {
+            item.instance_id for item in self.mass.music.providers
+        }:
+            raise ProviderUnavailableError(f"Provider {destination_provider} is not available")
+        if provider.domain != "builtin" and not provider.is_streaming_provider:
+            raise InvalidDataError(
+                "Playlists can only be migrated to Music Assistant or a streaming provider"
+            )
+        if not (
+            {
+                ProviderFeature.PLAYLIST_CREATE,
+                ProviderFeature.PLAYLIST_CREATE_TRACKS,
+            }
+            & provider.supported_features
+        ):
+            raise InvalidDataError(
+                f"Provider {provider.name} does not support creating track playlists"
+            )
+        if ProviderFeature.PLAYLIST_TRACKS_EDIT not in provider.supported_features:
+            raise InvalidDataError(f"Provider {provider.name} does not support editing playlists")
+        if MediaType.TRACK not in provider.supported_media_types:
+            raise InvalidDataError(f"Provider {provider.name} does not support track playlists")
+        destination_name = name or source_playlist.name
+        if not is_safe_name(destination_name):
+            raise InvalidDataError(f"{destination_name} is not a valid Playlist name")
+
+        user = get_current_user()
+        return self.mass.tasks.run_background_task(
+            task_id=(
+                f"playlist_migration.{source_playlist.item_id}."
+                f"{provider.instance_id}.{match_policy.value}"
+            ),
+            name=f"Migrate playlist {source_playlist.name}",
+            handler=lambda: self._handle_migrate_playlist(
+                source_playlist.item_id,
+                provider.instance_id,
+                destination_name,
+                match_policy,
+            ),
+            user_id=user.user_id if user else None,
+            metadata={
+                "task_domain": "playlist_migration",
+                "source_playlist_id": source_playlist.item_id,
+                "source_playlist_name": source_playlist.name,
+                "destination_provider": provider.instance_id,
+                "destination_provider_name": provider.name,
+                "match_policy": match_policy.value,
+            },
+            allow_cancel=True,
+            priority=True,
+        )
+
+    async def _handle_migrate_playlist(
+        self,
+        source_playlist_id: str,
+        destination_provider: str,
+        destination_name: str,
+        match_policy: PlaylistMigrationMatchPolicy,
+    ) -> None:
+        """Resolve and copy a playlist inside a managed task."""
+        source_playlist = await self.get_library_item(source_playlist_id)
+        provider = self.mass.get_provider(destination_provider)
+        if not provider or not isinstance(provider, MusicProvider):
+            raise ProviderUnavailableError(f"Provider {destination_provider} is not available")
+        update_current_task_progress(0, "Loading source playlist")
+        source_tracks: list[Track] = []
+        async for item in self.tracks(source_playlist.item_id, "library"):
+            if isinstance(item, Track):
+                source_tracks.append(item)
+                continue
+            report_current_task_failure(
+                f"{item.name}: {item.media_type.value} items are not supported"
+            )
+        if not source_tracks:
+            raise InvalidDataError("The source playlist has no tracks to migrate")
+
+        minimum_confidence = self._minimum_match_confidence(match_policy)
+        unique_tracks = {self._migration_track_key(track): track for track in source_tracks}
+        semaphore = asyncio.Semaphore(5)
+        completed = 0
+
+        async def resolve_track(
+            key: str, track: Track
+        ) -> tuple[str, _PlaylistMigrationTrackResult]:
+            nonlocal completed
+            async with semaphore:
+                result = await self._resolve_migration_track(
+                    track,
+                    provider,
+                    minimum_confidence,
+                )
+            completed += 1
+            _update_stage_progress(
+                completed,
+                len(unique_tracks),
+                5,
+                80,
+                f"Matching track {completed}/{len(unique_tracks)}",
+            )
+            return key, result
+
+        resolved_tracks = dict(
+            await asyncio.gather(
+                *(resolve_track(key, track) for key, track in unique_tracks.items())
+            )
+        )
+        target_ids: list[str] = []
+        builtin_entries: list[PlaylistItem] = []
+        counts = {
+            "total": len(source_tracks),
+            "exact": 0,
+            "same_recording": 0,
+            "best_effort": 0,
+            "skipped": 0,
+            "ambiguous": 0,
+            "library_matches": 0,
+            "provider_matches": 0,
+        }
+        for key, result in resolved_tracks.items():
+            track = unique_tracks[key]
+            if result.used_library_item:
+                counts["library_matches"] += 1
+            counts["provider_matches"] += len(result.provider_matches)
+            if result.error:
+                report_current_task_failure(f"{track.artist_str} - {track.name}: {result.error}")
+            for provider_name in result.failed_providers:
+                report_current_task_failure(
+                    f"{track.artist_str} - {track.name}: matching failed on {provider_name}"
+                )
+            for provider_name in result.ambiguous_providers:
+                report_current_task_failure(
+                    f"{track.artist_str} - {track.name}: ambiguous match on {provider_name}"
+                )
+            if provider.domain == "builtin" and result.track:
+                continue
+            if result.mapping:
+                continue
+            if result.error:
+                continue
+            reason = (
+                "multiple equally likely matches" if result.ambiguous else "no acceptable match"
+            )
+            report_current_task_failure(f"{track.artist_str} - {track.name}: {reason}")
+
+        for track in source_tracks:
+            result = resolved_tracks[self._migration_track_key(track)]
+            if provider.domain == "builtin" and result.track:
+                builtin_entries.append(media_item_to_playlist_item(result.track))
+                continue
+            if not result.mapping:
+                counts["skipped"] += 1
+                if result.ambiguous:
+                    counts["ambiguous"] += 1
+                continue
+            target_ids.append(result.mapping.item_id)
+            if result.confidence == TrackMatchConfidence.EXACT:
+                counts["exact"] += 1
+            elif result.confidence == TrackMatchConfidence.LIKELY:
+                counts["same_recording"] += 1
+            else:
+                counts["best_effort"] += 1
+
+        migrated_count = len(builtin_entries) if provider.domain == "builtin" else len(target_ids)
+        if not migrated_count:
+            raise InvalidDataError("No tracks could be migrated")
+        update_current_task_progress(85, "Creating destination playlist")
+        if provider.domain == "builtin":
+            destination_playlist = await self._create_builtin_migration_playlist(
+                destination_name,
+                builtin_entries,
+                source_playlist.image.path if source_playlist.image else None,
+            )
+        else:
+            destination_playlist = await self.create_playlist(
+                destination_name,
+                media_types=[MediaType.TRACK],
+                provider_instance_or_domain=provider.instance_id,
+            )
+            playlist_provider, playlist_item_id = self._select_provider_id(destination_playlist)
+            if playlist_provider != provider.instance_id:
+                raise ProviderUnavailableError(
+                    f"Created playlist is not available on provider {provider.name}"
+                )
+            update_current_task_progress(
+                90,
+                f"Adding {len(target_ids)} tracks to destination playlist",
+            )
+            await provider.add_playlist_tracks(playlist_item_id, target_ids)
+            destination_playlist.metadata.last_refresh = None
+            await self.update_item_in_library(
+                destination_playlist.item_id,
+                destination_playlist,
+            )
+
+        if current_task := get_current_task():
+            current_task.metadata.update(
+                {
+                    "playlist_id": destination_playlist.item_id,
+                    "playlist_name": destination_playlist.name,
+                    "migrated_count": migrated_count,
+                    **counts,
+                }
+            )
+        update_current_task_progress(
+            100,
+            f"Migrated {migrated_count} of {len(source_tracks)} tracks",
+        )
+
+    async def _resolve_migration_track(
+        self,
+        track: Track,
+        provider: MusicProvider,
+        minimum_confidence: TrackMatchConfidence,
+    ) -> _PlaylistMigrationTrackResult:
+        """Resolve one source track for a migration destination."""
+        try:
+            if provider.domain == "builtin":
+                enrichment = await self.mass.music.tracks.enrich_provider_mappings(
+                    track,
+                    minimum_confidence=minimum_confidence,
+                )
+                return _PlaylistMigrationTrackResult(
+                    track=enrichment.track,
+                    provider_matches=enrichment.matches,
+                    ambiguous_providers=enrichment.ambiguous_providers,
+                    failed_providers=enrichment.failed_providers,
+                    used_library_item=enrichment.used_library_item,
+                )
+            library_track = await self.mass.music.tracks.get_library_match(track)
+            base_track = library_track or track
+            result = await self.mass.music.tracks.find_provider_match(
+                base_track,
+                provider,
+                minimum_confidence=minimum_confidence,
+            )
+            if not result.match:
+                return _PlaylistMigrationTrackResult(
+                    used_library_item=library_track is not None,
+                    ambiguous=result.ambiguous,
+                )
+            return _PlaylistMigrationTrackResult(
+                track=result.match.track,
+                mapping=result.match.mapping,
+                confidence=result.match.confidence,
+                used_library_item=library_track is not None,
+            )
+        except (MusicAssistantError, ClientError, OSError, TimeoutError) as err:
+            return _PlaylistMigrationTrackResult(
+                track=track if provider.domain == "builtin" else None,
+                error=str(err),
+            )
+
+    async def _create_builtin_migration_playlist(
+        self,
+        name: str,
+        entries: list[PlaylistItem],
+        image_url: str | None,
+    ) -> Playlist:
+        """Create a Music Assistant playlist from resolved entries."""
+        provider = self.mass.get_provider("builtin")
+        if not provider or not isinstance(provider, MusicProvider):
+            raise ProviderUnavailableError("Builtin provider is not available")
+        builtin_provider = cast("BuiltinProvider", provider)
+        playlist = await builtin_provider.import_playlist(generate_m3u(name, entries, image_url))
+        for mapping in playlist.provider_mappings:
+            mapping.in_library = True
+        return await self.add_item_to_library(playlist, False)
+
+    @staticmethod
+    def _minimum_match_confidence(
+        match_policy: PlaylistMigrationMatchPolicy,
+    ) -> TrackMatchConfidence:
+        """Return the minimum confidence accepted by a migration policy."""
+        return {
+            PlaylistMigrationMatchPolicy.EXACT: TrackMatchConfidence.EXACT,
+            PlaylistMigrationMatchPolicy.SAME_RECORDING: TrackMatchConfidence.LIKELY,
+            PlaylistMigrationMatchPolicy.BEST_EFFORT: TrackMatchConfidence.LOOSE,
+        }[match_policy]
+
+    @staticmethod
+    def _migration_track_key(track: Track) -> str:
+        """Return a stable key for reusing duplicate track resolutions."""
+        return track.uri or f"{track.provider}://track/{track.item_id}"
 
     def _verify_update_allowed(self, current_item: Playlist, update: Playlist) -> None:
         """

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncGenerator, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
 from enum import StrEnum
+from itertools import batched
 from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp import ClientError
@@ -48,6 +49,8 @@ from .audiobooks import AudiobooksController
 from .base import MediaControllerBase
 from .radio import RadioController
 from .tracks import TrackProviderMatch, TracksController
+
+_PROVIDER_PLAYLIST_ADD_BATCH_SIZE = 100
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -648,7 +651,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 90,
                 f"Adding {len(target_ids)} tracks to destination playlist",
             )
-            await provider.add_playlist_tracks(playlist_item_id, target_ids)
+            await self._add_provider_playlist_tracks(
+                provider,
+                playlist_item_id,
+                target_ids,
+            )
             destination_playlist.metadata.last_refresh = None
             await self.update_item_in_library(
                 destination_playlist.item_id,
@@ -1235,7 +1242,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
 
         # actually add the tracks to the playlist on the provider
         update_current_task_progress(90, f"Adding {len(ids_to_add)} item(s) to playlist")
-        await playlist_prov.add_playlist_tracks(playlist_prov_item_id, ids_to_add)
+        await self._add_provider_playlist_tracks(
+            playlist_prov,
+            playlist_prov_item_id,
+            ids_to_add,
+        )
         # reset 'last_refresh' to force a refresh of the playlist's metadata
         # in the next scheduled run of the playlist metadata task
         playlist.metadata.last_refresh = None
@@ -1267,6 +1278,23 @@ class PlaylistController(MediaControllerBase[Playlist]):
         # in the next scheduled run of the playlist metadata task
         playlist.metadata.last_refresh = None
         await self.update_item_in_library(db_playlist_id, playlist)
+
+    @staticmethod
+    async def _add_provider_playlist_tracks(
+        provider: MusicProvider,
+        playlist_item_id: str,
+        track_ids: list[str],
+    ) -> None:
+        """Add tracks in ordered batches accepted by provider APIs."""
+        for track_id_batch in batched(
+            track_ids,
+            _PROVIDER_PLAYLIST_ADD_BATCH_SIZE,
+            strict=False,
+        ):
+            await provider.add_playlist_tracks(
+                playlist_item_id,
+                list(track_id_batch),
+            )
 
     def _parse_summary_row(self, db_row: Mapping[str, Any]) -> PlaylistSummary:
         """Parse a raw summary db row into a PlaylistSummary object."""

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -711,31 +711,44 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 target_ids,
             )
             update_current_task_progress(95, "Verifying destination playlist")
-            actual_target_ids = [
-                item.item_id
-                async for item in self.tracks(
-                    playlist_item_id,
-                    provider.instance_id,
-                    force_refresh=True,
+            try:
+                actual_target_ids = [
+                    item.item_id
+                    async for item in self.tracks(
+                        playlist_item_id,
+                        provider.instance_id,
+                        force_refresh=True,
+                    )
+                ]
+            except (MusicAssistantError, ClientError, OSError, TimeoutError) as err:
+                migrated_count = len(target_results)
+                issue = f"Could not verify destination playlist: {err}"
+                self.logger.warning(
+                    "Could not verify migrated playlist %s on provider %s: %s",
+                    destination_playlist.name,
+                    provider.name,
+                    err,
                 )
-            ]
-            missing_results = self._reconcile_migration_results(
-                actual_target_ids,
-                target_results,
-            )
-            migrated_count = len(target_results) - len(missing_results)
-            for track, result in missing_results:
-                reason = f"{provider.name} did not add this track"
-                counts["skipped"] += 1
-                self._adjust_migration_match_count(
-                    counts,
-                    result.confidence,
-                    -1,
+                report_current_task_failure(issue)
+                provider_issues.append(("Destination playlist", issue))
+            else:
+                missing_results = self._reconcile_migration_results(
+                    actual_target_ids,
+                    target_results,
                 )
-                report_current_task_failure(
-                    f"{self._migration_track_label(track)}: {reason.lower()}"
-                )
-                skipped_tracks.append((self._migration_track_label(track), reason))
+                migrated_count = len(target_results) - len(missing_results)
+                for track, result in missing_results:
+                    reason = f"{provider.name} did not add this track"
+                    counts["skipped"] += 1
+                    self._adjust_migration_match_count(
+                        counts,
+                        result.confidence,
+                        -1,
+                    )
+                    report_current_task_failure(
+                        f"{self._migration_track_label(track)}: {reason.lower()}"
+                    )
+                    skipped_tracks.append((self._migration_track_label(track), reason))
             destination_playlist.metadata.last_refresh = None
             await self.update_item_in_library(
                 destination_playlist.item_id,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from copy import deepcopy
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Never, cast
 
@@ -17,6 +19,7 @@ from music_assistant_models.enums import (
 )
 from music_assistant_models.errors import (
     InvalidDataError,
+    MediaNotFoundError,
     MusicAssistantError,
     ProviderUnavailableError,
     UnsupportedFeaturedException,
@@ -45,9 +48,12 @@ from music_assistant.controllers.music.helpers import (
     search_name_match_clause,
 )
 from music_assistant.helpers.compare import (
+    TrackMatchConfidence,
     compare_artists,
     compare_media_item,
     compare_track,
+    compare_track_evidence,
+    compare_track_title,
     loose_compare_strings,
 )
 from music_assistant.helpers.database import UNSET
@@ -63,6 +69,34 @@ if TYPE_CHECKING:
     from music_assistant import MusicAssistant
     from music_assistant.models.metadata_provider import MetadataProvider
     from music_assistant.models.plugin import PluginProvider
+
+
+@dataclass(frozen=True, slots=True)
+class TrackProviderMatch:
+    """Matched provider track with its confidence and target mapping."""
+
+    track: Track
+    mapping: ProviderMapping
+    confidence: TrackMatchConfidence
+
+
+@dataclass(frozen=True, slots=True)
+class TrackProviderMatchResult:
+    """Result of resolving a track on one provider."""
+
+    match: TrackProviderMatch | None = None
+    ambiguous: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TrackProviderEnrichment:
+    """Track enriched with provider matches without changing the library."""
+
+    track: Track
+    matches: tuple[TrackProviderMatch, ...]
+    ambiguous_providers: tuple[str, ...]
+    failed_providers: tuple[str, ...]
+    used_library_item: bool
 
 
 class TracksController(MediaControllerBase[Track]):
@@ -629,6 +663,187 @@ class TracksController(MediaControllerBase[Track]):
             in_library_only=True,
         )
 
+    async def get_library_match(self, item: Track) -> Track | None:
+        """
+        Return an existing library track matching the provider track.
+
+        :param item: Provider track to resolve.
+        """
+        if library_item_id := await self._get_library_item_by_match(item):
+            return await self.get_library_item(library_item_id)
+        return None
+
+    async def find_provider_match(
+        self,
+        base_track: Track,
+        provider: MusicProvider,
+        minimum_confidence: TrackMatchConfidence = TrackMatchConfidence.LIKELY,
+        base_album: Album | ItemMapping | None = None,
+    ) -> TrackProviderMatchResult:
+        """
+        Find the best track match on a music provider.
+
+        :param base_track: Reference track to match.
+        :param provider: Target provider.
+        :param minimum_confidence: Lowest confidence that may be returned.
+        :param base_album: Optional full reference album for release evidence.
+        """
+        if mapping := self._get_provider_mapping(base_track, provider):
+            return TrackProviderMatchResult(
+                match=TrackProviderMatch(
+                    track=base_track,
+                    mapping=mapping,
+                    confidence=TrackMatchConfidence.EXACT,
+                )
+            )
+        if ProviderFeature.SEARCH not in provider.supported_features:
+            return TrackProviderMatchResult()
+        if MediaType.TRACK not in provider.supported_media_types:
+            return TrackProviderMatchResult()
+        if not base_track.artists:
+            return TrackProviderMatchResult()
+
+        search_queries = list(
+            dict.fromkeys(f"{artist.name} - {base_track.name}" for artist in base_track.artists)
+        )
+        candidates: list[tuple[int, TrackProviderMatch]] = []
+        seen_candidates: set[tuple[str, str]] = set()
+        resolved_base_album = base_album
+        search_rank = 0
+        for search_query in search_queries:
+            for search_result in await self.search(search_query, provider.instance_id):
+                candidate_key = (search_result.provider, search_result.item_id)
+                if candidate_key in seen_candidates or not search_result.available:
+                    continue
+                seen_candidates.add(candidate_key)
+                if not compare_track_title(base_track.name, search_result.name):
+                    continue
+                if not compare_artists(base_track.artists, search_result.artists, any_match=True):
+                    continue
+                candidate = await self.get_provider_item(
+                    search_result.item_id,
+                    search_result.provider,
+                    fallback=search_result,
+                )
+                confidence = compare_track_evidence(
+                    base_track,
+                    candidate,
+                    base_album=resolved_base_album,
+                )
+                if confidence in (
+                    TrackMatchConfidence.LOOSE,
+                    TrackMatchConfidence.LIKELY,
+                ):
+                    if resolved_base_album is None:
+                        resolved_base_album = await self._get_full_track_album(base_track)
+                    candidate_album = await self._get_full_track_album(candidate)
+                    confidence = compare_track_evidence(
+                        base_track,
+                        candidate,
+                        base_album=resolved_base_album,
+                        compare_album_item=candidate_album,
+                    )
+                if confidence < minimum_confidence:
+                    continue
+                if not (mapping := self._get_provider_mapping(candidate, provider)):
+                    continue
+                candidates.append(
+                    (
+                        search_rank,
+                        TrackProviderMatch(
+                            track=candidate,
+                            mapping=mapping,
+                            confidence=confidence,
+                        ),
+                    )
+                )
+                search_rank += 1
+
+        if not candidates:
+            return TrackProviderMatchResult()
+        best_confidence = max(match.confidence for _, match in candidates)
+        best_matches = [
+            (rank, match) for rank, match in candidates if match.confidence == best_confidence
+        ]
+        if best_confidence == TrackMatchConfidence.LOOSE and not self._matches_are_compatible(
+            [match for _, match in best_matches]
+        ):
+            return TrackProviderMatchResult(ambiguous=True)
+        _, best_match = max(
+            best_matches,
+            key=lambda ranked_match: (
+                ranked_match[1].mapping.quality,
+                -ranked_match[0],
+            ),
+        )
+        return TrackProviderMatchResult(match=best_match)
+
+    async def enrich_provider_mappings(
+        self,
+        track: Track,
+        minimum_confidence: TrackMatchConfidence = TrackMatchConfidence.LIKELY,
+    ) -> TrackProviderEnrichment:
+        """
+        Resolve missing streaming-provider mappings without updating the library.
+
+        :param track: Provider track to enrich.
+        :param minimum_confidence: Lowest confidence that may be accepted.
+        """
+        library_track = await self.get_library_match(track)
+        base_track = library_track or track
+        enriched_track = deepcopy(base_track)
+        base_album = await self._get_full_track_album(base_track)
+        existing_domains = {
+            mapping.provider_domain
+            for mapping in enriched_track.provider_mappings
+            if mapping.available
+        }
+        matches: list[TrackProviderMatch] = []
+        ambiguous_providers: list[str] = []
+        failed_providers: list[str] = []
+        processed_domains: set[str] = set()
+        for provider in self.mass.music.providers:
+            if provider.domain in processed_domains or provider.domain in existing_domains:
+                continue
+            processed_domains.add(provider.domain)
+            if not provider.is_streaming_provider:
+                continue
+            try:
+                result = await self.find_provider_match(
+                    base_track,
+                    provider,
+                    minimum_confidence=minimum_confidence,
+                    base_album=base_album,
+                )
+            except (MusicAssistantError, ClientError, OSError, TimeoutError) as err:
+                self.logger.warning(
+                    "Failed to match %s on provider %s: %s",
+                    base_track.name,
+                    provider.name,
+                    err,
+                )
+                failed_providers.append(provider.name)
+                continue
+            if result.match:
+                enriched_track.provider_mappings = {
+                    mapping
+                    for mapping in enriched_track.provider_mappings
+                    if mapping.provider_domain != provider.domain or mapping.available
+                }
+                enriched_track.provider_mappings.add(result.match.mapping)
+                matches.append(result.match)
+                existing_domains.add(provider.domain)
+            elif result.ambiguous:
+                ambiguous_providers.append(provider.name)
+        self.mass.music.match_provider_instances(enriched_track)
+        return TrackProviderEnrichment(
+            track=enriched_track,
+            matches=tuple(matches),
+            ambiguous_providers=tuple(ambiguous_providers),
+            failed_providers=tuple(failed_providers),
+            used_library_item=library_track is not None,
+        )
+
     async def match_provider(
         self,
         base_track: Track,
@@ -701,6 +916,52 @@ class TracksController(MediaControllerBase[Track]):
                 # 100% match, we update the db with the additional provider mapping(s)
                 await self.add_provider_mappings(db_track.item_id, match)
                 processed_domains.add(provider.domain)
+
+    @staticmethod
+    def _get_provider_mapping(track: Track, provider: MusicProvider) -> ProviderMapping | None:
+        """Return an available mapping suitable for the provider instance."""
+        domain_mapping: ProviderMapping | None = None
+        for mapping in sorted(track.provider_mappings, key=lambda item: item.quality, reverse=True):
+            if not mapping.available:
+                continue
+            if mapping.provider_instance == provider.instance_id:
+                return mapping
+            if (
+                mapping.provider_domain == provider.domain
+                and not mapping.is_unique
+                and domain_mapping is None
+            ):
+                domain_mapping = mapping
+        if domain_mapping is None:
+            return None
+        return replace(domain_mapping, provider_instance=provider.instance_id)
+
+    async def _get_full_track_album(self, track: Track) -> Album | ItemMapping | None:
+        """Return full album details when they are available."""
+        if not track.album or isinstance(track.album, Album):
+            return track.album
+        try:
+            return await self.mass.music.albums.get(
+                track.album.item_id,
+                track.album.provider,
+                allow_update_metadata=False,
+            )
+        except (InvalidDataError, MediaNotFoundError, ProviderUnavailableError) as err:
+            self.logger.debug(
+                "Could not load album details for track %s: %s",
+                track.name,
+                err,
+            )
+            return track.album
+
+    @staticmethod
+    def _matches_are_compatible(matches: list[TrackProviderMatch]) -> bool:
+        """Return whether tied loose matches identify the same recording."""
+        first_match = matches[0]
+        return all(
+            compare_track_evidence(first_match.track, match.track) >= TrackMatchConfidence.LIKELY
+            for match in matches[1:]
+        )
 
     async def _add_library_item(self, item: Track, overwrite_existing: bool = False) -> int:
         """Add a new item record to the database."""

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -679,6 +679,8 @@ class TracksController(MediaControllerBase[Track]):
         provider: MusicProvider,
         minimum_confidence: TrackMatchConfidence = TrackMatchConfidence.LIKELY,
         base_album: Album | ItemMapping | None = None,
+        mapping_source: Track | None = None,
+        allowed_provider_instances: set[str] | None = None,
     ) -> TrackProviderMatchResult:
         """
         Find the best track match on a music provider.
@@ -687,15 +689,46 @@ class TracksController(MediaControllerBase[Track]):
         :param provider: Target provider.
         :param minimum_confidence: Lowest confidence that may be returned.
         :param base_album: Optional full reference album for release evidence.
+        :param mapping_source: Optional library track whose mappings may be reused as candidates.
+        :param allowed_provider_instances: Provider instances available to the initiating user.
         """
-        if mapping := self._get_provider_mapping(base_track, provider):
-            return TrackProviderMatchResult(
-                match=TrackProviderMatch(
-                    track=base_track,
-                    mapping=mapping,
-                    confidence=TrackMatchConfidence.EXACT,
+        resolved_base_album = base_album
+        mapping_source = mapping_source or base_track
+        if mapping := self._get_provider_mapping(mapping_source, provider):
+            if mapping_source is base_track:
+                return TrackProviderMatchResult(
+                    match=TrackProviderMatch(
+                        track=base_track,
+                        mapping=mapping,
+                        confidence=TrackMatchConfidence.EXACT,
+                    )
                 )
-            )
+            try:
+                mapped_candidate = await self.get_provider_item(
+                    mapping.item_id,
+                    provider.instance_id,
+                )
+            except MediaNotFoundError:
+                mapped_candidate = None
+            if mapped_candidate:
+                confidence, resolved_base_album = await self._get_match_confidence(
+                    base_track,
+                    mapped_candidate,
+                    resolved_base_album,
+                )
+                if confidence >= minimum_confidence and (
+                    candidate_mapping := self._get_provider_mapping(
+                        mapped_candidate,
+                        provider,
+                    )
+                ):
+                    return TrackProviderMatchResult(
+                        match=TrackProviderMatch(
+                            track=mapped_candidate,
+                            mapping=candidate_mapping,
+                            confidence=confidence,
+                        )
+                    )
         if ProviderFeature.SEARCH not in provider.supported_features:
             return TrackProviderMatchResult()
         if MediaType.TRACK not in provider.supported_media_types:
@@ -708,7 +741,6 @@ class TracksController(MediaControllerBase[Track]):
         )
         candidates: list[tuple[int, TrackProviderMatch]] = []
         seen_candidates: set[tuple[str, str]] = set()
-        resolved_base_album = base_album
         search_rank = 0
         for search_query in search_queries:
             search_results = await self.mass.music.search_provider(
@@ -716,6 +748,7 @@ class TracksController(MediaControllerBase[Track]):
                 provider.instance_id,
                 [MediaType.TRACK],
                 limit=5,
+                allowed_provider_instances=allowed_provider_instances,
             )
             for search_result in search_results.tracks:
                 if not isinstance(search_result, Track):
@@ -735,24 +768,11 @@ class TracksController(MediaControllerBase[Track]):
                     )
                 except MediaNotFoundError:
                     continue
-                confidence = compare_track_evidence(
+                confidence, resolved_base_album = await self._get_match_confidence(
                     base_track,
                     candidate,
-                    base_album=resolved_base_album,
+                    resolved_base_album,
                 )
-                if confidence in (
-                    TrackMatchConfidence.LOOSE,
-                    TrackMatchConfidence.LIKELY,
-                ):
-                    if resolved_base_album is None:
-                        resolved_base_album = await self._get_full_track_album(base_track)
-                    candidate_album = await self._get_full_track_album(candidate)
-                    confidence = compare_track_evidence(
-                        base_track,
-                        candidate,
-                        base_album=resolved_base_album,
-                        compare_album_item=candidate_album,
-                    )
                 if confidence < minimum_confidence:
                     continue
                 if not (mapping := self._get_provider_mapping(candidate, provider)):
@@ -792,17 +812,18 @@ class TracksController(MediaControllerBase[Track]):
         self,
         track: Track,
         minimum_confidence: TrackMatchConfidence = TrackMatchConfidence.LIKELY,
+        provider_instance_ids: set[str] | None = None,
     ) -> TrackProviderEnrichment:
         """
         Resolve missing streaming-provider mappings without updating the library.
 
         :param track: Provider track to enrich.
         :param minimum_confidence: Lowest confidence that may be accepted.
+        :param provider_instance_ids: Provider instances available to the initiating user.
         """
         library_track = await self.get_library_match(track)
-        base_track = library_track or track
-        enriched_track = deepcopy(base_track)
-        base_album = await self._get_full_track_album(base_track)
+        enriched_track = deepcopy(track)
+        base_album = await self._get_full_track_album(track)
         existing_domains = {
             mapping.provider_domain
             for mapping in enriched_track.provider_mappings
@@ -812,23 +833,39 @@ class TracksController(MediaControllerBase[Track]):
         ambiguous_providers: list[str] = []
         failed_providers: list[str] = []
         processed_domains: set[str] = set()
-        for provider in self.mass.music.providers:
+        providers = (
+            [
+                provider
+                for provider_instance_id in sorted(provider_instance_ids)
+                if isinstance(
+                    provider := self.mass.get_provider(provider_instance_id),
+                    MusicProvider,
+                )
+            ]
+            if provider_instance_ids is not None
+            else self.mass.music.providers
+        )
+        for provider in providers:
             if provider.domain in processed_domains or provider.domain in existing_domains:
                 continue
             processed_domains.add(provider.domain)
-            if not provider.is_streaming_provider:
+            if not provider.is_streaming_provider and not (
+                library_track and self._get_provider_mapping(library_track, provider)
+            ):
                 continue
             try:
                 result = await self.find_provider_match(
-                    base_track,
+                    track,
                     provider,
                     minimum_confidence=minimum_confidence,
                     base_album=base_album,
+                    mapping_source=library_track,
+                    allowed_provider_instances=provider_instance_ids,
                 )
             except (MusicAssistantError, ClientError, OSError, TimeoutError) as err:
                 self.logger.warning(
                     "Failed to match %s on provider %s: %s",
-                    base_track.name,
+                    track.name,
                     provider.name,
                     err,
                 )
@@ -845,7 +882,6 @@ class TracksController(MediaControllerBase[Track]):
                 existing_domains.add(provider.domain)
             elif result.ambiguous:
                 ambiguous_providers.append(provider.name)
-        self.mass.music.match_provider_instances(enriched_track)
         return TrackProviderEnrichment(
             track=enriched_track,
             matches=tuple(matches),
@@ -926,6 +962,36 @@ class TracksController(MediaControllerBase[Track]):
                 # 100% match, we update the db with the additional provider mapping(s)
                 await self.add_provider_mappings(db_track.item_id, match)
                 processed_domains.add(provider.domain)
+
+    async def _get_match_confidence(
+        self,
+        base_track: Track,
+        candidate: Track,
+        base_album: Album | ItemMapping | None,
+    ) -> tuple[TrackMatchConfidence, Album | ItemMapping | None]:
+        """Return candidate confidence with full album evidence when needed."""
+        confidence = compare_track_evidence(
+            base_track,
+            candidate,
+            base_album=base_album,
+        )
+        if confidence not in (
+            TrackMatchConfidence.LOOSE,
+            TrackMatchConfidence.LIKELY,
+        ):
+            return confidence, base_album
+        if base_album is None:
+            base_album = await self._get_full_track_album(base_track)
+        candidate_album = await self._get_full_track_album(candidate)
+        return (
+            compare_track_evidence(
+                base_track,
+                candidate,
+                base_album=base_album,
+                compare_album_item=candidate_album,
+            ),
+            base_album,
+        )
 
     @staticmethod
     def _get_provider_mapping(track: Track, provider: MusicProvider) -> ProviderMapping | None:

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -832,7 +832,6 @@ class TracksController(MediaControllerBase[Track]):
         matches: list[TrackProviderMatch] = []
         ambiguous_providers: list[str] = []
         failed_providers: list[str] = []
-        processed_domains: set[str] = set()
         providers = (
             [
                 provider
@@ -846,9 +845,8 @@ class TracksController(MediaControllerBase[Track]):
             else self.mass.music.providers
         )
         for provider in providers:
-            if provider.domain in processed_domains or provider.domain in existing_domains:
+            if provider.domain in existing_domains:
                 continue
-            processed_domains.add(provider.domain)
             if not provider.is_streaming_provider and not (
                 library_track and self._get_provider_mapping(library_track, provider)
             ):

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -681,6 +681,7 @@ class TracksController(MediaControllerBase[Track]):
         base_album: Album | ItemMapping | None = None,
         mapping_source: Track | None = None,
         allowed_provider_instances: set[str] | None = None,
+        trust_base_mapping: bool = True,
     ) -> TrackProviderMatchResult:
         """
         Find the best track match on a music provider.
@@ -691,12 +692,13 @@ class TracksController(MediaControllerBase[Track]):
         :param base_album: Optional full reference album for release evidence.
         :param mapping_source: Optional library track whose mappings may be reused as candidates.
         :param allowed_provider_instances: Provider instances available to the initiating user.
+        :param trust_base_mapping: Treat a direct base-track mapping as exact provider identity.
         """
         resolved_base_album = base_album
         mapped_match: TrackProviderMatch | None = None
         mapping_source = mapping_source or base_track
         if mapping := self._get_provider_mapping(mapping_source, provider):
-            if mapping_source is base_track:
+            if mapping_source is base_track and trust_base_mapping:
                 return TrackProviderMatchResult(
                     match=TrackProviderMatch(
                         track=base_track,
@@ -716,6 +718,7 @@ class TracksController(MediaControllerBase[Track]):
                     base_track,
                     mapped_candidate,
                     resolved_base_album,
+                    allow_item_id_match=trust_base_mapping,
                 )
                 if confidence >= minimum_confidence and (
                     candidate_mapping := self._get_provider_mapping(
@@ -775,6 +778,7 @@ class TracksController(MediaControllerBase[Track]):
                     base_track,
                     candidate,
                     resolved_base_album,
+                    allow_item_id_match=trust_base_mapping,
                 )
                 if confidence < minimum_confidence:
                     continue
@@ -816,6 +820,7 @@ class TracksController(MediaControllerBase[Track]):
         track: Track,
         minimum_confidence: TrackMatchConfidence = TrackMatchConfidence.LIKELY,
         provider_instance_ids: set[str] | None = None,
+        trust_track_mappings: bool = True,
     ) -> TrackProviderEnrichment:
         """
         Resolve missing streaming-provider mappings without updating the library.
@@ -823,6 +828,7 @@ class TracksController(MediaControllerBase[Track]):
         :param track: Provider track to enrich.
         :param minimum_confidence: Lowest confidence that may be accepted.
         :param provider_instance_ids: Provider instances available to the initiating user.
+        :param trust_track_mappings: Treat mappings attached to the source track as exact.
         """
         library_track = await self.get_library_match(track)
         enriched_track = deepcopy(track)
@@ -832,6 +838,8 @@ class TracksController(MediaControllerBase[Track]):
                 for mapping in enriched_track.provider_mappings
                 if mapping.provider_instance in provider_instance_ids
             }
+        if not trust_track_mappings:
+            enriched_track.provider_mappings.clear()
         base_album = await self._get_full_track_album(track)
         existing_domains = {
             mapping.provider_domain
@@ -868,6 +876,7 @@ class TracksController(MediaControllerBase[Track]):
                     base_album=base_album,
                     mapping_source=library_track,
                     allowed_provider_instances=provider_instance_ids,
+                    trust_base_mapping=trust_track_mappings,
                 )
             except (MusicAssistantError, ClientError, OSError, TimeoutError) as err:
                 self.logger.warning(
@@ -975,12 +984,15 @@ class TracksController(MediaControllerBase[Track]):
         base_track: Track,
         candidate: Track,
         base_album: Album | ItemMapping | None,
+        *,
+        allow_item_id_match: bool = True,
     ) -> tuple[TrackMatchConfidence, Album | ItemMapping | None]:
         """Return candidate confidence with full album evidence when needed."""
         confidence = compare_track_evidence(
             base_track,
             candidate,
             base_album=base_album,
+            allow_item_id_match=allow_item_id_match,
         )
         if confidence not in (
             TrackMatchConfidence.LOOSE,
@@ -996,6 +1008,7 @@ class TracksController(MediaControllerBase[Track]):
                 candidate,
                 base_album=base_album,
                 compare_album_item=candidate_album,
+                allow_item_id_match=allow_item_id_match,
             ),
             base_album,
         )

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1105,6 +1105,7 @@ class TracksController(MediaControllerBase[Track]):
             InvalidDataError,
             MediaNotFoundError,
             ProviderUnavailableError,
+            ResourceTemporarilyUnavailable,
             ClientError,
             OSError,
             TimeoutError,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1012,7 +1012,7 @@ class TracksController(MediaControllerBase[Track]):
                 try:
                     candidate = await self.get_provider_item(
                         search_result.item_id,
-                        search_result.provider,
+                        provider.instance_id,
                         allow_fallback=False,
                     )
                 except MediaNotFoundError:

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -245,7 +245,7 @@ class TracksController(MediaControllerBase[Track]):
                     allow_update_metadata=False,
                     recursive=False,
                 )
-        except MusicAssistantError as err:
+        except (InvalidDataError, MediaNotFoundError) as err:
             # edge case where playlist track has invalid albumdetails
             self.logger.warning("Unable to fetch album details for %s - %s", track.uri, str(err))
 

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -693,6 +693,7 @@ class TracksController(MediaControllerBase[Track]):
         :param allowed_provider_instances: Provider instances available to the initiating user.
         """
         resolved_base_album = base_album
+        mapped_match: TrackProviderMatch | None = None
         mapping_source = mapping_source or base_track
         if mapping := self._get_provider_mapping(mapping_source, provider):
             if mapping_source is base_track:
@@ -722,26 +723,28 @@ class TracksController(MediaControllerBase[Track]):
                         provider,
                     )
                 ):
-                    return TrackProviderMatchResult(
-                        match=TrackProviderMatch(
-                            track=mapped_candidate,
-                            mapping=candidate_mapping,
-                            confidence=confidence,
-                        )
+                    mapped_match = TrackProviderMatch(
+                        track=mapped_candidate,
+                        mapping=candidate_mapping,
+                        confidence=confidence,
                     )
+                    if confidence == TrackMatchConfidence.EXACT:
+                        return TrackProviderMatchResult(match=mapped_match)
         if ProviderFeature.SEARCH not in provider.supported_features:
-            return TrackProviderMatchResult()
+            return TrackProviderMatchResult(match=mapped_match)
         if MediaType.TRACK not in provider.supported_media_types:
-            return TrackProviderMatchResult()
+            return TrackProviderMatchResult(match=mapped_match)
         if not base_track.artists:
-            return TrackProviderMatchResult()
+            return TrackProviderMatchResult(match=mapped_match)
 
         search_queries = list(
             dict.fromkeys(f"{artist.name} - {base_track.name}" for artist in base_track.artists)
         )
-        candidates: list[tuple[int, TrackProviderMatch]] = []
+        candidates: list[tuple[int, TrackProviderMatch]] = (
+            [(0, mapped_match)] if mapped_match else []
+        )
         seen_candidates: set[tuple[str, str]] = set()
-        search_rank = 0
+        search_rank = len(candidates)
         for search_query in search_queries:
             search_results = await self.mass.music.search_provider(
                 search_query,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1028,6 +1028,16 @@ class TracksController(MediaControllerBase[Track]):
                     )
                 except MediaNotFoundError:
                     continue
+                except (
+                    ResourceTemporarilyUnavailable,
+                    ProviderUnavailableError,
+                    ClientError,
+                    OSError,
+                    TimeoutError,
+                ):
+                    if candidates:
+                        return candidates
+                    raise
                 confidence, base_album = await self._get_match_confidence(
                     base_track,
                     candidate,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -711,7 +711,15 @@ class TracksController(MediaControllerBase[Track]):
         resolved_base_album = base_album
         search_rank = 0
         for search_query in search_queries:
-            for search_result in await self.search(search_query, provider.instance_id):
+            search_results = await self.mass.music.search_provider(
+                search_query,
+                provider.instance_id,
+                [MediaType.TRACK],
+                limit=5,
+            )
+            for search_result in search_results.tracks:
+                if not isinstance(search_result, Track):
+                    continue
                 candidate_key = (search_result.provider, search_result.item_id)
                 if candidate_key in seen_candidates or not search_result.available:
                     continue
@@ -720,11 +728,13 @@ class TracksController(MediaControllerBase[Track]):
                     continue
                 if not compare_artists(base_track.artists, search_result.artists, any_match=True):
                     continue
-                candidate = await self.get_provider_item(
-                    search_result.item_id,
-                    search_result.provider,
-                    fallback=search_result,
-                )
+                try:
+                    candidate = await self.get_provider_item(
+                        search_result.item_id,
+                        search_result.provider,
+                    )
+                except MediaNotFoundError:
+                    continue
                 confidence = compare_track_evidence(
                     base_track,
                     candidate,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -794,7 +794,7 @@ class TracksController(MediaControllerBase[Track]):
             enriched_track.provider_mappings = {
                 mapping
                 for mapping in enriched_track.provider_mappings
-                if mapping.provider_instance in provider_instance_ids
+                if mapping.provider_instance in provider_instance_ids and mapping.available
             }
         existing_domains = (
             {

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -22,6 +22,7 @@ from music_assistant_models.errors import (
     MediaNotFoundError,
     MusicAssistantError,
     ProviderUnavailableError,
+    ResourceTemporarilyUnavailable,
     UnsupportedFeaturedException,
 )
 from music_assistant_models.helpers import create_safe_string
@@ -823,6 +824,7 @@ class TracksController(MediaControllerBase[Track]):
         minimum_confidence: TrackMatchConfidence = TrackMatchConfidence.LIKELY,
         provider_instance_ids: set[str] | None = None,
         trust_track_mappings: bool = True,
+        failed_provider_instances: set[str] | None = None,
     ) -> TrackProviderEnrichment:
         """
         Resolve missing streaming-provider mappings without updating the library.
@@ -831,6 +833,7 @@ class TracksController(MediaControllerBase[Track]):
         :param minimum_confidence: Lowest confidence that may be accepted.
         :param provider_instance_ids: Provider instances available to the initiating user.
         :param trust_track_mappings: Treat mappings attached to the source track as exact.
+        :param failed_provider_instances: Provider instances unavailable for the migration.
         """
         library_track = await self.get_library_match(track)
         enriched_track = deepcopy(track)
@@ -867,6 +870,11 @@ class TracksController(MediaControllerBase[Track]):
         )
         mapping_source = library_track or track
         for provider in providers:
+            if (
+                failed_provider_instances is not None
+                and provider.instance_id in failed_provider_instances
+            ):
+                continue
             if provider.domain in existing_domains:
                 continue
             if not provider.is_streaming_provider and not (
@@ -883,7 +891,24 @@ class TracksController(MediaControllerBase[Track]):
                     allowed_provider_instances=provider_instance_ids,
                     trust_base_mapping=trust_track_mappings,
                 )
-            except (MusicAssistantError, ClientError, OSError, TimeoutError) as err:
+            except (
+                ResourceTemporarilyUnavailable,
+                ProviderUnavailableError,
+                ClientError,
+                OSError,
+                TimeoutError,
+            ) as err:
+                if failed_provider_instances is not None:
+                    failed_provider_instances.add(provider.instance_id)
+                self.logger.warning(
+                    "Failed to match %s on provider %s: %s",
+                    track.name,
+                    provider.name,
+                    err,
+                )
+                failed_providers.append(provider.name)
+                continue
+            except MusicAssistantError as err:
                 self.logger.warning(
                     "Failed to match %s on provider %s: %s",
                     track.name,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -749,7 +749,6 @@ class TracksController(MediaControllerBase[Track]):
             [(0, mapped_match)] if mapped_match else []
         )
         seen_candidates: set[tuple[str, str]] = set()
-        search_rank = len(candidates)
         for search_query in search_queries:
             search_results = await self.mass.music.search_provider(
                 search_query,
@@ -787,17 +786,19 @@ class TracksController(MediaControllerBase[Track]):
                     continue
                 if not (mapping := self._get_provider_mapping(candidate, provider)):
                     continue
+                candidate_match = TrackProviderMatch(
+                    track=candidate,
+                    mapping=mapping,
+                    confidence=confidence,
+                )
+                if confidence == TrackMatchConfidence.EXACT:
+                    return TrackProviderMatchResult(match=candidate_match)
                 candidates.append(
                     (
-                        search_rank,
-                        TrackProviderMatch(
-                            track=candidate,
-                            mapping=mapping,
-                            confidence=confidence,
-                        ),
+                        len(candidates),
+                        candidate_match,
                     )
                 )
-                search_rank += 1
 
         if not candidates:
             return TrackProviderMatchResult()

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -710,6 +710,7 @@ class TracksController(MediaControllerBase[Track]):
                 mapped_candidate = await self.get_provider_item(
                     mapping.item_id,
                     provider.instance_id,
+                    allow_fallback=False,
                 )
             except MediaNotFoundError:
                 mapped_candidate = None
@@ -771,6 +772,7 @@ class TracksController(MediaControllerBase[Track]):
                     candidate = await self.get_provider_item(
                         search_result.item_id,
                         search_result.provider,
+                        allow_fallback=False,
                     )
                 except MediaNotFoundError:
                     continue

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -826,6 +826,12 @@ class TracksController(MediaControllerBase[Track]):
         """
         library_track = await self.get_library_match(track)
         enriched_track = deepcopy(track)
+        if provider_instance_ids is not None:
+            enriched_track.provider_mappings = {
+                mapping
+                for mapping in enriched_track.provider_mappings
+                if mapping.provider_instance in provider_instance_ids
+            }
         base_album = await self._get_full_track_album(track)
         existing_domains = {
             mapping.provider_domain

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -742,63 +742,15 @@ class TracksController(MediaControllerBase[Track]):
         if not base_track.artists:
             return TrackProviderMatchResult(match=mapped_match)
 
-        search_queries = list(
-            dict.fromkeys(f"{artist.name} - {base_track.name}" for artist in base_track.artists)
+        candidates = await self._search_provider_track_matches(
+            base_track,
+            provider,
+            minimum_confidence,
+            resolved_base_album,
+            allowed_provider_instances,
+            trust_base_mapping,
+            mapped_match,
         )
-        candidates: list[tuple[int, TrackProviderMatch]] = (
-            [(0, mapped_match)] if mapped_match else []
-        )
-        seen_candidates: set[tuple[str, str]] = set()
-        for search_query in search_queries:
-            search_results = await self.mass.music.search_provider(
-                search_query,
-                provider.instance_id,
-                [MediaType.TRACK],
-                limit=5,
-                allowed_provider_instances=allowed_provider_instances,
-            )
-            for search_result in search_results.tracks:
-                if not isinstance(search_result, Track):
-                    continue
-                candidate_key = (search_result.provider, search_result.item_id)
-                if candidate_key in seen_candidates or not search_result.available:
-                    continue
-                seen_candidates.add(candidate_key)
-                if not compare_track_title(base_track.name, search_result.name):
-                    continue
-                if not compare_artists(base_track.artists, search_result.artists, any_match=True):
-                    continue
-                try:
-                    candidate = await self.get_provider_item(
-                        search_result.item_id,
-                        search_result.provider,
-                        allow_fallback=False,
-                    )
-                except MediaNotFoundError:
-                    continue
-                confidence, resolved_base_album = await self._get_match_confidence(
-                    base_track,
-                    candidate,
-                    resolved_base_album,
-                    allow_item_id_match=trust_base_mapping,
-                )
-                if confidence < minimum_confidence:
-                    continue
-                if not (mapping := self._get_provider_mapping(candidate, provider)):
-                    continue
-                candidate_match = TrackProviderMatch(
-                    track=candidate,
-                    mapping=mapping,
-                    confidence=confidence,
-                )
-                if confidence == TrackMatchConfidence.EXACT:
-                    return TrackProviderMatchResult(match=candidate_match)
-                candidates.append(
-                    (
-                        len(candidates),
-                        candidate_match,
-                    )
-                )
 
         if not candidates:
             return TrackProviderMatchResult()
@@ -1010,6 +962,80 @@ class TracksController(MediaControllerBase[Track]):
                 # 100% match, we update the db with the additional provider mapping(s)
                 await self.add_provider_mappings(db_track.item_id, match)
                 processed_domains.add(provider.domain)
+
+    async def _search_provider_track_matches(
+        self,
+        base_track: Track,
+        provider: MusicProvider,
+        minimum_confidence: TrackMatchConfidence,
+        base_album: Album | ItemMapping | None,
+        allowed_provider_instances: set[str] | None,
+        allow_item_id_match: bool,
+        mapped_match: TrackProviderMatch | None,
+    ) -> list[tuple[int, TrackProviderMatch]]:
+        """Return ranked provider candidates, stopping when an exact match is found."""
+        search_queries = list(
+            dict.fromkeys(f"{artist.name} - {base_track.name}" for artist in base_track.artists)
+        )
+        candidates: list[tuple[int, TrackProviderMatch]] = (
+            [(0, mapped_match)] if mapped_match else []
+        )
+        seen_candidates: set[tuple[str, str]] = set()
+        for search_query in search_queries:
+            try:
+                search_results = await self.mass.music.search_provider(
+                    search_query,
+                    provider.instance_id,
+                    [MediaType.TRACK],
+                    limit=5,
+                    allowed_provider_instances=allowed_provider_instances,
+                )
+            except ResourceTemporarilyUnavailable:
+                if candidates:
+                    break
+                raise
+            for search_result in search_results.tracks:
+                if not isinstance(search_result, Track):
+                    continue
+                candidate_key = (search_result.provider, search_result.item_id)
+                if candidate_key in seen_candidates or not search_result.available:
+                    continue
+                seen_candidates.add(candidate_key)
+                if not compare_track_title(base_track.name, search_result.name):
+                    continue
+                if not compare_artists(
+                    base_track.artists,
+                    search_result.artists,
+                    any_match=True,
+                ):
+                    continue
+                try:
+                    candidate = await self.get_provider_item(
+                        search_result.item_id,
+                        search_result.provider,
+                        allow_fallback=False,
+                    )
+                except MediaNotFoundError:
+                    continue
+                confidence, base_album = await self._get_match_confidence(
+                    base_track,
+                    candidate,
+                    base_album,
+                    allow_item_id_match=allow_item_id_match,
+                )
+                if confidence < minimum_confidence:
+                    continue
+                if not (mapping := self._get_provider_mapping(candidate, provider)):
+                    continue
+                candidate_match = TrackProviderMatch(
+                    track=candidate,
+                    mapping=mapping,
+                    confidence=confidence,
+                )
+                candidates.append((len(candidates), candidate_match))
+                if confidence == TrackMatchConfidence.EXACT:
+                    return candidates
+        return candidates
 
     async def _get_match_confidence(
         self,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -245,7 +245,7 @@ class TracksController(MediaControllerBase[Track]):
                     allow_update_metadata=False,
                     recursive=False,
                 )
-        except (InvalidDataError, MediaNotFoundError) as err:
+        except MusicAssistantError as err:
             # edge case where playlist track has invalid albumdetails
             self.logger.warning("Unable to fetch album details for %s - %s", track.uri, str(err))
 
@@ -861,7 +861,7 @@ class TracksController(MediaControllerBase[Track]):
                 )
                 failed_providers.append(provider.name)
                 continue
-            except MusicAssistantError as err:
+            except (InvalidDataError, MediaNotFoundError) as err:
                 self.logger.warning(
                     "Failed to match %s on provider %s: %s",
                     track.name,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -838,14 +838,16 @@ class TracksController(MediaControllerBase[Track]):
                 for mapping in enriched_track.provider_mappings
                 if mapping.provider_instance in provider_instance_ids
             }
-        if not trust_track_mappings:
-            enriched_track.provider_mappings.clear()
         base_album = await self._get_full_track_album(track)
-        existing_domains = {
-            mapping.provider_domain
-            for mapping in enriched_track.provider_mappings
-            if mapping.available
-        }
+        existing_domains = (
+            {
+                mapping.provider_domain
+                for mapping in enriched_track.provider_mappings
+                if mapping.available
+            }
+            if trust_track_mappings
+            else set()
+        )
         matches: list[TrackProviderMatch] = []
         ambiguous_providers: list[str] = []
         failed_providers: list[str] = []
@@ -861,11 +863,12 @@ class TracksController(MediaControllerBase[Track]):
             if provider_instance_ids is not None
             else self.mass.music.providers
         )
+        mapping_source = library_track or track
         for provider in providers:
             if provider.domain in existing_domains:
                 continue
             if not provider.is_streaming_provider and not (
-                library_track and self._get_provider_mapping(library_track, provider)
+                self._get_provider_mapping(mapping_source, provider)
             ):
                 continue
             try:
@@ -874,7 +877,7 @@ class TracksController(MediaControllerBase[Track]):
                     provider,
                     minimum_confidence=minimum_confidence,
                     base_album=base_album,
-                    mapping_source=library_track,
+                    mapping_source=mapping_source,
                     allowed_provider_instances=provider_instance_ids,
                     trust_base_mapping=trust_track_mappings,
                 )
@@ -891,7 +894,8 @@ class TracksController(MediaControllerBase[Track]):
                 enriched_track.provider_mappings = {
                     mapping
                     for mapping in enriched_track.provider_mappings
-                    if mapping.provider_domain != provider.domain or mapping.available
+                    if mapping.provider_domain != provider.domain
+                    or (trust_track_mappings and mapping.available)
                 }
                 enriched_track.provider_mappings.add(result.match.mapping)
                 matches.append(result.match)

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -712,6 +712,7 @@ class TracksController(MediaControllerBase[Track]):
                     mapping.item_id,
                     provider.instance_id,
                     allow_fallback=False,
+                    strict_provider_instance=True,
                 )
             except MediaNotFoundError:
                 mapped_candidate = None
@@ -815,9 +816,14 @@ class TracksController(MediaControllerBase[Track]):
                 provider
                 for provider_instance_id in sorted(provider_instance_ids)
                 if isinstance(
-                    provider := self.mass.get_provider(provider_instance_id),
+                    provider := self.mass.get_provider(
+                        provider_instance_id,
+                        return_unavailable=True,
+                    ),
                     MusicProvider,
                 )
+                and provider.instance_id == provider_instance_id
+                and provider.available
             ]
             if provider_instance_ids is not None
             else self.mass.music.providers
@@ -1018,6 +1024,7 @@ class TracksController(MediaControllerBase[Track]):
                         search_result.item_id,
                         provider.instance_id,
                         allow_fallback=False,
+                        strict_provider_instance=True,
                     )
                 except MediaNotFoundError:
                     continue

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1097,7 +1097,14 @@ class TracksController(MediaControllerBase[Track]):
                 track.album.provider,
                 allow_update_metadata=False,
             )
-        except (InvalidDataError, MediaNotFoundError, ProviderUnavailableError) as err:
+        except (
+            InvalidDataError,
+            MediaNotFoundError,
+            ProviderUnavailableError,
+            ClientError,
+            OSError,
+            TimeoutError,
+        ) as err:
             self.logger.debug(
                 "Could not load album details for track %s: %s",
                 track.name,
@@ -1108,10 +1115,11 @@ class TracksController(MediaControllerBase[Track]):
     @staticmethod
     def _matches_are_compatible(matches: list[TrackProviderMatch]) -> bool:
         """Return whether tied loose matches identify the same recording."""
-        first_match = matches[0]
         return all(
-            compare_track_evidence(first_match.track, match.track) >= TrackMatchConfidence.LIKELY
-            for match in matches[1:]
+            compare_track_evidence(base_match.track, compare_match.track)
+            >= TrackMatchConfidence.LIKELY
+            for index, base_match in enumerate(matches)
+            for compare_match in matches[index + 1 :]
         )
 
     async def _add_library_item(self, item: Track, overwrite_existing: bool = False) -> int:

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1025,10 +1025,7 @@ class TracksController(MediaControllerBase[Track]):
             base_album=base_album,
             allow_item_id_match=allow_item_id_match,
         )
-        if confidence not in (
-            TrackMatchConfidence.LOOSE,
-            TrackMatchConfidence.LIKELY,
-        ):
+        if confidence == TrackMatchConfidence.EXACT:
             return confidence, base_album
         if base_album is None:
             base_album = await self._get_full_track_album(base_track)

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -796,7 +796,6 @@ class TracksController(MediaControllerBase[Track]):
                 for mapping in enriched_track.provider_mappings
                 if mapping.provider_instance in provider_instance_ids
             }
-        base_album = await self._get_full_track_album(track)
         existing_domains = (
             {
                 mapping.provider_domain
@@ -806,6 +805,8 @@ class TracksController(MediaControllerBase[Track]):
             if trust_track_mappings
             else set()
         )
+        base_album: Album | ItemMapping | None = None
+        base_album_loaded = False
         matches: list[TrackProviderMatch] = []
         ambiguous_providers: list[str] = []
         failed_providers: list[str] = []
@@ -834,6 +835,9 @@ class TracksController(MediaControllerBase[Track]):
                 self._get_provider_mapping(mapping_source, provider)
             ):
                 continue
+            if not base_album_loaded:
+                base_album = await self._get_full_track_album(track)
+                base_album_loaded = True
             try:
                 result = await self.find_provider_match(
                     track,

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -490,8 +490,6 @@ def compare_track_evidence(
 
     base_album = base_album or base_item.album
     compare_album_item = compare_album_item or compare_item.album
-    if _same_album_position_conflicts(base_item, compare_item, base_album, compare_album_item):
-        return TrackMatchConfidence.NO_MATCH
 
     base_version = _track_version(base_item)
     compare_version_value = _track_version(compare_item)
@@ -549,6 +547,13 @@ def compare_track_evidence(
     ):
         return TrackMatchConfidence.LIKELY
 
+    if _same_album_position_conflicts(
+        base_item,
+        compare_item,
+        base_album,
+        compare_album_item,
+    ):
+        return TrackMatchConfidence.NO_MATCH
     if not title_matches or not artists_match:
         return TrackMatchConfidence.NO_MATCH
     if versions_match and _track_durations_match(
@@ -1153,7 +1158,7 @@ def _same_album_position_conflicts(
     compare_album_item: Album | ItemMapping | None,
 ) -> bool:
     """Return whether tracks occupy different known positions on the same album."""
-    if not base_album or not compare_album_item:
+    if not isinstance(base_album, Album) or not isinstance(compare_album_item, Album):
         return False
     if not compare_album(base_album, compare_album_item, strict=False):
         return False

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -67,7 +67,8 @@ _RECORDING_CONFLICT_VERSION_TOKENS = {
     "session",
 }
 _FEATURED_ARTISTS_PATTERN = re.compile(
-    r"(?:\(|\[)?\b(?:feat(?:uring)?|ft)\.?\s+(.+?)(?=\s*(?:\(|\[|\)|\]| - |$))",
+    r"(?:\(|\[)?\b(?:feat(?:uring)?|ft)(?:(?:\.|:)\s*|\s+)"
+    r"(.+?)(?=\s*(?:\(|\[|\)|\]| - |$))",
     re.IGNORECASE,
 )
 _FEATURED_ARTIST_SPLITTER = re.compile(

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -524,13 +524,14 @@ def compare_track_evidence(
     title_matches = compare_track_title(base_item.name, compare_item.name)
     artists_match = _track_artist_credits_match(base_item, compare_item)
     versions_match = compare_version(base_version, compare_version_value)
-    same_album = bool(
-        base_album
-        and compare_album_item
-        and compare_album(base_album, compare_album_item, strict=False)
+    same_album = (
+        isinstance(base_album, Album)
+        and isinstance(compare_album_item, Album)
+        and bool(compare_album(base_album, compare_album_item, strict=False))
     )
     if (
-        same_album
+        mb_track_match is not False
+        and same_album
         and title_matches
         and artists_match
         and versions_match

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -6,7 +6,7 @@ import re
 import unicodedata
 from collections.abc import Sequence
 from difflib import SequenceMatcher
-from enum import Enum
+from enum import Enum, IntEnum
 from functools import lru_cache
 from typing import Final
 
@@ -27,6 +27,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.helpers.external_ids import is_valid_isrc, normalize_external_id
+from music_assistant.helpers.util import parse_title_and_version
 
 IGNORE_VERSIONS = (
     "explicit",  # explicit is matched separately
@@ -95,6 +96,8 @@ ALBUM_RETAIL_SUFFIX_KEYS: Final = tuple(
 # match allows more duration drift than a bare title/version fallback
 _ISRC_DURATION_TOLERANCE = 8
 _FALLBACK_DURATION_TOLERANCE = 2
+_TRACK_DURATION_TOLERANCE = 3
+_LOOSE_TRACK_DURATION_TOLERANCE = 5
 
 
 class AlbumMatchEvidence(Enum):
@@ -103,6 +106,15 @@ class AlbumMatchEvidence(Enum):
     MATCH = "match"
     NO_MATCH = "no_match"
     INSUFFICIENT = "insufficient"
+
+
+class TrackMatchConfidence(IntEnum):
+    """Confidence level for a cross-provider track match."""
+
+    NO_MATCH = 0
+    LOOSE = 1
+    LIKELY = 2
+    EXACT = 3
 
 
 def compare_media_item(
@@ -449,6 +461,109 @@ def compare_track(
     # Note that as this stage, all other info already matches,
     # such as title, artist etc.
     return abs(base_item.duration - compare_item.duration) <= 2
+
+
+def compare_track_evidence(
+    base_item: Track,
+    compare_item: Track,
+    base_album: Album | ItemMapping | None = None,
+    compare_album_item: Album | ItemMapping | None = None,
+) -> TrackMatchConfidence:
+    """
+    Return the confidence that two provider tracks represent the same recording.
+
+    :param base_item: Reference track.
+    :param compare_item: Candidate track.
+    :param base_album: Optional full album for the reference track.
+    :param compare_album_item: Optional full album for the candidate track.
+    """
+    if compare_item_ids(base_item, compare_item):
+        return TrackMatchConfidence.EXACT
+
+    base_album = base_album or base_item.album
+    compare_album_item = compare_album_item or compare_item.album
+    if _same_album_position_conflicts(base_item, compare_item, base_album, compare_album_item):
+        return TrackMatchConfidence.NO_MATCH
+
+    base_version = _track_version(base_item)
+    compare_version_value = _track_version(compare_item)
+    if _track_versions_conflict(base_version, compare_version_value):
+        return TrackMatchConfidence.NO_MATCH
+    base_explicit = _track_explicit(base_item)
+    compare_explicit_value = _track_explicit(compare_item)
+    if (
+        base_explicit is not None
+        and compare_explicit_value is not None
+        and base_explicit != compare_explicit_value
+    ):
+        return TrackMatchConfidence.NO_MATCH
+
+    mb_track_match = compare_external_ids(
+        base_item.external_ids, compare_item.external_ids, ExternalID.MB_TRACK
+    )
+
+    recording_id_match = False
+    for external_id_type in (ExternalID.MB_RECORDING, ExternalID.ACOUSTID):
+        external_id_match = compare_external_ids(
+            base_item.external_ids, compare_item.external_ids, external_id_type
+        )
+        if external_id_match is False:
+            return TrackMatchConfidence.NO_MATCH
+        recording_id_match |= external_id_match is True
+    if mb_track_match is True:
+        return TrackMatchConfidence.EXACT
+
+    title_matches = compare_track_title(base_item.name, compare_item.name)
+    artists_match = compare_artists(base_item.artists, compare_item.artists, any_match=True)
+    versions_match = compare_version(base_version, compare_version_value)
+    same_album = bool(
+        base_album
+        and compare_album_item
+        and compare_album(base_album, compare_album_item, strict=False)
+    )
+    if (
+        same_album
+        and title_matches
+        and artists_match
+        and versions_match
+        and _same_album_position_matches(base_item, compare_item)
+    ):
+        return TrackMatchConfidence.EXACT
+
+    if recording_id_match:
+        return TrackMatchConfidence.LIKELY
+
+    base_isrcs = _track_isrcs(base_item)
+    compare_isrcs = _track_isrcs(compare_item)
+    if base_isrcs.intersection(compare_isrcs) and _track_durations_match(
+        base_item, compare_item, _ISRC_DURATION_TOLERANCE
+    ):
+        return TrackMatchConfidence.LIKELY
+
+    if not title_matches or not artists_match:
+        return TrackMatchConfidence.NO_MATCH
+    if versions_match and _track_durations_match(
+        base_item, compare_item, _TRACK_DURATION_TOLERANCE
+    ):
+        return TrackMatchConfidence.LIKELY
+    if (
+        _is_missing_remaster_version(base_version, compare_version_value)
+        and _album_years_match(base_album, compare_album_item)
+        and _track_durations_match(base_item, compare_item, _TRACK_DURATION_TOLERANCE)
+    ):
+        return TrackMatchConfidence.LIKELY
+    if _track_durations_match(base_item, compare_item, _LOOSE_TRACK_DURATION_TOLERANCE):
+        return TrackMatchConfidence.LOOSE
+    return TrackMatchConfidence.NO_MATCH
+
+
+def compare_track_title(base_title: str, compare_title: str) -> bool:
+    """Return whether two track titles have the same identity."""
+    if compare_strings(base_title, compare_title, strict=True):
+        return True
+    base_search_title, _ = parse_title_and_version(base_title, strip_for_search=True)
+    compare_search_title, _ = parse_title_and_version(compare_title, strip_for_search=True)
+    return compare_strings(base_search_title, compare_search_title, strict=True)
 
 
 def compare_playlist(
@@ -950,6 +1065,91 @@ def _track_isrcs(track: Track) -> set[str]:
         for current_type, value in track.external_ids
         if current_type == ExternalID.ISRC and is_valid_isrc(value)
     }
+
+
+def _track_version(track: Track) -> str:
+    """Return version metadata combined with any version embedded in the title."""
+    _, version = parse_title_and_version(track.name, track.version)
+    return version
+
+
+def _track_versions_conflict(base_version: str, compare_version_value: str) -> bool:
+    """Return whether version metadata identifies different recordings."""
+    if compare_version(base_version, compare_version_value):
+        return False
+    base_tokens = set(_normalize_version_tokens(base_version))
+    compare_tokens = set(_normalize_version_tokens(compare_version_value))
+    return bool((base_tokens | compare_tokens) & _RECORDING_CONFLICT_VERSION_TOKENS)
+
+
+def _track_explicit(track: Track) -> bool | None:
+    """Return explicitness from the track or its full album."""
+    if track.metadata.explicit is not None:
+        return track.metadata.explicit
+    if isinstance(track.album, Album):
+        return track.album.metadata.explicit
+    return None
+
+
+def _same_album_position_matches(base_track: Track, compare_track: Track) -> bool:
+    """Return whether track positions agree or duration can stand in for a missing position."""
+    if base_track.track_number and compare_track.track_number:
+        return (base_track.disc_number or 1, base_track.track_number) == (
+            compare_track.disc_number or 1,
+            compare_track.track_number,
+        )
+    return _track_durations_match(base_track, compare_track, _TRACK_DURATION_TOLERANCE)
+
+
+def _same_album_position_conflicts(
+    base_track: Track,
+    compare_track: Track,
+    base_album: Album | ItemMapping | None,
+    compare_album_item: Album | ItemMapping | None,
+) -> bool:
+    """Return whether tracks occupy different known positions on the same album."""
+    if not base_album or not compare_album_item:
+        return False
+    if not compare_album(base_album, compare_album_item, strict=False):
+        return False
+    if not base_track.track_number or not compare_track.track_number:
+        return False
+    return (base_track.disc_number or 1, base_track.track_number) != (
+        compare_track.disc_number or 1,
+        compare_track.track_number,
+    )
+
+
+def _track_durations_match(base_track: Track, compare_track: Track, tolerance: int) -> bool:
+    """Return whether two known track durations are within tolerance."""
+    if not base_track.duration or not compare_track.duration:
+        return False
+    return _duration_close(base_track.duration, compare_track.duration, tolerance)
+
+
+def _is_missing_remaster_version(base_version: str, compare_version_value: str) -> bool:
+    """Return whether one provider omitted remaster-only version metadata."""
+    base_tokens = set(_normalize_version_tokens(base_version))
+    compare_tokens = set(_normalize_version_tokens(compare_version_value))
+    if bool(base_tokens) == bool(compare_tokens):
+        return False
+    version_tokens = base_tokens or compare_tokens
+    return "remaster" in version_tokens and all(
+        token == "remaster" or token.isdigit() for token in version_tokens
+    )
+
+
+def _album_years_match(
+    base_album: Album | ItemMapping | None,
+    compare_album_item: Album | ItemMapping | None,
+) -> bool:
+    """Return whether two full albums declare the same release year."""
+    return bool(
+        isinstance(base_album, Album)
+        and isinstance(compare_album_item, Album)
+        and base_album.year
+        and base_album.year == compare_album_item.year
+    )
 
 
 def _duration_close(base_duration: int, compare_duration: int, tolerance: int) -> bool:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -1092,15 +1092,24 @@ def _track_artist_credits_match(base_track: Track, compare_track: Track) -> bool
 
 def _track_artist_credit_keys(track: Track) -> set[str]:
     """Return normalized structured and title-embedded artist credits."""
-    artist_credits = {_artist_credit_key(artist.name) for artist in track.artists}
+    artist_credits: set[str] = set()
+    for artist in track.artists:
+        artist_credits.update(_artist_credit_variants(artist.name))
     for featured_artists in _FEATURED_ARTISTS_PATTERN.findall(track.name):
-        artist_credits.add(_artist_credit_key(featured_artists))
-        artist_credits.update(
-            _artist_credit_key(artist_name)
-            for artist_name in _FEATURED_ARTIST_SPLITTER.split(featured_artists)
-            if artist_name
-        )
+        artist_credits.update(_artist_credit_variants(featured_artists))
     return artist_credits
+
+
+def _artist_credit_variants(name: str) -> set[str]:
+    """Return equivalent keys for a single or combined artist credit."""
+    split_credits = {
+        _artist_credit_key(artist_name)
+        for artist_name in _FEATURED_ARTIST_SPLITTER.split(name)
+        if artist_name
+    }
+    if len(split_credits) <= 1:
+        return {_artist_credit_key(name)}
+    return {*split_credits, "".join(sorted(split_credits))}
 
 
 def _artist_credit_key(name: str) -> str:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -1094,6 +1094,7 @@ def _track_artist_credit_keys(track: Track) -> set[str]:
     """Return normalized structured and title-embedded artist credits."""
     artist_credits = {_artist_credit_key(artist.name) for artist in track.artists}
     for featured_artists in _FEATURED_ARTISTS_PATTERN.findall(track.name):
+        artist_credits.add(_artist_credit_key(featured_artists))
         artist_credits.update(
             _artist_credit_key(artist_name)
             for artist_name in _FEATURED_ARTIST_SPLITTER.split(featured_artists)

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -67,7 +67,7 @@ _RECORDING_CONFLICT_VERSION_TOKENS = {
     "session",
 }
 _FEATURED_ARTISTS_PATTERN = re.compile(
-    r"(?:\(|\[)?\b(?:feat(?:uring)?|ft)\.?\s+(.+?)(?=\)|\]| - |$)",
+    r"(?:\(|\[)?\b(?:feat(?:uring)?|ft)\.?\s+(.+?)(?=\s*(?:\(|\[|\)|\]| - |$))",
     re.IGNORECASE,
 )
 _FEATURED_ARTIST_SPLITTER = re.compile(
@@ -511,8 +511,8 @@ def compare_track_evidence(
     compare_version_value = _track_version(compare_item)
     if _track_versions_conflict(base_version, compare_version_value):
         return TrackMatchConfidence.NO_MATCH
-    base_explicit = _track_explicit(base_item)
-    compare_explicit_value = _track_explicit(compare_item)
+    base_explicit = _track_explicit(base_item, base_album)
+    compare_explicit_value = _track_explicit(compare_item, compare_album_item)
     if (
         base_explicit is not None
         and compare_explicit_value is not None
@@ -1133,12 +1133,16 @@ def _track_versions_conflict(base_version: str, compare_version_value: str) -> b
     return bool((base_tokens | compare_tokens) & _RECORDING_CONFLICT_VERSION_TOKENS)
 
 
-def _track_explicit(track: Track) -> bool | None:
+def _track_explicit(
+    track: Track,
+    album: Album | ItemMapping | None = None,
+) -> bool | None:
     """Return explicitness from the track or its full album."""
     if track.metadata.explicit is not None:
         return track.metadata.explicit
-    if isinstance(track.album, Album):
-        return track.album.metadata.explicit
+    album = album or track.album
+    if isinstance(album, Album):
+        return album.metadata.explicit
     return None
 
 

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -27,7 +27,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.helpers.external_ids import is_valid_isrc, normalize_external_id
-from music_assistant.helpers.util import parse_title_and_version
+from music_assistant.helpers.util import extract_title_artist_credits, parse_title_and_version
 
 IGNORE_VERSIONS = (
     "explicit",  # explicit is matched separately
@@ -66,11 +66,6 @@ _RECORDING_CONFLICT_VERSION_TOKENS = {
     "remix",
     "session",
 }
-_FEATURED_ARTISTS_PATTERN = re.compile(
-    r"(?:\(|\[)?\b(?:feat(?:uring)?|ft)(?:(?:\.|:)\s*|\s+)"
-    r"(.+?)(?=\s*(?:\(|\[|\)|\]| - |$))",
-    re.IGNORECASE,
-)
 _FEATURED_ARTIST_SPLITTER = re.compile(
     r"\s*(?:,|&|\+|\band\b|\bwith\b)\s*",
     re.IGNORECASE,
@@ -1106,7 +1101,7 @@ def _track_artist_credit_groups(track: Track) -> set[frozenset[str]]:
     artist_credits: set[frozenset[str]] = set()
     for artist in track.artists:
         artist_credits.add(_artist_credit_group(artist.name))
-    for featured_artists in _FEATURED_ARTISTS_PATTERN.findall(track.name):
+    for featured_artists in extract_title_artist_credits(track.name):
         artist_credits.add(_artist_credit_group(featured_artists))
     return artist_credits
 

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -66,6 +66,14 @@ _RECORDING_CONFLICT_VERSION_TOKENS = {
     "remix",
     "session",
 }
+_FEATURED_ARTISTS_PATTERN = re.compile(
+    r"(?:\(|\[)?\b(?:feat(?:uring)?|ft)\.?\s+(.+?)(?=\)|\]| - |$)",
+    re.IGNORECASE,
+)
+_FEATURED_ARTIST_SPLITTER = re.compile(
+    r"\s*(?:,|&|\+|\band\b|\bwith\b)\s*",
+    re.IGNORECASE,
+)
 
 # retail suffixes a provider (notably Apple Music) appends to an EP/single title.
 # Entries must be a single ASCII alphanumeric word: album_retail_suffix_sql_match matches
@@ -514,7 +522,7 @@ def compare_track_evidence(
         return TrackMatchConfidence.EXACT
 
     title_matches = compare_track_title(base_item.name, compare_item.name)
-    artists_match = compare_artists(base_item.artists, compare_item.artists, any_match=True)
+    artists_match = _track_artist_credits_match(base_item, compare_item)
     versions_match = compare_version(base_version, compare_version_value)
     same_album = bool(
         base_album
@@ -1071,6 +1079,32 @@ def _track_version(track: Track) -> str:
     """Return version metadata combined with any version embedded in the title."""
     _, version = parse_title_and_version(track.name, track.version)
     return version
+
+
+def _track_artist_credits_match(base_track: Track, compare_track: Track) -> bool:
+    """Return whether credited artists agree or one provider omitted credits."""
+    if not compare_artists(base_track.artists, compare_track.artists, any_match=True):
+        return False
+    base_credits = _track_artist_credit_keys(base_track)
+    compare_credits = _track_artist_credit_keys(compare_track)
+    return base_credits.issubset(compare_credits) or compare_credits.issubset(base_credits)
+
+
+def _track_artist_credit_keys(track: Track) -> set[str]:
+    """Return normalized structured and title-embedded artist credits."""
+    artist_credits = {_artist_credit_key(artist.name) for artist in track.artists}
+    for featured_artists in _FEATURED_ARTISTS_PATTERN.findall(track.name):
+        artist_credits.update(
+            _artist_credit_key(artist_name)
+            for artist_name in _FEATURED_ARTIST_SPLITTER.split(featured_artists)
+            if artist_name
+        )
+    return artist_credits
+
+
+def _artist_credit_key(name: str) -> str:
+    """Return a stable key for an artist credit."""
+    return create_safe_string(name, True, True) or "".join(name.split()).casefold()
 
 
 def _track_versions_conflict(base_version: str, compare_version_value: str) -> bool:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -1093,31 +1093,43 @@ def _track_artist_credits_match(base_track: Track, compare_track: Track) -> bool
     """Return whether credited artists agree or one provider omitted credits."""
     if not compare_artists(base_track.artists, compare_track.artists, any_match=True):
         return False
-    base_credits = _track_artist_credit_keys(base_track)
-    compare_credits = _track_artist_credit_keys(compare_track)
-    return base_credits.issubset(compare_credits) or compare_credits.issubset(base_credits)
+    base_credits = _track_artist_credit_groups(base_track)
+    compare_credits = _track_artist_credit_groups(compare_track)
+    return _artist_credit_groups_cover(
+        base_credits,
+        compare_credits,
+    ) or _artist_credit_groups_cover(compare_credits, base_credits)
 
 
-def _track_artist_credit_keys(track: Track) -> set[str]:
+def _track_artist_credit_groups(track: Track) -> set[frozenset[str]]:
     """Return normalized structured and title-embedded artist credits."""
-    artist_credits: set[str] = set()
+    artist_credits: set[frozenset[str]] = set()
     for artist in track.artists:
-        artist_credits.update(_artist_credit_variants(artist.name))
+        artist_credits.add(_artist_credit_group(artist.name))
     for featured_artists in _FEATURED_ARTISTS_PATTERN.findall(track.name):
-        artist_credits.update(_artist_credit_variants(featured_artists))
+        artist_credits.add(_artist_credit_group(featured_artists))
     return artist_credits
 
 
-def _artist_credit_variants(name: str) -> set[str]:
-    """Return equivalent keys for a single or combined artist credit."""
-    split_credits = {
+def _artist_credit_group(name: str) -> frozenset[str]:
+    """Return one artist credit as its grouped normalized components."""
+    return frozenset(
         _artist_credit_key(artist_name)
         for artist_name in _FEATURED_ARTIST_SPLITTER.split(name)
         if artist_name
-    }
-    if len(split_credits) <= 1:
-        return {_artist_credit_key(name)}
-    return {*split_credits, "".join(sorted(split_credits))}
+    )
+
+
+def _artist_credit_groups_cover(
+    source_groups: set[frozenset[str]],
+    target_groups: set[frozenset[str]],
+) -> bool:
+    """Return whether target credits contain every complete source credit."""
+    target_singletons = {next(iter(group)) for group in target_groups if len(group) == 1}
+    return all(
+        group in target_groups or (len(group) > 1 and group.issubset(target_singletons))
+        for group in source_groups
+    )
 
 
 def _artist_credit_key(name: str) -> str:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -476,6 +476,8 @@ def compare_track_evidence(
     compare_item: Track,
     base_album: Album | ItemMapping | None = None,
     compare_album_item: Album | ItemMapping | None = None,
+    *,
+    allow_item_id_match: bool = True,
 ) -> TrackMatchConfidence:
     """
     Return the confidence that two provider tracks represent the same recording.
@@ -484,12 +486,26 @@ def compare_track_evidence(
     :param compare_item: Candidate track.
     :param base_album: Optional full album for the reference track.
     :param compare_album_item: Optional full album for the candidate track.
+    :param allow_item_id_match: Trust shared provider item identity as exact evidence.
     """
-    if compare_item_ids(base_item, compare_item):
+    if allow_item_id_match and compare_item_ids(base_item, compare_item):
         return TrackMatchConfidence.EXACT
 
     base_album = base_album or base_item.album
     compare_album_item = compare_album_item or compare_item.album
+    mb_track_match = compare_external_ids(
+        base_item.external_ids, compare_item.external_ids, ExternalID.MB_TRACK
+    )
+    recording_id_match = False
+    for external_id_type in (ExternalID.MB_RECORDING, ExternalID.ACOUSTID):
+        external_id_match = compare_external_ids(
+            base_item.external_ids, compare_item.external_ids, external_id_type
+        )
+        if external_id_match is False:
+            return TrackMatchConfidence.NO_MATCH
+        recording_id_match |= external_id_match is True
+    if mb_track_match is True:
+        return TrackMatchConfidence.EXACT
 
     base_version = _track_version(base_item)
     compare_version_value = _track_version(compare_item)
@@ -503,21 +519,6 @@ def compare_track_evidence(
         and base_explicit != compare_explicit_value
     ):
         return TrackMatchConfidence.NO_MATCH
-
-    mb_track_match = compare_external_ids(
-        base_item.external_ids, compare_item.external_ids, ExternalID.MB_TRACK
-    )
-
-    recording_id_match = False
-    for external_id_type in (ExternalID.MB_RECORDING, ExternalID.ACOUSTID):
-        external_id_match = compare_external_ids(
-            base_item.external_ids, compare_item.external_ids, external_id_type
-        )
-        if external_id_match is False:
-            return TrackMatchConfidence.NO_MATCH
-        recording_id_match |= external_id_match is True
-    if mb_track_match is True:
-        return TrackMatchConfidence.EXACT
 
     title_matches = compare_track_title(base_item.name, compare_item.name)
     artists_match = _track_artist_credits_match(base_item, compare_item)

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -580,6 +580,23 @@ WITH_TITLE_WORDS = (
     "you",
     "no",
 )
+_TITLE_FEATURED_CREDIT_PATTERN = re.compile(
+    r"(?:\(|\[)?\b(?:feat(?:uring)?|ft)(?:(?:\.|:)\s*|\s+)"
+    r"(.+?)(?=\s*(?:\(|\[|\)|\]| - |$))",
+    re.IGNORECASE,
+)
+_TITLE_BRACKETED_WITH_CREDIT_PATTERN = re.compile(
+    r"(?:\(|\[)with\s+(?P<credit>.+?)(?:\)|\])",
+    re.IGNORECASE,
+)
+_TITLE_HYPHEN_WITH_CREDIT_PATTERN = re.compile(
+    r"\s+-\s+with\s+(?P<credit>.+?)(?=\s*(?:\(|\[| - |$))",
+    re.IGNORECASE,
+)
+_TITLE_WITH_CREDIT_PATTERNS = (
+    _TITLE_BRACKETED_WITH_CREDIT_PATTERN,
+    _TITLE_HYPHEN_WITH_CREDIT_PATTERN,
+)
 
 # Keywords for aggressive search cleaning (includes featuring).
 _VERSION_PATTERN = "|".join(re.escape(v) for v in VERSION_PARTS)
@@ -683,6 +700,30 @@ def normalize_unicode(value: str | None) -> str | None:
 
 
 @functools.lru_cache(maxsize=2048)
+def extract_title_artist_credits(title: str) -> tuple[str, ...]:
+    """Return artist credits embedded in a track title."""
+    matched_credits = [
+        *(
+            (match.start(), match.group(1).strip())
+            for match in _TITLE_FEATURED_CREDIT_PATTERN.finditer(title)
+        ),
+        *(
+            (match.start(), match.group("credit").strip())
+            for pattern in _TITLE_WITH_CREDIT_PATTERNS
+            for match in pattern.finditer(title)
+            if _is_with_artist_credit(match.group("credit"))
+        ),
+    ]
+    return tuple(credit for _, credit in sorted(matched_credits))
+
+
+def _is_with_artist_credit(value: str) -> bool:
+    """Return whether a with-suffix identifies an artist rather than title words."""
+    first_word = value.split(maxsplit=1)[0].casefold().strip(".,:;!?") if value else ""
+    return bool(first_word) and first_word not in WITH_TITLE_WORDS
+
+
+@functools.lru_cache(maxsize=2048)
 def parse_title_and_version(
     title: str,
     track_version: str | None = None,
@@ -702,6 +743,12 @@ def parse_title_and_version(
 
     # Strip featuring, bracketed version info, and hyphen suffixes (e.g. "- Remastered 2019")
     if strip_for_search:
+        with_credit_matches = [
+            match for pattern in _TITLE_WITH_CREDIT_PATTERNS for match in pattern.finditer(title)
+        ]
+        for match in sorted(with_credit_matches, key=lambda item: item.start(), reverse=True):
+            if _is_with_artist_credit(match.group("credit")):
+                title = f"{title[: match.start()]}{title[match.end() :]}"
         title = _SEARCH_PAREN_PATTERN.sub("", title)
         title = _SEARCH_HYPHEN_PATTERN.sub("", title)
         # Strip bare featuring credits (not in parentheses)
@@ -742,13 +789,7 @@ def parse_title_and_version(
                 if clean_part.startswith(ignore_str):
                     # Special handling for "with " - check if followed by title words
                     if ignore_str == "with ":
-                        # Extract the word after "with "
-                        after_with = (
-                            clean_part[len("with ") :].split()[0]
-                            if len(clean_part) > len("with ")
-                            else ""
-                        )
-                        if after_with in WITH_TITLE_WORDS:
+                        if not _is_with_artist_credit(clean_part[len("with ") :]):
                             # This is part of the title (e.g., "with you"), don't ignore
                             break
                     # Remove this part from the title

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -163,6 +163,8 @@ class MusicProvider(Provider):
     Music Provider implementations should inherit from this base model.
     """
 
+    playlist_duplicates_supported = True
+
     def __init__(
         self,
         mass: MusicAssistant,

--- a/music_assistant/providers/nicovideo/provider.py
+++ b/music_assistant/providers/nicovideo/provider.py
@@ -54,6 +54,8 @@ class NicovideoMusicProvider(
 ):
     """Coordinator combining all nicovideo provider mixins."""
 
+    playlist_duplicates_supported = False
+
     @override
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""

--- a/music_assistant/providers/tidal/provider.py
+++ b/music_assistant/providers/tidal/provider.py
@@ -80,6 +80,8 @@ SUPPORTED_FEATURES = {
 class TidalProvider(RecommendationPayloadMixin, MusicProvider):
     """Implementation of a Tidal MusicProvider."""
 
+    playlist_duplicates_supported = False
+
     def __init__(self, mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig):
         """Initialize Tidal provider."""
         super().__init__(mass, manifest, config, SUPPORTED_FEATURES)

--- a/music_assistant/providers/yousee/provider.py
+++ b/music_assistant/providers/yousee/provider.py
@@ -59,6 +59,8 @@ if TYPE_CHECKING:
 class YouSeeMusikProvider(RecommendationPayloadMixin, MusicProvider):
     """Provider implementation for YouSee Musik."""
 
+    playlist_duplicates_supported = False
+
     # the personalized sections barely change intraday; keep the pre-refactor 24h interval
     recommendation_payload_ttl = 3600 * 24
 

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -295,7 +295,11 @@ async def add_remove_playlist_tracks(
     def _add_playlist_tracks() -> str | dict[str, Any]:
         ytm = ytmusicapi.YTMusic(auth=headers, user=user)
         if add:
-            return ytm.add_playlist_items(playlistId=prov_playlist_id, videoIds=prov_track_ids)
+            return ytm.add_playlist_items(
+                playlistId=prov_playlist_id,
+                videoIds=prov_track_ids,
+                duplicates=True,
+            )
         return ytm.remove_playlist_items(playlistId=prov_playlist_id, videos=prov_track_ids)
 
     return await _run_ytmusic(_add_playlist_tracks)

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator
 from copy import deepcopy
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
@@ -139,6 +140,86 @@ async def test_provider_playlist_additions_are_batched_in_order() -> None:
     batches = [call.args[1] for call in provider.add_playlist_tracks.await_args_list]
     assert [len(batch) for batch in batches] == [100, 100, 5]
     assert [track_id for batch in batches for track_id in batch] == track_ids
+
+
+async def test_migration_resolves_tracks_in_bounded_batches(
+    music: MusicController,
+) -> None:
+    """Large playlists create at most five concurrent track resolutions."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    source_tracks = [create_track("spotify_1", f"source-{index}") for index in range(12)]
+    destination_playlist = _playlist("2", "Migrated", "builtin", "migrated")
+    builtin_provider = MagicMock(spec=MusicProvider)
+    builtin_provider.instance_id = "builtin"
+    builtin_provider.domain = "builtin"
+    builtin_provider.name = "Music Assistant"
+    source_provider = MagicMock(spec=MusicProvider)
+    source_provider.instance_id = "spotify_1"
+    source_provider.domain = "spotify"
+    active_resolutions = 0
+    max_active_resolutions = 0
+
+    async def iter_source_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Track]:
+        for track in source_tracks:
+            yield track
+
+    async def enrich_track(
+        track: Track,
+        **_kwargs: object,
+    ) -> TrackProviderEnrichment:
+        nonlocal active_resolutions, max_active_resolutions
+        active_resolutions += 1
+        max_active_resolutions = max(
+            max_active_resolutions,
+            active_resolutions,
+        )
+        await asyncio.sleep(0)
+        active_resolutions -= 1
+        return TrackProviderEnrichment(
+            track=track,
+            matches=(),
+            ambiguous_providers=(),
+            failed_providers=(),
+            used_library_item=False,
+        )
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(music.playlists, "tracks", iter_source_tracks),
+        patch.object(
+            music.tracks,
+            "enrich_provider_mappings",
+            AsyncMock(side_effect=enrich_track),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id: {
+                "builtin": builtin_provider,
+                "spotify_1": source_provider,
+            }[provider_instance_id],
+        ),
+        patch.object(
+            music.playlists,
+            "_create_builtin_migration_playlist",
+            AsyncMock(return_value=destination_playlist),
+        ),
+    ):
+        await music.playlists._handle_migrate_playlist(
+            source_playlist.item_id,
+            "source",
+            "spotify_1",
+            builtin_provider.instance_id,
+            "Migrated",
+            PlaylistMigrationMatchPolicy.SAME_RECORDING,
+            ("builtin", "spotify_1"),
+        )
+
+    assert max_active_resolutions == 5
 
 
 async def test_migrate_playlist_queues_validated_task(

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -172,6 +172,49 @@ def test_migration_reconciliation_preserves_order(
     assert result == (confirmed_indexes, destination_mismatch)
 
 
+async def test_migration_verification_retries_stale_provider_read(
+    music: MusicController,
+) -> None:
+    """Destination verification retries until successful writes become visible."""
+    source = create_track("spotify_1", "source")
+    target = create_track("tidal_1", "target")
+    target_results = [
+        (
+            source,
+            _PlaylistMigrationTrackResult(
+                track=target,
+                mapping=next(iter(target.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        )
+    ]
+    responses = iter(((), (target,)))
+
+    async def iter_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Track]:
+        for track in next(responses):
+            yield track
+
+    with (
+        patch.object(music.playlists, "tracks", iter_tracks),
+        patch(
+            "music_assistant.controllers.music.media.playlists._MIGRATION_VERIFY_RETRY_DELAYS",
+            (1,),
+        ),
+        patch(
+            "music_assistant.controllers.music.media.playlists.asyncio.sleep",
+            AsyncMock(),
+        ) as sleep,
+    ):
+        result = await music.playlists._verify_migration_results(
+            "playlist",
+            "tidal_1",
+            target_results,
+        )
+
+    assert result == ({0}, False)
+    sleep.assert_awaited_once_with(1)
+
+
 async def test_provider_playlist_additions_are_batched_in_order() -> None:
     """Large playlist writes respect common provider request limits."""
     provider = MagicMock(spec=MusicProvider)
@@ -546,6 +589,10 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
             return_value=("tidal_1", "target"),
         ),
         patch.object(music.playlists, "update_item_in_library", AsyncMock()),
+        patch(
+            "music_assistant.controllers.music.media.playlists._MIGRATION_VERIFY_RETRY_DELAYS",
+            (),
+        ),
         patch(
             "music_assistant.controllers.music.media.playlists.report_current_task_failure"
         ) as report_failure,

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -13,6 +13,7 @@ from music_assistant_models.media_items import Playlist, ProviderMapping, Track
 
 from music_assistant.controllers.music import MusicController
 from music_assistant.controllers.music.media.playlists import (
+    PlaylistController,
     PlaylistMigrationMatchPolicy,
 )
 from music_assistant.controllers.music.media.tracks import (
@@ -58,6 +59,36 @@ def _playlist(
         owner="Test",
         is_editable=True,
     )
+
+
+def test_migration_report_renders_substitutions_and_skips() -> None:
+    """Migration reports summarize counts and item-level decisions as Markdown."""
+    report = PlaylistController._build_migration_report(
+        "Source",
+        "Migrated",
+        "Tidal",
+        2,
+        {
+            "total": 3,
+            "exact": 1,
+            "same_recording": 1,
+            "best_effort": 0,
+            "skipped": 1,
+            "ambiguous": 0,
+            "library_matches": 1,
+            "provider_matches": 0,
+        },
+        [("Artist - Song", "Artist - Song (Remaster)", "Same recording")],
+        [("Artist - Missing", "No acceptable match")],
+        [],
+        completed=True,
+        builtin_destination=False,
+    )
+
+    assert "## Playlist migration complete" in report
+    assert "| Exact release | 1 |" in report
+    assert "### Substitutions" in report
+    assert "Artist - Missing" in report
 
 
 async def test_migrate_playlist_queues_validated_task(
@@ -197,6 +228,9 @@ async def test_streaming_migration_preserves_order_and_duplicates(
         patch(
             "music_assistant.controllers.music.media.playlists.report_current_task_failure"
         ) as report_failure,
+        patch(
+            "music_assistant.controllers.music.media.playlists.set_current_task_report"
+        ) as set_report,
     ):
         await music.playlists._handle_migrate_playlist(
             source_playlist.item_id,
@@ -212,6 +246,8 @@ async def test_streaming_migration_preserves_order_and_duplicates(
     )
     assert find_match.await_count == 3
     report_failure.assert_called_once_with("Test Artist - Test Track: no acceptable match")
+    assert set_report.call_count == 2
+    assert "### Skipped tracks" in set_report.call_args.args[0]
 
 
 async def test_builtin_migration_keeps_all_enriched_mappings(

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -274,8 +274,10 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
     source_provider = MagicMock(spec=MusicProvider)
     source_provider.instance_id = "spotify_1"
     source_provider.domain = "spotify"
+    track_requests: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
-    async def iter_source_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Track]:
+    async def iter_source_tracks(*args: object, **kwargs: object) -> AsyncGenerator[Track]:
+        track_requests.append((args, kwargs))
         for track in (
             source_one,
             source_two,
@@ -346,6 +348,7 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
         )
 
     create_playlist.assert_awaited_once()
+    assert track_requests == [(("source", "spotify_1"), {"force_refresh": True})]
     target_provider.add_playlist_tracks.assert_awaited_once_with(
         "target",
         expected_target_ids,

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -133,7 +133,11 @@ async def test_migrate_playlist_queues_validated_task(
             "get_library_item",
             AsyncMock(return_value=source_playlist),
         ),
-        patch.object(music.mass, "get_provider", return_value=target_provider),
+        patch.object(
+            music.mass,
+            "get_provider",
+            return_value=target_provider,
+        ) as get_provider,
         patch.object(
             MusicController,
             "providers",
@@ -154,13 +158,14 @@ async def test_migrate_playlist_queues_validated_task(
     ):
         result = await music.playlists.migrate_playlist(
             source_playlist.item_id,
-            destination_provider=target_provider.instance_id,
+            destination_provider=target_provider.domain,
             name="Migrated",
             match_policy=PlaylistMigrationMatchPolicy.BEST_EFFORT,
         )
         await tasks.run_background_task.call_args.kwargs["handler"]()
 
     assert result is queued_task
+    get_provider.assert_not_called()
     assert "task_id" not in tasks.run_background_task.call_args.kwargs
     assert tasks.run_background_task.call_args.kwargs["metadata"]["match_policy"] == "best_effort"
     handle_migration.assert_awaited_once_with(
@@ -219,6 +224,9 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
     target_provider.name = "Tidal"
     target_provider.playlist_duplicates_supported = duplicates_supported
     target_provider.add_playlist_tracks = AsyncMock()
+    source_provider = MagicMock(spec=MusicProvider)
+    source_provider.instance_id = "spotify_1"
+    source_provider.domain = "spotify"
 
     async def iter_source_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Track]:
         for track in (
@@ -254,7 +262,14 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
         patch.object(music.playlists, "tracks", iter_source_tracks),
         patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
         patch.object(music.tracks, "find_provider_match", find_match),
-        patch.object(music.mass, "get_provider", return_value=target_provider),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id: {
+                "spotify_1": source_provider,
+                "tidal_1": target_provider,
+            }[provider_instance_id],
+        ),
         patch.object(
             music.playlists,
             "create_playlist",
@@ -323,6 +338,9 @@ async def test_builtin_migration_keeps_all_enriched_mappings(
     builtin_provider.instance_id = "builtin"
     builtin_provider.domain = "builtin"
     builtin_provider.name = "Music Assistant"
+    source_provider = MagicMock(spec=MusicProvider)
+    source_provider.instance_id = "spotify_1"
+    source_provider.domain = "spotify"
     destination_playlist = _playlist("2", "Migrated", "builtin", "migrated")
 
     async def iter_source_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Track]:
@@ -351,7 +369,14 @@ async def test_builtin_migration_keeps_all_enriched_mappings(
             "enrich_provider_mappings",
             AsyncMock(return_value=enrichment),
         ) as enrich,
-        patch.object(music.mass, "get_provider", return_value=builtin_provider),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id: {
+                "builtin": builtin_provider,
+                "spotify_1": source_provider,
+            }[provider_instance_id],
+        ),
         patch.object(
             music.playlists,
             "_create_builtin_migration_playlist",
@@ -372,6 +397,7 @@ async def test_builtin_migration_keeps_all_enriched_mappings(
         source,
         minimum_confidence=TrackMatchConfidence.LOOSE,
         provider_instance_ids={"builtin", "spotify_1"},
+        trust_track_mappings=True,
     )
     assert create_builtin.await_args is not None
     entries = create_builtin.await_args.args[1]

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -304,13 +304,19 @@ async def test_migrate_playlist_rejects_dynamic_source(
             ["tidal-one", "tidal-one"],
             2,
         ),
+        (
+            True,
+            ["tidal-one", "tidal-two", "tidal-one"],
+            None,
+            2,
+        ),
     ],
 )
 async def test_streaming_migration_handles_provider_duplicate_policy(
     music: MusicController,
     duplicates_supported: bool,
     expected_target_ids: list[str],
-    actual_target_ids: list[str],
+    actual_target_ids: list[str] | None,
     expected_failure_count: int,
 ) -> None:
     """A provider migration preserves supported duplicates and reports unsupported ones."""
@@ -344,6 +350,8 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
                 source_missing,
             )
         else:
+            if actual_target_ids is None:
+                raise ResourceTemporarilyUnavailable("Verification timed out")
             target_tracks = {
                 "tidal-one": target_one,
                 "tidal-two": target_two,
@@ -433,8 +441,12 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
         expected_failures.append(
             call("Test Artist - Test Track: tidal does not support duplicate playlist entries")
         )
-    if "tidal-two" not in actual_target_ids:
+    if actual_target_ids is not None and "tidal-two" not in actual_target_ids:
         expected_failures.append(call("Test Artist - Test Track: tidal did not add this track"))
+    if actual_target_ids is None:
+        expected_failures.append(
+            call("Could not verify destination playlist: Verification timed out")
+        )
     assert report_failure.call_args_list == expected_failures
     assert report_failure.call_count == expected_failure_count
     assert set_report.call_count == 2

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -19,6 +19,7 @@ from music_assistant.controllers.music import MusicController
 from music_assistant.controllers.music.media.playlists import (
     PlaylistController,
     PlaylistMigrationMatchPolicy,
+    _PlaylistMigrationTrackResult,
 )
 from music_assistant.controllers.music.media.tracks import (
     TrackProviderEnrichment,
@@ -123,6 +124,52 @@ def test_migration_report_caps_detail_rows() -> None:
     assert "_1 additional rows omitted._" in report
     assert "| Artist - Track 199 |" in report
     assert "| Artist - Track 200 |" not in report
+
+
+@pytest.mark.parametrize(
+    ("actual_target_ids", "confirmed_indexes", "destination_mismatch"),
+    [
+        (["tidal-a", "tidal-b"], {0, 1}, False),
+        (["tidal-b"], {1}, False),
+        (["tidal-b", "tidal-a"], {1}, True),
+        (["tidal-a", "unexpected"], {0}, True),
+    ],
+)
+def test_migration_reconciliation_preserves_order(
+    actual_target_ids: list[str],
+    confirmed_indexes: set[int],
+    destination_mismatch: bool,
+) -> None:
+    """Migration verification distinguishes omissions from reordered or unexpected tracks."""
+    source_a = create_track("spotify_1", "source-a")
+    source_b = create_track("spotify_1", "source-b")
+    target_a = create_track("tidal_1", "tidal-a")
+    target_b = create_track("tidal_1", "tidal-b")
+    target_results = [
+        (
+            source_a,
+            _PlaylistMigrationTrackResult(
+                track=target_a,
+                mapping=next(iter(target_a.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        (
+            source_b,
+            _PlaylistMigrationTrackResult(
+                track=target_b,
+                mapping=next(iter(target_b.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+    ]
+
+    result = PlaylistController._reconcile_migration_results(
+        actual_target_ids,
+        target_results,
+    )
+
+    assert result == (confirmed_indexes, destination_mismatch)
 
 
 async def test_provider_playlist_additions_are_batched_in_order() -> None:
@@ -363,6 +410,7 @@ async def test_migrate_playlist_rejects_dynamic_source(
         "duplicates_supported",
         "expected_target_ids",
         "actual_target_ids",
+        "expected_verification_failures",
         "expected_failure_count",
     ),
     [
@@ -370,25 +418,39 @@ async def test_migrate_playlist_rejects_dynamic_source(
             True,
             ["tidal-one", "tidal-two", "tidal-one"],
             ["tidal-one", "tidal-two", "tidal-one"],
+            [],
             1,
         ),
         (
             False,
             ["tidal-one", "tidal-two"],
             ["tidal-one", "tidal-two"],
+            [],
             2,
         ),
         (
             True,
             ["tidal-one", "tidal-two", "tidal-one"],
             ["tidal-one", "tidal-one"],
+            ["Test Artist - Test Track: tidal did not add this track in the expected order"],
             2,
         ),
         (
             True,
             ["tidal-one", "tidal-two", "tidal-one"],
             None,
+            ["Could not verify destination playlist: Verification failed (TimeoutError)"],
             2,
+        ),
+        (
+            True,
+            ["tidal-one", "tidal-two", "tidal-one"],
+            ["tidal-two", "tidal-one", "tidal-one"],
+            [
+                "Test Artist - Test Track: tidal did not add this track in the expected order",
+                "Destination playlist contains unexpected or reordered tracks",
+            ],
+            3,
         ),
     ],
 )
@@ -397,6 +459,7 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
     duplicates_supported: bool,
     expected_target_ids: list[str],
     actual_target_ids: list[str] | None,
+    expected_verification_failures: list[str],
     expected_failure_count: int,
 ) -> None:
     """A provider migration preserves supported duplicates and reports unsupported ones."""
@@ -521,16 +584,14 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
         expected_failures.append(
             call("Test Artist - Test Track: tidal does not support duplicate playlist entries")
         )
-    if actual_target_ids is not None and "tidal-two" not in actual_target_ids:
-        expected_failures.append(call("Test Artist - Test Track: tidal did not add this track"))
-    if actual_target_ids is None:
-        expected_failures.append(
-            call("Could not verify destination playlist: Verification failed (TimeoutError)")
-        )
+    expected_failures.extend(call(message) for message in expected_verification_failures)
     assert report_failure.call_args_list == expected_failures
     assert report_failure.call_count == expected_failure_count
     assert set_report.call_count == 2
-    assert "### Skipped tracks" in set_report.call_args.args[0]
+    final_report = set_report.call_args.args[0]
+    assert "### Skipped tracks" in final_report
+    if actual_target_ids == ["tidal-one", "tidal-one"]:
+        assert "### Substitutions" not in final_report
 
 
 async def test_builtin_migration_keeps_all_enriched_mappings(

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -8,7 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
 from music_assistant_models.enums import MediaType, ProviderFeature
-from music_assistant_models.errors import InvalidDataError, ProviderUnavailableError
+from music_assistant_models.errors import (
+    InvalidDataError,
+    ProviderUnavailableError,
+    ResourceTemporarilyUnavailable,
+)
 from music_assistant_models.media_items import Playlist, ProviderMapping, Track
 
 from music_assistant.controllers.music import MusicController
@@ -89,6 +93,36 @@ def test_migration_report_renders_substitutions_and_skips() -> None:
     assert "| Exact release | 1 |" in report
     assert "### Substitutions" in report
     assert "Artist - Missing" in report
+
+
+def test_migration_report_caps_detail_rows() -> None:
+    """Large migrations retain totals without creating unbounded task payloads."""
+    skipped_tracks = [(f"Artist - Track {index}", "No acceptable match") for index in range(201)]
+    report = PlaylistController._build_migration_report(
+        "Source",
+        "Migrated",
+        "Tidal",
+        0,
+        {
+            "total": 201,
+            "exact": 0,
+            "same_recording": 0,
+            "best_effort": 0,
+            "skipped": 201,
+            "ambiguous": 0,
+            "library_matches": 0,
+            "provider_matches": 0,
+        },
+        [],
+        skipped_tracks,
+        [],
+        completed=True,
+        builtin_destination=False,
+    )
+
+    assert "_1 additional rows omitted._" in report
+    assert "| Artist - Track 199 |" in report
+    assert "| Artist - Track 200 |" not in report
 
 
 async def test_provider_playlist_additions_are_batched_in_order() -> None:
@@ -245,16 +279,38 @@ async def test_migrate_playlist_rejects_dynamic_source(
 
 
 @pytest.mark.parametrize(
-    ("duplicates_supported", "expected_target_ids", "expected_failure_count"),
+    (
+        "duplicates_supported",
+        "expected_target_ids",
+        "actual_target_ids",
+        "expected_failure_count",
+    ),
     [
-        (True, ["tidal-one", "tidal-two", "tidal-one"], 1),
-        (False, ["tidal-one", "tidal-two"], 2),
+        (
+            True,
+            ["tidal-one", "tidal-two", "tidal-one"],
+            ["tidal-one", "tidal-two", "tidal-one"],
+            1,
+        ),
+        (
+            False,
+            ["tidal-one", "tidal-two"],
+            ["tidal-one", "tidal-two"],
+            2,
+        ),
+        (
+            True,
+            ["tidal-one", "tidal-two", "tidal-one"],
+            ["tidal-one", "tidal-one"],
+            2,
+        ),
     ],
 )
 async def test_streaming_migration_handles_provider_duplicate_policy(
     music: MusicController,
     duplicates_supported: bool,
     expected_target_ids: list[str],
+    actual_target_ids: list[str],
     expected_failure_count: int,
 ) -> None:
     """A provider migration preserves supported duplicates and reports unsupported ones."""
@@ -276,15 +332,24 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
     source_provider.domain = "spotify"
     track_requests: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
-    async def iter_source_tracks(*args: object, **kwargs: object) -> AsyncGenerator[Track]:
+    async def iter_playlist_tracks(*args: object, **kwargs: object) -> AsyncGenerator[Track]:
         track_requests.append((args, kwargs))
-        for track in (
-            source_one,
-            source_two,
-            source_one,
-            source_missing,
-            source_missing,
-        ):
+        tracks: tuple[Track, ...]
+        if args == ("source", "spotify_1"):
+            tracks = (
+                source_one,
+                source_two,
+                source_one,
+                source_missing,
+                source_missing,
+            )
+        else:
+            target_tracks = {
+                "tidal-one": target_one,
+                "tidal-two": target_two,
+            }
+            tracks = tuple(target_tracks[item_id] for item_id in actual_target_ids)
+        for track in tracks:
             yield track
 
     matches = {
@@ -308,7 +373,7 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
 
     with (
         patch.object(music.playlists, "get_library_item", AsyncMock(return_value=source_playlist)),
-        patch.object(music.playlists, "tracks", iter_source_tracks),
+        patch.object(music.playlists, "tracks", iter_playlist_tracks),
         patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
         patch.object(music.tracks, "find_provider_match", find_match),
         patch.object(
@@ -348,7 +413,10 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
         )
 
     create_playlist.assert_awaited_once()
-    assert track_requests == [(("source", "spotify_1"), {"force_refresh": True})]
+    assert track_requests == [
+        (("source", "spotify_1"), {"force_refresh": True}),
+        (("target", "tidal_1"), {"force_refresh": True}),
+    ]
     target_provider.add_playlist_tracks.assert_awaited_once_with(
         "target",
         expected_target_ids,
@@ -365,6 +433,8 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
         expected_failures.append(
             call("Test Artist - Test Track: tidal does not support duplicate playlist entries")
         )
+    if "tidal-two" not in actual_target_ids:
+        expected_failures.append(call("Test Artist - Test Track: tidal did not add this track"))
     assert report_failure.call_args_list == expected_failures
     assert report_failure.call_count == expected_failure_count
     assert set_report.call_count == 2
@@ -448,6 +518,7 @@ async def test_builtin_migration_keeps_all_enriched_mappings(
         minimum_confidence=TrackMatchConfidence.LOOSE,
         provider_instance_ids={"builtin", "spotify_1"},
         trust_track_mappings=True,
+        failed_provider_instances=set(),
     )
     assert create_builtin.await_args is not None
     entries = create_builtin.await_args.args[1]
@@ -456,3 +527,32 @@ async def test_builtin_migration_keeps_all_enriched_mappings(
         {"spotify", "tidal"},
         {"spotify", "tidal"},
     ]
+
+
+async def test_builtin_resolution_does_not_return_unfiltered_track_on_failure(
+    music: MusicController,
+) -> None:
+    """A failed enrichment can not serialize the original out-of-scope mappings."""
+    source = create_track("spotify_1", "source")
+    builtin_provider = MagicMock(spec=MusicProvider)
+    builtin_provider.instance_id = "builtin"
+    builtin_provider.domain = "builtin"
+    builtin_provider.name = "Music Assistant"
+    failed_provider_instances: set[str] = set()
+
+    with patch.object(
+        music.tracks,
+        "enrich_provider_mappings",
+        AsyncMock(side_effect=ResourceTemporarilyUnavailable("Lookup failed")),
+    ):
+        result = await music.playlists._resolve_migration_track(
+            source,
+            builtin_provider,
+            TrackMatchConfidence.LIKELY,
+            {"builtin"},
+            False,
+            failed_provider_instances,
+        )
+
+    assert result.track is None
+    assert result.error == "Lookup failed"

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -29,6 +29,7 @@ from music_assistant.controllers.music.media.tracks import (
 from music_assistant.helpers.compare import TrackMatchConfidence
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.music_provider import MusicProvider
+from music_assistant.models.plugin import PluginProvider
 
 from .helpers import create_track
 
@@ -243,9 +244,11 @@ async def test_migration_resolves_tracks_in_bounded_batches(
     builtin_provider.instance_id = "builtin"
     builtin_provider.domain = "builtin"
     builtin_provider.name = "Music Assistant"
+    builtin_provider.available = True
     source_provider = MagicMock(spec=MusicProvider)
     source_provider.instance_id = "spotify_1"
     source_provider.domain = "spotify"
+    source_provider.available = True
     active_resolutions = 0
     max_active_resolutions = 0
 
@@ -288,7 +291,7 @@ async def test_migration_resolves_tracks_in_bounded_batches(
         patch.object(
             music.mass,
             "get_provider",
-            side_effect=lambda provider_instance_id: {
+            side_effect=lambda provider_instance_id, **_kwargs: {
                 "builtin": builtin_provider,
                 "spotify_1": source_provider,
             }[provider_instance_id],
@@ -321,6 +324,7 @@ async def test_migrate_playlist_queues_validated_task(
     target_provider.instance_id = "tidal_1"
     target_provider.domain = "tidal"
     target_provider.name = "Tidal"
+    target_provider.available = True
     target_provider.is_streaming_provider = True
     target_provider.supported_features = {
         ProviderFeature.PLAYLIST_CREATE,
@@ -330,6 +334,7 @@ async def test_migrate_playlist_queues_validated_task(
     source_provider = MagicMock(spec=MusicProvider)
     source_provider.instance_id = "spotify_1"
     source_provider.domain = "spotify"
+    source_provider.available = True
     queued_task = MagicMock()
     tasks = MagicMock()
     tasks.run_background_task.return_value = queued_task
@@ -343,7 +348,10 @@ async def test_migrate_playlist_queues_validated_task(
         patch.object(
             music.mass,
             "get_provider",
-            return_value=target_provider,
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "spotify_1": source_provider,
+                "tidal_1": target_provider,
+            }[provider_instance_id],
         ) as get_provider,
         patch.object(
             MusicController,
@@ -372,7 +380,10 @@ async def test_migrate_playlist_queues_validated_task(
         await tasks.run_background_task.call_args.kwargs["handler"]()
 
     assert result is queued_task
-    get_provider.assert_not_called()
+    get_provider.assert_called_once_with(
+        "spotify_1",
+        return_unavailable=True,
+    )
     assert "task_id" not in tasks.run_background_task.call_args.kwargs
     assert tasks.run_background_task.call_args.kwargs["metadata"]["match_policy"] == "best_effort"
     handle_migration.assert_awaited_once_with(
@@ -386,6 +397,72 @@ async def test_migrate_playlist_queues_validated_task(
     )
 
 
+async def test_migrate_playlist_accepts_static_plugin_source(
+    music: MusicController,
+) -> None:
+    """Static plugin playlists can be queued with untrusted source mappings."""
+    source_playlist = _playlist("1", "Smart", "smart_playlist_1", "source")
+    source_provider = MagicMock(spec=PluginProvider)
+    source_provider.instance_id = "smart_playlist_1"
+    source_provider.available = True
+    target_provider = MagicMock(spec=MusicProvider)
+    target_provider.instance_id = "tidal_1"
+    target_provider.domain = "tidal"
+    target_provider.name = "Tidal"
+    target_provider.available = True
+    target_provider.is_streaming_provider = True
+    target_provider.supported_features = {
+        ProviderFeature.PLAYLIST_CREATE,
+        ProviderFeature.PLAYLIST_TRACKS_EDIT,
+    }
+    target_provider.supported_media_types = {MediaType.TRACK}
+    tasks = MagicMock()
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(
+            MusicController,
+            "providers",
+            new_callable=PropertyMock,
+            return_value=[target_provider],
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            return_value=source_provider,
+        ) as get_provider,
+        patch.object(music.mass, "tasks", tasks, create=True),
+        patch.object(
+            music.playlists,
+            "_handle_migrate_playlist",
+            AsyncMock(),
+        ) as handle_migration,
+    ):
+        await music.playlists.migrate_playlist(
+            source_playlist.item_id,
+            destination_provider="tidal_1",
+        )
+        await tasks.run_background_task.call_args.kwargs["handler"]()
+
+    get_provider.assert_called_once_with(
+        "smart_playlist_1",
+        return_unavailable=True,
+    )
+    handle_migration.assert_awaited_once_with(
+        "1",
+        "source",
+        "smart_playlist_1",
+        "tidal_1",
+        "Smart",
+        PlaylistMigrationMatchPolicy.SAME_RECORDING,
+        ("tidal_1",),
+    )
+
+
 async def test_migrate_playlist_rejects_filtered_source_provider(
     music: MusicController,
 ) -> None:
@@ -394,10 +471,12 @@ async def test_migrate_playlist_rejects_filtered_source_provider(
     source_provider = MagicMock(spec=MusicProvider)
     source_provider.instance_id = "spotify_1"
     source_provider.domain = "spotify"
+    source_provider.available = True
     target_provider = MagicMock(spec=MusicProvider)
     target_provider.instance_id = "tidal_1"
     target_provider.domain = "tidal"
     target_provider.name = "Tidal"
+    target_provider.available = True
     target_provider.is_streaming_provider = True
     target_provider.supported_features = {
         ProviderFeature.PLAYLIST_CREATE,
@@ -474,11 +553,108 @@ async def test_migration_handler_revalidates_dynamic_source(
         )
 
 
+async def test_migration_handler_rejects_unavailable_destination_instance(
+    music: MusicController,
+) -> None:
+    """A deferred migration can not switch to another destination account."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    unavailable_provider = MagicMock(spec=MusicProvider)
+    unavailable_provider.instance_id = "qobuz_1"
+    unavailable_provider.available = False
+    outside_scope_provider = MagicMock(spec=MusicProvider)
+    outside_scope_provider.instance_id = "qobuz_2"
+    outside_scope_provider.available = True
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda _provider_instance_id, return_unavailable=False: (
+                unavailable_provider if return_unavailable else outside_scope_provider
+            ),
+        ),
+        pytest.raises(ProviderUnavailableError, match="qobuz_1"),
+    ):
+        await music.playlists._handle_migrate_playlist(
+            source_playlist.item_id,
+            "source",
+            "spotify_1",
+            "qobuz_1",
+            "Migrated",
+            PlaylistMigrationMatchPolicy.SAME_RECORDING,
+            ("qobuz_1", "spotify_1"),
+        )
+
+
+async def test_playlist_tracks_strict_provider_lookup_rejects_fallback(
+    music: MusicController,
+) -> None:
+    """A strict playlist read can not switch to another provider account."""
+    unavailable_provider = MagicMock(spec=MusicProvider)
+    unavailable_provider.instance_id = "qobuz_1"
+    unavailable_provider.available = False
+    outside_scope_provider = MagicMock(spec=MusicProvider)
+    outside_scope_provider.instance_id = "qobuz_2"
+    outside_scope_provider.available = True
+
+    with (
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda _provider_instance_id, return_unavailable=False: (
+                unavailable_provider if return_unavailable else outside_scope_provider
+            ),
+        ),
+        pytest.raises(ProviderUnavailableError, match="qobuz_1"),
+    ):
+        _ = [
+            item
+            async for item in music.playlists.tracks(
+                "source",
+                "qobuz_1",
+                strict_provider_instance=True,
+            )
+        ]
+
+
+async def test_create_playlist_strict_provider_lookup_rejects_fallback(
+    music: MusicController,
+) -> None:
+    """Strict playlist creation can not switch to another provider account."""
+    unavailable_provider = MagicMock(spec=MusicProvider)
+    unavailable_provider.instance_id = "qobuz_1"
+    unavailable_provider.available = False
+    outside_scope_provider = MagicMock(spec=MusicProvider)
+    outside_scope_provider.instance_id = "qobuz_2"
+    outside_scope_provider.available = True
+
+    with (
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda _provider_instance_id, return_unavailable=False: (
+                unavailable_provider if return_unavailable else outside_scope_provider
+            ),
+        ),
+        pytest.raises(ProviderUnavailableError),
+    ):
+        await music.playlists.create_playlist(
+            "Migrated",
+            provider_instance_or_domain="qobuz_1",
+            strict_provider_instance=True,
+        )
+
+
 async def test_migration_reports_unsupported_source_items(
     music: MusicController,
 ) -> None:
     """Mixed playlists include unsupported entries in skipped totals and reports."""
-    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    source_playlist = _playlist("1", "Source", "smart_playlist_1", "source")
     source_track = create_track("spotify_1", "track")
     source_radio = Radio(
         item_id="radio",
@@ -491,9 +667,11 @@ async def test_migration_reports_unsupported_source_items(
     builtin_provider.instance_id = "builtin"
     builtin_provider.domain = "builtin"
     builtin_provider.name = "Music Assistant"
-    source_provider = MagicMock(spec=MusicProvider)
-    source_provider.instance_id = "spotify_1"
-    source_provider.domain = "spotify"
+    builtin_provider.available = True
+    source_provider = MagicMock(spec=PluginProvider)
+    source_provider.instance_id = "smart_playlist_1"
+    source_provider.domain = "smart_playlist"
+    source_provider.available = True
     enrichment = TrackProviderEnrichment(
         track=source_track,
         matches=(),
@@ -517,13 +695,13 @@ async def test_migration_reports_unsupported_source_items(
             music.tracks,
             "enrich_provider_mappings",
             AsyncMock(return_value=enrichment),
-        ),
+        ) as enrich,
         patch.object(
             music.mass,
             "get_provider",
-            side_effect=lambda provider_instance_id: {
+            side_effect=lambda provider_instance_id, **_kwargs: {
                 "builtin": builtin_provider,
-                "spotify_1": source_provider,
+                "smart_playlist_1": source_provider,
             }[provider_instance_id],
         ),
         patch.object(
@@ -541,7 +719,7 @@ async def test_migration_reports_unsupported_source_items(
         await music.playlists._handle_migrate_playlist(
             source_playlist.item_id,
             "source",
-            "spotify_1",
+            "smart_playlist_1",
             "builtin",
             "Migrated",
             PlaylistMigrationMatchPolicy.SAME_RECORDING,
@@ -549,6 +727,8 @@ async def test_migration_reports_unsupported_source_items(
         )
 
     report_failure.assert_called_once_with("Test Radio: radio entries are not supported")
+    assert enrich.await_args is not None
+    assert enrich.await_args.kwargs["trust_track_mappings"] is False
     final_report = set_report.call_args.args[0]
     assert "Migrated **1** of **2** playlist items" in final_report
     assert "| Skipped | 1 |" in final_report
@@ -562,7 +742,6 @@ async def test_migration_reports_unsupported_source_items(
         "expected_target_ids",
         "actual_target_ids",
         "expected_verification_failures",
-        "expected_failure_count",
     ),
     [
         (
@@ -570,28 +749,24 @@ async def test_migration_reports_unsupported_source_items(
             ["tidal-one", "tidal-two", "tidal-one"],
             ["tidal-one", "tidal-two", "tidal-one"],
             [],
-            1,
         ),
         (
             False,
             ["tidal-one", "tidal-two"],
             ["tidal-one", "tidal-two"],
             [],
-            2,
         ),
         (
             True,
             ["tidal-one", "tidal-two", "tidal-one"],
             ["tidal-one", "tidal-one"],
             ["Test Artist - Test Track: tidal did not add this track in the expected order"],
-            2,
         ),
         (
             True,
             ["tidal-one", "tidal-two", "tidal-one"],
             None,
             ["Could not verify destination playlist: Verification failed (TimeoutError)"],
-            2,
         ),
         (
             True,
@@ -601,7 +776,6 @@ async def test_migration_reports_unsupported_source_items(
                 "Test Artist - Test Track: tidal did not add this track in the expected order",
                 "Destination playlist contains unexpected or reordered tracks",
             ],
-            3,
         ),
     ],
 )
@@ -611,7 +785,6 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
     expected_target_ids: list[str],
     actual_target_ids: list[str] | None,
     expected_verification_failures: list[str],
-    expected_failure_count: int,
 ) -> None:
     """A provider migration preserves supported duplicates and reports unsupported ones."""
     source_playlist = _playlist("1", "Source", "spotify_1", "source")
@@ -625,11 +798,13 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
     target_provider.instance_id = "tidal_1"
     target_provider.domain = "tidal"
     target_provider.name = "Tidal"
+    target_provider.available = True
     target_provider.playlist_duplicates_supported = duplicates_supported
     target_provider.add_playlist_tracks = AsyncMock()
     source_provider = MagicMock(spec=MusicProvider)
     source_provider.instance_id = "spotify_1"
     source_provider.domain = "spotify"
+    source_provider.available = True
     track_requests: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
     async def iter_playlist_tracks(*args: object, **kwargs: object) -> AsyncGenerator[Track]:
@@ -681,7 +856,7 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
         patch.object(
             music.mass,
             "get_provider",
-            side_effect=lambda provider_instance_id: {
+            side_effect=lambda provider_instance_id, **_kwargs: {
                 "spotify_1": source_provider,
                 "tidal_1": target_provider,
             }[provider_instance_id],
@@ -718,10 +893,21 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
             ("spotify_1", "tidal_1"),
         )
 
-    create_playlist.assert_awaited_once()
+    create_playlist.assert_awaited_once_with(
+        "Migrated",
+        media_types=[MediaType.TRACK],
+        provider_instance_or_domain="tidal_1",
+        strict_provider_instance=True,
+    )
     assert track_requests == [
-        (("source", "spotify_1"), {"force_refresh": True}),
-        (("target", "tidal_1"), {"force_refresh": True}),
+        (
+            ("source", "spotify_1"),
+            {"force_refresh": True, "strict_provider_instance": True},
+        ),
+        (
+            ("target", "tidal_1"),
+            {"force_refresh": True, "strict_provider_instance": True},
+        ),
     ]
     target_provider.add_playlist_tracks.assert_awaited_once_with(
         "target",
@@ -741,7 +927,6 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
         )
     expected_failures.extend(call(message) for message in expected_verification_failures)
     assert report_failure.call_args_list == expected_failures
-    assert report_failure.call_count == expected_failure_count
     assert set_report.call_count == 2
     final_report = set_report.call_args.args[0]
     assert "### Skipped items" in final_report
@@ -766,9 +951,11 @@ async def test_builtin_migration_keeps_all_enriched_mappings(
     builtin_provider.instance_id = "builtin"
     builtin_provider.domain = "builtin"
     builtin_provider.name = "Music Assistant"
+    builtin_provider.available = True
     source_provider = MagicMock(spec=MusicProvider)
     source_provider.instance_id = "spotify_1"
     source_provider.domain = "spotify"
+    source_provider.available = True
     destination_playlist = _playlist("2", "Migrated", "builtin", "migrated")
 
     async def iter_source_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Track]:
@@ -800,7 +987,7 @@ async def test_builtin_migration_keeps_all_enriched_mappings(
         patch.object(
             music.mass,
             "get_provider",
-            side_effect=lambda provider_instance_id: {
+            side_effect=lambda provider_instance_id, **_kwargs: {
                 "builtin": builtin_provider,
                 "spotify_1": source_provider,
             }[provider_instance_id],

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -11,7 +11,6 @@ from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import (
     InvalidDataError,
     ProviderUnavailableError,
-    ResourceTemporarilyUnavailable,
 )
 from music_assistant_models.media_items import Playlist, ProviderMapping, Track
 
@@ -351,7 +350,7 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
             )
         else:
             if actual_target_ids is None:
-                raise ResourceTemporarilyUnavailable("Verification timed out")
+                raise TimeoutError
             target_tracks = {
                 "tidal-one": target_one,
                 "tidal-two": target_two,
@@ -445,7 +444,7 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
         expected_failures.append(call("Test Artist - Test Track: tidal did not add this track"))
     if actual_target_ids is None:
         expected_failures.append(
-            call("Could not verify destination playlist: Verification timed out")
+            call("Could not verify destination playlist: Verification failed (TimeoutError)")
         )
     assert report_failure.call_args_list == expected_failures
     assert report_failure.call_count == expected_failure_count
@@ -555,7 +554,7 @@ async def test_builtin_resolution_does_not_return_unfiltered_track_on_failure(
     with patch.object(
         music.tracks,
         "enrich_provider_mappings",
-        AsyncMock(side_effect=ResourceTemporarilyUnavailable("Lookup failed")),
+        AsyncMock(side_effect=TimeoutError()),
     ):
         result = await music.playlists._resolve_migration_track(
             source,
@@ -567,4 +566,4 @@ async def test_builtin_resolution_does_not_return_unfiltered_track_on_failure(
         )
 
     assert result.track is None
-    assert result.error == "Lookup failed"
+    assert result.error == "Matching failed on Music Assistant (TimeoutError)"

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
 from music_assistant_models.enums import MediaType, ProviderFeature
-from music_assistant_models.errors import InvalidDataError
+from music_assistant_models.errors import InvalidDataError, ProviderUnavailableError
 from music_assistant_models.media_items import Playlist, ProviderMapping, Track
 
 from music_assistant.controllers.music import MusicController
@@ -123,6 +123,9 @@ async def test_migrate_playlist_queues_validated_task(
         ProviderFeature.PLAYLIST_TRACKS_EDIT,
     }
     target_provider.supported_media_types = {MediaType.TRACK}
+    source_provider = MagicMock(spec=MusicProvider)
+    source_provider.instance_id = "spotify_1"
+    source_provider.domain = "spotify"
     queued_task = MagicMock()
     tasks = MagicMock()
     tasks.run_background_task.return_value = queued_task
@@ -142,7 +145,7 @@ async def test_migrate_playlist_queues_validated_task(
             MusicController,
             "providers",
             new_callable=PropertyMock,
-            return_value=[target_provider],
+            return_value=[source_provider, target_provider],
         ),
         patch.object(
             music.mass,
@@ -177,6 +180,50 @@ async def test_migrate_playlist_queues_validated_task(
         PlaylistMigrationMatchPolicy.BEST_EFFORT,
         ("spotify_1", "tidal_1"),
     )
+
+
+async def test_migrate_playlist_rejects_filtered_source_provider(
+    music: MusicController,
+) -> None:
+    """A deferred migration can not expand the initiating user's provider scope."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    source_provider = MagicMock(spec=MusicProvider)
+    source_provider.instance_id = "spotify_1"
+    source_provider.domain = "spotify"
+    target_provider = MagicMock(spec=MusicProvider)
+    target_provider.instance_id = "tidal_1"
+    target_provider.domain = "tidal"
+    target_provider.name = "Tidal"
+    target_provider.is_streaming_provider = True
+    target_provider.supported_features = {
+        ProviderFeature.PLAYLIST_CREATE,
+        ProviderFeature.PLAYLIST_TRACKS_EDIT,
+    }
+    target_provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(
+            MusicController,
+            "providers",
+            new_callable=PropertyMock,
+            return_value=[target_provider],
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            return_value=source_provider,
+        ),
+        pytest.raises(ProviderUnavailableError, match="spotify_1"),
+    ):
+        await music.playlists.migrate_playlist(
+            source_playlist.item_id,
+            destination_provider=target_provider.instance_id,
+        )
 
 
 async def test_migrate_playlist_rejects_dynamic_source(

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -1,0 +1,283 @@
+"""Tests for playlist migration."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from copy import deepcopy
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.errors import InvalidDataError
+from music_assistant_models.media_items import Playlist, ProviderMapping, Track
+
+from music_assistant.controllers.music import MusicController
+from music_assistant.controllers.music.media.playlists import (
+    PlaylistMigrationMatchPolicy,
+)
+from music_assistant.controllers.music.media.tracks import (
+    TrackProviderEnrichment,
+    TrackProviderMatch,
+    TrackProviderMatchResult,
+)
+from music_assistant.helpers.compare import TrackMatchConfidence
+from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
+
+from .helpers import create_track
+
+
+@pytest.fixture
+async def music(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicController]:
+    """Return a music controller attached to the minimal mass instance."""
+    controller = MusicController(mass_minimal)
+    mass_minimal.music = controller
+    yield controller
+    if controller._database:
+        await controller._database.close()
+
+
+def _playlist(
+    item_id: str,
+    name: str,
+    provider_instance: str,
+    provider_item_id: str,
+) -> Playlist:
+    """Build a provider-backed playlist."""
+    return Playlist(
+        item_id=item_id,
+        provider="library",
+        name=name,
+        provider_mappings={
+            ProviderMapping(
+                item_id=provider_item_id,
+                provider_domain=provider_instance.split("_", maxsplit=1)[0],
+                provider_instance=provider_instance,
+            )
+        },
+        owner="Test",
+        is_editable=True,
+    )
+
+
+async def test_migrate_playlist_queues_validated_task(
+    music: MusicController,
+) -> None:
+    """The public command validates its destination and queues a managed task."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    target_provider = MagicMock(spec=MusicProvider)
+    target_provider.instance_id = "tidal_1"
+    target_provider.domain = "tidal"
+    target_provider.name = "Tidal"
+    target_provider.is_streaming_provider = True
+    target_provider.supported_features = {
+        ProviderFeature.PLAYLIST_CREATE,
+        ProviderFeature.PLAYLIST_TRACKS_EDIT,
+    }
+    target_provider.supported_media_types = {MediaType.TRACK}
+    queued_task = MagicMock()
+    tasks = MagicMock()
+    tasks.run_background_task.return_value = queued_task
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(music.mass, "get_provider", return_value=target_provider),
+        patch.object(
+            MusicController,
+            "providers",
+            new_callable=PropertyMock,
+            return_value=[target_provider],
+        ),
+        patch.object(
+            music.mass,
+            "tasks",
+            tasks,
+            create=True,
+        ),
+    ):
+        result = await music.playlists.migrate_playlist(
+            source_playlist.item_id,
+            destination_provider=target_provider.instance_id,
+            name="Migrated",
+            match_policy=PlaylistMigrationMatchPolicy.BEST_EFFORT,
+        )
+
+    assert result is queued_task
+    assert tasks.run_background_task.call_args.kwargs["task_id"] == (
+        "playlist_migration.1.tidal_1.best_effort"
+    )
+    assert tasks.run_background_task.call_args.kwargs["metadata"]["match_policy"] == "best_effort"
+
+
+async def test_migrate_playlist_rejects_dynamic_source(
+    music: MusicController,
+) -> None:
+    """A changing dynamic playlist can not be copied as a stable migration."""
+    source_playlist = _playlist("1", "Dynamic", "spotify_1", "source")
+    source_playlist.is_dynamic = True
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        pytest.raises(InvalidDataError, match="Dynamic playlists"),
+    ):
+        await music.playlists.migrate_playlist(source_playlist.item_id)
+
+
+async def test_streaming_migration_preserves_order_and_duplicates(
+    music: MusicController,
+) -> None:
+    """A provider migration resolves unique tracks once and preserves source order."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    source_one = create_track("spotify_1", "one")
+    source_two = create_track("spotify_1", "two")
+    source_missing = create_track("spotify_1", "missing")
+    target_one = create_track("tidal_1", "tidal-one")
+    target_two = create_track("tidal_1", "tidal-two")
+    target_playlist = _playlist("2", "Migrated", "tidal_1", "target")
+    target_provider = MagicMock(spec=MusicProvider)
+    target_provider.instance_id = "tidal_1"
+    target_provider.domain = "tidal"
+    target_provider.name = "Tidal"
+    target_provider.add_playlist_tracks = AsyncMock()
+
+    async def iter_source_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Track]:
+        for track in (
+            source_one,
+            source_two,
+            source_one,
+            source_missing,
+            source_missing,
+        ):
+            yield track
+
+    matches = {
+        "one": TrackProviderMatchResult(
+            match=TrackProviderMatch(
+                track=target_one,
+                mapping=next(iter(target_one.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            )
+        ),
+        "two": TrackProviderMatchResult(
+            match=TrackProviderMatch(
+                track=target_two,
+                mapping=next(iter(target_two.provider_mappings)),
+                confidence=TrackMatchConfidence.LIKELY,
+            )
+        ),
+        "missing": TrackProviderMatchResult(),
+    }
+    find_match = AsyncMock(side_effect=lambda track, *_args, **_kwargs: matches[track.item_id])
+
+    with (
+        patch.object(music.playlists, "get_library_item", AsyncMock(return_value=source_playlist)),
+        patch.object(music.playlists, "tracks", iter_source_tracks),
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "find_provider_match", find_match),
+        patch.object(music.mass, "get_provider", return_value=target_provider),
+        patch.object(
+            music.playlists,
+            "create_playlist",
+            AsyncMock(return_value=target_playlist),
+        ) as create_playlist,
+        patch.object(
+            music.playlists,
+            "_select_provider_id",
+            return_value=("tidal_1", "target"),
+        ),
+        patch.object(music.playlists, "update_item_in_library", AsyncMock()),
+        patch(
+            "music_assistant.controllers.music.media.playlists.report_current_task_failure"
+        ) as report_failure,
+    ):
+        await music.playlists._handle_migrate_playlist(
+            source_playlist.item_id,
+            target_provider.instance_id,
+            "Migrated",
+            PlaylistMigrationMatchPolicy.SAME_RECORDING,
+        )
+
+    create_playlist.assert_awaited_once()
+    target_provider.add_playlist_tracks.assert_awaited_once_with(
+        "target",
+        ["tidal-one", "tidal-two", "tidal-one"],
+    )
+    assert find_match.await_count == 3
+    report_failure.assert_called_once_with("Test Artist - Test Track: no acceptable match")
+
+
+async def test_builtin_migration_keeps_all_enriched_mappings(
+    music: MusicController,
+) -> None:
+    """A Music Assistant playlist stores every resolved mapping without deduplication."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    source = create_track("spotify_1", "one")
+    enriched = deepcopy(source)
+    tidal_mapping = ProviderMapping(
+        item_id="tidal-one",
+        provider_domain="tidal",
+        provider_instance="tidal_1",
+    )
+    enriched.provider_mappings.add(tidal_mapping)
+    builtin_provider = MagicMock(spec=MusicProvider)
+    builtin_provider.instance_id = "builtin"
+    builtin_provider.domain = "builtin"
+    builtin_provider.name = "Music Assistant"
+    destination_playlist = _playlist("2", "Migrated", "builtin", "migrated")
+
+    async def iter_source_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Track]:
+        yield source
+        yield source
+
+    enrichment = TrackProviderEnrichment(
+        track=enriched,
+        matches=(
+            TrackProviderMatch(
+                track=enriched,
+                mapping=tidal_mapping,
+                confidence=TrackMatchConfidence.LIKELY,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=True,
+    )
+
+    with (
+        patch.object(music.playlists, "get_library_item", AsyncMock(return_value=source_playlist)),
+        patch.object(music.playlists, "tracks", iter_source_tracks),
+        patch.object(
+            music.tracks,
+            "enrich_provider_mappings",
+            AsyncMock(return_value=enrichment),
+        ) as enrich,
+        patch.object(music.mass, "get_provider", return_value=builtin_provider),
+        patch.object(
+            music.playlists,
+            "_create_builtin_migration_playlist",
+            AsyncMock(return_value=destination_playlist),
+        ) as create_builtin,
+    ):
+        await music.playlists._handle_migrate_playlist(
+            source_playlist.item_id,
+            builtin_provider.instance_id,
+            "Migrated",
+            PlaylistMigrationMatchPolicy.BEST_EFFORT,
+        )
+
+    assert enrich.await_count == 1
+    assert create_builtin.await_args is not None
+    entries = create_builtin.await_args.args[1]
+    assert len(entries) == 2
+    assert [{provider.domain for provider in entry.providers} for entry in entries] == [
+        {"spotify", "tidal"},
+        {"spotify", "tidal"},
+    ]

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from copy import deepcopy
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
 from music_assistant_models.enums import MediaType, ProviderFeature
@@ -192,10 +192,20 @@ async def test_migrate_playlist_rejects_dynamic_source(
         await music.playlists.migrate_playlist(source_playlist.item_id)
 
 
-async def test_streaming_migration_preserves_order_and_duplicates(
+@pytest.mark.parametrize(
+    ("duplicates_supported", "expected_target_ids", "expected_failure_count"),
+    [
+        (True, ["tidal-one", "tidal-two", "tidal-one"], 1),
+        (False, ["tidal-one", "tidal-two"], 2),
+    ],
+)
+async def test_streaming_migration_handles_provider_duplicate_policy(
     music: MusicController,
+    duplicates_supported: bool,
+    expected_target_ids: list[str],
+    expected_failure_count: int,
 ) -> None:
-    """A provider migration resolves unique tracks once and preserves source order."""
+    """A provider migration preserves supported duplicates and reports unsupported ones."""
     source_playlist = _playlist("1", "Source", "spotify_1", "source")
     source_one = create_track("spotify_1", "one")
     source_two = create_track("spotify_1", "two")
@@ -207,6 +217,7 @@ async def test_streaming_migration_preserves_order_and_duplicates(
     target_provider.instance_id = "tidal_1"
     target_provider.domain = "tidal"
     target_provider.name = "Tidal"
+    target_provider.playlist_duplicates_supported = duplicates_supported
     target_provider.add_playlist_tracks = AsyncMock()
 
     async def iter_source_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Track]:
@@ -275,14 +286,22 @@ async def test_streaming_migration_preserves_order_and_duplicates(
     create_playlist.assert_awaited_once()
     target_provider.add_playlist_tracks.assert_awaited_once_with(
         "target",
-        ["tidal-one", "tidal-two", "tidal-one"],
+        expected_target_ids,
     )
     assert find_match.await_count == 3
     assert all(
         call.kwargs["allowed_provider_instances"] == {"spotify_1", "tidal_1"}
         for call in find_match.await_args_list
     )
-    report_failure.assert_called_once_with("Test Artist - Test Track: no acceptable match")
+    expected_failures = [
+        call("Test Artist - Test Track: no acceptable match"),
+    ]
+    if not duplicates_supported:
+        expected_failures.append(
+            call("Test Artist - Test Track: tidal does not support duplicate playlist entries")
+        )
+    assert report_failure.call_args_list == expected_failures
+    assert report_failure.call_count == expected_failure_count
     assert set_report.call_count == 2
     assert "### Skipped tracks" in set_report.call_args.args[0]
 

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -91,6 +91,23 @@ def test_migration_report_renders_substitutions_and_skips() -> None:
     assert "Artist - Missing" in report
 
 
+async def test_provider_playlist_additions_are_batched_in_order() -> None:
+    """Large playlist writes respect common provider request limits."""
+    provider = MagicMock(spec=MusicProvider)
+    provider.add_playlist_tracks = AsyncMock()
+    track_ids = [str(index) for index in range(205)]
+
+    await PlaylistController._add_provider_playlist_tracks(
+        provider,
+        "playlist",
+        track_ids,
+    )
+
+    batches = [call.args[1] for call in provider.add_playlist_tracks.await_args_list]
+    assert [len(batch) for batch in batches] == [100, 100, 5]
+    assert [track_id for batch in batches for track_id in batch] == track_ids
+
+
 async def test_migrate_playlist_queues_validated_task(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -13,7 +13,7 @@ from music_assistant_models.errors import (
     InvalidDataError,
     ProviderUnavailableError,
 )
-from music_assistant_models.media_items import Playlist, ProviderMapping, Track
+from music_assistant_models.media_items import Playlist, ProviderMapping, Radio, Track
 
 from music_assistant.controllers.music import MusicController
 from music_assistant.controllers.music.media.playlists import (
@@ -448,6 +448,114 @@ async def test_migrate_playlist_rejects_dynamic_source(
         await music.playlists.migrate_playlist(source_playlist.item_id)
 
 
+async def test_migration_handler_revalidates_dynamic_source(
+    music: MusicController,
+) -> None:
+    """A queued migration stops if its source playlist becomes dynamic."""
+    source_playlist = _playlist("1", "Dynamic", "spotify_1", "source")
+    source_playlist.is_dynamic = True
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        pytest.raises(InvalidDataError, match="Dynamic playlists"),
+    ):
+        await music.playlists._handle_migrate_playlist(
+            source_playlist.item_id,
+            "source",
+            "spotify_1",
+            "tidal_1",
+            "Migrated",
+            PlaylistMigrationMatchPolicy.SAME_RECORDING,
+            ("spotify_1", "tidal_1"),
+        )
+
+
+async def test_migration_reports_unsupported_source_items(
+    music: MusicController,
+) -> None:
+    """Mixed playlists include unsupported entries in skipped totals and reports."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    source_track = create_track("spotify_1", "track")
+    source_radio = Radio(
+        item_id="radio",
+        provider="spotify_1",
+        name="Test Radio",
+        provider_mappings=set(),
+    )
+    destination_playlist = _playlist("2", "Migrated", "builtin", "migrated")
+    builtin_provider = MagicMock(spec=MusicProvider)
+    builtin_provider.instance_id = "builtin"
+    builtin_provider.domain = "builtin"
+    builtin_provider.name = "Music Assistant"
+    source_provider = MagicMock(spec=MusicProvider)
+    source_provider.instance_id = "spotify_1"
+    source_provider.domain = "spotify"
+    enrichment = TrackProviderEnrichment(
+        track=source_track,
+        matches=(),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+
+    async def iter_source_items(*_args: object, **_kwargs: object) -> AsyncGenerator[Track | Radio]:
+        yield source_track
+        yield source_radio
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(music.playlists, "tracks", iter_source_items),
+        patch.object(
+            music.tracks,
+            "enrich_provider_mappings",
+            AsyncMock(return_value=enrichment),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id: {
+                "builtin": builtin_provider,
+                "spotify_1": source_provider,
+            }[provider_instance_id],
+        ),
+        patch.object(
+            music.playlists,
+            "_create_builtin_migration_playlist",
+            AsyncMock(return_value=destination_playlist),
+        ),
+        patch(
+            "music_assistant.controllers.music.media.playlists.report_current_task_failure"
+        ) as report_failure,
+        patch(
+            "music_assistant.controllers.music.media.playlists.set_current_task_report"
+        ) as set_report,
+    ):
+        await music.playlists._handle_migrate_playlist(
+            source_playlist.item_id,
+            "source",
+            "spotify_1",
+            "builtin",
+            "Migrated",
+            PlaylistMigrationMatchPolicy.SAME_RECORDING,
+            ("builtin", "spotify_1"),
+        )
+
+    report_failure.assert_called_once_with("Test Radio: radio entries are not supported")
+    final_report = set_report.call_args.args[0]
+    assert "Migrated **1** of **2** playlist items" in final_report
+    assert "| Skipped | 1 |" in final_report
+    assert "### Skipped items" in final_report
+    assert "Test Radio" in final_report
+
+
 @pytest.mark.parametrize(
     (
         "duplicates_supported",
@@ -636,7 +744,7 @@ async def test_streaming_migration_handles_provider_duplicate_policy(
     assert report_failure.call_count == expected_failure_count
     assert set_report.call_count == 2
     final_report = set_report.call_args.args[0]
-    assert "### Skipped tracks" in final_report
+    assert "### Skipped items" in final_report
     if actual_target_ids == ["tidal-one", "tidal-one"]:
         assert "### Substitutions" not in final_report
 

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -146,6 +146,11 @@ async def test_migrate_playlist_queues_validated_task(
             tasks,
             create=True,
         ),
+        patch.object(
+            music.playlists,
+            "_handle_migrate_playlist",
+            AsyncMock(),
+        ) as handle_migration,
     ):
         result = await music.playlists.migrate_playlist(
             source_playlist.item_id,
@@ -153,12 +158,20 @@ async def test_migrate_playlist_queues_validated_task(
             name="Migrated",
             match_policy=PlaylistMigrationMatchPolicy.BEST_EFFORT,
         )
+        await tasks.run_background_task.call_args.kwargs["handler"]()
 
     assert result is queued_task
-    assert tasks.run_background_task.call_args.kwargs["task_id"] == (
-        "playlist_migration.1.tidal_1.best_effort"
-    )
+    assert "task_id" not in tasks.run_background_task.call_args.kwargs
     assert tasks.run_background_task.call_args.kwargs["metadata"]["match_policy"] == "best_effort"
+    handle_migration.assert_awaited_once_with(
+        "1",
+        "source",
+        "spotify_1",
+        "tidal_1",
+        "Migrated",
+        PlaylistMigrationMatchPolicy.BEST_EFFORT,
+        ("spotify_1", "tidal_1"),
+    )
 
 
 async def test_migrate_playlist_rejects_dynamic_source(
@@ -251,9 +264,12 @@ async def test_streaming_migration_preserves_order_and_duplicates(
     ):
         await music.playlists._handle_migrate_playlist(
             source_playlist.item_id,
+            "source",
+            "spotify_1",
             target_provider.instance_id,
             "Migrated",
             PlaylistMigrationMatchPolicy.SAME_RECORDING,
+            ("spotify_1", "tidal_1"),
         )
 
     create_playlist.assert_awaited_once()
@@ -262,6 +278,10 @@ async def test_streaming_migration_preserves_order_and_duplicates(
         ["tidal-one", "tidal-two", "tidal-one"],
     )
     assert find_match.await_count == 3
+    assert all(
+        call.kwargs["allowed_provider_instances"] == {"spotify_1", "tidal_1"}
+        for call in find_match.await_args_list
+    )
     report_failure.assert_called_once_with("Test Artist - Test Track: no acceptable match")
     assert set_report.call_count == 2
     assert "### Skipped tracks" in set_report.call_args.args[0]
@@ -321,12 +341,19 @@ async def test_builtin_migration_keeps_all_enriched_mappings(
     ):
         await music.playlists._handle_migrate_playlist(
             source_playlist.item_id,
+            "source",
+            "spotify_1",
             builtin_provider.instance_id,
             "Migrated",
             PlaylistMigrationMatchPolicy.BEST_EFFORT,
+            ("builtin", "spotify_1"),
         )
 
-    assert enrich.await_count == 1
+    enrich.assert_awaited_once_with(
+        source,
+        minimum_confidence=TrackMatchConfidence.LOOSE,
+        provider_instance_ids={"builtin", "spotify_1"},
+    )
     assert create_builtin.await_args is not None
     entries = create_builtin.await_args.args[1]
     assert len(entries) == 2

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -201,14 +201,14 @@ async def test_search_provider_does_not_substitute_unavailable_scoped_instance()
     )
     controller._search_provider = AsyncMock()  # type: ignore[method-assign]
 
-    result = await controller.search_provider(
-        "My Song",
-        "qobuz_1",
-        [MediaType.TRACK],
-        allowed_provider_instances={"qobuz_1"},
-    )
+    with pytest.raises(ResourceTemporarilyUnavailable, match="qobuz_1"):
+        await controller.search_provider(
+            "My Song",
+            "qobuz_1",
+            [MediaType.TRACK],
+            allowed_provider_instances={"qobuz_1"},
+        )
 
-    assert result == SearchResults()
     controller._search_provider.assert_not_awaited()
     controller.mass.get_provider.assert_called_once_with(
         "qobuz_1",
@@ -235,7 +235,7 @@ async def test_internal_search_rejects_strict_instance_fallback() -> None:
         strict_provider_instance=True,
     )
 
-    assert result == SearchResults()
+    assert result is None
     outside_scope_provider.search.assert_not_awaited()
 
 

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -133,6 +133,30 @@ async def _wait_for(condition: Callable[[], bool], timeout: float = 1.0) -> None
             await asyncio.sleep(0.01)
 
 
+async def test_search_provider_uses_centralized_provider_search() -> None:
+    """A single-provider lookup uses the cached and timeout-bounded search path."""
+    provider = _make_search_provider("prov_a")
+    controller = _make_controller([provider])
+    expected = SearchResults(tracks=[_make_track("track1", "prov_a", "My Song")])
+    controller._apply_user_provider_filter = Mock(return_value=[provider])  # type: ignore[method-assign]
+    controller._search_provider = AsyncMock(return_value=expected)  # type: ignore[method-assign]
+
+    result = await controller.search_provider(
+        "My Song",
+        provider.instance_id,
+        [MediaType.TRACK],
+        limit=5,
+    )
+
+    assert result == expected
+    controller._search_provider.assert_awaited_once_with(
+        "My Song",
+        provider.instance_id,
+        [MediaType.TRACK],
+        limit=5,
+    )
+
+
 async def test_search_provider_returns_none_on_provider_error() -> None:
     """A provider error during search yields None instead of raising."""
     prov = _make_search_provider("prov_a")

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -138,7 +138,7 @@ async def test_search_provider_uses_centralized_provider_search() -> None:
     provider = _make_search_provider("prov_a")
     controller = _make_controller([provider])
     expected = SearchResults(tracks=[_make_track("track1", "prov_a", "My Song")])
-    controller._apply_user_provider_filter = Mock(return_value=[provider])  # type: ignore[method-assign]
+    controller._apply_user_provider_filter = Mock(return_value=[])  # type: ignore[method-assign]
     controller._search_provider = AsyncMock(return_value=expected)  # type: ignore[method-assign]
 
     result = await controller.search_provider(
@@ -146,6 +146,7 @@ async def test_search_provider_uses_centralized_provider_search() -> None:
         provider.instance_id,
         [MediaType.TRACK],
         limit=5,
+        allowed_provider_instances={"prov_a"},
     )
 
     assert result == expected

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -71,6 +71,7 @@ def _make_search_provider(instance_id: str, domain: str | None = None) -> Mock:
     prov.instance_id = instance_id
     prov.domain = domain or instance_id
     prov.name = instance_id
+    prov.available = True
     prov.supported_features = {ProviderFeature.SEARCH}
     prov.is_streaming_provider = True
     prov.search = AsyncMock(return_value=SearchResults())
@@ -157,6 +158,7 @@ async def test_search_provider_uses_centralized_provider_search() -> None:
         provider.instance_id,
         [MediaType.TRACK],
         limit=5,
+        strict_provider_instance=True,
     )
 
 
@@ -182,7 +184,59 @@ async def test_search_provider_resolves_domain_within_explicit_scope() -> None:
         "qobuz_2",
         [MediaType.TRACK],
         limit=5,
+        strict_provider_instance=True,
     )
+
+
+async def test_search_provider_does_not_substitute_unavailable_scoped_instance() -> None:
+    """An unavailable scoped account can not fall back to another account."""
+    unavailable_provider = _make_search_provider("qobuz_1", domain="qobuz")
+    unavailable_provider.available = False
+    outside_scope_provider = _make_search_provider("qobuz_2", domain="qobuz")
+    controller = _make_controller([unavailable_provider, outside_scope_provider])
+    controller.mass.get_provider = Mock(  # type: ignore[method-assign]
+        side_effect=lambda _instance_id, return_unavailable=False: (
+            unavailable_provider if return_unavailable else outside_scope_provider
+        )
+    )
+    controller._search_provider = AsyncMock()  # type: ignore[method-assign]
+
+    result = await controller.search_provider(
+        "My Song",
+        "qobuz_1",
+        [MediaType.TRACK],
+        allowed_provider_instances={"qobuz_1"},
+    )
+
+    assert result == SearchResults()
+    controller._search_provider.assert_not_awaited()
+    controller.mass.get_provider.assert_called_once_with(
+        "qobuz_1",
+        return_unavailable=True,
+    )
+
+
+async def test_internal_search_rejects_strict_instance_fallback() -> None:
+    """The cached provider search keeps an exact captured account."""
+    unavailable_provider = _make_search_provider("qobuz_1", domain="qobuz")
+    unavailable_provider.available = False
+    outside_scope_provider = _make_search_provider("qobuz_2", domain="qobuz")
+    controller = _make_controller([unavailable_provider, outside_scope_provider])
+    controller.mass.get_provider = Mock(  # type: ignore[method-assign]
+        side_effect=lambda _instance_id, return_unavailable=False, **_kwargs: (
+            unavailable_provider if return_unavailable else outside_scope_provider
+        )
+    )
+
+    result = await controller._search_provider(
+        "My Song",
+        "qobuz_1",
+        [MediaType.TRACK],
+        strict_provider_instance=True,
+    )
+
+    assert result == SearchResults()
+    outside_scope_provider.search.assert_not_awaited()
 
 
 async def test_search_provider_reports_timeout_as_failure() -> None:

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -8,8 +8,12 @@ import time
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from music_assistant_models.enums import MediaType, ProviderFeature
-from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.errors import (
+    MusicAssistantError,
+    ResourceTemporarilyUnavailable,
+)
 from music_assistant_models.media_items import (
     Artist,
     Genre,
@@ -27,8 +31,6 @@ from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    import pytest
 
 
 def _make_track(item_id: str, provider: str, name: str) -> Track:
@@ -181,6 +183,21 @@ async def test_search_provider_resolves_domain_within_explicit_scope() -> None:
         [MediaType.TRACK],
         limit=5,
     )
+
+
+async def test_search_provider_reports_timeout_as_failure() -> None:
+    """A provider timeout remains distinguishable from a genuine empty result."""
+    provider = _make_search_provider("prov_a")
+    controller = _make_controller([provider])
+    controller._search_provider = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    with pytest.raises(ResourceTemporarilyUnavailable, match="prov_a"):
+        await controller.search_provider(
+            "My Song",
+            provider.instance_id,
+            [MediaType.TRACK],
+            allowed_provider_instances={provider.instance_id},
+        )
 
 
 async def test_search_provider_returns_none_on_provider_error() -> None:

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -158,6 +158,31 @@ async def test_search_provider_uses_centralized_provider_search() -> None:
     )
 
 
+async def test_search_provider_resolves_domain_within_explicit_scope() -> None:
+    """A domain lookup selects an allowed instance rather than a filtered global instance."""
+    filtered_provider = _make_search_provider("qobuz_1", domain="qobuz")
+    allowed_provider = _make_search_provider("qobuz_2", domain="qobuz")
+    controller = _make_controller([filtered_provider, allowed_provider])
+    expected = SearchResults(tracks=[_make_track("track1", "qobuz_2", "My Song")])
+    controller._search_provider = AsyncMock(return_value=expected)  # type: ignore[method-assign]
+
+    result = await controller.search_provider(
+        "My Song",
+        "qobuz",
+        [MediaType.TRACK],
+        limit=5,
+        allowed_provider_instances={"qobuz_2"},
+    )
+
+    assert result == expected
+    controller._search_provider.assert_awaited_once_with(
+        "My Song",
+        "qobuz_2",
+        [MediaType.TRACK],
+        limit=5,
+    )
+
+
 async def test_search_provider_returns_none_on_provider_error() -> None:
     """A provider error during search yields None instead of raising."""
     prov = _make_search_provider("prov_a")

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -23,6 +23,7 @@ from music_assistant.controllers.music import MusicController
 from music_assistant.controllers.music.media.tracks import (
     TrackProviderMatch,
     TrackProviderMatchResult,
+    TracksController,
 )
 from music_assistant.helpers.compare import TrackMatchConfidence
 from music_assistant.mass import MusicAssistant
@@ -309,6 +310,28 @@ async def test_match_confidence_hydrates_album_after_initial_no_match(
     assert confidence == TrackMatchConfidence.EXACT
 
 
+async def test_full_track_album_falls_back_after_transient_failure(
+    music: MusicController,
+) -> None:
+    """Optional album evidence falls back to the mapping after a provider timeout."""
+    track = create_track("spotify_1", "track")
+    track.album = ItemMapping(
+        item_id="album",
+        provider="spotify_1",
+        name="Album",
+        media_type=MediaType.ALBUM,
+    )
+
+    with patch.object(
+        music.albums,
+        "get",
+        AsyncMock(side_effect=TimeoutError),
+    ):
+        result = await music.tracks._get_full_track_album(track)
+
+    assert result is track.album
+
+
 async def test_find_provider_match_classifies_library_mapping_against_source(
     music: MusicController,
 ) -> None:
@@ -568,6 +591,25 @@ async def test_find_provider_match_reports_ambiguous_loose_candidates(
 
     assert result.match is None
     assert result.ambiguous is True
+
+
+def test_tied_loose_matches_require_pairwise_compatibility() -> None:
+    """A middle-duration candidate can not make incompatible outer candidates look equivalent."""
+    tracks = [
+        create_track("qobuz_1", "middle", duration=103, isrc="MIDDLE"),
+        create_track("qobuz_1", "short", duration=100, isrc="SHORT"),
+        create_track("qobuz_1", "long", duration=106, isrc="LONG"),
+    ]
+    matches = [
+        TrackProviderMatch(
+            track=track,
+            mapping=next(iter(track.provider_mappings)),
+            confidence=TrackMatchConfidence.LOOSE,
+        )
+        for track in tracks
+    ]
+
+    assert TracksController._matches_are_compatible(matches) is False
 
 
 async def test_enrich_provider_mappings_uses_library_without_mutating_it(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -175,6 +175,38 @@ async def test_match_provider_uses_full_track_mapping(music: MusicController) ->
     assert mappings == list(full_track.provider_mappings)
 
 
+async def test_get_provider_item_can_disable_library_fallback(
+    music: MusicController,
+) -> None:
+    """Authoritative hydration surfaces a missing provider ID instead of stored details."""
+    provider = MagicMock(spec=MusicProvider)
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.get_track = AsyncMock(side_effect=MediaNotFoundError("gone"))
+    library_fallback = create_track("qobuz_1", "stale")
+
+    with (
+        patch.object(music.mass, "get_provider", return_value=provider),
+        patch.object(
+            music.tracks,
+            "get_library_item_by_prov_id",
+            AsyncMock(return_value=library_fallback),
+        ),
+    ):
+        with pytest.raises(MediaNotFoundError, match="not found"):
+            await music.tracks.get_provider_item(
+                "stale",
+                provider.instance_id,
+                allow_fallback=False,
+            )
+        result = await music.tracks.get_provider_item(
+            "stale",
+            provider.instance_id,
+        )
+
+    assert result is library_fallback
+
+
 async def test_find_provider_match_reuses_domain_mapping_for_target_instance(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -594,6 +594,45 @@ async def test_find_provider_match_keeps_fallback_after_later_timeout(
     assert search_provider.await_count == 2
 
 
+async def test_find_provider_match_keeps_fallback_after_later_hydration_failure(
+    music: MusicController,
+) -> None:
+    """A later hydration failure does not discard an acceptable candidate."""
+    base = create_track("spotify_1", "base")
+    candidate = create_track("qobuz_1", "candidate")
+    failing_candidate = create_track("qobuz_1", "failing")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+    get_provider_item = AsyncMock(
+        side_effect=(
+            candidate,
+            ResourceTemporarilyUnavailable("Hydration failed"),
+        )
+    )
+
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[candidate, failing_candidate])),
+        ),
+        patch.object(music.tracks, "get_provider_item", get_provider_item),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+    ):
+        result = await music.tracks.find_provider_match(
+            base,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+        )
+
+    assert result.match is not None
+    assert result.match.track.item_id == candidate.item_id
+    assert get_provider_item.await_count == 2
+
+
 async def test_find_provider_match_reports_ambiguous_loose_candidates(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -888,6 +888,48 @@ async def test_enrich_provider_mappings_preserves_allowed_untrusted_fallback(
     assert find_match.await_args.kwargs["trust_base_mapping"] is False
 
 
+async def test_enrich_provider_mappings_drops_unavailable_source_mappings(
+    music: MusicController,
+) -> None:
+    """Unavailable source mappings are not copied into a migrated playlist."""
+    source = create_track("qobuz_1", "source")
+    source.provider_mappings = {
+        ProviderMapping(
+            item_id="unavailable",
+            provider_domain="qobuz",
+            provider_instance="qobuz_1",
+            available=False,
+        )
+    }
+    provider = MagicMock(spec=MusicProvider)
+    provider.name = "Qobuz"
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.is_streaming_provider = True
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(return_value=TrackProviderMatchResult()),
+        ),
+        patch.object(music.mass, "get_provider", return_value=provider),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+            trust_track_mappings=False,
+        )
+
+    assert result.track.provider_mappings == set()
+
+
 async def test_enrich_provider_mappings_stops_after_provider_failure(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -12,6 +12,7 @@ from music_assistant_models.errors import (
 )
 from music_assistant_models.media_items import (
     Artist,
+    ItemMapping,
     ProviderMapping,
     SearchResults,
     Track,
@@ -27,7 +28,7 @@ from music_assistant.helpers.compare import TrackMatchConfidence
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.music_provider import MusicProvider
 
-from .helpers import create_track
+from .helpers import create_album, create_track
 
 
 @pytest.fixture
@@ -269,6 +270,43 @@ async def test_find_provider_match_revalidates_untrusted_source_mapping(
     assert exact_result.match is None
     assert likely_result.match is not None
     assert likely_result.match.confidence == TrackMatchConfidence.LIKELY
+
+
+async def test_match_confidence_hydrates_album_after_initial_no_match(
+    music: MusicController,
+) -> None:
+    """Full release evidence can resolve a duration-based first-pass rejection."""
+    base = create_track("spotify_1", "base", duration=200)
+    candidate = create_track("qobuz_1", "candidate", duration=210)
+    base.disc_number = candidate.disc_number = 1
+    base.track_number = candidate.track_number = 1
+    base_album = create_album("spotify_1", "base-album", name="Album")
+    candidate_album = create_album("qobuz_1", "candidate-album", name="Album")
+    base.album = ItemMapping(
+        item_id=base_album.item_id,
+        provider=base_album.provider,
+        name=base_album.name,
+        media_type=MediaType.ALBUM,
+    )
+    candidate.album = ItemMapping(
+        item_id=candidate_album.item_id,
+        provider=candidate_album.provider,
+        name=candidate_album.name,
+        media_type=MediaType.ALBUM,
+    )
+
+    with patch.object(
+        music.tracks,
+        "_get_full_track_album",
+        AsyncMock(side_effect=(base_album, candidate_album)),
+    ):
+        confidence, _ = await music.tracks._get_match_confidence(
+            base,
+            candidate,
+            None,
+        )
+
+    assert confidence == TrackMatchConfidence.EXACT
 
 
 async def test_find_provider_match_classifies_library_mapping_against_source(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -193,6 +193,57 @@ async def test_find_provider_match_reuses_domain_mapping_for_target_instance(
     search.assert_not_awaited()
 
 
+async def test_find_provider_match_classifies_library_mapping_against_source(
+    music: MusicController,
+) -> None:
+    """A library mapping is a candidate, not proof of an exact source release."""
+    source = create_track("spotify_1", "source")
+    library_track = create_track("spotify_1", "library")
+    target = create_track("qobuz_1", "target")
+    library_track.provider_mappings.add(next(iter(target.provider_mappings)))
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(return_value=target),
+        ),
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults()),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        exact_result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.EXACT,
+            mapping_source=library_track,
+            allowed_provider_instances={"qobuz_1"},
+        )
+        likely_result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+            mapping_source=library_track,
+            allowed_provider_instances={"qobuz_1"},
+        )
+
+    assert exact_result.match is None
+    assert likely_result.match is not None
+    assert likely_result.match.confidence == TrackMatchConfidence.LIKELY
+
+
 async def test_find_provider_match_prefers_exact_candidate(
     music: MusicController,
 ) -> None:
@@ -294,13 +345,9 @@ async def test_enrich_provider_mappings_uses_library_without_mutating_it(
     library_track = create_track("spotify_1", "library")
     library_track.provider = "library"
     library_track.item_id = "42"
-    library_track.provider_mappings.add(
-        ProviderMapping(
-            item_id="qobuz-track",
-            provider_domain="qobuz",
-            provider_instance="qobuz_1",
-        )
-    )
+    qobuz_track = create_track("qobuz_1", "qobuz-track")
+    qobuz_mapping = next(iter(qobuz_track.provider_mappings))
+    library_track.provider_mappings.add(qobuz_mapping)
     stale_tidal_mapping = ProviderMapping(
         item_id="old-tidal-track",
         provider_domain="tidal",
@@ -316,11 +363,25 @@ async def test_enrich_provider_mappings_uses_library_without_mutating_it(
     tidal_provider.instance_id = "tidal_1"
     tidal_provider.domain = "tidal"
     tidal_provider.is_streaming_provider = True
-    match = TrackProviderMatch(
+    qobuz_provider = MagicMock()
+    qobuz_provider.name = "Qobuz"
+    qobuz_provider.instance_id = "qobuz_1"
+    qobuz_provider.domain = "qobuz"
+    qobuz_provider.is_streaming_provider = True
+    qobuz_match = TrackProviderMatch(
+        track=qobuz_track,
+        mapping=qobuz_mapping,
+        confidence=TrackMatchConfidence.LIKELY,
+    )
+    tidal_match = TrackProviderMatch(
         track=tidal_track,
         mapping=tidal_mapping,
         confidence=TrackMatchConfidence.LIKELY,
     )
+    matches = {
+        "qobuz": TrackProviderMatchResult(match=qobuz_match),
+        "tidal": TrackProviderMatchResult(match=tidal_match),
+    }
 
     with (
         patch.object(
@@ -336,26 +397,26 @@ async def test_enrich_provider_mappings_uses_library_without_mutating_it(
         patch.object(
             music.tracks,
             "find_provider_match",
-            AsyncMock(return_value=TrackProviderMatchResult(match=match)),
+            AsyncMock(side_effect=lambda _track, provider, **_kwargs: matches[provider.domain]),
         ),
         patch.object(
             MusicController,
             "providers",
             new_callable=PropertyMock,
-            return_value=[tidal_provider],
+            return_value=[qobuz_provider, tidal_provider],
         ),
-        patch.object(music, "match_provider_instances", return_value=False),
     ):
         result = await music.tracks.enrich_provider_mappings(source)
 
     assert result.used_library_item is True
     assert result.track is not library_track
     assert result.track.provider_mappings == {
-        *(original_mappings - {stale_tidal_mapping}),
+        *source.provider_mappings,
+        qobuz_mapping,
         tidal_mapping,
     }
     assert library_track.provider_mappings == original_mappings
-    assert result.matches == (match,)
+    assert result.matches == (qobuz_match, tidal_match)
 
 
 async def test_overwrite_update_keeps_artists_when_none_are_given(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -627,6 +627,51 @@ async def test_enrich_provider_mappings_filters_inaccessible_source_mappings(
     )
 
 
+async def test_enrich_provider_mappings_preserves_allowed_untrusted_fallback(
+    music: MusicController,
+) -> None:
+    """A Music Assistant copy keeps an allowed source mapping when revalidation finds no match."""
+    source = create_track("qobuz_1", "source")
+    source_mapping = next(iter(source.provider_mappings))
+    provider = MagicMock(spec=MusicProvider)
+    provider.name = "Qobuz"
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.is_streaming_provider = True
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(return_value=TrackProviderMatchResult()),
+        ) as find_match,
+        patch.object(
+            music.mass,
+            "get_provider",
+            return_value=provider,
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+            trust_track_mappings=False,
+        )
+
+    assert result.track.provider_mappings == {source_mapping}
+    assert find_match.await_args is not None
+    assert find_match.await_args.kwargs["trust_base_mapping"] is False
+
+
 async def test_overwrite_update_keeps_artists_when_none_are_given(
     mass: MusicAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -2,12 +2,18 @@
 
 from collections.abc import AsyncGenerator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
+from music_assistant_models.enums import ExternalID, MediaType, ProviderFeature
 from music_assistant_models.media_items import Artist, ProviderMapping, UniqueList
 
 from music_assistant.controllers.music import MusicController
+from music_assistant.controllers.music.media.tracks import (
+    TrackProviderMatch,
+    TrackProviderMatchResult,
+)
+from music_assistant.helpers.compare import TrackMatchConfidence
 from music_assistant.mass import MusicAssistant
 
 from .helpers import create_track
@@ -159,6 +165,184 @@ async def test_match_provider_uses_full_track_mapping(music: MusicController) ->
         mappings = await music.tracks.match_provider(base_track, provider, ref_albums=[])
 
     assert mappings == list(full_track.provider_mappings)
+
+
+async def test_find_provider_match_reuses_domain_mapping_for_target_instance(
+    music: MusicController,
+) -> None:
+    """A catalog mapping is reused across instances without searching."""
+    track = create_track("qobuz_1", "track")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_2"
+    provider.domain = "qobuz"
+
+    with patch.object(music.tracks, "search", AsyncMock()) as search:
+        result = await music.tracks.find_provider_match(track, provider)
+
+    assert result.match is not None
+    assert result.match.mapping.item_id == "track"
+    assert result.match.mapping.provider_instance == "qobuz_2"
+    assert result.match.confidence == TrackMatchConfidence.EXACT
+    search.assert_not_awaited()
+
+
+async def test_find_provider_match_prefers_exact_candidate(
+    music: MusicController,
+) -> None:
+    """An exact candidate outranks a loose result returned earlier."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    base = create_track("spotify_1", "base", isrc="USRC17607839")
+    base.external_ids.add(mb_track)
+    loose = create_track("qobuz_1", "loose", isrc="OTHER")
+    loose.version = "Deluxe"
+    exact = create_track("qobuz_1", "exact", isrc="USRC17607839")
+    exact.external_ids.add(mb_track)
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(music.tracks, "search", AsyncMock(return_value=[loose, exact])),
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(
+                side_effect=lambda item_id, *_args, **_kwargs: {"loose": loose, "exact": exact}[
+                    item_id
+                ]
+            ),
+        ),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+    ):
+        result = await music.tracks.find_provider_match(
+            base,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LOOSE,
+        )
+
+    assert result.match is not None
+    assert result.match.track.item_id == "exact"
+    assert result.match.confidence == TrackMatchConfidence.EXACT
+
+
+async def test_find_provider_match_reports_ambiguous_loose_candidates(
+    music: MusicController,
+) -> None:
+    """Different tied best-effort versions are ambiguous rather than arbitrary."""
+    base = create_track("spotify_1", "base", isrc="BASE")
+    deluxe = create_track("qobuz_1", "deluxe", isrc="DELUXE")
+    deluxe.version = "Deluxe"
+    remaster = create_track("qobuz_1", "remaster", isrc="REMASTER")
+    remaster.version = "2022 Remaster"
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music.tracks,
+            "search",
+            AsyncMock(return_value=[deluxe, remaster]),
+        ),
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(
+                side_effect=lambda item_id, *_args, **_kwargs: {
+                    "deluxe": deluxe,
+                    "remaster": remaster,
+                }[item_id]
+            ),
+        ),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+    ):
+        result = await music.tracks.find_provider_match(
+            base,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LOOSE,
+        )
+
+    assert result.match is None
+    assert result.ambiguous is True
+
+
+async def test_enrich_provider_mappings_uses_library_without_mutating_it(
+    music: MusicController,
+) -> None:
+    """Library mappings seed playlist enrichment without being updated."""
+    source = create_track("spotify_1", "source")
+    library_track = create_track("spotify_1", "library")
+    library_track.provider = "library"
+    library_track.item_id = "42"
+    library_track.provider_mappings.add(
+        ProviderMapping(
+            item_id="qobuz-track",
+            provider_domain="qobuz",
+            provider_instance="qobuz_1",
+        )
+    )
+    stale_tidal_mapping = ProviderMapping(
+        item_id="old-tidal-track",
+        provider_domain="tidal",
+        provider_instance="tidal_1",
+        available=False,
+    )
+    library_track.provider_mappings.add(stale_tidal_mapping)
+    original_mappings = set(library_track.provider_mappings)
+    tidal_track = create_track("tidal_1", "tidal-track")
+    tidal_mapping = next(iter(tidal_track.provider_mappings))
+    tidal_provider = MagicMock()
+    tidal_provider.name = "Tidal"
+    tidal_provider.instance_id = "tidal_1"
+    tidal_provider.domain = "tidal"
+    tidal_provider.is_streaming_provider = True
+    match = TrackProviderMatch(
+        track=tidal_track,
+        mapping=tidal_mapping,
+        confidence=TrackMatchConfidence.LIKELY,
+    )
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=library_track),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(return_value=TrackProviderMatchResult(match=match)),
+        ),
+        patch.object(
+            MusicController,
+            "providers",
+            new_callable=PropertyMock,
+            return_value=[tidal_provider],
+        ),
+        patch.object(music, "match_provider_instances", return_value=False),
+    ):
+        result = await music.tracks.enrich_provider_mappings(source)
+
+    assert result.used_library_item is True
+    assert result.track is not library_track
+    assert result.track.provider_mappings == {
+        *(original_mappings - {stale_tidal_mapping}),
+        tidal_mapping,
+    }
+    assert library_track.provider_mappings == original_mappings
+    assert result.matches == (match,)
 
 
 async def test_overwrite_update_keeps_artists_when_none_are_given(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -365,6 +365,14 @@ async def test_library_mapping_does_not_preempt_exact_provider_search(
     )
     source = create_track("spotify_1", "source")
     source.external_ids.add(mb_track)
+    source.artists.append(
+        ItemMapping(
+            item_id="other-artist",
+            provider="spotify_1",
+            name="Other Artist",
+            media_type=MediaType.ARTIST,
+        )
+    )
     library_track = create_track("spotify_1", "library")
     mapped_candidate = create_track("qobuz_1", "mapped")
     exact_candidate = create_track("qobuz_1", "exact")
@@ -389,8 +397,13 @@ async def test_library_mapping_does_not_preempt_exact_provider_search(
         patch.object(
             music,
             "search_provider",
-            AsyncMock(return_value=SearchResults(tracks=[exact_candidate])),
-        ),
+            AsyncMock(
+                side_effect=(
+                    SearchResults(tracks=[exact_candidate]),
+                    ResourceTemporarilyUnavailable("Later search timed out"),
+                )
+            ),
+        ) as search_provider,
         patch.object(
             music.tracks,
             "_get_full_track_album",
@@ -408,6 +421,7 @@ async def test_library_mapping_does_not_preempt_exact_provider_search(
     assert result.match is not None
     assert result.match.track.item_id == "exact"
     assert result.match.confidence == TrackMatchConfidence.EXACT
+    assert search_provider.await_count == 1
 
 
 async def test_find_provider_match_prefers_exact_candidate(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from music_assistant_models.enums import ExternalID, MediaType, ProviderFeature
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import (
+    MediaNotFoundError,
+    ResourceTemporarilyUnavailable,
+)
 from music_assistant_models.media_items import (
     Artist,
     ProviderMapping,
@@ -702,6 +705,57 @@ async def test_enrich_provider_mappings_preserves_allowed_untrusted_fallback(
     assert result.track.provider_mappings == {source_mapping}
     assert find_match.await_args is not None
     assert find_match.await_args.kwargs["trust_base_mapping"] is False
+
+
+async def test_enrich_provider_mappings_stops_after_provider_failure(
+    music: MusicController,
+) -> None:
+    """A timed-out provider is not queried again for every remaining migration track."""
+    source = create_track("spotify_1", "source")
+    provider = MagicMock(spec=MusicProvider)
+    provider.name = "Qobuz"
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.is_streaming_provider = True
+    failed_provider_instances: set[str] = set()
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(side_effect=ResourceTemporarilyUnavailable("Search timed out")),
+        ) as find_match,
+        patch.object(
+            music.mass,
+            "get_provider",
+            return_value=provider,
+        ),
+    ):
+        first_result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+            failed_provider_instances=failed_provider_instances,
+        )
+        second_result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+            failed_provider_instances=failed_provider_instances,
+        )
+
+    assert failed_provider_instances == {"qobuz_1"}
+    assert find_match.await_count == 1
+    assert first_result.failed_providers == ("Qobuz",)
+    assert second_result.failed_providers == ()
 
 
 async def test_overwrite_update_keeps_artists_when_none_are_given(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -194,6 +194,48 @@ async def test_find_provider_match_reuses_domain_mapping_for_target_instance(
     search.assert_not_awaited()
 
 
+async def test_find_provider_match_revalidates_untrusted_source_mapping(
+    music: MusicController,
+) -> None:
+    """A mapping restored from a Music Assistant playlist is reclassified from metadata."""
+    source = create_track("qobuz_1", "source")
+    candidate = create_track("qobuz_1", "source")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = set()
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(return_value=candidate),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        exact_result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.EXACT,
+            trust_base_mapping=False,
+        )
+        likely_result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+            trust_base_mapping=False,
+        )
+
+    assert exact_result.match is None
+    assert likely_result.match is not None
+    assert likely_result.match.confidence == TrackMatchConfidence.LIKELY
+
+
 async def test_find_provider_match_classifies_library_mapping_against_source(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -6,7 +6,14 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from music_assistant_models.enums import ExternalID, MediaType, ProviderFeature
-from music_assistant_models.media_items import Artist, ProviderMapping, UniqueList
+from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.media_items import (
+    Artist,
+    ProviderMapping,
+    SearchResults,
+    Track,
+    UniqueList,
+)
 
 from music_assistant.controllers.music import MusicController
 from music_assistant.controllers.music.media.tracks import (
@@ -176,7 +183,7 @@ async def test_find_provider_match_reuses_domain_mapping_for_target_instance(
     provider.instance_id = "qobuz_2"
     provider.domain = "qobuz"
 
-    with patch.object(music.tracks, "search", AsyncMock()) as search:
+    with patch.object(music, "search_provider", AsyncMock()) as search:
         result = await music.tracks.find_provider_match(track, provider)
 
     assert result.match is not None
@@ -198,6 +205,7 @@ async def test_find_provider_match_prefers_exact_candidate(
     base.external_ids.add(mb_track)
     loose = create_track("qobuz_1", "loose", isrc="OTHER")
     loose.version = "Deluxe"
+    stale = create_track("qobuz_1", "stale", isrc="STALE")
     exact = create_track("qobuz_1", "exact", isrc="USRC17607839")
     exact.external_ids.add(mb_track)
     provider = MagicMock()
@@ -206,16 +214,21 @@ async def test_find_provider_match_prefers_exact_candidate(
     provider.supported_features = {ProviderFeature.SEARCH}
     provider.supported_media_types = {MediaType.TRACK}
 
+    async def get_provider_item(item_id: str, *_args: object, **_kwargs: object) -> Track:
+        if item_id == "stale":
+            raise MediaNotFoundError("Stale search result")
+        return {"loose": loose, "exact": exact}[item_id]
+
     with (
-        patch.object(music.tracks, "search", AsyncMock(return_value=[loose, exact])),
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[stale, loose, exact])),
+        ),
         patch.object(
             music.tracks,
             "get_provider_item",
-            AsyncMock(
-                side_effect=lambda item_id, *_args, **_kwargs: {"loose": loose, "exact": exact}[
-                    item_id
-                ]
-            ),
+            AsyncMock(side_effect=get_provider_item),
         ),
         patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
     ):
@@ -247,9 +260,9 @@ async def test_find_provider_match_reports_ambiguous_loose_candidates(
 
     with (
         patch.object(
-            music.tracks,
-            "search",
-            AsyncMock(return_value=[deluxe, remaster]),
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[deluxe, remaster])),
         ),
         patch.object(
             music.tracks,

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -205,7 +205,7 @@ async def test_find_provider_match_classifies_library_mapping_against_source(
     provider = MagicMock()
     provider.instance_id = "qobuz_1"
     provider.domain = "qobuz"
-    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_features = set()
     provider.supported_media_types = {MediaType.TRACK}
 
     with (
@@ -213,11 +213,6 @@ async def test_find_provider_match_classifies_library_mapping_against_source(
             music.tracks,
             "get_provider_item",
             AsyncMock(return_value=target),
-        ),
-        patch.object(
-            music,
-            "search_provider",
-            AsyncMock(return_value=SearchResults()),
         ),
         patch.object(
             music.tracks,
@@ -243,6 +238,61 @@ async def test_find_provider_match_classifies_library_mapping_against_source(
     assert exact_result.match is None
     assert likely_result.match is not None
     assert likely_result.match.confidence == TrackMatchConfidence.LIKELY
+
+
+async def test_library_mapping_does_not_preempt_exact_provider_search(
+    music: MusicController,
+) -> None:
+    """An alternate library mapping remains a fallback while exact search continues."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    source = create_track("spotify_1", "source")
+    source.external_ids.add(mb_track)
+    library_track = create_track("spotify_1", "library")
+    mapped_candidate = create_track("qobuz_1", "mapped")
+    exact_candidate = create_track("qobuz_1", "exact")
+    exact_candidate.external_ids.add(mb_track)
+    library_track.provider_mappings.add(next(iter(mapped_candidate.provider_mappings)))
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+    candidates = {
+        "mapped": mapped_candidate,
+        "exact": exact_candidate,
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(side_effect=lambda item_id, *_args, **_kwargs: candidates[item_id]),
+        ),
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[exact_candidate])),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+            mapping_source=library_track,
+            allowed_provider_instances={"qobuz_1"},
+        )
+
+    assert result.match is not None
+    assert result.match.track.item_id == "exact"
+    assert result.match.confidence == TrackMatchConfidence.EXACT
 
 
 async def test_find_provider_match_prefers_exact_candidate(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -310,10 +310,15 @@ async def test_match_confidence_hydrates_album_after_initial_no_match(
     assert confidence == TrackMatchConfidence.EXACT
 
 
+@pytest.mark.parametrize(
+    "error",
+    [TimeoutError(), ResourceTemporarilyUnavailable("Provider temporarily unavailable")],
+)
 async def test_full_track_album_falls_back_after_transient_failure(
     music: MusicController,
+    error: Exception,
 ) -> None:
-    """Optional album evidence falls back to the mapping after a provider timeout."""
+    """Optional album evidence falls back to the mapping after a transient provider failure."""
     track = create_track("spotify_1", "track")
     track.album = ItemMapping(
         item_id="album",
@@ -325,7 +330,7 @@ async def test_full_track_album_falls_back_after_transient_failure(
     with patch.object(
         music.albums,
         "get",
-        AsyncMock(side_effect=TimeoutError),
+        AsyncMock(side_effect=error),
     ):
         result = await music.tracks._get_full_track_album(track)
 

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -534,6 +534,57 @@ async def test_enrich_provider_mappings_tries_next_instance_after_miss(
     assert result.matches == (match,)
 
 
+async def test_enrich_provider_mappings_filters_inaccessible_source_mappings(
+    music: MusicController,
+) -> None:
+    """Builtin source entries retain only provider mappings allowed for the initiating user."""
+    source = create_track("spotify_1", "source")
+    allowed_track = create_track("spotify_2", "source")
+    allowed_mapping = next(iter(allowed_track.provider_mappings))
+    allowed_provider = MagicMock(spec=MusicProvider)
+    allowed_provider.name = "Spotify allowed"
+    allowed_provider.instance_id = "spotify_2"
+    allowed_provider.domain = "spotify"
+    allowed_provider.is_streaming_provider = True
+    match = TrackProviderMatch(
+        track=allowed_track,
+        mapping=allowed_mapping,
+        confidence=TrackMatchConfidence.EXACT,
+    )
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(return_value=TrackProviderMatchResult(match=match)),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            return_value=allowed_provider,
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"spotify_2"},
+        )
+
+    assert result.track.provider_mappings == {allowed_mapping}
+    assert all(
+        mapping.provider_instance != "spotify_1" for mapping in result.track.provider_mappings
+    )
+
+
 async def test_overwrite_update_keeps_artists_when_none_are_given(
     mass: MusicAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -461,6 +461,7 @@ async def test_find_provider_match_prefers_exact_candidate(
     loose.version = "Deluxe"
     stale = create_track("qobuz_1", "stale", isrc="STALE")
     exact = create_track("qobuz_1", "exact", isrc="USRC17607839")
+    exact.provider = "qobuz"
     exact.external_ids.add(mb_track)
     provider = MagicMock()
     provider.instance_id = "qobuz_1"
@@ -473,6 +474,7 @@ async def test_find_provider_match_prefers_exact_candidate(
             raise MediaNotFoundError("Stale search result")
         return {"loose": loose, "exact": exact}[item_id]
 
+    get_provider_item_mock = AsyncMock(side_effect=get_provider_item)
     with (
         patch.object(
             music,
@@ -482,7 +484,7 @@ async def test_find_provider_match_prefers_exact_candidate(
         patch.object(
             music.tracks,
             "get_provider_item",
-            AsyncMock(side_effect=get_provider_item),
+            get_provider_item_mock,
         ),
         patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
     ):
@@ -495,6 +497,9 @@ async def test_find_provider_match_prefers_exact_candidate(
     assert result.match is not None
     assert result.match.track.item_id == "exact"
     assert result.match.confidence == TrackMatchConfidence.EXACT
+    assert all(
+        call.args[1] == provider.instance_id for call in get_provider_item_mock.await_args_list
+    )
 
 
 async def test_find_provider_match_keeps_fallback_after_later_timeout(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -474,6 +474,59 @@ async def test_find_provider_match_prefers_exact_candidate(
     assert result.match.confidence == TrackMatchConfidence.EXACT
 
 
+async def test_find_provider_match_keeps_fallback_after_later_timeout(
+    music: MusicController,
+) -> None:
+    """A later artist-query timeout does not discard an acceptable candidate."""
+    base = create_track("spotify_1", "base")
+    base.artists.append(
+        ItemMapping(
+            item_id="other-artist",
+            provider="spotify_1",
+            name="Other Artist",
+            media_type=MediaType.ARTIST,
+        )
+    )
+    candidate = create_track("qobuz_1", "candidate")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(
+                side_effect=(
+                    SearchResults(tracks=[candidate]),
+                    ResourceTemporarilyUnavailable("Later search timed out"),
+                )
+            ),
+        ) as search_provider,
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(return_value=candidate),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        result = await music.tracks.find_provider_match(
+            base,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+        )
+
+    assert result.match is not None
+    assert result.match.confidence == TrackMatchConfidence.LIKELY
+    assert search_provider.await_count == 2
+
+
 async def test_find_provider_match_reports_ambiguous_loose_candidates(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -8,6 +8,7 @@ import pytest
 from music_assistant_models.enums import ExternalID, MediaType, ProviderFeature
 from music_assistant_models.errors import (
     MediaNotFoundError,
+    ProviderUnavailableError,
     ResourceTemporarilyUnavailable,
 )
 from music_assistant_models.media_items import (
@@ -210,6 +211,38 @@ async def test_get_provider_item_can_disable_library_fallback(
         )
 
     assert result is library_fallback
+
+
+async def test_get_provider_item_strict_instance_rejects_fallback(
+    music: MusicController,
+) -> None:
+    """Authoritative hydration can not switch to another provider account."""
+    unavailable_provider = MagicMock(spec=MusicProvider)
+    unavailable_provider.instance_id = "qobuz_1"
+    unavailable_provider.available = False
+    outside_scope_provider = MagicMock(spec=MusicProvider)
+    outside_scope_provider.instance_id = "qobuz_2"
+    outside_scope_provider.available = True
+    outside_scope_provider.get_track = AsyncMock()
+
+    with (
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda _provider_instance_id, return_unavailable=False: (
+                unavailable_provider if return_unavailable else outside_scope_provider
+            ),
+        ),
+        pytest.raises(ProviderUnavailableError, match="qobuz_1"),
+    ):
+        await music.tracks.get_provider_item(
+            "track",
+            "qobuz_1",
+            allow_fallback=False,
+            strict_provider_instance=True,
+        )
+
+    outside_scope_provider.get_track.assert_not_awaited()
 
 
 async def test_find_provider_match_reuses_domain_mapping_for_target_instance(
@@ -503,7 +536,8 @@ async def test_find_provider_match_prefers_exact_candidate(
     assert result.match.track.item_id == "exact"
     assert result.match.confidence == TrackMatchConfidence.EXACT
     assert all(
-        call.args[1] == provider.instance_id for call in get_provider_item_mock.await_args_list
+        call.args[1] == provider.instance_id and call.kwargs["strict_provider_instance"] is True
+        for call in get_provider_item_mock.await_args_list
     )
 
 
@@ -713,6 +747,7 @@ async def test_enrich_provider_mappings_skips_album_lookup_for_existing_domains(
     provider = MagicMock(spec=MusicProvider)
     provider.instance_id = "spotify_1"
     provider.domain = "spotify"
+    provider.available = True
     provider.is_streaming_provider = True
     get_full_track_album = AsyncMock()
     find_provider_match = AsyncMock()
@@ -733,6 +768,41 @@ async def test_enrich_provider_mappings_skips_album_lookup_for_existing_domains(
     find_provider_match.assert_not_awaited()
 
 
+async def test_enrich_provider_mappings_does_not_substitute_unavailable_instance(
+    music: MusicController,
+) -> None:
+    """A captured provider instance can not fall back to another account."""
+    source = create_track("spotify_1", "source")
+    unavailable_provider = MagicMock(spec=MusicProvider)
+    unavailable_provider.instance_id = "qobuz_1"
+    unavailable_provider.domain = "qobuz"
+    unavailable_provider.available = False
+    outside_scope_provider = MagicMock(spec=MusicProvider)
+    outside_scope_provider.instance_id = "qobuz_2"
+    outside_scope_provider.domain = "qobuz"
+    outside_scope_provider.available = True
+    find_provider_match = AsyncMock()
+
+    def get_provider(
+        _provider_instance_id: str,
+        return_unavailable: bool = False,
+    ) -> MusicProvider:
+        return unavailable_provider if return_unavailable else outside_scope_provider
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "find_provider_match", find_provider_match),
+        patch.object(music.mass, "get_provider", side_effect=get_provider),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+        )
+
+    assert result.track.provider_mappings == set()
+    find_provider_match.assert_not_awaited()
+
+
 async def test_enrich_provider_mappings_tries_next_instance_after_miss(
     music: MusicController,
 ) -> None:
@@ -744,11 +814,13 @@ async def test_enrich_provider_mappings_tries_next_instance_after_miss(
     first_provider.name = "Qobuz first"
     first_provider.instance_id = "qobuz_1"
     first_provider.domain = "qobuz"
+    first_provider.available = True
     first_provider.is_streaming_provider = True
     second_provider = MagicMock(spec=MusicProvider)
     second_provider.name = "Qobuz second"
     second_provider.instance_id = "qobuz_2"
     second_provider.domain = "qobuz"
+    second_provider.available = True
     second_provider.is_streaming_provider = True
     match = TrackProviderMatch(
         track=qobuz_track,
@@ -781,7 +853,7 @@ async def test_enrich_provider_mappings_tries_next_instance_after_miss(
         patch.object(
             music.mass,
             "get_provider",
-            side_effect=lambda provider_instance_id: {
+            side_effect=lambda provider_instance_id, **_kwargs: {
                 "qobuz_1": first_provider,
                 "qobuz_2": second_provider,
             }[provider_instance_id],
@@ -808,6 +880,7 @@ async def test_enrich_provider_mappings_filters_inaccessible_source_mappings(
     allowed_provider.name = "Spotify allowed"
     allowed_provider.instance_id = "spotify_2"
     allowed_provider.domain = "spotify"
+    allowed_provider.available = True
     allowed_provider.is_streaming_provider = True
     match = TrackProviderMatch(
         track=allowed_track,
@@ -858,6 +931,7 @@ async def test_enrich_provider_mappings_preserves_allowed_untrusted_fallback(
     provider.name = "Qobuz"
     provider.instance_id = "qobuz_1"
     provider.domain = "qobuz"
+    provider.available = True
     provider.is_streaming_provider = True
 
     with (
@@ -910,6 +984,7 @@ async def test_enrich_provider_mappings_drops_unavailable_source_mappings(
     provider.name = "Qobuz"
     provider.instance_id = "qobuz_1"
     provider.domain = "qobuz"
+    provider.available = True
     provider.is_streaming_provider = True
 
     with (
@@ -944,6 +1019,7 @@ async def test_enrich_provider_mappings_stops_after_provider_failure(
     provider.name = "Qobuz"
     provider.instance_id = "qobuz_1"
     provider.domain = "qobuz"
+    provider.available = True
     provider.is_streaming_provider = True
     failed_provider_instances: set[str] = set()
 

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -22,6 +22,7 @@ from music_assistant.controllers.music.media.tracks import (
 )
 from music_assistant.helpers.compare import TrackMatchConfidence
 from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
 
 from .helpers import create_track
 
@@ -417,6 +418,70 @@ async def test_enrich_provider_mappings_uses_library_without_mutating_it(
     }
     assert library_track.provider_mappings == original_mappings
     assert result.matches == (qobuz_match, tidal_match)
+
+
+async def test_enrich_provider_mappings_tries_next_instance_after_miss(
+    music: MusicController,
+) -> None:
+    """A miss on one account does not suppress another account of the same service."""
+    source = create_track("spotify_1", "source")
+    qobuz_track = create_track("qobuz_2", "qobuz-track")
+    qobuz_mapping = next(iter(qobuz_track.provider_mappings))
+    first_provider = MagicMock(spec=MusicProvider)
+    first_provider.name = "Qobuz first"
+    first_provider.instance_id = "qobuz_1"
+    first_provider.domain = "qobuz"
+    first_provider.is_streaming_provider = True
+    second_provider = MagicMock(spec=MusicProvider)
+    second_provider.name = "Qobuz second"
+    second_provider.instance_id = "qobuz_2"
+    second_provider.domain = "qobuz"
+    second_provider.is_streaming_provider = True
+    match = TrackProviderMatch(
+        track=qobuz_track,
+        mapping=qobuz_mapping,
+        confidence=TrackMatchConfidence.LIKELY,
+    )
+    results = {
+        "qobuz_1": TrackProviderMatchResult(),
+        "qobuz_2": TrackProviderMatchResult(match=match),
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(
+                side_effect=lambda _track, provider, **_kwargs: results[provider.instance_id]
+            ),
+        ) as find_match,
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id: {
+                "qobuz_1": first_provider,
+                "qobuz_2": second_provider,
+            }[provider_instance_id],
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1", "qobuz_2"},
+        )
+
+    assert find_match.await_count == 2
+    assert qobuz_mapping in result.track.provider_mappings
+    assert result.matches == (match,)
 
 
 async def test_overwrite_update_keeps_artists_when_none_are_given(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -673,7 +673,7 @@ async def test_enrich_provider_mappings_uses_library_without_mutating_it(
             music.tracks,
             "_get_full_track_album",
             AsyncMock(return_value=None),
-        ),
+        ) as get_full_track_album,
         patch.object(
             music.tracks,
             "find_provider_match",
@@ -697,6 +697,35 @@ async def test_enrich_provider_mappings_uses_library_without_mutating_it(
     }
     assert library_track.provider_mappings == original_mappings
     assert result.matches == (qobuz_match, tidal_match)
+    get_full_track_album.assert_awaited_once_with(source)
+
+
+async def test_enrich_provider_mappings_skips_album_lookup_for_existing_domains(
+    music: MusicController,
+) -> None:
+    """Trusted source mappings avoid unnecessary album and provider lookups."""
+    source = create_track("spotify_1", "source")
+    provider = MagicMock(spec=MusicProvider)
+    provider.instance_id = "spotify_1"
+    provider.domain = "spotify"
+    provider.is_streaming_provider = True
+    get_full_track_album = AsyncMock()
+    find_provider_match = AsyncMock()
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "_get_full_track_album", get_full_track_album),
+        patch.object(music.tracks, "find_provider_match", find_provider_match),
+        patch.object(music.mass, "get_provider", return_value=provider),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"spotify_1"},
+        )
+
+    assert result.track.provider_mappings == source.provider_mappings
+    get_full_track_album.assert_not_awaited()
+    find_provider_match.assert_not_awaited()
 
 
 async def test_enrich_provider_mappings_tries_next_instance_after_miss(

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1419,6 +1419,28 @@ def test_compare_track_evidence_handles_featured_artist_title_drift() -> None:
     )
 
 
+def test_compare_track_evidence_stops_feature_credit_before_version() -> None:
+    """Version brackets after a bare featured credit are not part of the artist name."""
+    title_credit = _provider_track(
+        "base",
+        "provider_a",
+        name="Track feat. Guest (Radio Edit)",
+        album_name="Original",
+    )
+    structured_credit = _provider_track(
+        "candidate",
+        "provider_b",
+        version="Radio Edit",
+        album_name="Compilation",
+        artist_names=("Artist A", "Guest"),
+    )
+
+    assert (
+        compare.compare_track_evidence(title_credit, structured_credit)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+
+
 def test_compare_track_evidence_allows_omitted_featured_artist() -> None:
     """A provider may omit a featured credit carried by the other provider."""
     credited = _provider_track(
@@ -1566,6 +1588,40 @@ def test_compare_track_evidence_rejects_explicitness_conflicts() -> None:
     clean.metadata.explicit = False
 
     assert compare.compare_track_evidence(explicit, clean) == compare.TrackMatchConfidence.NO_MATCH
+
+
+def test_compare_track_evidence_uses_hydrated_album_explicitness() -> None:
+    """Hydrated album metadata prevents clean and explicit substitutions."""
+    base = _provider_track("base", "provider_a")
+    candidate = _provider_track("candidate", "provider_b")
+    assert isinstance(base.album, media_items.Album)
+    assert isinstance(candidate.album, media_items.Album)
+    base_album = base.album
+    candidate_album = candidate.album
+    base_album.metadata.explicit = True
+    candidate_album.metadata.explicit = False
+    base.album = media_items.ItemMapping(
+        item_id=base_album.item_id,
+        provider=base_album.provider,
+        name=base_album.name,
+        media_type=MediaType.ALBUM,
+    )
+    candidate.album = media_items.ItemMapping(
+        item_id=candidate_album.item_id,
+        provider=candidate_album.provider,
+        name=candidate_album.name,
+        media_type=MediaType.ALBUM,
+    )
+
+    assert (
+        compare.compare_track_evidence(
+            base,
+            candidate,
+            base_album=base_album,
+            compare_album_item=candidate_album,
+        )
+        == compare.TrackMatchConfidence.NO_MATCH
+    )
 
 
 def test_compare_strings_accent_drift_matches() -> None:

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1382,6 +1382,23 @@ def test_compare_track_evidence_rejects_recording_version_conflicts() -> None:
     assert compare.compare_track_evidence(base, remix) == compare.TrackMatchConfidence.NO_MATCH
 
 
+def test_compare_track_evidence_release_track_id_overrides_version_drift() -> None:
+    """A shared release-track ID overrides conflicting provider version metadata."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    base = _provider_track("base", "provider_a", external_ids={mb_track})
+    mislabeled = _provider_track(
+        "candidate",
+        "provider_b",
+        version="Club Remix",
+        external_ids={mb_track},
+    )
+
+    assert compare.compare_track_evidence(base, mislabeled) == compare.TrackMatchConfidence.EXACT
+
+
 def test_compare_track_evidence_handles_featured_artist_title_drift() -> None:
     """Featured credits may move between the title and structured artist list."""
     title_credit = _provider_track(

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1419,6 +1419,26 @@ def test_compare_track_evidence_handles_featured_artist_title_drift() -> None:
     )
 
 
+def test_compare_track_evidence_handles_with_artist_title_drift() -> None:
+    """A with-credit may move between the title and structured artist list."""
+    title_credit = _provider_track(
+        "base",
+        "provider_a",
+        name="Track (with Guest)",
+    )
+    structured_credit = _provider_track(
+        "candidate",
+        "provider_b",
+        album_name="Compilation",
+        artist_names=("Artist A", "Guest"),
+    )
+
+    assert (
+        compare.compare_track_evidence(title_credit, structured_credit)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+
+
 def test_compare_track_evidence_stops_feature_credit_before_version() -> None:
     """Version brackets after a bare featured credit are not part of the artist name."""
     title_credit = _provider_track(

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1305,6 +1305,27 @@ def test_compare_track_evidence_conflicting_release_track_ids_are_not_exact() ->
     assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.LIKELY
 
 
+def test_compare_track_evidence_authoritative_id_overrides_position_drift() -> None:
+    """Provider track-number drift does not override an authoritative release-track ID."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "11111111-1111-1111-1111-111111111111",
+    )
+    base = _provider_track("base", "provider_a", external_ids={mb_track})
+    candidate = _provider_track(
+        "candidate",
+        "provider_b",
+        external_ids={mb_track},
+    )
+    candidate.track_number = 2
+
+    assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.EXACT
+
+    base.external_ids.clear()
+    candidate.external_ids.clear()
+    assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.NO_MATCH
+
+
 def test_compare_track_evidence_simplified_albums_do_not_prove_exact_release() -> None:
     """Album mappings without artist and year evidence only support a recording match."""
     base = _provider_track("base", "provider_a")

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -4,7 +4,7 @@ import sqlite3
 
 import pytest
 from music_assistant_models import media_items
-from music_assistant_models.enums import ExternalID
+from music_assistant_models.enums import ExternalID, MediaType
 
 from music_assistant.helpers import compare
 
@@ -69,6 +69,54 @@ def _track(
         provider_mappings={
             media_items.ProviderMapping(
                 item_id=item_id, provider_domain="test", provider_instance="test1"
+            )
+        },
+    )
+
+
+def _provider_track(
+    item_id: str,
+    provider: str,
+    *,
+    name: str = "Track",
+    version: str = "",
+    duration: int = 200,
+    album_name: str = "Album",
+    artist_names: tuple[str, ...] = ("Artist A",),
+    external_ids: set[tuple[ExternalID, str]] | None = None,
+) -> media_items.Track:
+    """Build a provider track for confidence comparisons."""
+    album = _album(
+        item_id=f"album-{item_id}",
+        provider=provider,
+        name=album_name,
+    )
+    return media_items.Track(
+        item_id=item_id,
+        provider=provider,
+        name=name,
+        version=version,
+        duration=duration,
+        disc_number=1,
+        track_number=1,
+        artists=media_items.UniqueList(
+            [
+                media_items.ItemMapping(
+                    item_id=f"artist-{index}",
+                    provider=provider,
+                    name=artist_name,
+                    media_type=MediaType.ARTIST,
+                )
+                for index, artist_name in enumerate(artist_names)
+            ]
+        ),
+        album=album,
+        external_ids=external_ids or set(),
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id=item_id,
+                provider_domain=provider,
+                provider_instance=provider,
             )
         },
     )
@@ -1212,6 +1260,172 @@ def test_compare_track_missing_disc_number_assumes_disc_one() -> None:
     disc_two = _albumtrack("3", "test2", disc_number=2)
     disc_two.duration = 320
     assert compare.compare_track(untagged, disc_two) is False
+
+
+def test_compare_track_evidence_ranks_release_and_recording_matches() -> None:
+    """Exact-release evidence outranks the same recording on another album."""
+    base = _provider_track("base", "provider_a")
+    exact = _provider_track("exact", "provider_b")
+    alternate_release = _provider_track(
+        "alternate",
+        "provider_b",
+        album_name="Compilation",
+    )
+
+    assert compare.compare_track_evidence(base, exact) == compare.TrackMatchConfidence.EXACT
+    assert (
+        compare.compare_track_evidence(base, alternate_release)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+
+
+def test_compare_track_evidence_accepts_missing_remaster_by_album_year() -> None:
+    """Matching album years resolve version metadata omitted by one provider."""
+    base = _provider_track("base", "provider_a")
+    remaster = _provider_track(
+        "remaster",
+        "provider_b",
+        version="2022 Remaster",
+    )
+    assert isinstance(base.album, media_items.Album)
+    base.album.year = 2022
+    assert isinstance(remaster.album, media_items.Album)
+    remaster.album.year = 2022
+
+    assert compare.compare_track_evidence(base, remaster) == compare.TrackMatchConfidence.LIKELY
+
+    remaster.album.year = 2021
+    assert compare.compare_track_evidence(base, remaster) == compare.TrackMatchConfidence.LOOSE
+
+
+def test_compare_track_evidence_rejects_recording_version_conflicts() -> None:
+    """A recording-changing version never matches the original recording."""
+    recording_id = (
+        ExternalID.MB_RECORDING,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    base = _provider_track("base", "provider_a", external_ids={recording_id})
+    remix = _provider_track(
+        "remix",
+        "provider_b",
+        version="Club Remix",
+        external_ids={recording_id},
+    )
+
+    assert compare.compare_track_evidence(base, remix) == compare.TrackMatchConfidence.NO_MATCH
+
+
+def test_compare_track_evidence_handles_featured_artist_title_drift() -> None:
+    """Featured credits may move between the title and structured artist list."""
+    title_credit = _provider_track(
+        "base",
+        "provider_a",
+        name="Track (feat. Guest)",
+    )
+    structured_credit = _provider_track(
+        "candidate",
+        "provider_b",
+        album_name="Compilation",
+        artist_names=("Artist A", "Guest"),
+    )
+
+    assert (
+        compare.compare_track_evidence(title_credit, structured_credit)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+
+
+def test_compare_track_evidence_ranks_recording_identifiers() -> None:
+    """Release-track IDs are exact while recording IDs identify alternate releases."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    mb_recording = (
+        ExternalID.MB_RECORDING,
+        "abcdefab-abcd-abcd-abcd-abcdefabcdef",
+    )
+    base = _provider_track(
+        "base",
+        "provider_a",
+        album_name="Original",
+        external_ids={mb_track, mb_recording},
+    )
+    exact = _provider_track(
+        "exact",
+        "provider_b",
+        album_name="Reissue",
+        external_ids={mb_track, mb_recording},
+    )
+    recording = _provider_track(
+        "recording",
+        "provider_b",
+        album_name="Compilation",
+        external_ids={
+            (
+                ExternalID.MB_TRACK,
+                "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb",
+            ),
+            mb_recording,
+        },
+    )
+    conflicting_recording = _provider_track(
+        "conflict",
+        "provider_b",
+        external_ids={
+            mb_track,
+            (
+                ExternalID.MB_RECORDING,
+                "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            ),
+        },
+    )
+
+    assert compare.compare_track_evidence(base, exact) == compare.TrackMatchConfidence.EXACT
+    assert compare.compare_track_evidence(base, recording) == compare.TrackMatchConfidence.LIKELY
+    assert (
+        compare.compare_track_evidence(base, conflicting_recording)
+        == compare.TrackMatchConfidence.NO_MATCH
+    )
+
+
+def test_compare_track_evidence_uses_isrc_duration_tolerance() -> None:
+    """A valid shared ISRC tolerates provider duration drift up to eight seconds."""
+    isrc = (ExternalID.ISRC, "USRC17607839")
+    base = _provider_track("base", "provider_a", duration=200, external_ids={isrc})
+    within_tolerance = _provider_track(
+        "within",
+        "provider_b",
+        duration=208,
+        album_name="Compilation",
+        external_ids={isrc},
+    )
+    outside_tolerance = _provider_track(
+        "outside",
+        "provider_b",
+        duration=209,
+        album_name="Compilation",
+        external_ids={isrc},
+    )
+
+    assert (
+        compare.compare_track_evidence(base, within_tolerance)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+    assert (
+        compare.compare_track_evidence(base, outside_tolerance)
+        == compare.TrackMatchConfidence.NO_MATCH
+    )
+
+
+def test_compare_track_evidence_rejects_explicitness_conflicts() -> None:
+    """Explicit and clean recordings are not interchangeable migration matches."""
+    explicit = _provider_track("explicit", "provider_a")
+    clean = _provider_track("clean", "provider_b")
+    explicit.metadata.explicit = True
+    clean.metadata.explicit = False
+
+    assert compare.compare_track_evidence(explicit, clean) == compare.TrackMatchConfidence.NO_MATCH
 
 
 def test_compare_strings_accent_drift_matches() -> None:

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1476,6 +1476,24 @@ def test_compare_track_evidence_rejects_conflicting_featured_artists() -> None:
     assert compare.compare_track_evidence(alice, bob) == compare.TrackMatchConfidence.NO_MATCH
 
 
+def test_compare_track_evidence_rejects_conflicting_colon_featured_artists() -> None:
+    """Colon-form featured credits remain part of track identity."""
+    alice = _provider_track(
+        "alice",
+        "provider_a",
+        name="Track (feat:Alice)",
+        album_name="Original",
+    )
+    bob = _provider_track(
+        "bob",
+        "provider_b",
+        name="Track (feat:Bob)",
+        album_name="Compilation",
+    )
+
+    assert compare.compare_track_evidence(alice, bob) == compare.TrackMatchConfidence.NO_MATCH
+
+
 def test_compare_track_evidence_keeps_complete_featured_artist_name() -> None:
     """A separator inside one featured artist name is not treated as conflicting credits."""
     title_credit = _provider_track(

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1375,7 +1375,7 @@ def test_compare_track_evidence_keeps_complete_featured_artist_name() -> None:
     title_credit = _provider_track(
         "base",
         "provider_a",
-        name="Track (feat. Simon & Garfunkel)",
+        name="Track (feat. Simon and Garfunkel)",
         album_name="Original",
     )
     structured_credit = _provider_track(

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1335,6 +1335,41 @@ def test_compare_track_evidence_handles_featured_artist_title_drift() -> None:
     )
 
 
+def test_compare_track_evidence_allows_omitted_featured_artist() -> None:
+    """A provider may omit a featured credit carried by the other provider."""
+    credited = _provider_track(
+        "base",
+        "provider_a",
+        name="Track (feat. Guest)",
+        album_name="Original",
+    )
+    omitted = _provider_track(
+        "candidate",
+        "provider_b",
+        album_name="Compilation",
+    )
+
+    assert compare.compare_track_evidence(credited, omitted) == compare.TrackMatchConfidence.LIKELY
+
+
+def test_compare_track_evidence_rejects_conflicting_featured_artists() -> None:
+    """Different explicit featured credits identify different collaborations."""
+    alice = _provider_track(
+        "alice",
+        "provider_a",
+        name="Track (feat. Alice)",
+        album_name="Original",
+    )
+    bob = _provider_track(
+        "bob",
+        "provider_b",
+        name="Track (feat. Bob)",
+        album_name="Compilation",
+    )
+
+    assert compare.compare_track_evidence(alice, bob) == compare.TrackMatchConfidence.NO_MATCH
+
+
 def test_compare_track_evidence_ranks_recording_identifiers() -> None:
     """Release-track IDs are exact while recording IDs identify alternate releases."""
     mb_track = (

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1370,6 +1370,27 @@ def test_compare_track_evidence_rejects_conflicting_featured_artists() -> None:
     assert compare.compare_track_evidence(alice, bob) == compare.TrackMatchConfidence.NO_MATCH
 
 
+def test_compare_track_evidence_keeps_complete_featured_artist_name() -> None:
+    """A separator inside one featured artist name is not treated as conflicting credits."""
+    title_credit = _provider_track(
+        "base",
+        "provider_a",
+        name="Track (feat. Simon & Garfunkel)",
+        album_name="Original",
+    )
+    structured_credit = _provider_track(
+        "candidate",
+        "provider_b",
+        album_name="Compilation",
+        artist_names=("Artist A", "Simon & Garfunkel"),
+    )
+
+    assert (
+        compare.compare_track_evidence(title_credit, structured_credit)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+
+
 def test_compare_track_evidence_ranks_recording_identifiers() -> None:
     """Release-track IDs are exact while recording IDs identify alternate releases."""
     mb_track = (

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1279,6 +1279,52 @@ def test_compare_track_evidence_ranks_release_and_recording_matches() -> None:
     )
 
 
+def test_compare_track_evidence_conflicting_release_track_ids_are_not_exact() -> None:
+    """Different MusicBrainz release-track IDs can still identify the same recording."""
+    base = _provider_track(
+        "base",
+        "provider_a",
+        external_ids={
+            (
+                ExternalID.MB_TRACK,
+                "11111111-1111-1111-1111-111111111111",
+            )
+        },
+    )
+    candidate = _provider_track(
+        "candidate",
+        "provider_b",
+        external_ids={
+            (
+                ExternalID.MB_TRACK,
+                "22222222-2222-2222-2222-222222222222",
+            )
+        },
+    )
+
+    assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.LIKELY
+
+
+def test_compare_track_evidence_simplified_albums_do_not_prove_exact_release() -> None:
+    """Album mappings without artist and year evidence only support a recording match."""
+    base = _provider_track("base", "provider_a")
+    candidate = _provider_track("candidate", "provider_b")
+    base.album = media_items.ItemMapping(
+        item_id="album-a",
+        provider="provider_a",
+        name="Album",
+        media_type=MediaType.ALBUM,
+    )
+    candidate.album = media_items.ItemMapping(
+        item_id="album-b",
+        provider="provider_b",
+        name="Album",
+        media_type=MediaType.ALBUM,
+    )
+
+    assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.LIKELY
+
+
 def test_compare_track_evidence_accepts_missing_remaster_by_album_year() -> None:
     """Matching album years resolve version metadata omitted by one provider."""
     base = _provider_track("base", "provider_a")

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1494,6 +1494,27 @@ def test_compare_track_evidence_rejects_conflicting_colon_featured_artists() -> 
     assert compare.compare_track_evidence(alice, bob) == compare.TrackMatchConfidence.NO_MATCH
 
 
+def test_compare_track_evidence_keeps_composite_artist_identity() -> None:
+    """A partial overlap does not match a complete composite artist credit."""
+    partial_credit = _provider_track(
+        "partial",
+        "provider_a",
+        name="Track (feat. Tyler)",
+        album_name="Original",
+    )
+    composite_credit = _provider_track(
+        "composite",
+        "provider_b",
+        album_name="Compilation",
+        artist_names=("Artist A", "Tyler, The Creator"),
+    )
+
+    assert (
+        compare.compare_track_evidence(partial_credit, composite_credit)
+        == compare.TrackMatchConfidence.NO_MATCH
+    )
+
+
 def test_compare_track_evidence_keeps_complete_featured_artist_name() -> None:
     """A separator inside one featured artist name is not treated as conflicting credits."""
     title_credit = _provider_track(

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -210,6 +210,30 @@ def test_with_handling_in_titles() -> None:
     assert version == "Remix"
 
 
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        ("Great Song (with John Smith)", ("John Smith",)),
+        ("Great Song [with Jane Doe]", ("Jane Doe",)),
+        ("Great Song - with John Smith (Duet)", ("John Smith",)),
+        ("Rockin' Around (With You)", ()),
+        ("The Catastrophe (Good Luck with That Man)", ()),
+        ("Great Song (feat:Alice)", ("Alice",)),
+    ],
+)
+def test_extract_title_artist_credits(title: str, expected: tuple[str, ...]) -> None:
+    """Embedded artist credits use the same title-word exceptions as title parsing."""
+    assert util.extract_title_artist_credits(title) == expected
+
+
+def test_with_artist_credit_preserves_trailing_title_content() -> None:
+    """Search normalization removes the credit without consuming later title content."""
+    assert util.parse_title_and_version(
+        "Great Song - with John Smith (Duet)",
+        strip_for_search=True,
+    ) == ("Great Song (Duet)", "")
+
+
 async def test_uri_parsing() -> None:
     """Test parsing of URI."""
     # test regular uri

--- a/tests/providers/ytmusic/test_helpers.py
+++ b/tests/providers/ytmusic/test_helpers.py
@@ -72,3 +72,23 @@ async def test_search_passes_auth_headers_and_user() -> None:
     with patch.object(ytmusicapi, "YTMusic", return_value=mock_ytm) as mock_ytmusic:
         await helpers.search(query="test", headers=headers, user="123")
     mock_ytmusic.assert_called_once_with(auth=headers, language="en", user="123")
+
+
+async def test_add_playlist_tracks_allows_duplicates() -> None:
+    """Playlist writes must opt into duplicate entries."""
+    mock_ytm = MagicMock()
+    headers = {"cookie": "abc"}
+    with patch.object(ytmusicapi, "YTMusic", return_value=mock_ytm):
+        await helpers.add_remove_playlist_tracks(
+            headers=headers,
+            prov_playlist_id="playlist",
+            prov_track_ids=["track", "track"],
+            add=True,
+            user="123",
+        )
+
+    mock_ytm.add_playlist_items.assert_called_once_with(
+        playlistId="playlist",
+        videoIds=["track", "track"],
+        duplicates=True,
+    )


### PR DESCRIPTION
# What does this implement/fix?

Copying a playlist between music services currently requires a manual export/import workflow.

- Migrate static playlists to Music Assistant or another streaming provider.
- Prefer exact releases, then same-recording or best-effort substitutes according to the selected policy.
- Reuse library mappings without adding to or changing library items.
- Preserve playlist order, retain duplicates where supported, report unsupported repeats, batch provider writes, and report substitutions or skipped tracks through the managed task.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR is https://github.com/music-assistant/frontend/pull/2614.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.