### PR TITLE
Report the audio quality Spotify serves, not a conversion Music Assistant did not make

### DIFF
--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -596,9 +596,12 @@ def _is_bit_perfect(
         )
     )
     reference = source_format
+    # a wider container carries the source samples untouched — F32 processing
+    # headroom, or a provider that decoded upstream and hands over PCM wider than
+    # the tier it advertises. Only a stage that narrows below the source loses bits.
     if any(
         audio_format.sample_rate != reference.sample_rate
-        or audio_format.bit_depth != reference.bit_depth
+        or audio_format.bit_depth < reference.bit_depth
         or audio_format.channels != reference.channels
         for audio_format in formats
     ):

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -64,10 +64,8 @@ from music_assistant.providers.spotify.constants import (
 )
 from music_assistant.providers.spotify.helpers import soloist_session_present
 from music_assistant.providers.spotify_connect.base import (
-    AUDIO_QUALITY_HIGH,
     AUDIO_QUALITY_LOSSLESS,
-    AUDIO_QUALITY_NORMAL,
-    AUDIO_QUALITY_VERY_HIGH,
+    spotify_source_audio_format,
 )
 from music_assistant.providers.spotify_connect.soloist import (
     SoloistBinaryManager,
@@ -109,16 +107,6 @@ if TYPE_CHECKING:
 # as the display format.
 _FRAME_BYTES: Final[int] = 4 * CAPTURE_CHANNELS
 _BYTES_PER_SECOND: Final[int] = CAPTURE_SAMPLE_RATE * _FRAME_BYTES
-
-# The bitrate each lossy tier is advertised at, matching the Spotify apps' own
-# vocabulary. Spoken content is never lossless, so the lossless tier falls back
-# to the highest lossy rate for it rather than claiming more than it can be.
-_MAX_LOSSY_BIT_RATE: Final[int] = 320
-_LOSSY_BIT_RATES: Final[dict[str, int]] = {
-    AUDIO_QUALITY_NORMAL: 96,
-    AUDIO_QUALITY_HIGH: 160,
-    AUDIO_QUALITY_VERY_HIGH: _MAX_LOSSY_BIT_RATE,
-}
 
 # Bounded soloist playback cache (docs: 0 = unlimited, otherwise at least 100 MB).
 _CACHE_SIZE_MB: Final[int] = 512
@@ -324,21 +312,9 @@ class SoloistBackend(SpotifyPlaybackBackend):
         :param media_type: What is being streamed.
         """
         quality = self._audio_quality
-        if media_type == MediaType.TRACK and quality == AUDIO_QUALITY_LOSSLESS:
-            return AudioFormat(
-                content_type=ContentType.FLAC,
-                codec_type=ContentType.FLAC,
-                sample_rate=44100,
-                bit_depth=24,
-                channels=2,
-            )
-        return AudioFormat(
-            content_type=ContentType.OGG,
-            codec_type=ContentType.VORBIS,
-            sample_rate=44100,
-            bit_depth=16,
-            channels=2,
-            bit_rate=_LOSSY_BIT_RATES.get(quality, _MAX_LOSSY_BIT_RATE),
+        return spotify_source_audio_format(
+            quality,
+            lossless=media_type == MediaType.TRACK and quality == AUDIO_QUALITY_LOSSLESS,
         )
 
     @property

--- a/music_assistant/providers/spotify_connect/base.py
+++ b/music_assistant/providers/spotify_connect/base.py
@@ -6,10 +6,11 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Final
 
 from music_assistant_models.config_entries import ConfigValueOption
+from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
 
 if TYPE_CHECKING:
     from music_assistant_models.enums import RepeatMode
-    from music_assistant_models.media_items import AudioFormat
 
     from music_assistant.providers.spotify_connect.models import (
         AudioChunkReader,
@@ -34,6 +35,50 @@ AUDIO_QUALITY_OPTIONS: Final = [
     ConfigValueOption(AUDIO_QUALITY_VERY_HIGH),
     ConfigValueOption(AUDIO_QUALITY_LOSSLESS),
 ]
+
+# The bitrate each tier maps onto in kbps, matching the Spotify apps' own
+# vocabulary. Both the engines' own bitrate setting and the format advertised for
+# display come from here, so what we ask for is what we claim. Spoken content is
+# never lossless, and neither is go-librespot, so the lossless tier falls back to
+# the highest lossy rate for both rather than claiming more than they can deliver.
+MAX_LOSSY_BIT_RATE: Final[int] = 320
+LOSSY_BIT_RATES: Final[dict[str, int]] = {
+    AUDIO_QUALITY_NORMAL: 96,
+    AUDIO_QUALITY_HIGH: 160,
+    AUDIO_QUALITY_VERY_HIGH: MAX_LOSSY_BIT_RATE,
+    AUDIO_QUALITY_LOSSLESS: MAX_LOSSY_BIT_RATE,
+}
+
+
+def spotify_source_audio_format(quality: str, *, lossless: bool) -> AudioFormat:
+    """
+    Return the format Spotify is asked to serve at a streaming tier.
+
+    No engine reveals what it actually fetched, so this describes the configured
+    ceiling — the same thing the Spotify apps show. An engine that decodes on our
+    behalf hands over its own PCM, which is what ``decoded_audio_format``
+    describes; this stays the source of those samples.
+
+    :param quality: The configured AUDIO_QUALITY_* tier.
+    :param lossless: Whether the stream is served losslessly, which needs both the
+        lossless tier and an engine and content that can deliver it.
+    """
+    if lossless:
+        return AudioFormat(
+            content_type=ContentType.FLAC,
+            codec_type=ContentType.FLAC,
+            sample_rate=44100,
+            bit_depth=24,
+            channels=2,
+        )
+    return AudioFormat(
+        content_type=ContentType.OGG,
+        codec_type=ContentType.VORBIS,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+        bit_rate=LOSSY_BIT_RATES.get(quality, MAX_LOSSY_BIT_RATE),
+    )
 
 
 class SpotifyConnectBackend(ABC):

--- a/music_assistant/providers/spotify_connect/go_librespot/backend.py
+++ b/music_assistant/providers/spotify_connect/go_librespot/backend.py
@@ -15,7 +15,7 @@ import os
 from contextlib import suppress
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import ContentType, StreamType
 from music_assistant_models.media_items import AudioFormat
@@ -27,11 +27,11 @@ from music_assistant.helpers.util import (
     select_free_port,
 )
 from music_assistant.providers.spotify_connect.base import (
-    AUDIO_QUALITY_HIGH,
     AUDIO_QUALITY_LOSSLESS,
-    AUDIO_QUALITY_NORMAL,
-    AUDIO_QUALITY_VERY_HIGH,
+    LOSSY_BIT_RATES,
+    MAX_LOSSY_BIT_RATE,
     SpotifyConnectBackend,
+    spotify_source_audio_format,
 )
 from music_assistant.providers.spotify_connect.helpers import (
     generate_device_id,
@@ -65,17 +65,6 @@ STREAM_READ_CHUNK = 16384
 # Port range the go-librespot API server binds to (loopback only, one per instance).
 API_PORT_RANGE_START = 38800
 API_PORT_RANGE_END = 38900
-
-# Quality tier -> go-librespot's `bitrate` setting, which only accepts these
-# three values. go-librespot cannot do lossless, so that tier gets the 320 kbps
-# ceiling rather than nothing.
-_MAX_BITRATE: Final = 320
-_BITRATES: Final[dict[str, int]] = {
-    AUDIO_QUALITY_NORMAL: 96,
-    AUDIO_QUALITY_HIGH: 160,
-    AUDIO_QUALITY_VERY_HIGH: _MAX_BITRATE,
-    AUDIO_QUALITY_LOSSLESS: _MAX_BITRATE,
-}
 
 
 class GoLibrespotBackend(SpotifyConnectBackend):
@@ -130,20 +119,14 @@ class GoLibrespotBackend(SpotifyConnectBackend):
         self._events_task: asyncio.Task[None] | None = None
         self._proc: AsyncProcess | None = None
         self._restart_error_count = 0
-        # _audio_format is the original Spotify source codec (Ogg Vorbis 320 kbps),
-        # advertised to clients for display. _decoded_audio_format is the raw PCM
-        # go-librespot actually writes to its stdout after decoding — what the
-        # audio reader yields and what the streams controller hands ffmpeg as
-        # the input format. We always emit the source's own format here; MA is
-        # responsible for converting it to whatever each player needs.
-        self._audio_format = AudioFormat(
-            content_type=ContentType.OGG,
-            codec_type=ContentType.VORBIS,
-            sample_rate=44100,
-            bit_depth=16,
-            channels=2,
-            bit_rate=320,
-        )
+        # _audio_format is the original Spotify source codec (Ogg Vorbis at the
+        # configured tier's bitrate), advertised to clients for display.
+        # _decoded_audio_format is the raw PCM go-librespot actually writes to its
+        # stdout after decoding — what the audio reader yields and what the streams
+        # controller hands ffmpeg as the input format. We always emit the source's
+        # own format here; MA is responsible for converting it to whatever each
+        # player needs.
+        self._audio_format = spotify_source_audio_format(audio_quality, lossless=False)
         self._decoded_audio_format = AudioFormat(
             content_type=ContentType.PCM_S16LE,
             codec_type=ContentType.PCM_S16LE,
@@ -280,7 +263,7 @@ class GoLibrespotBackend(SpotifyConnectBackend):
             "device_name": self._publish_name,
             "device_type": "speaker",
             "device_id": generate_device_id(self._instance_id),
-            "bitrate": _BITRATES.get(self._audio_quality, _MAX_BITRATE),
+            "bitrate": LOSSY_BIT_RATES.get(self._audio_quality, MAX_LOSSY_BIT_RATE),
             "audio_backend": "pipe",
             # write decoded PCM to the daemon's stdout, which we capture and
             # forward (the process pipe is always attached, so the daemon's

--- a/music_assistant/providers/spotify_connect/soloist/backend.py
+++ b/music_assistant/providers/spotify_connect/soloist/backend.py
@@ -217,7 +217,9 @@ class SoloistBackend(SpotifyConnectBackend):
         # Soloist decodes internally and never exposes the source codec or
         # quality, so this capture format doubles as the display format: MA's
         # input really is 32-bit PCM (24-bit lossless fits losslessly), while
-        # Spotify's upstream quality stays unknowable either way.
+        # Spotify's upstream quality stays unknowable either way. The advertised
+        # format also decides the internal PCM depth and the ffmpeg-free
+        # passthrough for an AudioSource, so it has to stay what arrives.
         self._capture_format = AudioFormat(
             content_type=ContentType.PCM_S32LE,
             codec_type=ContentType.PCM_S32LE,

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -200,6 +200,80 @@ def test_lossy_source_can_have_bit_perfect_lossless_output() -> None:
     assert serialized_outputs["lossless-player"]["fidelity"]["bit_perfect"] is True
 
 
+def test_a_wider_provider_handoff_preserves_the_source_samples() -> None:
+    """A provider that decodes upstream into wider PCM does not lose the source samples."""
+    streamdetails = _source_handled_soloist_item(_format(ContentType.FLAC, 44100, 24))
+
+    chain = cast("AudioProcessingChain", streamdetails.audio_processing)
+    assert chain.input_fidelity.quality == AudioQuality.HI_RES
+    assert chain.outputs[0].fidelity.bit_perfect is True
+
+
+def test_an_output_narrower_than_the_source_is_not_bit_perfect() -> None:
+    """Dropping a 24-bit source to a 16-bit output loses bits, wide handoff or not."""
+    streamdetails = _source_handled_soloist_item(_format(ContentType.FLAC, 44100, 16))
+
+    chain = cast("AudioProcessingChain", streamdetails.audio_processing)
+    assert chain.outputs[0].fidelity.bit_perfect is False
+
+
+def test_an_internal_stage_narrower_than_the_source_is_not_bit_perfect() -> None:
+    """A narrowed internal stage loses bits the output cannot bring back."""
+    manager, _mass, _queue_data, streamdetails, lossless_plan, _lossy_plan = _manager_context()
+    streamdetails.audio_format = _format(ContentType.FLAC, 44100, 24)
+    narrowed = _format(ContentType.PCM_S16LE, 44100, 16)
+    manager.update_item_runtime(
+        "queue-1",
+        "session-1",
+        "item-1",
+        input_format=narrowed,
+        pcm_format=narrowed,
+        normalization=None,
+        playback_speed=1.0,
+    )
+    lossless_plan.input_format = narrowed
+    lossless_plan.output_details.output_format = _format(ContentType.FLAC, 44100, 24)
+    manager.update_output(
+        "player-1",
+        lossless_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+
+    chain = cast("AudioProcessingChain", streamdetails.audio_processing)
+    assert chain.outputs[0].fidelity.bit_perfect is False
+
+
+def test_float_headroom_alone_does_not_break_the_bit_perfect_claim() -> None:
+    """DSP enabled with no filters gets F32 headroom but leaves the samples alone."""
+    manager, _mass, _queue_data, streamdetails, lossless_plan, _lossy_plan = _manager_context()
+    streamdetails.audio_format = _format(ContentType.FLAC, 44100, 24)
+    headroom = _format(ContentType.PCM_F32LE, 44100, 32)
+    manager.update_item_runtime(
+        "queue-1",
+        "session-1",
+        "item-1",
+        input_format=headroom,
+        pcm_format=headroom,
+        normalization=None,
+        playback_speed=1.0,
+    )
+    lossless_plan.input_format = headroom
+    lossless_plan.output_details.dsp = AudioDSPDetails(state=DSPState.ENABLED)
+    lossless_plan.output_details.output_format = _format(ContentType.FLAC, 44100, 24)
+    manager.update_output(
+        "player-1",
+        lossless_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+
+    chain = cast("AudioProcessingChain", streamdetails.audio_processing)
+    assert chain.outputs[0].fidelity.bit_perfect is True
+
+
 def test_shared_output_destinations_are_registered_atomically() -> None:
     """One shared output publishes all destinations in a single queue update."""
     manager, mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()
@@ -1313,6 +1387,41 @@ def _manager_context(
         input_format=pcm_format,
     )
     return manager, mass, queue_data, streamdetails, lossless_plan, lossy_plan
+
+
+def _source_handled_soloist_item(
+    output_format: AudioFormat,
+) -> StreamDetails:
+    """Prepare a Spotify-soloist-shaped item: a 24-bit tier delivered as 32-bit PCM."""
+    manager, _mass, _queue_data, streamdetails, lossless_plan, _lossy_plan = _manager_context()
+    streamdetails.audio_format = _format(ContentType.FLAC, 44100, 24)
+    streamdetails.decoded_audio_format = _format(ContentType.PCM_S32LE, 44100, 32)
+    pcm_format = _format(ContentType.PCM_S32LE, 44100, 32)
+    manager.update_item_runtime(
+        "queue-1",
+        "session-1",
+        "item-1",
+        input_format=pcm_format,
+        pcm_format=pcm_format,
+        normalization=AudioNormalizationDetails(mode=VolumeNormalizationMode.SOURCE),
+        playback_speed=1.0,
+    )
+    manager.update_item_context(
+        "queue-1",
+        "session-1",
+        "item-1",
+        AudioQueueProcessing(pcm_format=pcm_format, crossfade_mode=CrossfadeMode.SOURCE),
+    )
+    lossless_plan.input_format = pcm_format
+    lossless_plan.output_details.output_format = output_format
+    manager.update_output(
+        "player-1",
+        lossless_plan,
+        queue_id="queue-1",
+        session_id="session-1",
+        queue_item_id="item-1",
+    )
+    return streamdetails
 
 
 def _streamdetails(item_id: str = "item-1") -> StreamDetails:

--- a/tests/providers/spotify_connect/test_backend_contract.py
+++ b/tests/providers/spotify_connect/test_backend_contract.py
@@ -27,7 +27,14 @@ from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamMetadata
 
 from music_assistant.providers.spotify_connect import provider as provider_mod
-from music_assistant.providers.spotify_connect.base import SpotifyConnectBackend
+from music_assistant.providers.spotify_connect.base import (
+    AUDIO_QUALITY_HIGH,
+    AUDIO_QUALITY_LOSSLESS,
+    AUDIO_QUALITY_NORMAL,
+    AUDIO_QUALITY_VERY_HIGH,
+    SpotifyConnectBackend,
+    spotify_source_audio_format,
+)
 from music_assistant.providers.spotify_connect.go_librespot.backend import (
     GoLibrespotBackend,
 )
@@ -801,6 +808,35 @@ async def test_go_librespot_stream_source_is_custom_with_nobuffer() -> None:
     assert source.stream_type is StreamType.CUSTOM
     assert source.path is None
     assert source.extra_input_args == ["-fflags", "nobuffer"]
+
+
+@pytest.mark.parametrize(
+    ("quality", "lossless", "codec", "bit_depth", "bit_rate"),
+    [
+        (AUDIO_QUALITY_LOSSLESS, True, ContentType.FLAC, 24, None),
+        # an engine or item that cannot be served losslessly keeps the tier's ceiling
+        (AUDIO_QUALITY_LOSSLESS, False, ContentType.VORBIS, 16, 320),
+        (AUDIO_QUALITY_VERY_HIGH, False, ContentType.VORBIS, 16, 320),
+        (AUDIO_QUALITY_HIGH, False, ContentType.VORBIS, 16, 160),
+        (AUDIO_QUALITY_NORMAL, False, ContentType.VORBIS, 16, 96),
+        ("future_tier", False, ContentType.VORBIS, 16, 320),
+    ],
+)
+def test_the_advertised_source_format_follows_the_tier(
+    quality: str,
+    lossless: bool,
+    codec: ContentType,
+    bit_depth: int,
+    bit_rate: int | None,
+) -> None:
+    """Every soloist/librespot engine advertises the tier it was configured with."""
+    fmt = spotify_source_audio_format(quality, lossless=lossless)
+
+    assert fmt.codec_type is codec
+    assert fmt.sample_rate == 44100
+    assert fmt.bit_depth == bit_depth
+    assert fmt.channels == 2
+    assert fmt.bit_rate == bit_rate
 
 
 def _make_backend() -> GoLibrespotBackend:


### PR DESCRIPTION
# What does this implement/fix?

Spotify's soloist engine decodes the audio itself and hands Music Assistant 32-bit PCM, while the source format describes the quality tier Spotify was asked for (FLAC 44.1/24 on lossless, Ogg Vorbis otherwise). The audio pipeline report treated every difference between the two as a loss, so a Spotify track could never be reported as bit-perfect and was shown as an internal format conversion Music Assistant never performed — which also made the "handled by the source" exemptions from #5937 unreachable.

A wider container carries the same samples; only a stage that narrows below the source drops bits.

**Changes**

- the bit-perfect check accepts a wider stage anywhere in the chain, and still rejects a narrower one
- go-librespot advertises the bitrate it is actually configured with, instead of a fixed 320 kbps on every tier
- one shared tier-to-format mapping for the Spotify playback engines, so what we ask for is what we report

**Related issue (if applicable):**

- follow-up on review feedback in #5918

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: music-assistant/frontend#2623
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
