### PR TITLE
Show when a music service handles loudness and crossfade itself

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 56
+API_SCHEMA_VERSION: Final[int] = 57
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2297,11 +2297,17 @@ class StreamsAudio:
                     )
                     continue
                 # a realtime source delivers at playback pace, so it has no audio to spare
-                # for an overlap in either direction
+                # for an overlap in either direction - but one that crossfades its own
+                # playback still does that boundary itself, inside the audio it hands over
                 item_crossfade_mode = (
                     CrossfadeMode.DISABLED
                     if queue_track.streamdetails.is_realtime
                     else crossfade_mode
+                )
+                item_source_crossfade_mode = (
+                    self.mass.streams.get_source_crossfade_mode(queue, queue_track.streamdetails)
+                    if queue_track.streamdetails.is_realtime
+                    else CrossfadeMode.DISABLED
                 )
                 self.logger.debug(
                     "Start Streaming queue track: %s (%s) for queue %s",
@@ -2426,12 +2432,13 @@ class StreamsAudio:
                             + (timing_info.fadein_trimmed_duration + timing_info.crossfade_duration)
                             * track_playback_speed
                         )
-                # no fade is credited to this track until one is really rendered below
+                # no fade is credited to this track until one is really rendered below,
+                # unless its own source is the one applying it
                 self._report_crossfade_mode(
                     queue.queue_id,
                     queue_track,
                     pcm_format,
-                    CrossfadeMode.DISABLED,
+                    item_source_crossfade_mode,
                     flow_session_id,
                     overlay_enabled=overlay_active(queue),
                 )
@@ -3685,7 +3692,8 @@ class StreamsAudio:
         :param queue_id: Queue the item is streamed from.
         :param queue_item: Queue item the fade touches.
         :param pcm_format: Shared PCM format leaving queue processing.
-        :param crossfade_mode: Mode of the applied fade, or DISABLED when none is applied.
+        :param crossfade_mode: Mode of the applied fade, SOURCE when the item's own
+            source applies it, or DISABLED when none is applied.
         :param session_id: Queue session that owns processing-detail updates.
         :param overlay_enabled: Whether an overlay is mixed into this stream.
         """
@@ -4157,7 +4165,8 @@ class StreamsAudio:
         needs_headroom = (
             crossfade_enabled
             or overlay_active
-            or streamdetails.volume_normalization_mode != VolumeNormalizationMode.DISABLED
+            or streamdetails.volume_normalization_mode
+            not in (VolumeNormalizationMode.DISABLED, VolumeNormalizationMode.SOURCE)
             or any(self._resolve_player_dsp_config(player).enabled for player in players)
         )
         if needs_headroom:

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -102,6 +102,8 @@ from music_assistant.controllers.streams.constants import (
     CACHE_CATEGORY_RESOLVED_RADIO_URL,
     CACHE_PROVIDER,
     CONF_ALLOW_CROSSFADE_SAME_ALBUM,
+    DEFAULT_VOLUME_NORMALIZATION_MODE,
+    OUTCOME_ONLY_NORMALIZATION_MODES,
     STREAM_SLOT_MATCH_TIMEOUT,
     STREAM_SLOT_PLAYBACK_WAIT_TIMEOUT,
     STREAM_SLOT_WAIT_TIMEOUT,
@@ -3009,9 +3011,14 @@ class StreamsAudio:
             if streamdetails.media_type == MediaType.RADIO
             else CONF_VOLUME_NORMALIZATION_TRACKS
         )
-        return VolumeNormalizationMode(
+        preference = VolumeNormalizationMode(
             self.mass.streams.get_config_value(conf_key, return_type=str)
         )
+        # a stored value the options never offered is not a preference: nothing
+        # validates a saved config value against them
+        if preference in OUTCOME_ONLY_NORMALIZATION_MODES:
+            return DEFAULT_VOLUME_NORMALIZATION_MODE
+        return preference
 
     def _update_radio_stream_metadata(
         self,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -611,7 +611,7 @@ class StreamsAudio:
             self._get_volume_normalization_preference(streamdetails),
             volume_normalization_enabled,
             streamdetails,
-            self._source_delivers_normalized_audio(streamdetails),
+            self.mass.streams.source_normalizes_audio(streamdetails),
         )
 
         self.logger.debug(
@@ -1560,7 +1560,7 @@ class StreamsAudio:
                     self._get_volume_normalization_preference(streamdetails),
                     volume_normalization_enabled,
                     streamdetails,
-                    self._source_delivers_normalized_audio(streamdetails),
+                    self.mass.streams.source_normalizes_audio(streamdetails),
                 )
 
         # get or create the AudioBuffer (stores raw decoded PCM). This runs before the
@@ -2999,17 +2999,6 @@ class StreamsAudio:
             return
         music_prov = cast("MusicProvider", provider)
         self.mass.create_task(music_prov.on_streamed(streamdetails))
-
-    def _source_delivers_normalized_audio(self, streamdetails: StreamDetails) -> bool:
-        """
-        Return whether the provider already normalized this audio on the way out.
-
-        :param streamdetails: The stream to evaluate.
-        """
-        # plugin providers serve playable items too, and only a music provider
-        # declares this (a plugin's live audio is handled by the media type)
-        provider = self.mass.get_provider(streamdetails.provider)
-        return isinstance(provider, MusicProvider) and provider.delivers_normalized_audio
 
     def _get_volume_normalization_preference(
         self, streamdetails: StreamDetails

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2304,10 +2304,8 @@ class StreamsAudio:
                     if queue_track.streamdetails.is_realtime
                     else crossfade_mode
                 )
-                item_source_crossfade_mode = (
-                    self.mass.streams.get_source_crossfade_mode(queue, queue_track.streamdetails)
-                    if queue_track.streamdetails.is_realtime
-                    else CrossfadeMode.DISABLED
+                item_source_crossfade_mode = self.mass.streams.get_source_crossfade_mode(
+                    queue, queue_track
                 )
                 self.logger.debug(
                     "Start Streaming queue track: %s (%s) for queue %s",

--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -603,10 +603,14 @@ def _is_bit_perfect(
         for audio_format in formats
     ):
         return False
+    # a step the source performed is reported for context but leaves our path untouched
     if (
-        queue_processing.normalization is not None
+        (
+            queue_processing.normalization is not None
+            and queue_processing.normalization.mode != VolumeNormalizationMode.SOURCE
+        )
         or queue_processing.playback_speed != 1.0
-        or queue_processing.crossfade_mode != CrossfadeMode.DISABLED
+        or queue_processing.crossfade_mode not in (CrossfadeMode.DISABLED, CrossfadeMode.SOURCE)
         or queue_processing.overlay_active
     ):
         return False

--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -523,6 +523,10 @@ def get_normalization_details(
     if mode in (None, VolumeNormalizationMode.DISABLED, VolumeNormalizationMode.UNKNOWN):
         return None
     assert mode is not None
+    if mode == VolumeNormalizationMode.SOURCE:
+        # the source set the level without saying to what, and a measurement of our
+        # own would describe audio it already levelled, so only the mode is known
+        return AudioNormalizationDetails(mode=mode)
     measurement_source = AudioNormalizationMeasurementSource.UNKNOWN
     measured_lufs: float | None = None
     if mode == VolumeNormalizationMode.DYNAMIC:

--- a/music_assistant/controllers/streams/constants.py
+++ b/music_assistant/controllers/streams/constants.py
@@ -5,7 +5,22 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Final
 
+from music_assistant_models.enums import VolumeNormalizationMode
+
 from music_assistant.helpers.util import get_total_system_memory, meets_memory_target
+
+# What the volume normalization preference falls back to.
+DEFAULT_VOLUME_NORMALIZATION_MODE: Final = VolumeNormalizationMode.FALLBACK_DYNAMIC
+
+# Modes that are only ever an outcome, never something to ask for: SOURCE is set by a
+# source that levels its own audio and UNKNOWN is what an unrecognised value
+# deserializes to. Neither is offered as a preference, and one that reaches the config
+# anyway is not honoured as one - it would otherwise be handed straight back as the
+# mode to apply, which for SOURCE also means claiming a source levelled the audio.
+OUTCOME_ONLY_NORMALIZATION_MODES: Final = (
+    VolumeNormalizationMode.SOURCE,
+    VolumeNormalizationMode.UNKNOWN,
+)
 
 
 class BufferMode(StrEnum):

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -83,7 +83,9 @@ from music_assistant.controllers.streams.constants import (
     CONF_BUFFER_SIZE_DEFAULT,
     CONF_SMART_FADES_LOG_LEVEL,
     DEFAULT_PORT,
+    DEFAULT_VOLUME_NORMALIZATION_MODE,
     FLOW_STREAM_LEAD_OUT_SECONDS,
+    OUTCOME_ONLY_NORMALIZATION_MODES,
     SINGLE_ITEM_READRATE,
     SINGLE_ITEM_READRATE_INITIAL_BURST,
     BufferSize,
@@ -138,17 +140,11 @@ isfile = wrap(os.path.isfile)
 
 
 def _volume_normalization_preference_options() -> list[ConfigValueOption]:
-    """
-    Return the normalization modes that can be picked as a preference.
-
-    The preference says what Music Assistant should do, so the two modes that only
-    ever come back as an outcome are left out: SOURCE is set by a source that levels
-    its own audio, UNKNOWN is what an unrecognised value deserializes to.
-    """
+    """Return the normalization modes that can be picked as a preference."""
     return [
         ConfigValueOption(mode.value, title=mode.value.replace("_", " ").title())
         for mode in VolumeNormalizationMode
-        if mode not in (VolumeNormalizationMode.SOURCE, VolumeNormalizationMode.UNKNOWN)
+        if mode not in OUTCOME_ONLY_NORMALIZATION_MODES
     ]
 
 
@@ -383,8 +379,8 @@ class StreamsController(CoreController):
         A source that crossfades its own playback is handed the queue's crossfade
         setting instead of Music Assistant mixing the overlap. This only answers for
         audio we do not mix ourselves, and the same two limits apply as to a fade of
-        our own: only tracks are faded, and an item with nothing queued after it has
-        no boundary the same source owns both sides of.
+        our own: only tracks are faded, and an item needs a boundary the same source
+        owns both sides of.
 
         :param queue: Queue the item is played from.
         :param queue_item: Queue item to report the fade for.
@@ -404,7 +400,7 @@ class StreamsController(CoreController):
             source_fades = self.get_crossfade_mode(queue) != CrossfadeMode.DISABLED
         if not source_fades:
             return CrossfadeMode.DISABLED
-        if not self._source_serves_next_item(queue, queue_item):
+        if not self._source_fades_an_adjacent_item(queue, queue_item):
             return CrossfadeMode.DISABLED
         return CrossfadeMode.SOURCE
 
@@ -429,14 +425,14 @@ class StreamsController(CoreController):
             ConfigEntry(
                 key=CONF_VOLUME_NORMALIZATION_RADIO,
                 type=ConfigEntryType.STRING,
-                default_value=VolumeNormalizationMode.FALLBACK_DYNAMIC,
+                default_value=DEFAULT_VOLUME_NORMALIZATION_MODE,
                 options=_volume_normalization_preference_options(),
                 category="playback",
             ),
             ConfigEntry(
                 key=CONF_VOLUME_NORMALIZATION_TRACKS,
                 type=ConfigEntryType.STRING,
-                default_value=VolumeNormalizationMode.FALLBACK_DYNAMIC,
+                default_value=DEFAULT_VOLUME_NORMALIZATION_MODE,
                 options=_volume_normalization_preference_options(),
                 category="playback",
             ),
@@ -1979,25 +1975,43 @@ class StreamsController(CoreController):
                     queue_id,
                 )
 
-    def _source_serves_next_item(self, queue: PlayerQueue, queue_item: QueueItem) -> bool:
+    def _source_fades_an_adjacent_item(self, queue: PlayerQueue, queue_item: QueueItem) -> bool:
         """
