### PR TITLE
Fix Spotify Connect playback not starting

### DIFF
--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -158,10 +158,9 @@ class SpotifyConnectProvider(PluginProvider):
         # True while MA is the active Spotify Connect device (set on 'active',
         # cleared on 'inactive'); gates get_stream_details and transport commands.
         self._spotify_session_active: bool = False
-        # holds the single in-flight deferred play_media task scheduled from a
-        # 'playing' event; cancelled when a 'paused' / 'stopped' / 'active' event
-        # arrives during the debounce so we don't act on stale state from a dying
-        # session.
+        # holds the single in-flight deferred play_media task scheduled once the
+        # session is both active and playing; cancelled when a later event makes
+        # that state stale.
         self._pending_play_media_task: asyncio.Task[None] | None = None
         # holds the in-flight stop of a paused player (pipe-fed backends
         # only); the stop dispatches right away, but a 'playing' event cancels
@@ -706,6 +705,20 @@ class SpotifyConnectProvider(PluginProvider):
         except Exception as err:
             self.logger.debug("Failed to stop player %s on pause: %s", player_id, err)
 
+    def _schedule_play_media(self) -> None:
+        """Schedule playback when Spotify is active and no player owns the source."""
+        if (
+            not self._playing
+            or not self._spotify_session_active
+            or self._in_use_by_player
+            or (
+                self._pending_play_media_task is not None
+                and not self._pending_play_media_task.done()
+            )
+        ):
+            return
+        self._pending_play_media_task = self.mass.create_task(self._deferred_play_media_fire())
+
     def _cancel_pending_play_media(self) -> None:
         """Cancel any pending deferred play_media trigger."""
         task = self._pending_play_media_task
@@ -839,9 +852,8 @@ class SpotifyConnectProvider(PluginProvider):
         if event.type is BackendEventType.SESSION_ACTIVE:
             self._spotify_session_active = True
             self._last_session_active_time = time.time()
-            # A (re)activation supersedes any deferred play_media scheduled from a
-            # previous session's stale 'playing'; the fresh 'playing' that follows
-            # schedules a new one.
+            # A (re)activation supersedes any deferred play_media from a previous
+            # session. Reconcile afterwards because 'playing' may arrive first.
             self._cancel_pending_play_media()
             self.logger.info("Spotify Connect session active for %s", self.name)
             # A new session starts at the backend's 100% volume default; push the
@@ -851,6 +863,7 @@ class SpotifyConnectProvider(PluginProvider):
             # value — the app slider staying at 100 there is by design.)
             if player_id := self._get_target_player_id():
                 await self._sync_player_volume_to_spotify(player_id)
+            self._schedule_play_media()
         elif event.type is BackendEventType.SESSION_INACTIVE:
             self.logger.info("Spotify Connect session inactive for %s", self.name)
             self._spotify_session_active = False
@@ -875,14 +888,7 @@ class SpotifyConnectProvider(PluginProvider):
             # Only while the session is active: a daemon playing without being
             # the active Connect device (e.g. right after a deactivate) must
             # not grab MA players in a loop.
-            if (
-                not self._in_use_by_player
-                and self._spotify_session_active
-                and (self._pending_play_media_task is None or self._pending_play_media_task.done())
-            ):
-                self._pending_play_media_task = self.mass.create_task(
-                    self._deferred_play_media_fire()
-                )
+            self._schedule_play_media()
         elif event.type in (BackendEventType.PAUSED, BackendEventType.STOPPED):
             was_playing = self._playing
             self._playing = False

--- a/tests/providers/spotify_connect/test_backend_contract.py
+++ b/tests/providers/spotify_connect/test_backend_contract.py
@@ -262,6 +262,28 @@ async def test_playing_fires_play_media_after_debounce(monkeypatch: pytest.Monke
     mass.player_queues.play_media.assert_called_once_with("player1", _SOURCE_URI)
 
 
+async def test_playing_before_session_active_fires_play_media(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Playback starts when 'playing' arrives before the session becomes active."""
+    monkeypatch.setattr(provider_mod, "PLAY_MEDIA_DEBOUNCE_S", 0.01)
+    backend = FakeBackend()
+    provider, mass = _make_provider(backend, active_player_id="player1")
+    _player_with_volume(mass, 40)
+
+    await provider._handle_backend_event(BackendEvent(BackendEventType.PLAYING))
+
+    pending_before_active = provider._pending_play_media_task
+    assert pending_before_active is None
+
+    await provider._handle_backend_event(BackendEvent(BackendEventType.SESSION_ACTIVE))
+
+    task = provider._pending_play_media_task
+    assert task is not None
+    await task
+    mass.player_queues.play_media.assert_called_once_with("player1", _SOURCE_URI)
+
+
 async def test_playing_without_active_session_fires_no_play_media() -> None:
     """A 'playing' from a daemon that is not the active Connect device grabs no player."""
     backend = FakeBackend()


### PR DESCRIPTION
# What does this implement/fix?

Spotify Connect playback could remain silent when Soloist reported playback before the session became active.

- Start playback once both states are present, regardless of event order.
- Keep the existing stale-session debounce and volume sync behavior.
- Cover the reported event sequence with a regression test.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/6169

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.