### PR TITLE
Fix Spotify Connect quality reporting and a leftover audio process

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -4196,7 +4196,11 @@ class StreamsAudio:
             if supported_sample_rates is not None
             else [sample_rate for sample_rate, _ in player.get_supported_sample_rates()]
         )
-        source_rate = streamdetails.audio_format.sample_rate
+        # the format the audio arrives in, not the one the source claims: a provider
+        # that decoded on our behalf may advertise a narrower format for display, and
+        # narrowing the stream to that would truncate it
+        source_format = arriving_audio_format(streamdetails)
+        source_rate = source_format.sample_rate
         if source_rate in resolved_sample_rates:
             output_sample_rate = source_rate
         else:
@@ -4204,15 +4208,14 @@ class StreamsAudio:
                 (rate for rate in resolved_sample_rates if rate <= source_rate),
                 default=min(resolved_sample_rates),
             )
-        bit_depth = streamdetails.audio_format.bit_depth
         return AudioFormat(
-            content_type=ContentType.from_bit_depth(bit_depth),
+            content_type=ContentType.from_bit_depth(source_format.bit_depth),
             sample_rate=output_sample_rate,
-            bit_depth=bit_depth,
+            bit_depth=source_format.bit_depth,
             # a realtime source may announce more channels than anything downstream can
             # carry (a VBAN stream can be configured up to 8), and player handoff formats
             # copy this count straight through, so fold it here
-            channels=min(streamdetails.audio_format.channels, 2),
+            channels=min(source_format.channels, 2),
         )
 
     def _flow_restart_context(

--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -26,6 +26,11 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.helpers.process")
 
 DEFAULT_CHUNKSIZE = 64000
 
+# Ceiling on draining a pipe while closing. A child wedged in a read syscall never
+# closes its pipes, so an unbounded drain would keep close() from ever reaching the
+# terminate/SIGKILL escalation that actually reaps it.
+PIPE_DRAIN_TIMEOUT = 5
+
 
 def get_subprocess_env(env: dict[str, str] | None = None) -> dict[str, str]:
     """Get environment for subprocess, stripping LD_PRELOAD to avoid jemalloc warnings."""
@@ -319,7 +324,7 @@ class AsyncProcess:
             await asyncio.wait_for(self._stdout_lock.acquire(), 5)
         if self.proc.stdout and not self.proc.stdout.at_eof():
             with suppress(Exception):
-                await self.proc.stdout.read(-1)
+                await asyncio.wait_for(self.proc.stdout.read(-1), PIPE_DRAIN_TIMEOUT)
         # if we have a stderr task active, allow it to finish
         if self._stderr_reader_task:
             with suppress(TimeoutError, asyncio.CancelledError):
@@ -329,7 +334,7 @@ class AsyncProcess:
                 await asyncio.wait_for(self._stderr_lock.acquire(), 5)
             # drain stderr
             with suppress(Exception):
-                await self.proc.stderr.read(-1)
+                await asyncio.wait_for(self.proc.stderr.read(-1), PIPE_DRAIN_TIMEOUT)
 
         # make sure the process is really cleaned up.
         # especially with pipes this can cause deadlocks if not properly guarded

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -109,9 +109,11 @@ class PluginProvider(Provider):
 
         The returned StreamDetails uses the standard fields:
         ``stream_type`` selects between a custom async generator and a path
-        (e.g. NAMED_PIPE); ``audio_format`` describes the PCM format the source
-        emits; ``stream_metadata`` carries the initial live metadata (and can
-        be updated at runtime via ``mass.players.update_source_metadata(player_id, ...)``).
+        (e.g. NAMED_PIPE); ``audio_format`` describes the source for display and
+        ``decoded_audio_format`` the PCM actually delivered, which a plugin that
+        decoded the source itself has to set; ``stream_metadata`` carries the initial
+        live metadata (and can be updated at runtime via
+        ``mass.players.update_source_metadata(player_id, ...)``).
 
         Silence-during-pause contract:
         the player consuming the stream needs a continuous byte flow or it will
@@ -142,8 +144,9 @@ class PluginProvider(Provider):
         Return the (custom) audio stream for an AudioSource.
 
         Will only be called when the StreamDetails returned by get_stream_details
-        has ``stream_type=StreamType.CUSTOM``. The yielded bytes must be in
-        the PCM format declared by ``streamdetails.audio_format``.
+        has ``stream_type=StreamType.CUSTOM``. The yielded bytes must be in the PCM
+        format declared by ``streamdetails.decoded_audio_format``, falling back to
+        ``audio_format`` when the plugin delivers its source untouched.
 
         Pausing is fine: when the upstream device is paused the plugin can stop
         yielding bytes. The server wraps this generator with a silence-keepalive

--- a/music_assistant/providers/spotify_connect/README.md
+++ b/music_assistant/providers/spotify_connect/README.md
@@ -83,7 +83,8 @@ crossfade and streaming quality are provider settings, applied by the engines th
 (see the per-engine READMEs for the mechanics). Streaming quality is a ceiling, not a
 guarantee: Spotify still downshifts on a slow connection and falls back when a track or the
 account has no file at that tier, and what it actually delivered is not observable — so the
-reported source format stays the capture PCM rather than a guess.
+reported source format is the tier that was asked for, the same ceiling the Spotify apps
+show.
 
 ## Multi-instance support
 

--- a/music_assistant/providers/spotify_connect/soloist/README.md
+++ b/music_assistant/providers/spotify_connect/soloist/README.md
@@ -118,15 +118,24 @@ marker that makes the engine honor the non-metered value. Measured against build
 (bytes fetched for a whole 4:20 track): `2` ≈ 96 kbps, `3` ≈ 160 kbps, `4` ≈ 320 kbps and
 `5` lossless FLAC (~810 kbps). **`5` is the ceiling** — values outside `1`-`5` are rejected
 and silently fall back to ~160 kbps, so an unrecognized tier must never reach the file.
-Despite the `FLAC_FLAC_24BIT` name in the binary, no value produced a 24-bit stream.
+That measurement only covers the wire: the capture sink always delivers s32le whatever the
+engine fetched, so the source bit depth cannot be read off the audio at all and the
+`FLAC_FLAC_24BIT` name in the binary is the only indication either way.
 
-The delivered quality is **not** observable, so it is never reported as the source format.
-The engine keeps no quality field on the WebSocket API, its audio cache is encrypted, and
-the log templates that would name the codec (`AudioRendererImpl ... format [...]`,
-`FileStreamer file average bitrate`) sit behind a log level with no exposed control: the
-daemon's real optstring is `hn:D:C:z:d:i:AVw:k:s:p` (no `-v`; the `-v, --verbose` string in
-the binary is dead text, and no environment variable raises the level either). The setting
-is therefore a ceiling only, and `_capture_format` stays the displayed format.
+The delivered quality is **not** observable. The engine keeps no quality field on the
+WebSocket API, its audio cache is encrypted, and the log templates that would name the
+codec (`AudioRendererImpl ... format [...]`, `FileStreamer file average bitrate`) sit
+behind a log level with no exposed control: the daemon's real optstring is
+`hn:D:C:z:d:i:AVw:k:s:p` (no `-v`; the `-v, --verbose` string in the binary is dead text,
+and no environment variable raises the level either).
+
+So the configured tier is what gets reported as the source format — the same ceiling the
+Spotify apps show, and the same claim the Spotify music provider makes. Spotify serves
+lossless for music only, so an episode or audiobook chapter is reported as Ogg Vorbis
+whatever the tier says; a Connect session plays whatever the app picked, so the item
+playing when the stream starts is the only media-type signal there is. `_capture_format`
+describes the PCM the FIFO delivers and is reported separately as the decoded format, so
+every decision about the bytes follows it and the tier claim stays display-only.
 
 ## Security
 

