### PR TITLE
Report what a music service did to the audio per queue and per track boundary

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -370,7 +370,9 @@ class StreamsController(CoreController):
         # plugin providers serve playable items too, and only a music provider
         # declares this (a plugin's live audio is handled by the media type)
         provider = self.mass.get_provider(streamdetails.provider)
-        return isinstance(provider, MusicProvider) and provider.delivers_normalized_audio
+        return isinstance(provider, MusicProvider) and provider.delivers_normalized_audio(
+            streamdetails
+        )
 
     def get_source_crossfade_mode(self, queue: PlayerQueue, queue_item: QueueItem) -> CrossfadeMode:
         """
@@ -378,9 +380,12 @@ class StreamsController(CoreController):
 
         A source that crossfades its own playback is handed the queue's crossfade
         setting instead of Music Assistant mixing the overlap. This only answers for
-        audio we do not mix ourselves, and the same two limits apply as to a fade of
-        our own: only tracks are faded, and an item needs a boundary the same source
-        owns both sides of.
+        audio we do not mix ourselves, and only for tracks - the same limit as applies
+        to a fade of our own.
+
+        A source already serving this item's queue answers for the item's own
+        boundaries. Before it does, the answer can only be the setting it will be
+        handed together with a boundary it would own both sides of.
 
         :param queue: Queue the item is played from.
         :param queue_item: Queue item to report the fade for.
@@ -393,16 +398,13 @@ class StreamsController(CoreController):
         provider = self.mass.get_provider(queue_item.streamdetails.provider)
         if not isinstance(provider, MusicProvider):
             return CrossfadeMode.DISABLED
-        source_fades = provider.delivers_crossfaded_audio
+        source_fades = provider.delivers_crossfaded_audio(queue_item.streamdetails)
         if source_fades is None:
-            # nothing is playing from this source yet, so the setting it would be
-            # handed when it starts is the only thing to go on
-            source_fades = self.get_crossfade_mode(queue) != CrossfadeMode.DISABLED
-        if not source_fades:
-            return CrossfadeMode.DISABLED
-        if not self._source_fades_an_adjacent_item(queue, queue_item):
-            return CrossfadeMode.DISABLED
-        return CrossfadeMode.SOURCE
+            # the source is not serving this queue yet, so the setting it will be
+            # handed and a boundary it would own are all there is to go on
+            queue_fades = self.get_crossfade_mode(queue) != CrossfadeMode.DISABLED
+            source_fades = queue_fades and self._source_fades_an_adjacent_item(queue, queue_item)
+        return CrossfadeMode.SOURCE if source_fades else CrossfadeMode.DISABLED
 
     def is_smart_fades_active(self, queue: PlayerQueue) -> bool:
         """Return whether the queue's effective crossfade mode is smart crossfade."""
@@ -1979,10 +1981,11 @@ class StreamsController(CoreController):
         """
         Return whether the same source serves an item next to this one.
 
-        A source can only fade across a boundary it owns both sides of: with anything
-        else next to this item it plays the item out and the cut is a hard one. Both
-        neighbours count, the same way one of our own fades credits both of its sides -
-        the last track of a queue is still the side that was faded into.
+        Stands in for a source that is not serving this queue yet and so cannot answer
+        for the item itself: a source can only fade across a boundary it owns both
+        sides of, which makes this a necessary condition rather than proof of a fade.
+        Both neighbours count, the same way one of our own fades credits both of its
+        sides - the last track of a queue is still the side that was faded into.
 
         :param queue: Queue the item is played from.
         :param queue_item: Queue item whose neighbours to check.

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -181,8 +181,7 @@ class MusicProvider(Provider):
             else None
         )
 
-    @property
-    def delivers_normalized_audio(self) -> bool:
+    def delivers_normalized_audio(self, streamdetails: StreamDetails) -> bool:
         """
         Return whether this provider hands over audio it has already normalized.
 
@@ -190,19 +189,26 @@ class MusicProvider(Provider):
         Assistant leaves the level alone instead of measuring and correcting it
         a second time. Only say so when the audio really is normalized on the
         way out: nothing downstream double-checks it.
+
+        :param streamdetails: Stream details of the item being asked about. A
+            provider that normalizes per playback session answers for the queue
+            these details belong to, not for whatever it happens to serve
+            elsewhere.
         """
         return False
 
-    @property
-    def delivers_crossfaded_audio(self) -> bool | None:
+    def delivers_crossfaded_audio(self, streamdetails: StreamDetails) -> bool | None:
         """
         Return whether this provider crossfades the playback it is serving.
 
-        True means the source applies the overlap between consecutive items itself,
+        True means the source applies the overlap at a boundary of this item itself,
         so Music Assistant hands its crossfade setting over instead of mixing one.
