### PR TITLE
Skipping a Spotify track no longer starts with a moment of the previous one

### DIFF
--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -20,9 +20,12 @@ capture) is owned by the Spotify Connect provider / core helpers and reused here
 
 from __future__ import annotations
 
+import array
 import asyncio
+import fcntl
 import os
 import shutil
+import termios
 import time
 from collections import deque
 from contextlib import suppress
@@ -671,10 +674,10 @@ class _SoloistSession:
         self._backpressured = False
         self._sink_lock = asyncio.Lock()
         self._idle_since: float | None = None
-        # while set, captured audio is dropped until the engine reports this item:
-        # what is still in the sink and the FIFO belongs to the item jumped away
-        # from, and would otherwise land at the head of this one
+        # while set, captured audio is dropped until the engine reports this item
         self._discard_until: str | None = None
+        # bytes of the item jumped away from still to drop, measured at the jump
+        self._stale_budget = 0
 
     @property
     def in_use(self) -> bool:
@@ -1262,7 +1265,16 @@ class _SoloistSession:
         :param chunk: Whole sample frames just read from the capture FIFO.
         """
         if self._discard_until is not None:
+            # the marker drops everything, an earlier jump's remainder included
+            self._stale_budget = max(0, self._stale_budget - len(chunk))
             return
+        if self._stale_budget > 0:
+            # both are whole frames - the budget floored, the chunk shaped - so
+            # what is kept stays on the session's frame grid
+            drop = min(self._stale_budget, len(chunk))
+            self._stale_budget -= drop
+            if not (chunk := chunk[drop:]):
+                return
         if (item := self._current) is not None:
             item.write(chunk)
 
@@ -1417,6 +1429,34 @@ class _SoloistSession:
                 return
             self._sink_running = want
 
+    def _stale_bytes(self) -> int:
+        """
+        Whole frames of rendered audio sitting between the capture sink and the reader.
+
+        Measured rather than assumed: the reader's share alone ranges over
+        several hundred milliseconds as its flow control fills and drains, so no
+        fixed amount describes it.
+        """
+        stale = 0
+        if self._transport is not None:
+            pipe = self._transport.get_extra_info("pipe")
+            if pipe is not None:
+                try:
+                    pending = array.array("i", [0])
+                    fcntl.ioctl(pipe.fileno(), termios.FIONREAD, pending, True)
+                    stale += pending[0]
+                except OSError as err:
+                    self.logger.debug("Could not size the capture FIFO: %s", err)
+        if (reader := self._reader) is not None:
+            # asyncio exposes no public view of what a StreamReader still holds.
+            # It appends before it pauses at twice its limit, so it tops out a
+            # further pipe read above that - the bound to stand in with if the
+            # attribute ever goes, since dropping extra beats leaving the
+            # previous item audible.
+            held = getattr(reader, "_buffer", None)
+            stale += len(held) if held is not None else 6 * _READ_CHUNK_SIZE
+        return stale - (stale % _FRAME_BYTES)
+
     def _retained_bytes(self) -> int:
         """Return how much captured audio is buffered but not delivered yet."""
         return sum(item.buffered for item in self._items.values())
@@ -1483,6 +1523,13 @@ class _SoloistSession:
         self._current = item
         if self._discard_until == uri:
             self._discard_until = None
+            # The engine confirms a jump over the WebSocket within a few
+            # milliseconds, long before the audio it describes reaches the
+            # reader, so the marker above drops next to nothing on its own. The
+            # engine does flush its own output, but what the sink already mixed
+            # is still on its way here and belongs to the item being left
+            # behind - drop that, so it cannot open this one.
+            self._stale_budget = self._stale_bytes()
         item.started.set()
         if current is not None and current.started.is_set():
             # Only an item that was actually playing has a boundary to cut at.
@@ -1655,6 +1702,7 @@ class _ItemAudio:
     def release(self) -> None:
         """Release the channel after its stream ended (or was abandoned)."""
         self.claimed = False
+        self._drop_undelivered()
 
     def write(self, chunk: bytes) -> None:
         """Append captured audio for this item."""
@@ -1696,6 +1744,7 @@ class _ItemAudio:
         # a closed channel no longer holds the capture sink open for its tail
         self.draining = False
         self._available.set()
+        self._drop_undelivered()
 
     def observe_position(self, position_ms: int) -> None:
         """Record a reported playback position (and confirm a pending seek)."""
@@ -1756,6 +1805,19 @@ class _ItemAudio:
             starving_for += _READ_SLICE_S
             if starving_for >= _STALL_TIMEOUT_S:
                 raise AudioError(f"Spotify Soloist delivered no audio for {self.uri}")
+
+    def _drop_undelivered(self) -> None:
+        """
+        Free audio nothing can read any more, so it stops gating the capture sink.
+
+        A skip leaves its channel closed with its reader gone; without this the
+        buffer it had filled would count against ``_MAX_RETAINED_S`` for the rest
+        of the session, and enough of them would suspend the sink for good.
+        """
+        if self.claimed or not self._closed or not self.spent:
+            return
+        self._chunks.clear()
+        self._buffered = 0
 
     def _duration_bytes(self) -> int | None:
         """

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -12,9 +12,10 @@ setup. No real process or PulseAudio is involved.
 from __future__ import annotations
 
 import asyncio
