### PR TITLE
Keep custom audio sources connected while paused

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -3623,8 +3623,12 @@ class StreamsAudio:
                 # we were cancelled, just raise
                 cancelled = True
                 raise
-            if isinstance(ffmpeg_proc.stdin_feeder_exception, ProviderStreamLimitError):
-                raise ffmpeg_proc.stdin_feeder_exception
+            if feeder_exception := ffmpeg_proc.stdin_feeder_exception:
+                if isinstance(feeder_exception, ProviderStreamLimitError):
+                    raise ffmpeg_proc.stdin_feeder_exception
+                err = feeder_exception
+            if isinstance(err, ProviderStreamLimitError):
+                raise
             # dump the last 10 lines of the log in case of an unclean exit
             logger.warning("\n".join(list(ffmpeg_proc.log_history)[-10:]))
             raise AudioError(f"Error while streaming: {err}") from err

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -3609,8 +3609,8 @@ class StreamsAudio:
             )
             # a nested source raises through the stdin feeder, where ffmpeg's own exit
             # would otherwise flatten it into a generic AudioError
-            if isinstance(ffmpeg_proc.stdin_feeder_exception, ProviderStreamLimitError):
-                raise ffmpeg_proc.stdin_feeder_exception
+            if feeder_exception := ffmpeg_proc.stdin_feeder_exception:
+                raise feeder_exception
             if ffmpeg_proc.returncode not in (0, None):
                 log_trail = "\n".join(list(ffmpeg_proc.log_history)[-5:])
                 raise AudioError(f"FFMpeg exited with code {ffmpeg_proc.returncode}: {log_trail}")

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -123,6 +123,7 @@ from music_assistant.helpers.audio import (
     HTTP_HEADERS,
     HTTP_HEADERS_ICY,
     arriving_audio_format,
+    audio_source_silence_keepalive,
     build_concat_filelist,
     calculate_content_length,
     get_bit_rate,
@@ -3778,18 +3779,24 @@ class StreamsAudio:
         """
         stream_type = streamdetails.stream_type
         if stream_type == StreamType.CUSTOM:
-            # MusicProvider and PluginProvider both expose get_audio_stream with the same shape.
-            # Pin the exact instance: a domain fallback would stream from a sibling account
-            # while the source-stream slot is charged to the instance that issued the details.
-            provider = self.mass.get_provider(streamdetails.provider, return_unavailable=True)
-            if provider is None or not provider.available:
-                raise ProviderUnavailableError(
-                    f"Provider {streamdetails.provider} for stream is no longer available"
+            if streamdetails.media_type == MediaType.AUDIO_SOURCE:
+                audio_source = self._open_audio_source_generator(
+                    streamdetails,
+                    seek_position=seek_position if streamdetails.can_seek else 0,
                 )
-            provider = cast("MusicProvider | PluginProvider", provider)
-            audio_source = provider.get_audio_stream(
-                streamdetails, seek_position=seek_position if streamdetails.can_seek else 0
-            )
+            else:
+                # MusicProvider and PluginProvider both expose get_audio_stream with the same
+                # shape. Pin the exact instance: a domain fallback would stream from a sibling
+                # account while the source-stream slot is charged to the issuing instance.
+                provider = self.mass.get_provider(streamdetails.provider, return_unavailable=True)
+                if provider is None or not provider.available:
+                    raise ProviderUnavailableError(
+                        f"Provider {streamdetails.provider} for stream is no longer available"
+                    )
+                provider = cast("MusicProvider | PluginProvider", provider)
+                audio_source = provider.get_audio_stream(
+                    streamdetails, seek_position=seek_position if streamdetails.can_seek else 0
+                )
             return audio_source, 0 if streamdetails.can_seek else seek_position, extra_input_args
         if stream_type == StreamType.ICY:
             assert streamdetails.path is not None
@@ -3856,8 +3863,17 @@ class StreamsAudio:
         ):
             yield chunk
 
-    def _open_audio_source_generator(self, streamdetails: StreamDetails) -> AsyncGenerator[bytes]:
-        """Open the raw PCM generator for an AudioSource (CUSTOM or NAMED_PIPE)."""
+    def _open_audio_source_generator(
+        self,
+        streamdetails: StreamDetails,
+        seek_position: int = 0,
+    ) -> AsyncGenerator[bytes]:
+        """
+        Open the raw PCM generator for an AudioSource.
+
+        :param streamdetails: Details of the AudioSource to stream.
+        :param seek_position: Requested seek offset in seconds.
+        """
         if streamdetails.stream_type == StreamType.CUSTOM:
             # pin the exact instance, see _resolve_media_stream_source
             provider = self.mass.get_provider(streamdetails.provider, return_unavailable=True)
@@ -3866,7 +3882,12 @@ class StreamsAudio:
                     f"Provider {streamdetails.provider} for stream is no longer available"
                 )
             provider = cast("MusicProvider | PluginProvider", provider)
-            return provider.get_audio_stream(streamdetails)
+            audio_source = provider.get_audio_stream(
+                streamdetails, seek_position=seek_position if streamdetails.can_seek else 0
+            )
+            return audio_source_silence_keepalive(
+                audio_source, arriving_audio_format(streamdetails)
+            )
         if streamdetails.stream_type == StreamType.NAMED_PIPE:
             assert isinstance(streamdetails.path, str)  # for type checking
             return read_named_pipe(streamdetails.path)

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -451,32 +451,42 @@ async def audio_source_silence_keepalive(
     raw_silence_bytes = bytes_per_second * silence_chunk_ms // 1000
     silence_bytes = max(frame_size, (raw_silence_bytes // frame_size) * frame_size)
     silence_chunk = b"\x00" * silence_bytes
-    # empty bytes is the end-of-stream sentinel; real PCM frames are never empty
     queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=8)
 
     async def _producer() -> None:
-        # aclosing ensures inner.aclose() runs on cancellation so the underlying
-        # generator's own finally (e.g. plugin lock release, fd cleanup) fires
-        # instead of leaking until GC.
-        try:
-            async with aclosing(inner) as managed_inner:
-                async for chunk in managed_inner:
-                    await queue.put(chunk)
-        finally:
-            await queue.put(b"")
+        async with aclosing(inner) as managed_inner:
+            async for chunk in managed_inner:
+                await queue.put(chunk)
 
     producer_task = asyncio.create_task(_producer())
+    queue_task: asyncio.Task[bytes] | None = None
     try:
         while True:
-            try:
-                chunk = await asyncio.wait_for(queue.get(), timeout=idle_threshold_s)
-            except TimeoutError:
-                yield silence_chunk
+            if queue_task is None:
+                queue_task = asyncio.create_task(queue.get())
+            done, _ = await asyncio.wait(
+                (queue_task, producer_task),
+                timeout=idle_threshold_s,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if queue_task in done:
+                chunk = queue_task.result()
+                queue_task = None
+                yield chunk
                 continue
-            if not chunk:
+            if producer_task in done:
+                queue_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await queue_task
+                queue_task = None
+                await producer_task
                 break
-            yield chunk
+            yield silence_chunk
     finally:
+        if queue_task is not None:
+            queue_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await queue_task
         producer_task.cancel()
         with suppress(asyncio.CancelledError):
             await producer_task

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -451,14 +451,19 @@ async def audio_source_silence_keepalive(
     raw_silence_bytes = bytes_per_second * silence_chunk_ms // 1000
     silence_bytes = max(frame_size, (raw_silence_bytes // frame_size) * frame_size)
     silence_chunk = b"\x00" * silence_bytes
-    queue: asyncio.Queue[bytes | Exception | None] = asyncio.Queue(maxsize=8)
+    queue: asyncio.Queue[bytes | BaseException | None] = asyncio.Queue(maxsize=8)
 
     async def _producer() -> None:
         try:
             async with aclosing(inner) as managed_inner:
                 async for chunk in managed_inner:
                     await queue.put(chunk)
-        except Exception as err:
+        except (Exception, asyncio.CancelledError) as err:
+            task = asyncio.current_task()
+            assert task is not None
+            # Cancellation must not wait for a queue the closing consumer no longer drains.
+            if task.cancelling():
+                raise
             await queue.put(err)
         else:
             await queue.put(None)
@@ -473,7 +478,7 @@ async def audio_source_silence_keepalive(
                 continue
             if item is None:
                 break
-            if isinstance(item, Exception):
+            if isinstance(item, BaseException):
                 raise item
             yield item
     finally:

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -451,7 +451,7 @@ async def audio_source_silence_keepalive(
     raw_silence_bytes = bytes_per_second * silence_chunk_ms // 1000
     silence_bytes = max(frame_size, (raw_silence_bytes // frame_size) * frame_size)
     silence_chunk = b"\x00" * silence_bytes
-    queue: asyncio.Queue[bytes | BaseException | None] = asyncio.Queue(maxsize=8)
+    queue: asyncio.Queue[bytes | Exception | None] = asyncio.Queue(maxsize=8)
 
     async def _producer() -> None:
         try:
@@ -464,7 +464,8 @@ async def audio_source_silence_keepalive(
             # Cancellation must not wait for a queue the closing consumer no longer drains.
             if task.cancelling():
                 raise
-            await queue.put(err)
+            # A source-raised cancellation is a clean end, matching FFmpeg feeder semantics.
+            await queue.put(None if isinstance(err, asyncio.CancelledError) else err)
         else:
             await queue.put(None)
 
@@ -478,7 +479,7 @@ async def audio_source_silence_keepalive(
                 continue
             if item is None:
                 break
-            if isinstance(item, BaseException):
+            if isinstance(item, Exception):
                 raise item
             yield item
     finally:

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -451,42 +451,32 @@ async def audio_source_silence_keepalive(
     raw_silence_bytes = bytes_per_second * silence_chunk_ms // 1000
     silence_bytes = max(frame_size, (raw_silence_bytes // frame_size) * frame_size)
     silence_chunk = b"\x00" * silence_bytes
-    queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=8)
+    queue: asyncio.Queue[bytes | Exception | None] = asyncio.Queue(maxsize=8)
 
     async def _producer() -> None:
-        async with aclosing(inner) as managed_inner:
-            async for chunk in managed_inner:
-                await queue.put(chunk)
+        try:
+            async with aclosing(inner) as managed_inner:
+                async for chunk in managed_inner:
+                    await queue.put(chunk)
+        except Exception as err:
+            await queue.put(err)
+        else:
+            await queue.put(None)
 
     producer_task = asyncio.create_task(_producer())
-    queue_task: asyncio.Task[bytes] | None = None
     try:
         while True:
-            if queue_task is None:
-                queue_task = asyncio.create_task(queue.get())
-            done, _ = await asyncio.wait(
-                (queue_task, producer_task),
-                timeout=idle_threshold_s,
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            if queue_task in done:
-                chunk = queue_task.result()
-                queue_task = None
-                yield chunk
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=idle_threshold_s)
+            except TimeoutError:
+                yield silence_chunk
                 continue
-            if producer_task in done:
-                queue_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await queue_task
-                queue_task = None
-                await producer_task
+            if item is None:
                 break
-            yield silence_chunk
+            if isinstance(item, Exception):
+                raise item
+            yield item
     finally:
-        if queue_task is not None:
-            queue_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await queue_task
         producer_task.cancel()
         with suppress(asyncio.CancelledError):
             await producer_task

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -8,7 +8,7 @@ import re
 import struct
 import urllib.parse
 from collections.abc import AsyncGenerator, Iterable, Iterator
-from contextlib import aclosing
+from contextlib import aclosing, suppress
 from io import BytesIO
 from math import isfinite
 from typing import TYPE_CHECKING, Final
@@ -478,14 +478,8 @@ async def audio_source_silence_keepalive(
             yield chunk
     finally:
         producer_task.cancel()
-        try:
+        with suppress(asyncio.CancelledError):
             await producer_task
-        except asyncio.CancelledError:
-            pass
-        except Exception:
-            # log but don't re-raise: we're already in a finally and the
-            # downstream consumer has its own error handling for the outer stream.
-            LOGGER.exception("AudioSource producer task raised")
 
 
 async def get_silence(

--- a/tests/controllers/streams/test_audio_sources.py
+++ b/tests/controllers/streams/test_audio_sources.py
@@ -744,6 +744,33 @@ class TestAudioSourceSilenceKeepalive:
             await anext(stream)
 
     @pytest.mark.asyncio
+    async def test_cancellation_with_full_queue_completes(self) -> None:
+        """Cancelling the wrapper also closes a source blocked on a full queue."""
+        from music_assistant.helpers.audio import (  # noqa: PLC0415
+            audio_source_silence_keepalive,
+        )
+
+        queue_full = asyncio.Event()
+        source_closed = asyncio.Event()
+
+        async def _inner() -> AsyncGenerator[bytes]:
+            try:
+                for index in range(10):
+                    if index == 9:
+                        queue_full.set()
+                    yield b"audio"
+            finally:
+                source_closed.set()
+
+        stream = audio_source_silence_keepalive(_inner(), _audio_format(), idle_threshold_s=1)
+        assert await anext(stream) == b"audio"
+        await asyncio.wait_for(queue_full.wait(), timeout=1)
+
+        await asyncio.wait_for(stream.aclose(), timeout=1)
+
+        assert source_closed.is_set()
+
+    @pytest.mark.asyncio
     async def test_custom_audio_source_path_applies_wrapper(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/controllers/streams/test_audio_sources.py
+++ b/tests/controllers/streams/test_audio_sources.py
@@ -796,8 +796,8 @@ class TestAudioSourceSilenceKeepalive:
             await asyncio.wait_for(stream.aclose(), timeout=1)
 
     @pytest.mark.asyncio
-    async def test_propagates_source_cancelled_error(self) -> None:
-        """A source-raised cancellation reaches the stream consumer."""
+    async def test_source_cancelled_error_completes(self) -> None:
+        """A source-raised cancellation cleanly ends the stream."""
         from music_assistant.helpers.audio import (  # noqa: PLC0415
             audio_source_silence_keepalive,
         )
@@ -806,10 +806,10 @@ class TestAudioSourceSilenceKeepalive:
             yield b"one"
             raise asyncio.CancelledError
 
-        stream = audio_source_silence_keepalive(_inner(), _audio_format())
-        assert await anext(stream) == b"one"
-        with pytest.raises(asyncio.CancelledError):
-            await anext(stream)
+        chunks = [
+            chunk async for chunk in audio_source_silence_keepalive(_inner(), _audio_format())
+        ]
+        assert chunks == [b"one"]
 
     @pytest.mark.asyncio
     async def test_custom_audio_source_path_applies_wrapper(

--- a/tests/controllers/streams/test_audio_sources.py
+++ b/tests/controllers/streams/test_audio_sources.py
@@ -771,6 +771,47 @@ class TestAudioSourceSilenceKeepalive:
         assert source_closed.is_set()
 
     @pytest.mark.asyncio
+    async def test_cancellation_with_full_queue_propagates_cleanup_error(self) -> None:
+        """Source cleanup errors propagate without blocking wrapper cancellation."""
+        from music_assistant.helpers.audio import (  # noqa: PLC0415
+            audio_source_silence_keepalive,
+        )
+
+        queue_full = asyncio.Event()
+
+        async def _inner() -> AsyncGenerator[bytes]:
+            try:
+                for index in range(10):
+                    if index == 9:
+                        queue_full.set()
+                    yield b"audio"
+            finally:
+                raise RuntimeError("cleanup failed")
+
+        stream = audio_source_silence_keepalive(_inner(), _audio_format(), idle_threshold_s=1)
+        assert await anext(stream) == b"audio"
+        await asyncio.wait_for(queue_full.wait(), timeout=1)
+
+        with pytest.raises(RuntimeError, match="cleanup failed"):
+            await asyncio.wait_for(stream.aclose(), timeout=1)
+
+    @pytest.mark.asyncio
+    async def test_propagates_source_cancelled_error(self) -> None:
+        """A source-raised cancellation reaches the stream consumer."""
+        from music_assistant.helpers.audio import (  # noqa: PLC0415
+            audio_source_silence_keepalive,
+        )
+
+        async def _inner() -> AsyncGenerator[bytes]:
+            yield b"one"
+            raise asyncio.CancelledError
+
+        stream = audio_source_silence_keepalive(_inner(), _audio_format())
+        assert await anext(stream) == b"one"
+        with pytest.raises(asyncio.CancelledError):
+            await anext(stream)
+
+    @pytest.mark.asyncio
     async def test_custom_audio_source_path_applies_wrapper(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/controllers/streams/test_audio_sources.py
+++ b/tests/controllers/streams/test_audio_sources.py
@@ -727,6 +727,69 @@ class TestAudioSourceSilenceKeepalive:
         ]
         assert chunks == [b"one"]
 
+    @pytest.mark.asyncio
+    async def test_propagates_inner_error(self) -> None:
+        """An error from the source generator reaches the stream consumer."""
+        from music_assistant.helpers.audio import (  # noqa: PLC0415
+            audio_source_silence_keepalive,
+        )
+
+        async def _inner() -> AsyncGenerator[bytes]:
+            yield b"one"
+            raise RuntimeError("source failed")
+
+        stream = audio_source_silence_keepalive(_inner(), _audio_format())
+        assert await anext(stream) == b"one"
+        with pytest.raises(RuntimeError, match="source failed"):
+            await anext(stream)
+
+    @pytest.mark.asyncio
+    async def test_custom_audio_source_path_applies_wrapper(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CUSTOM AudioSources are wrapped using the format their bytes arrive in."""
+        decoded_format = _audio_format()
+        wrapped_formats: list[AudioFormat] = []
+
+        async def _inner() -> AsyncGenerator[bytes]:
+            yield b"audio"
+
+        async def _keepalive(
+            inner: AsyncGenerator[bytes], pcm_format: AudioFormat
+        ) -> AsyncGenerator[bytes]:
+            wrapped_formats.append(pcm_format)
+            async for chunk in inner:
+                yield chunk
+
+        monkeypatch.setattr(
+            "music_assistant.controllers.streams.audio.audio_source_silence_keepalive",
+            _keepalive,
+        )
+        provider = MagicMock()
+        provider.available = True
+        provider.get_audio_stream.return_value = _inner()
+        mass = MagicMock()
+        mass.get_provider.return_value = provider
+        controller = StreamsAudio(mass)
+        streamdetails = StreamDetails(
+            provider="fake_plugin",
+            item_id="main",
+            audio_format=AudioFormat(content_type=ContentType.FLAC),
+            decoded_audio_format=decoded_format,
+            media_type=MediaType.AUDIO_SOURCE,
+            stream_type=StreamType.CUSTOM,
+        )
+
+        source, seek_position, extra_input_args = await controller._resolve_media_stream_source(
+            streamdetails, seek_position=0, extra_input_args=[]
+        )
+
+        assert not isinstance(source, str)
+        assert [chunk async for chunk in source] == [b"audio"]
+        assert wrapped_formats == [decoded_format]
+        assert seek_position == 0
+        assert extra_input_args == []
+
 
 class TestAudioSourceLibraryRejection:
     """AudioSources are dynamic plugin surfaces — favorites/library must reject them."""

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -215,6 +215,14 @@ class _FeederErrorFFMpeg(_FakeFFMpeg):
             yield b""
 
 
+class _FeederErrorAfterOutputFFMpeg(_FeederErrorFFMpeg):
+    """FFMpeg double whose input feeder fails after producing PCM."""
+
+    async def iter_chunked(self, _chunk_size: int) -> AsyncGenerator[bytes]:
+        """Yield PCM before the feeder failure ends the stream."""
+        yield b"\x00\x01" * 256
+
+
 class _LimitedProvider(MusicProvider):
     """Music provider with one source-stream slot."""
 
@@ -749,6 +757,21 @@ async def test_provider_capacity_error_from_ffmpeg_feeder_remains_typed(
                 _make_pcm_format(),
             )
         )