--- a/music_assistant/providers/spotify_connect/soloist/backend.py
+++ b/music_assistant/providers/spotify_connect/soloist/backend.py
@@ -16,6 +16,7 @@ import asyncio
 import re
 from asyncio import FIRST_COMPLETED
 from contextlib import suppress
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
@@ -34,6 +35,7 @@ from music_assistant.helpers.pulse_capture import (
 from music_assistant.providers.spotify_connect.base import (
     AUDIO_QUALITY_LOSSLESS,
     SpotifyConnectBackend,
+    spotify_source_audio_format,
 )
 from music_assistant.providers.spotify_connect.models import (
     BackendEvent,
@@ -102,6 +104,9 @@ BINARY_REFRESH_INTERVAL_S: Final = 24 * 3600
 # invalidates the capture sink), so the sink is replaced proactively instead
 # of on the (side-effect-free) stream request.
 GENERATION_WATCH_INTERVAL_S: Final = 5
+
+# item uri prefixes Spotify never serves losslessly, whatever the tier is set to.
+_SPOKEN_URI_PREFIXES: Final = ("spotify:episode:", "spotify:chapter:")
 
 # playback_state/playback_changed status values mapped to normalized events;
 # undocumented values degrade to OTHER.
@@ -212,14 +217,9 @@ class SoloistBackend(SpotifyConnectBackend):
         self._was_logged_in: bool = False
         self._last_context_uri: str | None = None
         self._last_track_uri: str | None = None
-        # the capture sink delivers fixed s32le/44.1kHz/2ch PCM (the pulse
-        # capture format) — that is what actually arrives on the named pipe.
-        # Soloist decodes internally and never exposes the source codec or
-        # quality, so this capture format doubles as the display format: MA's
-        # input really is 32-bit PCM (24-bit lossless fits losslessly), while
-        # Spotify's upstream quality stays unknowable either way. The advertised
-        # format also decides the internal PCM depth and the ffmpeg-free
-        # passthrough for an AudioSource, so it has to stay what arrives.
+        # the capture sink delivers fixed s32le/44.1kHz/2ch PCM — that is what
+        # actually arrives on the named pipe, and every decision about the bytes
+        # follows it because it is reported as the decoded format
         self._capture_format = AudioFormat(
             content_type=ContentType.PCM_S32LE,
             codec_type=ContentType.PCM_S32LE,
@@ -227,17 +227,33 @@ class SoloistBackend(SpotifyConnectBackend):
             bit_depth=32,
             channels=CAPTURE_CHANNELS,
         )
-        self._audio_format = self._capture_format
+        self._tier_format = spotify_source_audio_format(
+            audio_quality, lossless=audio_quality == AUDIO_QUALITY_LOSSLESS
+        )
+        # spoken content is Ogg Vorbis whatever the tier says; on the lossy tiers
+        # that is the tier format itself
+        self._spoken_format = (
+            spotify_source_audio_format(audio_quality, lossless=False)
+            if audio_quality == AUDIO_QUALITY_LOSSLESS
+            else self._tier_format
+        )
 
     @property
     def audio_format(self) -> AudioFormat:
         """Return the source audio format (advertised to clients for display)."""
-        return self._audio_format
+        # a Connect session plays whatever the Spotify app picked, so the uri of the
+        # item playing when the stream starts is the only media-type signal there is;
+        # an unknown item is treated as music, the dominant case for a ceiling claim
+        if self._last_track_uri and self._last_track_uri.startswith(_SPOKEN_URI_PREFIXES):
+            return self._spoken_format
+        return self._tier_format
 
     @property
     def decoded_audio_format(self) -> AudioFormat:
         """Return the PCM format the capture sink's named pipe delivers."""
-        return self._capture_format
+        # a copy per stream: the core mirrors what ffmpeg probes onto this object,
+        # which must not land on the one format every stream shares
+        return replace(self._capture_format)
 
     @property
     def stream_ends_on_pause(self) -> bool:

--- a/tests/controllers/streams/test_buffer_pcm_format.py
+++ b/tests/controllers/streams/test_buffer_pcm_format.py
@@ -3,21 +3,28 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.enums import ContentType, MediaType, VolumeNormalizationMode
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
+if TYPE_CHECKING:
+    from music_assistant.models.player import Player
 
-def _streamdetails(advertised: AudioFormat, arriving: AudioFormat | None) -> StreamDetails:
+
+def _streamdetails(
+    advertised: AudioFormat,
+    arriving: AudioFormat | None,
+    media_type: MediaType = MediaType.TRACK,
+) -> StreamDetails:
     """Return StreamDetails advertising one format while delivering another."""
     return StreamDetails(
         provider="test--1",
         item_id="1",
         audio_format=advertised,
         decoded_audio_format=arriving,
-        media_type=MediaType.TRACK,
+        media_type=media_type,
     )
 
 
@@ -120,3 +127,42 @@ def test_the_flow_depth_follows_the_arriving_audio() -> None:
 
     assert bit_depth == 32
     assert content_type == ContentType.PCM_S32LE
+
+
+def test_the_audio_source_passthrough_follows_the_arriving_audio() -> None:
+    """
+    A live source's passthrough format must not narrow the audio it passes through.
+
+    The passthrough exists to hand the player the source's own samples, so it
+    has to read the format the bytes arrive in - an engine that decoded for us
+    (Spotify Connect) advertises the quality tier it asked for, which is
+    narrower than the PCM it hands over.
+    """
+    from music_assistant.controllers.streams.audio import StreamsAudio  # noqa: PLC0415
+
+    advertised = AudioFormat(
+        content_type=ContentType.OGG,
+        codec_type=ContentType.VORBIS,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+        bit_rate=160,
+    )
+    arriving = AudioFormat(
+        content_type=ContentType.PCM_S32LE,
+        codec_type=ContentType.PCM_S32LE,
+        sample_rate=44100,
+        bit_depth=32,
+        channels=2,
+    )
+
+    pcm_format = StreamsAudio._select_audio_source_pcm_format(
+        cast("StreamsAudio", SimpleNamespace()),
+        player=cast("Player", SimpleNamespace()),
+        streamdetails=_streamdetails(advertised, arriving, MediaType.AUDIO_SOURCE),
+        supported_sample_rates=(44100, 48000),
+    )
+
+    assert pcm_format.bit_depth == 32
+    assert pcm_format.content_type == ContentType.PCM_S32LE
+    assert pcm_format.sample_rate == 44100

--- a/tests/controllers/streams/test_pcm_passthrough_gate.py
+++ b/tests/controllers/streams/test_pcm_passthrough_gate.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 
-from music_assistant_models.enums import ContentType
+from music_assistant_models.enums import ContentType, MediaType, StreamType
 from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.controllers.streams import audio_buffer as audio_buffer_module
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
@@ -15,6 +17,8 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
     import pytest
+
+    from music_assistant.controllers.streams.audio import StreamsAudio
 
 _S32 = AudioFormat(content_type=ContentType.PCM_S32LE, sample_rate=44100, bit_depth=32, channels=2)
 _F32 = AudioFormat(content_type=ContentType.PCM_F32LE, sample_rate=44100, bit_depth=32, channels=2)
@@ -69,3 +73,62 @@ def test_a_warm_airplay_replace_refuses_a_differently_encoded_source() -> None:
     session.sync_clients = []
     assert session.can_replace([], _S32) is False
     assert session.can_replace([], _F32) is True
+
+
+async def _which_path(advertised: AudioFormat, arriving: AudioFormat | None) -> str:
+    """Return which branch of the AudioSource gate a live source is routed through."""
+    from music_assistant.controllers.streams.audio import StreamsAudio  # noqa: PLC0415
+
+    took: list[str] = []
+
+    async def _bytes() -> AsyncGenerator[bytes]:
+        yield b"\x00" * 8
+
+    def _fake_open(_streamdetails: object) -> AsyncGenerator[bytes]:
+        took.append("raw")
+        return _bytes()
+
+    async def _fake_ffmpeg(**_kwargs: object) -> AsyncGenerator[bytes]:
+        took.append("ffmpeg")
+        yield b"\x00" * 8
+
+    controller = cast(
+        "StreamsAudio",
+        SimpleNamespace(_open_audio_source_generator=_fake_open, get_media_stream=_fake_ffmpeg),
+    )
+    streamdetails = StreamDetails(
+        provider="test--1",
+        item_id="1",
+        audio_format=advertised,
+        decoded_audio_format=arriving,
+        media_type=MediaType.AUDIO_SOURCE,
+        stream_type=StreamType.NAMED_PIPE,
+        path="/fake/fifo",
+    )
+    async for _ in StreamsAudio._iter_audio_source_pcm(controller, streamdetails, _S32):
+        pass
+    return took[0]
+
+
+async def test_a_codec_advertising_live_source_keeps_ffmpeg_in_the_path() -> None:
+    """
+    The gate reads the advertised format on purpose, not the arriving one.
+
+    A live source that advertises a codec relies on ffmpeg to notice its
+    producer going away - shairport-sync leaves the pipe behind on an unclean
+    disconnect, which a direct read would simply reopen and wait on.
+    """
+    advertised = AudioFormat(
+        content_type=ContentType.OGG,
+        codec_type=ContentType.VORBIS,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+        bit_rate=160,
+    )
+    assert await _which_path(advertised, _S32) == "ffmpeg"
+
+
+async def test_a_pcm_advertising_live_source_is_read_directly() -> None:
+    """A source that states the PCM it delivers is handed through unconverted."""
+    assert await _which_path(_S32, None) == "raw"

--- a/tests/helpers/test_process.py
+++ b/tests/helpers/test_process.py
@@ -4,17 +4,26 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 import time
 from collections.abc import AsyncGenerator
 from unittest.mock import MagicMock
 
 import pytest
 
+from music_assistant.helpers import process as process_module
 from music_assistant.helpers.process import AsyncProcess
 
 # Comfortably beyond the OS pipe capacity plus asyncio's default high-water mark,
 # so the bytes are guaranteed to still be queued in our own write buffer.
 _MORE_THAN_THE_PIPE_HOLDS = b"\x00" * (4 * 1024 * 1024)
+
+# Ignores SIGINT and keeps stdout open, so nothing but SIGKILL ends it and its
+# pipe never reaches EOF. The marker tells the test the handler is installed.
+_WEDGED_CHILD = (
+    "import signal, sys, time; signal.signal(signal.SIGINT, signal.SIG_IGN); "
+    "sys.stdout.write('ready\\n'); sys.stdout.flush(); time.sleep(30)"
+)
 
 
 @pytest.fixture(name="piped_process")
@@ -201,3 +210,27 @@ async def test_second_close_returns_without_waiting_out_the_stream_locks() -> No
     await proc.close()
 
     assert time.monotonic() - started < 1
+
+
+@pytest.mark.asyncio
+async def test_close_reaps_a_child_that_never_closes_its_pipes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A child holding its pipes open must not keep close() from reaping it.
+
+    Draining stdout is what lets a healthy process flush before it is reaped, so
+    an unbounded drain waits out a wedged child forever and the terminate/SIGKILL
+    escalation is never reached.
+    """
+    monkeypatch.setattr(process_module, "PIPE_DRAIN_TIMEOUT", 0.2)
+    proc = AsyncProcess(
+        [sys.executable, "-c", _WEDGED_CHILD], stdout=True, stderr=asyncio.subprocess.STDOUT
+    )
+    await proc.start()
+    assert await proc.read_stdout() == b"ready\n"
+
+    async with asyncio.timeout(20):
+        await proc.close()
+
+    assert proc.returncode is not None

--- a/tests/providers/spotify_connect/test_soloist_backend.py
+++ b/tests/providers/spotify_connect/test_soloist_backend.py
@@ -166,6 +166,7 @@ def _make_backend(
     instance_id: str = _INSTANCE_ID,
     base_dir: Path | None = None,
     consent: bool = True,
+    audio_quality: str = AUDIO_QUALITY_LOSSLESS,
 ) -> tuple[SoloistBackend, list[BackendEvent]]:
     """Build a backend on a mocked mass, capturing every emitted BackendEvent."""
     mass = MagicMock()
@@ -186,6 +187,7 @@ def _make_backend(
         api_key=_API_KEY,
         consent=consent,
         volume_mode=volume_mode,
+        audio_quality=audio_quality,
     )
     return backend, events
 
@@ -1352,16 +1354,55 @@ def test_sink_prefix_is_sanitized() -> None:
     assert backend._sink_prefix == "weird_id__"
 
 
-def test_audio_formats_report_the_capture_pcm() -> None:
-    """Display and decoded format both report the fixed capture PCM (s32le/44.1/2)."""
+def test_decoded_format_reports_the_capture_pcm() -> None:
+    """The decoded format is the fixed capture PCM (s32le/44.1/2) the pipe delivers."""
     backend, _events = _make_backend()
 
-    for fmt in (backend.audio_format, backend.decoded_audio_format):
-        assert fmt.content_type is ContentType.PCM_S32LE
-        assert fmt.sample_rate == 44100
-        assert fmt.bit_depth == 32
-        assert fmt.channels == 2
+    decoded = backend.decoded_audio_format
+    assert decoded.content_type is ContentType.PCM_S32LE
+    assert decoded.sample_rate == 44100
+    assert decoded.bit_depth == 32
+    assert decoded.channels == 2
     assert backend.get_audio_reader() is None
+
+
+@pytest.mark.parametrize(
+    ("audio_quality", "content_type", "bit_depth"),
+    [
+        (AUDIO_QUALITY_NORMAL, ContentType.OGG, 16),
+        (AUDIO_QUALITY_HIGH, ContentType.OGG, 16),
+        (AUDIO_QUALITY_VERY_HIGH, ContentType.OGG, 16),
+        (AUDIO_QUALITY_LOSSLESS, ContentType.FLAC, 24),
+    ],
+)
+def test_advertised_format_follows_the_configured_tier(
+    audio_quality: str, content_type: ContentType, bit_depth: int
+) -> None:
+    """The display format is the tier Spotify was asked for, not the capture PCM."""
+    backend, _events = _make_backend(audio_quality=audio_quality)
+
+    assert backend.audio_format.content_type is content_type
+    assert backend.audio_format.bit_depth == bit_depth
+
+
+@pytest.mark.parametrize(
+    ("entity_type", "content_type"),
+    [
+        ("track", ContentType.FLAC),
+        ("episode", ContentType.OGG),
+        ("chapter", ContentType.OGG),
+    ],
+)
+async def test_spoken_content_is_never_advertised_as_lossless(
+    entity_type: str, content_type: ContentType
+) -> None:
+    """Spotify serves lossless for music only, whatever the tier is set to."""
+    backend, _events = _make_backend(audio_quality=AUDIO_QUALITY_LOSSLESS)
+    item = SoloistEntity(uri=f"spotify:{entity_type}:x1", entity_type=entity_type)
+
+    await backend._handle_event(_event("track_changed", SoloistTrackChanged(item=item)))
+
+    assert backend.audio_format.content_type is content_type
 
 
 async def test_transport_commands_map_to_client() -> None:

--- a/tests/providers/spotify_connect/test_soloist_backend.py
+++ b/tests/providers/spotify_connect/test_soloist_backend.py
@@ -1366,6 +1366,24 @@ def test_decoded_format_reports_the_capture_pcm() -> None:
     assert backend.get_audio_reader() is None
 
 
+def test_each_stream_gets_its_own_copy_of_the_capture_format() -> None:
+    """
+    Every stream is handed its own decoded format, not one shared object.
+
+    ffmpeg writes what it probes onto the format it is given, so a shared instance
+    would carry one stream's probe over into the next.
+    """
+    backend, _events = _make_backend()
+
+    first = backend.decoded_audio_format
+    second = backend.decoded_audio_format
+
+    assert first is not second
+    first.bit_rate = 12345
+    assert second.bit_rate != 12345
+    assert backend.decoded_audio_format.bit_rate != 12345
+
+
 @pytest.mark.parametrize(
     ("audio_quality", "content_type", "bit_depth"),
     [


### PR DESCRIPTION
# What does this implement/fix?

Spotify Connect through the Soloist engine reported the raw 32-bit audio it captures from
the engine as its source format, which classifies as hi-res, so a 96 kbps stream looked
identical to a lossless one. It now reports the quality tier Spotify was actually asked
for, the same way the Spotify music provider and the go-librespot engine already do.
Spotify only serves lossless for music, so a podcast or audiobook chapter is reported as
Ogg Vorbis whatever the quality setting says.

Worth being clear: external sources do not currently surface a quality badge anywhere, so
this corrects the underlying data rather than a value anyone can see today. It matters
because that data is what any future display would read, and because the old format claim
was also driving the internal audio depth.

Separately, closing a process could wait forever on a child that never closes its pipes,
which left the process behind and hid the error that caused the shutdown. Pausing an
external source for more than 20 seconds hits exactly that path.

**Changes**

- Spotify Connect reports the configured quality tier as its source format instead of the
  internal capture format
- spoken content is never reported as lossless
- the internal audio depth for live sources follows the audio that actually arrives, so
  reporting a tier can never narrow the stream
- the capture format is handed out per stream, so ffmpeg's probe can no longer write back
  onto the one format every stream shares
- closing a process no longer waits forever on a child that never closes its pipes
- corrected the two Spotify Connect READMEs and the plugin AudioSource docs, which still
  described the old behaviour

Tested on a real Spotify Connect session (playback, pause, quality tiers), plus locally
against the core stream path for unconverted passthrough and realtime pacing.

**Related issue (if applicable):**

- follow-up on #5942

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