-        Return whether the item that follows comes from the same source.
+        Return whether the same source serves an item next to this one.
 
         A source can only fade across a boundary it owns both sides of: with anything
-        else queued next it plays the current item out and the cut is a hard one.
+        else next to this item it plays the item out and the cut is a hard one. Both
+        neighbours count, the same way one of our own fades credits both of its sides -
+        the last track of a queue is still the side that was faded into.
 
         :param queue: Queue the item is played from.
-        :param queue_item: Queue item whose follower to check.
+        :param queue_item: Queue item whose neighbours to check.
         """
-        follower = self.mass.player_queues.get_next_item(queue.queue_id, queue_item.queue_item_id)
-        if follower is None or follower.media_type != MediaType.TRACK:
-            return False
         assert queue_item.streamdetails is not None  # guaranteed by the caller
-        provider_instance = queue_item.streamdetails.provider
-        if (follower_details := follower.streamdetails) is not None:
+        controller = self.mass.player_queues
+        queue_id = queue.queue_id
+        neighbours = [controller.get_next_item(queue_id, queue_item.queue_item_id)]
+        index = controller.index_by_id(queue_id, queue_item.queue_item_id)
+        if index is not None and index > 0:
+            neighbours.append(controller.get_item(queue_id, index - 1))
+        return any(
+            self._served_by(neighbour, queue_item.streamdetails.provider)
+            for neighbour in neighbours
+        )
+
+    def _served_by(self, queue_item: QueueItem | None, provider_instance: str) -> bool:
+        """
+        Return whether a queue item is a track the given provider instance serves.
+
+        :param queue_item: Queue item to check, or None when there is none.
+        :param provider_instance: Instance id of the provider to match.
+        """
+        if queue_item is None or queue_item.media_type != MediaType.TRACK:
+            return False
+        if (streamdetails := queue_item.streamdetails) is not None:
             # already resolved, so this is the provider that will really serve it
-            return follower_details.provider == provider_instance
-        if (media_item := follower.media_item) is None:
+            return streamdetails.provider == provider_instance
+        if (media_item := queue_item.media_item) is None:
             return False
         return media_item.provider == provider_instance or any(
             mapping.provider_instance == provider_instance

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -137,7 +137,7 @@ if TYPE_CHECKING:
 isfile = wrap(os.path.isfile)
 
 
-def volume_normalization_preference_options() -> list[ConfigValueOption]:
+def _volume_normalization_preference_options() -> list[ConfigValueOption]:
     """
     Return the normalization modes that can be picked as a preference.
 
@@ -362,25 +362,37 @@ class StreamsController(CoreController):
             return CrossfadeMode.SMART_CROSSFADE
         return CrossfadeMode.STANDARD_CROSSFADE
 
-    def get_source_crossfade_mode(
-        self, queue: PlayerQueue, streamdetails: StreamDetails
-    ) -> CrossfadeMode:
+    def get_source_crossfade_mode(self, queue: PlayerQueue, queue_item: QueueItem) -> CrossfadeMode:
         """
         Return the crossfade an item's own source applies, or DISABLED when none does.
 
         A source that crossfades its own playback is handed the queue's crossfade
-        setting instead of Music Assistant mixing the overlap, so the queue
-        preference still decides whether a fade happens at all.
+        setting instead of Music Assistant mixing the overlap. This only answers for
+        audio we do not mix ourselves, and the same two limits apply as to a fade of
+        our own: only tracks are faded, and an item with nothing queued after it has
+        no boundary to fade across.
 
         :param queue: Queue the item is played from.
-        :param streamdetails: Stream details of the item.
+        :param queue_item: Queue item to report the fade for.
         """
-        if self.get_crossfade_mode(queue) == CrossfadeMode.DISABLED:
+        if queue_item.media_type != MediaType.TRACK or queue_item.streamdetails is None:
             return CrossfadeMode.DISABLED
-        provider = self.mass.get_provider(streamdetails.provider)
-        if isinstance(provider, MusicProvider) and provider.delivers_crossfaded_audio:
-            return CrossfadeMode.SOURCE
-        return CrossfadeMode.DISABLED
+        if not queue_item.streamdetails.is_realtime:
+            # we mix this item's overlap ourselves, so the source's is not in play
+            return CrossfadeMode.DISABLED
+        provider = self.mass.get_provider(queue_item.streamdetails.provider)
+        if not isinstance(provider, MusicProvider):
+            return CrossfadeMode.DISABLED
+        source_fades = provider.delivers_crossfaded_audio
+        if source_fades is None:
+            # nothing is playing from this source yet, so the setting it would be
+            # handed when it starts is the only thing to go on
+            source_fades = self.get_crossfade_mode(queue) != CrossfadeMode.DISABLED
+        if not source_fades:
+            return CrossfadeMode.DISABLED
+        if self.mass.player_queues.get_next_item(queue.queue_id, queue_item.queue_item_id) is None:
+            return CrossfadeMode.DISABLED
+        return CrossfadeMode.SOURCE
 
     def is_smart_fades_active(self, queue: PlayerQueue) -> bool:
         """Return whether the queue's effective crossfade mode is smart crossfade."""
@@ -404,14 +416,14 @@ class StreamsController(CoreController):
                 key=CONF_VOLUME_NORMALIZATION_RADIO,
                 type=ConfigEntryType.STRING,
                 default_value=VolumeNormalizationMode.FALLBACK_DYNAMIC,
-                options=volume_normalization_preference_options(),
+                options=_volume_normalization_preference_options(),
                 category="playback",
             ),
             ConfigEntry(
                 key=CONF_VOLUME_NORMALIZATION_TRACKS,
                 type=ConfigEntryType.STRING,
                 default_value=VolumeNormalizationMode.FALLBACK_DYNAMIC,
-                options=volume_normalization_preference_options(),
+                options=_volume_normalization_preference_options(),
                 category="playback",
             ),
             ConfigEntry(
@@ -768,16 +780,13 @@ class StreamsController(CoreController):
             )
             # a crossfade the source performs itself is never mixed here, so it is
             # tracked apart from the mode that drives our own mixer
-            source_crossfade_mode = CrossfadeMode.DISABLED
+            source_crossfade_mode = self.get_source_crossfade_mode(queue, queue_item)
             if queue_item.media_type != MediaType.TRACK:
                 crossfade_mode = CrossfadeMode.DISABLED
             elif queue_item.streamdetails.is_realtime:
                 # a realtime source delivers at playback pace, so it has no audio to
                 # spare for an overlap in either direction
                 crossfade_mode = CrossfadeMode.DISABLED
-                source_crossfade_mode = self.get_source_crossfade_mode(
-                    queue, queue_item.streamdetails
-                )
             else:
                 crossfade_mode = self.get_crossfade_mode(queue)
             if (
@@ -1549,6 +1558,7 @@ class StreamsController(CoreController):
                         queue_item.media_type == MediaType.RADIO and overlay_active(queue)
                     ),
                     session_id=queue_session_id,
