### PR TITLE
Prevent stale live source releases

### DIFF
--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -40,14 +40,14 @@ class AudioSourceSession:
     ``streamdetails`` and ``stream_session_id`` are independent of the session's
     own existence: a paused external source keeps the player while its stream is
     torn down, so both fall back to None without the session ending. The
-    ``playback_session_id`` is the one identifier that lasts as long as the
-    session does, which is why the stream URLs are built from it.
+    ``playback_session_id`` identifies the current selection through pauses and
+    stream reconnects, and is refreshed when the source is explicitly reselected.
     """
 
     player_id: str
     source: AudioSource
     provider_instance_id: str
-    # identifies this session in its stream URLs, for the whole time it plays
+    # identifies the current selection in its stream URLs
     playback_session_id: str = field(default_factory=lambda: uuid4().hex)
     started_at: float = field(default_factory=time.time)
     streamdetails: StreamDetails | None = None
@@ -292,6 +292,8 @@ class AudioSourceMixin:
             and session.provider_instance_id == provider_instance_id
         ):
             session.source = source
+            session.playback_session_id = uuid4().hex
+            session.stream_session_id = None
             return session
         # a source plays on one player at a time, so it leaves whichever other player
         # was holding it: two players both reporting it would let a command on the one

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1158,7 +1158,8 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         elif player.state.synced_to:
             await self.cmd_ungroup(player_id)
         # Delegate to internal handler for actual implementation
-        await self._handle_select_source(player_id, source)
+        async with self.get_player_lock(player_id, PlayerLockPurpose.PLAYBACK):
+            await self._handle_select_source(player_id, source)
 
     async def deselect_source(
         self,
@@ -1181,43 +1182,44 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         :param provider_instance_id: Optional provider instance that owns the source session.
         :param source_id: Optional provider-scoped source id that owns the source session.
         """
-        player = self.get_player(player_id, raise_unavailable=False)
-        if not player:
-            return
-        session = self._source_sessions.get(player_id)
-        active_provider_instance_id = session.provider_instance_id if session else None
-        active_source_id = session.source_id if session else None
-        if provider_instance_id is not None and (
-            active_provider_instance_id != provider_instance_id
-            or (source_id is not None and active_source_id != source_id)
-        ):
-            self.logger.debug(
-                "Ignoring source release for provider %s source %s on player %s: "
-                "active source is provider %s source %s",
-                provider_instance_id,
-                source_id,
-                player_id,
-                active_provider_instance_id,
-                active_source_id,
-            )
-            return
-        await self._release_audio_source(player_id)
-        if not stop_playback:
-            return
-        replacement_session = self._source_sessions.get(player_id)
-        if provider_instance_id is not None and replacement_session is not None:
-            self.logger.debug(
-                "Not stopping player %s after releasing provider %s source %s: "
-                "provider %s source %s took over",
-                player_id,
-                provider_instance_id,
-                source_id,
-                replacement_session.provider_instance_id,
-                replacement_session.source_id,
-            )
-            return
-        with suppress(PlayerCommandFailed, PlayerUnavailableError, RuntimeError):
-            await self._handle_cmd_stop(player_id)
+        async with self.get_player_lock(player_id, PlayerLockPurpose.PLAYBACK):
+            player = self.get_player(player_id, raise_unavailable=False)
+            if not player:
+                return
+            session = self._source_sessions.get(player_id)
+            active_provider_instance_id = session.provider_instance_id if session else None
+            active_source_id = session.source_id if session else None
+            if provider_instance_id is not None and (
+                active_provider_instance_id != provider_instance_id
+                or (source_id is not None and active_source_id != source_id)
+            ):
+                self.logger.debug(
+                    "Ignoring source release for provider %s source %s on player %s: "
+                    "active source is provider %s source %s",
+                    provider_instance_id,
+                    source_id,
+                    player_id,
+                    active_provider_instance_id,
+                    active_source_id,
+                )
+                return
+            await self._release_audio_source(player_id)
+            if not stop_playback:
+                return
+            replacement_session = self._source_sessions.get(player_id)
+            if provider_instance_id is not None and replacement_session is not None:
+                self.logger.debug(
+                    "Not stopping player %s after releasing provider %s source %s: "
+                    "provider %s source %s took over",
+                    player_id,
+                    provider_instance_id,
+                    source_id,
+                    replacement_session.provider_instance_id,
+                    replacement_session.source_id,
+                )
+                return
+            with suppress(PlayerCommandFailed, PlayerUnavailableError, RuntimeError):
+                await self._handle_cmd_stop(player_id)
 
     async def release_provider_sources(self, provider_instance_id: str) -> None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -653,7 +653,8 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                 return
 
         # Delegate to internal handler for actual implementation
-        await self._handle_cmd_play(player.player_id)
+        async with self.get_player_lock(player.player_id, PlayerLockPurpose.PLAYBACK):
+            await self._handle_cmd_play(player.player_id)
 
     @api_command("players/cmd/pause", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
@@ -685,7 +686,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
             await self.cmd_play(player.player_id)
 
     @api_command("players/cmd/resume", required_scope=Scope.PLAYERS_CONTROL)
-    @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
+    @handle_player_command
     async def cmd_resume(
         self, player_id: str, source: str | None = None, media: PlayerMedia | None = None
     ) -> None:
@@ -698,7 +699,9 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         :param source: Optional source to resume.
         :param media: Optional media to resume.
         """
-        await self._handle_cmd_resume(player_id, source, media)
+        player = self._get_player_with_redirect(player_id)
+        async with self.get_player_lock(player.player_id, PlayerLockPurpose.PLAYBACK):
+            await self._handle_cmd_resume(player.player_id, source, media)
 
     @api_command("players/cmd/seek", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -616,7 +616,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
     # Player commands
 
     @api_command("players/cmd/stop", required_scope=Scope.PLAYERS_CONTROL)
-    @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
+    @handle_player_command
     async def cmd_stop(self, player_id: str) -> None:
         """
         Send STOP command to given player.
@@ -624,12 +624,13 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         - player_id: player_id of the player to handle the command.
         """
         player = self._get_player_with_redirect(player_id)
-        # Redirect to queue controller if it is active (skip if already in queue command context)
-        if active_queue := self.get_active_queue(player):
-            await self.mass.player_queues.stop(active_queue.queue_id)
-            return
-        # Delegate to internal handler for actual implementation
-        await self._handle_cmd_stop(player.player_id)
+        async with self.get_player_lock(player.player_id, PlayerLockPurpose.PLAYBACK):
+            # Redirect to queue controller if it is active (skip if already in queue command context)
+            if active_queue := self.get_active_queue(player):
+                await self.mass.player_queues.stop(active_queue.queue_id)
+                return
+            # Delegate to internal handler for actual implementation
+            await self._handle_cmd_stop(player.player_id)
 
     @api_command("players/cmd/play", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1213,23 +1213,27 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                     active_playback_session_id,
                 )
                 return
-            await self._release_audio_source(player_id)
-            if not stop_playback:
-                return
-            replacement_session = self._source_sessions.get(player_id)
-            if provider_instance_id is not None and replacement_session is not None:
-                self.logger.debug(
-                    "Not stopping player %s after releasing provider %s source %s: "
-                    "provider %s source %s took over",
-                    player_id,
-                    provider_instance_id,
-                    source_id,
-                    replacement_session.provider_instance_id,
-                    replacement_session.source_id,
-                )
-                return
-            with suppress(PlayerCommandFailed, PlayerUnavailableError, RuntimeError):
-                await self._handle_cmd_stop(player_id)
+            try:
+                if stop_playback:
+                    with suppress(PlayerCommandFailed, PlayerUnavailableError, RuntimeError):
+                        await self._handle_cmd_stop(player_id)
+            finally:
+                if session is not None:
+                    current_session = self._source_sessions.get(player_id)
+                    if (
+                        current_session is session
+                        and current_session.playback_session_id == active_playback_session_id
+                    ):
+                        await self._release_audio_source(player_id)
+                    else:
+                        self.logger.debug(
+                            "Not releasing provider %s source %s session %s on player %s: "
+                            "the source changed while playback was stopping",
+                            provider_instance_id,
+                            source_id,
+                            playback_session_id,
+                            player_id,
+                        )
 
     async def release_provider_sources(self, provider_instance_id: str) -> None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1183,21 +1183,27 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         if not player:
             return
         session = self._source_sessions.get(player_id)
-        if (
-            provider_instance_id is not None
-            and session is not None
-            and session.provider_instance_id != provider_instance_id
-        ):
+        active_provider_instance_id = session.provider_instance_id if session else None
+        if provider_instance_id is not None and active_provider_instance_id != provider_instance_id:
             self.logger.debug(
                 "Ignoring source release from provider %s on player %s: "
-                "the active source belongs to provider %s",
+                "active source provider is %s",
                 provider_instance_id,
                 player_id,
-                session.provider_instance_id,
+                active_provider_instance_id,
             )
             return
         await self._release_audio_source(player_id)
         if not stop_playback:
+            return
+        replacement_session = self._source_sessions.get(player_id)
+        if provider_instance_id is not None and replacement_session is not None:
+            self.logger.debug(
+                "Not stopping player %s after releasing provider %s: provider %s took over",
+                player_id,
+                provider_instance_id,
+                replacement_session.provider_instance_id,
+            )
             return
         with suppress(PlayerCommandFailed, PlayerUnavailableError, RuntimeError):
             await self._handle_cmd_stop(player_id)

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1160,7 +1160,12 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         # Delegate to internal handler for actual implementation
         await self._handle_select_source(player_id, source)
 
-    async def deselect_source(self, player_id: str, stop_playback: bool = True) -> None:
+    async def deselect_source(
+        self,
+        player_id: str,
+        stop_playback: bool = True,
+        provider_instance_id: str | None = None,
+    ) -> None:
         """
         Give up the source a player was playing, and stop it.
 
@@ -1172,9 +1177,24 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         :param player_id: player_id of the player to give the source up on.
         :param stop_playback: Whether to stop the player as well. Pass False when the
             caller has already stopped it, or is about to.
+        :param provider_instance_id: Optional provider instance that owns the source session.
         """
         player = self.get_player(player_id, raise_unavailable=False)
         if not player:
+            return
+        session = self._source_sessions.get(player_id)
+        if (
+            provider_instance_id is not None
+            and session is not None
+            and session.provider_instance_id != provider_instance_id
+        ):
+            self.logger.debug(
+                "Ignoring source release from provider %s on player %s: "
+                "the active source belongs to provider %s",
+                provider_instance_id,
+                player_id,
+                session.provider_instance_id,
+            )
             return
         await self._release_audio_source(player_id)
         if not stop_playback:

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1165,6 +1165,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         player_id: str,
         stop_playback: bool = True,
         provider_instance_id: str | None = None,
+        source_id: str | None = None,
     ) -> None:
         """
         Give up the source a player was playing, and stop it.
@@ -1178,19 +1179,26 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         :param stop_playback: Whether to stop the player as well. Pass False when the
             caller has already stopped it, or is about to.
         :param provider_instance_id: Optional provider instance that owns the source session.
+        :param source_id: Optional provider-scoped source id that owns the source session.
         """
         player = self.get_player(player_id, raise_unavailable=False)
         if not player:
             return
         session = self._source_sessions.get(player_id)
         active_provider_instance_id = session.provider_instance_id if session else None
-        if provider_instance_id is not None and active_provider_instance_id != provider_instance_id:
+        active_source_id = session.source_id if session else None
+        if provider_instance_id is not None and (
+            active_provider_instance_id != provider_instance_id
+            or (source_id is not None and active_source_id != source_id)
+        ):
             self.logger.debug(
-                "Ignoring source release from provider %s on player %s: "
-                "active source provider is %s",
+                "Ignoring source release for provider %s source %s on player %s: "
+                "active source is provider %s source %s",
                 provider_instance_id,
+                source_id,
                 player_id,
                 active_provider_instance_id,
+                active_source_id,
             )
             return
         await self._release_audio_source(player_id)
@@ -1199,10 +1207,13 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         replacement_session = self._source_sessions.get(player_id)
         if provider_instance_id is not None and replacement_session is not None:
             self.logger.debug(
-                "Not stopping player %s after releasing provider %s: provider %s took over",
+                "Not stopping player %s after releasing provider %s source %s: "
+                "provider %s source %s took over",
                 player_id,
                 provider_instance_id,
+                source_id,
                 replacement_session.provider_instance_id,
+                replacement_session.source_id,
             )
             return
         with suppress(PlayerCommandFailed, PlayerUnavailableError, RuntimeError):
@@ -1226,7 +1237,11 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                 provider_instance_id,
                 player_id,
             )
-            await self.deselect_source(player_id)
+            await self.deselect_source(
+                player_id,
+                provider_instance_id=provider_instance_id,
+                source_id=session.source_id,
+            )
 
     @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
     async def enqueue_next_media(self, player_id: str, media: PlayerMedia) -> None:

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -640,20 +640,20 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         - player_id: player_id of the player to handle the command.
         """
         player = self._get_player_with_redirect(player_id)
-        if player.state.playback_state == PlaybackState.PLAYING:
-            self.logger.info(
-                "Ignore PLAY request to player %s: player is already playing", player.state.name
-            )
-            return
-        # player is not paused: check for queue redirect, then delegate to internal handler
-        if player.state.playback_state != PlaybackState.PAUSED:
-            source = player.state.active_source
-            if active_queue := self.mass.player_queues.get(source or player_id):
-                await self.mass.player_queues.resume(active_queue.queue_id)
-                return
-
-        # Delegate to internal handler for actual implementation
         async with self.get_player_lock(player.player_id, PlayerLockPurpose.PLAYBACK):
+            if player.state.playback_state == PlaybackState.PLAYING:
+                self.logger.info(
+                    "Ignore PLAY request to player %s: player is already playing",
+                    player.state.name,
+                )
+                return
+            # player is not paused: check for queue redirect, then delegate to internal handler
+            if player.state.playback_state != PlaybackState.PAUSED:
+                source = player.state.active_source
+                if active_queue := self.mass.player_queues.get(source or player_id):
+                    await self.mass.player_queues.resume(active_queue.queue_id)
+                    return
+            # Delegate to internal handler for actual implementation
             await self._handle_cmd_play(player.player_id)
 
     @api_command("players/cmd/pause", required_scope=Scope.PLAYERS_CONTROL)

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1167,6 +1167,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         stop_playback: bool = True,
         provider_instance_id: str | None = None,
         source_id: str | None = None,
+        playback_session_id: str | None = None,
     ) -> None:
         """
         Give up the source a player was playing, and stop it.
@@ -1181,6 +1182,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
             caller has already stopped it, or is about to.
         :param provider_instance_id: Optional provider instance that owns the source session.
         :param source_id: Optional provider-scoped source id that owns the source session.
+        :param playback_session_id: Optional playback session expected to own the player.
         """
         async with self.get_player_lock(player_id, PlayerLockPurpose.PLAYBACK):
             player = self.get_player(player_id, raise_unavailable=False)
