### PR TITLE
Bump wiim from 0.1.5 to 0.1.7

### DIFF
--- a/music_assistant/providers/wiim/manifest.json
+++ b/music_assistant/providers/wiim/manifest.json
@@ -5,7 +5,7 @@
   "name": "WiiM / LinkPlay",
   "description": "Discover and control WiiM, Audio Pro and other compatible LinkPlay speakers, including generic LinkPlay devices such as Edifier.",
   "codeowners": ["@davidanthoff", "@music-assistant"],
-  "requirements": ["wiim==0.1.5", "pywiim==2.3.0"],
+  "requirements": ["wiim==0.1.7", "pywiim==2.3.0"],
   "documentation": "https://music-assistant.io/player-support/wiim/",
   "mdns_discovery": ["_linkplay._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -104,7 +104,7 @@ transformers==5.14.1
 usearch==2.26.0
 uv>=0.8.0
 websocket-client==1.9.0
-wiim==0.1.5
+wiim==0.1.7
 xmltodict==1.0.4
 ya-dialogs-api==2.4.0
 ya-passport-auth[ma]==1.8.0


### PR DESCRIPTION
# What does this implement/fix?

Bumps the `wiim` SDK from 0.1.5 to 0.1.7.

The reason for the bump is a fix in 0.1.7 (Linkplay2020/wiim#22) for a speaker losing its UPnP event subscription along with its renewal timer. A resubscribe of a service the event handler no longer holds a subscription id for raised a plain `KeyError`, which escaped before the next renewal was scheduled and before the SDK's own re-init fallback could run. The speaker kept reporting itself as available while no longer receiving events, so the player showed stale state until something else reinitialised it. WiiM state reaches us only over UPnP NOTIFY, so there was nothing to fall back on.

0.1.6 and 0.1.7 also bring two changes from other contributors: track metadata, URI and duration now get populated from polled `GetInfoEx` replies (guarded so a NOTIFY that arrives mid-poll still wins), and the UPnP event listener source is derived from the device address family for IPv6 and hostname-addressed devices. We pass `local_host` explicitly, so that second one does not change our behaviour.

Verified against the real 0.1.7 wheel: the 32 `WiimDevice` attributes and 4 `WiimController` methods our provider uses are all still present, `async_create_wiim_device` keeps the same signature, all four exception classes are intact, and the provider test suite and mypy both pass. Also ran it against my own speakers, where a group and ungroup renewed cleanly and armed exactly one renewal timer per run.

**Related issue (if applicable):**

- upstream fix: https://github.com/Linkplay2020/wiim/pull/22

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
