### PR TITLE
AI DJ no longer announces the wrong day of the week

### DIFF
--- a/music_assistant/providers/ai_radio/helpers.py
+++ b/music_assistant/providers/ai_radio/helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import random
 import re
 from typing import Any
@@ -17,6 +18,12 @@ from .models import Slot
 def utc_now_iso() -> str:
     """Return a UTC ISO timestamp."""
     return utc().isoformat()
+
+
+def format_ai_radio_timestamp(moment: datetime.datetime) -> str:
+    """Format a moment for the <timestamp> placeholder, spelling out the weekday and month."""
+    # spelled out so the LLM never has to derive the weekday from a numeric date
+    return moment.strftime("%A %d %B %Y, %H:%M %Z")
 
 
 def slugify(value: str) -> str:

--- a/music_assistant/providers/ai_radio/rendering.py
+++ b/music_assistant/providers/ai_radio/rendering.py
@@ -57,7 +57,7 @@ from .constants import (
     TTS_SPEECHNORM_FILTER,
     WEATHER_PLACEHOLDER_TOKENS,
 )
-from .helpers import coerce_int, soft_limit_text
+from .helpers import coerce_int, format_ai_radio_timestamp, soft_limit_text
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -348,7 +348,7 @@ class AIRadioRenderMixin:
     async def _resolve_deferred_placeholders(self, prompt: str) -> dict[str, str]:
         """Return freshly resolved values for the placeholders deferred until airtime."""
         values = dict.fromkeys(DEFERRED_PLACEHOLDERS, "")
-        values["<timestamp>"] = self._configured_now().strftime("%Y-%m-%d %H:%M %Z")
+        values["<timestamp>"] = format_ai_radio_timestamp(self._configured_now())
         # weather is the only deferred placeholder that costs a network round-trip, so it is
         # only fetched when the prompt actually references it
         if any(token in prompt for token in WEATHER_PLACEHOLDER_TOKENS):

--- a/music_assistant/providers/ai_radio/runtime.py
+++ b/music_assistant/providers/ai_radio/runtime.py
@@ -66,6 +66,7 @@ from .helpers import (
     build_slots,
     coerce_float,
     coerce_int,
+    format_ai_radio_timestamp,
     is_empty_section,
     pick_weighted_choice,
     slugify,
@@ -1223,7 +1224,7 @@ class AIRadioRuntimeMixin:
             "<very_next_songinfo>": track_songinfo(very_next_track),
         }
         deferred = dict.fromkeys(DEFERRED_PLACEHOLDERS, "")
-        deferred["<timestamp>"] = self._configured_now().strftime("%Y-%m-%d %H:%M %Z")
+        deferred["<timestamp>"] = format_ai_radio_timestamp(self._configured_now())
         for key, value in runtime_tokens.items():
             if str(key) in DEFERRED_PLACEHOLDERS:
                 deferred[str(key)] = str(value)

--- a/tests/providers/ai_radio/test_rendering.py
+++ b/tests/providers/ai_radio/test_rendering.py
@@ -764,6 +764,16 @@ async def test_resolve_deferred_placeholders_skips_weather_without_token() -> No
     assert values["<weather_daily>"] == ""
 
 
+async def test_resolve_deferred_placeholders_timestamp_spells_out_weekday() -> None:
+    """The <timestamp> value names the weekday so the LLM never has to derive it."""
+    renderer = DummyRenderer()
+
+    values = await renderer._resolve_deferred_placeholders("Just plain text, no tokens.")
+
+    assert "Thursday" in values["<timestamp>"]
+    assert "July" in values["<timestamp>"]
+
+
 async def test_mint_clip_media_resolves_host_tts_engine() -> None:
     """A clip whose host declares a tts_engine reaches _get_tts_engine with that override."""
     renderer = _tts_renderer("http://example.test/api/tts_proxy/abc123.mp3")

--- a/tests/providers/ai_radio/test_runtime.py
+++ b/tests/providers/ai_radio/test_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import json
 import logging
 import random
@@ -884,6 +885,34 @@ def test_resolve_placeholders_keeps_time_and_weather_deferred() -> None:
     assert "<weather_hourly>" not in static
     assert deferred["<weather_hourly>"] == "12 degrees"
     assert "<timestamp>" in deferred
+
+
+def test_resolve_placeholders_timestamp_spells_out_weekday() -> None:
+    """The deferred <timestamp> value names the weekday so the LLM never has to derive it."""
+    runtime = DummyRuntime()
+    moment = datetime.datetime(2026, 8, 22, 16, 20, tzinfo=datetime.UTC)
+    runtime._configured_now = lambda: moment  # type: ignore[method-assign]
+    tracks = [
+        {"index": 0, "songinfo": "A - One", "duration": 200},
+        {"index": 1, "songinfo": "B - Two", "duration": 200},
+    ]
+    slot = Slot(
+        when="between_songs",
+        at_index=1,
+        prev_index=0,
+        next_index=1,
+        very_next_index=None,
+        minute_mark=3.3,
+    )
+
+    _static, deferred = runtime._resolve_placeholders(
+        program={},
+        tracks=tracks,
+        slot=slot,
+        runtime_tokens={},
+    )
+
+    assert deferred["<timestamp>"] == "Saturday 22 August 2026, 16:20 UTC"
 
 
 def test_plan_sections_leaves_deferred_tokens_in_the_prompt() -> None:


### PR DESCRIPTION
# What does this implement/fix?

The AI DJ kept naming the wrong day. Asked to mention the weekday, it would say "Friday" on a Saturday, while getting the time right.

The `<timestamp>` placeholder gave the DJ a numeric date like `2026-08-22 16:20 CEST`, and that placeholder is the only time information the DJ ever gets. So it had to work out the weekday from the numbers itself, and it consistently landed a day off. It now gets the day and month spelled out, so there is nothing left to work out.

**Related issue (if applicable):**

- Reported on Discord (no issue filed)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

## Changes

- `<timestamp>` now reads `Saturday 22 August 2026, 16:20 CEST` instead of `2026-08-22 16:20 CEST`
- One shared helper formats it, so the planning and airtime paths cannot drift apart