-        None means the provider is not serving anything yet and the queue's own
-        setting answers instead. Only say True when the source really does fade:
-        nothing downstream verifies it.
+        None means the provider is not serving this item's queue yet, in which case
+        the queue's own setting answers instead. Only say True when the source really
+        does fade this item: nothing downstream verifies it.
+
+        :param streamdetails: Stream details of the item being asked about, whose
+            boundaries the answer is about.
         """
         return False
 

--- a/music_assistant/providers/spotify/README.md
+++ b/music_assistant/providers/spotify/README.md
@@ -112,8 +112,11 @@ audio prefs, wire models) is shared infrastructure owned by the Spotify Connect 
   before every spawn. Its unit is milliseconds and sub-second values silently disable
   crossfade, which the seconds-based queue setting can never produce. Changing the
   setting mid-playback takes effect on the next playback, which is also why
-  `delivers_crossfaded_audio` reports the running session's captured value rather
-  than the current setting.
+  `delivers_crossfaded_audio(streamdetails)` reports the captured value of the session
+  serving *that item's* queue rather than the current setting. It answers per boundary:
+  a fade is only reported where the engine plays across the cut, so an item the session
+  was jumped to, one it was handed but has not reached, and the item a fresh session
+  starts on are all reported as hard cuts.
 - **Pacing**: the capture FIFO is reader-clocked — how fast it is read *is* how fast
   the engine plays, because the pipe sink applies no rate limit of its own (read
   unpaced, PulseAudio renders silence rather than pushing back, and the session runs
@@ -144,10 +147,12 @@ audio prefs, wire models) is shared infrastructure owned by the Spotify Connect 
   Exit code 10 (expired build) triggers a forced binary refresh.
 - **Normalization**: exactly one of the two normalizes, and a provider option decides
   which. On (the default) the engine's own normalizer is enabled and the provider
-  declares `delivers_normalized_audio`, which makes the streams core skip normalization
-  for these items — Spotify uses values computed over its whole catalogue and will not
-  push a quiet track past its remaining headroom, and MA correcting that again would be
-  normalizing twice, the second time against a measurement of Spotify's own output.
+  declares `delivers_normalized_audio(streamdetails)` for the queue that session serves,
+  which makes the streams core skip normalization for those items — another queue gets
+  the configured answer instead, since the running session says nothing about it.
+  Spotify uses values computed over its whole catalogue and will not push a quiet track
+  past its remaining headroom, and MA correcting that again would be normalizing twice,
+  the second time against a measurement of Spotify's own output.
   Skipping also means the loudness analyzer declines the stream, so no measurement is
   stored: a value measured on one backend's output can never be applied to the other's,
   with no erase step needed. Off, `audio.normalize_v2=false` is written and MA measures

--- a/music_assistant/providers/spotify/README.md
+++ b/music_assistant/providers/spotify/README.md
@@ -114,9 +114,11 @@ audio prefs, wire models) is shared infrastructure owned by the Spotify Connect 
   setting mid-playback takes effect on the next playback, which is also why
   `delivers_crossfaded_audio(streamdetails)` reports the captured value of the session
   serving *that item's* queue rather than the current setting. It answers per boundary:
-  a fade is only reported where the engine plays across the cut, so an item the session
-  was jumped to, one it was handed but has not reached, and the item a fresh session
-  starts on are all reported as hard cuts.
+  a fade is only reported where the engine plays across the cut. Nothing is faded *into*
+  the item a session starts on, one it was jumped to, or one it was handed but has not
+  reached; those are credited only if the engine plays on out of them. Likewise nothing
+  is faded out of an item whose follower this session can no longer serve — a drained
+  channel or a repeat starts a fresh session, so that boundary is a hard cut.
 - **Pacing**: the capture FIFO is reader-clocked — how fast it is read *is* how fast
   the engine plays, because the pipe sink applies no rate limit of its own (read
   unpaced, PulseAudio renders silence rather than pushing back, and the session runs

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -935,11 +935,14 @@ class _SoloistSession:
         if self.crossfade_ms == 0 or streamdetails.media_type != MediaType.TRACK:
             return False
         uri = f"spotify:track:{streamdetails.item_id}"
-        if (item := self._items.get(uri)) is not None:
-            if uri in self._pending:
-                # the engine has not played on to this item, so it is reached by a
-                # jump - which drops the overlap already rendered for it
-                return False
+        if uri in self._pending:
+            # the engine has not played on to this item, so it is reached by a jump -
+            # which drops the overlap already rendered for it
+            return False
+        # Channels are keyed by track, so an entry left from an earlier play of the
+        # same one says nothing about this play: only the channel the engine is on
+        # can answer for its own boundaries.
+        if (item := self._items.get(uri)) is not None and item is self._current:
             if item.faded_in:
                 return True
             if item.fades_out is not None:

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -946,7 +946,10 @@ class _SoloistSession:
                 return item.fades_out
         # what happens at this item's end is not settled yet, so the follower the
         # engine would be fed is what the boundary rests on
-        return self._feedable_follower_uri(streamdetails) is not None
+        next_uri = self._feedable_follower_uri(streamdetails)
+        if next_uri is None:
+            return False
+        return next_uri not in self._items or self._engine_plays_on_into(next_uri, uri)
 
     async def validate_item(self, item: _ItemAudio) -> None:
         """
@@ -1116,9 +1119,9 @@ class _SoloistSession:
         if next_uri is None:
             return False
         if next_uri in self._items:
-            # already fed, unless the follower is the item being streamed itself: a
-            # repeat starts a fresh session rather than replaying a drained channel
-            return next_uri != spotify_uri
+            # nothing left to send, so whether the engine plays on rests entirely on
+            # the channel this session already holds for it
+            return self._engine_plays_on_into(next_uri, spotify_uri)
         # Registered before the command goes out: the engine can reach the item
         # while it is still in flight, and the events task has to find its
         # channel rather than mistake it for something nobody asked for.
@@ -1137,6 +1140,21 @@ class _SoloistSession:
             return False
         self.logger.debug("Fed %s to the soloist session", next_uri)
         return True
+
+    def _engine_plays_on_into(self, next_uri: str, streamed_uri: str) -> bool:
+        """
+        Return whether the engine plays on into a follower this session already holds.
+
+        Only a channel that can still be served across the boundary is played on into:
+        a drained one cannot be replayed, and neither can the item being streamed
+        itself, so both start a fresh session instead.
+
+        :param next_uri: URI of the follower.
+        :param streamed_uri: URI of the item being streamed.
+        """
+        if next_uri == streamed_uri:
+            return False
+        return self.pending_item(next_uri) is not None or self.item_for(next_uri) is not None
 
     def _feedable_follower_uri(self, streamdetails: StreamDetails) -> str | None:
         """

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -1136,10 +1136,13 @@ class _SoloistSession:
             # a failed feed only costs the crossfade at that boundary: the next
             # item still plays, on a fresh session
             self.logger.debug("Unable to feed %s to the soloist session: %s", next_uri, err)
-            if self._current is not item:
-                del self._items[next_uri]
-                with suppress(ValueError):
-                    self._pending.remove(next_uri)
+            if self._current is item:
+                # the engine acted on the command before the failure got back to
+                # us, so it does play on into this item after all
+                return True
+            del self._items[next_uri]
+            with suppress(ValueError):
+                self._pending.remove(next_uri)
             return False
         self.logger.debug("Fed %s to the soloist session", next_uri)
         return True

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -344,27 +344,29 @@ class SoloistBackend(SpotifyPlaybackBackend):
         """Soloist delivers at playback pace (~1.1x ceiling): no read-ahead."""
         return True
 
-    @property
-    def session_normalizes(self) -> bool | None:
+    def session_normalizes(self, streamdetails: StreamDetails) -> bool | None:
         """
-        Return whether the running session's engine is normalizing, if there is one.
+        Return whether the session serving this item's queue is normalizing.
 
