### PR TITLE
Smart fades no longer discards every plan on tracks with a mastered fade-out

### DIFF
--- a/music_assistant/controllers/streams/smart_fades/planner/candidates.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/candidates.py
@@ -77,7 +77,8 @@ _TRIM_GUARD_LOW_FLOOR: float = 0.25
 _TRIM_GUARD_VOICE_FLOOR: float = 0.4
 
 # Trim-closing anchors engage only when the audible end sits this much past
-# the energy anchor; below it the default anchor's trim is already acceptable
+# the energy anchor; below it the default anchor leads the main pass (the
+# rescue pass re-runs this generator ungated when that pass rejects everything)
 _TRIM_CLOSING_MIN_GAP_S: float = 8.0
 
 # Lazy-overlay length: a long unphrased equal-power blend, not a rung on any ladder
@@ -329,10 +330,14 @@ class TrimClosingAnchorGenerator(CandidateGenerator):
 
     name = "trim-closing-anchor"
 
+    def __init__(self, min_gap: float = _TRIM_CLOSING_MIN_GAP_S) -> None:
+        """Initialize the generator with the smallest stranded-tail gap that engages it."""
+        self._min_gap = min_gap
+
     def generate(self, ctx: TransitionContext) -> Iterable[CandidateSpec]:
         """Emit every ladder rung at the audible end, or nothing when the trim gap is small."""
         anchor = ctx.audio_end
-        if anchor - ctx.default_anchor < _TRIM_CLOSING_MIN_GAP_S:
+        if anchor - ctx.default_anchor < self._min_gap:
             return
         # ctx.tier is decided at the early anchor; the grid can be blendable at the audible end
         _, tier = choose_tier(ctx.outgoing, ctx.incoming, anchor)

--- a/music_assistant/controllers/streams/smart_fades/planner/planner.py
+++ b/music_assistant/controllers/streams/smart_fades/planner/planner.py
@@ -5,9 +5,10 @@ Smart Fades - the candidate/policy transition planner.
 build the immutable ``TransitionContext``, let the generators propose
 candidate specs, build each into a timed candidate, score them all with the
 rejection/penalty policies, finalize the winner's EQ - or, when every
