### PR TITLE
Make publish IP tests reliable

### DIFF
--- a/tests/controllers/streams/conftest.py
+++ b/tests/controllers/streams/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -10,7 +11,7 @@ from music_assistant.controllers.streams.controller import StreamsController
 from music_assistant.controllers.tasks import TasksController
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
+    from collections.abc import AsyncGenerator, Iterator
 
     from music_assistant.mass import MusicAssistant
 
@@ -32,3 +33,22 @@ async def streams_controller(mass_minimal: MusicAssistant) -> AsyncGenerator[Str
         # close unconditionally: a failed assertion must not leave the socket bound
         await streams.close()
         await mass_minimal.tasks.close()
+
+
+@pytest.fixture
+def streamserver_fallback(
+    streams_controller: StreamsController,
+) -> Iterator[AsyncMock]:
+    """
+    Make the streamserver report a successful fallback to all interfaces.
+
+    :param streams_controller: StreamsController whose server should report the fallback.
+    """
+    server = streams_controller._server
+
+    async def setup(*, bind_port: int, **_kwargs: object) -> None:
+        server._bind_ip = None
+        server._bind_port = bind_port
+
+    with patch.object(server, "setup", AsyncMock(side_effect=setup)) as setup_mock:
+        yield setup_mock

--- a/tests/controllers/streams/test_bind_fallback.py
+++ b/tests/controllers/streams/test_bind_fallback.py
@@ -8,13 +8,17 @@ from music_assistant.constants import CONF_BIND_IP, CONF_BIND_PORT
 from music_assistant.controllers.streams.controller import StreamsController
 from music_assistant.mass import MusicAssistant
 
-# TEST-NET-3 (RFC 5737) is never assigned to a host, so binding it always fails
+# TEST-NET-3 (RFC 5737) represents an unavailable configured address
 UNBINDABLE_IP = "203.0.113.7"
 ALL_ADDRESSES = ("192.168.1.10", "fd00::10")
+FALLBACK_PORT = 8097
 
 
 async def _setup_with_bind_ip(
-    controller: StreamsController, mass: MusicAssistant, bind_ip: str
+    controller: StreamsController,
+    mass: MusicAssistant,
+    bind_ip: str,
+    bind_port: int | None = None,
 ) -> None:
     """
     Run the streamserver's setup against a config that binds the given address.
@@ -22,9 +26,15 @@ async def _setup_with_bind_ip(
     :param controller: The StreamsController to set up.
     :param mass: The MusicAssistant instance owning the controller.
     :param bind_ip: Address to configure as bind IP.
+    :param bind_port: Port to configure as bind port.
     """
     config = await mass.config.get_core_config(controller.domain)
-    config.update({CONF_BIND_IP: bind_ip, CONF_BIND_PORT: unused_port()})
+    config.update(
+        {
+            CONF_BIND_IP: bind_ip,
+            CONF_BIND_PORT: unused_port() if bind_port is None else bind_port,
+        }
+    )
     with (
         patch(
             "music_assistant.controllers.streams.controller.get_publish_ip_candidates",
@@ -39,11 +49,19 @@ async def _setup_with_bind_ip(
 
 
 async def test_unavailable_bind_ip_publishes_dialable_addresses(
-    streams_controller: StreamsController, mass_minimal: MusicAssistant
+    streams_controller: StreamsController,
+    mass_minimal: MusicAssistant,
+    streamserver_fallback: AsyncMock,
 ) -> None:
     """An address that cannot be bound leaves the streamserver advertising reachable addresses."""
-    await _setup_with_bind_ip(streams_controller, mass_minimal, UNBINDABLE_IP)
+    await _setup_with_bind_ip(
+        streams_controller, mass_minimal, UNBINDABLE_IP, bind_port=FALLBACK_PORT
+    )
 
+    streamserver_fallback.assert_awaited_once()
+    assert (setup_call := streamserver_fallback.await_args) is not None
+    assert setup_call.kwargs["bind_ip"] == UNBINDABLE_IP
+    assert setup_call.kwargs["bind_port"] == FALLBACK_PORT
     assert streams_controller.bind_ip == "0.0.0.0"
     assert streams_controller._publish_addresses == list(ALL_ADDRESSES)
 

--- a/tests/controllers/streams/test_publish_ip.py
+++ b/tests/controllers/streams/test_publish_ip.py
@@ -13,11 +13,12 @@ from music_assistant.constants import (
 from music_assistant.controllers.streams.controller import StreamsController
 from music_assistant.mass import MusicAssistant
 
-# TEST-NET-3 (RFC 5737) is never assigned to a host, so binding it always fails
+# TEST-NET-3 (RFC 5737) represents an unavailable configured address
 UNBINDABLE_IP = "203.0.113.7"
 # a publish IP does not have to exist on this host at all (NAT/port forward setups)
 EXTERNAL_PUBLISH_IP = "203.0.113.9"
 LOOPBACK_IP = "127.0.0.1"
+FALLBACK_PORT = 8097
 # the address the tests bind is deliberately absent here, so a publish IP that follows
 # the bind address can never be mistaken for the one auto-detection would have picked
 ALL_ADDRESSES = ("192.168.1.10", "10.0.0.5", "fd00::10")
@@ -101,11 +102,23 @@ async def test_configured_publish_ip_outranks_bind_ip(
 
 
 async def test_unavailable_bind_ip_publishes_dialable_address(
-    streams_controller: StreamsController, mass_minimal: MusicAssistant
+    streams_controller: StreamsController,
+    mass_minimal: MusicAssistant,
+    streamserver_fallback: AsyncMock,
 ) -> None:
     """A bind that fell back to all interfaces advertises a reachable address, not the failed one."""
-    await _setup_streams(streams_controller, mass_minimal, bind_ip=UNBINDABLE_IP)
+    await _setup_streams(
+        streams_controller,
+        mass_minimal,
+        bind_ip=UNBINDABLE_IP,
+        bind_port=FALLBACK_PORT,
+    )
 
+    streamserver_fallback.assert_awaited_once()
+    assert (setup_call := streamserver_fallback.await_args) is not None
+    assert setup_call.kwargs["bind_ip"] == UNBINDABLE_IP
+    assert setup_call.kwargs["bind_port"] == FALLBACK_PORT
+    assert streams_controller.bind_ip == "0.0.0.0"
     assert streams_controller.publish_ip == ALL_ADDRESSES[0]
     assert (
         streams_controller.base_url


### PR DESCRIPTION
# What does this implement/fix?

The publish IP fallback tests depended on the host rejecting a TEST-NET address and on an unreserved port, which could make them flaky.

- Model the streamserver fallback result deterministically.
- Keep verifying that a failed bind publishes a reachable address.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