-        None when nothing is playing yet, in which case the configuration is the
-        only thing to go on.
-        """
-        session = self._session
-        return session.engine_normalizes if session is not None and session.usable else None
+        None when no session serves that queue, in which case the configuration is
+        the only thing to go on.
 
-    @property
-    def session_crossfades(self) -> bool | None:
+        :param streamdetails: Stream details of the item being asked about.
         """
-        Return whether the running session's engine is crossfading, if there is one.
+        session = self._session_for(streamdetails)
+        return session.engine_normalizes if session is not None else None
 
-        None when nothing is playing yet, in which case the configuration is the
-        only thing to go on.
+    def session_crossfades(self, streamdetails: StreamDetails) -> bool | None:
         """
-        session = self._session
-        return session.crossfade_ms > 0 if session is not None and session.usable else None
+        Return whether the session serving this item's queue fades one of its boundaries.
+
+        None when no session serves that queue, in which case the queue's own setting
+        is the only thing to go on.
+
+        :param streamdetails: Stream details of the item being asked about.
+        """
+        session = self._session_for(streamdetails)
+        return session.fades_a_boundary_of(streamdetails) if session is not None else None
 
     async def setup(self) -> None:
         """
@@ -506,6 +508,20 @@ class SoloistBackend(SpotifyPlaybackBackend):
         return "".join(
             ch if ch.isalnum() or ch in "_.-" else "_" for ch in self.provider.instance_id
         )
+
+    def _session_for(self, streamdetails: StreamDetails) -> _SoloistSession | None:
+        """
+        Return the session serving this item's queue, if one can still serve it.
+
+        A session serves one queue: another queue's session says nothing about
+        this item, however much it knows about its own.
+
+        :param streamdetails: Stream details of the item being asked about.
+        """
+        session = self._session
+        if session is None or not session.usable or session.queue_id != streamdetails.queue_id:
+            return None
+        return session
 
     async def _acquire(
         self, spotify_uri: str, seek_position: int, queue_id: str | None
@@ -894,45 +910,43 @@ class _SoloistSession:
 
         Only consecutive tracks are stitched: the engine's queue command takes
         track URIs, and a podcast episode or audiobook chapter gains nothing
-        from a crossfade anyway.
+        from a crossfade anyway. Whether the feed landed also settles what
+        happens at the streamed item's end, which ``fades_a_boundary_of`` reports.
 
         :param streamdetails: The StreamDetails of the item being streamed, used
             to locate it in the queue.
         :param spotify_uri: The URI being streamed (only tracks are fed ahead).
         """
-        client = self._client
-        if client is None or not spotify_uri.startswith("spotify:track:"):
-            return
-        follower = self._follower(streamdetails)
-        if follower is None:
-            return
-        next_uri = self._track_uri(follower)
-        if next_uri is None or next_uri in self._items:
-            return
-        if (
-            follower_details := follower.streamdetails
-        ) is not None and follower_details.provider != self.backend.provider.instance_id:
-            # the queue has already resolved this item to another provider, so
-            # feeding it here would have the engine play audio nobody reads -
-            # and cut the current item short when it starts
-            return
-        # Registered before the command goes out: the engine can reach the item
-        # while it is still in flight, and the events task has to find its
-        # channel rather than mistake it for something nobody asked for.
-        item = self._items[next_uri] = _ItemAudio(next_uri, self)
-        self._pending.append(next_uri)
-        try:
-            await client.add_to_queue(next_uri)
-        except (TimeoutError, OSError, ClientError, SoloistError) as err:
-            # a failed feed only costs the crossfade at that boundary: the next
-            # item still plays, on a fresh session
-            self.logger.debug("Unable to feed %s to the soloist session: %s", next_uri, err)
-            if self._current is not item:
-                del self._items[next_uri]
-                with suppress(ValueError):
-                    self._pending.remove(next_uri)
-            return
-        self.logger.debug("Fed %s to the soloist session", next_uri)
+        plays_on = await self._feed_follower(streamdetails, spotify_uri)
+        if (item := self._items.get(spotify_uri)) is not None:
+            item.fades_out = plays_on and self.crossfade_ms > 0
+
+    def fades_a_boundary_of(self, streamdetails: StreamDetails) -> bool:
+        """
+        Return whether this session fades one of an item's two boundaries.
+
+        Either side counts: an item's audio carries the overlap whether it was faded
+        into or out of. The engine has to play across the cut for that overlap to
+        exist, so nothing is faded into the item a session starts on, nor into one
+        the engine is jumped to.
+
+        :param streamdetails: Stream details of the item whose boundaries to report.
+        """
+        if self.crossfade_ms == 0 or streamdetails.media_type != MediaType.TRACK:
+            return False
+        uri = f"spotify:track:{streamdetails.item_id}"
+        if (item := self._items.get(uri)) is not None:
+            if uri in self._pending:
+                # the engine has not played on to this item, so it is reached by a
+                # jump - which drops the overlap already rendered for it
+                return False
+            if item.faded_in:
+                return True
+            if item.fades_out is not None:
+                return item.fades_out
+        # what happens at this item's end is not settled yet, so the follower the
+        # engine would be fed is what the boundary rests on
+        return self._feedable_follower_uri(streamdetails) is not None
 
     async def validate_item(self, item: _ItemAudio) -> None:
         """
@@ -1087,6 +1101,63 @@ class _SoloistSession:
             )
             != CONF_VALUE_DISABLED
         )
+
+    async def _feed_follower(self, streamdetails: StreamDetails, spotify_uri: str) -> bool:
+        """
+        Feed the engine the track after this one, and report whether it will play on into it.
+
+        :param streamdetails: The StreamDetails of the item being streamed.
+        :param spotify_uri: The URI being streamed (only tracks are fed ahead).
+        """
+        client = self._client
+        if client is None or not spotify_uri.startswith("spotify:track:"):
+            return False
+        next_uri = self._feedable_follower_uri(streamdetails)
+        if next_uri is None:
+            return False
+        if next_uri in self._items:
+            # already fed, unless the follower is the item being streamed itself: a
+            # repeat starts a fresh session rather than replaying a drained channel
+            return next_uri != spotify_uri
+        # Registered before the command goes out: the engine can reach the item
+        # while it is still in flight, and the events task has to find its
+        # channel rather than mistake it for something nobody asked for.
+        item = self._items[next_uri] = _ItemAudio(next_uri, self)
+        self._pending.append(next_uri)
+        try:
+            await client.add_to_queue(next_uri)
+        except (TimeoutError, OSError, ClientError, SoloistError) as err:
+            # a failed feed only costs the crossfade at that boundary: the next
+            # item still plays, on a fresh session
+            self.logger.debug("Unable to feed %s to the soloist session: %s", next_uri, err)
+            if self._current is not item:
+                del self._items[next_uri]
+                with suppress(ValueError):
+                    self._pending.remove(next_uri)
+            return False
+        self.logger.debug("Fed %s to the soloist session", next_uri)
+        return True
+
+    def _feedable_follower_uri(self, streamdetails: StreamDetails) -> str | None:
+        """
+        Return the URI of the track after this one, when the engine can be fed it.
+
+        :param streamdetails: The StreamDetails of the item being streamed.
+        """
+        follower = self._follower(streamdetails)
+        if follower is None:
+            return None
+        next_uri = self._track_uri(follower)
+        if next_uri is None:
+            return None
+        if (
+            follower_details := follower.streamdetails
+        ) is not None and follower_details.provider != self.backend.provider.instance_id:
+            # the queue has already resolved this item to another provider, so
+            # feeding it here would have the engine play audio nobody reads -
+            # and cut the current item short when it starts
+            return None
+        return next_uri
 
     def _follower(self, streamdetails: StreamDetails) -> QueueItem | None:
         """Return the queue item that follows the one these StreamDetails belong to."""
@@ -1637,6 +1708,7 @@ class _SoloistSession:
             item.spent = True
         if duration_ms:
             item.duration_ms = duration_ms
+        was_fed = uri in self._pending
         with suppress(ValueError):
             self._pending.remove(uri)
         self._current = item
@@ -1650,6 +1722,10 @@ class _SoloistSession:
             # is still on its way here and belongs to the item being left
             # behind - drop that, so it cannot open this one.
             self._stale_budget = self._stale_bytes()
+        elif was_fed and self.crossfade_ms > 0:
+            # reached by the engine playing on rather than by a jump, so this
+            # channel opens inside the overlap with the item before it
+            item.faded_in = True
         item.started.set()
         if current is not None and current.started.is_set():
             # Only an item that was actually playing has a boundary to cut at.
@@ -1811,6 +1887,12 @@ class _ItemAudio:
         self.claimed = False
         # served once already: its audio was handed over and cannot be replayed
         self.spent = False
+        # the engine played on into this channel, so its audio opens inside the
+        # overlap with the item before it
+        self.faded_in = False
+        # whether the engine plays on into another item at this one's end; None
+        # until the feed that decides it has been attempted
+        self.fades_out: bool | None = None
         self.drain_task: asyncio.Task[None] | None = None
         self._last_write = 0.0
         self._chunks: deque[bytes] = deque()

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -242,35 +242,37 @@ class SpotifyProvider(MusicProvider):
             self.config.get_value(CONF_SPOTIFY_NORMALIZATION, True)
         )
 
-    @property
-    def delivers_normalized_audio(self) -> bool:
+    def delivers_normalized_audio(self, streamdetails: StreamDetails) -> bool:
         """
         Return whether Spotify's own loudness normalization handles this audio.
 
