### PR TITLE
Drop the audio format comparison workaround

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -129,7 +129,6 @@ from music_assistant.helpers.audio import (
     is_grouping_preventing_dsp,
     iter_pcm_slices,
     parse_extinf_metadata,
-    pcm_formats_match,
     realtime_pcm_pacer,
     resample_pcm_audio,
     resolve_output_player_ids,
@@ -3841,7 +3840,7 @@ class StreamsAudio:
         # deliberately the advertised format: an AudioSource provider states the
         # PCM it delivers here, and providers that advertise a codec instead rely
         # on the ffmpeg path below to notice their source ending
-        if pcm_formats_match(streamdetails.audio_format, pcm_format):
+        if streamdetails.audio_format == pcm_format:
             source_gen = self._open_audio_source_generator(streamdetails)
             async for chunk in realtime_pcm_pacer(source_gen, pcm_format):
                 yield chunk

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -37,7 +37,7 @@ from music_assistant.controllers.streams.constants import (
     BufferMode,
     BufferSize,
 )
-from music_assistant.helpers.audio import arriving_audio_format, pcm_formats_match
+from music_assistant.helpers.audio import arriving_audio_format
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
 from music_assistant.models.music_provider import MusicProvider
 
@@ -283,9 +283,7 @@ class AudioBuffer:
         :param filter_params: FFmpeg filter parameters to apply.
         :param exact_seek: Preserve millisecond precision for the input buffer position.
         """
-        # not `!=`: that compares equal for integer and float PCM of the same
-        # depth, and passing one through as the other reinterprets every sample
-        needs_ffmpeg = bool(filter_params) or not pcm_formats_match(self.pcm_format, output_format)
+        needs_ffmpeg = bool(filter_params) or self.pcm_format != output_format
 
         if not needs_ffmpeg:
             async for chunk in self.get_raw_stream(

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -98,7 +98,6 @@ from music_assistant.helpers.audio import (
     create_streaming_wave_header,
     get_content_length,
     get_mime_type,
-    pcm_formats_match,
     store_content_length_in_cache,
 )
 from music_assistant.helpers.ffmpeg import (
@@ -1428,7 +1427,7 @@ class StreamsController(CoreController):
             ugp_player = cast("UniversalGroupPlayer", self.mass.players.get_player(media.source_id))
             ugp_stream = ugp_player.stream
             assert ugp_stream is not None  # for type checker
-            if pcm_formats_match(ugp_stream.base_pcm_format, pcm_format):
+            if ugp_stream.base_pcm_format == pcm_format:
                 # no conversion needed
                 return ugp_stream.subscribe_raw()
             return ugp_stream.get_stream(output_format=pcm_format)

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -740,27 +740,6 @@ async def store_probed_duration(mass: MusicAssistant, uri: str, duration: int) -
     )
 
 
-def pcm_formats_match(a: AudioFormat, b: AudioFormat) -> bool:
-    """
-    Return True if two PCM formats describe identical raw bytes.
-
-    ``AudioFormat.__eq__`` cannot answer this: every PCM content type renders
-    the same ``output_format_str``, so integer and float PCM of equal depth
-    compare equal. Anything that decides whether audio may be passed through
-    unconverted has to use this instead, or it will hand one to a consumer
-    expecting the other.
-
-    :param a: One format.
-    :param b: The format to compare it against.
-    """
-    return (
-        a.content_type == b.content_type
-        and a.sample_rate == b.sample_rate
-        and a.bit_depth == b.bit_depth
-        and a.channels == b.channels
-    )
-
-
 def arriving_audio_format(streamdetails: StreamDetails) -> AudioFormat:
     """
     Return the format the audio actually arrives in.

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -13,7 +13,6 @@ from music_assistant_models.errors import MusicAssistantError, PlayerCommandFail
 
 from music_assistant.constants import CONF_SYNC_ADJUST
 from music_assistant.controllers.streams.audio_processing import get_media_session_id
-from music_assistant.helpers.audio import pcm_formats_match
 from music_assistant.helpers.ffmpeg import FFMpeg
 
 from .constants import (
@@ -246,9 +245,8 @@ class AirPlayStreamSession:
         """
         if {p.player_id for p in sync_clients} != {p.player_id for p in self.sync_clients}:
             return False
-        # the encoding counts as much as the rate and depth: replace() wires the
-        # new source into the session's existing declared format
-        if not pcm_formats_match(pcm_format, self.pcm_format):
+        # replace() wires the new source into the session's existing declared format
+        if pcm_format != self.pcm_format:
             return False
         return all(
             p.stream is not None and p.stream.running and p.stream.connected

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -245,7 +245,8 @@ class AirPlayStreamSession:
         """
         if {p.player_id for p in sync_clients} != {p.player_id for p in self.sync_clients}:
             return False
-        # replace() wires the new source into the session's existing declared format
+        # the encoding matters as much as the depth here (a 24-bit session carries
+        # PCM_S32LE): replace() wires the new source into the session's declared format
         if pcm_format != self.pcm_format:
             return False
         return all(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "ifaddr==0.2.0",
   "getmac==0.9.5",
   "mashumaro==3.20",
-  "music-assistant-models==1.1.196",
+  "music-assistant-models==1.1.197",
   "music-assistant-frontend==2.17.285",
   "mutagen==1.48.1",
   "orjson==3.11.6",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -51,7 +51,7 @@ markdownify==1.2.3
 mashumaro==3.20
 modern_colorthief==0.2.1
 music-assistant-frontend==2.17.285
-music-assistant-models==1.1.196
+music-assistant-models==1.1.197
 mutagen==1.48.1
 niconico.py-ma==2.1.0.post3
 nnAudio==0.3.4

--- a/tests/controllers/streams/test_pcm_passthrough_gate.py
+++ b/tests/controllers/streams/test_pcm_passthrough_gate.py
@@ -9,7 +9,6 @@ from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.controllers.streams import audio_buffer as audio_buffer_module
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
-from music_assistant.helpers.audio import pcm_formats_match
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
 
 if TYPE_CHECKING:
@@ -23,15 +22,16 @@ _F32 = AudioFormat(content_type=ContentType.PCM_F32LE, sample_rate=44100, bit_de
 
 def test_integer_and_float_pcm_are_not_interchangeable() -> None:
     """
-    Equality cannot be used to decide a passthrough.
+    The gates below rely on the model telling PCM encodings apart.
 
-    Every PCM content type renders the same ``output_format_str``, so the model's
-    own ``==`` reports integer and float PCM of one depth as the same format;
+    Integer and float PCM of one depth share their rate, depth and channel count;
     passing one through as the other reinterprets every sample.
     """
-    assert _S32 == _F32  # the trap this predicate exists to avoid
-    assert not pcm_formats_match(_S32, _F32)
-    assert pcm_formats_match(_S32, _S32)
+    assert _S32 != _F32
+    same_as_s32 = AudioFormat(
+        content_type=ContentType.PCM_S32LE, sample_rate=44100, bit_depth=32, channels=2
+    )
+    assert same_as_s32 == _S32
 
 
 async def test_the_buffer_converts_rather_than_reinterprets(

--- a/tests/controllers/streams/test_pcm_passthrough_gate.py
+++ b/tests/controllers/streams/test_pcm_passthrough_gate.py
@@ -68,3 +68,4 @@ def test_a_warm_airplay_replace_refuses_a_differently_encoded_source() -> None:
     session.pcm_format = _F32
     session.sync_clients = []
     assert session.can_replace([], _S32) is False
+    assert session.can_replace([], _F32) is True


### PR DESCRIPTION
# What does this implement/fix?

`AudioFormat.__eq__` used to ignore the PCM encoding, so integer and float PCM of the same
depth compared as one format. #5918 worked around that with a local `pcm_formats_match()`
helper. The model now compares on its content type, so the helper is a literal duplicate of
`==` and the four gates can go back to plain equality.

**Related issue (if applicable):**

- music-assistant/models#375

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Bump `music-assistant-models` to 1.1.197.
- Remove `pcm_formats_match()` and use `==` / `!=` in `AudioBuffer.get_stream`, the UGP
  `subscribe_raw` shortcut, the AudioSource ffmpeg bypass and `AirPlayStreamSession.can_replace`.
- Two passthrough gates that were already on `==`, and were therefore wrong for
  integer-vs-float PCM, become correct with the bump: the crossfade resample check in
  `controllers/streams/audio.py` and the announcement render in
  `controllers/streams/announcements.py`. Neither can be hit with a mismatch today, but they
  no longer depend on call-site discipline.
- Rework `test_pcm_passthrough_gate.py`, which asserted the old behaviour on purpose. Its two
  behavioural tests are unchanged.

This supersedes the automatic models bump PR: that one on its own leaves the above test failing.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
