### PR TITLE
Improve local album and artist folder matching

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -9,15 +9,14 @@ import os
 import os.path
 import posixpath
 import urllib.parse
-from collections.abc import AsyncGenerator, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Iterator, Sequence
+from contextvars import ContextVar
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast
-from xml.parsers.expat import ExpatError
 
 import aiofiles
 import shortuuid
-import xmltodict
 from aiofiles.os import wrap
 from music_assistant_models.enums import (
     ContentType,
@@ -69,6 +68,7 @@ from music_assistant.constants import (
     VARIOUS_ARTISTS_NAME,
     VERBOSE_LOG_LEVEL,
 )
+from music_assistant.controllers.cache import BYPASS_CACHE
 from music_assistant.controllers.tasks.context import (
     report_current_task_failure,
     update_current_task_progress_from_index,
@@ -76,9 +76,10 @@ from music_assistant.controllers.tasks.context import (
 )
 from music_assistant.helpers import lyrics
 from music_assistant.helpers.compare import compare_strings
+from music_assistant.helpers.cue_sheet import CueSheet
 from music_assistant.helpers.json import SerializableType, json_loads
 from music_assistant.helpers.playlists import parse_m3u, parse_pls
-from music_assistant.helpers.tags import AudioTags, async_parse_tags, clean_mbid, split_items
+from music_assistant.helpers.tags import AudioTags, async_parse_tags, clean_mbid
 from music_assistant.helpers.uri import create_uri
 from music_assistant.helpers.util import (
     TaskManager,
@@ -113,6 +114,7 @@ from .constants import (
     IMAGE_EXTENSIONS,
     METADATA_FILE_CACHE_EXPIRATION,
     METADATA_FILE_EXTENSIONS,
+    NFO_FILENAMES,
     PARTIAL_LISTING_CACHE_EXPIRATION,
     PLAYLIST_EXTENSIONS,
     PODCAST_EPISODE_EXTENSIONS,
@@ -137,12 +139,14 @@ from .helpers import (
     get_artist_dir,
     get_folder_signature,
     get_relative_path,
+    is_disc_dir,
     is_image_file,
     is_metadata_file,
+    parse_nfo_root,
     recursive_iter,
     sorted_scandir,
 )
-from .parsers import parse_album_nfo
+from .parsers import parse_album_nfo, parse_artist_nfo
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
@@ -163,6 +167,34 @@ SUPPORTED_FEATURES = {
     ProviderFeature.BROWSE,
     ProviderFeature.SEARCH,
 }
+
+# task-local memo of on-demand folder listings (NFO files only) for one outermost parse, so
+# overlapping lookups for the same candidate folder list it only once; unset outside such a
+# scope, and unused entirely once the sync's own NFO index is ready
+_ONDEMAND_NFO_ITEMS: ContextVar[dict[str, dict[str, FileSystemItem]] | None] = ContextVar(
+    "ondemand_nfo_items", default=None
+)
+
+# every field parse_album_nfo/parse_artist_nfo reads; each, if present, must be a plain scalar
+# (not a repeated/nested XML element) or the NFO is not trusted as folder identity
+_ALBUM_NFO_FIELDS = (
+    "title",
+    "name",
+    "sortname",
+    "review",
+    "year",
+    "genre",
+    "musicbrainzalbumid",
+    "musicbrainzreleasegroupid",
+    "musicbrainzalbumartistid",
+)
+_ARTIST_NFO_FIELDS = ("title", "name", "sortname", "biography", "genre", "musicbrainzartistid")
+# fields whose consumer (split_items) explicitly also accepts a list/tuple of scalars, since
+# xmltodict yields a list for a repeated element (e.g. multiple <genre> tags)
+_LIST_ALLOWED_NFO_FIELDS = ("genre",)
+# the MusicBrainz id fields among the above: if present at all, must also be a valid UUID
+_ALBUM_MBID_FIELDS = ("musicbrainzalbumid", "musicbrainzreleasegroupid", "musicbrainzalbumartistid")
+_ARTIST_MBID_FIELDS = ("musicbrainzartistid",)
 
 
 async def setup(
@@ -206,6 +238,14 @@ class LocalFileSystemProvider(MusicProvider):
             "str", self.get_setup_value(CONF_CONTENT_TYPE, CONF_ENTRY_CONTENT_TYPE.default_value)
         )
         self._cue = CueSheetHandler(self)
+        # sync-scoped index of this sync's walked album.nfo/artist.nfo, keyed by parent
+        # directory; an O(1) lookup for the NFO-resolution fallback instead of a filesystem
+        # probe per candidate folder. Ephemeral: built after the walk, cleared in _run_sync.
+        self._sync_nfo_by_dir: dict[str, dict[str, FileSystemItem]] = {}
+        # True only once _sync_nfo_by_dir reflects a completed walk; `sync_running` alone
+        # is not enough, since a concurrent on-demand parse could otherwise start consulting
+        # the index for the entire (potentially long) walk before it is actually populated
+        self._sync_nfo_index_ready: bool = False
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""
@@ -503,6 +543,8 @@ class LocalFileSystemProvider(MusicProvider):
         scan_errors = ScanErrors()
 
         self.sync_running = True
+        self._sync_nfo_by_dir = {}
+        self._sync_nfo_index_ready = False
         try:
             await self._enumerate_files_for_sync(
                 file_checksums=file_checksums,
@@ -521,6 +563,12 @@ class LocalFileSystemProvider(MusicProvider):
                 report_current_task_failure("Sync aborted: filesystem unavailable during scan")
                 self._set_available(False)
                 return
+            self._sync_nfo_by_dir = self._build_nfo_index(metadata_files)
+            # an incomplete scan (some folders/files failed to read) may be missing NFOs
+            # that do exist on disk; treating this partial index as authoritative could
+            # make a changed track wrongly resolve to a synthetic identity. Leave it
+            # unready so lookups fall back to listing each folder directly instead
+            self._sync_nfo_index_ready = not scan_errors.incomplete
             if metadata_files:
                 await self._queue_changed_metadata_files(
                     metadata_files,
@@ -589,11 +637,14 @@ class LocalFileSystemProvider(MusicProvider):
                         f"Processed {processed_count}/{total_items} files",
                     )
 
-            async with TaskManager(self.mass, self._SYNC_CONCURRENCY) as tm:
-                for item, prev_checksum in items_to_process:
-                    await tm.create_task_with_limit(_process(item, prev_checksum))
+            with self._ondemand_listing_scope():
+                async with TaskManager(self.mass, self._SYNC_CONCURRENCY) as tm:
+                    for item, prev_checksum in items_to_process:
+                        await tm.create_task_with_limit(_process(item, prev_checksum))
         finally:
             self.sync_running = False
+            self._sync_nfo_by_dir = {}
+            self._sync_nfo_index_ready = False
 
         # do not run deletions on a clean but empty scan of a previously non-empty library
         # (wrong share mounted, empty backup mount, ...)
@@ -629,10 +680,42 @@ class LocalFileSystemProvider(MusicProvider):
             prov_artist_id, self.instance_id
         )
         if not db_artist:
-            # this may happen if the artist is not in the db yet
-            # e.g. when browsing the filesystem
+            # no db item yet (e.g. browsing, or a manual refresh's second fetch after a
+            # normal/NFO match resolved a new path before its mapping was persisted).
+            # Recover identity from that path instead of falling back to its basename
             if await self.exists(prov_artist_id):
-                return await self._parse_artist(prov_artist_id, artist_path=prov_artist_id)
+                with self._ondemand_listing_scope():
+                    name = Path(prov_artist_id).name
+                    sort_name: str | None = None
+                    mbid: str | None = None
+                    if nfo_item := await self._nfo_item_for(prov_artist_id, "artist.nfo"):
+                        nfo_root = await self._load_nfo_root(nfo_item, "artist")
+                        if nfo_root and (
+                            nfo_mbid := clean_mbid(
+                                nfo_root.get("musicbrainzartistid"), nfo_item.relative_path
+                            )
+                        ):
+                            mbid = nfo_mbid
+                            if library_artist := (
+                                await self.mass.music.artists.get_library_item_by_external_id(
+                                    mbid, ExternalID.MB_ARTIST
+                                )
+                            ):
+                                name = library_artist.name
+                                sort_name = library_artist.sort_name
+                    if not mbid and (
+                        library_artist := await self._find_artist_by_folder_name(name)
+                    ):
+                        # no MBID to resolve by (this path was matched via a normal
+                        # folder/sort-name-alias match, not an artist.nfo): recover the
+                        # one already-known library artist this path belongs to instead
+                        # of renaming it to the folder's own basename
+                        name = library_artist.name
+                        sort_name = library_artist.sort_name
+                        mbid = library_artist.mbid
+                    return await self._parse_artist(
+                        name, sort_name=sort_name, mbid=mbid, artist_path=prov_artist_id
+                    )
             return await self._parse_artist(prov_artist_id)
 
         # prov_artist_id is either an actual (relative) path or a name (as fallback)
@@ -649,8 +732,19 @@ class LocalFileSystemProvider(MusicProvider):
                     artist_path = prov_mapping.url
                     break
             else:
-                # this is an artist without an actual path on disk
-                # return the info we already have in the db
+                # no path of its own: anchor a bounded artist.nfo attempt on one of its own
+                # tracks instead of giving up, so adding an artist.nfo and refreshing can
+                # still resolve it
+                representative_track = await self._resolve_artist_representative_track(db_artist)
+                if representative_track:
+                    with self._ondemand_listing_scope():
+                        return await self._parse_artist(
+                            db_artist.name,
+                            sort_name=db_artist.sort_name,
+                            mbid=db_artist.mbid,
+                            album_dir=os.path.dirname(representative_track),
+                            representative_track=representative_track,
+                        )
                 return db_artist
         return await self._parse_artist(
             db_artist.name,
@@ -663,25 +757,35 @@ class LocalFileSystemProvider(MusicProvider):
     async def get_album(self, prov_album_id: str) -> Album:
         """Get full album details by id."""
         parsed_cue_paths: set[str] = set()
-        for track in await self.get_album_tracks(prov_album_id):
-            for prov_mapping in track.provider_mappings:
-                if prov_mapping.provider_instance != self.instance_id:
-                    continue
-                if parsed := parse_cue_track_id(prov_mapping.item_id):
-                    # every track from the same CUE shares the same album; only parse once
-                    if parsed[0] in parsed_cue_paths:
+        # early returns below stop iterating this generator before it's exhausted; without an
+        # explicit aclose() that leaves its _ondemand_listing_scope() cleanup (a ContextVar
+        # reset) to whenever the event loop's async-generator finalizer happens to run, instead
+        # of deterministically, right here
+        async with contextlib.aclosing(self._iter_album_tracks(prov_album_id)) as tracks:
+            async for track in tracks:
+                if isinstance(track.album, Album):
+                    # already a fully parsed album: the folder-scan fallback (used when this id
+                    # has no library mapping yet) yields these directly, so re-resolving and
+                    # re-parsing the same file below would only repeat the same tag/NFO work
+                    return track.album
+                for prov_mapping in track.provider_mappings:
+                    if prov_mapping.provider_instance != self.instance_id:
                         continue
-                    parsed_cue_paths.add(parsed[0])
-                    cue_item = await self.resolve(parsed[0])
-                    for cue_track in await self._cue.parse_tracks(cue_item):
-                        if isinstance(cue_track.album, Album):
-                            return cue_track.album
-                    continue
-                file_item = await self.resolve(prov_mapping.item_id)
-                tags = await async_parse_tags(file_item.absolute_path, file_item.file_size)
-                full_track = await self._parse_track(file_item, tags)
-                assert isinstance(full_track.album, Album)
-                return full_track.album
+                    if parsed := parse_cue_track_id(prov_mapping.item_id):
+                        # every track from the same CUE shares the same album; only parse once
+                        if parsed[0] in parsed_cue_paths:
+                            continue
+                        parsed_cue_paths.add(parsed[0])
+                        cue_item = await self.resolve(parsed[0])
+                        for cue_track in await self._cue.parse_tracks(cue_item):
+                            if isinstance(cue_track.album, Album):
+                                return cue_track.album
+                        continue
+                    file_item = await self.resolve(prov_mapping.item_id)
+                    tags = await async_parse_tags(file_item.absolute_path, file_item.file_size)
+                    full_track = await self._parse_track(file_item, tags)
+                    assert isinstance(full_track.album, Album)
+                    return full_track.album
         msg = f"Album not found: {prov_album_id}"
         raise MediaNotFoundError(msg)
 
@@ -790,19 +894,15 @@ class LocalFileSystemProvider(MusicProvider):
 
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
         """Get album tracks for given album id."""
-        # filesystem items are always stored in db so we can query the database
+        tracks = [track async for track in self._iter_album_tracks(prov_album_id)]
         db_album = await self.mass.music.albums.get_library_item_by_prov_id(
             prov_album_id, self.instance_id
         )
         if db_album is None:
-            msg = f"Album not found: {prov_album_id}"
-            raise MediaNotFoundError(msg)
-        album_tracks = await self.mass.music.albums.get_library_album_tracks(db_album.item_id)
-        return [
-            track
-            for track in album_tracks
-            if any(x.provider_instance == self.instance_id for x in track.provider_mappings)
-        ]
+            # mappingless result: folder listing order (WebDAV/cloud listings are not
+            # guaranteed ordered) would otherwise be returned to the caller as-is
+            tracks.sort(key=lambda track: (track.disc_number, track.track_number))
+        return tracks
 
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
         """Get playlist tracks."""
@@ -1246,31 +1346,111 @@ class LocalFileSystemProvider(MusicProvider):
             return item.ext in PODCAST_EPISODE_EXTENSIONS
         return False
 
+    async def _root_artist_path(self, name: str) -> str | None:
+        """
+        Return a root-level artist folder matching this exact name, if any.
+
+        Tries the plain name and its filesystem-safe variant, so a root-level folder that
+        differs only in punctuation (e.g. "AC/DC" stored as "ACDC") still resolves.
+
+        :param name: The artist name (or a sort-name alias) to match against a root folder.
+        """
+        if await self.exists(name):
+            return name
+        safe_name = create_safe_string(name, lowercase=False, replace_space=False)
+        if await self.exists(safe_name):
+            return safe_name
+        return None
+
+    async def _find_artist_path(
+        self, candidate_name: str, album_dir: str | None, *, exact_only: bool = False
+    ) -> str | None:
+        """
+        Return an artist folder for one name candidate: a root, ancestor, or known item's path.
+
+        :param candidate_name: The artist name (or a sort-name alias) to match against a folder.
+        :param album_dir: The album directory whose ancestors are searched, if any.
+        :param exact_only: Only accept an exact (normalized) match, skipping the relaxed
+            (fuzzy) fallback built into the ancestor search.
+        """
+        if artist_path := await self._root_artist_path(candidate_name):
+            return artist_path
+        if album_dir and (
+            artist_path := get_artist_dir(
+                candidate_name, album_dir=album_dir, exact_only=exact_only
+            )
+        ):
+            return artist_path
+        # check if we have an existing item to retrieve the artist path
+        async for item in self.mass.music.artists.iter_library_items(
+            search=candidate_name, provider=self.instance_id
+        ):
+            if not compare_strings(candidate_name, item.name):
+                continue
+            for prov_mapping in item.provider_mappings:
+                if prov_mapping.provider_instance == self.instance_id and prov_mapping.url:
+                    return prov_mapping.url
+        return None
+
     async def _resolve_artist_representative_track(self, artist: Artist) -> str | None:
         """
         Return one of this artist's own track paths, to register a metadata-file baseline.
 
-        Used when explicitly (re)fetching an artist (e.g. a manual "Refresh item"), which does
-        not otherwise go through `_parse_track`/`_parse_album` and so would leave a freshly
-        read artist.nfo/image unregistered - permanently invisible to the sync's automatic
-        change detection until an unrelated track/album parse happens to register it instead.
+        Needed for a manual "Refresh item", which doesn't go through `_parse_track`/
+        `_parse_album` and would otherwise leave a freshly read artist.nfo/image
+        unregistered. Falls back to an album-only artist's own albums (e.g. credited only
+        as ALBUMARTIST, never as a track artist) - a bounded, first-success lookup; not
+        optimized further since this only runs for a one-off manual refresh.
 
-        :param artist: The library artist whose own tracks (if any) are searched.
+        :param artist: The library artist whose own tracks are searched.
         """
-        tracks = await self.mass.music.artists.get_library_artist_tracks(
+        for track in await self.mass.music.artists.get_library_artist_tracks(
             artist.item_id, provider_filter=self.instance_id
-        )
-        for track in tracks:
-            for prov_mapping in track.provider_mappings:
-                if prov_mapping.provider_instance != self.instance_id:
-                    continue
-                # a CUE-derived track's mapping is a synthetic "<cue path>::<track>" id, not
-                # itself a resolvable path; its CUE sheet is, and reprocessing that sheet
-                # already refreshes every track (and this artist) it describes
-                if parsed := parse_cue_track_id(prov_mapping.item_id):
-                    return parsed[0]
-                return prov_mapping.item_id
+        ):
+            if path := self._track_representative_path(track):
+                return path
+        for album in await self.mass.music.artists.get_library_artist_albums(
+            artist.item_id, provider_filter=self.instance_id
+        ):
+            for track in await self.mass.music.albums.get_library_album_tracks(
+                album.item_id, provider_filter=[self.instance_id]
+            ):
+                if path := self._track_representative_path(track):
+                    return path
         return None
+
+    def _track_representative_path(self, track: Track) -> str | None:
+        """Return this instance's own resolvable path (or CUE sheet path) for one track."""
+        for prov_mapping in track.provider_mappings:
+            if prov_mapping.provider_instance != self.instance_id or not prov_mapping.available:
+                # an unavailable mapping is a stale library row, not a resolvable path: using
+                # it anyway could point the caller's next `_scandir`/`exists` at an already
+                # removed folder instead of trying another candidate track
+                continue
+            # a CUE-derived track's mapping is a synthetic "<cue path>::<track>" id, not
+            # itself a resolvable path; its CUE sheet is, and reprocessing that sheet
+            # already refreshes every track (and this artist) it describes
+            if parsed := parse_cue_track_id(prov_mapping.item_id):
+                return parsed[0]
+            return prov_mapping.item_id
+        return None
+
+    async def _find_artist_by_folder_name(self, folder_name: str) -> Artist | None:
+        """
+        Return the one library artist (on this provider) whose name or sort-name matches.
+
+        Used to recover a synthetic artist's identity on the second, not-yet-persisted
+        fetch of a path a normal folder/sort-name-alias match just resolved onto.
+
+        :param folder_name: The resolved folder's own basename.
+        """
+        matches = [
+            item
+            async for item in self.mass.music.artists.iter_library_items(provider=self.instance_id)
+            if compare_strings(folder_name, item.name)
+            or (item.sort_name and compare_strings(folder_name, item.sort_name))
+        ]
+        return matches[0] if len(matches) == 1 else None
 
     async def _drop_stale_album_artist_caches(self) -> None:
         """
@@ -1402,6 +1582,463 @@ class LocalFileSystemProvider(MusicProvider):
             # cache: keep it out of a generic "clear cache" action
             persistent=True,
         )
+
+    @staticmethod
+    def _add_nfo_candidate(by_name: dict[str, FileSystemItem], item: FileSystemItem) -> None:
+        """
+        Add one recognized NFO file to a per-directory candidate map, order-independently.
+
+        Two files differing only in case (e.g. ``album.nfo`` and ``ALBUM.NFO`` in the same
+        directory - an unusual layout, but possible on a case-sensitive filesystem) must resolve
+        to the same one regardless of directory-listing order, so the sync's walk and an
+        on-demand listing never disagree: the lexicographically first literal filename always
+        wins, deterministically.
+        """
+        name = item.filename.lower()
+        if name not in NFO_FILENAMES:
+            return
+        existing = by_name.get(name)
+        if existing is None or item.filename < existing.filename:
+            by_name[name] = item
+
+    @staticmethod
+    def _build_nfo_index(
+        metadata_files: list[FileSystemItem],
+    ) -> dict[str, dict[str, FileSystemItem]]:
+        """Group this sync's walked album.nfo/artist.nfo by parent directory."""
+        index: dict[str, dict[str, FileSystemItem]] = {}
+        for item in metadata_files:
+            # metadata_files also carries folder artwork; skip those before creating a
+            # per-directory entry, or every image-bearing folder would get an empty one
+            if item.filename.lower() not in NFO_FILENAMES:
+                continue
+            LocalFileSystemProvider._add_nfo_candidate(
+                index.setdefault(item.relative_parent_path, {}), item
+            )
+        return index
+
+    @contextlib.contextmanager
+    def _ondemand_listing_scope(self) -> Iterator[None]:
+        """
+        Memoize on-demand folder listings for one outermost parse.
+
+        A no-op once the sync's own NFO index is ready (lookups are already O(1) from it) or
+        when already inside an outer scope, so nested album/artist resolution within one
+        parse shares a single memo and reuses a folder's already-completed listing - though
+        two concurrent lookups racing the very first listing of a folder can still both list
+        it, bounded by concurrency - including for a track processed while the sync's walk is
+        still in progress, or the whole batch of tracks processed while an incomplete scan
+        left that index unready. A forced refresh never takes that index shortcut regardless
+        (see :meth:`_nfo_item_for`),
+        so it still needs - and gets - its own memo here.
+        """
+        if (self._sync_nfo_index_ready and not BYPASS_CACHE.get()) or (
+            _ONDEMAND_NFO_ITEMS.get() is not None
+        ):
+            yield
+            return
+        items_token = _ONDEMAND_NFO_ITEMS.set({})
+        try:
+            yield
+        finally:
+            _ONDEMAND_NFO_ITEMS.reset(items_token)
+
+    async def _nfo_item_for(self, folder: str, filename: str) -> FileSystemItem | None:
+        """
+        Return a folder's named NFO file, from the sync index or a listing on demand.
+
+        Listing (not a direct path probe) matches the sync's own case-insensitive NFO
+        recognition. A forced refresh (``BYPASS_CACHE``) always lists directly, even during
+        a concurrent background sync, since that sync's index is a provider-wide snapshot
+        that could otherwise still serve the stale listing the refresh was meant to bypass.
+        Outside that index (before it is built, or an incomplete scan left it unready), the
+        per-parse on-demand memo below still applies, since `sync_library` wraps its whole
+        batch in one shared :meth:`_ondemand_listing_scope`, not a scope per track.
+
+        :param folder: The candidate directory to look in.
+        :param filename: ``album.nfo`` or ``artist.nfo``.
+        """
+        if self._sync_nfo_index_ready and not BYPASS_CACHE.get():
+            return self._sync_nfo_by_dir.get(folder, {}).get(filename)
+        memo = _ONDEMAND_NFO_ITEMS.get()
+        if memo is not None:
+            if folder not in memo:
+                memo[folder] = await self._list_nfo_candidates(folder)
+            candidates = memo[folder]
+        else:
+            candidates = await self._list_nfo_candidates(folder)
+        return candidates.get(filename)
+
+    async def _list_nfo_candidates(self, folder: str) -> dict[str, FileSystemItem]:
+        """
+        Return a folder's recognized NFO files, keyed by lowercase filename.
+
+        A listing failure is not caught here: every bounded candidate directory is either the
+        track's own directory or an ancestor of it, so it necessarily exists; a raised error is
+        therefore a genuine transient storage failure and must propagate just like a `_read_file`
+        failure, so the caller (and, during a sync, `_process_item_async`) can defer and retry
+        instead of silently treating the folder as having no NFO.
+        """
+        # bypass a cloud-backed provider's own short-lived listing cache during an explicit
+        # "Refresh item", so an NFO just added to disk is seen right away instead of only
+        # after that cache naturally expires
+        items = await self._scandir(folder, use_cache=not BYPASS_CACHE.get())
+        by_name: dict[str, FileSystemItem] = {}
+        for item in items:
+            if not item.is_dir:
+                self._add_nfo_candidate(by_name, item)
+        return by_name
+
+    async def _load_nfo_root(
+        self, nfo_item: FileSystemItem, root_tag: str
+    ) -> dict[str, Any] | None:
+        """
+        Read and parse one NFO file, returning its root element or None when malformed.
+
+        :param nfo_item: The NFO file to read.
+        :param root_tag: The expected root element name (``album`` or ``artist``).
+        """
+        raw = await self._read_file(nfo_item.relative_path)
+        return await asyncio.to_thread(parse_nfo_root, raw, root_tag)
+
+    def _nfo_applies_cleanly(self, root: dict[str, Any], kind: str) -> bool:
+        """
+        Return True when an NFO root's consumed fields are well-shaped and apply without error.
+
+        Used before trusting an NFO as folder identity, so a title/id that happens to match but
+        carries an invalid field never resolves a directory that enrichment would then reject
+        anyway. Every field ``parse_album_nfo``/``parse_artist_nfo`` reads must be a plain scalar
+        (not a repeated/nested XML element reaching a string-only assignment or helper without
+        raising), and a present MusicBrainz id must actually be a valid UUID, not merely absent.
+
+        :param root: The parsed NFO root.
+        :param kind: ``album`` or ``artist``.
+        """
+        fields, mbid_fields = (
+            (_ALBUM_NFO_FIELDS, _ALBUM_MBID_FIELDS)
+            if kind == "album"
+            else (_ARTIST_NFO_FIELDS, _ARTIST_MBID_FIELDS)
+        )
+        for field in fields:
+            value = root.get(field)
+            if value is None:
+                continue
+            if field in _LIST_ALLOWED_NFO_FIELDS:
+                if not isinstance(value, str) and not (
+                    isinstance(value, list | tuple) and all(isinstance(v, str) for v in value)
+                ):
+                    return False
+            elif not isinstance(value, str):
+                return False
+        for field in mbid_fields:
+            raw = root.get(field)
+            if isinstance(raw, str) and raw.strip() and clean_mbid(raw) is None:
+                return False
+        try:
+            if kind == "album":
+                scratch_album = Album(
+                    item_id="", provider=self.instance_id, name="", provider_mappings=set()
+                )
+                parse_album_nfo(scratch_album, root)
+            else:
+                scratch_artist = Artist(
+                    item_id="", provider=self.instance_id, name="", provider_mappings=set()
+                )
+                parse_artist_nfo(scratch_artist, root)
+        except ValueError, TypeError, AttributeError:
+            # AttributeError covers a non-scalar field shape (e.g. a repeated/nested XML
+            # element) reaching a string-only helper such as split_items
+            return False
+        return True
+
+    async def _resolve_album_dir_via_nfo(
+        self, track_dir: str, tags: AudioTags, rejected: set[str] | None = None
+    ) -> tuple[str, FileSystemItem, dict[str, Any]] | None:
+        """
+        Return ``(album_dir, nfo_item, root)`` resolved from a validated album.nfo, or None.
+
+        Bounded to ``track_dir`` and its immediate parent: a recognized disc subfolder's own
+        album.nfo is never trusted as identity, only its parent's is, and the provider's own
+        root is never a candidate either (like the normal, non-NFO folder match, it can never
+        identify one specific album out of the many the root may contain). ``track_dir`` itself
+        is tried first - it is the nearer, more specific candidate - before falling back to the
+        parent, so a same-title album.nfo one level up (e.g. a stray leftover from a prior,
+        flatter layout) can never outrank the track's own, definitively correct one. A
+        candidate's album.nfo must positively match this track's MusicBrainz album/release-
+        group id or its album title, and apply cleanly, before it is trusted; a malformed or
+        non-matching NFO leaves the album unresolved (synthetic, tag-only).
+
+        :param track_dir: The directory the track file lives in.
+        :param tags: The track's audio tags, matched against a candidate NFO.
+        :param rejected: When given, every folder whose own album.nfo exists but fails to
+            positively identify this album is added here, so a later relaxed (fuzzy/layout/
+            date-prefix) match landing on that same folder knows not to trust that same
+            rejected file.
+        """
+        album_id = clean_mbid(tags.musicbrainz_albumid, tags.filename)
+        rg_id = clean_mbid(tags.musicbrainz_releasegroupid, tags.filename)
+        album_name, album_version = (
+            parse_title_and_version(tags.album) if tags.album else (None, "")
+        )
+        album_artist_ids = tuple(
+            cleaned
+            for raw_id in tags.musicbrainz_albumartistids
+            if (cleaned := clean_mbid(raw_id, tags.filename))
+        )
+        candidates: list[str] = []
+        if track_dir and not is_disc_dir(Path(track_dir).name):
+            candidates.append(track_dir)
+        candidates.extend(d for d in (os.path.dirname(track_dir),) if d)
+        for folder in candidates:
+            nfo_item = await self._nfo_item_for(folder, "album.nfo")
+            if nfo_item is None:
+                continue
+            root = await self._load_nfo_root(nfo_item, "album")
+            if (
+                root is not None
+                and self._album_nfo_matches(
+                    root, album_id, rg_id, album_name, album_artist_ids, album_version
+                )
+                and self._nfo_applies_cleanly(root, "album")
+            ):
+                return folder, nfo_item, root
+            if root is not None and rejected is not None:
+                rejected.add(folder)
+        return None
+
+    @staticmethod
+    def _album_nfo_matches(
+        root: dict[str, Any],
+        album_id: str | None,
+        rg_id: str | None,
+        album_name: str | None,
+        album_artist_ids: tuple[str, ...] = (),
+        album_version: str = "",
+    ) -> bool:
+        """Return True when an album.nfo positively identifies this track's album."""
+        nfo_artist_id = clean_mbid(root.get("musicbrainzalbumartistid"), "musicbrainzalbumartistid")
+        if nfo_artist_id and album_artist_ids and nfo_artist_id not in album_artist_ids:
+            # the NFO names a different album artist than this track's tags: reject even a
+            # matching title or album id, since it may belong to another artist's same-named
+            # or same-catalog-numbered album
+            return False
+        comparisons: list[bool] = []
+        for field, tag_id in (
+            ("musicbrainzalbumid", album_id),
+            ("musicbrainzreleasegroupid", rg_id),
+        ):
+            if not tag_id:
+                continue
+            nfo_id = clean_mbid(root.get(field), field)
+            if nfo_id:
+                comparisons.append(nfo_id == tag_id)
+        if comparisons:
+            # every comparable id must agree; one mismatch rejects even if another id matched
+            return all(comparisons)
+        if not album_name:
+            return False
+        nfo_title = root.get("title") or root.get("name")
+        if not nfo_title:
+            return False
+        # strip the NFO title's own edition/version suffix the same way the track's tag-derived
+        # album name already was (matching how parse_album_nfo treats the title once applied),
+        # so e.g. "Album (Deluxe Edition)" compares as "Album" on both sides
+        nfo_name, nfo_version = parse_title_and_version(str(nfo_title))
+        if album_version and nfo_version and not compare_strings(album_version, nfo_version, False):
+            # both sides name a specific edition (e.g. "Live" vs "Remix"): never a match on
+            # the base title alone, even though it is otherwise identical on both sides
+            return False
+        # strict comparison: folder identity must not be granted on a fuzzy/near match (e.g.
+        # "Album 1" vs "Album 2"), only an (almost) exact one after normalization
+        return compare_strings(nfo_name, album_name)
+
+    async def _resolve_artist_dir_via_nfo(
+        self, album_dir: str, name: str, mbid: str | None, rejected: set[str] | None = None
+    ) -> tuple[str, FileSystemItem, dict[str, Any]] | None:
+        """
+        Return ``(artist_path, nfo_item, root)`` resolved from a validated artist.nfo, or None.
+
+        Walks the same bounded ancestor levels as the normal folder-name lookup, from the album
+        directory's parent upward, but never as far as the provider's own root: like the normal
+        folder-name match, an artist.nfo there could not identify one specific artist out of the
+        many the root may contain. The first ancestor whose artist.nfo positively matches this
+        artist's MusicBrainz id or name - and applies cleanly - is trusted; a mismatching,
+        malformed or marker-only (no id or name) NFO is skipped and the walk continues.
+
+        :param album_dir: The album directory whose ancestors are searched.
+        :param name: The artist name to match.
+        :param mbid: The artist's cleaned MusicBrainz id, if any.
+        :param rejected: When given, every folder whose own artist.nfo exists but fails to
+            positively identify this artist is added here, so a later relaxed (fuzzy/alias)
+            match landing on that same folder knows not to trust that same rejected file.
+        """
+        parentdir = os.path.dirname(album_dir)
+        for _ in range(3):
+            if not parentdir:
+                break
+            nfo_item = await self._nfo_item_for(parentdir, "artist.nfo")
+            if nfo_item is not None:
+                root = await self._load_nfo_root(nfo_item, "artist")
+                if (
+                    root is not None
+                    and self._artist_nfo_matches(root, name, mbid)
+                    and self._nfo_applies_cleanly(root, "artist")
+                ):
+                    return parentdir, nfo_item, root
+                if rejected is not None:
+                    rejected.add(parentdir)
+            parentdir = os.path.dirname(parentdir)
+        return None
+
+    @staticmethod
+    def _artist_nfo_matches(root: dict[str, Any], name: str, mbid: str | None) -> bool:
+        """Return True when an artist.nfo positively identifies this artist by id or name."""
+        if mbid:
+            nfo_mbid = clean_mbid(root.get("musicbrainzartistid"), "artist.nfo")
+            if nfo_mbid:
+                return nfo_mbid == mbid
+        nfo_name = root.get("title") or root.get("name")
+        # strict comparison: folder identity must not be granted on a fuzzy/near match (e.g.
+        # "Artist 1" vs "Artist 2"), only an (almost) exact one after normalization
+        return bool(nfo_name) and compare_strings(str(nfo_name), name)
+
+    async def _iter_album_tracks(self, prov_album_id: str) -> AsyncGenerator[Track]:
+        """
+        Yield an album's tracks, lazily, so a caller needing only the first can stop early.
+
+        Served from the database when this id is already mapped; otherwise (the second,
+        id-changed fetch of a manual "Refresh item" that has just resolved a previously
+        synthetic album onto its real folder, before that mapping is persisted) the folder's
+        own tracks are parsed directly, so the refresh still succeeds instead of raising on a
+        mapping that is only about to exist.
+
+        :param prov_album_id: This provider's album id (a path, once resolved).
+        """
+        db_album = await self.mass.music.albums.get_library_item_by_prov_id(
+            prov_album_id, self.instance_id
+        )
+        if db_album is not None:
+            album_tracks = await self.mass.music.albums.get_library_album_tracks(db_album.item_id)
+            for track in album_tracks:
+                if any(x.provider_instance == self.instance_id for x in track.provider_mappings):
+                    yield track
+            return
+        if not await self.exists(prov_album_id):
+            msg = f"Album not found: {prov_album_id}"
+            raise MediaNotFoundError(msg)
+        # one shared scope for the whole scan, not one per track: every _parse_track call below
+        # would otherwise open and close its own scope, re-listing the same candidate ancestor
+        # folders once per track instead of once for the album
+        with self._ondemand_listing_scope():
+            async for track in self._scan_folder_tracks(prov_album_id):
+                yield track
+
+    async def _scan_folder_tracks(self, folder: str) -> AsyncIterator[Track]:
+        """
+        Yield every parseable track under a folder or one of its immediate child directories.
+
+        The folder itself is scanned first; a child directory is only listed if the caller
+        needs more than the folder alone provided, so a single-track lookup (:meth:`get_album`)
+        skips subfolder listings entirely on a cloud/WebDAV backend. Every child is tried, not
+        only regex-recognized disc folders, since the album may live in an arbitrarily named
+        subfolder; the ``track.album.item_id == folder`` filter keeps only tracks belonging to
+        this exact folder.
+
+        :param folder: The folder to scan; also every one of its immediate child directories.
+        """
+        # shared across this folder and every child directory below, so a single CUE sheet
+        # naming a child folder's companion audio file (e.g. one CUE covering the whole
+        # album, split across "Disc 1"/"Disc 2" subfolders) still excludes that companion
+        # once its own subfolder is scanned, instead of parsing it again as a duplicate track
+        cue_stems: set[str] = set()
+        entries = await self._scandir(folder)
+        async for track in self._yield_scanned_tracks(folder, entries, cue_stems):
+            yield track
+        for entry in entries:
+            if entry.is_dir:
+                child_entries = await self._scandir(entry.relative_path)
+                async for track in self._yield_scanned_tracks(folder, child_entries, cue_stems):
+                    yield track
+
+    async def _yield_scanned_tracks(
+        self, folder: str, items: list[FileSystemItem], cue_stems: set[str]
+    ) -> AsyncIterator[Track]:
+        """
+        Yield every parseable track among one directory's own (already listed) items.
+
+        A CUE's own file and the companion audio file it names are never yielded separately -
+        only the CUE's own segmented tracks represent them, mirroring the sync/browse paths'
+        CUE-stem exclusion. A missing companion audio file or unparsable CUE sheet is checked
+        explicitly before constructing the CUE's album, and only that is treated as "this file
+        is unreadable" and skipped. A failure past that point (constructing the album via this
+        same NFO resolution) propagates instead, since a cloud/WebDAV `_read_file` also raises
+        `MediaNotFoundError` for a transient read failure, not only a genuinely missing file.
+        Used only by :meth:`_scan_folder_tracks`.
+
+        :param folder: The top-level folder this album resolved to, matched against each
+            parsed track's own album identity.
+        :param items: One directory's own listed entries (never a nested listing).
+        :param cue_stems: Companion-audio stems already absorbed by a CUE sheet found in this
+            folder or an earlier one in this same scan; grown here with this folder's own
+            CUEs and still shared with every directory scanned afterwards.
+        """
+        cue_sheets: dict[str, CueSheet] = {}
+        for item in items:
+            if item.is_dir or item.ext not in CUE_EXTENSIONS:
+                continue
+            try:
+                cue_sheet = await self._cue.load_cue_sheet(item)
+            except InvalidDataError:
+                continue
+            if not cue_sheet.tracks:
+                # parses cleanly but names no tracks (e.g. truncated/malformed content):
+                # excluding its same-named companion here would lose that otherwise
+                # playable file entirely, since this CUE itself yields nothing below
+                continue
+            cue_stems.add(item.absolute_path.rsplit(".", 1)[0])
+            cue_sheets[item.relative_path] = cue_sheet
+            if companion_stem := cue_referenced_audio_stem(item, cue_sheet):
+                cue_stems.add(companion_stem)
+        for item in items:
+            if item.is_dir:
+                continue
+            if item.ext in CUE_EXTENSIONS:
+                loaded_cue_sheet = cue_sheets.get(item.relative_path)
+                if loaded_cue_sheet is None:
+                    self.logger.warning("Skipping unreadable CUE sheet %s", item.relative_path)
+                    continue
+                if await self._cue.find_audio_file(item, loaded_cue_sheet) is None:
+                    self.logger.warning(
+                        "Skipping CUE sheet with missing companion audio file: %s",
+                        item.relative_path,
+                    )
+                    continue
+                try:
+                    # InvalidDataError here covers the audio file's own unreadable/corrupt
+                    # tags (e.g. no determinable duration); a MediaNotFoundError past this
+                    # point can only come from constructing this CUE's album (this call's own
+                    # NFO resolution reading an NFO file) or a similarly transient storage
+                    # failure, and must propagate instead of being mistaken for a bad CUE
+                    cue_tracks = await self._cue.parse_tracks(item)
+                except InvalidDataError as err:
+                    self.logger.warning(
+                        "Skipping unreadable CUE sheet %s: %s", item.relative_path, err
+                    )
+                    continue
+                for track in cue_tracks:
+                    if isinstance(track.album, Album) and track.album.item_id == folder:
+                        yield track
+            elif item.ext in TRACK_EXTENSIONS:
+                if item.absolute_path.rsplit(".", 1)[0] in cue_stems:
+                    continue  # absorbed into its CUE sheet's own segmented tracks
+                try:
+                    tags = await async_parse_tags(item.absolute_path, item.file_size)
+                except InvalidDataError as err:
+                    self.logger.warning("Skipping unreadable track %s: %s", item.relative_path, err)
+                    continue
+                track = await self._parse_track(item, tags)
+                if isinstance(track.album, Album) and track.album.item_id == folder:
+                    yield track
 
     def _set_available(self, available: bool) -> None:
         """Update the provider availability and notify listeners on change."""
@@ -1787,6 +2424,13 @@ class LocalFileSystemProvider(MusicProvider):
         self, file_item: FileSystemItem, tags: AudioTags, full_album_metadata: bool = False
     ) -> Track:
         """Parse full track details from file tags."""
+        with self._ondemand_listing_scope():
+            return await self._parse_track_impl(file_item, tags, full_album_metadata)
+
+    async def _parse_track_impl(
+        self, file_item: FileSystemItem, tags: AudioTags, full_album_metadata: bool = False
+    ) -> Track:
+        """Parse full track details from file tags (implementation, see :meth:`_parse_track`)."""
         # ruff: noqa: PLR0915
         name, version = parse_title_and_version(tags.title, tags.version)
         track = Track(
@@ -2027,31 +2671,34 @@ class LocalFileSystemProvider(MusicProvider):
         representative_track: str | None = None,
     ) -> Artist:
         """Parse full (album) Artist."""
+        nfo_item: FileSystemItem | None = None
+        nfo_root: dict[str, Any] | None = None
+        # folders whose own artist.nfo was already read and rejected by the validated NFO
+        # tier below; a later relaxed/fuzzy match landing on one of these must not blindly
+        # trust that same rejected file during enrichment further down
+        rejected_nfo_folders: set[str] = set()
+        cleaned_mbid = clean_mbid(mbid, f"tags of artist {name}")
         if not artist_path:
-            # we need to hunt for the artist (metadata) path on disk
-            # this can either be relative to the album path or at root level
-            # check if we have an artist folder for this artist at root level
-            safe_artist_name = create_safe_string(name, lowercase=False, replace_space=False)
-            if await self.exists(name):
-                artist_path = name
-            elif await self.exists(safe_artist_name):
-                artist_path = safe_artist_name
-            elif album_dir and (foldermatch := get_artist_dir(name, album_dir=album_dir)):
-                # try to find (album)artist folder based on album path
-                artist_path = foldermatch
-            else:
-                # check if we have an existing item to retrieve the artist path
-                async for item in self.mass.music.artists.iter_library_items(
-                    search=name, provider=self.instance_id
-                ):
-                    if not compare_strings(name, item.name):
-                        continue
-                    for prov_mapping in item.provider_mappings:
-                        if prov_mapping.provider_instance != self.instance_id:
-                            continue
-                        if prov_mapping.url:
-                            artist_path = prov_mapping.url
-                            break
+            # exact tier: an already-known mapped identity or an exact (normalized) plain-name
+            # match at a root/ancestor folder always wins - a validated artist.nfo (below)
+            # still outranks a *relaxed* (fuzzy or sort-name-alias) match, but never this
+            artist_path = await self._find_artist_path(name, album_dir, exact_only=True)
+            if not artist_path and album_dir:
+                # exact matching found nothing at all: fall back to a bounded validated
+                # artist.nfo before trying any relaxed heuristic
+                for candidate_name in (n for n in (name, sort_name) if n):
+                    resolved = await self._resolve_artist_dir_via_nfo(
+                        album_dir, candidate_name, cleaned_mbid, rejected_nfo_folders
+                    )
+                    if resolved:
+                        artist_path, nfo_item, nfo_root = resolved
+                        break
+            if not artist_path:
+                # relaxed tier: plain name is tried at every location before the sort-name
+                # alias is tried anywhere - a sort-name match must never outrank a (relaxed)
+                # plain-name match found elsewhere
+                for candidate_name in (n for n in (name, sort_name) if n):
+                    artist_path = await self._find_artist_path(candidate_name, album_dir)
                     if artist_path:
                         break
 
@@ -2082,41 +2729,32 @@ class LocalFileSystemProvider(MusicProvider):
                 )
             },
         )
-        if mbid := clean_mbid(mbid, f"tags of artist {name}"):
-            artist.mbid = mbid
+        if cleaned_mbid:
+            artist.mbid = cleaned_mbid
         if not artist_path or not await self.exists(artist_path):
             return artist
 
         # grab additional metadata within the Artist's folder
-        nfo_file = os.path.join(artist_path, "artist.nfo")
-        if await self.exists(nfo_file):
-            # resolve before reading: the registered token must reflect the version we are
-            # about to parse, not whatever the file happens to be once parsing has finished
-            nfo_item = await self.resolve(nfo_file)
-            # found NFO file with metadata
-            # https://kodi.wiki/view/NFO_files/Artists
-            try:
-                data = (await self._read_file(nfo_file)).decode("utf-8")
-                info = await asyncio.to_thread(xmltodict.parse, data)
-                info = info["artist"]
-                artist.name = info.get("title", info.get("name", name))
-                if sort_name := info.get("sortname"):
-                    artist.sort_name = sort_name
-                if mbid := clean_mbid(info.get("musicbrainzartistid"), nfo_file):
-                    artist.mbid = mbid
-                if description := info.get("biography"):
-                    artist.metadata.description = description
-                if genre := info.get("genre"):
-                    artist.metadata.genres = set(split_items(genre))
+        if nfo_item is not None and nfo_root is not None:
+            # already read and validated while resolving this artist's folder above
+            parse_artist_nfo(artist, nfo_root, nfo_item.relative_path)
+            await self._register_metadata_file(nfo_item, representative_track)
+        elif artist_path not in rejected_nfo_folders and (
+            read_nfo_item := await self._nfo_item_for(artist_path, "artist.nfo")
+        ):
+            # found NFO file with metadata; read and parse it. Skipped when this folder's
+            # own artist.nfo was already read and rejected by the validated NFO tier above,
+            # so a relaxed (fuzzy/sort-name-alias) match landing here can't silently trust
+            # that same rejected file
+            if read_root := await self._load_nfo_root(read_nfo_item, "artist"):
+                parse_artist_nfo(artist, read_root, read_nfo_item.relative_path)
                 # only a successful parse counts as having read this NFO: registering on a
                 # malformed file would advance its token and treat the bad edit as handled,
                 # permanently masking it (until unrelated changes trigger a full reparse)
-                await self._register_metadata_file(nfo_item, representative_track)
-            except (ExpatError, KeyError) as err:
+                await self._register_metadata_file(read_nfo_item, representative_track)
+            else:
                 self.logger.warning(
-                    "Failed to parse artist NFO file %s: %s",
-                    nfo_file,
-                    str(err),
+                    "Failed to parse artist NFO file %s", read_nfo_item.relative_path
                 )
         # find local images
         if images := await self._get_local_images(
@@ -2493,7 +3131,27 @@ class LocalFileSystemProvider(MusicProvider):
         # this may be a separate disc folder (Disc 1, Disc 2 etc) underneath the album folder
         # or this is an album folder with the disc attached
         track_dir = os.path.dirname(track_path)
-        album_dir = get_album_dir(track_dir, track_tags.album)
+        # exact tier: an exact (normalized) plain-name folder match always wins, so a
+        # validated album.nfo elsewhere never displaces an already-obvious folder
+        album_dir = get_album_dir(track_dir, track_tags.album, exact_only=True)
+        nfo_item: FileSystemItem | None = None
+        nfo_root: dict[str, Any] | None = None
+        # folders whose own album.nfo was already read and rejected by the validated NFO
+        # tier below; a later relaxed/fuzzy match landing on one of these must not blindly
+        # trust that same rejected file during enrichment further down
+        rejected_nfo_folders: set[str] = set()
+        if not album_dir:
+            # exact matching found nothing: fall back to a bounded validated album.nfo
+            # (the immediate parent, and the track directory itself unless it is a disc
+            # subfolder, whose own album.nfo is never trusted as identity) before trying
+            # any relaxed (fuzzy/layout-variant/date-prefixed/sort-name-alias) heuristic
+            resolved = await self._resolve_album_dir_via_nfo(
+                track_dir, track_tags, rejected_nfo_folders
+            )
+            if resolved:
+                album_dir, nfo_item, nfo_root = resolved
+        if not album_dir:
+            album_dir = get_album_dir(track_dir, track_tags.album, track_tags.album_sort)
 
         if album_dir and (
             cache := await self.cache.get(
@@ -2506,6 +3164,9 @@ class LocalFileSystemProvider(MusicProvider):
             return cache  # type: ignore[no-any-return]
 
         # album artist(s)
+        # anchor the artist lookup on the track's own directory when the album itself never
+        # resolved (e.g. no matching album.nfo), so the artist can still be found independently
+        artist_lookup_dir = album_dir or track_dir
         album_artists: UniqueList[Artist | ItemMapping] = UniqueList()
         if track_tags.album_artists:
             resolved_album_artists = await self._resolve_artists_with_mbids(
@@ -2517,7 +3178,7 @@ class LocalFileSystemProvider(MusicProvider):
             for name, mbid, sort_name in resolved_album_artists:
                 artist = await self._parse_artist(
                     name,
-                    album_dir=album_dir,
+                    album_dir=artist_lookup_dir,
                     sort_name=sort_name,
                     mbid=mbid,
                     representative_track=representative_track,
@@ -2553,7 +3214,7 @@ class LocalFileSystemProvider(MusicProvider):
                     [
                         await self._parse_artist(
                             name=track_artist_str,
-                            album_dir=album_dir,
+                            album_dir=artist_lookup_dir,
                             representative_track=representative_track,
                         )
                         for track_artist_str in track_tags.artists
@@ -2621,30 +3282,35 @@ class LocalFileSystemProvider(MusicProvider):
         if not album_dir:
             return album
 
-        for folder_path in (track_dir, album_dir):
+        for folder_path in dict.fromkeys((track_dir, album_dir)):
             if not folder_path or not await self.exists(folder_path):
                 continue
-            nfo_file = os.path.join(folder_path, "album.nfo")
-            if await self.exists(nfo_file):
-                # resolve before reading: the registered token must reflect the version we
-                # are about to parse, not whatever the file happens to be once parsing has
-                # finished
-                nfo_item = await self.resolve(nfo_file)
-                # found NFO file with metadata
-                # https://kodi.wiki/view/NFO_files/Artists
-                try:
-                    data = (await self._read_file(nfo_file)).decode("utf-8")
-                    info = await asyncio.to_thread(xmltodict.parse, data)
-                    parse_album_nfo(album, info["album"], nfo_file)
-                    # only a successful parse counts as having read this NFO: registering on a
-                    # malformed file would advance its token and treat the bad edit as handled,
-                    # permanently masking it (until unrelated changes trigger a full reparse)
+            if nfo_item is not None and nfo_root is not None:
+                # identity was established through the bounded, validated NFO resolution
+                # fallback above: only that one winning NFO ever applies. An unrelated
+                # album.nfo the other candidate folder (track_dir or album_dir) happens to
+                # also have was never validated against this track and must not silently
+                # overwrite the resolved album's metadata.
+                if folder_path == nfo_item.relative_parent_path:
+                    parse_album_nfo(album, nfo_root, nfo_item.relative_path)
                     await self._register_metadata_file(nfo_item, representative_track)
-                except (ExpatError, KeyError) as err:
+            elif folder_path not in rejected_nfo_folders and (
+                read_nfo_item := await self._nfo_item_for(folder_path, "album.nfo")
+            ):
+                # found NFO file with metadata; read and parse it. Skipped when this folder's
+                # own album.nfo was already read and rejected by the validated NFO tier above,
+                # so a relaxed (fuzzy/layout/date-prefix) match landing here can't silently
+                # trust that same rejected file
+                if read_root := await self._load_nfo_root(read_nfo_item, "album"):
+                    parse_album_nfo(album, read_root, read_nfo_item.relative_path)
+                    # only a successful parse counts as having read this NFO: registering on
+                    # a malformed file would advance its token and treat the bad edit as
+                    # handled, permanently masking it (until unrelated changes trigger a full
+                    # reparse)
+                    await self._register_metadata_file(read_nfo_item, representative_track)
+                else:
                     self.logger.warning(
-                        "Failed to parse album NFO file %s: %s",
-                        nfo_file,
-                        str(err),
+                        "Failed to parse album NFO file %s", read_nfo_item.relative_path
                     )
 
             # find local images
@@ -3023,8 +3689,15 @@ class LocalFileSystemProvider(MusicProvider):
         )
         return data
 
-    async def _scandir(self, path: str) -> list[FileSystemItem]:
-        """List directory contents in natural sort order."""
+    async def _scandir(self, path: str, use_cache: bool = True) -> list[FileSystemItem]:
+        """
+        List directory contents in natural sort order.
+
+        :param use_cache: Unused for local disk (a read is always fresh); accepted so shared,
+            cache-sensitive callers (e.g. on-demand NFO/image lookups honoring a manual "Refresh
+            item") can request a bypass the same way regardless of which subclass overrides
+            this, since a cloud-backed provider serves its own short-lived listing cache here.
+        """
         # raw scandir order depends on the underlying filesystem (e.g. hash order
         # on ext4) so sort to make browse and folder playback order deterministic
         abs_path = self.get_absolute_path(path)

--- a/music_assistant/providers/filesystem_local/cue.py
+++ b/music_assistant/providers/filesystem_local/cue.py
@@ -210,101 +210,8 @@ class CueSheetHandler:
 
         :param cue_item: The CUE file's FileSystemItem.
         """
-        provider = self.provider
-        logger = provider.logger
-        cue_sheet = await self.load_cue_sheet(cue_item)
-
-        if not cue_sheet.tracks:
-            msg = f"CUE sheet has no tracks: {cue_item.relative_path}"
-            raise InvalidDataError(msg)
-
-        audio_relative_path = await self.find_audio_file(cue_item, cue_sheet)
-        if audio_relative_path is None:
-            msg = f"Audio file not found for CUE sheet: {cue_item.relative_path}"
-            raise MediaNotFoundError(msg)
-
-        audio_item = await provider.resolve(audio_relative_path)
-        tags = await async_parse_tags(audio_item.absolute_path, audio_item.file_size)
-        total_duration = tags.duration or 0.0
-        if total_duration <= 0:
-            msg = f"Could not determine duration for audio file of CUE sheet: {cue_item.relative_path}"
-            raise InvalidDataError(msg)
-
-        self._apply_cue_overrides(tags, cue_sheet)
-
-        album: Album | None = None
-        if tags.album:
-            album = await provider._parse_album(
-                track_path=audio_relative_path,
-                track_tags=tags,
-                track_created_at=cue_item.created_at,
-                # the companion audio file is absorbed into CUE tracks and is never itself a
-                # synced item (its own sync entry is dropped, see sync_library's CUE-companion
-                # filter), so it cannot be re-queued for reparsing; register the CUE sheet's own
-                # path instead, since re-processing that path re-runs this same parse
-                representative_track=cue_item.relative_path,
-            )
-        else:
-            logger.warning(
-                "CUE sheet %s has no TITLE and audio file has no album tag",
-                cue_item.relative_path,
-            )
-
-        # embedded cover art is shared across all CUE tracks from this audio file
-        embedded_image = (
-            MediaItemImage(
-                type=ImageType.THUMB,
-                path=audio_relative_path,
-                provider=provider.instance_id,
-                remotely_accessible=False,
-            )
-            if tags.has_cover_image
-            else None
-        )
-        # if the album lacks its own image, adopt the embedded one
-        if album and embedded_image and not album.image:
-            album.metadata.images = UniqueList([embedded_image])
-
-        ctx = _TrackBuildContext(
-            audio_format=self._audio_format_from_tags(audio_relative_path, tags),
-            # honor audio file's DISCNUMBER (CUE does not carry disc info); defaults to 1
-            disc_number=tags.disc or 1,
-            date_added=(
-                datetime.fromtimestamp(cue_item.created_at, tz=UTC) if cue_item.created_at else None
-            ),
-            embedded_image=embedded_image,
-            track_genres=set(tags.genres) if tags.genres else None,
-            album=album,
-            album_performers=tuple(cue_sheet.performers),
-        )
-
-        sorted_tracks = sorted(cue_sheet.tracks, key=lambda t: t.start_position)
-        tracks: list[Track] = []
-        for i, cue_track in enumerate(sorted_tracks):
-            if i + 1 < len(sorted_tracks):
-                duration = sorted_tracks[i + 1].start_position - cue_track.start_position
-            else:
-                duration = total_duration - cue_track.start_position
-
-            if duration <= 0:
-                logger.warning(
-                    "CUE sheet %s track %d has non-positive duration (%.2fs); skipping",
-                    cue_item.relative_path,
-                    cue_track.number,
-                    duration,
-                )
-                continue
-            if not cue_track.title:
-                logger.warning(
-                    "CUE sheet %s track %d has no TITLE; skipping",
-                    cue_item.relative_path,
-                    cue_track.number,
-                )
-                continue
-
-            tracks.append(await self._build_track(cue_track, cue_item, duration, ctx))
-
-        return tracks
+        with self.provider._ondemand_listing_scope():
+            return await self._parse_tracks_impl(cue_item)
 
     async def get_stream_details(self, item_id: str) -> StreamDetails:
         """
@@ -401,6 +308,104 @@ class CueSheetHandler:
             extra_input_args=["-ss", str(actual_seek), "-t", str(remaining_duration)],
         ):
             yield chunk
+
+    async def _parse_tracks_impl(self, cue_item: FileSystemItem) -> list[Track]:
+        """Parse a CUE sheet's tracks (implementation, see :meth:`parse_tracks`)."""
+        provider = self.provider
+        logger = provider.logger
+        cue_sheet = await self.load_cue_sheet(cue_item)
+
+        if not cue_sheet.tracks:
+            msg = f"CUE sheet has no tracks: {cue_item.relative_path}"
+            raise InvalidDataError(msg)
+
+        audio_relative_path = await self.find_audio_file(cue_item, cue_sheet)
+        if audio_relative_path is None:
+            msg = f"Audio file not found for CUE sheet: {cue_item.relative_path}"
+            raise MediaNotFoundError(msg)
+
+        audio_item = await provider.resolve(audio_relative_path)
+        tags = await async_parse_tags(audio_item.absolute_path, audio_item.file_size)
+        total_duration = tags.duration or 0.0
+        if total_duration <= 0:
+            msg = f"Could not determine duration for audio file of CUE sheet: {cue_item.relative_path}"
+            raise InvalidDataError(msg)
+
+        self._apply_cue_overrides(tags, cue_sheet)
+
+        album: Album | None = None
+        if tags.album:
+            album = await provider._parse_album(
+                track_path=audio_relative_path,
+                track_tags=tags,
+                track_created_at=cue_item.created_at,
+                # the companion audio file is absorbed into CUE tracks and is never itself a
+                # synced item (its own sync entry is dropped, see sync_library's CUE-companion
+                # filter), so it cannot be re-queued for reparsing; register the CUE sheet's own
+                # path instead, since re-processing that path re-runs this same parse
+                representative_track=cue_item.relative_path,
+            )
+        else:
+            logger.warning(
+                "CUE sheet %s has no TITLE and audio file has no album tag",
+                cue_item.relative_path,
+            )
+
+        # embedded cover art is shared across all CUE tracks from this audio file
+        embedded_image = (
+            MediaItemImage(
+                type=ImageType.THUMB,
+                path=audio_relative_path,
+                provider=provider.instance_id,
+                remotely_accessible=False,
+            )
+            if tags.has_cover_image
+            else None
+        )
+        # if the album lacks its own image, adopt the embedded one
+        if album and embedded_image and not album.image:
+            album.metadata.images = UniqueList([embedded_image])
+
+        ctx = _TrackBuildContext(
+            audio_format=self._audio_format_from_tags(audio_relative_path, tags),
+            # honor audio file's DISCNUMBER (CUE does not carry disc info); defaults to 1
+            disc_number=tags.disc or 1,
+            date_added=(
+                datetime.fromtimestamp(cue_item.created_at, tz=UTC) if cue_item.created_at else None
+            ),
+            embedded_image=embedded_image,
+            track_genres=set(tags.genres) if tags.genres else None,
+            album=album,
+            album_performers=tuple(cue_sheet.performers),
+        )
+
+        sorted_tracks = sorted(cue_sheet.tracks, key=lambda t: t.start_position)
+        tracks: list[Track] = []
+        for i, cue_track in enumerate(sorted_tracks):
+            if i + 1 < len(sorted_tracks):
+                duration = sorted_tracks[i + 1].start_position - cue_track.start_position
+            else:
+                duration = total_duration - cue_track.start_position
+
+            if duration <= 0:
+                logger.warning(
+                    "CUE sheet %s track %d has non-positive duration (%.2fs); skipping",
+                    cue_item.relative_path,
+                    cue_track.number,
+                    duration,
+                )
+                continue
+            if not cue_track.title:
+                logger.warning(
+                    "CUE sheet %s track %d has no TITLE; skipping",
+                    cue_item.relative_path,
+                    cue_track.number,
+                )
+                continue
+
+            tracks.append(await self._build_track(cue_track, cue_item, duration, ctx))
+
+        return tracks
 
     @staticmethod
     def _audio_format_from_tags(audio_path: str, tags: AudioTags) -> AudioFormat:

--- a/music_assistant/providers/filesystem_local/helpers.py
+++ b/music_assistant/providers/filesystem_local/helpers.py
@@ -10,7 +10,10 @@ import re
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
+from xml.parsers.expat import ExpatError
 
+import xmltodict
 from music_assistant_models.errors import MediaNotFoundError
 
 from music_assistant.helpers.compare import compare_strings
@@ -261,6 +264,32 @@ def is_image_file(item: FileSystemItem) -> bool:
     return item.ext is not None and item.ext.lower() in IMAGE_EXTENSIONS
 
 
+# folder names that denote a disc/volume subfolder underneath an album folder; its own NFO is
+# never trusted as the album's identity, only the parent's is
+_DISC_DIR_RE = re.compile(r"^(?:disc|disk|cd|dvd|vol(?:ume)?)[\s._-]*\d+\b", re.IGNORECASE)
+
+
+def is_disc_dir(name: str) -> bool:
+    """Return True when a folder name looks like a disc subfolder (e.g. ``Disc 1``, ``CD2``)."""
+    return bool(_DISC_DIR_RE.match(name.strip()))
+
+
+def parse_nfo_root(data: bytes, root_tag: str) -> dict[str, Any] | None:
+    """
+    Parse an NFO file's bytes and return its expected root element, or None when malformed.
+
+    :param data: The raw NFO file content.
+    :param root_tag: The expected root element name (``album`` or ``artist``).
+    """
+    try:
+        text = data.decode("utf-8")
+        parsed = xmltodict.parse(text)
+    except UnicodeDecodeError, ExpatError, ValueError:
+        return None
+    root = parsed.get(root_tag)
+    return root if isinstance(root, dict) else None
+
+
 def get_folder_signature(items: list[FileSystemItem]) -> str:
     """
     Return an order-independent digest of the given files' paths, mtimes and sizes.
@@ -276,22 +305,42 @@ def get_folder_signature(items: list[FileSystemItem]) -> str:
 def get_artist_dir(
     artist_name: str,
     album_dir: str | None,
+    sort_name: str | None = None,
+    *,
+    exact_only: bool = False,
 ) -> str | None:
-    """Look for (Album)Artist directory in path of a track (or album)."""
+    """
+    Look for (Album)Artist directory in path of a track (or album).
+
+    :param artist_name: The artist name to match against a folder name.
+    :param album_dir: The album directory whose ancestors are searched.
+    :param sort_name: The artist sort name, tried as an alias when the plain name does not
+        match a folder (e.g. a folder named ``Beatles, The`` for the artist ``The Beatles``).
+        Ignored when `exact_only` is set: a sort-name alias is itself a relaxed heuristic.
+    :param exact_only: Only accept an exact (normalized) match of the plain name, skipping
+        the relaxed (fuzzy) fallback built into the default comparison.
+    """
     if not album_dir:
         return None
-    parentdir = os.path.dirname(album_dir)
-    # account for disc or album sublevel by ignoring (max) 2 levels if needed
-    matched_dir: str | None = None
-    for _ in range(3):
-        dirname = Path(parentdir).name
-        if compare_strings(artist_name, dirname, False):
-            # literal match
-            # we keep hunting further down to account for the
-            # edge case where the album name has the same name as the artist
-            matched_dir = parentdir
-        parentdir = os.path.dirname(parentdir)
-    return matched_dir
+    # the plain name's own bounded search completes in full before the sort-name alias is
+    # ever tried, so a farther (grandparent-level) alias match can never outrank a nearer,
+    # exact plain-name match
+    candidate_names = (artist_name,) if exact_only else (n for n in (artist_name, sort_name) if n)
+    for candidate_name in candidate_names:
+        parentdir = os.path.dirname(album_dir)
+        matched_dir: str | None = None
+        # account for disc or album sublevel by ignoring (max) 2 levels if needed
+        for _ in range(3):
+            dirname = Path(parentdir).name
+            if compare_strings(candidate_name, dirname, exact_only):
+                # literal match
+                # we keep hunting further down to account for the
+                # edge case where the album name has the same name as the artist
+                matched_dir = parentdir
+            parentdir = os.path.dirname(parentdir)
+        if matched_dir:
+            return matched_dir
+    return None
 
 
 def tokenize(input_str: str, delimiters: str) -> list[str]:
@@ -337,46 +386,102 @@ def _dir_contains_album_name(id3_album_name: str, directory_name: str) -> bool:
     return False
 
 
-def get_album_dir(track_dir: str, album_name: str) -> str | None:
-    """Return album/parent directory of a track."""
-    parentdir = track_dir
-    # account for disc sublevel by ignoring 1 level if needed
-    for _ in range(2):
-        dirname = Path(parentdir).name
-        if compare_strings(album_name, dirname, False):
-            # literal match
-            return parentdir
-        if compare_strings(album_name, dirname.split(" - ")[-1], False):
-            # account for ArtistName - AlbumName format in the directory name
-            return parentdir
-        if compare_strings(album_name, dirname.split(" - ")[-1].split("(")[0], False):
-            # account for ArtistName - AlbumName (Version) format in the directory name
-            return parentdir
+# a recognized leading release-date/year marker: YYYY-MM-DD, YYYY.MM.DD, a bare/parenthesized/
+# bracketed YYYY - each only when followed by a real separator, so an arbitrary leading number
+# (e.g. a catalogue prefix like "CAT-1234", which does not even start with 4 digits) is untouched
+_DATE_PREFIX_RE = re.compile(
+    r"^(?:\d{4}-\d{2}-\d{2}|\d{4}\.\d{2}\.\d{2}|\(\d{4}\)|\[\d{4}\]|\d{4})(?=[\s._-])[\s._-]+"
+)
 
-        if any(sep in dirname for sep in ["-", " ", "_"]) and album_name:
-            album_chunks = album_name.split(" - ", 1)
-            album_name_includes_artist = len(album_chunks) > 1
-            just_album_name = album_chunks[1] if album_name_includes_artist else None
 
-            # attempt matching using tokenized version of path and album name
-            # with _dir_contains_album_name()
-            if just_album_name and _dir_contains_album_name(just_album_name, dirname):
+def _strip_date_prefix(name: str) -> str:
+    """Strip one recognized leading release-date/year marker from a folder name, if present."""
+    return _DATE_PREFIX_RE.sub("", name, count=1)
+
+
+def _dir_matches_album(dirname: str, album_name: str) -> bool:
+    """
+    Return True when a directory name matches an album name, allowing common layout variants.
+
+    :param dirname: The directory name to test.
+    :param album_name: The album name (or an alias such as the album sort name) to match.
+    """
+    if compare_strings(album_name, dirname, False):
+        # literal match
+        return True
+    if (stripped := _strip_date_prefix(dirname)) != dirname and compare_strings(
+        album_name, stripped, True
+    ):
+        # a leading release date/year (e.g. "2025-03-14 Album Name") is common release
+        # folder naming but not part of the album's own title; comparing what remains with
+        # strict normalized equality (not token/fuzzy matching) keeps word order significant
+        return True
+    if compare_strings(album_name, dirname.rsplit(" - ", maxsplit=1)[-1], False):
+        # account for ArtistName - AlbumName format in the directory name
+        return True
+    if compare_strings(
+        album_name, dirname.rsplit(" - ", maxsplit=1)[-1].split("(", maxsplit=1)[0], False
+    ):
+        # account for ArtistName - AlbumName (Version) format in the directory name
+        return True
+    if any(sep in dirname for sep in ["-", " ", "_"]):
+        album_chunks = album_name.split(" - ", 1)
+        just_album_name = album_chunks[1] if len(album_chunks) > 1 else None
+        # attempt matching using tokenized version of path and album name
+        # with _dir_contains_album_name()
+        if just_album_name and _dir_contains_album_name(just_album_name, dirname):
+            return True
+        if _dir_contains_album_name(album_name, dirname):
+            return True
+    if compare_strings(album_name.split("(", maxsplit=1)[0], dirname, False):
+        # account for AlbumName (Version) format in the album name
+        return True
+    if compare_strings(
+        album_name.split("(", maxsplit=1)[0], dirname.rsplit(" - ", maxsplit=1)[-1], False
+    ):
+        # account for ArtistName - AlbumName (Version) format
+        return True
+    # dirname contains album name (could potentially lead to false positives, hence the length check)
+    return len(album_name) > 8 and album_name in dirname
+
+
+def get_album_dir(
+    track_dir: str,
+    album_name: str,
+    album_sort: str | None = None,
+    *,
+    exact_only: bool = False,
+) -> str | None:
+    """
+    Return the album (or parent) directory of a track, or None when no folder matches.
+
+    :param track_dir: The directory the track file lives in.
+    :param album_name: The album name to match against a folder name.
+    :param album_sort: The album sort name, tried as an alias when the plain name does not
+        match a folder (e.g. a folder named ``Wall, The`` for the album ``The Wall``).
+        Ignored when `exact_only` is set: a sort-name alias is itself a relaxed heuristic.
+    :param exact_only: Only accept an exact (normalized) match of the plain name, skipping
+        every relaxed layout/alias/date-prefix heuristic below.
+    """
+    # the plain name's own bounded search (nearer level first) completes in full before the
+    # sort-name alias is ever tried, so an alias match at track_dir can never outrank an exact
+    # plain-name match at its parent
+    candidate_names = (
+        (album_name,) if exact_only else (name for name in (album_name, album_sort) if name)
+    )
+    for candidate_name in candidate_names:
+        parentdir = track_dir
+        # account for disc sublevel by ignoring 1 level if needed
+        for _ in range(2):
+            dirname = Path(parentdir).name
+            matches = (
+                compare_strings(candidate_name, dirname, True)
+                if exact_only
+                else _dir_matches_album(dirname, candidate_name)
+            )
+            if matches:
                 return parentdir
-
-            if _dir_contains_album_name(album_name, dirname):
-                return parentdir
-
-        if compare_strings(album_name.split("(", maxsplit=1)[0], dirname, False):
-            # account for AlbumName (Version) format in the album name
-            return parentdir
-        if compare_strings(album_name.split("(", maxsplit=1)[0], dirname.split(" - ")[-1], False):
-            # account for ArtistName - AlbumName (Version) format
-            return parentdir
-        if len(album_name) > 8 and album_name in dirname:
-            # dirname contains album name
-            # (could potentially lead to false positives, hence the length check)
-            return parentdir
-        parentdir = os.path.dirname(parentdir)
+            parentdir = os.path.dirname(parentdir)
     return None
 
 

--- a/music_assistant/providers/filesystem_local/parsers.py
+++ b/music_assistant/providers/filesystem_local/parsers.py
@@ -8,7 +8,7 @@ from music_assistant.helpers.tags import clean_mbid, split_items
 from music_assistant.helpers.util import parse_title_and_version
 
 if TYPE_CHECKING:
-    from music_assistant_models.media_items import Album
+    from music_assistant_models.media_items import Album, Artist
 
 
 def parse_album_nfo(album: Album, nfo_album: dict[Any, Any], source: str | None = None) -> None:
@@ -36,3 +36,23 @@ def parse_album_nfo(album: Album, nfo_album: dict[Any, Any], source: str | None 
         album.year = int(year)
     if genre := nfo_album.get("genre"):
         album.metadata.genres = set(split_items(genre))
+
+
+def parse_artist_nfo(artist: Artist, nfo_artist: dict[Any, Any], source: str | None = None) -> None:
+    """
+    Enrich artist metadata from NFO file.
+
+    :param artist: The artist to enrich.
+    :param nfo_artist: The parsed 'artist' element from the NFO file.
+    :param source: Origin of the NFO data (e.g. file path), included in log messages.
+    """
+    if title := nfo_artist.get("title") or nfo_artist.get("name"):
+        artist.name = title
+    if sort_name := nfo_artist.get("sortname"):
+        artist.sort_name = sort_name
+    if mbid := clean_mbid(nfo_artist.get("musicbrainzartistid"), source):
+        artist.mbid = mbid
+    if description := nfo_artist.get("biography"):
+        artist.metadata.description = description
+    if genre := nfo_artist.get("genre"):
+        artist.metadata.genres = set(split_items(genre))

--- a/music_assistant/providers/webdav/provider.py
+++ b/music_assistant/providers/webdav/provider.py
@@ -186,12 +186,14 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
             metadata_token=webdav_item.etag,
         )
 
-    async def _scandir(self, path: str) -> list[FileSystemItem]:
+    async def _scandir(self, path: str, use_cache: bool = True) -> list[FileSystemItem]:
         """List WebDAV directory contents with caching."""
         cache_key = f"scandir_{path}"
-        # bypass the cache during sync so edits are picked up immediately;
-        # the fresh result is still written back for subsequent browse/exists calls
-        if not self.sync_running:
+        # bypass the cache during sync (edits must be picked up immediately) or when the
+        # caller explicitly asks not to use it (e.g. an on-demand NFO lookup honoring a manual
+        # "Refresh item"); the fresh result is still written back for subsequent browse/exists
+        # calls
+        if use_cache and not self.sync_running:
             if cached := await self.cache.get(
                 key=cache_key,
                 provider=self.instance_id,

--- a/tests/providers/filesystem/test_artist_path.py
+++ b/tests/providers/filesystem/test_artist_path.py
@@ -53,6 +53,9 @@ def _make_provider(base_path: str, lib_artists: list[Artist]) -> LocalFileSystem
     provider.cache = MagicMock()
     provider.cache.get = AsyncMock(return_value=None)
     provider.cache.set = AsyncMock(return_value=None)
+    provider.sync_running = False
+    provider._sync_nfo_by_dir = {}
+    provider._sync_nfo_index_ready = False
 
     async def iter_library_items(
         search: str | None = None,  # noqa: ARG001

--- a/tests/providers/filesystem/test_cue_integration.py
+++ b/tests/providers/filesystem/test_cue_integration.py
@@ -98,6 +98,9 @@ def _make_provider(base_path: str = "/music") -> LocalFileSystemProvider:
     provider.mass.cache.set = AsyncMock(return_value=None)
     provider.cache = MagicMock()
     provider._sync_tracks = True
+    provider.sync_running = False
+    provider._sync_nfo_by_dir = {}
+    provider._sync_nfo_index_ready = False
     provider._cue = CueSheetHandler(provider)
     return provider
 

--- a/tests/providers/filesystem/test_helpers.py
+++ b/tests/providers/filesystem/test_helpers.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
+from music_assistant.helpers.compare import compare_strings
 from music_assistant.providers.filesystem_local import helpers
 
 # ruff: noqa: S108
@@ -120,6 +121,173 @@ def test_get_artist_dir() -> None:
 def test_get_album_dir(album_name: str, track_dir: str, expected: str) -> None:
     """Test the extraction of an album dir."""
     assert helpers.get_album_dir(track_dir, album_name) == expected
+
+
+def test_get_album_dir_falls_back_to_sort_name_alias() -> None:
+    """When the plain album name does not match a folder, the sort-name alias is tried."""
+    track_dir = "/tmp/Artist/Wall, The"
+    assert helpers.get_album_dir(track_dir, "The Wall") is None
+    assert helpers.get_album_dir(track_dir, "The Wall", album_sort="Wall, The") == track_dir
+    # the plain name still wins when it matches, without needing the alias
+    assert helpers.get_album_dir("/tmp/Artist/The Wall", "The Wall", album_sort="Wall, The") == (
+        "/tmp/Artist/The Wall"
+    )
+
+
+def test_get_album_dir_plain_name_at_a_farther_level_outranks_a_nearer_sort_name_alias() -> None:
+    """
+    A nearer sort-name alias match must never outrank a farther, exact plain-name match.
+
+    Both levels are searched for the plain album name first; the sort-name alias is only
+    tried afterwards, and only if the plain name matched nowhere.
+    """
+    # "Wall, The" (the sort-name alias) is the track's own directory, one level nearer than
+    # "The Wall" (the plain, exact name) at its parent
+    track_dir = "/tmp/Artist/The Wall/Wall, The"
+    assert (
+        helpers.get_album_dir(track_dir, "The Wall", album_sort="Wall, The")
+        == "/tmp/Artist/The Wall"
+    )
+
+
+def test_get_artist_dir_falls_back_to_sort_name_alias() -> None:
+    """When the plain artist name does not match a folder, the sort-name alias is tried."""
+    album_path = "/tmp/Beatles, The/Album"
+    assert helpers.get_artist_dir("The Beatles", album_path) is None
+    assert helpers.get_artist_dir("The Beatles", album_path, sort_name="Beatles, The") == (
+        "/tmp/Beatles, The"
+    )
+
+
+def test_get_artist_dir_plain_name_outranks_a_farther_sort_name_alias() -> None:
+    """
+    A farther sort-name alias match must never outrank a nearer, exact plain-name match.
+
+    The plain artist name's own bounded (up to 3 ancestor levels) search completes in full
+    before the sort-name alias is tried at all.
+    """
+    # "The Beatles" (the plain, exact name) is the immediate parent; "Beatles, The" (the
+    # sort-name alias) is one level further up
+    album_path = "/tmp/Beatles, The/The Beatles/Album"
+    assert (
+        helpers.get_artist_dir("The Beatles", album_path, sort_name="Beatles, The")
+        == "/tmp/Beatles, The/The Beatles"
+    )
+
+
+def test_get_artist_dir_exact_only_ignores_the_sort_name_alias_and_fuzzy_matches() -> None:
+    """`exact_only` skips the sort-name alias and the relaxed (fuzzy) comparison entirely."""
+    # the sort-name alias itself is a relaxed heuristic and must not be tried
+    album_path = "/tmp/Beatles, The/Album"
+    assert (
+        helpers.get_artist_dir("The Beatles", album_path, sort_name="Beatles, The", exact_only=True)
+        is None
+    )
+    # a near-miss that only the fuzzy (non-strict) comparison would accept must not match
+    album_path = "/tmp/The Beetles/Album"
+    assert helpers.get_artist_dir("The Beatles", album_path, exact_only=True) is None
+    assert helpers.get_artist_dir("The Beatles", album_path) == "/tmp/The Beetles"
+    # an exact (normalized) match still succeeds
+    album_path = "/tmp/The Beatles/Album"
+    assert helpers.get_artist_dir("The Beatles", album_path, exact_only=True) == (
+        "/tmp/The Beatles"
+    )
+
+
+@pytest.mark.parametrize(
+    ("dirname", "expected"),
+    [
+        ("2025-03-14 Vaxis Act III The Father of Make Believe", True),
+        ("2025.03.14 Vaxis Act III The Father of Make Believe", True),
+        ("1995-03-13 Vaxis Act III The Father of Make Believe", True),
+        ("2025-03-14 VAXIS ACT III THE FATHER OF MAKE BELIEVE", True),
+        ("(2025) Vaxis Act III The Father of Make Believe", True),
+        ("[2025] Vaxis Act III The Father of Make Believe", True),
+        ("2025 Vaxis Act III The Father of Make Believe", True),
+        ("Vaxis Act III The Father of Make Believe", True),
+    ],
+)
+def test_dir_matches_album_strips_a_recognized_date_prefix(dirname: str, expected: bool) -> None:
+    """A leading release date/year, in any recognized format or case, is not part of the title."""
+    assert helpers._dir_matches_album(dirname, "Vaxis Act III: The Father of Make Believe") is (
+        expected
+    )
+
+
+def test_dir_matches_album_date_prefixed_king_for_a_day_example() -> None:
+    """The second #3994 reproduction: a date-prefixed folder with an ellipsis-free title."""
+    assert helpers._dir_matches_album(
+        "1995-03-13 King for a Day Fool for a Lifetime",
+        "King for a Day... Fool for a Lifetime",
+    )
+
+
+def test_dir_matches_album_king_for_a_day_example_without_date_prefix() -> None:
+    """The #3994 examples without a date prefix already matched before this change too."""
+    assert helpers._dir_matches_album(
+        "King for a Day Fool for a Lifetime",
+        "King for a Day... Fool for a Lifetime",
+    )
+
+
+def test_strip_date_prefix_does_not_touch_an_arbitrary_catalogue_prefix() -> None:
+    """A catalogue prefix like "CAT-1234" does not start with a 4-digit date/year at all."""
+    assert helpers._strip_date_prefix("CAT-1234 Album Name") == "CAT-1234 Album Name"
+
+
+def test_strip_date_prefix_requires_a_real_separator_after_the_year() -> None:
+    """A bare year glued directly onto the title (no separator) is not stripped."""
+    assert helpers._strip_date_prefix("2025Album") == "2025Album"
+
+
+def test_dir_matches_album_date_prefix_path_rejects_reordered_words() -> None:
+    """The new date-prefix comparison is strict normalized equality, not token matching."""
+    stripped = helpers._strip_date_prefix("2025-03-14 Beta Alpha")
+    assert stripped == "Beta Alpha"
+    assert compare_strings("Alpha Beta", stripped, True) is False
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("Disc 1", True),
+        ("disc1", True),
+        ("CD2", True),
+        ("cd 03", True),
+        ("Disk 1", True),
+        ("DVD1", True),
+        ("Volume 2", True),
+        ("Vol. 2", True),
+        ("Album", False),
+        ("weird-disc-name", False),
+        ("", False),
+    ],
+)
+def test_is_disc_dir(name: str, expected: bool) -> None:
+    """Only a recognized disc/volume naming pattern is treated as a disc subfolder."""
+    assert helpers.is_disc_dir(name) is expected
+
+
+def test_parse_nfo_root_returns_the_named_root_element() -> None:
+    """A well-formed NFO with the expected root element returns it as a dict."""
+    data = b"<album><title>My Album</title></album>"
+    root = helpers.parse_nfo_root(data, "album")
+    assert root is not None
+    assert root["title"] == "My Album"
+
+
+@pytest.mark.parametrize(
+    ("data", "root_tag"),
+    [
+        (b"not xml at all <<<", "album"),
+        (b"<artist><title>Name</title></artist>", "album"),  # wrong root element
+        (b"\xff\xfe not utf-8", "album"),
+        (b"<album>just text, no dict</album>", "album"),
+    ],
+)
+def test_parse_nfo_root_returns_none_for_malformed_content(data: bytes, root_tag: str) -> None:
+    """Malformed XML, an undecodable file or the wrong/non-dict root element returns None."""
+    assert helpers.parse_nfo_root(data, root_tag) is None
 
 
 SUPPORTED = {"mp3", "flac"}

--- a/tests/providers/filesystem/test_metadata_file_cache.py
+++ b/tests/providers/filesystem/test_metadata_file_cache.py
@@ -6,7 +6,7 @@ from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.media_items import Artist, ProviderMapping, Track, UniqueList
+from music_assistant_models.media_items import Album, Artist, ProviderMapping, Track, UniqueList
 
 from music_assistant.providers.filesystem_local import LocalFileSystemProvider
 from music_assistant.providers.filesystem_local.constants import (
@@ -31,6 +31,9 @@ def _provider() -> Any:
     provider.media_content_type = "music"
     provider._sync_tracks = True
     provider.cache = MagicMock()
+    provider.sync_running = False
+    provider._sync_nfo_by_dir = {}
+    provider._sync_nfo_index_ready = False
     return provider
 
 
@@ -452,6 +455,7 @@ async def test_parse_artist_registers_metadata_file_after_successful_read() -> N
     provider._read_file = AsyncMock(return_value=b"<artist><title>Name</title></artist>")
     provider._get_local_images = AsyncMock(return_value=UniqueList())
     provider.resolve = AsyncMock(return_value=_item("Artist/artist.nfo", checksum="42"))
+    provider._scandir = AsyncMock(return_value=[_item("Artist/artist.nfo", checksum="42")])
     provider.cache.get = AsyncMock(return_value=None)
     provider.cache.set = AsyncMock()
 
@@ -475,6 +479,7 @@ async def test_parse_artist_does_not_register_when_nfo_read_fails() -> None:
     provider.manifest = MagicMock(domain="filesystem_local")
     provider.exists = AsyncMock(return_value=True)
     provider.resolve = AsyncMock(return_value=_item("Artist/artist.nfo"))
+    provider._scandir = AsyncMock(return_value=[_item("Artist/artist.nfo")])
     provider._read_file = AsyncMock(side_effect=OSError("network blip"))
     provider.cache.get = AsyncMock(return_value=None)
     provider.cache.set = AsyncMock()
@@ -498,6 +503,7 @@ async def test_parse_artist_does_not_register_on_malformed_nfo() -> None:
     provider.manifest = MagicMock(domain="filesystem_local")
     provider.exists = AsyncMock(return_value=True)
     provider.resolve = AsyncMock(return_value=_item("Artist/artist.nfo"))
+    provider._scandir = AsyncMock(return_value=[_item("Artist/artist.nfo")])
     provider._read_file = AsyncMock(return_value=b"not xml at all <<<")
     provider._get_local_images = AsyncMock(return_value=UniqueList())
     provider.cache.get = AsyncMock(return_value=None)
@@ -522,6 +528,7 @@ async def test_parse_album_does_not_register_on_malformed_nfo() -> None:
     provider.manifest = MagicMock(domain="filesystem_local")
     provider.exists = AsyncMock(return_value=True)
     provider.resolve = AsyncMock(return_value=_item("Artist/Album/album.nfo"))
+    provider._scandir = AsyncMock(return_value=[_item("Artist/Album/album.nfo")])
     provider._read_file = AsyncMock(return_value=b"not xml at all <<<")
     provider._get_local_images = AsyncMock(return_value=UniqueList())
     provider.cache.get = AsyncMock(return_value=None)
@@ -604,7 +611,7 @@ async def test_resolve_artist_representative_track_uses_own_provider_mapping() -
         provider_mappings=set(),
     )
     other_track = Track(
-        item_id="other",
+        item_id="100",
         provider="library",
         name="Other Provider Track",
         provider_mappings={
@@ -614,7 +621,7 @@ async def test_resolve_artist_representative_track_uses_own_provider_mapping() -
         },
     )
     own_track = Track(
-        item_id="mine",
+        item_id="101",
         provider="library",
         name="Local Track",
         provider_mappings={
@@ -628,6 +635,9 @@ async def test_resolve_artist_representative_track_uses_own_provider_mapping() -
     provider.mass.music.artists.get_library_artist_tracks = AsyncMock(
         return_value=[other_track, own_track]
     )
+    provider.mass.music.artists.get_library_artist_albums = AsyncMock(
+        side_effect=AssertionError("must not query albums when a direct track already resolved")
+    )
 
     result = await provider._resolve_artist_representative_track(artist)
 
@@ -638,12 +648,50 @@ async def test_resolve_artist_representative_track_uses_own_provider_mapping() -
 
 
 async def test_resolve_artist_representative_track_returns_none_without_tracks() -> None:
-    """An artist with no tracks under this provider (album-only) yields no representative."""
+    """An artist with no tracks or albums under this provider yields no representative."""
     provider = _provider()
     artist = Artist(item_id="42", provider="library", name="Test Artist", provider_mappings=set())
     provider.mass.music.artists.get_library_artist_tracks = AsyncMock(return_value=[])
+    provider.mass.music.artists.get_library_artist_albums = AsyncMock(return_value=[])
 
     assert await provider._resolve_artist_representative_track(artist) is None
+
+
+async def test_resolve_artist_representative_track_falls_back_to_album_only_credit() -> None:
+    """
+    An album-only artist (never a direct track artist) falls back to its own albums.
+
+    E.g. credited only as ALBUMARTIST, never as a track artist - "Refresh item" must still
+    find a representative track to register a freshly read artist.nfo/image against.
+    """
+    provider = _provider()
+    artist = Artist(item_id="42", provider="library", name="Test Artist", provider_mappings=set())
+    album = Album(item_id="7", provider="library", name="Test Album", provider_mappings=set())
+    own_track = Track(
+        item_id="101",
+        provider="library",
+        name="Local Track",
+        provider_mappings={
+            ProviderMapping(
+                item_id="Artist/Album/t1.mp3",
+                provider_domain="filesystem_local",
+                provider_instance=INSTANCE_ID,
+            )
+        },
+    )
+    provider.mass.music.artists.get_library_artist_tracks = AsyncMock(return_value=[])
+    provider.mass.music.artists.get_library_artist_albums = AsyncMock(return_value=[album])
+    provider.mass.music.albums.get_library_album_tracks = AsyncMock(return_value=[own_track])
+
+    result = await provider._resolve_artist_representative_track(artist)
+
+    assert result == "Artist/Album/t1.mp3"
+    provider.mass.music.artists.get_library_artist_albums.assert_awaited_once_with(
+        "42", provider_filter=INSTANCE_ID
+    )
+    provider.mass.music.albums.get_library_album_tracks.assert_awaited_once_with(
+        "7", provider_filter=[INSTANCE_ID]
+    )
 
 
 async def test_resolve_artist_representative_track_converts_cue_track_id_to_cue_path() -> None:
@@ -657,7 +705,7 @@ async def test_resolve_artist_representative_track_converts_cue_track_id_to_cue_
     provider = _provider()
     artist = Artist(item_id="42", provider="library", name="Test Artist", provider_mappings=set())
     cue_track = Track(
-        item_id="cue-track",
+        item_id="102",
         provider="library",
         name="CUE Track",
         provider_mappings={
@@ -673,6 +721,50 @@ async def test_resolve_artist_representative_track_converts_cue_track_id_to_cue_
     result = await provider._resolve_artist_representative_track(artist)
 
     assert result == "Artist/Album/album.cue"
+
+
+async def test_resolve_artist_representative_track_skips_an_unavailable_mapping() -> None:
+    """
+    A track whose own-instance mapping is marked unavailable is not a resolvable candidate.
+
+    An unavailable mapping is a stale library row (e.g. the file has since been removed);
+    using its path anyway would point the next resolution attempt at a folder that no longer
+    exists instead of skipping ahead to another candidate track.
+    """
+    provider = _provider()
+    artist = Artist(item_id="42", provider="library", name="Test Artist", provider_mappings=set())
+    stale_track = Track(
+        item_id="10",
+        provider="library",
+        name="Stale Track",
+        provider_mappings={
+            ProviderMapping(
+                item_id="Artist/Removed/track.flac",
+                provider_domain="filesystem_local",
+                provider_instance=INSTANCE_ID,
+                available=False,
+            )
+        },
+    )
+    live_track = Track(
+        item_id="20",
+        provider="library",
+        name="Live Track",
+        provider_mappings={
+            ProviderMapping(
+                item_id="Artist/Album/track.flac",
+                provider_domain="filesystem_local",
+                provider_instance=INSTANCE_ID,
+            )
+        },
+    )
+    provider.mass.music.artists.get_library_artist_tracks = AsyncMock(
+        return_value=[stale_track, live_track]
+    )
+
+    result = await provider._resolve_artist_representative_track(artist)
+
+    assert result == "Artist/Album/track.flac"
 
 
 async def test_get_artist_passes_representative_track_to_parse_artist() -> None:
@@ -702,7 +794,7 @@ async def test_get_artist_passes_representative_track_to_parse_artist() -> None:
     provider.mass.music.artists.get_library_artist_tracks = AsyncMock(
         return_value=[
             Track(
-                item_id="mine",
+                item_id="103",
                 provider="library",
                 name="Local Track",
                 provider_mappings={

--- a/tests/providers/filesystem/test_nfo_resolution.py
+++ b/tests/providers/filesystem/test_nfo_resolution.py
@@ -1,0 +1,1913 @@
+"""Tests for the bounded, validated NFO-based folder resolution fallback."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.enums import AlbumType, ExternalID
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
+from music_assistant_models.media_items import Album
+
+from music_assistant.controllers.cache import BYPASS_CACHE
+from music_assistant.helpers.util import parse_title_and_version
+from music_assistant.providers.filesystem_local import _ONDEMAND_NFO_ITEMS, LocalFileSystemProvider
+from music_assistant.providers.filesystem_local.helpers import FileSystemItem
+
+INSTANCE_ID = "filesystem_local--test"
+ALBUM_MBID = "11111111-1111-1111-1111-111111111111"
+OTHER_MBID = "22222222-2222-2222-2222-222222222222"
+ARTIST_MBID = "33333333-3333-3333-3333-333333333333"
+
+
+def _provider() -> Any:
+    """Create a bare provider with a mocked cache, outside a sync (on-demand resolution)."""
+    with patch.object(LocalFileSystemProvider, "__init__", lambda *_a, **_kw: None):
+        provider = LocalFileSystemProvider.__new__(LocalFileSystemProvider)
+    provider.logger = MagicMock()
+    provider.mass = MagicMock()
+    provider.config = MagicMock(instance_id=INSTANCE_ID)
+    provider.media_content_type = "music"
+    provider.cache = MagicMock()
+    provider.sync_running = False
+    provider._sync_nfo_by_dir = {}
+    provider._sync_nfo_index_ready = False
+    provider._cue = MagicMock()
+    return provider
+
+
+def _item(relative_path: str) -> FileSystemItem:
+    """Build a minimal FileSystemItem for a resolved NFO file."""
+    return FileSystemItem(
+        filename=relative_path.rsplit("/", 1)[-1],
+        relative_path=relative_path,
+        absolute_path=f"/media/{relative_path}",
+        is_dir=False,
+        checksum="1",
+    )
+
+
+def _mock_single_file(provider: Any, path: str, data: bytes) -> None:
+    """Make exactly one NFO file exist, discoverable via a folder listing (on demand)."""
+    folder, _sep, _name = path.rpartition("/")
+    item = _item(path)
+
+    async def _scandir(scan_folder: str, use_cache: bool = True) -> list[FileSystemItem]:  # noqa: ARG001
+        return [item] if scan_folder == folder else []
+
+    provider._scandir = AsyncMock(side_effect=_scandir)
+    provider._read_file = AsyncMock(return_value=data)
+
+
+def _async_iter(items: list[Any]) -> Any:
+    """Build an async-generator stand-in for a controller's `iter_library_items`."""
+
+    async def _iter(*_args: object, **_kwargs: object) -> Any:
+        for item in items:
+            yield item
+
+    return _iter
+
+
+def _tags(
+    album: str | None = "My Album",
+    album_id: str | None = None,
+    rg_id: str | None = None,
+    album_artist_ids: tuple[str, ...] = (),
+) -> Any:
+    """Build minimal audio tags for album resolution."""
+    return MagicMock(
+        album=album,
+        filename="track.flac",
+        musicbrainz_albumid=album_id,
+        musicbrainz_releasegroupid=rg_id,
+        musicbrainz_albumartistids=album_artist_ids,
+    )
+
+
+# --- album.nfo resolution ----------------------------------------------------------------
+
+
+async def test_album_resolves_via_parent_nfo_with_matching_mbid() -> None:
+    """A recognized disc subfolder's own NFO is never tried; only the parent's matching NFO is."""
+    provider = _provider()
+    track_dir = "Artist/Album/Disc 1"
+    _mock_single_file(
+        provider,
+        "Artist/Album/album.nfo",
+        f"<album><title>Other Title</title>"
+        f"<musicbrainzalbumid>{ALBUM_MBID}</musicbrainzalbumid></album>".encode(),
+    )
+    result = await provider._resolve_album_dir_via_nfo(track_dir, _tags(album_id=ALBUM_MBID))
+    assert result is not None
+    album_dir, nfo_item, root = result
+    assert album_dir == "Artist/Album"
+    assert nfo_item.relative_path == "Artist/Album/album.nfo"
+    assert root["title"] == "Other Title"
+
+
+async def test_album_resolves_via_title_match_when_no_mbid() -> None:
+    """A candidate's album.nfo title, matched against the track's album tag, is sufficient."""
+    provider = _provider()
+    track_dir = "Artist/CAT-1234"  # a catalogue-number folder that folder matching cannot resolve
+    _mock_single_file(
+        provider, "Artist/CAT-1234/album.nfo", b"<album><title>My Album</title></album>"
+    )
+    result = await provider._resolve_album_dir_via_nfo(track_dir, _tags())
+    assert result is not None
+    assert result[0] == track_dir
+
+
+async def test_album_title_match_ignores_edition_suffix_on_both_sides() -> None:
+    """An NFO title's own edition suffix is stripped the same way the tag's album name was."""
+    provider = _provider()
+    track_dir = "Artist/CAT-1234"
+    _mock_single_file(
+        provider,
+        "Artist/CAT-1234/album.nfo",
+        b"<album><title>My Album (Deluxe Edition)</title></album>",
+    )
+    result = await provider._resolve_album_dir_via_nfo(
+        track_dir, _tags(album="My Album (Deluxe Edition)")
+    )
+    assert result is not None
+    assert result[0] == track_dir
+
+
+async def test_album_conflicting_mbid_is_rejected_even_with_matching_title() -> None:
+    """A conflicting MusicBrainz album id is rejected outright, never falling back to title."""
+    provider = _provider()
+    track_dir = "Artist/CAT-1234"
+    _mock_single_file(
+        provider,
+        "Artist/CAT-1234/album.nfo",
+        f"<album><title>My Album</title>"
+        f"<musicbrainzalbumid>{OTHER_MBID}</musicbrainzalbumid></album>".encode(),
+    )
+    result = await provider._resolve_album_dir_via_nfo(track_dir, _tags(album_id=ALBUM_MBID))
+    assert result is None
+
+
+async def test_album_matching_id_still_rejected_on_conflicting_second_id() -> None:
+    """A matching album id does not short-circuit a conflicting release-group id."""
+    provider = _provider()
+    track_dir = "Artist/CAT-1234"
+    other_rg_mbid = "44444444-4444-4444-4444-444444444444"
+    _mock_single_file(
+        provider,
+        "Artist/CAT-1234/album.nfo",
+        f"<album><title>My Album</title>"
+        f"<musicbrainzalbumid>{ALBUM_MBID}</musicbrainzalbumid>"
+        f"<musicbrainzreleasegroupid>{other_rg_mbid}</musicbrainzreleasegroupid></album>".encode(),
+    )
+    result = await provider._resolve_album_dir_via_nfo(
+        track_dir, _tags(album_id=ALBUM_MBID, rg_id="55555555-5555-5555-5555-555555555555")
+    )
+    assert result is None
+
+
+async def test_album_falls_through_to_track_dir_when_parent_has_no_match() -> None:
+    """The track directory itself is tried when the parent has no (or no matching) album.nfo."""
+    provider = _provider()
+    track_dir = "Artist/CAT-1234"
+    _mock_single_file(
+        provider, "Artist/CAT-1234/album.nfo", b"<album><title>My Album</title></album>"
+    )
+    result = await provider._resolve_album_dir_via_nfo(track_dir, _tags())
+    assert result is not None
+    assert result[0] == "Artist/CAT-1234"
+
+
+async def test_album_own_directory_nfo_takes_precedence_over_parent() -> None:
+    """
+    The track's own directory is tried before its parent, being the nearer, more specific one.
+
+    Otherwise a same-title album.nfo one level up (e.g. a stray leftover from a prior, flatter
+    single-album layout) could outrank the track's own, definitively correct album.nfo.
+    """
+    provider = _provider()
+    track_dir = "Artist/CAT-1234"
+
+    async def _scandir(scan_folder: str, use_cache: bool = True) -> list[FileSystemItem]:  # noqa: ARG001
+        if scan_folder in ("Artist", "Artist/CAT-1234"):
+            return [_item(f"{scan_folder}/album.nfo")]
+        return []
+
+    async def _read_file(path: str) -> bytes:
+        return (
+            b"<album><title>My Album</title></album>"
+            if path == "Artist/CAT-1234/album.nfo"
+            else b"<album><title>My Album</title><year>1999</year></album>"
+        )
+
+    provider._scandir = AsyncMock(side_effect=_scandir)
+    provider._read_file = AsyncMock(side_effect=_read_file)
+
+    result = await provider._resolve_album_dir_via_nfo(track_dir, _tags())
+    assert result is not None
+    assert result[0] == "Artist/CAT-1234"
+
+
+async def test_album_matches_nfo_regardless_of_filename_case() -> None:
+    """A case-insensitive filesystem's ALBUM.NFO resolves the same as a lowercase album.nfo."""
+    provider = _provider()
+    track_dir = "Artist/CAT-1234"
+    _mock_single_file(
+        provider, "Artist/CAT-1234/ALBUM.NFO", b"<album><title>My Album</title></album>"
+    )
+    result = await provider._resolve_album_dir_via_nfo(track_dir, _tags())
+    assert result is not None
+    assert result[0] == track_dir
+
+
+async def test_album_malformed_nfo_stays_unresolved() -> None:
+    """Malformed (unparsable) NFO content leaves the album synthetic, not a failure."""
+    provider = _provider()
+    track_dir = "Artist/CAT-1234"
+    _mock_single_file(provider, "Artist/CAT-1234/album.nfo", b"not xml at all <<<")
+    result = await provider._resolve_album_dir_via_nfo(track_dir, _tags())
+    assert result is None
+
+
+async def test_album_invalid_field_leaves_item_unresolved() -> None:
+    """A matching title with a later invalid field (bad year) does not resolve the folder."""
+    provider = _provider()
+    track_dir = "Artist/CAT-1234"
+    _mock_single_file(
+        provider,
+        "Artist/CAT-1234/album.nfo",
+        b"<album><title>My Album</title><year>not-a-year</year></album>",
+    )
+    result = await provider._resolve_album_dir_via_nfo(track_dir, _tags())
+    assert result is None
+
+
+async def test_album_no_candidate_nfo_returns_none() -> None:
+    """No album.nfo at either candidate directory resolves to nothing, not an error."""
+    provider = _provider()
+    provider._scandir = AsyncMock(return_value=[])
+    result = await provider._resolve_album_dir_via_nfo("Artist/CAT-1234", _tags())
+    assert result is None
+
+
+async def test_album_resolution_never_uses_provider_root_as_identity() -> None:
+    """
+    A valid album.nfo living at the provider's own root is never trusted as identity.
+
+    Like the normal, non-NFO folder match, the provider root cannot identify one specific
+    album out of the many it may contain, even when a track happens to sit directly in it.
+    """
+    provider = _provider()
+    track_dir = ""  # the track file lives directly in the provider's configured root
+    _mock_single_file(
+        provider,
+        "album.nfo",
+        f"<album><title>My Album</title>"
+        f"<musicbrainzalbumid>{ALBUM_MBID}</musicbrainzalbumid></album>".encode(),
+    )
+    result = await provider._resolve_album_dir_via_nfo(track_dir, _tags(album_id=ALBUM_MBID))
+    assert result is None
+
+
+async def test_album_transient_read_failure_propagates() -> None:
+    """A genuine read failure (not malformed content) propagates so the sync can defer/retry."""
+    provider = _provider()
+    track_dir = "Artist/CAT-1234"
+    _mock_single_file(provider, "Artist/CAT-1234/album.nfo", b"irrelevant")
+    provider._read_file = AsyncMock(side_effect=OSError("network hiccup"))
+    with pytest.raises(OSError, match="network hiccup"):
+        await provider._resolve_album_dir_via_nfo(track_dir, _tags())
+
+
+async def test_nfo_listing_bypasses_cache_during_a_forced_refresh() -> None:
+    """
+    A manual "Refresh item" must see an NFO just added, not a stale cloud directory listing.
+
+    `_scandir`'s `use_cache` is a cloud-backed provider's own separate, short-lived listing
+    cache (unrelated to the core cache controller's `self.cache`); it must be bypassed the same
+    way the core cache is, via the same `BYPASS_CACHE` context, or an NFO added to disk right
+    before a refresh could still be missed for up to that cache's own TTL.
+    """
+    provider = _provider()
+    provider._scandir = AsyncMock(return_value=[])
+
+    token = BYPASS_CACHE.set(True)
+    try:
+        await provider._list_nfo_candidates("Artist/Album")
+    finally:
+        BYPASS_CACHE.reset(token)
+
+    provider._scandir.assert_awaited_once_with("Artist/Album", use_cache=False)
+
+
+async def test_nfo_listing_uses_cache_outside_a_forced_refresh() -> None:
+    """Outside an explicit refresh, the cloud provider's own listing cache is left in play."""
+    provider = _provider()
+    provider._scandir = AsyncMock(return_value=[])
+
+    await provider._list_nfo_candidates("Artist/Album")
+
+    provider._scandir.assert_awaited_once_with("Artist/Album", use_cache=True)
+
+
+# --- artist.nfo resolution ---------------------------------------------------------------
+
+
+async def test_artist_resolves_via_ancestor_nfo_by_name() -> None:
+    """The nearest ancestor's artist.nfo, matched by name, resolves the artist's folder."""
+    provider = _provider()
+    album_dir = "Music/The Artist/Album"
+    _mock_single_file(
+        provider, "Music/The Artist/artist.nfo", b"<artist><title>The Artist</title></artist>"
+    )
+    result = await provider._resolve_artist_dir_via_nfo(album_dir, "The Artist", None)
+    assert result is not None
+    assert result[0] == "Music/The Artist"
+
+
+async def test_artist_resolves_via_ancestor_nfo_by_mbid() -> None:
+    """A matching MusicBrainz artist id resolves even when the name in the NFO differs."""
+    provider = _provider()
+    album_dir = "Music/Weird Folder Name/Album"
+    _mock_single_file(
+        provider,
+        "Music/Weird Folder Name/artist.nfo",
+        f"<artist><title>Some Other Name</title>"
+        f"<musicbrainzartistid>{ARTIST_MBID}</musicbrainzartistid></artist>".encode(),
+    )
+    result = await provider._resolve_artist_dir_via_nfo(album_dir, "The Artist", ARTIST_MBID)
+    assert result is not None
+    assert result[0] == "Music/Weird Folder Name"
+
+
+async def test_artist_marker_only_nfo_is_never_accepted() -> None:
+    """An artist.nfo with no id or name/title is never trusted as identity (no marker mode)."""
+    provider = _provider()
+    album_dir = "Music/Weird Folder Name/Album"
+    _mock_single_file(
+        provider, "Music/Weird Folder Name/artist.nfo", b"<artist><genre>Rock</genre></artist>"
+    )
+    result = await provider._resolve_artist_dir_via_nfo(album_dir, "The Artist", None)
+    assert result is None
+
+
+async def test_artist_resolution_bounded_to_three_ancestor_levels() -> None:
+    """A matching artist.nfo four levels up is never found (mirrors the normal lookup's bound)."""
+    provider = _provider()
+    album_dir = "A/B/C/D/Album"
+    _mock_single_file(provider, "A/artist.nfo", b"<artist><title>The Artist</title></artist>")
+    result = await provider._resolve_artist_dir_via_nfo(album_dir, "The Artist", None)
+    assert result is None
+
+
+async def test_artist_no_matching_ancestor_returns_none() -> None:
+    """No artist.nfo anywhere within the bound resolves to nothing, not an error."""
+    provider = _provider()
+    provider._scandir = AsyncMock(return_value=[])
+    result = await provider._resolve_artist_dir_via_nfo("Music/Artist/Album", "The Artist", None)
+    assert result is None
+
+
+async def test_artist_resolution_never_walks_into_provider_root() -> None:
+    """
+    A valid artist.nfo living at the provider's own root is never trusted as identity.
+
+    Like the normal, non-NFO folder match, the provider root cannot identify one specific
+    artist out of the many it may contain, so the ancestor walk stops one level short of it.
+    """
+    provider = _provider()
+    album_dir = "The Artist/Album"  # "The Artist" is a top-level folder; its parent is the root
+    _mock_single_file(provider, "artist.nfo", b"<artist><title>The Artist</title></artist>")
+    result = await provider._resolve_artist_dir_via_nfo(album_dir, "The Artist", None)
+    assert result is None
+
+
+# --- payload validation -------------------------------------------------------------------
+
+
+def test_nfo_applies_cleanly_rejects_invalid_field() -> None:
+    """A field that would raise while applying to a scratch item fails validation."""
+    provider = _provider()
+    assert provider._nfo_applies_cleanly({"title": "Album", "year": "1999"}, "album") is True
+    assert provider._nfo_applies_cleanly({"title": "Album", "year": "not-a-year"}, "album") is False
+
+
+def test_nfo_applies_cleanly_rejects_non_scalar_field() -> None:
+    """A nested (dict-shaped) field, e.g. a malformed <genre> element, fails validation."""
+    provider = _provider()
+    non_scalar_genre = {"title": "Album", "genre": {"name": "Rock"}}
+    assert provider._nfo_applies_cleanly(non_scalar_genre, "album") is False
+
+
+def test_nfo_applies_cleanly_accepts_repeated_genre_list() -> None:
+    """A repeated <genre> element (xmltodict yields a list) is valid, split_items accepts it."""
+    provider = _provider()
+    repeated_genre = {"title": "Album", "genre": ["Rock", "Pop"]}
+    assert provider._nfo_applies_cleanly(repeated_genre, "album") is True
+
+
+def test_nfo_applies_cleanly_rejects_non_scalar_title() -> None:
+    """A non-scalar title (a plain assignment target, not a raising helper) also fails."""
+    provider = _provider()
+    non_scalar_title = {"title": {"name": "Album"}}
+    assert provider._nfo_applies_cleanly(non_scalar_title, "album") is False
+
+
+def test_nfo_applies_cleanly_rejects_malformed_mbid() -> None:
+    """A present but malformed MusicBrainz id fails validation, not just a missing one."""
+    provider = _provider()
+    assert (
+        provider._nfo_applies_cleanly(
+            {"title": "Album", "musicbrainzalbumid": "not-a-valid-uuid"}, "album"
+        )
+        is False
+    )
+    assert (
+        provider._nfo_applies_cleanly({"title": "Album", "musicbrainzalbumid": ALBUM_MBID}, "album")
+        is True
+    )
+
+
+def test_album_nfo_matches_absent_ids_falls_back_to_title() -> None:
+    """With no MusicBrainz ids at all, a title match is the deciding factor."""
+    root = {"title": "My Album"}
+    assert LocalFileSystemProvider._album_nfo_matches(root, None, None, "My Album") is True
+    assert LocalFileSystemProvider._album_nfo_matches(root, None, None, "Other Album") is False
+
+
+def test_album_nfo_matches_rejects_near_but_different_title() -> None:
+    """Title matching must be strict: a near-miss like 'Album 1' vs 'Album 2' is not a match."""
+    root = {"title": "Album 1"}
+    assert LocalFileSystemProvider._album_nfo_matches(root, None, None, "Album 2") is False
+
+
+def test_album_nfo_matches_rejects_conflicting_album_artist_mbid() -> None:
+    """A same-title NFO for a different album artist mbid must not resolve the folder."""
+    root = {"title": "Greatest Hits", "musicbrainzalbumartistid": OTHER_MBID}
+    assert (
+        LocalFileSystemProvider._album_nfo_matches(
+            root, None, None, "Greatest Hits", (ARTIST_MBID,)
+        )
+        is False
+    )
+    # a matching (or absent) album artist mbid still resolves via title
+    assert (
+        LocalFileSystemProvider._album_nfo_matches(root, None, None, "Greatest Hits", (OTHER_MBID,))
+        is True
+    )
+
+
+def test_album_nfo_matches_rejects_a_conflicting_edition_despite_identical_base_title() -> None:
+    """
+    Stripping each side's own edition suffix must not make two different editions equal.
+
+    "Album (Live)" and "Album (Remix)" both reduce to the base title "Album", but they name
+    two different, incompatible releases - the NFO must not resolve the folder for either.
+    """
+    root = {"title": "Album (Remix)"}
+    album_name, album_version = parse_title_and_version("Album (Live)")
+    assert (
+        LocalFileSystemProvider._album_nfo_matches(
+            root, None, None, album_name, album_version=album_version
+        )
+        is False
+    )
+
+
+def test_album_nfo_matches_absent_edition_stays_inconclusive() -> None:
+    """A plain, edition-less title on either side never blocks an otherwise matching title."""
+    root = {"title": "Album (Live)"}
+    # the track's own tag carries no edition of its own: still resolves via the title
+    assert LocalFileSystemProvider._album_nfo_matches(root, None, None, "Album") is True
+    # the NFO's edition still applies to the resolved album regardless
+    root = {"title": "Album"}
+    album_name, album_version = parse_title_and_version("Album (Live)")
+    assert (
+        LocalFileSystemProvider._album_nfo_matches(
+            root, None, None, album_name, album_version=album_version
+        )
+        is True
+    )
+
+
+async def test_album_resolves_via_title_match_despite_differently_cased_album_artist_mbid() -> None:
+    """The album-artist mbid conflict check must canonicalize both sides before comparing."""
+    provider = _provider()
+    track_dir = "Artist/CAT-1234"
+    _mock_single_file(
+        provider,
+        "Artist/CAT-1234/album.nfo",
+        f"<album><title>My Album</title>"
+        f"<musicbrainzalbumartistid>{ARTIST_MBID}</musicbrainzalbumartistid></album>".encode(),
+    )
+    result = await provider._resolve_album_dir_via_nfo(
+        track_dir, _tags(album_artist_ids=(ARTIST_MBID.upper(),))
+    )
+    assert result is not None
+    assert result[0] == track_dir
+
+
+def test_artist_nfo_matches_prefers_mbid_over_name() -> None:
+    """A present, matching artist mbid is sufficient even without checking the name."""
+    root = {"musicbrainzartistid": ARTIST_MBID}
+    assert LocalFileSystemProvider._artist_nfo_matches(root, "Anything", ARTIST_MBID) is True
+    assert LocalFileSystemProvider._artist_nfo_matches(root, "Anything", OTHER_MBID) is False
+
+
+def test_artist_nfo_matches_rejects_near_but_different_name() -> None:
+    """Name matching must be strict: a near-miss like 'Artist 1' vs 'Artist 2' is not a match."""
+    root = {"title": "Artist 1"}
+    assert LocalFileSystemProvider._artist_nfo_matches(root, "Artist 2", None) is False
+
+
+# --- get_artist refresh reaches the NFO fallback for a synthetic (no-path) artist ---------
+
+
+async def test_get_artist_refresh_anchors_on_representative_track_for_synthetic_artist() -> None:
+    """Refreshing a synthetic (path-less) artist still attempts resolution via its own track."""
+    provider = _provider()
+    db_artist = MagicMock(
+        item_id="1",
+        name="The Artist",
+        sort_name=None,
+        mbid=None,
+        provider_mappings=[MagicMock(provider_instance=INSTANCE_ID, url=None)],
+    )
+    provider.mass.music.artists.get_library_item_by_prov_id = AsyncMock(return_value=db_artist)
+    provider.exists = AsyncMock(return_value=False)
+    provider._resolve_artist_representative_track = AsyncMock(
+        return_value="Music/The Artist/Album/track.mp3"
+    )
+    parsed_artist = MagicMock()
+    provider._parse_artist = AsyncMock(return_value=parsed_artist)
+
+    result = await provider.get_artist("The Artist")
+
+    assert result is parsed_artist
+    provider._parse_artist.assert_awaited_once()
+    _args, kwargs = provider._parse_artist.await_args
+    assert kwargs["album_dir"] == "Music/The Artist/Album"
+    assert kwargs["representative_track"] == "Music/The Artist/Album/track.mp3"
+
+
+async def test_get_artist_refresh_returns_db_artist_with_no_track_to_anchor_on() -> None:
+    """A synthetic artist with no track of its own at all still just returns the db item."""
+    provider = _provider()
+    db_artist = MagicMock(
+        item_id="1",
+        name="The Artist",
+        provider_mappings=[MagicMock(provider_instance=INSTANCE_ID, url=None)],
+    )
+    provider.mass.music.artists.get_library_item_by_prov_id = AsyncMock(return_value=db_artist)
+    provider.exists = AsyncMock(return_value=False)
+    provider._resolve_artist_representative_track = AsyncMock(return_value=None)
+    provider._parse_artist = AsyncMock()
+
+    result = await provider.get_artist("The Artist")
+
+    assert result is db_artist
+
+
+async def test_get_artist_mappingless_refetch_uses_folder_basename_as_name() -> None:
+    """
+    The stateless second fetch of a just-resolved artist never leaks the full path as name.
+
+    A manual "Refresh item" re-fetches the artist by its new (resolved) id before that mapping
+    is persisted, so this id-only lookup finds no db item yet. With no NFO mbid and no matching
+    library artist to recover identity from, the folder's basename (not its full, possibly
+    nested, path) is the display name until an artist.nfo title (if any) overrides it inside
+    ``_parse_artist``.
+    """
+    provider = _provider()
+    provider.mass.music.artists.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    provider._scandir = AsyncMock(return_value=[])  # no artist.nfo to recover an mbid from
+    provider.mass.music.artists.iter_library_items = _async_iter([])
+    parsed_artist = MagicMock()
+    provider._parse_artist = AsyncMock(return_value=parsed_artist)
+
+    result = await provider.get_artist("Various Artists/CAT-1234")
+
+    assert result is parsed_artist
+    args, kwargs = provider._parse_artist.await_args
+    assert args[0] == "CAT-1234"
+    assert kwargs["artist_path"] == "Various Artists/CAT-1234"
+
+
+async def test_get_artist_mappingless_refetch_recovers_identity_from_mbid_only_nfo() -> None:
+    """
+    An mbid-only artist.nfo must recover the real name, not leak the folder basename.
+
+    This is the same stateless second fetch as above, but the resolved folder's own
+    artist.nfo carries only a `musicbrainzartistid` (no title/name), which `parse_artist_nfo`
+    can't use to fix up a wrong name after the fact. The already-known library artist behind
+    that mbid is looked up instead, so its real name/sort_name survive the refetch.
+    """
+    provider = _provider()
+    provider.mass.music.artists.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    provider._scandir = AsyncMock(return_value=[_item("CAT-1234/artist.nfo")])
+    provider._read_file = AsyncMock(
+        return_value=f"<artist><musicbrainzartistid>{ARTIST_MBID}</musicbrainzartistid></artist>".encode()
+    )
+    library_artist = MagicMock(sort_name="Real Artist, The")
+    library_artist.name = "The Real Artist"
+    provider.mass.music.artists.get_library_item_by_external_id = AsyncMock(
+        return_value=library_artist
+    )
+    parsed_artist = MagicMock()
+    provider._parse_artist = AsyncMock(return_value=parsed_artist)
+
+    result = await provider.get_artist("CAT-1234")
+
+    assert result is parsed_artist
+    provider.mass.music.artists.get_library_item_by_external_id.assert_awaited_once_with(
+        ARTIST_MBID, ExternalID.MB_ARTIST
+    )
+    _args, kwargs = provider._parse_artist.await_args
+    assert kwargs == {
+        "sort_name": "Real Artist, The",
+        "mbid": ARTIST_MBID,
+        "artist_path": "CAT-1234",
+    }
+    assert provider._parse_artist.await_args.args == ("The Real Artist",)
+
+
+async def test_get_artist_mappingless_refetch_recovers_identity_via_sort_name_alias() -> None:
+    """
+    A sort-name-alias folder match must recover the real name, not the folder's own basename.
+
+    A normal folder/sort-name-alias match (not an artist.nfo) carries no mbid to recover
+    identity from; the one already-known library artist whose name or sort-name matches this
+    folder is looked up instead, so the second, not-yet-persisted fetch doesn't rename it.
+    """
+    provider = _provider()
+    provider.mass.music.artists.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    provider._scandir = AsyncMock(return_value=[])  # no artist.nfo in this folder
+    library_artist = MagicMock(sort_name="Beatles, The", mbid=None)
+    library_artist.name = "The Beatles"
+    provider.mass.music.artists.iter_library_items = _async_iter([library_artist])
+    parsed_artist = MagicMock()
+    provider._parse_artist = AsyncMock(return_value=parsed_artist)
+
+    result = await provider.get_artist("Music/Beatles, The")
+
+    assert result is parsed_artist
+    _args, kwargs = provider._parse_artist.await_args
+    assert kwargs == {
+        "sort_name": "Beatles, The",
+        "mbid": None,
+        "artist_path": "Music/Beatles, The",
+    }
+    assert provider._parse_artist.await_args.args == ("The Beatles",)
+
+
+async def test_get_artist_mappingless_refetch_ignores_ambiguous_folder_name_match() -> None:
+    """Two library artists matching the same folder name is never a safe positive identity."""
+    provider = _provider()
+    provider.mass.music.artists.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    provider._scandir = AsyncMock(return_value=[])
+    ambiguous_a = MagicMock(sort_name=None)
+    ambiguous_a.name = "Beatles, The"
+    ambiguous_b = MagicMock(sort_name=None)
+    ambiguous_b.name = "Beatles, The"
+    provider.mass.music.artists.iter_library_items = _async_iter([ambiguous_a, ambiguous_b])
+    parsed_artist = MagicMock()
+    provider._parse_artist = AsyncMock(return_value=parsed_artist)
+
+    result = await provider.get_artist("Music/Beatles, The")
+
+    assert result is parsed_artist
+    _args, kwargs = provider._parse_artist.await_args
+    assert kwargs["sort_name"] is None
+    assert kwargs["mbid"] is None
+    assert provider._parse_artist.await_args.args == ("Beatles, The",)
+
+
+# --- sync-index lookup vs on-demand ------------------------------------------------------
+
+
+async def test_nfo_item_for_uses_sync_index_during_a_sync() -> None:
+    """Once the sync's NFO index is ready, the lookup is pure, never a filesystem probe."""
+    provider = _provider()
+    provider.sync_running = True
+    provider._sync_nfo_index_ready = True
+    nfo_item = _item("Artist/Album/album.nfo")
+    provider._sync_nfo_by_dir = {"Artist/Album": {"album.nfo": nfo_item}}
+    provider._scandir = AsyncMock(side_effect=AssertionError("must not touch the filesystem"))
+    result = await provider._nfo_item_for("Artist/Album", "album.nfo")
+    assert result is nfo_item
+    result = await provider._nfo_item_for("Artist/Other", "album.nfo")
+    assert result is None
+
+
+async def test_nfo_item_for_bypasses_a_concurrent_syncs_index_during_a_forced_refresh() -> None:
+    """
+    A forced refresh never joins a concurrently running sync's provider-wide index.
+
+    `_sync_nfo_index_ready` is set once for the whole provider, not scoped to one request; a
+    manual "Refresh item" racing an unrelated background sync must still see a live listing
+    instead of that sync's own (possibly already-stale) snapshot.
+    """
+    provider = _provider()
+    provider.sync_running = True
+    provider._sync_nfo_index_ready = True
+    provider._sync_nfo_by_dir = {"Artist/Album": {"album.nfo": _item("Artist/Album/stale.nfo")}}
+    fresh_item = _item("Artist/Album/album.nfo")
+    provider._scandir = AsyncMock(return_value=[fresh_item])
+
+    token = BYPASS_CACHE.set(True)
+    try:
+        result = await provider._nfo_item_for("Artist/Album", "album.nfo")
+    finally:
+        BYPASS_CACHE.reset(token)
+
+    assert result is fresh_item
+
+
+async def test_ondemand_listing_scope_memoizes_during_a_forced_refresh_racing_a_sync() -> None:
+    """
+    A forced refresh gets its own memo even while a concurrent sync's index is ready.
+
+    Otherwise a refresh touching several candidate folders (e.g. an artist's ancestor levels)
+    would repeat every listing once per lookup instead of once for the whole parse, since
+    `_nfo_item_for` never takes the sync's index shortcut during a refresh in the first place.
+    """
+    provider = _provider()
+    provider.sync_running = True
+    provider._sync_nfo_index_ready = True
+    nfo_item = _item("Artist/Album/album.nfo")
+    provider._scandir = AsyncMock(return_value=[nfo_item])
+
+    token = BYPASS_CACHE.set(True)
+    try:
+        with provider._ondemand_listing_scope():
+            first = await provider._nfo_item_for("Artist/Album", "album.nfo")
+            second = await provider._nfo_item_for("Artist/Album", "artist.nfo")
+    finally:
+        BYPASS_CACHE.reset(token)
+
+    assert first is nfo_item
+    assert second is None
+    provider._scandir.assert_awaited_once()
+
+
+async def test_nfo_item_for_reuses_the_sync_batch_scope_while_the_index_is_unready() -> None:
+    """
+    While the sync index isn't trusted, a folder shared by several tracks is listed once.
+
+    This is the fallback used before the walk completes (or, permanently for that sync,
+    after an incomplete scan): `sync_library` wraps its whole track-processing batch in one
+    shared `_ondemand_listing_scope`, so this reuses the same per-parse memo used outside a
+    sync, rather than a fresh listing per track sharing the folder.
+    """
+    provider = _provider()
+    provider.sync_running = True
+    provider._sync_nfo_index_ready = False
+    nfo_item = _item("Artist/Album/album.nfo")
+    provider._scandir = AsyncMock(return_value=[nfo_item])
+
+    with provider._ondemand_listing_scope():
+        first = await provider._nfo_item_for("Artist/Album", "album.nfo")
+        second = await provider._nfo_item_for("Artist/Album", "artist.nfo")
+
+    assert first is nfo_item
+    assert second is None
+    provider._scandir.assert_awaited_once()
+
+
+async def test_nfo_item_for_memoizes_on_demand_lookups() -> None:
+    """Outside a sync, repeated lookups for the same candidate folder list it only once."""
+    provider = _provider()
+    nfo_item = _item("Artist/Album/album.nfo")
+    provider._scandir = AsyncMock(return_value=[nfo_item])
+    with provider._ondemand_listing_scope():
+        first = await provider._nfo_item_for("Artist/Album", "album.nfo")
+        second = await provider._nfo_item_for("Artist/Album", "artist.nfo")
+    assert first is nfo_item
+    assert second is None
+    provider._scandir.assert_awaited_once()
+
+
+# --- refresh reachability after an id-changing resolution ---------------------------------
+
+
+async def test_get_album_tracks_falls_back_to_folder_scan_without_a_db_mapping() -> None:
+    """
+    A folder not yet mapped in the library is scanned directly for tracks.
+
+    This is the second, id-changed fetch of a manual "Refresh item" that has just resolved a
+    previously synthetic album onto its real folder, before that mapping is persisted.
+    """
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    track_item = _item("Artist/Album/01 Track.flac")
+    provider._scandir = AsyncMock(return_value=[track_item])
+    parsed_track = MagicMock(
+        album=Album(
+            item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+        )
+    )
+    provider._parse_track = AsyncMock(return_value=parsed_track)
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        result = await provider.get_album_tracks("Artist/Album")
+
+    assert result == [parsed_track]
+
+
+async def test_get_album_tracks_sorts_a_mappingless_result_by_disc_and_track_number() -> None:
+    """
+    A mappingless result is sorted, since a WebDAV/cloud folder listing order isn't guaranteed.
+
+    The albums controller returns this provider's list unchanged when there is no library
+    album yet, so an out-of-order (or reversed) listing must be sorted here.
+    """
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    good_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+    )
+    track_items = [_item(f"Artist/Album/{n:02d} Track.flac") for n in (3, 1, 2)]
+    provider._scandir = AsyncMock(return_value=track_items)
+    parsed_tracks = {
+        3: MagicMock(album=good_album, disc_number=1, track_number=3),
+        1: MagicMock(album=good_album, disc_number=1, track_number=1),
+        2: MagicMock(album=good_album, disc_number=1, track_number=2),
+    }
+
+    async def _parse_track_side_effect(item: FileSystemItem, _tags: Any) -> Any:
+        track_number = int(item.filename.split(" ", 1)[0])
+        return parsed_tracks[track_number]
+
+    provider._parse_track = AsyncMock(side_effect=_parse_track_side_effect)
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        result = await provider.get_album_tracks("Artist/Album")
+
+    assert [track.track_number for track in result] == [1, 2, 3]
+
+
+async def test_get_album_tracks_raises_when_folder_is_genuinely_missing() -> None:
+    """A folder that has no library mapping and does not exist on disk still raises."""
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=False)
+
+    with pytest.raises(MediaNotFoundError, match="Album not found"):
+        await provider.get_album_tracks("Artist/Album")
+
+
+async def test_parse_artist_enrichment_matches_nfo_case_insensitively() -> None:
+    """Direct-path artist parsing (bypassing resolution) still finds a case-variant NFO."""
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    provider.exists = AsyncMock(return_value=True)
+    provider._scandir = AsyncMock(return_value=[_item("Artist/ARTIST.NFO")])
+    provider._read_file = AsyncMock(return_value=b"<artist><title>The Artist</title></artist>")
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+
+    artist = await provider._parse_artist("The Artist", artist_path="Artist")
+
+    assert artist.name == "The Artist"
+
+
+async def test_parse_artist_ancestor_plain_name_outranks_a_root_sort_name_alias() -> None:
+    """
+    A root-level sort-name folder must not outrank a nearer ancestor plain-name match.
+
+    The plain name is tried at every location (root, then ancestor) before the sort-name
+    alias is tried anywhere, mirroring the precedence already enforced within a single
+    location by `get_artist_dir`/`get_album_dir`.
+    """
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    # "Beatles, The" (the sort-name alias) exists at the provider root; "The Beatles" (the
+    # plain, exact name) does not exist at the root, but does exist as the real ancestor
+    # folder one level up from the album
+    provider.exists = AsyncMock(side_effect=lambda path: path == "Beatles, The")
+    provider._scandir = AsyncMock(return_value=[])
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+
+    artist = await provider._parse_artist(
+        "The Beatles",
+        sort_name="Beatles, The",
+        album_dir="Beatles, The/The Beatles/Album",
+    )
+
+    assert artist.item_id == "Beatles, The/The Beatles"
+
+
+async def test_parse_artist_validated_nfo_outranks_sort_name_alias_normal_match() -> None:
+    """
+    A validated artist.nfo now outranks a sort-name alias found through ordinary matching.
+
+    An exact (normalized) plain-name match is tried first; once that finds nothing, the
+    bounded artist.nfo fallback is attempted before any relaxed heuristic - including the
+    sort-name alias, itself a relaxed/fuzzy guess - so a folder found only via the alias
+    must not win over a validated NFO elsewhere.
+    """
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    # "Beatles, The" (the sort-name alias) exists at the provider root; the album lives
+    # elsewhere, under an ancestor whose own artist.nfo identifies "The Beatles" by plain
+    # name - that validated NFO now wins over the alias's ordinary (non-NFO) root match
+    provider.exists = AsyncMock(side_effect=lambda path: path == "Beatles, The")
+    _mock_single_file(
+        provider, "Various/artist.nfo", b"<artist><title>The Beatles</title></artist>"
+    )
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+
+    artist = await provider._parse_artist(
+        "The Beatles",
+        sort_name="Beatles, The",
+        album_dir="Various/Album",
+    )
+
+    assert artist.item_id == "Various"
+    provider._read_file.assert_awaited_once()
+
+
+async def test_parse_artist_relaxed_match_never_trusts_a_folder_the_nfo_tier_rejected() -> None:
+    """
+    A relaxed match landing on a folder the NFO tier already rejected must not trust it.
+
+    The bounded validated artist.nfo fallback reads and rejects "Music/Beatles, The"'s own
+    artist.nfo (it names a different artist entirely). The sort-name alias then matches that
+    exact same folder through ordinary (non-NFO) matching - the rejected file must not be
+    silently re-applied during enrichment just because the folder matched some other way.
+    """
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    # only the ancestor folder itself exists (the one the NFO tier rejects and the sort-name
+    # alias later matches); no root-level shortcut for either candidate name
+    provider.exists = AsyncMock(side_effect=lambda path: path == "Music/Beatles, The")
+    _mock_single_file(
+        provider, "Music/Beatles, The/artist.nfo", b"<artist><title>Someone Else</title></artist>"
+    )
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+
+    async def _empty_iter(*_args: object, **_kwargs: object) -> Any:
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+    provider.mass.music.artists.iter_library_items = _empty_iter
+
+    artist = await provider._parse_artist(
+        "The Beatles",
+        sort_name="Beatles, The",
+        album_dir="Music/Beatles, The/Album",
+    )
+
+    # resolved via the sort-name alias, but never renamed from the rejected NFO's own title
+    assert artist.item_id == "Music/Beatles, The"
+    assert artist.name == "The Beatles"
+
+
+async def test_parse_artist_exact_plain_name_match_skips_nfo_resolution() -> None:
+    """An exact (normalized) plain-name folder match wins outright; NFO is never consulted."""
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    # only the true ancestor folder "Music/The Artist" exists at all
+    provider.exists = AsyncMock(side_effect=lambda path: path == "Music/The Artist")
+    provider._scandir = AsyncMock(return_value=[])
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+    provider._resolve_artist_dir_via_nfo = AsyncMock(
+        return_value=(
+            "Music/Someone Else",
+            _item("Music/Someone Else/artist.nfo"),
+            {"title": "The Artist"},
+        )
+    )
+
+    artist = await provider._parse_artist("The Artist", album_dir="Music/The Artist/Album")
+
+    assert artist.item_id == "Music/The Artist"
+    provider._resolve_artist_dir_via_nfo.assert_not_awaited()
+
+
+async def test_parse_artist_malformed_nfo_falls_through_to_relaxed_sort_name_match() -> None:
+    """A malformed/non-matching artist.nfo leaves the sort-name alias as the last resort."""
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    # "Beatles, The" (the sort-name alias) exists at the provider root; the album's ancestor
+    # has its own artist.nfo, but it names a different artist entirely
+    provider.exists = AsyncMock(side_effect=lambda path: path == "Beatles, The")
+    _mock_single_file(
+        provider, "Various/artist.nfo", b"<artist><title>Somebody Else</title></artist>"
+    )
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+
+    artist = await provider._parse_artist(
+        "The Beatles",
+        sort_name="Beatles, The",
+        album_dir="Various/Album",
+    )
+
+    # the mismatching NFO was rejected; the sort-name alias resolved it instead
+    assert artist.item_id == "Beatles, The"
+    # tried once against each candidate (name, then sort-name alias); no root cache to
+    # single-flight the second attempt against the same file
+    assert provider._read_file.await_count == 2
+
+
+async def test_get_album_tracks_skips_a_malformed_sibling_track() -> None:
+    """One sibling file whose tags cannot be read is skipped, not fatal to the folder scan."""
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    good_item = _item("Artist/Album/01 Track.flac")
+    bad_item = _item("Artist/Album/02 Track.flac")
+    provider._scandir = AsyncMock(return_value=[bad_item, good_item])
+    parsed_track = MagicMock(
+        album=Album(
+            item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+        )
+    )
+    provider._parse_track = AsyncMock(return_value=parsed_track)
+
+    async def _parse_tags_side_effect(absolute_path: str, _file_size: int) -> Any:
+        if absolute_path == bad_item.absolute_path:
+            raise InvalidDataError("corrupt file")
+        return MagicMock()
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(side_effect=_parse_tags_side_effect),
+    ):
+        result = await provider.get_album_tracks("Artist/Album")
+
+    assert result == [parsed_track]
+
+
+def test_build_nfo_index_skips_folders_with_only_non_nfo_metadata_files() -> None:
+    """
+    An image-only folder must not get an (empty) entry in the sync's NFO index.
+
+    ``metadata_files`` also carries folder artwork; a folder with cover art but no
+    album.nfo/artist.nfo must be absent from the index entirely, not present with an empty
+    per-directory map, or a large image-heavy library would retain a library-sized index.
+    """
+    nfo_item = _item("Artist/Album/album.nfo")
+    image_item = _item("Artist/Album/folder.jpg")
+    image_only_item = _item("Artist/OtherAlbum/cover.jpg")
+
+    index = LocalFileSystemProvider._build_nfo_index([nfo_item, image_item, image_only_item])
+
+    assert index == {"Artist/Album": {"album.nfo": nfo_item}}
+    assert "Artist/OtherAlbum" not in index
+
+
+async def test_get_album_reuses_the_already_parsed_album_from_the_folder_scan() -> None:
+    """The mappingless refresh path never re-resolves/re-parses the same representative file."""
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    track_item = _item("Artist/Album/01 Track.flac")
+    provider._scandir = AsyncMock(return_value=[track_item])
+    parsed_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="My Album", provider_mappings=set()
+    )
+    parsed_track = MagicMock(album=parsed_album)
+    provider._parse_track = AsyncMock(return_value=parsed_track)
+    provider.resolve = AsyncMock(side_effect=AssertionError("must not re-resolve the same file"))
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        result = await provider.get_album("Artist/Album")
+
+    assert result is parsed_album
+    provider._parse_track.assert_awaited_once()
+
+
+async def test_get_album_closes_the_track_scan_deterministically_on_early_return() -> None:
+    """
+    Returning early from `get_album` still closes its underlying scan generator right away.
+
+    Otherwise the generator's `_ondemand_listing_scope()` cleanup (a ContextVar reset) is left
+    to whenever the event loop's async-generator finalizer happens to run, instead of
+    deterministically, right when `get_album` returns.
+    """
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    track_item = _item("Artist/Album/01 Track.flac")
+    provider._scandir = AsyncMock(return_value=[track_item])
+    parsed_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="My Album", provider_mappings=set()
+    )
+    provider._parse_track = AsyncMock(return_value=MagicMock(album=parsed_album))
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        await provider.get_album("Artist/Album")
+
+    # the on-demand memo must already be torn down, synchronously, not left for GC to close
+    assert _ONDEMAND_NFO_ITEMS.get() is None
+
+
+async def test_get_album_tracks_skips_a_leading_track_without_an_album() -> None:
+    """A parseable file with no album tag is skipped, not returned as a false representative."""
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    no_album_item = _item("Artist/Album/00 Intro.flac")
+    good_item = _item("Artist/Album/01 Track.flac")
+    provider._scandir = AsyncMock(return_value=[no_album_item, good_item])
+    good_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+    )
+    no_album_track = MagicMock(album=None)
+    good_track = MagicMock(album=good_album)
+
+    async def _parse_track_side_effect(item: FileSystemItem, _tags: Any) -> Any:
+        return no_album_track if item is no_album_item else good_track
+
+    provider._parse_track = AsyncMock(side_effect=_parse_track_side_effect)
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        result = await provider.get_album_tracks("Artist/Album")
+
+    assert result == [good_track]
+
+
+async def test_get_album_tracks_propagates_a_transient_failure_from_parse_track() -> None:
+    """A transient failure while building the full track (e.g. NFO I/O) propagates for retry."""
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    track_item = _item("Artist/Album/01 Track.flac")
+    provider._scandir = AsyncMock(return_value=[track_item])
+    provider._parse_track = AsyncMock(side_effect=OSError("network hiccup"))
+
+    with (
+        patch(
+            "music_assistant.providers.filesystem_local.async_parse_tags",
+            AsyncMock(return_value=MagicMock()),
+        ),
+        pytest.raises(OSError, match="network hiccup"),
+    ):
+        await provider.get_album_tracks("Artist/Album")
+
+
+async def test_get_album_tracks_ignores_a_track_resolving_to_a_different_folder() -> None:
+    """A stray/mis-tagged file whose own identity resolves elsewhere is never mistaken for this folder."""
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    stray_item = _item("Artist/Album/00 Stray.flac")
+    good_item = _item("Artist/Album/01 Track.flac")
+    provider._scandir = AsyncMock(return_value=[stray_item, good_item])
+    other_album = Album(
+        item_id="Other/Folder", provider=INSTANCE_ID, name="Other", provider_mappings=set()
+    )
+    good_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+    )
+    stray_track = MagicMock(album=other_album)
+    good_track = MagicMock(album=good_album)
+
+    async def _parse_track_side_effect(item: FileSystemItem, _tags: Any) -> Any:
+        return stray_track if item is stray_item else good_track
+
+    provider._parse_track = AsyncMock(side_effect=_parse_track_side_effect)
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        result = await provider.get_album_tracks("Artist/Album")
+
+    assert result == [good_track]
+
+
+async def test_get_album_tracks_tolerates_an_invalid_cue_sheet() -> None:
+    """An empty/invalid CUE sheet is skipped, not fatal to the rest of the folder scan."""
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    bad_cue = _item("Artist/Album/bad.cue")
+    good_item = _item("Artist/Album/01 Track.flac")
+    provider._scandir = AsyncMock(return_value=[bad_cue, good_item])
+    good_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+    )
+    good_track = MagicMock(album=good_album)
+    provider._parse_track = AsyncMock(return_value=good_track)
+
+    async def _cue_parse_tracks_side_effect(item: FileSystemItem) -> Any:
+        if item is bad_cue:
+            raise InvalidDataError("CUE sheet has no tracks")
+        return []
+
+    provider._cue.parse_tracks = AsyncMock(side_effect=_cue_parse_tracks_side_effect)
+    provider._cue.load_cue_sheet = AsyncMock(return_value=MagicMock(file_path=None))
+    provider._cue.find_audio_file = AsyncMock(return_value="Artist/Album/audio.flac")
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        result = await provider.get_album_tracks("Artist/Album")
+
+    assert result == [good_track]
+
+
+async def test_get_album_tracks_propagates_a_transient_cue_album_resolution_failure() -> None:
+    """A transient failure while resolving a CUE track's album (e.g. NFO I/O) propagates."""
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    cue_item = _item("Artist/Album/album.cue")
+    provider._scandir = AsyncMock(return_value=[cue_item])
+    provider._cue.parse_tracks = AsyncMock(side_effect=OSError("network hiccup"))
+    provider._cue.load_cue_sheet = AsyncMock(return_value=MagicMock(file_path=None))
+    provider._cue.find_audio_file = AsyncMock(return_value="Artist/Album/audio.flac")
+
+    with pytest.raises(OSError, match="network hiccup"):
+        await provider.get_album_tracks("Artist/Album")
+
+
+async def test_get_album_tracks_propagates_media_not_found_from_cue_album_construction() -> None:
+    """
+    A `MediaNotFoundError` while constructing a CUE track's album must propagate too.
+
+    A cloud/WebDAV provider's own `_read_file` raises `MediaNotFoundError` for any failed
+    read, not only a genuinely missing file, so this specific error type must not be treated
+    as "this CUE is unreadable" once its companion audio file is already confirmed present.
+    """
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    cue_item = _item("Artist/Album/album.cue")
+    provider._scandir = AsyncMock(return_value=[cue_item])
+    provider._cue.load_cue_sheet = AsyncMock(return_value=MagicMock(file_path="album.flac"))
+    provider._cue.find_audio_file = AsyncMock(return_value="Artist/Album/album.flac")
+    provider._cue.parse_tracks = AsyncMock(
+        side_effect=MediaNotFoundError("transient NFO file read failure")
+    )
+
+    with pytest.raises(MediaNotFoundError, match="transient NFO file read failure"):
+        await provider.get_album_tracks("Artist/Album")
+
+
+async def test_get_album_tracks_propagates_a_non_tag_error_from_a_plain_track() -> None:
+    """
+    A transient storage failure while reading a plain track's tags is not "unreadable tags".
+
+    Only `InvalidDataError` (genuinely malformed tags) is treated as "skip this track";
+    anything else - e.g. a cloud/WebDAV provider's own transient read failure - must
+    propagate so the sync can retry instead of silently dropping the track.
+    """
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    track_item = _item("Artist/Album/01 Track.flac")
+    provider._scandir = AsyncMock(return_value=[track_item])
+
+    with (
+        patch(
+            "music_assistant.providers.filesystem_local.async_parse_tags",
+            AsyncMock(side_effect=MediaNotFoundError("transient read failure")),
+        ),
+        pytest.raises(MediaNotFoundError, match="transient read failure"),
+    ):
+        await provider.get_album_tracks("Artist/Album")
+
+
+async def test_get_album_tracks_propagates_an_os_error_from_a_plain_track() -> None:
+    """An `OSError` (e.g. ffprobe failing to launch) must propagate, not mark a track unreadable."""
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    track_item = _item("Artist/Album/01 Track.flac")
+    provider._scandir = AsyncMock(return_value=[track_item])
+
+    with (
+        patch(
+            "music_assistant.providers.filesystem_local.async_parse_tags",
+            AsyncMock(side_effect=OSError("ffprobe not found")),
+        ),
+        pytest.raises(OSError, match="ffprobe not found"),
+    ):
+        await provider.get_album_tracks("Artist/Album")
+
+
+async def test_get_album_tracks_skips_a_cue_with_missing_companion_audio() -> None:
+    """A CUE sheet whose companion audio file cannot be found is skipped, not fatal."""
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    cue_item = _item("Artist/Album/album.cue")
+    good_item = _item("Artist/Album/01 Track.flac")
+    provider._scandir = AsyncMock(return_value=[cue_item, good_item])
+    provider._cue.load_cue_sheet = AsyncMock(return_value=MagicMock(file_path="missing.flac"))
+    provider._cue.find_audio_file = AsyncMock(return_value=None)
+    provider._cue.parse_tracks = AsyncMock(
+        side_effect=AssertionError("must not attempt to fully parse a CUE with no companion")
+    )
+    good_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+    )
+    good_track = MagicMock(album=good_album)
+    provider._parse_track = AsyncMock(return_value=good_track)
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        result = await provider.get_album_tracks("Artist/Album")
+
+    assert result == [good_track]
+
+
+async def test_get_album_tracks_excludes_cue_companion_audio() -> None:
+    """A CUE's companion audio file is never yielded as its own unsegmented track."""
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    cue_item = _item("Artist/Album/album.cue")
+    companion_item = _item("Artist/Album/album.flac")
+    provider._scandir = AsyncMock(return_value=[cue_item, companion_item])
+    good_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+    )
+    cue_track = MagicMock(album=good_album)
+    provider._cue.load_cue_sheet = AsyncMock(return_value=MagicMock(file_path="album.flac"))
+    provider._cue.find_audio_file = AsyncMock(return_value="Artist/Album/album.flac")
+    provider._cue.parse_tracks = AsyncMock(return_value=[cue_track])
+    provider._parse_track = AsyncMock(
+        side_effect=AssertionError("the companion audio must not be parsed as its own track")
+    )
+
+    result = await provider.get_album_tracks("Artist/Album")
+
+    assert result == [cue_track]
+
+
+async def test_get_album_tracks_processes_the_companion_of_a_track_less_cue_sheet() -> None:
+    """
+    A CUE sheet that parses cleanly but names no tracks must not exclude its companion.
+
+    `load_cue_sheet` never raises for malformed/truncated content with no TRACK lines - it
+    just returns a track-less sheet - so the companion audio file must still be processed as
+    a normal, standalone track instead of silently disappearing.
+    """
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    cue_item = _item("Artist/Album/album.cue")
+    companion_item = _item("Artist/Album/album.flac")
+    provider._scandir = AsyncMock(return_value=[cue_item, companion_item])
+    good_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+    )
+    good_track = MagicMock(album=good_album)
+    provider._cue.load_cue_sheet = AsyncMock(
+        return_value=MagicMock(file_path="album.flac", tracks=[])
+    )
+    provider._cue.parse_tracks = AsyncMock(
+        side_effect=AssertionError("a track-less CUE sheet must not be parsed for tracks")
+    )
+    provider._parse_track = AsyncMock(return_value=good_track)
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        result = await provider.get_album_tracks("Artist/Album")
+
+    assert result == [good_track]
+
+
+async def test_get_album_tracks_excludes_a_cross_directory_cue_companion() -> None:
+    """
+    A CUE's companion audio is excluded even when it lives in a different subfolder.
+
+    One CUE at the album's top level can cover a companion audio file split across a "Disc 1"
+    subfolder; that companion must still be recognized as absorbed once the subfolder itself
+    is scanned, not parsed again there as an unsegmented duplicate track.
+    """
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    cue_item = _item("Artist/Album/album.cue")
+    disc_dir = _item("Artist/Album/Disc 1")
+    disc_dir.is_dir = True
+    companion_item = _item("Artist/Album/Disc 1/album.flac")
+    good_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+    )
+    cue_track = MagicMock(album=good_album)
+    provider._cue.load_cue_sheet = AsyncMock(return_value=MagicMock(file_path="Disc 1/album.flac"))
+    provider._cue.find_audio_file = AsyncMock(return_value="Artist/Album/Disc 1/album.flac")
+    provider._cue.parse_tracks = AsyncMock(return_value=[cue_track])
+    provider._parse_track = AsyncMock(
+        side_effect=AssertionError(
+            "the cross-directory companion audio must not be parsed as its own track"
+        )
+    )
+
+    async def _scandir_side_effect(scan_folder: str) -> list[FileSystemItem]:
+        if scan_folder == "Artist/Album":
+            return [cue_item, disc_dir]
+        if scan_folder == "Artist/Album/Disc 1":
+            return [companion_item]
+        return []
+
+    provider._scandir = AsyncMock(side_effect=_scandir_side_effect)
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(
+            side_effect=AssertionError(
+                "the cross-directory companion audio must not be tag-parsed either"
+            )
+        ),
+    ):
+        result = await provider.get_album_tracks("Artist/Album")
+
+    assert result == [cue_track]
+
+
+async def test_get_album_tracks_scans_arbitrarily_named_subfolder() -> None:
+    """
+    An arbitrarily named subfolder (not a regex-recognized disc dir) is still scanned.
+
+    An album resolved via NFO onto an oddly named parent folder may have all of its tracks in a
+    subfolder that normal disc-folder detection cannot recognize (e.g. "weird-disc-name").
+    """
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    subfolder = _item("Artist/Album/weird-disc-name")
+    subfolder.is_dir = True
+    track_item = _item("Artist/Album/weird-disc-name/01 Track.flac")
+    good_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+    )
+    good_track = MagicMock(album=good_album)
+
+    async def _scandir_side_effect(scan_folder: str) -> list[FileSystemItem]:
+        if scan_folder == "Artist/Album":
+            return [subfolder]
+        if scan_folder == "Artist/Album/weird-disc-name":
+            return [track_item]
+        return []
+
+    provider._scandir = AsyncMock(side_effect=_scandir_side_effect)
+    provider._parse_track = AsyncMock(return_value=good_track)
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        result = await provider.get_album_tracks("Artist/Album")
+
+    assert result == [good_track]
+
+
+async def test_get_album_never_lists_a_subfolder_when_the_root_already_satisfies_it() -> None:
+    """
+    `get_album` (needing just one track) must not pay for a subfolder listing it never uses.
+
+    Each folder listing is a remote round trip for a cloud/WebDAv-backed provider, so a caller
+    that stops as soon as it finds a usable track in the root should never cause a subfolder to
+    be listed at all.
+    """
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    root_track_item = _item("Artist/Album/01 Track.flac")
+    subfolder = _item("Artist/Album/Disc 2")
+    subfolder.is_dir = True
+    good_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+    )
+    good_track = MagicMock(album=good_album)
+
+    async def _scandir_side_effect(scan_folder: str) -> list[FileSystemItem]:
+        if scan_folder == "Artist/Album":
+            return [root_track_item, subfolder]
+        raise AssertionError(f"must not list the subfolder {scan_folder!r}")
+
+    provider._scandir = AsyncMock(side_effect=_scandir_side_effect)
+    provider._parse_track = AsyncMock(return_value=good_track)
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        result = await provider.get_album("Artist/Album")
+
+    assert result is good_album
+
+
+async def test_get_album_tracks_shares_one_listing_memo_across_the_whole_scan() -> None:
+    """A mappingless multi-track album lists each candidate folder once, not once per track."""
+    provider = _provider()
+    provider.mass.music.albums.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.exists = AsyncMock(return_value=True)
+    track_items = [_item(f"Artist/Album/{n:02d} Track.flac") for n in range(1, 4)]
+    provider._scandir = AsyncMock(return_value=list(track_items))
+    good_album = Album(
+        item_id="Artist/Album", provider=INSTANCE_ID, name="Album", provider_mappings=set()
+    )
+
+    async def _parse_track_side_effect(_item: FileSystemItem, _tags: Any) -> Any:
+        # exercise the real _ondemand_listing_scope-driven lookup path for each track
+        nfo_item = await provider._nfo_item_for("Artist", "artist.nfo")
+        assert nfo_item is None  # no artist.nfo in this fixture; only the call count matters
+        return MagicMock(album=good_album, disc_number=1, track_number=1)
+
+    provider._parse_track = AsyncMock(side_effect=_parse_track_side_effect)
+
+    with patch(
+        "music_assistant.providers.filesystem_local.async_parse_tags",
+        AsyncMock(return_value=MagicMock()),
+    ):
+        result = await provider.get_album_tracks("Artist/Album")
+
+    assert len(result) == 3
+    # "Artist" is listed once for the whole scan, not once per track
+    listed_folders = [call.args[0] for call in provider._scandir.await_args_list]
+    assert listed_folders.count("Artist") == 1
+
+
+async def test_parse_album_scans_folder_once_when_track_dir_equals_album_dir() -> None:
+    """When NFO resolution resolves album_dir onto track_dir itself, it is only processed once."""
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    provider.exists = AsyncMock(return_value=True)
+    nfo_item = _item("Artist/CAT-1234/album.nfo")
+    provider._scandir = AsyncMock(return_value=[nfo_item])
+    provider._read_file = AsyncMock(return_value=b"<album><title>My Album</title></album>")
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+    provider._resolve_artists_with_mbids = AsyncMock(return_value=[])
+    provider.config.get_value = MagicMock(return_value="various_artists")
+
+    tags = MagicMock(
+        album="My Album",
+        album_sort=None,
+        album_artists=[],
+        barcode=None,
+        musicbrainz_albumid=None,
+        musicbrainz_releasegroupid=None,
+        year=None,
+        album_type=AlbumType.ALBUM,
+        filename="track.mp3",
+    )
+    await provider._parse_album(track_path="Artist/CAT-1234/t1.mp3", track_tags=tags)
+
+    # the resolved album folder ("Artist/CAT-1234") must be scanned for images only once,
+    # even though it is both the track's own directory and the resolved album directory
+    album_folder_calls = [
+        call
+        for call in provider._get_local_images.await_args_list
+        if call.args[0] == "Artist/CAT-1234"
+    ]
+    assert len(album_folder_calls) == 1
+
+
+async def test_parse_album_never_enriches_from_the_losing_candidate_folders_own_nfo() -> None:
+    """
+    Only the validated, winning NFO applies - a rejected candidate's own NFO must not too.
+
+    The track's own directory ("Artist/CAT-1234") has its own album.nfo, but it names a
+    different album and is rejected during resolution; the parent's album.nfo wins instead.
+    Both folders are still visited by the enrichment loop (`dict.fromkeys((track_dir,
+    album_dir))`), so the losing folder's unvalidated album.nfo must not leak its own genre
+    into the resolved album (the winning NFO here sets no genre of its own, so a leaked value
+    would otherwise survive even though the losing folder is processed before the winner).
+    """
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    provider.exists = AsyncMock(return_value=True)
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+    provider._resolve_artists_with_mbids = AsyncMock(return_value=[])
+    provider.config.get_value = MagicMock(return_value="various_artists")
+
+    async def _scandir(folder: str, use_cache: bool = True) -> list[FileSystemItem]:  # noqa: ARG001
+        return [_item(f"{folder}/album.nfo")]
+
+    async def _read_file(path: str) -> bytes:
+        if path == "Artist/CAT-1234/album.nfo":
+            return b"<album><title>Wrong Album</title><genre>Jazz</genre></album>"
+        return b"<album><title>My Album</title></album>"
+
+    provider._scandir = AsyncMock(side_effect=_scandir)
+    provider._read_file = AsyncMock(side_effect=_read_file)
+
+    tags = MagicMock(
+        album="My Album",
+        album_sort=None,
+        album_artists=[],
+        barcode=None,
+        musicbrainz_albumid=None,
+        musicbrainz_releasegroupid=None,
+        year=None,
+        album_type=AlbumType.ALBUM,
+        filename="track.mp3",
+    )
+    album = await provider._parse_album(track_path="Artist/CAT-1234/t1.mp3", track_tags=tags)
+
+    assert album.name == "My Album"
+    assert not album.metadata.genres
+
+
+async def test_parse_album_artist_resolves_from_ancestor_nfo_while_album_stays_synthetic() -> None:
+    """
+    The artist's own ancestor resolution must not depend on the album resolving too.
+
+    The track's directory ("Artist/CAT-1234") matches neither the album name nor any
+    album.nfo there, so the album stays synthetic (tag-only, no folder). The artist must
+    still be looked up starting from that same directory (not only when an album folder was
+    found), so its ancestor artist.nfo one level up ("Artist") still resolves it to a real
+    folder.
+    """
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    # deliberately not the root-level "The Artist" folder itself: forces the resolution to
+    # rely on the ancestor artist.nfo, not a root-level literal name match
+    provider.exists = AsyncMock(return_value=False)
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+    provider._resolve_artists_with_mbids = AsyncMock(
+        return_value=[("The Artist", ARTIST_MBID, None)]
+    )
+
+    async def _scandir(folder: str, use_cache: bool = True) -> list[FileSystemItem]:  # noqa: ARG001
+        if folder == "Artist":
+            return [_item("Artist/artist.nfo")]
+        return []  # no album.nfo anywhere: the album can never resolve to a folder
+
+    async def _read_file(path: str) -> bytes:
+        assert path == "Artist/artist.nfo"
+        return f"<artist><musicbrainzartistid>{ARTIST_MBID}</musicbrainzartistid></artist>".encode()
+
+    provider._scandir = AsyncMock(side_effect=_scandir)
+    provider._read_file = AsyncMock(side_effect=_read_file)
+
+    tags = MagicMock(
+        album="My Album",
+        album_sort=None,
+        album_artists=["The Artist"],
+        barcode=None,
+        musicbrainz_albumid=None,
+        musicbrainz_releasegroupid=None,
+        year=None,
+        album_type=AlbumType.ALBUM,
+        filename="track.mp3",
+    )
+    album = await provider._parse_album(track_path="Artist/CAT-1234/t1.mp3", track_tags=tags)
+
+    # the album itself never resolved to a folder: a synthetic, name-based identity
+    assert album.provider_mappings
+    album_mapping = next(iter(album.provider_mappings))
+    assert album_mapping.url is None
+    assert album_mapping.item_id == "The Artist" + os.sep + "My Album"
+    # the artist resolved to its real ancestor folder regardless
+    assert album.artists[0].item_id == "Artist"
+
+
+async def test_parse_album_artist_resolves_from_ancestor_name_while_album_stays_synthetic() -> None:
+    """The same anchoring also applies to a normal (non-NFO) ancestor name match."""
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    # only the true ancestor folder "Music/The Artist" exists; a root-level "The Artist" (or
+    # its filesystem-safe variant) does not, so a false-positive root-level shortcut can't mask
+    # whether the ancestor walk itself is actually anchored on the track's own directory
+    provider.exists = AsyncMock(side_effect=lambda path: path == "Music/The Artist")
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+    provider._resolve_artists_with_mbids = AsyncMock(return_value=[("The Artist", None, None)])
+    provider._scandir = AsyncMock(return_value=[])  # no NFOs anywhere
+
+    tags = MagicMock(
+        album="My Album",
+        album_sort=None,
+        album_artists=["The Artist"],
+        barcode=None,
+        musicbrainz_albumid=None,
+        musicbrainz_releasegroupid=None,
+        year=None,
+        album_type=AlbumType.ALBUM,
+        filename="track.mp3",
+    )
+    album = await provider._parse_album(
+        track_path="Music/The Artist/CAT-1234/t1.mp3", track_tags=tags
+    )
+
+    assert album.provider_mappings
+    album_mapping = next(iter(album.provider_mappings))
+    assert album_mapping.url is None
+    # the artist resolved by ordinary folder-name matching, anchored on the track's own
+    # directory rather than a (never-resolved) album directory
+    assert album.artists[0].item_id == "Music/The Artist"
+
+
+# --- three-tier precedence: exact folder match, then validated NFO, then relaxed match ----
+
+
+async def test_parse_album_exact_folder_match_skips_nfo_resolution() -> None:
+    """An exact (normalized) folder match wins outright; a validated album.nfo is never tried."""
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    provider.exists = AsyncMock(return_value=True)
+    provider._scandir = AsyncMock(return_value=[])
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+    provider._resolve_artists_with_mbids = AsyncMock(return_value=[("The Artist", None, None)])
+    provider._resolve_album_dir_via_nfo = AsyncMock(
+        return_value=("Artist", _item("Artist/album.nfo"), {"title": "My Album"})
+    )
+
+    tags = MagicMock(
+        album="My Album",
+        album_sort=None,
+        album_artists=["The Artist"],
+        barcode=None,
+        musicbrainz_albumid=None,
+        musicbrainz_releasegroupid=None,
+        year=None,
+        album_type=AlbumType.ALBUM,
+        filename="track.mp3",
+    )
+    album = await provider._parse_album(track_path="Artist/My Album/t1.mp3", track_tags=tags)
+
+    album_mapping = next(iter(album.provider_mappings))
+    assert album_mapping.url == "Artist/My Album"
+    provider._resolve_album_dir_via_nfo.assert_not_awaited()
+
+
+async def test_parse_album_validated_nfo_outranks_a_relaxed_date_prefix_match() -> None:
+    """
+    A validated album.nfo at the parent outranks a relaxed date-prefix match at track_dir.
+
+    The track's own directory is date-prefixed ("2025-03-14 My Album") and would match the
+    album by the new relaxed date-prefix heuristic alone; but its true parent has its own
+    validated album.nfo, and the bounded NFO fallback is tried before any relaxed heuristic.
+    """
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    provider.exists = AsyncMock(return_value=True)
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+    provider._resolve_artists_with_mbids = AsyncMock(return_value=[("The Artist", None, None)])
+
+    async def _scandir(folder: str, use_cache: bool = True) -> list[FileSystemItem]:  # noqa: ARG001
+        if folder == "Artist/RealAlbumFolder":
+            return [_item("Artist/RealAlbumFolder/album.nfo")]
+        return []  # the date-prefixed track_dir itself has no album.nfo of its own
+
+    async def _read_file(path: str) -> bytes:
+        assert path == "Artist/RealAlbumFolder/album.nfo"
+        return b"<album><title>My Album</title></album>"
+
+    provider._scandir = AsyncMock(side_effect=_scandir)
+    provider._read_file = AsyncMock(side_effect=_read_file)
+
+    tags = MagicMock(
+        album="My Album",
+        album_sort=None,
+        album_artists=["The Artist"],
+        barcode=None,
+        musicbrainz_albumid=None,
+        musicbrainz_releasegroupid=None,
+        year=None,
+        album_type=AlbumType.ALBUM,
+        filename="track.mp3",
+    )
+    album = await provider._parse_album(
+        track_path="Artist/RealAlbumFolder/2025-03-14 My Album/t1.mp3", track_tags=tags
+    )
+
+    album_mapping = next(iter(album.provider_mappings))
+    # the validated parent NFO won, not the date-prefixed track_dir a relaxed match would pick
+    assert album_mapping.url == "Artist/RealAlbumFolder"
+
+
+async def test_parse_album_malformed_nfo_falls_through_to_relaxed_date_prefix_match() -> None:
+    """A malformed/non-matching album.nfo leaves the relaxed heuristic as the last resort."""
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    provider.exists = AsyncMock(return_value=True)
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+    provider._resolve_artists_with_mbids = AsyncMock(return_value=[("The Artist", None, None)])
+
+    async def _scandir(folder: str, use_cache: bool = True) -> list[FileSystemItem]:  # noqa: ARG001
+        if folder == "Artist":
+            return [_item("Artist/album.nfo")]
+        return []
+
+    async def _read_file(path: str) -> bytes:
+        assert path == "Artist/album.nfo"
+        # names a different album entirely: never a positive identity match
+        return b"<album><title>Somebody Else's Album</title></album>"
+
+    provider._scandir = AsyncMock(side_effect=_scandir)
+    provider._read_file = AsyncMock(side_effect=_read_file)
+
+    tags = MagicMock(
+        album="My Album",
+        album_sort=None,
+        album_artists=["The Artist"],
+        barcode=None,
+        musicbrainz_albumid=None,
+        musicbrainz_releasegroupid=None,
+        year=None,
+        album_type=AlbumType.ALBUM,
+        filename="track.mp3",
+    )
+    album = await provider._parse_album(
+        track_path="Artist/2025-03-14 My Album/t1.mp3", track_tags=tags
+    )
+
+    album_mapping = next(iter(album.provider_mappings))
+    # the mismatching NFO was rejected; the relaxed date-prefix match resolved it instead
+    assert album_mapping.url == "Artist/2025-03-14 My Album"
+
+
+async def test_parse_album_relaxed_match_never_trusts_a_folder_the_nfo_tier_rejected() -> None:
+    """
+    A relaxed match landing on a folder the NFO tier already rejected must not trust it.
+
+    The bounded validated album.nfo fallback reads and rejects the track's own directory's
+    album.nfo (it names a different album entirely). The relaxed date-prefix heuristic then
+    matches that exact same folder through ordinary (non-NFO) matching - the rejected file
+    must not be silently re-applied during enrichment just because the folder matched some
+    other way.
+    """
+    provider = _provider()
+    provider.manifest = MagicMock(domain="filesystem_local")
+    provider.exists = AsyncMock(return_value=True)
+    provider._get_local_images = AsyncMock(return_value=[])
+    provider.cache.get = AsyncMock(return_value=None)
+    provider.cache.set = AsyncMock()
+    provider._resolve_artists_with_mbids = AsyncMock(return_value=[("The Artist", None, None)])
+    _mock_single_file(
+        provider,
+        "Artist/2025-03-14 My Album/album.nfo",
+        b"<album><title>Somebody Else's Album</title></album>",
+    )
+
+    tags = MagicMock(
+        album="My Album",
+        album_sort=None,
+        album_artists=["The Artist"],
+        barcode=None,
+        musicbrainz_albumid=None,
+        musicbrainz_releasegroupid=None,
+        year=None,
+        album_type=AlbumType.ALBUM,
+        filename="track.mp3",
+    )
+    album = await provider._parse_album(
+        track_path="Artist/2025-03-14 My Album/t1.mp3", track_tags=tags
+    )
+
+    # resolved via the relaxed date-prefix match, but never renamed from the rejected NFO
+    album_mapping = next(iter(album.provider_mappings))
+    assert album_mapping.url == "Artist/2025-03-14 My Album"
+    assert album.name == "My Album"

