### PR TITLE
Fix AirPlay players stuck 'playing' from a stale snapshot

### DIFF
--- a/music_assistant/providers/airplay/control_player.py
+++ b/music_assistant/providers/airplay/control_player.py
@@ -626,6 +626,10 @@ class AirPlayControlPlayer(AirPlayPlayer):
                 if mrp_device.push_updater.active:
                     mrp_device.push_updater.stop()
             mrp_device.close()
+            # _handle_connection_closed skips its cleanup for this device because
+            # _mrp_device was already detached above, so drop the external playback
+            # snapshot here or it survives forced reconnects indefinitely.
+            self._clear_external_state()
         if companion_device:
             companion_device.close()
         self._disconnecting = False
@@ -1076,10 +1080,19 @@ class AirPlayControlPlayer(AirPlayPlayer):
         app = self._mrp_device.metadata.app if self._mrp_device else None
         playback_state = {
             DeviceState.Playing: PlaybackState.PLAYING,
-            DeviceState.Loading: PlaybackState.PLAYING,
             DeviceState.Seeking: PlaybackState.PLAYING,
             DeviceState.Paused: PlaybackState.PAUSED,
         }.get(playing.device_state, PlaybackState.IDLE)
+        # Loading only means "about to play" while playback is already going on
+        # (buffering between tracks). HomePods can get stuck in a perpetual
+        # Loading state carrying the cached metadata of a long-dead session, so
+        # a Loading snapshot on a player that is not already playing must map
+        # to idle (matching Home Assistant's apple_tv handling), not playing.
+        if (
+            playing.device_state == DeviceState.Loading
+            and self._attr_playback_state == PlaybackState.PLAYING
+        ):
+            playback_state = PlaybackState.PLAYING
         # Many tvOS apps (e.g. Netflix) report Idle rather than Paused when
         # paused. While the same app stays the active source, keep it paused
         # instead of going idle so transport controls resume the app itself

--- a/tests/providers/airplay/test_control_player.py
+++ b/tests/providers/airplay/test_control_player.py
@@ -666,6 +666,68 @@ def test_mrp_idle_update_clears_external_media() -> None:
     assert player.current_media is None
 
 
+def test_mrp_loading_snapshot_without_playback_stays_idle() -> None:
+    """A Loading snapshot on an idle player maps to idle, not playing."""
+    # HomePods can hold a stale Loading session (with the cached metadata of a
+    # long-dead AirPlay sender) for days; trusting it would show an eternal
+    # "playing" at position 0.
+    player = _make_control_player()
+    device = MagicMock(spec=AppleTV)
+    device.metadata.app = App("Music", "com.apple.Music")
+    player._mrp_device = device
+    playing = Playing(
+        media_type=PyatvMediaType.Music,
+        device_state=DeviceState.Loading,
+        title="King of Spain",
+        total_time=209,
+        position=0,
+    )
+
+    with patch.object(player, "update_state"):
+        player._handle_playing_update(playing)
+
+    assert player.playback_state == PlaybackState.IDLE
+    assert player.active_source is None
+    assert player.current_media is None
+
+
+def test_mrp_loading_update_during_playback_stays_playing() -> None:
+    """A Loading update while already playing means buffering, so keep playing."""
+    player = _make_control_player()
+    device = MagicMock(spec=AppleTV)
+    device.metadata.app = App("Music", "com.apple.Music")
+    player._mrp_device = device
+    player._attr_playback_state = PlaybackState.PLAYING
+    player._attr_active_source = "com.apple.Music"
+
+    with patch.object(player, "update_state"):
+        player._handle_playing_update(Playing(device_state=DeviceState.Loading, title="Next track"))
+
+    assert player.playback_state == PlaybackState.PLAYING
+    assert player.active_source == "com.apple.Music"
+    assert player.current_media is not None
+    assert player.current_media.title == "Next track"
+
+
+async def test_disconnect_control_services_clears_external_state() -> None:
+    """A forced teardown drops the external snapshot owned by the closed MRP link."""
+    # _handle_connection_closed ignores the late close callback for a device
+    # that was already detached, so the teardown itself must clear the snapshot.
+    player = _make_control_player()
+    device = MagicMock(spec=AppleTV)
+    player._mrp_device = device
+    player._attr_playback_state = PlaybackState.PLAYING
+    player._attr_active_source = "com.apple.Music"
+    player._attr_current_media = MagicMock()
+
+    with patch.object(player, "update_state"):
+        await player._disconnect_control_services()
+
+    assert player.playback_state == PlaybackState.IDLE
+    assert player.active_source is None
+    assert player.current_media is None
+
+
 def test_lost_mrp_connection_clears_external_state() -> None:
     """Losing MRP playback monitoring clears the last external snapshot."""
     player = _make_control_player()


### PR DESCRIPTION
# What does this implement/fix?

I noticed that my MA HomePod's entities would show that they were 'playing' in HA, which the same HomePod HA entities would (properly) show them as stopped/paused. This lasted through multiple restarts of both HA and MA. The robot tracked it down to this, which in my testing does now make the entities match each other and reality. Tagging Marcel directly as the AirPlay guru, in case my robots are missing something that makes this the not-right approach for a fix. Note that I do *not* run betas on my HomePods, this is the current/stable HomePodOS.

HomePods can hold a perpetual DeviceState.Loading snapshot carrying the cached metadata of a long-dead AirPlay session (position pinned at 0, no push updates). Mapping Loading unconditionally to PLAYING rendered such players as playing forever, re-latched on every MRP reconnect and surviving server restarts since the state lives on the device.

- Map Loading to PLAYING only while the player is already playing (buffering between tracks); otherwise treat it as idle, matching Home Assistant's apple_tv integration.
- Clear the external playback snapshot in _disconnect_control_services: the late connection_closed callback is ignored for an already-detached device, so forced reconnects leaked the stale snapshot indefinitely.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