@@ -1189,18 +1191,23 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
             session = self._source_sessions.get(player_id)
             active_provider_instance_id = session.provider_instance_id if session else None
             active_source_id = session.source_id if session else None
+            active_playback_session_id = session.playback_session_id if session else None
             if provider_instance_id is not None and (
                 active_provider_instance_id != provider_instance_id
                 or (source_id is not None and active_source_id != source_id)
+                or playback_session_id is None
+                or active_playback_session_id != playback_session_id
             ):
                 self.logger.debug(
-                    "Ignoring source release for provider %s source %s on player %s: "
-                    "active source is provider %s source %s",
+                    "Ignoring source release for provider %s source %s session %s on player %s: "
+                    "active source is provider %s source %s session %s",
                     provider_instance_id,
                     source_id,
+                    playback_session_id,
                     player_id,
                     active_provider_instance_id,
                     active_source_id,
+                    active_playback_session_id,
                 )
                 return
             await self._release_audio_source(player_id)
@@ -1231,9 +1238,12 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
 
         :param provider_instance_id: Instance id of the plugin that is going away.
         """
-        for player_id, session in list(self._source_sessions.items()):
-            if session.provider_instance_id != provider_instance_id:
-                continue
+        sessions = [
+            (player_id, session.source_id, session.playback_session_id)
+            for player_id, session in self._source_sessions.items()
+            if session.provider_instance_id == provider_instance_id
+        ]
+        for player_id, source_id, playback_session_id in sessions:
             self.logger.debug(
                 "Provider %s is unloading, releasing its source on player %s",
                 provider_instance_id,
@@ -1242,7 +1252,8 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
             await self.deselect_source(
                 player_id,
                 provider_instance_id=provider_instance_id,
-                source_id=session.source_id,
+                source_id=source_id,
+                playback_session_id=playback_session_id,
             )
 
     @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1058,6 +1058,7 @@ class StreamsController(CoreController):
         """Stream a live AudioSource playing on a player."""
         self._log_request(request)
         session, player, prov = self._resolve_audio_source_request(request)
+        playback_session_id = session.playback_session_id
         # the session's own player, never the url's: the consuming player differs for
         # protocol and group members, and the claim belongs to the owner
         source_player_id = session.player_id
@@ -1151,7 +1152,7 @@ class StreamsController(CoreController):
                         exc_info=True,
                     )
             if not serving:
-                await self._release_unstarted_audio_source(session)
+                await self._release_unstarted_audio_source(session, playback_session_id)
 
     async def serve_queue_flow_stream(self, request: web.Request) -> web.StreamResponse:  # noqa: PLR0915
         """Stream Queue Flow audio to player."""
@@ -1728,7 +1729,9 @@ class StreamsController(CoreController):
             )
         return session, player, prov
 
-    async def _release_unstarted_audio_source(self, session: AudioSourceSession) -> None:
+    async def _release_unstarted_audio_source(
+        self, session: AudioSourceSession, playback_session_id: str
+    ) -> None:
         """
         Take a source that never started off the player holding it.
 
@@ -1737,8 +1740,13 @@ class StreamsController(CoreController):
         source that never played, with its own queue held inactive behind it.
 
         :param session: The session whose stream failed before any audio flowed.
+        :param playback_session_id: Playback session active when stream setup started.
         """
-        if self.mass.players.get_audio_source_session(session.player_id) is not session:
+        current_session = self.mass.players.get_audio_source_session(session.player_id)
+        if (
+            current_session is not session
+            or current_session.playback_session_id != playback_session_id
+        ):
             # already superseded, so it is not ours to release
             return
         self.logger.debug(
@@ -1751,6 +1759,7 @@ class StreamsController(CoreController):
                 session.player_id,
                 provider_instance_id=session.provider_instance_id,
                 source_id=session.source_id,
+                playback_session_id=playback_session_id,
             )
         except Exception:
             # deselect_source already absorbs the expected stop failures, so anything
@@ -1886,6 +1895,7 @@ class StreamsController(CoreController):
             raise AudioError(
                 f"AudioSource provider {session.provider_instance_id} is not available"
             )
+        playback_session_id = session.playback_session_id
         stream_session_id = uuid4().hex
         serving = False
         try:
@@ -1927,7 +1937,7 @@ class StreamsController(CoreController):
                     exc_info=True,
                 )
             if not serving:
-                await self._release_unstarted_audio_source(session)
+                await self._release_unstarted_audio_source(session, playback_session_id)
 
     async def _wrap_with_audio_source_lifecycle(
         self,

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1747,7 +1747,11 @@ class StreamsController(CoreController):
             session.player_id,
         )
         try:
-            await self.mass.players.deselect_source(session.player_id)
+            await self.mass.players.deselect_source(
+                session.player_id,
+                provider_instance_id=session.provider_instance_id,
+                source_id=session.source_id,
+            )
         except Exception:
             # deselect_source already absorbs the expected stop failures, so anything
             # arriving here is a defect worth a trail rather than a silent half-cleanup

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1086,6 +1086,11 @@ class StreamsController(CoreController):
                     source_player_id,
                     stream_session_id,
                 )
+                if (
+                    self.mass.players.get_audio_source_session(source_player_id) is not session
+                    or session.playback_session_id != playback_session_id
+                ):
+                    raise web.HTTPNotFound(reason="AudioSource session was superseded")
                 session.stream_session_id = stream_session_id
             except RuntimeError as err:
                 # the plugin refuses this player (e.g. it just redirected playback
@@ -1124,7 +1129,12 @@ class StreamsController(CoreController):
             try:
                 async with aclosing(audio_bytes):
                     async for chunk in audio_bytes:
-                        if session.stream_session_id != stream_session_id:
+                        if (
+                            self.mass.players.get_audio_source_session(source_player_id)
+                            is not session
+                            or session.playback_session_id != playback_session_id
+                            or session.stream_session_id != stream_session_id
+                        ):
                             self.logger.debug(
                                 "Ending stream for %s: a newer request took the source over",
                                 session.source.name,
@@ -1909,6 +1919,11 @@ class StreamsController(CoreController):
             except RuntimeError as err:
                 # the plugin refuses this consumer, e.g. it just redirected playback
                 raise AudioError(str(err)) from err
+            if (
+                self.mass.players.get_audio_source_session(session.player_id) is not session
+                or session.playback_session_id != playback_session_id
+            ):
+                raise AudioError("AudioSource session was superseded")
             session.stream_session_id = stream_session_id
             if (streamdetails := session.streamdetails) is None:
                 streamdetails = await prov.get_stream_details(
@@ -1922,6 +1937,12 @@ class StreamsController(CoreController):
                 raise_on_error=False,
                 display_name=session.source.name,
             ):
+                if (
+                    self.mass.players.get_audio_source_session(session.player_id) is not session
+                    or session.playback_session_id != playback_session_id
+                    or session.stream_session_id != stream_session_id
+                ):
+                    break
                 yield chunk
         finally:
             try:

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -423,6 +423,9 @@ class AirPlayReceiverProvider(PluginProvider):
         Called when playback ends to reset the plugin state.
         """
         prev_player_id = self._active_player_id