+import os
 import time
-from collections.abc import AsyncGenerator, Callable
-from contextlib import suppress
+from collections.abc import AsyncGenerator, Callable, Iterator
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -31,6 +32,7 @@ from music_assistant.providers.spotify.backends.soloist import (
     _FRAME_BYTES,
     _IDLE_TIMEOUT_S,
     _MAX_LEAD_TRIM_S,
+    _READ_CHUNK_SIZE,
     SoloistBackend,
     _CaptureShaper,
     _ItemAudio,
@@ -891,13 +893,14 @@ async def test_skipping_to_the_fed_item_keeps_the_session(tmp_path: Path) -> Non
     _client_of(session).skip_next.assert_awaited_once()
 
 
-async def test_a_skip_drops_what_the_old_track_left_in_the_pipeline(tmp_path: Path) -> None:
+async def test_a_skip_drops_what_arrives_while_the_command_is_in_flight(
+    tmp_path: Path,
+) -> None:
     """
-    Audio already rendered when the skip is issued belongs to the track left behind.
+    Audio captured between the skip command and the engine's answer is dropped.
 
-    The sink and the FIFO hold a few hundred milliseconds of it, which would
-    otherwise be written to the head of the item skipped to - audible as a blip
-    of the previous track.
+    Only covers the marker's own window; what the pipeline still holds when the
+    answer arrives is measured at the cut instead.
     """
     session = _make_session(tmp_path)
     leaving = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
@@ -1422,6 +1425,152 @@ def test_session_present_detection(tmp_path: Path) -> None:
     assert soloist_session_present(data_dir) is False
     (data_dir / "session.bin").write_bytes(b"x")
     assert soloist_session_present(data_dir) is True
+
+
+async def test_a_skip_drops_the_audio_still_in_flight(tmp_path: Path) -> None:
+    """The item jumped to opens with its own audio, not the tail of the one left behind."""
+    session = _make_session(tmp_path)
+    left_behind = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    session._current = left_behind
+    left_behind.started.set()
+    left_behind.claim()
+    jumped_to = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
+    session._pending.append(TRACK_B)
+    session._discard_until = TRACK_B
+    with _capture_holding(session, fifo_bytes=2 * _FRAME_BYTES, reader_bytes=2 * _FRAME_BYTES):
+        await session._observe_current(TRACK_B, 200_000)
+    assert session._stale_budget == 4 * _FRAME_BYTES
+    session._write_if_wanted(b"s" * (4 * _FRAME_BYTES))
+    session._write_if_wanted(b"n" * (2 * _FRAME_BYTES))
+    jumped_to.claim()
+    jumped_to.close()
+    assert b"".join([chunk async for chunk in jumped_to.read()]) == b"n" * (2 * _FRAME_BYTES)
+
+
+async def test_a_skip_drops_the_stale_audio_across_reads(tmp_path: Path) -> None:
+    """A budget larger than one read keeps dropping, and resumes on a frame boundary."""
+    session = _make_session(tmp_path)
+    session._stale_budget = 3 * _FRAME_BYTES
+    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item.claim()
+    session._write_if_wanted(b"s" * (2 * _FRAME_BYTES))
+    session._write_if_wanted(b"s" * _FRAME_BYTES + b"n" * _FRAME_BYTES)
+    item.close()
+    assert b"".join([chunk async for chunk in item.read()]) == b"n" * _FRAME_BYTES
+
+
+async def test_the_marker_spends_an_earlier_jumps_budget(tmp_path: Path) -> None:
+    """What the marker drops still counts against a budget left from an earlier jump."""
+    session = _make_session(tmp_path)
+    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    session._stale_budget = 4 * _FRAME_BYTES
+    session._discard_until = TRACK_B
+    session._write_if_wanted(b"s" * (3 * _FRAME_BYTES))
+    assert session._stale_budget == _FRAME_BYTES
+    # a refused command leaves only what is genuinely still in flight to drop
+    session._discard_until = None
+    session._write_if_wanted(b"s" * _FRAME_BYTES + b"n" * _FRAME_BYTES)
+    item = session._current
+    item.claim()
+    item.close()
+    assert b"".join([chunk async for chunk in item.read()]) == b"n" * _FRAME_BYTES
+
+
+async def test_a_natural_cut_keeps_the_audio_in_flight(tmp_path: Path) -> None:
+    """Nothing is dropped without a jump: what is in flight is the continuation."""
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    session._current = playing
+    playing.started.set()
+    playing.claim()
+    with _capture_holding(session, fifo_bytes=4 * _FRAME_BYTES, reader_bytes=4 * _FRAME_BYTES):
+        await session._observe_current(TRACK_B, 200_000)
+    assert session._stale_budget == 0
+
+
+def test_stale_bytes_spans_both_buffers_in_whole_frames(tmp_path: Path) -> None:
+    """The in-flight measure covers the FIFO and the reader, and never splits a frame."""
+    session = _make_session(tmp_path)
+    with _capture_holding(session, fifo_bytes=3 * _FRAME_BYTES + 3, reader_bytes=2 * _FRAME_BYTES):
+        assert session._stale_bytes() == 5 * _FRAME_BYTES
+
+
+def test_stale_bytes_falls_back_when_the_reader_cannot_be_sized(tmp_path: Path) -> None:
+    """Losing the reader's internal view drops extra rather than leaving audio behind."""
+    session = _make_session(tmp_path)
+    with _capture_holding(session, fifo_bytes=0, reader_bytes=None):
+        assert session._stale_bytes() == 6 * _READ_CHUNK_SIZE
+
+
+async def test_a_channel_abandoned_at_the_cut_stops_holding_the_cushion(
+    tmp_path: Path,
+) -> None:
+    """A skip closes the channel first and only then unwinds its stream."""
+    session = _make_session(tmp_path)
+    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item.started.set()
+    item.claim()
+    item.write(b"x" * 4096)
+    # the cut lands while the abandoned stream is still unwinding
+    await session._observe_current(TRACK_B, 200_000)
+    assert session._retained_bytes() == 4096
+    item.release()
+    assert session._retained_bytes() == 0
+
+
+def test_an_abandoned_channel_stops_holding_the_cushion(tmp_path: Path) -> None:
+    """A channel skipped away from frees its buffer instead of gating the sink for good."""
+    session = _make_session(tmp_path)
+    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item.claim()
+    item.write(b"x" * 4096)
+    assert session._retained_bytes() == 4096
+    # the stream is gone, then the cut closes the channel
+    item.release()
+    item.close()
+    assert session._retained_bytes() == 0
+
+
+async def test_a_channel_still_being_read_keeps_its_tail(tmp_path: Path) -> None:
+    """Closing the playing item at a cut must not discard what its stream is still owed."""
+    session = _make_session(tmp_path)
+    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item.claim()
+    item.write(b"tail" * 4)
+    item.close()
+    assert item.buffered == 16
+    assert b"".join([chunk async for chunk in item.read()]) == b"tail" * 4
+
+
+@contextmanager
+def _capture_holding(
+    session: _SoloistSession, *, fifo_bytes: int, reader_bytes: int | None
+) -> Iterator[None]:
+    """
+    Give the session a real capture FIFO and a reader holding the given amounts.
+
+    A real pipe is used so the byte count comes from the same ioctl the backend
+    relies on. Pass ``reader_bytes=None`` for a reader whose buffer cannot be read.
+    """
+    read_fd, write_fd = os.pipe()
+    try:
+        if fifo_bytes:
+            os.write(write_fd, bytes(fifo_bytes))
+        pipe = MagicMock()
+        pipe.fileno.return_value = read_fd
+        transport = MagicMock()
+        transport.get_extra_info.return_value = pipe
+        session._transport = transport
+        reader = MagicMock(spec=[]) if reader_bytes is None else MagicMock()
+        if reader_bytes is not None:
+            reader._buffer = bytearray(reader_bytes)
+        session._reader = reader
+        yield
+    finally:
+        session._transport = None
+        session._reader = None
+        os.close(read_fd)
+        os.close(write_fd)
 
 
 def _make_provider(tmp_path: Path, setup_data: dict[str, Any] | None = None) -> SpotifyProvider:


### PR DESCRIPTION
# What does this implement/fix?

Skipping to the next track, while Spotify plays through Spotify's own playback engine, started the new track with up to half a second of the track you had just skipped away from.

Music Assistant reads the engine's audio through a capture pipe. When it asks the engine to jump, the engine confirms within about ten milliseconds — but the audio it had already produced is still travelling through that pipe, so the tail of the old track ended up at the head of the new one. Music Assistant now measures how much audio is still in flight at the moment of the jump and drops exactly that much, so the new track starts on its own first note.

Changes:

- Measure the audio still held between the capture sink and the reader when the engine confirms a skip, and drop that, instead of trusting the confirmation to arrive before the audio does. The amount is measured per skip because it varies (383–627 ms across a test run), so no fixed value fits.
- Free a track's leftover audio once its stream is gone, so what a skip abandons stops counting against the session's buffer limit for the rest of the session.
- Tests for both, driving a real pipe so the measurement itself is exercised.

**Related issue (if applicable):**

- none; found while testing #5918

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