-        A running session answers for itself. The engine reads its settings only
-        at startup, so a setting changed mid-playback must not make the streams
-        core normalize on top of what the engine is still doing - it takes effect
-        on the next playback instead.
+        The session serving this item's queue answers for itself. The engine reads
+        its settings only at startup, so a setting changed mid-playback must not make
+        the streams core normalize on top of what the engine is still doing - it
+        takes effect on the next playback instead.
+
+        :param streamdetails: Stream details of the item being asked about.
         """
         backend = self._soloist_backend
-        if backend is not None and (live := backend.session_normalizes) is not None:
+        if backend is not None and (live := backend.session_normalizes(streamdetails)) is not None:
             return live
         return self.spotify_normalization_configured
 
-    @property
-    def delivers_crossfaded_audio(self) -> bool | None:
+    def delivers_crossfaded_audio(self, streamdetails: StreamDetails) -> bool | None:
         """
         Return whether Spotify's own engine crossfades this playback.
 
         Only the soloist backend can: it keeps one session across items and is handed
         the queue's crossfade duration when that session starts, so the overlap lives
-        in the audio it delivers. librespot fetches every track on its own. A running
-        session answers for itself, because it read that duration once - a setting
-        changed mid-playback applies to the next session, not to the audio this one
-        is still serving.
+        in the audio it delivers. librespot fetches every track on its own. The session
+        serving this item's queue answers for the item's own boundaries, because it read
+        that duration once - a setting changed mid-playback applies to the next session,
+        not to the audio this one is still serving.
+
+        :param streamdetails: Stream details of the item being asked about.
         """
         backend = self._soloist_backend
-        return backend.session_crossfades if backend is not None else False
+        return backend.session_crossfades(streamdetails) if backend is not None else False
 
     @property
     def max_concurrent_streams(self) -> int:

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -1207,19 +1207,25 @@ async def test_single_item_handler_keeps_crossfade_for_a_buffered_item() -> None
 
 
 class _CrossfadingProvider(MusicProvider):
-    """A music provider whose running source crossfades its own playback."""
+    """A music provider whose running source crossfades this item's boundary."""
 
-    @property
-    def delivers_crossfaded_audio(self) -> bool | None:
+    def delivers_crossfaded_audio(self, streamdetails: StreamDetails) -> bool | None:
         """Declare the source fade."""
         return True
+
+
+class _NonCrossfadingServingProvider(MusicProvider):
+    """A music provider serving this item, whose session fades neither of its boundaries."""
+
+    def delivers_crossfaded_audio(self, streamdetails: StreamDetails) -> bool | None:
+        """Deny the source fade for this item."""
+        return False
 
 
 class _UndecidedCrossfadingProvider(MusicProvider):
     """A music provider that can crossfade its own playback but serves nothing yet."""
 
-    @property
-    def delivers_crossfaded_audio(self) -> bool | None:
+    def delivers_crossfaded_audio(self, streamdetails: StreamDetails) -> bool | None:
         """Leave the answer to the queue's own setting."""
         return None
 
@@ -1301,18 +1307,19 @@ def test_no_source_fade_for_audio_we_mix_ourselves(
     ],
 )
 @pytest.mark.parametrize("side", ["follower", "predecessor"])