-candidate is rejected, try a modest late-anchored rescue rung before falling
-back to the click-free emergency handoff as a last resort. Alternative
-strategies slot in as sibling ``TransitionPlanner`` subclasses.
+candidate is rejected, retry with late-anchored rescue candidates (the
+ungated audible-end ladder plus a modest rescue rung) before falling back to
+the click-free emergency handoff as a last resort. Alternative strategies
+slot in as sibling ``TransitionPlanner`` subclasses.
 """
 
 from __future__ import annotations
@@ -21,7 +22,12 @@ from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.controllers.streams.smart_fades.models import SmartFadeNotApplicable
 
 from .assembly import EmergencyHandoffFactory, PlanAssembler
-from .candidates import CandidateFactory, RescueAnchorGenerator, default_generators
+from .candidates import (
+    CandidateFactory,
+    RescueAnchorGenerator,
+    TrimClosingAnchorGenerator,
+    default_generators,
+)
 from .context import build_transition_context
 from .policies import default_policies
 from .selection import CandidateSelector
@@ -99,16 +105,22 @@ class SmartCrossFadePlanner(TransitionPlanner):
         selector = CandidateSelector(default_policies(), self.logger)
         winner = selector.select(candidates, ctx)
         if winner is None:
-            # every phrased candidate breached a hard rejection: try a modest,
-            # late-anchored rescue rung before falling back to the handoff
+            # every phrased candidate breached a hard rejection: retry with the
+            # ungated audible-end ladder plus a modest late-anchored rescue rung
+            # before falling back to the handoff
+            rescue_specs = [
+                *TrimClosingAnchorGenerator(min_gap=0.0).generate(ctx),
+                *RescueAnchorGenerator().generate(ctx),
+            ]
             rescue_candidates = [
-                candidate
-                for spec in RescueAnchorGenerator().generate(ctx)
-                if (candidate := factory.build(spec)) is not None
+                candidate for spec in rescue_specs if (candidate := factory.build(spec)) is not None
             ]
             winner = selector.select(rescue_candidates, ctx) if rescue_candidates else None
             if winner is not None:
-                self.logger.debug("shipping a rescue candidate instead of the emergency handoff")
+                self.logger.debug(
+                    "shipping a rescue-pass candidate (source=%s) instead of the emergency handoff",
+                    winner.candidate.spec.source,
+                )
         if winner is None:
             self.logger.debug("shipping click-free emergency handoff")
             plan = EmergencyHandoffFactory(ctx, factory, self.logger).build()

--- a/tests/controllers/streams/smart_fades/test_planner_rungs.py
+++ b/tests/controllers/streams/smart_fades/test_planner_rungs.py
@@ -146,6 +146,54 @@ def _small_trim_gap_ctx() -> TransitionContext:
     return build_transition_context(aa_out, aa_in, 45.0, logging.getLogger("test"))
 
 
+def _small_positive_trim_gap_ctx() -> TransitionContext:
+    """
+    Build a context whose energy anchor lands a few seconds before the audible end.
+
+    Same shape as the big-gap fixture but with a short mid-tier energy
+    segment, giving a gap under the trim-closing generator's default min gap.
+    """
+    beats = [i * 60 / 128 for i in range(int(45 * 128 / 60))]
+    downbeats = beats[::4]
+    rms_energy = [0.9] * 1550 + [0.25] * 160 + [0.0] * 90
+    aa_out = AudioAnalysisData(
+        duration=45.0,
+        bpm=128.0,
+        beats=beats,
+        downbeats=downbeats,
+        beats_per_bar=4,
+        rms_energy=rms_energy,
+        key="C",
+        mode="minor",
+        extra_data={},
+    )
+    aa_in = AudioAnalysisData(
+        duration=45.0,
+        bpm=128.0,
+        beats=beats,
+        downbeats=downbeats,
+        beats_per_bar=4,
+        rms_energy=[0.8] * 1800,
+        key="C",
+        mode="minor",
+        extra_data={},
+    )
+    ctx = build_transition_context(aa_out, aa_in, 45.0, logging.getLogger("test"))
+    assert 0.0 < ctx.audio_end - ctx.default_anchor < 8.0
+    return ctx
+
+
+def test_trim_closing_min_gap_zero_bypasses_the_gate() -> None:
+    """An ungated instance emits the ladder at the audible end even for a small trim gap."""
+    ctx = _small_positive_trim_gap_ctx()
+    assert list(TrimClosingAnchorGenerator().generate(ctx)) == []
+    specs = list(TrimClosingAnchorGenerator(min_gap=0.0).generate(ctx))
+    assert specs
+    assert any(
+        spec.anchor_s == ctx.audio_end and spec.source == "trim-closing-anchor" for spec in specs
+    )
+
+
 def test_energy_ladder_emits_only_plain_rungs() -> None:
     """A one-instrumental/one-vocal pair gets the plain ladder, no 16-bar spec."""
     instrumental_vs_vocal_ctx = _instrumental_vs_vocal_ctx()

--- a/tests/controllers/streams/test_smartfade_transition_timings.py
+++ b/tests/controllers/streams/test_smartfade_transition_timings.py
@@ -1083,6 +1083,30 @@ class TestQuickFadeMasteredFadeDeadZone:
         self._build_fade(caplog, level=VERBOSE_LOG_LEVEL)
         assert "source=trim-closing-anchor" in caplog.text
 
+    def test_trim_closing_wins_when_the_ladder_outgrows_the_rescue_rung(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A 4-bar dead zone ships the audible-end ladder rung, not the capped rescue rung."""
+        duration = 240.0
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(
+                bpm=128.0,
+                duration=duration,
+                # longer mastered fade: the 7.78s trim gap exceeds even the 4-bar
+                # rung (7.5s) yet stays under the trim-closing generator's 8s gate
+                rms_energy=_rms_with_mastered_fade(duration, 228.4, 238.9),
+            ),
+            # 9.4% BPM gap: QUICK_FADE with the [4, 2, 1] rung ladder
+            fade_in_analysis=_analysis(bpm=140.0, duration=duration),
+        )
+        with caplog.at_level(logging.DEBUG):
+            fade.build(_seconds(45), _seconds(45), PCM)
+        assert "shipping a rescue-pass candidate (source=trim-closing-anchor)" in caplog.text
+        # the audible-end anchor keeps the full 4-bar overlap and trims nothing audible
+        assert fade.effective_end == pytest.approx(43.40, abs=0.05)
+        assert fade.timing_info.crossfade_duration == pytest.approx(7.78, abs=0.05)
+
 
 # ---------------------------------------------------------------------------
 # SmartCrossFade — rubberband stretch savings compensation

--- a/tests/controllers/streams/test_smartfade_transition_timings.py
+++ b/tests/controllers/streams/test_smartfade_transition_timings.py
@@ -27,6 +27,7 @@ from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
 import music_assistant.controllers.streams.smart_fades.mixer as mixer_module