+
+
+@pytest.mark.asyncio
+async def test_generic_ffmpeg_feeder_error_is_not_treated_as_clean_eof(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A source failure after ffmpeg output still fails the media stream."""
+    _FeederErrorAfterOutputFFMpeg.error = RuntimeError("source failed")
+    monkeypatch.setattr(audio_mod, "FFMpeg", _FeederErrorAfterOutputFFMpeg)
+    audio = _make_audio_controller()
+
+    with pytest.raises(AudioError, match="source failed") as err:
+        await _drain(audio.get_media_stream(_flac_streamdetails(), _make_pcm_format()))
+
+    assert isinstance(err.value.__cause__, RuntimeError)
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -174,6 +174,16 @@ class _StallingFFMpeg(_FakeFFMpeg):
         yield b""  # unreachable
 
 
+class _StallingFeederErrorFFMpeg(_StallingFFMpeg):
+    """FFMpeg double that stalls after its input feeder fails."""
+
+    error: Exception
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.stdin_feeder_exception = self.error
+
+
 class _SlowConsumerFFMpeg(_FakeFFMpeg):
     """FFMpeg double that hands over chunks instantly when asked."""
 
@@ -215,12 +225,17 @@ class _FeederErrorFFMpeg(_FakeFFMpeg):
             yield b""
 
 
-class _FeederErrorAfterOutputFFMpeg(_FeederErrorFFMpeg):
-    """FFMpeg double whose input feeder fails after producing PCM."""
+class _SourceConsumingFFMpeg(_FakeFFMpeg):
+    """FFMpeg double that consumes its generator input before ending stdout."""
 
     async def iter_chunked(self, _chunk_size: int) -> AsyncGenerator[bytes]:
-        """Yield PCM before the feeder failure ends the stream."""
-        yield b"\x00\x01" * 256
+        """Yield source bytes and record a source failure like the real feeder."""
+        assert isinstance(self.audio_input, AsyncGenerator)
+        try:
+            async for chunk in self.audio_input:
+                yield chunk
+        except Exception as err:
+            self.stdin_feeder_exception = err
 
 
 class _LimitedProvider(MusicProvider):
@@ -760,12 +775,38 @@ async def test_provider_capacity_error_from_ffmpeg_feeder_remains_typed(
 
 
 @pytest.mark.asyncio
-async def test_generic_ffmpeg_feeder_error_is_not_treated_as_clean_eof(
+async def test_custom_audio_source_failure_survives_ffmpeg_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A source failure after ffmpeg output still fails the media stream."""
-    _FeederErrorAfterOutputFFMpeg.error = RuntimeError("source failed")
-    monkeypatch.setattr(audio_mod, "FFMpeg", _FeederErrorAfterOutputFFMpeg)
+    """A CUSTOM AudioSource failure after PCM output reaches the consumer."""
+    monkeypatch.setattr(audio_mod, "FFMpeg", _SourceConsumingFFMpeg)
+    audio = _make_audio_controller()
+
+    async def _source() -> AsyncGenerator[bytes]:
+        yield b"\x00\x01" * 256
+        raise RuntimeError("source failed")
+
+    provider = MagicMock(available=True)
+    provider.get_audio_stream.return_value = _source()
+    cast("MagicMock", audio.mass).get_provider.return_value = provider
+    streamdetails = _flac_streamdetails()
+    streamdetails.stream_type = StreamType.CUSTOM
+    streamdetails.decoded_audio_format = _make_pcm_format()
+
+    with pytest.raises(AudioError, match="source failed") as err:
+        await _drain(audio.get_audio_source_stream(streamdetails, _make_pcm_format()))
+
+    assert isinstance(err.value.__cause__, RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_ffmpeg_error_path_prefers_source_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A feeder failure remains the cause when ffmpeg also stalls."""
+    _StallingFeederErrorFFMpeg.error = RuntimeError("source failed")
+    monkeypatch.setattr(audio_mod, "FFMpeg", _StallingFeederErrorFFMpeg)
+    monkeypatch.setattr(audio_mod, "STREAM_START_TIMEOUT", 0.1)
     audio = _make_audio_controller()
 
     with pytest.raises(AudioError, match="source failed") as err:


### PR DESCRIPTION
# What does this implement/fix?

CUSTOM AudioSource plugins are documented to stay connected when their upstream source pauses, but the silence wrapper was dropped from the realtime stream path. This restores that contract.

- Apply the keepalive before pacing or ffmpeg for CUSTOM AudioSources
- Size silence from the PCM format the provider actually delivers
- Propagate source failures and cover the restored wiring with tests

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.