+        source_session = (
+            self.mass.players.get_audio_source_session(prev_player_id) if prev_player_id else None
+        )
         self._active_player_id = None
         self._in_use_by_player = None
         self._active_session_id = None
@@ -436,6 +439,9 @@ class AirPlayReceiverProvider(PluginProvider):
                     stop_playback=False,
                     provider_instance_id=self.instance_id,
                     source_id=AUDIO_SOURCE_ID,
+                    playback_session_id=(
+                        source_session.playback_session_id if source_session else None
+                    ),
                 )
             )
 

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -431,7 +431,11 @@ class AirPlayReceiverProvider(PluginProvider):
             self.logger.debug("Playback ended on player %s, clearing active player", prev_player_id)
             # the player is not playing us any more, so it should stop saying it is
             self.mass.create_task(
-                self.mass.players.deselect_source(prev_player_id, stop_playback=False)
+                self.mass.players.deselect_source(
+                    prev_player_id,
+                    stop_playback=False,
+                    provider_instance_id=self.instance_id,
+                )
             )
 
     def _save_last_player_id(self, player_id: str) -> None:

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -435,6 +435,7 @@ class AirPlayReceiverProvider(PluginProvider):
                     prev_player_id,
                     stop_playback=False,
                     provider_instance_id=self.instance_id,
+                    source_id=AUDIO_SOURCE_ID,
                 )
             )
 

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -759,7 +759,11 @@ class AriaCastReceiver(PluginProvider):
             owner_player_id = self._in_use_by_player
             # Clear the guard before the stop so a fast resume can re-trigger
             self._in_use_by_player = None
-            self.mass.create_task(self.mass.players.deselect_source(owner_player_id))
+            self.mass.create_task(
+                self.mass.players.deselect_source(
+                    owner_player_id, provider_instance_id=self.instance_id
+                )
+            )
 
         await self._broadcast_meta()
 

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -761,7 +761,9 @@ class AriaCastReceiver(PluginProvider):
             self._in_use_by_player = None
             self.mass.create_task(
                 self.mass.players.deselect_source(
-                    owner_player_id, provider_instance_id=self.instance_id
+                    owner_player_id,
+                    provider_instance_id=self.instance_id,
+                    source_id=AUDIO_SOURCE_ID,
                 )
             )
 

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -757,6 +757,7 @@ class AriaCastReceiver(PluginProvider):
             # deselect the owner, not _active_player_id: that can be a protocol player
             # whose stream we were consumed over, while the session hangs off the owner
             owner_player_id = self._in_use_by_player
+            source_session = self.mass.players.get_audio_source_session(owner_player_id)
             # Clear the guard before the stop so a fast resume can re-trigger
             self._in_use_by_player = None
             self.mass.create_task(
@@ -764,6 +765,9 @@ class AriaCastReceiver(PluginProvider):
                     owner_player_id,
                     provider_instance_id=self.instance_id,
                     source_id=AUDIO_SOURCE_ID,
+                    playback_session_id=(
+                        source_session.playback_session_id if source_session else None
+                    ),
                 )
             )
 

--- a/music_assistant/providers/msx_bridge/player.py
+++ b/music_assistant/providers/msx_bridge/player.py
@@ -11,6 +11,7 @@ from music_assistant_models.errors import PlayerUnavailableError
 from music_assistant_models.player import DeviceInfo
 
 from music_assistant.constants import CONF_ENTRY_OUTPUT_CODEC_DEFAULT_MP3
+from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.models.player import Player, PlayerMedia
 
 if TYPE_CHECKING:
@@ -401,18 +402,21 @@ class MSXPlayer(Player):
     async def _propagate_single(self, member: MSXPlayer, command: str, **kwargs: Any) -> None:
         """Propagate a single command to one group member."""
         try:
-            if command == "play_media":
-                media = kwargs.get("media")
-                if media:
-                    # Call member.play_media directly — mass.players.play_media
-                    # would redirect synced/grouped players back to the leader
-                    await member.play_media(media)
-            elif command == "stop":
-                await member.stop()
-            elif command == "pause":
-                await member.pause()
-            elif command == "play":
-                await member.play()
+            async with self.mass.players.get_player_lock(
+                member.player_id, PlayerLockPurpose.PLAYBACK
+            ):
+                if command == "play_media":
+                    media = kwargs.get("media")
+                    if media:
+                        # Call member.play_media directly — mass.players.play_media
+                        # would redirect synced/grouped players back to the leader
+                        await member.play_media(media)
+                elif command == "stop":
+                    await member.stop()
+                elif command == "pause":
+                    await member.pause()
+                elif command == "play":
+                    await member.play()
         except Exception:
             self.logger.warning(
                 "Failed to propagate %s to member %s",

--- a/music_assistant/providers/msx_bridge/player.py
+++ b/music_assistant/providers/msx_bridge/player.py
@@ -408,15 +408,15 @@ class MSXPlayer(Player):
                 if command == "play_media":
                     media = kwargs.get("media")
                     if media:
-                        # Call member.play_media directly — mass.players.play_media
-                        # would redirect synced/grouped players back to the leader
-                        await member.play_media(media)
+                        # Use the internal handler so active source sessions are released,
+                        # while avoiding the public redirect back to the leader.
+                        await self.mass.players._handle_play_media(member.player_id, media)
                 elif command == "stop":
-                    await member.stop()
+                    await self.mass.players._handle_cmd_stop(member.player_id)
                 elif command == "pause":
-                    await member.pause()
+                    await self.mass.players._handle_cmd_pause(member.player_id)
                 elif command == "play":
-                    await member.play()
+                    await self.mass.players._handle_cmd_play(member.player_id)
         except Exception:
             self.logger.warning(
                 "Failed to propagate %s to member %s",

--- a/music_assistant/providers/sendspin_source/provider.py
+++ b/music_assistant/providers/sendspin_source/provider.py
@@ -101,6 +101,7 @@ class _SourceSession:
     player_id: str
     owner_player_id: str
     stream_session_id: str
+    playback_session_id: str | None = None
     # Retires the prior generator when the same player reclaims the session.
     generation: int = 0
     bridge: SourceBridge | None = None
@@ -268,6 +269,7 @@ class SendspinSourceProvider(PluginProvider):
                                 autostart_queue_id,
                                 provider_instance_id=self.instance_id,
                                 source_id=source_id,
+                                playback_session_id=autostart_session_id,
                             )
                         except (KeyError, PlayerCommandFailed, PlayerUnavailableError) as err:
                             self.logger.debug(
@@ -281,6 +283,7 @@ class SendspinSourceProvider(PluginProvider):
                     live.owner_player_id,
                 ) == (player_id, owner_player_id):
                     live.stream_session_id = stream_session_id
+                    live.playback_session_id = queue_session_id
                     live.generation += 1
                     return
                 await self._teardown_session(source_id, superseded_by_player_id=player_id)
@@ -296,6 +299,7 @@ class SendspinSourceProvider(PluginProvider):
                     player_id=player_id,
                     owner_player_id=owner_player_id,
                     stream_session_id=stream_session_id,
+                    playback_session_id=queue_session_id,
                 )
                 role.request_start()
         finally:
@@ -544,6 +548,7 @@ class SendspinSourceProvider(PluginProvider):
                 session.owner_player_id,
                 provider_instance_id=self.instance_id,
                 source_id=client_id,
+                playback_session_id=session.playback_session_id,
             )
         except (KeyError, PlayerCommandFailed, PlayerUnavailableError) as err:
             self.logger.debug("Failed to stop player %s: %s", session.owner_player_id, err)

--- a/music_assistant/providers/sendspin_source/provider.py
+++ b/music_assistant/providers/sendspin_source/provider.py
@@ -264,7 +264,9 @@ class SendspinSourceProvider(PluginProvider):
                             # deselect rather than stopping the queue: the source plays on
                             # the player, so stopping the queue would leave the source
                             # published on it while resetting the queue we are preserving
-                            await self.mass.players.deselect_source(autostart_queue_id)
+                            await self.mass.players.deselect_source(
+                                autostart_queue_id, provider_instance_id=self.instance_id
+                            )
                         except (KeyError, PlayerCommandFailed, PlayerUnavailableError) as err:
                             self.logger.debug(
                                 "Failed to release autostart player %s: %s",
@@ -536,7 +538,9 @@ class SendspinSourceProvider(PluginProvider):
         self.logger.info("Line-in signal gone on %s, stopping playback", client_id)
         try:
             # Queue stop also cancels pending preload and enqueue timers.
-            await self.mass.players.deselect_source(session.owner_player_id)
+            await self.mass.players.deselect_source(
+                session.owner_player_id, provider_instance_id=self.instance_id
+            )
         except (KeyError, PlayerCommandFailed, PlayerUnavailableError) as err:
             self.logger.debug("Failed to stop player %s: %s", session.owner_player_id, err)
 

--- a/music_assistant/providers/sendspin_source/provider.py
+++ b/music_assistant/providers/sendspin_source/provider.py
@@ -265,7 +265,9 @@ class SendspinSourceProvider(PluginProvider):
                             # the player, so stopping the queue would leave the source
                             # published on it while resetting the queue we are preserving
                             await self.mass.players.deselect_source(
-                                autostart_queue_id, provider_instance_id=self.instance_id
+                                autostart_queue_id,
+                                provider_instance_id=self.instance_id,
+                                source_id=source_id,
                             )
                         except (KeyError, PlayerCommandFailed, PlayerUnavailableError) as err:
                             self.logger.debug(
@@ -539,7 +541,9 @@ class SendspinSourceProvider(PluginProvider):
         try:
             # Queue stop also cancels pending preload and enqueue timers.
             await self.mass.players.deselect_source(
-                session.owner_player_id, provider_instance_id=self.instance_id
+                session.owner_player_id,
+                provider_instance_id=self.instance_id,
+                source_id=client_id,
             )
         except (KeyError, PlayerCommandFailed, PlayerUnavailableError) as err:
             self.logger.debug("Failed to stop player %s: %s", session.owner_player_id, err)

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -780,7 +780,11 @@ class SpotifyConnectProvider(PluginProvider):
             # the player is not playing us any more, so it should stop saying it is;
             # the stop itself is scheduled separately by the caller
             self.mass.create_task(
-                self.mass.players.deselect_source(prev_player_id, stop_playback=False)
+                self.mass.players.deselect_source(
+                    prev_player_id,
+                    stop_playback=False,
+                    provider_instance_id=self.instance_id,
+                )
             )
 
     def _save_last_player_id(self, player_id: str) -> None:

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -784,6 +784,7 @@ class SpotifyConnectProvider(PluginProvider):
                     prev_player_id,
                     stop_playback=False,
                     provider_instance_id=self.instance_id,
+                    source_id=AUDIO_SOURCE_ID,
                 )
             )
 

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -771,6 +771,9 @@ class SpotifyConnectProvider(PluginProvider):
     def _clear_active_player(self) -> None:
         """Clear the active player and reset playback state when a session ends."""
         prev_player_id = self._active_player_id