-def test_a_source_fade_needs_a_boundary_the_source_owns(
+def test_an_undecided_source_needs_a_boundary_it_would_own(
     neighbour_kind: str, side: str, expected: CrossfadeMode
 ) -> None:
     """
-    Only a boundary between two items of the same source is credited with its fade.
+    A source that is not serving this queue yet is credited only where it could fade.
 
-    Either side counts: the last track of a queue has no follower but was still the
-    side faded into. Reporting one anywhere else would describe an overlap nobody
-    rendered - we do not mix a realtime item's boundaries either, so it is a hard cut.
+    It cannot answer for the item, so the boundary stands in: either side counts,
+    the same way one of our own fades credits both of its sides. Reporting a fade
+    anywhere else would describe an overlap nobody rendered - we do not mix a
+    realtime item's boundaries either, so it is a hard cut.
     """
     controller = _source_crossfade_controller(
-        object.__new__(_CrossfadingProvider), CrossfadeMode.SMART_CROSSFADE
+        object.__new__(_UndecidedCrossfadingProvider), CrossfadeMode.SMART_CROSSFADE
     )
     queues = controller.mass.player_queues
     neighbour = _follower(neighbour_kind)
@@ -1329,6 +1336,35 @@ def test_a_source_fade_needs_a_boundary_the_source_owns(
     )
 
     assert controller.get_source_crossfade_mode(MagicMock(), queue_item) == expected
+
+
+@pytest.mark.parametrize(
+    ("provider", "neighbour_kind", "expected"),
+    [
+        # the source says it fades this item, so its own boundary answer stands even
+        # where the queue offers nothing to fade against
+        (_CrossfadingProvider, "none", CrossfadeMode.SOURCE),
+        # and it says it does not, so the neighbour it happens to own is not credited:
+        # a list predecessor that never played is exactly this case
+        (_NonCrossfadingServingProvider, "same-provider", CrossfadeMode.DISABLED),
+    ],
+)
+def test_a_serving_source_is_not_second_guessed_by_the_queue(
+    provider: type[MusicProvider], neighbour_kind: str, expected: CrossfadeMode
+) -> None:
+    """
+    A source already serving the item answers for its boundaries, and that answer stands.
+
+    It knows what it fed and what it played across; the neighbour check is only a
+    necessary condition, so applying it on top would both deny fades that happened
+    and credit ones that did not.
+    """
+    controller = _source_crossfade_controller(
+        object.__new__(provider), CrossfadeMode.SMART_CROSSFADE
+    )
+    controller.mass.player_queues.get_next_item.return_value = _follower(neighbour_kind)
+
+    assert controller.get_source_crossfade_mode(MagicMock(), _realtime_track()) == expected
 
 
 def test_the_raw_pcm_path_reports_a_source_fade_too() -> None:
@@ -1382,7 +1418,12 @@ def test_the_raw_pcm_path_reports_a_source_fade_too() -> None:
 
 def test_a_music_provider_declares_no_source_fade_by_default() -> None:
     """The declaration is opt-in: nothing downstream verifies it."""
-    assert object.__new__(MusicProvider).delivers_crossfaded_audio is False
+    assert (
+        object.__new__(MusicProvider).delivers_crossfaded_audio(
+            _make_stream_details(MediaType.TRACK, is_realtime=True)
+        )
+        is False
+    )
 
 
 def _source_crossfade_controller(provider: Any, queue_crossfade_mode: CrossfadeMode) -> Any:

--- a/tests/controllers/streams/test_source_normalized.py
+++ b/tests/controllers/streams/test_source_normalized.py
@@ -38,8 +38,7 @@ from music_assistant.models.music_provider import MusicProvider
 class _NormalizingProvider(MusicProvider):
     """A music provider that hands over audio it already levelled."""
 
-    @property
-    def delivers_normalized_audio(self) -> bool:
+    def delivers_normalized_audio(self, streamdetails: StreamDetails) -> bool:
         """Declare the source normalization."""
         return True
 
@@ -107,7 +106,7 @@ def test_the_queue_setting_still_wins() -> None:
 
 def test_a_music_provider_declares_nothing_by_default() -> None:
     """The declaration is opt-in: nothing downstream verifies it."""
-    assert object.__new__(MusicProvider).delivers_normalized_audio is False
+    assert object.__new__(MusicProvider).delivers_normalized_audio(_streamdetails()) is False
 
 
 @pytest.mark.parametrize("mode", [VolumeNormalizationMode.DISABLED, VolumeNormalizationMode.SOURCE])

--- a/tests/providers/spotify/test_backends.py
+++ b/tests/providers/spotify/test_backends.py
@@ -14,6 +14,8 @@ from unittest.mock import MagicMock
 
 import pytest
 from music_assistant_models.enums import ContentType, MediaType
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.providers.spotify.backends.librespot import LibrespotBackend
 from music_assistant.providers.spotify.backends.soloist import SoloistBackend
@@ -91,10 +93,10 @@ def test_only_the_soloist_backend_declares_normalized_audio() -> None:
     prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
     cast("MagicMock", prov.config).get_value = MagicMock(return_value=True)
     prov.backend = SoloistBackend(prov)
-    assert prov.delivers_normalized_audio is True
+    assert prov.delivers_normalized_audio(_streamdetails()) is True
     # the same setting on librespot declares nothing: its audio is the raw master
     prov.backend = LibrespotBackend(prov)
-    assert prov.delivers_normalized_audio is False
+    assert prov.delivers_normalized_audio(_streamdetails()) is False
 
 
 def test_only_the_soloist_backend_can_declare_crossfaded_audio() -> None:
@@ -106,14 +108,14 @@ def test_only_the_soloist_backend_can_declare_crossfaded_audio() -> None:
     """
     prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
     prov.backend = SoloistBackend(prov)
-    assert prov.delivers_crossfaded_audio is None
+    assert prov.delivers_crossfaded_audio(_streamdetails()) is None
     prov.backend = LibrespotBackend(prov)
-    assert prov.delivers_crossfaded_audio is False
+    assert prov.delivers_crossfaded_audio(_streamdetails()) is False
 
 
-@pytest.mark.parametrize(("crossfade_ms", "expected"), [(8000, True), (0, False)])
-def test_a_running_session_reports_the_crossfade_it_was_started_with(
-    crossfade_ms: int, expected: bool
+@pytest.mark.parametrize("expected", [True, False])
+def test_a_running_session_answers_for_the_boundary_it_is_asked_about(
+    expected: bool,
 ) -> None:
     """
     The engine reads the crossfade once, at spawn, so the session answers for itself.
@@ -124,13 +126,34 @@ def test_a_running_session_reports_the_crossfade_it_was_started_with(
     prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
     backend = SoloistBackend(prov)
     prov.backend = backend
-    session = MagicMock()
-    session.usable = True
-    session.crossfade_ms = crossfade_ms
-    backend._session = session
+    streamdetails = _streamdetails(queue_id="queue-1")
+    backend._session = _session(queue_id="queue-1", fades=expected)
 
-    assert backend.session_crossfades is expected
-    assert prov.delivers_crossfaded_audio is expected
+    assert backend.session_crossfades(streamdetails) is expected
+    assert prov.delivers_crossfaded_audio(streamdetails) is expected
+
+
+@pytest.mark.parametrize("normalizes", [True, False])
+def test_another_queues_session_answers_for_neither_hook(normalizes: bool) -> None:
+    """
+    A session serves one queue, so it says nothing about an item played on another.
+
+    Reading it anyway would hand the asking queue the other one's answers: MA
+    normalization applied on top of the engine's, or skipped when nobody applies it.
+    """
+    prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
+    cast("MagicMock", prov.config).get_value = MagicMock(return_value=normalizes)
+    backend = SoloistBackend(prov)
+    prov.backend = backend
+    backend._session = _session(queue_id="queue-1", fades=True, normalizes=not normalizes)
+    other_queue = _streamdetails(queue_id="queue-2")
+
+    assert backend.session_normalizes(other_queue) is None
+    assert backend.session_crossfades(other_queue) is None
+    # so the configuration answers for normalization, and the queue's own setting
+    # (resolved by the streams core) for the crossfade
+    assert prov.delivers_normalized_audio(other_queue) is normalizes
+    assert prov.delivers_crossfaded_audio(other_queue) is None
 
 
 def test_turning_spotify_normalization_off_hands_it_back_to_ma() -> None:
@@ -138,7 +161,7 @@ def test_turning_spotify_normalization_off_hands_it_back_to_ma() -> None:
     prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
     cast("MagicMock", prov.config).get_value = MagicMock(return_value=False)
     prov.backend = SoloistBackend(prov)
-    assert prov.delivers_normalized_audio is False
+    assert prov.delivers_normalized_audio(_streamdetails()) is False
 
 
 @pytest.mark.parametrize("normalize", [True, False])
@@ -235,6 +258,27 @@ async def test_librespot_seek_adds_start_position(
         pass
     args = captured[0]
     assert args[args.index("--start-position") + 1] == "42"
+
+
+def _streamdetails(*, queue_id: str | None = None, item_id: str = "track-1") -> StreamDetails:
+    """Return minimal stream details for the source-treatment hooks to answer about."""
+    return StreamDetails(
+        provider="spotify--test",
+        item_id=item_id,
+        audio_format=AudioFormat(content_type=ContentType.PCM_S16LE),
+        media_type=MediaType.TRACK,
+        queue_id=queue_id,
+    )
+
+
+def _session(*, queue_id: str, fades: bool, normalizes: bool = True) -> MagicMock:
+    """Return a stand-in for a running soloist session serving one queue."""
+    session = MagicMock()
+    session.usable = True
+    session.queue_id = queue_id
+    session.engine_normalizes = normalizes
+    session.fades_a_boundary_of = MagicMock(return_value=fades)
+    return session
 
 
 def _make_provider(setup_data: dict[str, Any]) -> SpotifyProvider:

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -1516,6 +1516,39 @@ async def test_a_jumped_to_item_opens_on_a_hard_cut(tmp_path: Path) -> None:
     assert session.fades_a_boundary_of(_streamdetails_for(uri=TRACK_B)) is False
 
 
+async def test_a_feed_the_engine_acted_on_before_failing_still_fades(tmp_path: Path) -> None:
+    """
+    The engine can reach a fed item and the command still fail on the way back.
+
+    The channel is kept for it in that case, because the reader is already writing
+    there - so the boundary was played across and denying the fade would describe a
+    cut the engine never made.
+    """
+    session = _make_session(tmp_path, queue_id="player1")
+    session.crossfade_ms = 8000
+    streamdetails = _streamdetails_for(uri=TRACK_A)
+    playing = _queue_item(TRACK_A, streamdetails=streamdetails)
+    streamed = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    streamed.started.set()
+    session._current = streamed
+    queues = _queues_of(session)
+    queues.get.return_value = MagicMock(current_index=0)
+    queues.get_item.side_effect = lambda _queue_id, index: playing if index == 0 else None
+    queues.get_next_item.return_value = _queue_item(TRACK_B)
+
+    async def _reached_then_failed(_uri: str, **_kwargs: Any) -> None:
+        await session._observe_current(TRACK_B, 200_000)
+        raise TimeoutError
+
+    _client_of(session).add_to_queue.side_effect = _reached_then_failed
+
+    await session.feed_after(streamdetails, TRACK_A)
+
+    # the channel survived because the engine is playing it, so the fade is real
+    assert session._items[TRACK_B].faded_in is True
+    assert streamed.fades_out is True
+
+
 async def test_an_item_only_fed_is_reached_by_a_jump(tmp_path: Path) -> None:
     """
     An item MA opens before the engine gets to it is jumped to, so no fade reaches it.

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -1516,6 +1516,74 @@ async def test_a_jumped_to_item_opens_on_a_hard_cut(tmp_path: Path) -> None:
     assert session.fades_a_boundary_of(_streamdetails_for(uri=TRACK_B)) is False
 
 
+async def test_an_item_only_fed_is_reached_by_a_jump(tmp_path: Path) -> None:
+    """
+    An item MA opens before the engine gets to it is jumped to, so no fade reaches it.
+
+    Its own follower would otherwise stand in and claim one, which is why being handed
+    over but not reached has to answer first.
+    """
+    session = _make_session(tmp_path, queue_id="player1")
+    session.crossfade_ms = 8000
+    streamdetails = _streamdetails_for(uri=TRACK_B)
+    playing = _queue_item(TRACK_B, streamdetails=streamdetails)
+    session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
+    session._pending.append(TRACK_B)
+    queues = _queues_of(session)
+    queues.get.return_value = MagicMock(current_index=1)
+    queues.get_item.side_effect = lambda _queue_id, index: playing if index == 1 else None
+    # a follower it could be fed, so only the pending state can produce the hard cut
+    queues.get_next_item.return_value = _queue_item(TRACK_A)
+
+    assert session.fades_a_boundary_of(streamdetails) is False
+
+
+async def test_an_item_the_engine_reached_unfed_carries_no_fade(tmp_path: Path) -> None:
+    """
+    Only an item handed to the engine can be played on into.
+
+    The engine also reports items nobody asked for - the session it restores at
+    startup, its own autoplay - and crediting those would claim an overlap that
+    was never rendered.
+    """
+    session = _make_session(tmp_path, queue_id="player1")
+    session.crossfade_ms = 8000
+
+    await session._observe_current("spotify:track:restored", 200_000)
+
+    assert session._items["spotify:track:restored"].faded_in is False
+
+
+async def test_an_earlier_play_of_a_track_does_not_answer_for_a_later_one(
+    tmp_path: Path,
+) -> None:
+    """
+    Channels are keyed by track, so a repeated one must not read the first play's fades.
+
+    In an A-B-A queue the first A faded out into B, but the last A plays on a fresh
+    session with nothing after it, so both of its boundaries are hard cuts.
+    """
+    session = _make_session(tmp_path, queue_id="player1")
+    session.crossfade_ms = 8000
+    first_a = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    first_a.started.set()
+    first_a.spent = True
+    first_a.fades_out = True
+    playing_b = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
+    playing_b.started.set()
+    playing_b.faded_in = True
+    session._current = playing_b
+    last_a = _streamdetails_for(uri=TRACK_A)
+    queues = _queues_of(session)
+    queues.get.return_value = MagicMock(current_index=2)
+    queues.get_item.side_effect = lambda _queue_id, index: (
+        _queue_item(TRACK_A, streamdetails=last_a) if index == 2 else None
+    )
+    queues.get_next_item.return_value = None
+
+    assert session.fades_a_boundary_of(last_a) is False
+
+
 async def test_a_fresh_sessions_first_item_rests_on_its_own_follower(tmp_path: Path) -> None:
     """
     Nothing was faded into the item a session starts on, so only its end can be faded.

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -1574,6 +1574,58 @@ async def test_feeding_the_follower_settles_the_boundary_at_the_items_end(
     assert session.fades_a_boundary_of(streamdetails) is expected
 
 
+@pytest.mark.parametrize(
+    ("follower_state", "expected"),
+    [
+        # handed over and waiting: the engine reaches it by playing on
+        ("pending", True),
+        # the engine is already there, ahead of the stream MA is still reading
+        ("current", True),
+        # served once already, so the next play of it starts a fresh session - an
+        # A-B-A queue reaches this after jumping to B
+        ("drained", False),
+    ],
+)
+async def test_a_follower_the_session_already_holds_decides_the_boundary(
+    tmp_path: Path, follower_state: str, expected: bool
+) -> None:
+    """
+    With nothing left to feed, the channel already there is what the boundary rests on.
+
+    A drained channel cannot be replayed, so crediting it would report an overlap the
+    engine never renders - and the answer has to be the same before and after the feed
+    that finds nothing to send.
+    """
+    session = _make_session(tmp_path, queue_id="player1")
+    session.crossfade_ms = 8000
+    streamdetails = _streamdetails_for(uri=TRACK_B)
+    playing = _queue_item(TRACK_B, streamdetails=streamdetails)
+    streamed = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
+    streamed.started.set()
+    session._current = streamed
+    follower = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    if follower_state == "pending":
+        session._pending.append(TRACK_A)
+    else:
+        follower.started.set()
+        if follower_state == "current":
+            session._current = follower
+        else:
+            follower.spent = True
+    queues = _queues_of(session)
+    queues.get.return_value = MagicMock(current_index=1)
+    queues.get_item.side_effect = lambda _queue_id, index: playing if index == 1 else None
+    queues.get_next_item.return_value = _queue_item(TRACK_A)
+
+    assert session.fades_a_boundary_of(streamdetails) is expected
+
+    await session.feed_after(streamdetails, TRACK_B)
+
+    _client_of(session).add_to_queue.assert_not_awaited()
+    assert streamed.fades_out is expected
+    assert session.fades_a_boundary_of(streamdetails) is expected
+
+
 async def test_only_a_track_can_carry_a_source_fade(tmp_path: Path) -> None:
     """A podcast episode is never stitched, so both of its boundaries are hard cuts."""
     session = _make_session(tmp_path, queue_id="player1")

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -21,8 +21,10 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import ContentType, MediaType
 from music_assistant_models.errors import AudioError, LoginFailed
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.helpers.pulse_capture import CAPTURE_SAMPLE_RATE
 from music_assistant.models.music_provider import ProviderStreamLimitError
@@ -1437,19 +1439,23 @@ def test_a_running_session_answers_for_what_the_engine_is_doing(tmp_path: Path) 
     """
     backend = _make_backend(tmp_path)
     provider = backend.provider
+    streamdetails = _streamdetails_for(queue_id="player1")
     # nothing playing yet: the configuration is all there is to go on
-    before_any_session = backend.session_normalizes
+    before_any_session = backend.session_normalizes(streamdetails)
     session = _SoloistSession(backend, "player1")
     session.engine_normalizes = True
     backend._session = session
-    while_playing = backend.session_normalizes
+    while_playing = backend.session_normalizes(streamdetails)
     # ... and a session that has been torn down no longer speaks for the engine
     session._stopped = True
-    after_teardown = backend.session_normalizes
+    after_teardown = backend.session_normalizes(streamdetails)
     assert before_any_session is None
     assert while_playing is True
     assert after_teardown is None
-    assert provider.delivers_normalized_audio is provider.spotify_normalization_configured
+    assert (
+        provider.delivers_normalized_audio(streamdetails)
+        is provider.spotify_normalization_configured
+    )
 
 
 def test_crossfade_comes_from_the_queue_preference(tmp_path: Path) -> None:
@@ -1471,6 +1477,110 @@ def test_no_queue_means_no_crossfade(tmp_path: Path) -> None:
     """Without a queue to read the preference from, the engine gets no crossfade."""
     session = _make_session(tmp_path, queue_id=None)
     assert session._queue_crossfade_ms() == 0
+
+
+async def test_a_fed_boundary_the_engine_played_across_is_reported(tmp_path: Path) -> None:
+    """The engine playing on into a fed item is what puts the overlap in its audio."""
+    session = _make_session(tmp_path, queue_id="player1")
+    session.crossfade_ms = 8000
+    streamdetails = _streamdetails_for(uri=TRACK_B)
+    session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
+    session._pending.append(TRACK_B)
+    queues = _queues_of(session)
+    queues.get.return_value = MagicMock(current_index=0)
+    queues.get_item.return_value = None
+
+    # fed but not reached, so MA arriving here now means a jump - not a fade
+    assert session.fades_a_boundary_of(streamdetails) is False
+
+    await session._observe_current(TRACK_B, 200_000)
+
+    assert session._items[TRACK_B].faded_in is True
+    assert session.fades_a_boundary_of(streamdetails) is True
+
+
+async def test_a_jumped_to_item_opens_on_a_hard_cut(tmp_path: Path) -> None:
+    """A skip discards the overlap the engine rendered, so no fade reaches the item."""
+    session = _make_session(tmp_path, queue_id="player1")
+    session.crossfade_ms = 8000
+    session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
+    session._pending.append(TRACK_B)
+    session._discard_until = TRACK_B
+    queues = _queues_of(session)
+    queues.get.return_value = MagicMock(current_index=0)
+    queues.get_item.return_value = None
+
+    await session._observe_current(TRACK_B, 200_000)
+
+    assert session._items[TRACK_B].faded_in is False
+    assert session.fades_a_boundary_of(_streamdetails_for(uri=TRACK_B)) is False
+
+
+async def test_a_fresh_sessions_first_item_rests_on_its_own_follower(tmp_path: Path) -> None:
+    """
+    Nothing was faded into the item a session starts on, so only its end can be faded.
+
+    A single-track play from the middle of a list is exactly this: the item before it
+    never played, so crediting that boundary would report an overlap nobody rendered.
+    """
+    session = _make_session(tmp_path, queue_id="player1")
+    session.crossfade_ms = 8000
+    streamdetails = _streamdetails_for(uri=TRACK_A)
+    playing = _queue_item(TRACK_A, streamdetails=streamdetails)
+    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item.started.set()
+    queues = _queues_of(session)
+    queues.get.return_value = MagicMock(current_index=0)
+    queues.get_item.side_effect = lambda _queue_id, index: playing if index == 0 else None
+
+    queues.get_next_item.return_value = None
+    assert session.fades_a_boundary_of(streamdetails) is False
+
+    queues.get_next_item.return_value = _queue_item(TRACK_B)
+    assert session.fades_a_boundary_of(streamdetails) is True
+
+
+@pytest.mark.parametrize(
+    ("crossfade_ms", "feed_fails", "expected"),
+    [
+        (8000, False, True),
+        # a feed that did not land costs the crossfade at exactly that boundary
+        (8000, True, False),
+        # and an engine started without crossfade cuts hard whatever it was fed
+        (0, False, False),
+    ],
+)
+async def test_feeding_the_follower_settles_the_boundary_at_the_items_end(
+    tmp_path: Path, crossfade_ms: int, feed_fails: bool, expected: bool
+) -> None:
+    """Once the feed has been attempted, its outcome is what the boundary rests on."""
+    session = _make_session(tmp_path, queue_id="player1")
+    session.crossfade_ms = crossfade_ms
+    streamdetails = _streamdetails_for(uri=TRACK_A)
+    playing = _queue_item(TRACK_A, streamdetails=streamdetails)
+    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item.started.set()
+    session._current = item
+    queues = _queues_of(session)
+    queues.get.return_value = MagicMock(current_index=0)
+    queues.get_item.side_effect = lambda _queue_id, index: playing if index == 0 else None
+    queues.get_next_item.return_value = _queue_item(TRACK_B)
+    if feed_fails:
+        _client_of(session).add_to_queue.side_effect = TimeoutError
+
+    await session.feed_after(streamdetails, TRACK_A)
+
+    assert item.fades_out is expected
+    assert session.fades_a_boundary_of(streamdetails) is expected
+
+
+async def test_only_a_track_can_carry_a_source_fade(tmp_path: Path) -> None:
+    """A podcast episode is never stitched, so both of its boundaries are hard cuts."""
+    session = _make_session(tmp_path, queue_id="player1")
+    session.crossfade_ms = 8000
+    episode = _streamdetails_for(uri="spotify:episode:xyz", media_type=MediaType.PODCAST_EPISODE)
+
+    assert session.fades_a_boundary_of(episode) is False
 
 
 async def test_short_delivery_is_rejected_as_incomplete(tmp_path: Path) -> None:
@@ -1953,6 +2063,22 @@ def _make_session(tmp_path: Path, queue_id: str | None = "player1") -> _SoloistS
     session._logged_in = True
     session._was_active = True
     return session
+
+
+def _streamdetails_for(
+    *,
+    queue_id: str | None = "player1",
+    uri: str = TRACK_A,
+    media_type: MediaType = MediaType.TRACK,
+) -> StreamDetails:
+    """Return stream details for a Spotify item served by the test instance."""
+    return StreamDetails(
+        provider="spotify--test",
+        item_id=uri.rsplit(":", 1)[1],
+        audio_format=AudioFormat(content_type=ContentType.PCM_S16LE),
+        media_type=media_type,
+        queue_id=queue_id,
+    )
 
 
 def _make_item(tmp_path: Path, uri: str) -> _ItemAudio:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5937 and #5918. The two hooks that tell Music Assistant what a music
service already did to its audio — normalize the loudness, crossfade the boundary —
were bare properties, so they answered from whatever the provider last served rather
than from the playback this question was actually about.

For Spotify that meant one queue could read another queue's session: a second queue
starting while the first sat idle could get MA's normalization applied on top of
Spotify's, or miss it entirely. It also meant the crossfade was reported from a guess
about the queue's neighbours, so a single-track play was credited with a fade off a
list item that never played.

Both hooks now take the stream they are answering about, so the source answers for the
right queue and the right boundary.

**Related issue (if applicable):**

- follow-up to #5937 and #5918

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- `delivers_normalized_audio` and `delivers_crossfaded_audio` take the `StreamDetails`
  of the item being asked about instead of being properties
- Spotify's Soloist session only answers for the queue it is actually serving
- the crossfade is reported per boundary, from what the session fed and played across,
  instead of from the queue's neighbours
- a fresh session's first item is no longer credited with a fade off a predecessor that
  never played, and a failed feed no longer claims one either
- the neighbour check in the streams core is now the fallback for a source that is not
  serving the queue yet

No change to the audio itself: every gate that means "MA applies nothing" still treats
a source-performed step the same as none at all.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