--- a/tests/providers/filesystem/test_parsers.py
+++ b/tests/providers/filesystem/test_parsers.py
@@ -6,7 +6,7 @@ from music_assistant_models.enums import ExternalID
 from music_assistant_models.media_items import Album, Artist
 from music_assistant_models.unique_list import UniqueList
 
-from music_assistant.providers.filesystem_local.parsers import parse_album_nfo
+from music_assistant.providers.filesystem_local.parsers import parse_album_nfo, parse_artist_nfo
 
 
 def test_parse_album_nfo() -> None:
@@ -64,3 +64,41 @@ def test_parse_album_nfo() -> None:
         },
     )
     _asserts(album)
+
+
+def test_parse_artist_nfo() -> None:
+    """Test parsing of an artist NFO file."""
+    artist = Artist(item_id="test", provider="test", name="", provider_mappings=set())
+
+    mb_artist = str(uuid.uuid4())
+
+    def _asserts(res: Artist) -> None:
+        assert res.name == "Test Artist"
+        assert res.sort_name == "Test Sortname"
+        assert res.mbid == mb_artist
+        assert res.metadata.description == "Test Biography"
+        assert res.metadata.genres == {"Test Genre"}
+
+    parse_artist_nfo(
+        artist,
+        {
+            "title": "Test Artist",
+            "sortname": "Test Sortname",
+            "musicbrainzartistid": mb_artist,
+            "biography": "Test Biography",
+            "genre": "Test Genre",
+        },
+    )
+    _asserts(artist)
+
+    parse_artist_nfo(artist, {})  # empty dict or missing keys should not change anything
+    _asserts(artist)
+
+    parse_artist_nfo(
+        artist,
+        {  # None and empty string should not erase existing values
+            "title": None,
+            "sortname": "",
+        },
+    )
+    _asserts(artist)