+        source_session = (
+            self.mass.players.get_audio_source_session(prev_player_id) if prev_player_id else None
+        )
         self._active_player_id = None
         self._in_use_by_player = None
         self._active_session_id = None
@@ -785,6 +788,9 @@ class SpotifyConnectProvider(PluginProvider):
                     stop_playback=False,
                     provider_instance_id=self.instance_id,
                     source_id=AUDIO_SOURCE_ID,
+                    playback_session_id=(
+                        source_session.playback_session_id if source_session else None
+                    ),
                 )
             )
 

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -425,7 +425,12 @@ class SyncGroupPlayer(Player):
             # bypassing group/sync redirect that would loop back to this player.
             # Hold the group's playback lock until the leader confirms playback
             # (see play()) so a concurrent (un)group command can't race the start.
-            async with self._await_leader_playback():
+            async with (
+                self.mass.players.get_player_lock(
+                    sync_leader.player_id, PlayerLockPurpose.PLAYBACK
+                ),
+                self._await_leader_playback(),
+            ):
                 await self.mass.players._handle_play_media(sync_leader.player_id, media)
         else:
             raise RuntimeError("An empty group cannot play media, consider adding members first")

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -31,6 +31,7 @@ from music_assistant.constants import (
     DEFAULT_STREAM_HEADERS,
     DLNA_CONTENT_FEATURES_REALTIME,
 )
+from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.controllers.streams.audio_processing import get_media_session_id
 from music_assistant.helpers.audio import get_mime_type
 from music_assistant.helpers.util import TaskManager