+                    source_crossfade_mode=self.get_source_crossfade_mode(queue, queue_item),
                 )
             inner_stream = self.audio.get_queue_item_stream(
                 queue_item=queue_item,

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -384,7 +384,7 @@ class StreamsController(CoreController):
         setting instead of Music Assistant mixing the overlap. This only answers for
         audio we do not mix ourselves, and the same two limits apply as to a fade of
         our own: only tracks are faded, and an item with nothing queued after it has
-        no boundary to fade across.
+        no boundary the same source owns both sides of.
 
         :param queue: Queue the item is played from.
         :param queue_item: Queue item to report the fade for.
@@ -404,7 +404,7 @@ class StreamsController(CoreController):
             source_fades = self.get_crossfade_mode(queue) != CrossfadeMode.DISABLED
         if not source_fades:
             return CrossfadeMode.DISABLED
-        if self.mass.player_queues.get_next_item(queue.queue_id, queue_item.queue_item_id) is None:
+        if not self._source_serves_next_item(queue, queue_item):
             return CrossfadeMode.DISABLED
         return CrossfadeMode.SOURCE
 
@@ -792,9 +792,6 @@ class StreamsController(CoreController):
             standard_crossfade_duration = self.mass.config.get_raw_core_config_value(
                 CONF_PLAYER_QUEUES, CONF_CROSSFADE_DURATION, 8
             )
-            # a crossfade the source performs itself is never mixed here, so it is
-            # tracked apart from the mode that drives our own mixer
-            source_crossfade_mode = self.get_source_crossfade_mode(queue, queue_item)
             if queue_item.media_type != MediaType.TRACK:
                 crossfade_mode = CrossfadeMode.DISABLED
             elif queue_item.streamdetails.is_realtime:
@@ -879,7 +876,9 @@ class StreamsController(CoreController):
                     queue_item.media_type == MediaType.RADIO and overlay_active(queue)
                 ),
                 session_id=session_id,
-                source_crossfade_mode=source_crossfade_mode,
+                # a crossfade the source performs itself is never mixed here, so it
+                # is reported apart from the mode that drives our own mixer
+                source_crossfade_mode=self.get_source_crossfade_mode(queue, queue_item),
             )
 
             if crossfade_mode != CrossfadeMode.DISABLED:
@@ -1979,6 +1978,31 @@ class StreamsController(CoreController):
                     source_id,
                     queue_id,
                 )
+
+    def _source_serves_next_item(self, queue: PlayerQueue, queue_item: QueueItem) -> bool:
+        """
+        Return whether the item that follows comes from the same source.
+
+        A source can only fade across a boundary it owns both sides of: with anything
+        else queued next it plays the current item out and the cut is a hard one.
+
+        :param queue: Queue the item is played from.
+        :param queue_item: Queue item whose follower to check.
+        """
+        follower = self.mass.player_queues.get_next_item(queue.queue_id, queue_item.queue_item_id)
+        if follower is None or follower.media_type != MediaType.TRACK:
+            return False
+        assert queue_item.streamdetails is not None  # guaranteed by the caller
+        provider_instance = queue_item.streamdetails.provider
+        if (follower_details := follower.streamdetails) is not None:
+            # already resolved, so this is the provider that will really serve it
+            return follower_details.provider == provider_instance
+        if (media_item := follower.media_item) is None:
+            return False
+        return media_item.provider == provider_instance or any(
+            mapping.provider_instance == provider_instance
+            for mapping in media_item.provider_mappings
+        )
 
     def _update_audio_processing_context(
         self,

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -137,6 +137,21 @@ if TYPE_CHECKING:
 isfile = wrap(os.path.isfile)
 
 
+def volume_normalization_preference_options() -> list[ConfigValueOption]:
+    """
+    Return the normalization modes that can be picked as a preference.
+
+    The preference says what Music Assistant should do, so the two modes that only
+    ever come back as an outcome are left out: SOURCE is set by a source that levels
+    its own audio, UNKNOWN is what an unrecognised value deserializes to.
+    """
+    return [
+        ConfigValueOption(mode.value, title=mode.value.replace("_", " ").title())
+        for mode in VolumeNormalizationMode
+        if mode not in (VolumeNormalizationMode.SOURCE, VolumeNormalizationMode.UNKNOWN)
+    ]
+
+
 def _audio_source_headers(session: AudioSourceSession, output_format_str: str) -> dict[str, str]:
     """
     Return the response headers for a live audio source stream.
@@ -347,6 +362,26 @@ class StreamsController(CoreController):
             return CrossfadeMode.SMART_CROSSFADE
         return CrossfadeMode.STANDARD_CROSSFADE
 
+    def get_source_crossfade_mode(
+        self, queue: PlayerQueue, streamdetails: StreamDetails
+    ) -> CrossfadeMode:
+        """
+        Return the crossfade an item's own source applies, or DISABLED when none does.
+
+        A source that crossfades its own playback is handed the queue's crossfade
+        setting instead of Music Assistant mixing the overlap, so the queue
+        preference still decides whether a fade happens at all.
+
+        :param queue: Queue the item is played from.
+        :param streamdetails: Stream details of the item.
+        """
+        if self.get_crossfade_mode(queue) == CrossfadeMode.DISABLED:
+            return CrossfadeMode.DISABLED
+        provider = self.mass.get_provider(streamdetails.provider)
+        if isinstance(provider, MusicProvider) and provider.delivers_crossfaded_audio:
+            return CrossfadeMode.SOURCE
+        return CrossfadeMode.DISABLED
+
     def is_smart_fades_active(self, queue: PlayerQueue) -> bool:
         """Return whether the queue's effective crossfade mode is smart crossfade."""
         return self.get_crossfade_mode(queue) == CrossfadeMode.SMART_CROSSFADE
@@ -369,20 +404,14 @@ class StreamsController(CoreController):
                 key=CONF_VOLUME_NORMALIZATION_RADIO,
                 type=ConfigEntryType.STRING,
                 default_value=VolumeNormalizationMode.FALLBACK_DYNAMIC,
-                options=[
-                    ConfigValueOption(x.value, title=x.value.replace("_", " ").title())
-                    for x in VolumeNormalizationMode
-                ],
+                options=volume_normalization_preference_options(),
                 category="playback",
             ),
             ConfigEntry(
                 key=CONF_VOLUME_NORMALIZATION_TRACKS,
                 type=ConfigEntryType.STRING,
                 default_value=VolumeNormalizationMode.FALLBACK_DYNAMIC,
-                options=[
-                    ConfigValueOption(x.value, title=x.value.replace("_", " ").title())
-                    for x in VolumeNormalizationMode
-                ],
+                options=volume_normalization_preference_options(),
                 category="playback",
             ),
             ConfigEntry(
@@ -737,12 +766,18 @@ class StreamsController(CoreController):
             standard_crossfade_duration = self.mass.config.get_raw_core_config_value(
                 CONF_PLAYER_QUEUES, CONF_CROSSFADE_DURATION, 8
             )
+            # a crossfade the source performs itself is never mixed here, so it is
+            # tracked apart from the mode that drives our own mixer
+            source_crossfade_mode = CrossfadeMode.DISABLED
             if queue_item.media_type != MediaType.TRACK:
                 crossfade_mode = CrossfadeMode.DISABLED
             elif queue_item.streamdetails.is_realtime:
                 # a realtime source delivers at playback pace, so it has no audio to
                 # spare for an overlap in either direction
                 crossfade_mode = CrossfadeMode.DISABLED
+                source_crossfade_mode = self.get_source_crossfade_mode(
+                    queue, queue_item.streamdetails
+                )
             else:
                 crossfade_mode = self.get_crossfade_mode(queue)
             if (
@@ -821,6 +856,7 @@ class StreamsController(CoreController):
                     queue_item.media_type == MediaType.RADIO and overlay_active(queue)
                 ),
                 session_id=session_id,
+                source_crossfade_mode=source_crossfade_mode,
             )
 
             if crossfade_mode != CrossfadeMode.DISABLED:
@@ -1927,18 +1963,22 @@ class StreamsController(CoreController):
         pcm_format: AudioFormat,
         overlay_enabled: bool,
         session_id: str | None = None,
+        source_crossfade_mode: CrossfadeMode = CrossfadeMode.DISABLED,
     ) -> None:
         """
         Store the shared processing context selected for a queue item.
 
-        The crossfade is left out on purpose: only the audio layer knows whether one
-        really happens, and it reports that itself once the boundary has decided.
+        Our own crossfade is left out on purpose: only the audio layer knows whether
+        one really happens, and it reports that itself once the boundary has decided.
+        A crossfade the source performs is the exception - the audio layer never sees
+        that one, so it is carried here.
 
         :param queue: Active player queue.
         :param queue_item: Queue item being prepared.
         :param pcm_format: Shared PCM format leaving queue processing.
         :param overlay_enabled: Whether an overlay is mixed into this stream.
         :param session_id: Queue session that owns processing-detail updates.
+        :param source_crossfade_mode: Crossfade the item's own source applies, if any.
         """
         if queue_item.streamdetails is None:
             return
@@ -1960,6 +2000,7 @@ class StreamsController(CoreController):
                     "float",
                     queue_item.extra_attributes.get("playback_speed", 1.0),
                 ),
+                crossfade_mode=source_crossfade_mode,
                 overlay_active=overlay_enabled,
             ),
             alters_audio=queue_item.streamdetails.fade_in,

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -362,6 +362,20 @@ class StreamsController(CoreController):
             return CrossfadeMode.SMART_CROSSFADE
         return CrossfadeMode.STANDARD_CROSSFADE
 