--- a/tests/providers/filesystem/test_sync_resilience.py
+++ b/tests/providers/filesystem/test_sync_resilience.py
@@ -1,13 +1,14 @@
 """Tests for filesystem provider sync behavior when the storage misbehaves."""
 
+import asyncio
 import errno
-from typing import Any, cast
+from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import ProviderUnavailableError
 
-from music_assistant.providers.filesystem_local import LocalFileSystemProvider
+from music_assistant.providers.filesystem_local import _ONDEMAND_NFO_ITEMS, LocalFileSystemProvider
 from music_assistant.providers.filesystem_local.constants import (
     CONF_ENTRY_CONTENT_TYPE,
     CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS,
@@ -99,6 +100,42 @@ async def test_deletions_run_on_clean_scan() -> None:
     provider._process_orphaned_albums_and_artists.assert_awaited_once()  # type: ignore[attr-defined]
 
 
+async def test_sync_shares_one_ondemand_listing_scope_across_the_whole_batch() -> None:
+    """
+    Every track processed in a sync shares one on-demand listing/NFO-root memo.
+
+    This is what lets a folder shared by several tracks be listed - and its NFO parsed -
+    only once for the whole sync, instead of once per track, whenever the up-front index
+    isn't trusted (before it is built, or after an incomplete scan leaves it unready).
+    """
+    provider = _create_provider()
+    item_a = MagicMock(relative_path="Artist/Album/a.flac")
+    item_b = MagicMock(relative_path="Artist/Album/b.flac")
+
+    async def _enumerate(**kwargs: Any) -> None:
+        kwargs["items_to_process"].extend([(item_a, None), (item_b, None)])
+        kwargs["cur_filenames"].update({FOUND_FILE})
+        # an incomplete scan leaves the up-front index unready for the whole sync -
+        # exactly the scenario this shared batch scope exists for
+        kwargs["scan_errors"].failed_dirs = 1
+
+    provider._enumerate_files_for_sync = _enumerate  # type: ignore[method-assign]
+    provider.mass.create_task = lambda coro, **_kwargs: asyncio.ensure_future(coro)  # type: ignore[method-assign]
+    captured_memos: list[Any] = []
+
+    async def _process_item_async(*_args: Any, **_kwargs: Any) -> bool:
+        captured_memos.append(_ONDEMAND_NFO_ITEMS.get())
+        return False
+
+    provider._process_item_async = _process_item_async  # type: ignore[method-assign]
+
+    await provider.sync_library(MediaType.TRACK)
+
+    assert len(captured_memos) == 2
+    assert captured_memos[0] is not None
+    assert captured_memos[0] is captured_memos[1]
+
+
 async def test_deletions_skipped_when_directories_failed() -> None:
     """A scan that could not read some directories must not delete their content."""
     provider = _create_provider()
@@ -126,6 +163,41 @@ async def test_deletions_skipped_when_files_failed() -> None:
     provider._process_deletions.assert_not_called()  # type: ignore[attr-defined]
     provider._process_orphaned_albums_and_artists.assert_not_called()  # type: ignore[attr-defined]
     provider._set_available.assert_called_once_with(True)  # type: ignore[attr-defined]
+
+
+async def test_nfo_index_not_marked_ready_after_an_incomplete_scan() -> None:
+    """
+    An incomplete scan must not make the sync-wide NFO index authoritative.
+
+    Some folders/files failing to read means the walk may have missed an NFO that does
+    exist on disk; trusting the resulting (partial) index anyway could make a changed
+    track wrongly resolve to a synthetic identity instead of retrying a direct lookup.
+    A cleanup at the very end of the sync always resets the flag, so its in-sync value
+    is captured via a `TaskManager` stand-in, the last thing entered before that cleanup.
+    """
+    provider = _create_provider()
+    provider._enumerate_files_for_sync = _enumerate_result(  # type: ignore[method-assign]
+        failed_dirs=1, found_files={FOUND_FILE}
+    )
+    captured_ready_states: list[bool] = []
+
+    class _CapturingTaskManager:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            captured_ready_states.append(provider._sync_nfo_index_ready)
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+        async def create_task_with_limit(self, _coro: Any) -> None:
+            """Discard the task; nothing to process in this scenario."""
+
+    with patch("music_assistant.providers.filesystem_local.TaskManager", _CapturingTaskManager):
+        await provider.sync_library(MediaType.TRACK)
+
+    assert captured_ready_states == [False]
 
 
 async def test_failed_item_is_kept_in_the_scan_result() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Some local library layouts cannot be matched reliably from track tags alone, leaving albums or artists without their folder artwork and metadata. This adds safer folder matching and a validated Kodi-style `album.nfo` / `artist.nfo` fallback.

Existing name-based items are not migrated automatically. After adding a new NFO file, use **Refresh item** or reimport the item.

Supersedes #5702; thanks @terwarf.

**Related issue (if applicable):**

- Fixes music-assistant/support#3994.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Match exact normalized folder names first, validated NFO files second, and relaxed layout/sort-name rules last.
- Support common release-date/year folder prefixes such as `2025-03-14`, `2025.03.14`, `(2025)`, and `[2025]`.
- Validate NFO identity before using it and keep album, artist, disc, CUE, and WebDAV lookups bounded and provider-local.
- Reuse NFO paths discovered by the normal sync walk without adding a second directory-listing pass.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.