@@ -333,7 +334,7 @@ class UniversalGroupPlayer(Player):
             for member in self.mass.players.iter_group_members(self, only_powered=True):
                 # Use internal handler to get protocol selection and avoid redirect
                 tg.create_task(
-                    self.mass.players._handle_play_media(
+                    self._play_media_on_member(
                         member.player_id,
                         PlayerMedia(
                             uri=f"{base_url}?player_id={member.player_id}",
@@ -388,7 +389,7 @@ class UniversalGroupPlayer(Player):
                 )
                 base_url = f"{self.mass.streams.base_url}/ugp/{self.player_id}.{fmt_str}"
                 # Use internal handler to get protocol selection and avoid redirect
-                await self.mass.players._handle_play_media(
+                await self._play_media_on_member(
                     player_id,
                     PlayerMedia(
                         uri=f"{base_url}?player_id={player_id}",
@@ -437,6 +438,11 @@ class UniversalGroupPlayer(Player):
             # tear down any in-flight session before unloading
             await self.stop()
             self._attr_powered = False
+
+    async def _play_media_on_member(self, player_id: str, media: PlayerMedia) -> None:
+        """Play media directly on a group member under its playback lock."""
+        async with self.mass.players.get_player_lock(player_id, PlayerLockPurpose.PLAYBACK):
+            await self.mass.players._handle_play_media(player_id, media)
 
     async def _capture_members(self) -> None:
         """

--- a/music_assistant/providers/yandex_ynison/provider.py
+++ b/music_assistant/providers/yandex_ynison/provider.py
@@ -1588,7 +1588,11 @@ class YandexYnisonProvider(PluginProvider):
             if owner_player_id:
                 # give the source back as well as stopping: a session left on the player
                 # keeps it publishing this source, so its own queue stays unreachable
-                self.mass.create_task(self.mass.players.deselect_source(owner_player_id))
+                self.mass.create_task(
+                    self.mass.players.deselect_source(
+                        owner_player_id, provider_instance_id=self.instance_id
+                    )
+                )
             self.mass.players.trigger_player_update(prev_player_id)
 
     # ------------------------------------------------------------------

--- a/music_assistant/providers/yandex_ynison/provider.py
+++ b/music_assistant/providers/yandex_ynison/provider.py
@@ -1569,6 +1569,9 @@ class YandexYnisonProvider(PluginProvider):
         # the owner is the user-facing MA player; _active_player_id can be the protocol
         # player that consumed the stream, which is not what holds the source session
         owner_player_id = self._in_use_by_player
+        source_session = (
+            self.mass.players.get_audio_source_session(owner_player_id) if owner_player_id else None
+        )
         self._active_player_id = None
         self._in_use_by_player = None
         self._active_session_id = None
@@ -1593,6 +1596,9 @@ class YandexYnisonProvider(PluginProvider):
                         owner_player_id,
                         provider_instance_id=self.instance_id,
                         source_id=AUDIO_SOURCE_ID,
+                        playback_session_id=(
+                            source_session.playback_session_id if source_session else None
+                        ),
                     )
                 )
             self.mass.players.trigger_player_update(prev_player_id)

--- a/music_assistant/providers/yandex_ynison/provider.py
+++ b/music_assistant/providers/yandex_ynison/provider.py
@@ -1590,7 +1590,9 @@ class YandexYnisonProvider(PluginProvider):
                 # keeps it publishing this source, so its own queue stays unreachable
                 self.mass.create_task(
                     self.mass.players.deselect_source(
-                        owner_player_id, provider_instance_id=self.instance_id
+                        owner_player_id,
+                        provider_instance_id=self.instance_id,
+                        source_id=AUDIO_SOURCE_ID,
                     )
                 )
             self.mass.players.trigger_player_update(prev_player_id)

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -12,7 +12,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.enums import MediaType, PlaybackState, ProviderFeature
 from music_assistant_models.errors import MediaNotFoundError, PlayerCommandFailed
 from music_assistant_models.media_items import AudioSource, Track
 from music_assistant_models.media_items.provider_mapping import ProviderMapping
@@ -246,8 +246,8 @@ async def test_deselecting_another_source_from_the_same_provider_is_rejected() -
 
 
 async def test_deselecting_finishes_before_new_playback_starts() -> None:
-    """Release and stop complete before queued playback or source selection starts."""
-    controller, provider, _player = _controller(_source())
+    """Release and stop complete before any player playback entry point starts."""
+    controller, provider, player = _controller(_source())
     await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
     session = controller.get_audio_source_session(PLAYER_ID)
     assert session is not None
@@ -268,10 +268,24 @@ async def test_deselecting_finishes_before_new_playback_starts() -> None:
     async def select_source(_player_id: str, _source_id: str | None) -> None:
         events.append("select")
 
+    async def play(_player_id: str) -> None:
+        events.append("play_command")
+
+    async def resume(
+        _player_id: str,
+        _source_id: str | None,
+        _media: PlayerMedia | None,
+    ) -> None:
+        events.append("resume")
+
     provider.on_source_released.side_effect = release_source
     controller._handle_cmd_stop.side_effect = stop_player
     controller._handle_play_media = AsyncMock(side_effect=play_media)
     controller._handle_select_source = AsyncMock(side_effect=select_source)
+    controller._handle_cmd_play = AsyncMock(side_effect=play)
+    controller._handle_cmd_resume = AsyncMock(side_effect=resume)
+    player.state.playback_state = PlaybackState.IDLE
+    controller.mass.player_queues.get.return_value = None
 
     release_task = asyncio.create_task(
         controller.deselect_source(
@@ -289,15 +303,23 @@ async def test_deselecting_finishes_before_new_playback_starts() -> None:
         )
     )
     select_task = asyncio.create_task(controller.select_source(PLAYER_ID, PLAYER_ID))
+    play_command_task = asyncio.create_task(controller.cmd_play(PLAYER_ID))
+    resume_task = asyncio.create_task(controller.cmd_resume(PLAYER_ID))
     await asyncio.sleep(0)
     playback_waited = not events
 
     finish_release.set()
-    await asyncio.gather(release_task, play_task, select_task)
+    await asyncio.gather(
+        release_task,
+        play_task,
+        select_task,
+        play_command_task,
+        resume_task,
+    )
 
     assert playback_waited
     assert events[0] == "stop"
-    assert set(events[1:]) == {"play", "select"}
+    assert set(events[1:]) == {"play", "play_command", "resume", "select"}
 
 
 async def test_releasing_a_player_with_nothing_playing_is_a_no_op() -> None:

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -140,6 +140,47 @@ async def test_deselecting_from_another_provider_leaves_the_source_playing() -> 
     controller._handle_cmd_stop.assert_not_awaited()
 
 
+async def test_deselecting_without_an_owned_session_does_not_stop_the_player() -> None:
+    """A provider cannot stop a player when it owns no source session."""
+    controller, provider, _player = _controller(None)
+
+    await controller.deselect_source(PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE)
+
+    provider.on_source_released.assert_not_awaited()
+    controller._handle_cmd_stop.assert_not_awaited()
+
+
+async def test_a_replacement_source_during_release_is_not_stopped() -> None:
+    """A source taking over during release remains active and playing."""
+    controller, provider, _player = _controller(_source())
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    replacement_instance = "airplay_receiver--xyz"
+    replacement = AudioSource(
+        item_id="receiver",
+        provider=replacement_instance,
+        name="AirPlay",
+        provider_mappings={
+            ProviderMapping(
+                item_id="receiver",
+                provider_domain="airplay_receiver",
+                provider_instance=replacement_instance,
+            )
+        },
+    )
+
+    async def start_replacement(_source_id: str, _player_id: str) -> None:
+        controller._start_audio_source_session(PLAYER_ID, replacement, replacement_instance)
+
+    provider.on_source_released.side_effect = start_replacement
+
+    await controller.deselect_source(PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE)
+
+    session = controller.get_audio_source_session(PLAYER_ID)
+    assert session is not None
+    assert session.source is replacement
+    controller._handle_cmd_stop.assert_not_awaited()
+
+
 async def test_releasing_a_player_with_nothing_playing_is_a_no_op() -> None:
     """A release for a player holding no source tells no plugin anything."""
     controller, provider, _player = _controller(None)

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -26,14 +26,14 @@ PROVIDER_INSTANCE = "spotify_connect--abc"
 SOURCE_URI = "spotify_connect--abc://audio_source/main"
 
 
-def _source() -> AudioSource:
+def _source(item_id: str = "main") -> AudioSource:
     return AudioSource(
-        item_id="main",
+        item_id=item_id,
         provider=PROVIDER_INSTANCE,
         name="Spotify Connect",
         provider_mappings={
             ProviderMapping(
-                item_id="main",
+                item_id=item_id,
                 provider_domain="spotify_connect",
                 provider_instance=PROVIDER_INSTANCE,
             )
@@ -120,7 +120,9 @@ async def test_deselecting_releases_the_source_and_stops_the_player() -> None:
     controller, provider, _player = _controller(_source())
     await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
 
-    await controller.deselect_source(PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE)
+    await controller.deselect_source(
+        PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE, source_id="main"
+    )
 
     assert controller.get_audio_source_session(PLAYER_ID) is None
     provider.on_source_released.assert_awaited_once_with("main", PLAYER_ID)
@@ -133,7 +135,9 @@ async def test_deselecting_from_another_provider_leaves_the_source_playing() -> 
     await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
     session = controller.get_audio_source_session(PLAYER_ID)
 
-    await controller.deselect_source(PLAYER_ID, provider_instance_id="airplay_receiver--xyz")
+    await controller.deselect_source(
+        PLAYER_ID, provider_instance_id="airplay_receiver--xyz", source_id="main"
+    )
 
     assert controller.get_audio_source_session(PLAYER_ID) is session
     provider.on_source_released.assert_not_awaited()
@@ -144,7 +148,9 @@ async def test_deselecting_without_an_owned_session_does_not_stop_the_player() -
     """A provider cannot stop a player when it owns no source session."""
     controller, provider, _player = _controller(None)
 
-    await controller.deselect_source(PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE)
+    await controller.deselect_source(
+        PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE, source_id="main"
+    )
 
     provider.on_source_released.assert_not_awaited()
     controller._handle_cmd_stop.assert_not_awaited()
@@ -173,11 +179,29 @@ async def test_a_replacement_source_during_release_is_not_stopped() -> None:
 
     provider.on_source_released.side_effect = start_replacement
 
-    await controller.deselect_source(PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE)
+    await controller.deselect_source(
+        PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE, source_id="main"
+    )
 
     session = controller.get_audio_source_session(PLAYER_ID)
     assert session is not None
     assert session.source is replacement
+    controller._handle_cmd_stop.assert_not_awaited()
+
+
+async def test_deselecting_another_source_from_the_same_provider_is_rejected() -> None:
+    """A provider cannot release a different source session from the one that ended."""
+    controller, provider, _player = _controller(_source())
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    replacement = _source("other")
+    session = controller._start_audio_source_session(PLAYER_ID, replacement, PROVIDER_INSTANCE)
+
+    await controller.deselect_source(
+        PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE, source_id="main"
+    )
+
+    assert controller.get_audio_source_session(PLAYER_ID) is session
+    provider.on_source_released.assert_not_awaited()
     controller._handle_cmd_stop.assert_not_awaited()
 
 

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -6,6 +6,7 @@ selecting anything else, or deselecting, gives the source back and tells the
 plugin so an upstream session stops pointing at Music Assistant.
 """
 
+import asyncio
 from contextlib import suppress
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -203,6 +204,56 @@ async def test_deselecting_another_source_from_the_same_provider_is_rejected() -
     assert controller.get_audio_source_session(PLAYER_ID) is session
     provider.on_source_released.assert_not_awaited()
     controller._handle_cmd_stop.assert_not_awaited()
+
+
+async def test_deselecting_finishes_before_new_playback_starts() -> None:
+    """Release and stop complete before queued playback or source selection starts."""
+    controller, provider, _player = _controller(_source())
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    release_started = asyncio.Event()
+    finish_release = asyncio.Event()
+    events: list[str] = []
+
+    async def release_source(_source_id: str, _player_id: str) -> None:
+        release_started.set()
+        await finish_release.wait()
+
+    async def stop_player(_player_id: str) -> None:
+        events.append("stop")
+
+    async def play_media(_player_id: str, _media: PlayerMedia) -> None:
+        events.append("play")
+
+    async def select_source(_player_id: str, _source_id: str | None) -> None:
+        events.append("select")
+
+    provider.on_source_released.side_effect = release_source
+    controller._handle_cmd_stop.side_effect = stop_player
+    controller._handle_play_media = AsyncMock(side_effect=play_media)
+    controller._handle_select_source = AsyncMock(side_effect=select_source)
+
+    release_task = asyncio.create_task(
+        controller.deselect_source(
+            PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE, source_id="main"
+        )
+    )
+    await release_started.wait()
+    play_task = asyncio.create_task(
+        controller.play_media(
+            PLAYER_ID,
+            PlayerMedia(uri="library://track/1", media_type=MediaType.TRACK),
+        )
+    )
+    select_task = asyncio.create_task(controller.select_source(PLAYER_ID, PLAYER_ID))
+    await asyncio.sleep(0)
+    playback_waited = not events
+
+    finish_release.set()
+    await asyncio.gather(release_task, play_task, select_task)
+
+    assert playback_waited
+    assert events[0] == "stop"
+    assert set(events[1:]) == {"play", "select"}
 
 
 async def test_releasing_a_player_with_nothing_playing_is_a_no_op() -> None:

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -120,9 +120,14 @@ async def test_deselecting_releases_the_source_and_stops_the_player() -> None:
     """The source owner can give its source back and stop playback."""
     controller, provider, _player = _controller(_source())
     await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    session = controller.get_audio_source_session(PLAYER_ID)
+    assert session is not None
 
     await controller.deselect_source(
-        PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE, source_id="main"
+        PLAYER_ID,
+        provider_instance_id=PROVIDER_INSTANCE,
+        source_id="main",
+        playback_session_id=session.playback_session_id,
     )
 
     assert controller.get_audio_source_session(PLAYER_ID) is None
@@ -135,9 +140,13 @@ async def test_deselecting_from_another_provider_leaves_the_source_playing() -> 
     controller, provider, _player = _controller(_source())
     await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
     session = controller.get_audio_source_session(PLAYER_ID)
+    assert session is not None
 
     await controller.deselect_source(
-        PLAYER_ID, provider_instance_id="airplay_receiver--xyz", source_id="main"
+        PLAYER_ID,
+        provider_instance_id="airplay_receiver--xyz",
+        source_id="main",
+        playback_session_id=session.playback_session_id,
     )
 
     assert controller.get_audio_source_session(PLAYER_ID) is session
@@ -150,9 +159,29 @@ async def test_deselecting_without_an_owned_session_does_not_stop_the_player() -
     controller, provider, _player = _controller(None)
 
     await controller.deselect_source(
-        PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE, source_id="main"
+        PLAYER_ID,
+        provider_instance_id=PROVIDER_INSTANCE,
+        source_id="main",
+        playback_session_id="stale-session",
     )
 
+    provider.on_source_released.assert_not_awaited()
+    controller._handle_cmd_stop.assert_not_awaited()
+
+
+async def test_a_provider_release_without_a_playback_session_is_rejected() -> None:
+    """Provider cleanup without a captured playback generation is not authoritative."""
+    controller, provider, _player = _controller(_source())
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    session = controller.get_audio_source_session(PLAYER_ID)
+
+    await controller.deselect_source(
+        PLAYER_ID,
+        provider_instance_id=PROVIDER_INSTANCE,
+        source_id="main",
+    )
+
+    assert controller.get_audio_source_session(PLAYER_ID) is session
     provider.on_source_released.assert_not_awaited()
     controller._handle_cmd_stop.assert_not_awaited()
 
@@ -161,6 +190,8 @@ async def test_a_replacement_source_during_release_is_not_stopped() -> None:
     """A source taking over during release remains active and playing."""
     controller, provider, _player = _controller(_source())
     await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    original_session = controller.get_audio_source_session(PLAYER_ID)
+    assert original_session is not None
     replacement_instance = "airplay_receiver--xyz"
     replacement = AudioSource(
         item_id="receiver",
@@ -181,7 +212,10 @@ async def test_a_replacement_source_during_release_is_not_stopped() -> None:
     provider.on_source_released.side_effect = start_replacement
 
     await controller.deselect_source(
-        PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE, source_id="main"
+        PLAYER_ID,
+        provider_instance_id=PROVIDER_INSTANCE,
+        source_id="main",
+        playback_session_id=original_session.playback_session_id,
     )
 
     session = controller.get_audio_source_session(PLAYER_ID)
@@ -194,11 +228,16 @@ async def test_deselecting_another_source_from_the_same_provider_is_rejected() -
     """A provider cannot release a different source session from the one that ended."""
     controller, provider, _player = _controller(_source())
     await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    original_session = controller.get_audio_source_session(PLAYER_ID)
+    assert original_session is not None
     replacement = _source("other")
     session = controller._start_audio_source_session(PLAYER_ID, replacement, PROVIDER_INSTANCE)
 
     await controller.deselect_source(
-        PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE, source_id="main"
+        PLAYER_ID,
+        provider_instance_id=PROVIDER_INSTANCE,
+        source_id="main",
+        playback_session_id=original_session.playback_session_id,
     )
 
     assert controller.get_audio_source_session(PLAYER_ID) is session
@@ -210,6 +249,8 @@ async def test_deselecting_finishes_before_new_playback_starts() -> None:
     """Release and stop complete before queued playback or source selection starts."""
     controller, provider, _player = _controller(_source())
     await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    session = controller.get_audio_source_session(PLAYER_ID)
+    assert session is not None
     release_started = asyncio.Event()
     finish_release = asyncio.Event()
     events: list[str] = []
@@ -234,7 +275,10 @@ async def test_deselecting_finishes_before_new_playback_starts() -> None:
 
     release_task = asyncio.create_task(
         controller.deselect_source(
-            PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE, source_id="main"
+            PLAYER_ID,
+            provider_instance_id=PROVIDER_INSTANCE,
+            source_id="main",
+            playback_session_id=session.playback_session_id,
         )
     )
     await release_started.wait()
@@ -426,11 +470,35 @@ async def test_reselecting_the_same_source_does_not_hand_it_back() -> None:
     controller, provider, _player = _controller(_source())
     await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
     first = controller.get_audio_source_session(PLAYER_ID)
+    assert first is not None
+    first_playback_session_id = first.playback_session_id
 
     await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
 
     provider.on_source_released.assert_not_awaited()
     assert controller.get_audio_source_session(PLAYER_ID) is first
+    assert first.playback_session_id != first_playback_session_id
+
+
+async def test_a_stale_release_cannot_end_a_reselected_source() -> None:
+    """A delayed cleanup cannot release a new selection of the same source."""
+    controller, provider, _player = _controller(_source())
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    session = controller.get_audio_source_session(PLAYER_ID)
+    assert session is not None
+    stale_playback_session_id = session.playback_session_id
+
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    await controller.deselect_source(
+        PLAYER_ID,
+        provider_instance_id=PROVIDER_INSTANCE,
+        source_id="main",
+        playback_session_id=stale_playback_session_id,
+    )
+
+    assert controller.get_audio_source_session(PLAYER_ID) is session
+    provider.on_source_released.assert_not_awaited()
+    controller._handle_cmd_stop.assert_not_awaited()
 
 
 async def test_a_source_that_fails_to_start_is_not_left_on_the_player() -> None:

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -186,6 +186,26 @@ async def test_a_provider_release_without_a_playback_session_is_rejected() -> No
     controller._handle_cmd_stop.assert_not_awaited()
 
 
+async def test_an_unexpected_stop_failure_still_releases_the_source() -> None:
+    """Source cleanup completes before an unexpected stop error propagates."""
+    controller, provider, _player = _controller(_source())
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    session = controller.get_audio_source_session(PLAYER_ID)
+    assert session is not None
+    controller._handle_cmd_stop.side_effect = OSError("transport failed")
+
+    with pytest.raises(OSError, match="transport failed"):
+        await controller.deselect_source(
+            PLAYER_ID,
+            provider_instance_id=PROVIDER_INSTANCE,
+            source_id="main",
+            playback_session_id=session.playback_session_id,
+        )
+
+    assert controller.get_audio_source_session(PLAYER_ID) is None
+    provider.on_source_released.assert_awaited_once_with("main", PLAYER_ID)
+
+
 async def test_a_replacement_source_during_release_is_not_stopped() -> None:
     """A source taking over during release remains active and playing."""
     controller, provider, _player = _controller(_source())
@@ -221,7 +241,7 @@ async def test_a_replacement_source_during_release_is_not_stopped() -> None:
     session = controller.get_audio_source_session(PLAYER_ID)
     assert session is not None
     assert session.source is replacement
-    controller._handle_cmd_stop.assert_not_awaited()
+    controller._handle_cmd_stop.assert_awaited_once()
 
 
 async def test_deselecting_another_source_from_the_same_provider_is_rejected() -> None:
@@ -296,6 +316,7 @@ async def test_deselecting_finishes_before_new_playback_starts() -> None:
         )
     )
     await release_started.wait()
+    assert events == ["stop"]
     play_task = asyncio.create_task(
         controller.play_media(
             PLAYER_ID,
@@ -306,7 +327,7 @@ async def test_deselecting_finishes_before_new_playback_starts() -> None:
     play_command_task = asyncio.create_task(controller.cmd_play(PLAYER_ID))
     resume_task = asyncio.create_task(controller.cmd_resume(PLAYER_ID))
     await asyncio.sleep(0)
-    playback_waited = not events
+    playback_waited = events == ["stop"]
 
     finish_release.set()
     await asyncio.gather(
@@ -320,6 +341,49 @@ async def test_deselecting_finishes_before_new_playback_starts() -> None:
     assert playback_waited
     assert events[0] == "stop"
     assert set(events[1:]) == {"play", "play_command", "resume", "select"}
+
+
+async def test_playback_starting_during_release_callback_is_not_stopped() -> None:
+    """Playback bypassing the lock during plugin release sees no later stale stop."""
+    controller, provider, _player = _controller(_source())
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    session = controller.get_audio_source_session(PLAYER_ID)
+    assert session is not None
+    release_started = asyncio.Event()
+    finish_release = asyncio.Event()
+    events: list[str] = []
+
+    async def release_source(_source_id: str, _player_id: str) -> None:
+        release_started.set()
+        await finish_release.wait()
+
+    async def stop_player(_player_id: str) -> None:
+        events.append("stop")
+
+    async def play_media(_player_id: str, _media: PlayerMedia) -> None:
+        events.append("play")
+
+    provider.on_source_released.side_effect = release_source
+    controller._handle_cmd_stop.side_effect = stop_player
+    controller._handle_play_media = AsyncMock(side_effect=play_media)
+
+    release_task = asyncio.create_task(
+        controller.deselect_source(
+            PLAYER_ID,
+            provider_instance_id=PROVIDER_INSTANCE,
+            source_id="main",
+            playback_session_id=session.playback_session_id,
+        )
+    )
+    await release_started.wait()
+    await controller._handle_play_media(
+        PLAYER_ID,
+        PlayerMedia(uri="library://track/1", media_type=MediaType.TRACK),
+    )
+    finish_release.set()
+    await release_task
+
+    assert events == ["stop", "play"]
 
 
 async def test_releasing_a_player_with_nothing_playing_is_a_no_op() -> None:

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -19,6 +19,7 @@ from music_assistant_models.media_items.provider_mapping import ProviderMapping
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.controllers.players import PlayerController
+from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.models.player import Player, PlayerMedia
 from music_assistant.models.plugin import PluginProvider
 
@@ -422,6 +423,29 @@ async def test_cmd_play_checks_playing_state_after_cleanup_finishes() -> None:
     await asyncio.gather(release_task, play_task)
 
     controller._handle_cmd_play.assert_awaited_once_with(PLAYER_ID)
+
+
+async def test_cmd_stop_locks_the_redirected_playback_owner() -> None:
+    """A member stop locks its group rather than taking the locks in reverse order."""
+    controller, _provider, player = _controller(None)
+    group_id = "group_1"
+    group = MagicMock()
+    group.player_id = group_id
+    group.available = True
+    group.protocol_parent_id = None
+    group.state.active_group = None
+    group.state.synced_to = None
+    controller._players[group_id] = group
+    players = {PLAYER_ID: player, group_id: group}
+    controller.get_player.side_effect = lambda player_id, *_args, **_kwargs: players.get(player_id)
+    player.state.active_group = group_id
+    controller.mass.player_queues.get.return_value = None
+
+    await controller.cmd_stop(PLAYER_ID)
+
+    controller._handle_cmd_stop.assert_awaited_once_with(group_id)
+    assert f"{PlayerLockPurpose.PLAYBACK.value}_{group_id}" in controller._player_command_locks
+    assert f"{PlayerLockPurpose.PLAYBACK.value}_{PLAYER_ID}" not in controller._player_command_locks
 
 
 async def test_releasing_a_player_with_nothing_playing_is_a_no_op() -> None:

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -116,15 +116,28 @@ async def test_selecting_another_source_releases_the_first() -> None:
 
 
 async def test_deselecting_releases_the_source_and_stops_the_player() -> None:
-    """An explicit deselect gives the source back and stops playback."""
+    """The source owner can give its source back and stop playback."""
     controller, provider, _player = _controller(_source())
     await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
 
-    await controller.deselect_source(PLAYER_ID)
+    await controller.deselect_source(PLAYER_ID, provider_instance_id=PROVIDER_INSTANCE)
 
     assert controller.get_audio_source_session(PLAYER_ID) is None
     provider.on_source_released.assert_awaited_once_with("main", PLAYER_ID)
     controller._handle_cmd_stop.assert_awaited_once()
+
+
+async def test_deselecting_from_another_provider_leaves_the_source_playing() -> None:
+    """A provider cannot release or stop a source session it does not own."""
+    controller, provider, _player = _controller(_source())
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    session = controller.get_audio_source_session(PLAYER_ID)
+
+    await controller.deselect_source(PLAYER_ID, provider_instance_id="airplay_receiver--xyz")
+
+    assert controller.get_audio_source_session(PLAYER_ID) is session
+    provider.on_source_released.assert_not_awaited()
+    controller._handle_cmd_stop.assert_not_awaited()
 
 
 async def test_releasing_a_player_with_nothing_playing_is_a_no_op() -> None:

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -386,6 +386,44 @@ async def test_playback_starting_during_release_callback_is_not_stopped() -> Non
     assert events == ["stop", "play"]
 
 
+async def test_cmd_play_checks_playing_state_after_cleanup_finishes() -> None:
+    """A play command waiting on cleanup rechecks state after the old stop."""
+    controller, _provider, player = _controller(_source())
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    session = controller.get_audio_source_session(PLAYER_ID)
+    assert session is not None
+    player.state.playback_state = PlaybackState.PLAYING
+    stop_started = asyncio.Event()
+    finish_stop = asyncio.Event()
+
+    async def stop_player(_player_id: str) -> None:
+        stop_started.set()
+        await finish_stop.wait()
+        player.state.playback_state = PlaybackState.IDLE
+
+    controller._handle_cmd_stop.side_effect = stop_player
+    controller._handle_cmd_play = AsyncMock()
+    controller.mass.player_queues.get.return_value = None
+
+    release_task = asyncio.create_task(
+        controller.deselect_source(
+            PLAYER_ID,
+            provider_instance_id=PROVIDER_INSTANCE,
+            source_id="main",
+            playback_session_id=session.playback_session_id,
+        )
+    )
+    await stop_started.wait()
+    play_task = asyncio.create_task(controller.cmd_play(PLAYER_ID))
+    await asyncio.sleep(0)
+    controller._handle_cmd_play.assert_not_awaited()
+
+    finish_stop.set()
+    await asyncio.gather(release_task, play_task)
+
+    controller._handle_cmd_play.assert_awaited_once_with(PLAYER_ID)
+
+
 async def test_releasing_a_player_with_nothing_playing_is_a_no_op() -> None:
     """A release for a player holding no source tells no plugin anything."""
     controller, provider, _player = _controller(None)

--- a/tests/controllers/streams/test_audio_source_route.py
+++ b/tests/controllers/streams/test_audio_source_route.py
@@ -8,6 +8,7 @@ same holds for the direct-PCM consumers, which never reach the route at all.
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -255,3 +256,60 @@ async def test_a_reselected_session_is_not_released_after_setup_failure() -> Non
         await ctrl.serve_audio_source_stream(_request(session_id=session.playback_session_id))
 
     ctrl.mass.players.deselect_source.assert_not_awaited()
+
+
+async def test_http_setup_stops_when_the_session_is_reselected() -> None:
+    """HTTP setup cannot stamp its stream token onto a newer source selection."""
+    session = _session()
+    ctrl, provider, _player = _controller(session)
+    request_session_id = session.playback_session_id
+
+    async def supersede_session(*_args: Any) -> None:
+        session.playback_session_id = "replacement-session"
+
+    provider.on_source_selected = AsyncMock(side_effect=supersede_session)
+    ctrl._prepare_audio_source_stream = AsyncMock()
+
+    with pytest.raises(web.HTTPNotFound, match="superseded"):
+        await ctrl.serve_audio_source_stream(_request(session_id=request_session_id))
+
+    ctrl._prepare_audio_source_stream.assert_not_awaited()
+    ctrl.mass.players.deselect_source.assert_not_awaited()
+
+
+async def test_direct_pcm_setup_stops_when_the_session_is_reselected() -> None:
+    """PCM setup cannot stamp its stream token onto a newer source selection."""
+    session = _session()
+    ctrl, provider, _player = _controller(session)
+
+    async def supersede_session(*_args: Any) -> None:
+        session.playback_session_id = "replacement-session"
+
+    provider.on_source_selected = AsyncMock(side_effect=supersede_session)
+    stream = ctrl._get_audio_source_session_stream(session, AudioFormat(), CONSUMER_ID)
+
+    with pytest.raises(AudioError, match="superseded"):
+        await anext(stream)
+
+    ctrl.mass.players.deselect_source.assert_not_awaited()
+
+
+async def test_direct_pcm_stream_stops_when_the_session_is_reselected() -> None:
+    """A running PCM stream ends before yielding audio for a newer selection."""
+    session = _session()
+    session.streamdetails = MagicMock()
+    ctrl, _provider, _player = _controller(session)
+    ctrl.audio = MagicMock()
+
+    async def chunks() -> AsyncGenerator[bytes]:
+        yield b"first"
+        yield b"stale"
+
+    ctrl.audio.get_audio_source_stream = MagicMock(return_value=chunks())
+    stream = ctrl._get_audio_source_session_stream(session, AudioFormat(), CONSUMER_ID)
+
+    assert await anext(stream) == b"first"
+    session.playback_session_id = "replacement-session"
+
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)

--- a/tests/controllers/streams/test_audio_source_route.py
+++ b/tests/controllers/streams/test_audio_source_route.py
@@ -205,6 +205,7 @@ async def test_a_plugin_refusing_the_stream_takes_the_source_off_the_player() ->
         OWNER_ID,
         provider_instance_id=session.provider_instance_id,
         source_id=session.source_id,
+        playback_session_id=session.playback_session_id,
     )
 
 
@@ -221,6 +222,7 @@ async def test_failing_stream_details_also_takes_the_source_off_the_player() -> 
         OWNER_ID,
         provider_instance_id=session.provider_instance_id,
         source_id=session.source_id,
+        playback_session_id=session.playback_session_id,
     )
 
 
@@ -231,6 +233,23 @@ async def test_a_session_already_superseded_is_not_released() -> None:
     provider.on_source_selected = AsyncMock(side_effect=RuntimeError("nope"))
     # the player moved on to a different session while this request was setting up
     ctrl.mass.players.get_audio_source_session = MagicMock(return_value=_session())
+
+    with pytest.raises(web.HTTPNotFound):
+        await ctrl.serve_audio_source_stream(_request(session_id=session.playback_session_id))
+
+    ctrl.mass.players.deselect_source.assert_not_awaited()
+
+
+async def test_a_reselected_session_is_not_released_after_setup_failure() -> None:
+    """A failed request cannot release a newer selection using the same session object."""
+    session = _session()
+    ctrl, provider, _player = _controller(session)
+
+    async def supersede_session(*_args: Any) -> None:
+        session.playback_session_id = "replacement-session"
+        raise RuntimeError("nope")
+
+    provider.on_source_selected = AsyncMock(side_effect=supersede_session)
 
     with pytest.raises(web.HTTPNotFound):
         await ctrl.serve_audio_source_stream(_request(session_id=session.playback_session_id))

--- a/tests/controllers/streams/test_audio_source_route.py
+++ b/tests/controllers/streams/test_audio_source_route.py
@@ -201,7 +201,11 @@ async def test_a_plugin_refusing_the_stream_takes_the_source_off_the_player() ->
     with pytest.raises(web.HTTPNotFound):
         await ctrl.serve_audio_source_stream(_request(session_id=session.playback_session_id))
 
-    ctrl.mass.players.deselect_source.assert_awaited_once_with(OWNER_ID)
+    ctrl.mass.players.deselect_source.assert_awaited_once_with(
+        OWNER_ID,
+        provider_instance_id=session.provider_instance_id,
+        source_id=session.source_id,
+    )
 
 
 async def test_failing_stream_details_also_takes_the_source_off_the_player() -> None:
@@ -213,7 +217,11 @@ async def test_failing_stream_details_also_takes_the_source_off_the_player() -> 
     with pytest.raises(web.HTTPNotFound):
         await ctrl.serve_audio_source_stream(_request(session_id=session.playback_session_id))
 
-    ctrl.mass.players.deselect_source.assert_awaited_once_with(OWNER_ID)
+    ctrl.mass.players.deselect_source.assert_awaited_once_with(
+        OWNER_ID,
+        provider_instance_id=session.provider_instance_id,
+        source_id=session.source_id,
+    )
 
 
 async def test_a_session_already_superseded_is_not_released() -> None:

--- a/tests/providers/ariacast_receiver/test_control.py
+++ b/tests/providers/ariacast_receiver/test_control.py
@@ -105,6 +105,7 @@ async def test_forward_action_without_exclusion_reaches_all_senders() -> None:
 def _playback_receiver(*, active_player_id: str | None, owner: str | None) -> SimpleNamespace:
     """Build a bare receiver namespace for driving _handle_playback_state."""
     return SimpleNamespace(
+        instance_id="ariacast_receiver--test",
         _is_playing=True,
         _in_use_by_player=owner,
         _active_player_id=active_player_id,
@@ -133,7 +134,9 @@ async def test_the_sender_stopping_gives_the_source_back_to_its_owner() -> None:
 
     await _playback(receiver, False)
 
-    receiver.mass.players.deselect_source.assert_called_once_with("owner-player")
+    receiver.mass.players.deselect_source.assert_called_once_with(
+        "owner-player", provider_instance_id=receiver.instance_id
+    )
     assert receiver._in_use_by_player is None
 
 

--- a/tests/providers/ariacast_receiver/test_control.py
+++ b/tests/providers/ariacast_receiver/test_control.py
@@ -104,6 +104,10 @@ async def test_forward_action_without_exclusion_reaches_all_senders() -> None:
 
 def _playback_receiver(*, active_player_id: str | None, owner: str | None) -> SimpleNamespace:
     """Build a bare receiver namespace for driving _handle_playback_state."""
+    mass = MagicMock()
+    mass.players.get_audio_source_session.return_value = SimpleNamespace(
+        playback_session_id="playback-session"
+    )
     return SimpleNamespace(
         instance_id="ariacast_receiver--test",
         _is_playing=True,
@@ -112,7 +116,7 @@ def _playback_receiver(*, active_player_id: str | None, owner: str | None) -> Si
         _get_target_player_id=MagicMock(return_value=None),
         _safe_play_media=AsyncMock(),
         _broadcast_meta=AsyncMock(),
-        mass=MagicMock(),
+        mass=mass,
         logger=MagicMock(),
     )
 
@@ -138,6 +142,7 @@ async def test_the_sender_stopping_gives_the_source_back_to_its_owner() -> None:
         "owner-player",
         provider_instance_id=receiver.instance_id,
         source_id=AUDIO_SOURCE_ID,
+        playback_session_id="playback-session",
     )
     assert receiver._in_use_by_player is None
 

--- a/tests/providers/ariacast_receiver/test_control.py
+++ b/tests/providers/ariacast_receiver/test_control.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
-from music_assistant.providers.ariacast_receiver import AriaCastReceiver
+from music_assistant.providers.ariacast_receiver import AUDIO_SOURCE_ID, AriaCastReceiver
 
 
 def _receiver(in_use_by_queue: str | None = "queue_1") -> SimpleNamespace:
@@ -135,7 +135,9 @@ async def test_the_sender_stopping_gives_the_source_back_to_its_owner() -> None:
     await _playback(receiver, False)
 
     receiver.mass.players.deselect_source.assert_called_once_with(
-        "owner-player", provider_instance_id=receiver.instance_id
+        "owner-player",
+        provider_instance_id=receiver.instance_id,
+        source_id=AUDIO_SOURCE_ID,
     )
     assert receiver._in_use_by_player is None
 

--- a/tests/providers/msx_bridge/conftest.py
+++ b/tests/providers/msx_bridge/conftest.py
@@ -83,6 +83,10 @@ def mass_mock(player_config_mock: Mock) -> Mock:
     mass.players.cmd_stop = AsyncMock()
     mass.players.cmd_next_track = AsyncMock()
     mass.players.cmd_previous_track = AsyncMock()
+    mass.players._handle_cmd_pause = AsyncMock()
+    mass.players._handle_cmd_play = AsyncMock()
+    mass.players._handle_cmd_stop = AsyncMock()
+    mass.players._handle_play_media = AsyncMock()
     mass.players.get = Mock(return_value=None)
     mass.players.get_player = Mock(return_value=None)
 

--- a/tests/providers/msx_bridge/conftest.py
+++ b/tests/providers/msx_bridge/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
@@ -84,6 +85,12 @@ def mass_mock(player_config_mock: Mock) -> Mock:
     mass.players.cmd_previous_track = AsyncMock()
     mass.players.get = Mock(return_value=None)
     mass.players.get_player = Mock(return_value=None)
+
+    @asynccontextmanager
+    async def _player_lock(*_args: Any, **_kwargs: Any) -> AsyncGenerator[None]:
+        yield
+
+    mass.players.get_player_lock = Mock(side_effect=_player_lock)
     mass.players.register = AsyncMock()
     mass.players.unregister = AsyncMock()
     mass.players.all = Mock(return_value=[])

--- a/tests/providers/msx_bridge/test_player.py
+++ b/tests/providers/msx_bridge/test_player.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
 from music_assistant_models.player import PlayerMedia
 
+from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.providers.msx_bridge.player import MSXPlayer
 
 # --- Initialization and properties ---
@@ -356,6 +357,9 @@ async def test_play_media_propagates_to_group_members(provider: Any, mass_mock: 
 
     # We call member.play_media directly (not mass.players.play_media) to avoid redirect
     member.play_media.assert_called_once_with(media)
+    mass_mock.players.get_player_lock.assert_called_once_with(
+        "msx_member", PlayerLockPurpose.PLAYBACK
+    )
 
 
 async def test_play_media_no_propagation_when_empty_group(provider: Any, mass_mock: Mock) -> None:

--- a/tests/providers/msx_bridge/test_player.py
+++ b/tests/providers/msx_bridge/test_player.py
@@ -334,7 +334,7 @@ async def test_set_members_ignores_self_and_non_msx(provider: Any, mass_mock: Mo
 
 
 async def test_play_media_propagates_to_group_members(provider: Any, mass_mock: Mock) -> None:
-    """play_media should propagate to group members when leader (direct member.play_media)."""
+    """play_media should propagate to group members through the internal handler."""
     leader = MSXPlayer(provider, "msx_leader", name="Leader TV", output_format="mp3")
     leader.update_state = Mock()  # type: ignore[misc,method-assign]
     leader._attr_group_members = ["msx_leader", "msx_member"]
@@ -355,8 +355,8 @@ async def test_play_media_propagates_to_group_members(provider: Any, mass_mock: 
     with patch.object(leader.provider, "notify_play_started", Mock()):
         await leader.play_media(media)
 
-    # We call member.play_media directly (not mass.players.play_media) to avoid redirect
-    member.play_media.assert_called_once_with(media)
+    mass_mock.players._handle_play_media.assert_awaited_once_with("msx_member", media)
+    member.play_media.assert_not_called()
     mass_mock.players.get_player_lock.assert_called_once_with(
         "msx_member", PlayerLockPurpose.PLAYBACK
     )
@@ -396,8 +396,8 @@ async def test_stop_propagates_to_group_members(provider: Any, mass_mock: Mock) 
     with patch.object(leader.provider, "notify_play_stopped", Mock()):
         await leader.stop()
 
-    # group_members may include leader; we skip self and propagate only to members
-    member.stop.assert_called_once()
+    mass_mock.players._handle_cmd_stop.assert_awaited_once_with("msx_member")
+    member.stop.assert_not_called()
 
 
 # --- Grouping: disable and recursion guard ---
@@ -473,6 +473,11 @@ async def test_propagation_recursion_guard(provider: Any, mass_mock: Mock) -> No
             member if pid == "msx_member" else leader if pid == "msx_leader" else None
         )
     )
+
+    async def play_member(player_id: str, propagated_media: PlayerMedia) -> None:
+        await mass_mock.players.get_player(player_id).play_media(propagated_media)
+
+    mass_mock.players._handle_play_media.side_effect = play_member
 
     media = Mock(spec=PlayerMedia)
     media.uri = "library://track/123"

--- a/tests/providers/sendspin_source/conftest.py
+++ b/tests/providers/sendspin_source/conftest.py
@@ -135,7 +135,12 @@ class _FakePlayers:
     def get_audio_source_session(self, player_id: str) -> Any:
         return self.source_sessions.get(player_id)
 
-    async def deselect_source(self, player_id: str, stop_playback: bool = True) -> None:
+    async def deselect_source(
+        self,
+        player_id: str,
+        stop_playback: bool = True,
+        provider_instance_id: str | None = None,
+    ) -> None:
         self.deselected.append(player_id)
         if stop_playback:
             await self.cmd_stop(player_id)

--- a/tests/providers/sendspin_source/conftest.py
+++ b/tests/providers/sendspin_source/conftest.py
@@ -141,6 +141,7 @@ class _FakePlayers:
         stop_playback: bool = True,
         provider_instance_id: str | None = None,
         source_id: str | None = None,
+        playback_session_id: str | None = None,
     ) -> None:
         self.deselected.append(player_id)
         if stop_playback:

--- a/tests/providers/sendspin_source/conftest.py
+++ b/tests/providers/sendspin_source/conftest.py
@@ -140,6 +140,7 @@ class _FakePlayers:
         player_id: str,
         stop_playback: bool = True,
         provider_instance_id: str | None = None,
+        source_id: str | None = None,
     ) -> None:
         self.deselected.append(player_id)
         if stop_playback:

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -175,6 +175,13 @@ def _tethered_provider() -> tuple[SpotifyConnectProvider, AsyncMock]:
     provider = object.__new__(SpotifyConnectProvider)
     provider.mass = MagicMock()
     provider.logger = MagicMock()
+    provider.config = ProviderConfig(
+        values={},
+        type=ProviderType.PLUGIN,
+        domain="spotify_connect",
+        instance_id="spotify_connect--test",
+        name="Spotify Connect",
+    )
     backend = MagicMock()
     deactivate = AsyncMock()
     backend.deactivate = deactivate

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -118,6 +118,9 @@ def _volume_sync_provider(volume_level: int | None) -> tuple[SpotifyConnectProvi
     """Build a minimal provider whose linked player reports the given volume."""
     provider = object.__new__(SpotifyConnectProvider)
     provider.mass = MagicMock()
+    provider.mass.players.get_audio_source_session.return_value = MagicMock(
+        playback_session_id="playback-session"
+    )
     provider.logger = MagicMock()
     provider._last_volume_sent = None
     backend = MagicMock()

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -13,6 +13,7 @@ from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerTyp
 from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import CONF_GROUP_MEMBERS, CONF_PLAYERS, PROTOCOL_PRIORITY
+from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.models.player import LinkedOutputProtocol
 from music_assistant.providers.sync_group.player import SyncGroupPlayer
 
@@ -2094,6 +2095,7 @@ class TestLeaderPlaybackAwaited:
             "play_media",
             "await",
         ]
+        mass.players.get_player_lock.assert_any_call("leader", PlayerLockPurpose.PLAYBACK)
 
     @pytest.mark.asyncio
     async def test_no_wait_when_group_has_no_leader(self) -> None:

--- a/tests/providers/universal_group/test_universal_group.py
+++ b/tests/providers/universal_group/test_universal_group.py
@@ -22,6 +22,7 @@ from music_assistant_models.constants import (
 from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
 
 from music_assistant.constants import CONF_GROUP_MEMBERS
+from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.providers.universal_group.player import UniversalGroupPlayer
 
 
@@ -34,6 +35,11 @@ def _make_mock_mass() -> MagicMock:
     mass.players._handle_play_media = AsyncMock()
     mass.players.cmd_power = AsyncMock()
     mass.players.iter_group_members = MagicMock(return_value=[])
+
+    lock_ctx = AsyncMock()
+    lock_ctx.__aenter__.return_value = None
+    lock_ctx.__aexit__.return_value = False
+    mass.players.get_player_lock = MagicMock(return_value=lock_ctx)
 
     wait_ctx = AsyncMock()
     wait_ctx.__aenter__.return_value = None
@@ -222,6 +228,8 @@ class TestPowerlessLifecycle:
         assert mass.players._handle_play_media.await_count == 2
         for call in mass.players._handle_play_media.await_args_list:
             assert call.args[1].queue_session_id == "session-1"
+        mass.players.get_player_lock.assert_any_call("m1", PlayerLockPurpose.PLAYBACK)
+        mass.players.get_player_lock.assert_any_call("m2", PlayerLockPurpose.PLAYBACK)
         # power command was NOT used to capture the members
         mass.players.cmd_power.assert_not_awaited()
 

--- a/tests/providers/yandex_ynison/test_provider.py
+++ b/tests/providers/yandex_ynison/test_provider.py
@@ -378,7 +378,9 @@ class TestClearActivePlayer:
         provider._clear_active_player()
 
         provider.mass.players.deselect_source.assert_called_once_with(
-            "some-player", provider_instance_id=provider.instance_id
+            "some-player",
+            provider_instance_id=provider.instance_id,
+            source_id=AUDIO_SOURCE_ID,
         )
 
     def test_the_owner_is_released_not_the_consuming_player(self) -> None:
@@ -391,7 +393,9 @@ class TestClearActivePlayer:
         provider._clear_active_player()
 
         provider.mass.players.deselect_source.assert_called_once_with(
-            "owner-player", provider_instance_id=provider.instance_id
+            "owner-player",
+            provider_instance_id=provider.instance_id,
+            source_id=AUDIO_SOURCE_ID,
         )
 
     def test_nothing_is_released_when_the_source_was_not_in_use(self) -> None:

--- a/tests/providers/yandex_ynison/test_provider.py
+++ b/tests/providers/yandex_ynison/test_provider.py
@@ -377,7 +377,9 @@ class TestClearActivePlayer:
 
         provider._clear_active_player()
 
-        provider.mass.players.deselect_source.assert_called_once_with("some-player")
+        provider.mass.players.deselect_source.assert_called_once_with(
+            "some-player", provider_instance_id=provider.instance_id
+        )
 
     def test_the_owner_is_released_not_the_consuming_player(self) -> None:
         """The session hangs off the owner, which is not who consumed the audio."""
@@ -388,7 +390,9 @@ class TestClearActivePlayer:
 
         provider._clear_active_player()
 
-        provider.mass.players.deselect_source.assert_called_once_with("owner-player")
+        provider.mass.players.deselect_source.assert_called_once_with(
+            "owner-player", provider_instance_id=provider.instance_id
+        )
 
     def test_nothing_is_released_when_the_source_was_not_in_use(self) -> None:
         """No owner means no session to give back."""

--- a/tests/providers/yandex_ynison/test_provider.py
+++ b/tests/providers/yandex_ynison/test_provider.py
@@ -149,6 +149,9 @@ def _make_mock_mass() -> MagicMock:
     mass.players.cmd_play = AsyncMock()
     mass.players.cmd_volume_set = AsyncMock()
     mass.players.trigger_player_update = MagicMock()
+    mass.players.get_audio_source_session.return_value = MagicMock(
+        playback_session_id="playback-session"
+    )
 
     # Player queues
     mass.player_queues.play_media = AsyncMock()
@@ -381,6 +384,7 @@ class TestClearActivePlayer:
             "some-player",
             provider_instance_id=provider.instance_id,
             source_id=AUDIO_SOURCE_ID,
+            playback_session_id="playback-session",
         )
 
     def test_the_owner_is_released_not_the_consuming_player(self) -> None:
@@ -396,6 +400,7 @@ class TestClearActivePlayer:
             "owner-player",
             provider_instance_id=provider.instance_id,
             source_id=AUDIO_SOURCE_ID,
+            playback_session_id="playback-session",
         )
 
     def test_nothing_is_released_when_the_source_was_not_in_use(self) -> None:


### PR DESCRIPTION
# What does this implement/fix?

A delayed plugin cleanup could release or stop newer playback that had taken over the same player. Source cleanup now verifies its owning provider, source, and playback generation, and is serialized with new playback commands so stale work cannot affect the replacement.

- Guard cleanup when provider, source, or playback generation is missing or changes.
- Serialize release and stop with every media playback and source-selection path.
- Pass ownership from each live-source plugin and internal asynchronous cleanup path.
- Cover accepted, stale, same-source, and concurrent takeover paths.

**Related issue (if applicable):**

- Follow-up to #5914

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.