+    def source_normalizes_audio(self, streamdetails: StreamDetails) -> bool:
+        """
+        Return whether the item's own source already levelled this audio.
+
+        Correcting a level the source set would mean normalizing twice, the second
+        time against a measurement of its own output.
+
+        :param streamdetails: Stream details of the item.
+        """
+        # plugin providers serve playable items too, and only a music provider
+        # declares this (a plugin's live audio is handled by the media type)
+        provider = self.mass.get_provider(streamdetails.provider)
+        return isinstance(provider, MusicProvider) and provider.delivers_normalized_audio
+
     def get_source_crossfade_mode(self, queue: PlayerQueue, queue_item: QueueItem) -> CrossfadeMode:
         """
         Return the crossfade an item's own source applies, or DISABLED when none does.

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -855,8 +855,9 @@ def get_normalization_mode(
         return VolumeNormalizationMode.DISABLED
     if source_normalized:
         # the source owns loudness here too: correcting a level it already set would
-        # mean normalizing twice, against a measurement of its own output
-        return VolumeNormalizationMode.DISABLED
+        # mean normalizing twice, against a measurement of its own output. SOURCE says
+        # that out loud - the audio is levelled, just not by us
+        return VolumeNormalizationMode.SOURCE
     if streamdetails.media_type == MediaType.SOUND_EFFECT:
         # never measured, and the dynamic fallback compresses short clips
         return VolumeNormalizationMode.DISABLED

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -194,13 +194,15 @@ class MusicProvider(Provider):
         return False
 
     @property
-    def delivers_crossfaded_audio(self) -> bool:
+    def delivers_crossfaded_audio(self) -> bool | None:
         """
-        Return whether this provider crossfades its own playback.
+        Return whether this provider crossfades the playback it is serving.
 
         True means the source applies the overlap between consecutive items itself,
         so Music Assistant hands its crossfade setting over instead of mixing one.
-        Only say so when the source really does fade: nothing downstream verifies it.
+        None means the provider is not serving anything yet and the queue's own
+        setting answers instead. Only say True when the source really does fade:
+        nothing downstream verifies it.
         """
         return False
 

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -194,6 +194,17 @@ class MusicProvider(Provider):
         return False
 
     @property
+    def delivers_crossfaded_audio(self) -> bool:
+        """
+        Return whether this provider crossfades its own playback.
+
+        True means the source applies the overlap between consecutive items itself,
+        so Music Assistant hands its crossfade setting over instead of mixing one.
+        Only say so when the source really does fade: nothing downstream verifies it.
+        """
+        return False
+
+    @property
     def max_concurrent_streams(self) -> int | None:
         """
         Return the number of source streams Music Assistant may run against this provider.

--- a/music_assistant/providers/loudness_analysis/provider.py
+++ b/music_assistant/providers/loudness_analysis/provider.py
@@ -124,9 +124,14 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
         audio_format: AudioFormat,
     ) -> bool:
         """Prepare provider state for a new analysis session."""
-        # skip when the requesting player has explicitly opted out of normalization;
-        # the nightly background job will pick up the measurement if ever needed
-        if streamdetails.volume_normalization_mode == VolumeNormalizationMode.DISABLED:
+        # skip when nothing here normalizes on our side: the player opted out, or the
+        # source levelled the audio itself and measuring its output would store that
+        # level as the track's own. The nightly background job picks the measurement
+        # up if it is ever needed
+        if streamdetails.volume_normalization_mode in (
+            VolumeNormalizationMode.DISABLED,
+            VolumeNormalizationMode.SOURCE,
+        ):
             return False
         ffmpeg = FFMpeg(
             audio_input="-",

--- a/music_assistant/providers/spotify/README.md
+++ b/music_assistant/providers/spotify/README.md
@@ -83,7 +83,9 @@ audio prefs, wire models) is shared infrastructure owned by the Spotify Connect 
   mixing, so the queue's own crossfade preference is written into the engine's prefs
   before every spawn. Its unit is milliseconds and sub-second values silently disable
   crossfade, which the seconds-based queue setting can never produce. Changing the