+from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.controllers.streams.smart_fades.fades import (
     CrossfadeTimingInfo,
     SmartCrossFade,
@@ -1003,6 +1004,84 @@ class TestSilenceAwareAnchoring:
         assert fade.timing_info.crossfade_duration <= fade.effective_end + 1e-6
         # the capped crossfade consumes the whole audible tail, so the stretch is skipped
         assert not any(isinstance(f, GradualTimeStretchFilter) for f in fade.filters)
+
+
+def _rms_with_mastered_fade(
+    track_duration: float, fade_start: float, fade_end: float
+) -> np.ndarray:
+    """Steady energy with the record's own gradual fade-out between the given media times."""
+    bins = np.full(1800, 0.5, dtype=np.float32)
+    bin_seconds = track_duration / 1800
+    t = (np.arange(1800) + 0.5) * bin_seconds
+    ramp = 0.5 * (1.0 - (t - fade_start) / (fade_end - fade_start)) + 0.0005
+    return np.where(t < fade_start, bins, np.where(t >= fade_end, 0.0005, ramp)).astype(np.float32)
+
+
+class TestQuickFadeMasteredFadeDeadZone:
+    """
+    A mastered fade-out under a quick-fade tier lands in the audible-trim dead zone.
+
+    The 70% mix-out floor anchors mid-fade while the 5% audible floor sits
+    several seconds later; every quick-fade rung is far shorter than that gap,
+    so AudibleTrimPolicy rejects the entire main candidate set. The rescue
+    pass (ungated trim-closing ladder plus rescue rungs) then ships a
+    late-anchored fade.
+    """
+
+    def _build_fade(
+        self, caplog: pytest.LogCaptureFixture, level: int = logging.DEBUG
+    ) -> SmartCrossFade:
+        duration = 240.0
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(
+                bpm=128.0,
+                duration=duration,
+                # the record fades itself out over 229s..237s: mix-out (70% floor)
+                # anchors near 231s while audible content (5% floor) runs to ~237s
+                rms_energy=_rms_with_mastered_fade(duration, 229.0, 237.0),
+            ),
+            # 17.2% BPM gap: QUICK_FADE with the [2, 1] rung ladder (3.75s / 1.88s)
+            fade_in_analysis=_analysis(bpm=150.0, duration=duration),
+        )
+        with caplog.at_level(level):
+            fade.build(_seconds(45), _seconds(45), PCM)
+        return fade
+
+    def test_main_pass_rejects_every_candidate_on_the_trim_guard_alone(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Every main-pass candidate dies on the one guard; the rescue pass ships the fade."""
+        self._build_fade(caplog)
+        assert (
+            "all 2 candidates rejected (audible trim exceeds a short fade's own duration x2)"
+            in caplog.text
+        )
+        assert (
+            "shipping a rescue-pass candidate (source=rescue-anchor) instead of the "
+            "emergency handoff" in caplog.text
+        )
+
+    def test_rescue_ships_a_late_anchored_chain_within_the_trim_bound(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The shipped chain anchors near the audible end, honoring the short-fade trim bound."""
+        fade = self._build_fade(caplog)
+        # rescue anchor: last protective downbeat at/after audio_end - 2 bars (128 BPM)
+        assert fade.effective_end == pytest.approx(41.25, abs=0.05)
+        assert isinstance(fade.filters[0], FadeOutTrimFilter)
+        assert fade.filters[0].fadeout_end_pos == pytest.approx(fade.effective_end)
+        # the guard's own invariant holds on the shipped plan: audible material
+        # dropped past the anchor stays within the overlap length (~41.67s RMS boundary)
+        audible_trim = 41.67 - fade.effective_end
+        assert audible_trim <= fade.timing_info.crossfade_duration + 1e-6
+
+    def test_rescue_pass_scores_trim_closing_candidates(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The rescue pass runs the audible-end ladder ungated, so the selector scores it."""
+        self._build_fade(caplog, level=VERBOSE_LOG_LEVEL)
+        assert "source=trim-closing-anchor" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

On tracks that fade themselves out, the smart-fades planner anchors every candidate mid-fade: the energy mix-out point sits several seconds before the audible end. For quick fades every candidate then trips the audible-trim guard, the whole candidate set is rejected, and only the capped 2-bar rescue rung saves the transition. Seen 16 times in one night of listening; the trim-closing generator that would anchor at the audible end only engages when the stranded tail is 8s or more, which these cases never reach.

- The rescue pass now also runs the trim-closing generator ungated, so full-ladder candidates anchored at the audible end compete alongside the rescue rungs
- `TrimClosingAnchorGenerator` takes a `min_gap` parameter; the default (8s) keeps the main pass unchanged
- The rescue-pass log line now names the winning generator
- Tests pin the dead-zone scenario end to end: main pass rejects the whole set, the rescue pass ships a late-anchored fade that honours the trim bound

**Related issue (if applicable):** none, found during nightly log triage

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