-  setting mid-playback takes effect on the next playback.
+  setting mid-playback takes effect on the next playback, which is also why
+  `delivers_crossfaded_audio` reports the running session's captured value rather
+  than the current setting.
 - **Pacing**: the capture FIFO is reader-clocked — how fast it is read *is* how fast
   the engine plays, because the pipe sink applies no rate limit of its own (read
   unpaced, PulseAudio renders silence rather than pushing back, and the session runs

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -316,6 +316,17 @@ class SoloistBackend(SpotifyPlaybackBackend):
         session = self._session
         return session.engine_normalizes if session is not None and session.usable else None
 
+    @property
+    def session_crossfades(self) -> bool | None:
+        """
+        Return whether the running session's engine is crossfading, if there is one.
+
+        None when nothing is playing yet, in which case the configuration is the
+        only thing to go on.
+        """
+        session = self._session
+        return session.crossfade_ms > 0 if session is not None and session.usable else None
+
     async def setup(self) -> None:
         """
         Validate the binary and paired session, and start the capture server.

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -258,6 +258,17 @@ class SpotifyProvider(MusicProvider):
         return self.spotify_normalization_configured
 
     @property
+    def delivers_crossfaded_audio(self) -> bool:
+        """
+        Return whether Spotify's own engine crossfades this playback.
+
+        Only the soloist backend can: it keeps one session across items and is handed
+        the queue's crossfade duration when that session starts, so the overlap lives
+        in the audio it delivers. librespot fetches every track on its own.
+        """
+        return isinstance(getattr(self, "backend", None), SoloistBackend)
+
+    @property
     def max_concurrent_streams(self) -> int:
         """
         Return how many source streams Music Assistant may run against this provider.

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -236,7 +236,7 @@ class SpotifyProvider(MusicProvider):
         Only the soloist backend can: librespot hands over Spotify's file
         untouched, so its audio arrives at the master's own level.
         """
-        return isinstance(getattr(self, "backend", None), SoloistBackend) and bool(
+        return self._soloist_backend is not None and bool(
             # the default is stated here too: get_value answers with the argument,
             # not the entry's default, if the key was never parsed into the config
             self.config.get_value(CONF_SPOTIFY_NORMALIZATION, True)
@@ -252,8 +252,8 @@ class SpotifyProvider(MusicProvider):
         core normalize on top of what the engine is still doing - it takes effect
         on the next playback instead.
         """
-        backend = getattr(self, "backend", None)
-        if isinstance(backend, SoloistBackend) and (live := backend.session_normalizes) is not None:
+        backend = self._soloist_backend
+        if backend is not None and (live := backend.session_normalizes) is not None:
             return live
         return self.spotify_normalization_configured
 
@@ -269,10 +269,8 @@ class SpotifyProvider(MusicProvider):
         changed mid-playback applies to the next session, not to the audio this one
         is still serving.
         """
-        backend = getattr(self, "backend", None)
-        if not isinstance(backend, SoloistBackend):
-            return False
-        return backend.session_crossfades
+        backend = self._soloist_backend
+        return backend.session_crossfades if backend is not None else False
 
     @property
     def max_concurrent_streams(self) -> int:
@@ -1261,6 +1259,12 @@ class SpotifyProvider(MusicProvider):
                 self.logger.warning("Failed to remove %s: %s", failed, err)
 
         shutil.rmtree(path, onexc=_report)
+
+    @property
+    def _soloist_backend(self) -> SoloistBackend | None:
+        """Return the playback backend when the soloist one is in use, else None."""
+        backend = getattr(self, "backend", None)
+        return backend if isinstance(backend, SoloistBackend) else None
 
     @property
     def _instance_storage_dir(self) -> Path:

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -258,15 +258,21 @@ class SpotifyProvider(MusicProvider):
         return self.spotify_normalization_configured
 
     @property
-    def delivers_crossfaded_audio(self) -> bool:
+    def delivers_crossfaded_audio(self) -> bool | None:
         """
         Return whether Spotify's own engine crossfades this playback.
 
         Only the soloist backend can: it keeps one session across items and is handed
         the queue's crossfade duration when that session starts, so the overlap lives
-        in the audio it delivers. librespot fetches every track on its own.
+        in the audio it delivers. librespot fetches every track on its own. A running
+        session answers for itself, because it read that duration once - a setting
+        changed mid-playback applies to the next session, not to the audio this one
+        is still serving.
         """
-        return isinstance(getattr(self, "backend", None), SoloistBackend)
+        backend = getattr(self, "backend", None)
+        if not isinstance(backend, SoloistBackend):
+            return False
+        return backend.session_crossfades
 
     @property
     def max_concurrent_streams(self) -> int:

--- a/tests/controllers/streams/test_crossfade_transition.py
+++ b/tests/controllers/streams/test_crossfade_transition.py
@@ -97,6 +97,8 @@ def _flow_audio(
     mass.player_queues.get.return_value = queue
     mass.player_queues.get_next_item.return_value = next_item
     mass.streams.get_crossfade_mode.return_value = crossfade_mode
+    # these items are ours to mix, so no source claims their boundaries
+    mass.streams.get_source_crossfade_mode.return_value = CrossfadeMode.DISABLED
     mass.config.get_raw_core_config_value.return_value = STANDARD_CROSSFADE_DURATION
     mass.streams.audio_processing.update_item_context = MagicMock()
     player = MagicMock()

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1182,18 +1182,14 @@ def _single_item_handler(*, is_realtime: bool) -> tuple[Any, MagicMock, dict[str
 
 
 async def test_single_item_handler_skips_crossfade_for_a_realtime_item() -> None:
-    """
-    A realtime item is never steered into the crossfaded single-item stream.
-
-    The queue preference is still read for such an item, but only to work out
-    whether its source was handed the fade; our own mixer stays out of it.
-    """
+    """A realtime item is never steered into the crossfaded single-item stream."""
     controller, request, seen = _single_item_handler(is_realtime=True)
 
     with pytest.raises(_PcmFormatRequested):
         await controller.serve_queue_item_stream(request)
 
     assert seen["crossfade_enabled"] is False
+    controller.get_crossfade_mode.assert_not_called()
 
 
 async def test_single_item_handler_keeps_crossfade_for_a_buffered_item() -> None:
@@ -1265,25 +1261,21 @@ def test_only_a_declared_source_fade_is_reported_as_such(
 
 
 @pytest.mark.parametrize(
-    ("media_type", "is_realtime", "has_next"),
+    ("media_type", "is_realtime"),
     [
         # our own mixer owns both of these, so the source's fade is not in play
-        (MediaType.TRACK, False, True),
-        (MediaType.AUDIOBOOK, True, True),
-        # nothing queued after it means there is no boundary to fade across
-        (MediaType.TRACK, True, False),
+        (MediaType.TRACK, False),
+        (MediaType.AUDIOBOOK, True),
     ],
 )
-def test_no_source_fade_where_one_cannot_apply(
-    media_type: MediaType, is_realtime: bool, has_next: bool
+def test_no_source_fade_for_audio_we_mix_ourselves(
+    media_type: MediaType, is_realtime: bool
 ) -> None:
-    """An item is only credited with a source fade where such a fade can happen."""
+    """A source fade is only reported for audio Music Assistant does not mix."""
     controller = _source_crossfade_controller(
         object.__new__(_CrossfadingProvider), CrossfadeMode.SMART_CROSSFADE
     )
-    controller.mass.player_queues.get_next_item.return_value = (
-        SimpleNamespace() if has_next else None
-    )
+    controller.mass.player_queues.get_next_item.return_value = _follower("same-provider")
     queue_item = SimpleNamespace(
         queue_item_id="item-1",
         media_type=media_type,
@@ -1291,6 +1283,43 @@ def test_no_source_fade_where_one_cannot_apply(
     )
 
     assert controller.get_source_crossfade_mode(MagicMock(), queue_item) == CrossfadeMode.DISABLED
+
+
+@pytest.mark.parametrize(
+    ("follower_kind", "expected"),
+    [
+        # a boundary the source owns both sides of, as a provider item and as a
+        # library item that carries the source in its mappings instead
+        ("same-provider", CrossfadeMode.SOURCE),
+        ("library-mapped", CrossfadeMode.SOURCE),
+        # nothing queued after it, so there is no boundary at all
+        ("none", CrossfadeMode.DISABLED),
+        # the source plays the current item out at any of these, so the cut is hard
+        ("other-provider", CrossfadeMode.DISABLED),
+        ("not-a-track", CrossfadeMode.DISABLED),
+        ("unresolvable", CrossfadeMode.DISABLED),
+    ],
+)
+def test_a_source_fade_needs_a_boundary_the_source_owns(
+    follower_kind: str, expected: CrossfadeMode
+) -> None:
+    """
+    Only a boundary between two items of the same source is credited with its fade.
+
+    Reporting one anywhere else would describe an overlap nobody rendered: we do not
+    mix a realtime item's boundaries either, so what plays there is a hard cut.
+    """
+    controller = _source_crossfade_controller(
+        object.__new__(_CrossfadingProvider), CrossfadeMode.SMART_CROSSFADE
+    )
+    controller.mass.player_queues.get_next_item.return_value = _follower(follower_kind)
+    queue_item = SimpleNamespace(
+        queue_item_id="item-1",
+        media_type=MediaType.TRACK,
+        streamdetails=_make_stream_details(MediaType.TRACK, is_realtime=True),
+    )
+
+    assert controller.get_source_crossfade_mode(MagicMock(), queue_item) == expected
 
 
 def test_the_raw_pcm_path_reports_a_source_fade_too() -> None:
@@ -1348,12 +1377,48 @@ def test_a_music_provider_declares_no_source_fade_by_default() -> None:
 
 
 def _source_crossfade_controller(provider: Any, queue_crossfade_mode: CrossfadeMode) -> Any:
-    """Return a controller resolving source fades against one provider and setting."""
+    """
+    Return a controller resolving source fades against one provider and setting.
+
+    The queue follows on with another item of the same source, so only the provider
+    and the setting decide; the boundary cases are covered on their own.
+    """
     controller = cast("Any", object.__new__(StreamsController))
     controller.mass = MagicMock()
     controller.mass.get_provider.return_value = provider
+    controller.mass.player_queues.get_next_item.return_value = _follower("same-provider")
     controller.get_crossfade_mode = MagicMock(return_value=queue_crossfade_mode)
     return controller
+
+
+def _follower(kind: str) -> Any:
+    """Return the queue item that follows, in each shape the resolver has to handle."""
+    if kind == "none":
+        return None
+    if kind == "not-a-track":
+        return SimpleNamespace(media_type=MediaType.AUDIOBOOK, streamdetails=None, media_item=None)
+    if kind == "same-provider":
+        # already resolved to the provider that will serve it
+        return SimpleNamespace(
+            media_type=MediaType.TRACK,
+            streamdetails=_make_stream_details(MediaType.TRACK, is_realtime=True),
+            media_item=None,
+        )
+    if kind == "other-provider":
+        other = _make_stream_details(MediaType.TRACK, is_realtime=True)
+        other.provider = "other--1"
+        return SimpleNamespace(media_type=MediaType.TRACK, streamdetails=other, media_item=None)
+    if kind == "library-mapped":
+        return SimpleNamespace(
+            media_type=MediaType.TRACK,
+            streamdetails=None,
+            media_item=SimpleNamespace(
+                provider="library",
+                provider_mappings=[SimpleNamespace(provider_instance="builtin")],
+            ),
+        )
+    # nothing to resolve it with at all
+    return SimpleNamespace(media_type=MediaType.TRACK, streamdetails=None, media_item=None)
 
 
 def _realtime_track() -> Any:

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -34,6 +34,7 @@ from music_assistant.controllers.streams.constants import BufferSize
 from music_assistant.controllers.streams.controller import StreamsController
 from music_assistant.controllers.streams.smart_fades.fades import StandardCrossFade
 from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
+from music_assistant.models.music_provider import MusicProvider
 
 # Standard test PCM format: 44100Hz, 16-bit, stereo
 TEST_PCM_FORMAT = AudioFormat(
@@ -924,10 +925,17 @@ async def test_smartfade_stub_remainder_does_not_crossfade(
     build.assert_not_awaited()
 
 
-async def test_flow_reports_no_crossfade_for_a_realtime_item(
+@pytest.mark.parametrize("source_crossfade_mode", [CrossfadeMode.DISABLED, CrossfadeMode.SOURCE])
+async def test_flow_reports_the_crossfade_a_realtime_item_really_gets(
     monkeypatch: pytest.MonkeyPatch,
+    source_crossfade_mode: CrossfadeMode,
 ) -> None:
-    """The audio pipeline shown for a realtime item reports that no crossfade is applied."""
+    """
+    A realtime item is credited with its source's fade, never one of ours.
+
+    Music Assistant has no audio to spare for an overlap on either side of such an
+    item, so the only fade it can report is the one the source applies itself.
+    """
     pcm_format = AudioFormat(
         content_type=ContentType.PCM_S16LE,
         sample_rate=8000,
@@ -969,6 +977,7 @@ async def test_flow_reports_no_crossfade_for_a_realtime_item(
     mass.player_queues.load_next_queue_item = AsyncMock(side_effect=QueueEmpty)
     mass.player_queues.get.return_value = queue
     mass.streams.get_crossfade_mode.return_value = CrossfadeMode.SMART_CROSSFADE
+    mass.streams.get_source_crossfade_mode.return_value = source_crossfade_mode
     mass.config.get_raw_core_config_value.return_value = 8
     update_item_context = MagicMock()
     mass.streams.audio_processing.update_item_context = update_item_context
@@ -992,7 +1001,7 @@ async def test_flow_reports_no_crossfade_for_a_realtime_item(
 
     update_item_context.assert_called()
     reported = update_item_context.call_args.kwargs["queue_processing"]
-    assert reported.crossfade_mode == CrossfadeMode.DISABLED
+    assert reported.crossfade_mode == source_crossfade_mode
 
 
 async def test_flow_standard_fade_only_holds_back_its_overlap(
@@ -1173,14 +1182,18 @@ def _single_item_handler(*, is_realtime: bool) -> tuple[Any, MagicMock, dict[str
 
 
 async def test_single_item_handler_skips_crossfade_for_a_realtime_item() -> None:
-    """A realtime item is never steered into the crossfaded single-item stream."""
+    """
+    A realtime item is never steered into the crossfaded single-item stream.
+
+    The queue preference is still read for such an item, but only to work out
+    whether its source was handed the fade; our own mixer stays out of it.
+    """
     controller, request, seen = _single_item_handler(is_realtime=True)
 
     with pytest.raises(_PcmFormatRequested):
         await controller.serve_queue_item_stream(request)
 
     assert seen["crossfade_enabled"] is False
-    controller.get_crossfade_mode.assert_not_called()
 
 
 async def test_single_item_handler_keeps_crossfade_for_a_buffered_item() -> None:
@@ -1192,6 +1205,89 @@ async def test_single_item_handler_keeps_crossfade_for_a_buffered_item() -> None
 
     assert seen["crossfade_enabled"] is True
     controller.get_crossfade_mode.assert_called_once()
+
+
+# -- StreamsController.get_source_crossfade_mode --
+
+
+class _CrossfadingProvider(MusicProvider):
+    """A music provider that crossfades its own playback."""
+
+    @property
+    def delivers_crossfaded_audio(self) -> bool:
+        """Declare the source fade."""
+        return True
+
+
+@pytest.mark.parametrize(
+    ("queue_crossfade_mode", "provider", "expected"),
+    [
+        # the queue preference decides whether the source was handed a fade at all
+        (
+            CrossfadeMode.DISABLED,
+            object.__new__(_CrossfadingProvider),
+            CrossfadeMode.DISABLED,
+        ),
+        (
+            CrossfadeMode.SMART_CROSSFADE,
+            object.__new__(_CrossfadingProvider),
+            CrossfadeMode.SOURCE,
+        ),
+        # a provider that does not fade its own playback, and a plugin-served item
+        (CrossfadeMode.SMART_CROSSFADE, object.__new__(MusicProvider), CrossfadeMode.DISABLED),
+        (CrossfadeMode.SMART_CROSSFADE, None, CrossfadeMode.DISABLED),
+    ],
+)
+def test_only_a_declared_source_fade_is_reported_as_such(
+    queue_crossfade_mode: CrossfadeMode,
+    provider: Any,
+    expected: CrossfadeMode,
+) -> None:
+    """Only a provider that says it crossfades its own playback is credited with one."""
+    controller = cast("Any", object.__new__(StreamsController))
+    controller.mass = MagicMock()
+    controller.mass.get_provider.return_value = provider
+    controller.get_crossfade_mode = MagicMock(return_value=queue_crossfade_mode)
+    streamdetails = _make_stream_details(MediaType.TRACK, is_realtime=True)
+
+    assert controller.get_source_crossfade_mode(MagicMock(), streamdetails) == expected
+
+
+def test_a_music_provider_declares_no_source_fade_by_default() -> None:
+    """The declaration is opt-in: nothing downstream verifies it."""
+    assert object.__new__(MusicProvider).delivers_crossfaded_audio is False
+
+
+def test_the_context_update_carries_a_source_fade_the_audio_layer_never_sees() -> None:
+    """
+    A crossfade performed by the source is published with the item's context.
+
+    Our own mixer reports the fades it renders, but it renders none here, so this is
+    the only place the source's fade can reach the processing details.
+    """
+    controller = cast("Any", object.__new__(StreamsController))
+    controller.mass = MagicMock()
+    controller.mass.player_queues.queue_data_or_none.return_value = SimpleNamespace(
+        session_id="session-1"
+    )
+    controller.audio_processing = MagicMock()
+    queue_item = SimpleNamespace(
+        queue_item_id="item-1",
+        streamdetails=_make_stream_details(MediaType.TRACK, is_realtime=True),
+        extra_attributes={},
+    )
+
+    controller._update_audio_processing_context(
+        queue=SimpleNamespace(queue_id="queue-1"),
+        queue_item=queue_item,
+        pcm_format=TEST_PCM_FORMAT,
+        overlay_enabled=False,
+        session_id="session-1",
+        source_crossfade_mode=CrossfadeMode.SOURCE,
+    )
+
+    reported = controller.audio_processing.update_item_context.call_args.kwargs["queue_processing"]
+    assert reported.crossfade_mode == CrossfadeMode.SOURCE
 
 
 # -- StreamsAudio.get_stream_details --

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1286,13 +1286,13 @@ def test_no_source_fade_for_audio_we_mix_ourselves(
 
 
 @pytest.mark.parametrize(
-    ("follower_kind", "expected"),
+    ("neighbour_kind", "expected"),
     [
         # a boundary the source owns both sides of, as a provider item and as a
         # library item that carries the source in its mappings instead
         ("same-provider", CrossfadeMode.SOURCE),
         ("library-mapped", CrossfadeMode.SOURCE),
-        # nothing queued after it, so there is no boundary at all
+        # nothing next to it, so there is no boundary at all
         ("none", CrossfadeMode.DISABLED),
         # the source plays the current item out at any of these, so the cut is hard
         ("other-provider", CrossfadeMode.DISABLED),
@@ -1300,19 +1300,28 @@ def test_no_source_fade_for_audio_we_mix_ourselves(
         ("unresolvable", CrossfadeMode.DISABLED),
     ],
 )
+@pytest.mark.parametrize("side", ["follower", "predecessor"])
 def test_a_source_fade_needs_a_boundary_the_source_owns(
-    follower_kind: str, expected: CrossfadeMode
+    neighbour_kind: str, side: str, expected: CrossfadeMode
 ) -> None:
     """
     Only a boundary between two items of the same source is credited with its fade.
 
-    Reporting one anywhere else would describe an overlap nobody rendered: we do not
-    mix a realtime item's boundaries either, so what plays there is a hard cut.
+    Either side counts: the last track of a queue has no follower but was still the
+    side faded into. Reporting one anywhere else would describe an overlap nobody
+    rendered - we do not mix a realtime item's boundaries either, so it is a hard cut.
     """
     controller = _source_crossfade_controller(
         object.__new__(_CrossfadingProvider), CrossfadeMode.SMART_CROSSFADE
     )
-    controller.mass.player_queues.get_next_item.return_value = _follower(follower_kind)
+    queues = controller.mass.player_queues
+    neighbour = _follower(neighbour_kind)
+    if side == "follower":
+        queues.get_next_item.return_value = neighbour
+    else:
+        queues.get_next_item.return_value = None
+        queues.index_by_id.return_value = 1
+        queues.get_item.return_value = neighbour
     queue_item = SimpleNamespace(
         queue_item_id="item-1",
         media_type=MediaType.TRACK,
@@ -1387,6 +1396,8 @@ def _source_crossfade_controller(provider: Any, queue_crossfade_mode: CrossfadeM
     controller.mass = MagicMock()
     controller.mass.get_provider.return_value = provider
     controller.mass.player_queues.get_next_item.return_value = _follower("same-provider")
+    # first in the queue, so nothing precedes it and only the follower decides
+    controller.mass.player_queues.index_by_id.return_value = 0
     controller.get_crossfade_mode = MagicMock(return_value=queue_crossfade_mode)
     return controller
 

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1211,25 +1211,40 @@ async def test_single_item_handler_keeps_crossfade_for_a_buffered_item() -> None
 
 
 class _CrossfadingProvider(MusicProvider):
-    """A music provider that crossfades its own playback."""
+    """A music provider whose running source crossfades its own playback."""
 
     @property
-    def delivers_crossfaded_audio(self) -> bool:
+    def delivers_crossfaded_audio(self) -> bool | None:
         """Declare the source fade."""
         return True
+
+
+class _UndecidedCrossfadingProvider(MusicProvider):
+    """A music provider that can crossfade its own playback but serves nothing yet."""
+
+    @property
+    def delivers_crossfaded_audio(self) -> bool | None:
+        """Leave the answer to the queue's own setting."""
+        return None
 
 
 @pytest.mark.parametrize(
     ("queue_crossfade_mode", "provider", "expected"),
     [
-        # the queue preference decides whether the source was handed a fade at all
+        # with no session running the queue preference is all there is to go on
         (
             CrossfadeMode.DISABLED,
-            object.__new__(_CrossfadingProvider),
+            object.__new__(_UndecidedCrossfadingProvider),
             CrossfadeMode.DISABLED,
         ),
         (
             CrossfadeMode.SMART_CROSSFADE,
+            object.__new__(_UndecidedCrossfadingProvider),
+            CrossfadeMode.SOURCE,
+        ),
+        # a running source answers for itself, whatever the setting says now
+        (
+            CrossfadeMode.DISABLED,
             object.__new__(_CrossfadingProvider),
             CrossfadeMode.SOURCE,
         ),
@@ -1244,18 +1259,110 @@ def test_only_a_declared_source_fade_is_reported_as_such(
     expected: CrossfadeMode,
 ) -> None:
     """Only a provider that says it crossfades its own playback is credited with one."""
+    controller = _source_crossfade_controller(provider, queue_crossfade_mode)
+
+    assert controller.get_source_crossfade_mode(MagicMock(), _realtime_track()) == expected
+
+
+@pytest.mark.parametrize(
+    ("media_type", "is_realtime", "has_next"),
+    [
+        # our own mixer owns both of these, so the source's fade is not in play
+        (MediaType.TRACK, False, True),
+        (MediaType.AUDIOBOOK, True, True),
+        # nothing queued after it means there is no boundary to fade across
+        (MediaType.TRACK, True, False),
+    ],
+)
+def test_no_source_fade_where_one_cannot_apply(
+    media_type: MediaType, is_realtime: bool, has_next: bool
+) -> None:
+    """An item is only credited with a source fade where such a fade can happen."""
+    controller = _source_crossfade_controller(
+        object.__new__(_CrossfadingProvider), CrossfadeMode.SMART_CROSSFADE
+    )
+    controller.mass.player_queues.get_next_item.return_value = (
+        SimpleNamespace() if has_next else None
+    )
+    queue_item = SimpleNamespace(
+        queue_item_id="item-1",
+        media_type=media_type,
+        streamdetails=_make_stream_details(media_type, is_realtime=is_realtime),
+    )
+
+    assert controller.get_source_crossfade_mode(MagicMock(), queue_item) == CrossfadeMode.DISABLED
+
+
+def test_the_raw_pcm_path_reports_a_source_fade_too() -> None:
+    """
+    A source fade reaches the processing details on the raw-PCM entry point as well.
+
+    Gapless players are served per item straight from ``get_stream`` rather than over
+    the http route, so leaving it out there would report nothing for most players.
+    """
+    queue_item = SimpleNamespace(
+        queue_id="queue-1",
+        queue_item_id="item-1",
+        name="Track",
+        media_type=MediaType.TRACK,
+        media_item=None,
+        streamdetails=_make_stream_details(MediaType.TRACK, is_realtime=True),
+        extra_attributes={},
+        image=None,
+    )
+    queue = SimpleNamespace(
+        queue_id="queue-1",
+        display_name="Queue",
+        crossfade_enabled=True,
+        overlay_enabled=False,
+        overlay_source=None,
+    )
     controller = cast("Any", object.__new__(StreamsController))
     controller.mass = MagicMock()
-    controller.mass.get_provider.return_value = provider
-    controller.get_crossfade_mode = MagicMock(return_value=queue_crossfade_mode)
-    streamdetails = _make_stream_details(MediaType.TRACK, is_realtime=True)
+    controller.mass.player_queues.get.return_value = queue
+    controller.mass.player_queues.get_item.return_value = queue_item
+    controller.mass.players.get_player.return_value = None
+    controller.logger = MagicMock()
+    controller.audio = MagicMock()
+    controller._update_audio_processing_context = MagicMock()
+    controller.get_source_crossfade_mode = MagicMock(return_value=CrossfadeMode.SOURCE)
+    media = SimpleNamespace(
+        media_type=MediaType.TRACK,
+        source_id="queue-1",
+        queue_item_id="item-1",
+        queue_session_id="session-1",
+        uri="",
+    )
 
-    assert controller.get_source_crossfade_mode(MagicMock(), streamdetails) == expected
+    controller.get_stream(cast("Any", media), TEST_PCM_FORMAT)
+
+    assert (
+        controller._update_audio_processing_context.call_args.kwargs["source_crossfade_mode"]
+        == CrossfadeMode.SOURCE
+    )
 
 
 def test_a_music_provider_declares_no_source_fade_by_default() -> None:
     """The declaration is opt-in: nothing downstream verifies it."""
     assert object.__new__(MusicProvider).delivers_crossfaded_audio is False
+
+
+def _source_crossfade_controller(provider: Any, queue_crossfade_mode: CrossfadeMode) -> Any:
+    """Return a controller resolving source fades against one provider and setting."""
+    controller = cast("Any", object.__new__(StreamsController))
+    controller.mass = MagicMock()
+    controller.mass.get_provider.return_value = provider
+    controller.get_crossfade_mode = MagicMock(return_value=queue_crossfade_mode)
+    return controller
+
+
+def _realtime_track() -> Any:
+    """Return a queue item whose track arrives at playback pace."""
+    return SimpleNamespace(
+        queue_item_id="item-1",
+        media_type=MediaType.TRACK,
+        streamdetails=_make_stream_details(MediaType.TRACK, is_realtime=True),
+    )
 
 
 def test_the_context_update_carries_a_source_fade_the_audio_layer_never_sees() -> None:

--- a/tests/controllers/streams/test_source_normalized.py
+++ b/tests/controllers/streams/test_source_normalized.py
@@ -23,7 +23,7 @@ from music_assistant_models.streamdetails import StreamDetails
 from music_assistant.controllers.streams.audio import StreamsAudio
 from music_assistant.controllers.streams.audio_processing import get_normalization_details
 from music_assistant.controllers.streams.controller import (
-    volume_normalization_preference_options,
+    _volume_normalization_preference_options,
 )
 from music_assistant.helpers.audio import get_normalization_mode
 
@@ -171,7 +171,7 @@ def test_an_outcome_only_mode_is_not_offered_as_a_preference() -> None:
     SOURCE is set by a source that levels its own audio and UNKNOWN is what an
     unrecognised value deserializes to; neither is something to ask a user for.
     """
-    offered = {option.value for option in volume_normalization_preference_options()}
+    offered = {option.value for option in _volume_normalization_preference_options()}
 
     assert VolumeNormalizationMode.SOURCE.value not in offered
     assert VolumeNormalizationMode.UNKNOWN.value not in offered

--- a/tests/controllers/streams/test_source_normalized.py
+++ b/tests/controllers/streams/test_source_normalized.py
@@ -12,6 +12,7 @@ loudness analyzer declines such a stream, so no measurement is stored for it.
 
 from __future__ import annotations
 
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -23,9 +24,21 @@ from music_assistant_models.streamdetails import StreamDetails
 from music_assistant.controllers.streams.audio import StreamsAudio
 from music_assistant.controllers.streams.audio_processing import get_normalization_details
 from music_assistant.controllers.streams.controller import (
+    StreamsController,
     _volume_normalization_preference_options,
 )
 from music_assistant.helpers.audio import get_normalization_mode
+from music_assistant.models.music_provider import MusicProvider
+
+
+class _NormalizingProvider(MusicProvider):
+    """A music provider that hands over audio it already levelled."""
+
+    @property
+    def delivers_normalized_audio(self) -> bool:
+        """Declare the source normalization."""
+        return True
+
 
 PCM_FORMAT = AudioFormat(
     content_type=ContentType.PCM_S16LE,
@@ -90,10 +103,7 @@ def test_the_queue_setting_still_wins() -> None:
 
 def test_a_music_provider_declares_nothing_by_default() -> None:
     """The declaration is opt-in: nothing downstream verifies it."""
-    from music_assistant.models.music_provider import MusicProvider  # noqa: PLC0415
-
-    provider = object.__new__(MusicProvider)
-    assert provider.delivers_normalized_audio is False
+    assert object.__new__(MusicProvider).delivers_normalized_audio is False
 
 
 @pytest.mark.parametrize("mode", [VolumeNormalizationMode.DISABLED, VolumeNormalizationMode.SOURCE])
@@ -162,6 +172,30 @@ def test_source_normalized_audio_reports_a_mode_without_a_measurement() -> None:
     assert details.target_lufs is None
     assert details.measured_lufs is None
     assert details.applied_gain_db is None
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [
+        (object.__new__(_NormalizingProvider), True),
+        (object.__new__(MusicProvider), False),
+        # a plugin provider, which never declares it
+        (MagicMock(), False),
+    ],
+)
+def test_only_a_music_provider_can_claim_it_levelled_the_audio(
+    provider: object, expected: bool
+) -> None:
+    """
+    A plugin provider serves playable items too, but never answers this.
+
+    Its live audio is taken out of the loudness path by its media type instead.
+    """
+    controller = cast("Any", object.__new__(StreamsController))
+    controller.mass = MagicMock()
+    controller.mass.get_provider.return_value = provider
+
+    assert controller.source_normalizes_audio(_streamdetails()) is expected
 
 
 def test_an_outcome_only_mode_is_not_offered_as_a_preference() -> None:

--- a/tests/controllers/streams/test_source_normalized.py
+++ b/tests/controllers/streams/test_source_normalized.py
@@ -4,18 +4,27 @@ Tests for skipping volume normalization when the source already did it.
 A provider that hands over audio at a loudness target of its own declares that
 with ``MusicProvider.delivers_normalized_audio``; correcting such a level again
 would mean normalizing twice, the second time against a measurement of the
-source's own output. Also verified: the loudness analyzer declines to measure a
-stream whose normalization is disabled, so no measurement is stored for it.
+source's own output. That outcome is reported as ``SOURCE`` rather than
+``DISABLED`` - the audio is levelled, just not by us - so the gates that mean
+"Music Assistant applies nothing" have to accept both. Also verified: the
+loudness analyzer declines such a stream, so no measurement is stored for it.
 """
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+from music_assistant_models.audio_processing import AudioNormalizationMeasurementSource
 from music_assistant_models.enums import ContentType, MediaType, VolumeNormalizationMode
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
+from music_assistant.controllers.streams.audio import StreamsAudio
+from music_assistant.controllers.streams.audio_processing import get_normalization_details
+from music_assistant.controllers.streams.controller import (
+    volume_normalization_preference_options,
+)
 from music_assistant.helpers.audio import get_normalization_mode
 
 PCM_FORMAT = AudioFormat(
@@ -34,7 +43,7 @@ def test_a_normalized_source_is_left_alone() -> None:
         get_normalization_mode(
             VolumeNormalizationMode.FALLBACK_DYNAMIC, True, streamdetails, source_normalized=True
         )
-        == VolumeNormalizationMode.DISABLED
+        == VolumeNormalizationMode.SOURCE
     )
 
 
@@ -58,7 +67,7 @@ def test_a_stored_measurement_does_not_override_a_normalized_source() -> None:
         get_normalization_mode(
             VolumeNormalizationMode.FALLBACK_DYNAMIC, True, streamdetails, source_normalized=True
         )
-        == VolumeNormalizationMode.DISABLED
+        == VolumeNormalizationMode.SOURCE
     )
     assert (
         get_normalization_mode(
@@ -87,12 +96,16 @@ def test_a_music_provider_declares_nothing_by_default() -> None:
     assert provider.delivers_normalized_audio is False
 
 
-async def test_the_analyzer_declines_a_stream_it_must_not_measure() -> None:
+@pytest.mark.parametrize("mode", [VolumeNormalizationMode.DISABLED, VolumeNormalizationMode.SOURCE])
+async def test_the_analyzer_declines_a_stream_it_must_not_measure(
+    mode: VolumeNormalizationMode,
+) -> None:
     """
-    A disabled stream is not measured, so a normalized source stores no loudness.
+    A stream we do not normalize is not measured either, so no loudness is stored.
 
     That is what keeps a value measured on one backend's output from being applied
-    to the other's, without any erase step.
+    to the other's, without any erase step. SOURCE has to decline for a second
+    reason: measuring there would record the source's own level as the track's.
     """
     from music_assistant.providers.loudness_analysis.provider import (  # noqa: PLC0415
         LoudnessAnalysisProvider,
@@ -101,8 +114,72 @@ async def test_the_analyzer_declines_a_stream_it_must_not_measure() -> None:
     provider = object.__new__(LoudnessAnalysisProvider)
     provider.logger = MagicMock()
     streamdetails = _streamdetails()
-    streamdetails.volume_normalization_mode = VolumeNormalizationMode.DISABLED
+    streamdetails.volume_normalization_mode = mode
     assert await provider._start_analysis("session-1", streamdetails, PCM_FORMAT) is False
+
+
+@pytest.mark.parametrize("mode", [VolumeNormalizationMode.DISABLED, VolumeNormalizationMode.SOURCE])
+def test_no_headroom_is_reserved_for_normalization_we_do_not_apply(
+    mode: VolumeNormalizationMode,
+) -> None:
+    """
+    F32 headroom is only paid for when Music Assistant itself touches the level.
+
+    A source-normalized stream keeps its native depth, exactly as a disabled one does.
+    """
+    audio = object.__new__(StreamsAudio)
+    streamdetails = _streamdetails()
+    streamdetails.volume_normalization_mode = mode
+
+    content_type, bit_depth = audio._pick_pcm_bit_depth(
+        [],
+        streamdetails,
+        crossfade_enabled=False,
+        overlay_active=False,
+    )
+
+    assert bit_depth == 16
+    assert content_type == ContentType.PCM_S16LE
+
+
+def test_source_normalized_audio_reports_a_mode_without_a_measurement() -> None:
+    """
+    A source-normalized stream reports who levelled it and nothing more.
+
+    The target and the measurement are ours, and neither describes what the source
+    did - a stale library measurement in particular must not be presented as the
+    level this audio was corrected against.
+    """
+    streamdetails = _streamdetails()
+    streamdetails.volume_normalization_mode = VolumeNormalizationMode.SOURCE
+    streamdetails.loudness = -7.2
+
+    details = get_normalization_details(streamdetails, None)
+
+    assert details is not None
+    assert details.mode == VolumeNormalizationMode.SOURCE
+    assert details.measurement_source == AudioNormalizationMeasurementSource.UNKNOWN
+    assert details.target_lufs is None
+    assert details.measured_lufs is None
+    assert details.applied_gain_db is None
+
+
+def test_an_outcome_only_mode_is_not_offered_as_a_preference() -> None:
+    """
+    The setting says what Music Assistant should do, so outcomes are not choices.
+
+    SOURCE is set by a source that levels its own audio and UNKNOWN is what an
+    unrecognised value deserializes to; neither is something to ask a user for.
+    """
+    offered = {option.value for option in volume_normalization_preference_options()}
+
+    assert VolumeNormalizationMode.SOURCE.value not in offered
+    assert VolumeNormalizationMode.UNKNOWN.value not in offered
+    assert offered == {
+        mode.value
+        for mode in VolumeNormalizationMode
+        if mode not in (VolumeNormalizationMode.SOURCE, VolumeNormalizationMode.UNKNOWN)
+    }
 
 
 def _streamdetails() -> StreamDetails:

--- a/tests/controllers/streams/test_source_normalized.py
+++ b/tests/controllers/streams/test_source_normalized.py
@@ -23,6 +23,10 @@ from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.controllers.streams.audio import StreamsAudio
 from music_assistant.controllers.streams.audio_processing import get_normalization_details
+from music_assistant.controllers.streams.constants import (
+    DEFAULT_VOLUME_NORMALIZATION_MODE,
+    OUTCOME_ONLY_NORMALIZATION_MODES,
+)
 from music_assistant.controllers.streams.controller import (
     StreamsController,
     _volume_normalization_preference_options,
@@ -207,13 +211,30 @@ def test_an_outcome_only_mode_is_not_offered_as_a_preference() -> None:
     """
     offered = {option.value for option in _volume_normalization_preference_options()}
 
-    assert VolumeNormalizationMode.SOURCE.value not in offered
-    assert VolumeNormalizationMode.UNKNOWN.value not in offered
     assert offered == {
         mode.value
         for mode in VolumeNormalizationMode
-        if mode not in (VolumeNormalizationMode.SOURCE, VolumeNormalizationMode.UNKNOWN)
+        if mode not in OUTCOME_ONLY_NORMALIZATION_MODES
     }
+
+
+@pytest.mark.parametrize("stored", OUTCOME_ONLY_NORMALIZATION_MODES)
+def test_an_outcome_only_mode_stored_as_a_preference_is_not_honoured(
+    stored: VolumeNormalizationMode,
+) -> None:
+    """
+    Hiding an option does not make it unacceptable: nothing validates a saved value.
+
+    Handed back as the preference it would be applied as the mode, which for SOURCE
+    also means reporting that a source levelled audio nobody levelled.
+    """
+    audio = object.__new__(StreamsAudio)
+    audio.mass = MagicMock()
+    audio.mass.streams.get_config_value.return_value = stored.value
+
+    preference = audio._get_volume_normalization_preference(_streamdetails())
+
+    assert preference == DEFAULT_VOLUME_NORMALIZATION_MODE
 
 
 def _streamdetails() -> StreamDetails:

--- a/tests/providers/spotify/test_backends.py
+++ b/tests/providers/spotify/test_backends.py
@@ -97,19 +97,40 @@ def test_only_the_soloist_backend_declares_normalized_audio() -> None:
     assert prov.delivers_normalized_audio is False
 
 
-def test_only_the_soloist_backend_declares_crossfaded_audio() -> None:
+def test_only_the_soloist_backend_can_declare_crossfaded_audio() -> None:
     """
-    The declaration follows the backend, not the queue setting.
+    Librespot fetches every track on its own, so it has nothing to fade into.
 
-    The soloist backend keeps one session across items and is handed the queue's
-    crossfade when it starts, so the overlap is in the audio it delivers; librespot
-    fetches every track on its own and has nothing to fade into.
+    With no soloist session running yet there is nothing to report either, and the
+    queue's own setting answers instead.
     """
     prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
     prov.backend = SoloistBackend(prov)
-    assert prov.delivers_crossfaded_audio is True
+    assert prov.delivers_crossfaded_audio is None
     prov.backend = LibrespotBackend(prov)
     assert prov.delivers_crossfaded_audio is False
+
+
+@pytest.mark.parametrize(("crossfade_ms", "expected"), [(8000, True), (0, False)])
+def test_a_running_session_reports_the_crossfade_it_was_started_with(
+    crossfade_ms: int, expected: bool
+) -> None:
+    """
+    The engine reads the crossfade once, at spawn, so the session answers for itself.
+
+    Following the current setting instead would claim a fade the running engine is
+    not applying, or deny the one it still is.
+    """
+    prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
+    backend = SoloistBackend(prov)
+    prov.backend = backend
+    session = MagicMock()
+    session.usable = True
+    session.crossfade_ms = crossfade_ms
+    backend._session = session
+
+    assert backend.session_crossfades is expected
+    assert prov.delivers_crossfaded_audio is expected
 
 
 def test_turning_spotify_normalization_off_hands_it_back_to_ma() -> None:

--- a/tests/providers/spotify/test_backends.py
+++ b/tests/providers/spotify/test_backends.py
@@ -97,6 +97,21 @@ def test_only_the_soloist_backend_declares_normalized_audio() -> None:
     assert prov.delivers_normalized_audio is False
 
 
+def test_only_the_soloist_backend_declares_crossfaded_audio() -> None:
+    """
+    The declaration follows the backend, not the queue setting.
+
+    The soloist backend keeps one session across items and is handed the queue's
+    crossfade when it starts, so the overlap is in the audio it delivers; librespot
+    fetches every track on its own and has nothing to fade into.
+    """
+    prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
+    prov.backend = SoloistBackend(prov)
+    assert prov.delivers_crossfaded_audio is True
+    prov.backend = LibrespotBackend(prov)
+    assert prov.delivers_crossfaded_audio is False
+
+
 def test_turning_spotify_normalization_off_hands_it_back_to_ma() -> None:
     """With the setting off, MA measures and normalizes as it does for any source."""
     prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})


### PR DESCRIPTION
# What does this implement/fix?

Spotify's own playback engine levels the loudness and applies the queue's crossfade, and Music Assistant deliberately stays out of both. Until now the only outcome it could report was "disabled", which means nothing is happening at all — so the stream details showed volume normalization and crossfade as off while the audio really was levelled and faded, just not by us.

Both now report as handled by the source. Nothing about the audio changes: every gate that means "Music Assistant applies nothing" was audited and treats the new value exactly like disabled, so no second normalization pass and no F32 headroom cost come back.

A source fade is only credited where one can actually happen: tracks only, only while the source is the one delivering at playback pace, and never on an item with nothing queued after it. A running Spotify session answers for itself, because the engine reads the crossfade setting once at startup — following the current setting instead would claim a fade the engine is not applying, or deny the one it still is.

**Related issue (if applicable):**

- models: https://github.com/music-assistant/models/pull/374
- frontend: https://github.com/music-assistant/frontend/pull/2621
- deferred from https://github.com/music-assistant/server/pull/5918

## Changes

- Report `SOURCE` instead of `DISABLED` for volume normalization when the provider levels its own audio, and for crossfade when it fades its own playback.
- Providers declare the crossfade the same way they already declare normalization; Spotify says so from the running Soloist session.
- Source-normalized audio reports who levelled it and nothing else — our target and any stored measurement describe neither.
- The loudness analyzer, the F32 headroom check and the bit-perfect check keep treating it as nothing we applied.
- Volume normalization no longer offers "Source" or "Unknown" in its dropdown: both are only ever outcomes, never something to ask for.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
