### PR TITLE
Let Music Assistant mix crossfades for Spotify and other realtime sources

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -258,16 +258,16 @@ class _TailHold:
     # the player's supply must stay at least this far ahead of the wall clock
     _LEAD_RESERVE_S = 3.0
 
-    def __init__(self, pcm_format: AudioFormat, audio_buffer: AudioBuffer | None) -> None:
+    def __init__(self, pcm_format: AudioFormat, streamdetails: StreamDetails) -> None:
         """
         Initialize the tracker for one track's stream.
 
         :param pcm_format: PCM format of the stream's chunks.
-        :param audio_buffer: The track's source buffer, if any; its EOF releases
-            the full window.
+        :param streamdetails: Details of the track being streamed; its source buffer
+            is read at hold time, because opening the stream is what creates it.
         """
         self._pcm_format = pcm_format
-        self._audio_buffer = audio_buffer
+        self._streamdetails = streamdetails
         self._started: float | None = None
         self._last_noted = 0.0
         self._received_bytes = 0
@@ -299,7 +299,7 @@ class _TailHold:
         """
         if self._started is None:
             return 0
-        audio_buffer = self._audio_buffer
+        audio_buffer = cast("AudioBuffer | None", self._streamdetails.buffer)
         if audio_buffer is not None:
             if audio_buffer.has_error:
                 # a failed source is skipped without a fade, so its remaining audio
@@ -330,7 +330,7 @@ async def _incoming_overlap_stream(
         beyond the overlap are not lost (see ``overshoot``) and the stream itself
         stays open for the track's body.
     :param target_size: Exact number of overlap bytes to yield.
-    :param fed: Receives every yielded part, for the mixer-failure fallback.
+    :param fed: Receives every yielded part, so the caller can account for them.
     :param overshoot: Receives bytes read beyond the overlap (they open the body).
     """
     taken = 0
@@ -2013,11 +2013,7 @@ class StreamsAudio:
         # the holdback is grown out of the audio banked ahead of playback instead of
         # armed as one fixed window, so a source delivering near playback pace keeps
         # feeding the player
-        tail_hold = (
-            _TailHold(pcm_format, cast("AudioBuffer | None", streamdetails.buffer))
-            if crossfade_buffer_size > 0
-            else None
-        )
+        tail_hold = _TailHold(pcm_format, streamdetails) if crossfade_buffer_size > 0 else None
         async for chunk in self.get_queue_item_stream(
             queue_item,
             pcm_format,
@@ -2197,8 +2193,7 @@ class StreamsAudio:
                 )
                 # aclosing so an aborted stream tears the mix (and its feeder,
                 # which holds a read on the fade-in stream) down first
-                stack = aclosing(mix_stream)
-                async with stack:
+                async with aclosing(mix_stream):
                     async for mix_chunk in mix_stream:
                         if first_part_written < fadeout_share_bytes:
                             # split this chunk so A gets exactly fadeout_share_bytes
@@ -2576,9 +2571,7 @@ class StreamsAudio:
                 # of armed as one fixed window, so a source delivering near playback pace
                 # keeps feeding the player
                 tail_hold = (
-                    _TailHold(
-                        pcm_format, cast("AudioBuffer | None", queue_track.streamdetails.buffer)
-                    )
+                    _TailHold(pcm_format, queue_track.streamdetails)
                     if item_crossfade_mode != CrossfadeMode.DISABLED
                     else None
                 )

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2052,11 +2052,15 @@ class StreamsAudio:
             if len(buffer) <= hold_target:
                 await asyncio.sleep(0)
                 continue
-            # yield everything above the current holdback window
+            # yield everything above the current holdback window; the slice can
+            # run short of a whole second when the window is small, so credit
+            # what is actually yielded - a nominal full-second credit inflates
+            # the play log and the reported duration
             while len(buffer) > hold_target:
-                yield bytes(buffer[: pcm_format.pcm_sample_size])
-                bytes_written += pcm_format.pcm_sample_size
-                del buffer[: pcm_format.pcm_sample_size]
+                pcm_slice = bytes(buffer[: pcm_format.pcm_sample_size])
+                yield pcm_slice
+                bytes_written += len(pcm_slice)
+                del buffer[: len(pcm_slice)]
                 await asyncio.sleep(0)
 
         #### HANDLE END OF TRACK
@@ -2804,11 +2808,16 @@ class StreamsAudio:
                             crossfade_buffer = bytearray()
                             warmup_bytes = 0
 
-                        # yield everything above the current holdback window
+                        # yield everything above the current holdback window; the
+                        # slice can run short of a whole second when the window is
+                        # small, so credit what is actually yielded - a nominal
+                        # full-second credit inflates the play log and pins the
+                        # queue's position mapping to the wrong track
                         while len(crossfade_buffer) > hold_target:
-                            yield bytes(crossfade_buffer[:pcm_sample_size])
-                            bytes_written += pcm_sample_size
-                            del crossfade_buffer[:pcm_sample_size]
+                            pcm_slice = bytes(crossfade_buffer[:pcm_sample_size])
+                            yield pcm_slice
+                            bytes_written += len(pcm_slice)
+                            del crossfade_buffer[: len(pcm_slice)]
                             await asyncio.sleep(0)
 
                 # A source error after partial audio must not look like a completed item.

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -301,7 +301,9 @@ class _RealtimeTailHold:
         surplus_seconds = (
             self._content_bytes / self._pcm_format.pcm_sample_size + resident_seconds - elapsed
         )
-        surplus_bytes = int(max(0.0, surplus_seconds) * self._pcm_format.pcm_sample_size)
+        # half the surplus: the other half keeps growing the player's lead, which
+        # is what absorbs the source's own delivery wobble mid-track
+        surplus_bytes = int(max(0.0, surplus_seconds) * self._pcm_format.pcm_sample_size) // 2
         return min(max_bytes, surplus_bytes // frame_size * frame_size)
 
 
@@ -1939,11 +1941,11 @@ class StreamsAudio:
 
         buffer = bytearray()
         bytes_written = 0
-        # calculate crossfade buffer size; a realtime source never holds the smart
-        # window (45s of resident audio it cannot have), only the standard overlap
+        # calculate crossfade buffer size; a realtime source's holdback only ever
+        # withholds its banked surplus, so the smart window is a ceiling there
         crossfade_buffer_duration = (
             SMART_CROSSFADE_DURATION
-            if crossfade_mode == CrossfadeMode.SMART_CROSSFADE and not streamdetails.is_realtime
+            if crossfade_mode == CrossfadeMode.SMART_CROSSFADE
             else standard_crossfade_duration
         )
         crossfade_buffer_duration = min(
@@ -2018,8 +2020,6 @@ class StreamsAudio:
             exact_seek=exact_buffer_seek,
         ):
             total_chunks_received += 1
-            if tail_hold is not None:
-                tail_hold.note_bytes(len(chunk))
 
             if warmup_bytes < warmup_size:
                 # warmup: yield directly, don't buffer
@@ -2028,6 +2028,11 @@ class StreamsAudio:
                 bytes_written += len(chunk)
                 del chunk
                 continue
+
+            if tail_hold is not None:
+                # counted from warmup end on purpose: what the warmup banked
+                # stays with the player as its lead
+                tail_hold.note_bytes(len(chunk))
 
             if tail_hold is None and not holdback_armed:
                 holdback_armed = self._crossfade_holdback_allowed(
@@ -2125,6 +2130,7 @@ class StreamsAudio:
                     crossfade_mode,
                     standard_crossfade_duration,
                     fade_in_playback_speed,
+                    fade_out_seconds=len(buffer) / pcm_format.pcm_sample_size,
                 )
                 crossfade_allowed = transition_mode != CrossfadeMode.DISABLED
         if not crossfade_allowed:
@@ -2459,13 +2465,12 @@ class StreamsAudio:
                 track_playback_speed = cast(
                     "float", queue_track.extra_attributes.get("playback_speed", 1.0)
                 )
-                # calculate crossfade buffer size; a realtime source never holds the
-                # smart window (45s of resident audio it cannot have), only the
-                # standard overlap
+                # calculate crossfade buffer size; a realtime source's holdback only
+                # ever withholds its banked surplus, so the smart window is a
+                # ceiling there
                 crossfade_buffer_duration = (
                     SMART_CROSSFADE_DURATION
                     if item_crossfade_mode == CrossfadeMode.SMART_CROSSFADE
-                    and not queue_track.streamdetails.is_realtime
                     else standard_crossfade_duration
                 )
                 crossfade_buffer_duration = min(
@@ -2510,6 +2515,7 @@ class StreamsAudio:
                             item_crossfade_mode,
                             standard_crossfade_duration,
                             track_playback_speed,
+                            fade_out_seconds=len(last_fadeout_part) / pcm_sample_size,
                         )
                     if transition_mode == CrossfadeMode.DISABLED:
                         # nothing to fade into: flush the held-back tail of the previous track
@@ -2626,8 +2632,6 @@ class StreamsAudio:
                             )
                             return
                         total_chunks_received += 1
-                        if tail_hold is not None:
-                            tail_hold.note_bytes(len(chunk))
                         if not first_chunk_received:
                             first_chunk_received = True
                             # inform the queue that the track is now loaded in the buffer
@@ -2653,6 +2657,11 @@ class StreamsAudio:
                             bytes_written += len(chunk)
                             del chunk
                             continue
+
+                        if tail_hold is not None:
+                            # counted from warmup end on purpose: what the warmup banked
+                            # stays with the player as its lead
+                            tail_hold.note_bytes(len(chunk))
 
                         if tail_hold is None and not last_fadeout_part and not holdback_armed:
                             holdback_armed = self._crossfade_holdback_allowed(
@@ -3927,14 +3936,22 @@ class StreamsAudio:
         crossfade_mode: CrossfadeMode,
         standard_crossfade_duration: int,
         playback_speed: float = 1.0,
+        fade_out_seconds: float | None = None,
     ) -> tuple[CrossfadeMode, float]:
         """
         Select a crossfade that can be completed from resident incoming PCM.
+
+        What the boundary has in hand picks the rung: a smart fade on whatever
+        window both sides can carry (the full smart window is a ceiling, its
+        effective minimum the floor), a standard fade otherwise, none when there
+        is not enough to blend at all.
 
         :param streamdetails: Incoming track stream details.
         :param crossfade_mode: Requested crossfade mode.
         :param standard_crossfade_duration: Configured standard overlap in seconds.
         :param playback_speed: Incoming track playback-speed multiplier.
+        :param fade_out_seconds: Held-back outgoing tail in seconds, when known;
+            a smart fade needs its effective minimum on that side too.
         :return: Effective mode and resident fade-in duration in seconds.
         """
         audio_buffer = streamdetails.buffer
@@ -3947,14 +3964,24 @@ class StreamsAudio:
         ):
             return CrossfadeMode.DISABLED, 0
 
+        available_seconds = audio_buffer.duration_available / playback_speed
+        if (
+            crossfade_mode == CrossfadeMode.SMART_CROSSFADE
+            and audio_buffer.ready.is_set()
+            and available_seconds >= MIN_EFFECTIVE_FADE_BUFFER
+            and (fade_out_seconds is None or fade_out_seconds >= MIN_EFFECTIVE_FADE_BUFFER)
+        ):
+            return crossfade_mode, min(SMART_CROSSFADE_DURATION, available_seconds)
+
         if streamdetails.is_realtime:
-            # A realtime source cannot bank the whole overlap up front, but it does
-            # not have to: the mix streams, so the blend flows at the source's own
-            # (overpaced) delivery rate. The resident audio only has to prove the
-            # source is actually delivering; a source that is not there yet means
-            # this boundary simply plays without a fade. Smart fades need their
-            # full analysis window resident, so a realtime source always gets the
-            # standard overlap.
+            # A realtime source cannot bank the whole standard overlap up front,
+            # but it does not have to: the standard mix streams, so the blend
+            # flows at the source's own (overpaced) delivery rate. The resident
+            # audio only has to prove the source is actually delivering; a source
+            # that is not there yet means this boundary simply plays without a
+            # fade. The smart rung above stays out of reach for now: a strictly
+            # sequential session cannot have the incoming window resident at the
+            # boundary, and the smart chain does not stream yet.
             if (
                 not audio_buffer.ready.is_set()
                 or standard_crossfade_duration < MIN_CROSSFADE_FALLBACK_DURATION
@@ -3962,13 +3989,6 @@ class StreamsAudio:
                 return CrossfadeMode.DISABLED, 0
             return CrossfadeMode.STANDARD_CROSSFADE, standard_crossfade_duration
 
-        available_seconds = audio_buffer.duration_available / playback_speed
-        if (
-            crossfade_mode == CrossfadeMode.SMART_CROSSFADE
-            and audio_buffer.ready.is_set()
-            and available_seconds >= MIN_EFFECTIVE_FADE_BUFFER
-        ):
-            return crossfade_mode, min(SMART_CROSSFADE_DURATION, available_seconds)
         if (
             crossfade_mode == CrossfadeMode.STANDARD_CROSSFADE
             and standard_crossfade_duration >= MIN_CROSSFADE_FALLBACK_DURATION

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -181,6 +181,11 @@ WARMUP_DURATION = 8
 # boundary can carry one at all.
 MIN_CROSSFADE_DURATION = 3
 
+# Bounded wait for the fade-in prefetcher to release a stream at the handover. In
+# normal operation it returns on its next chunk; only a stalled source takes longer,
+# and then the flow stream is better off opening the track itself.
+PREFETCH_HANDOVER_TIMEOUT = 5.0
+
 # Bounded wait at a boundary for a realtime incoming track to start delivering.
 # Its buffer only exists once its session produces audio, which happens around the
 # moment the outgoing track's audio ends; the wait trades a little of the player's
@@ -479,7 +484,13 @@ class _IncomingFadePrefetcher:
             return None
         # stop collecting: from here the flow stream reads the same generator itself
         self._target = 0
-        await self._task
+        try:
+            # the collector only sees the new target once its next chunk arrives, so a
+            # source that stalled would hold the handover; give up on it instead
+            await asyncio.wait_for(self._task, timeout=PREFETCH_HANDOVER_TIMEOUT)
+        except TimeoutError:
+            await self.close()
+            return None
         if self._failed or (self._streamdetails is not None and self._streamdetails.stream_error):
             await self.close()
             return None
@@ -3936,6 +3947,9 @@ class StreamsAudio:
             else standard_crossfade_duration,
             fade_out_seconds,
         )
+        if audio_buffer.eof:
+            # the source is done, so what is resident is all there will ever be
+            window = min(window, audio_buffer.duration_available / playback_speed)
         if streamdetails.duration:
             # a short incoming track cannot supply a long overlap, and blending into
             # more than half of it would leave the listener no clean part of it. The

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -3911,8 +3911,8 @@ class StreamsAudio:
         Select the crossfade this boundary can carry.
 
         The configured mode picks the fade; the held-back outgoing tail sizes its
-        window, up to that mode's ceiling. Too short a tail to blend at all means no
-        fade rather than a different one.
+        window, up to that mode's ceiling and to what the incoming track can supply.
+        Too short a tail to blend at all means no fade rather than a different one.
 
         :param streamdetails: Incoming track stream details.
         :param crossfade_mode: Requested crossfade mode.
@@ -3938,6 +3938,10 @@ class StreamsAudio:
             else standard_crossfade_duration,
             fade_out_seconds,
         )
+        if streamdetails.duration:
+            # a short incoming track cannot supply a long overlap, and blending into
+            # more than half of it would leave the listener no clean part of it
+            window = min(window, streamdetails.duration / 2)
         if window < MIN_CROSSFADE_DURATION:
             return CrossfadeMode.DISABLED, 0
         self.logger.debug(

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2114,6 +2114,7 @@ class StreamsAudio:
                     crossfade_mode,
                     standard_crossfade_duration,
                     fade_out_seconds=len(buffer) / pcm_format.pcm_sample_size,
+                    playback_speed=fade_in_playback_speed,
                 )
                 crossfade_allowed = transition_mode != CrossfadeMode.DISABLED
         if not crossfade_allowed:
@@ -2493,6 +2494,7 @@ class StreamsAudio:
                             item_crossfade_mode,
                             standard_crossfade_duration,
                             fade_out_seconds=len(last_fadeout_part) / pcm_sample_size,
+                            playback_speed=track_playback_speed,
                         )
                     if transition_mode == CrossfadeMode.DISABLED:
                         # nothing to fade into: flush the held-back tail of the previous track
@@ -3899,6 +3901,7 @@ class StreamsAudio:
         crossfade_mode: CrossfadeMode,
         standard_crossfade_duration: int,
         fade_out_seconds: float,
+        playback_speed: float = 1.0,
     ) -> tuple[CrossfadeMode, float]:
         """
         Select the crossfade this boundary can carry.
@@ -3911,11 +3914,13 @@ class StreamsAudio:
         :param crossfade_mode: Requested crossfade mode.
         :param standard_crossfade_duration: Configured standard overlap in seconds.
         :param fade_out_seconds: Held-back outgoing tail in seconds.
+        :param playback_speed: Incoming track playback-speed multiplier.
         :return: Effective mode and fade-in duration in seconds.
         """
         audio_buffer = streamdetails.buffer
         if (
             crossfade_mode == CrossfadeMode.DISABLED
+            or playback_speed <= 0
             or audio_buffer is None
             or audio_buffer.has_error
             or not audio_buffer.is_valid()
@@ -3933,8 +3938,10 @@ class StreamsAudio:
         )
         if streamdetails.duration:
             # a short incoming track cannot supply a long overlap, and blending into
-            # more than half of it would leave the listener no clean part of it
-            window = min(window, streamdetails.duration / 2)
+            # more than half of it would leave the listener no clean part of it. The
+            # window is stream time, the track's remaining audio is media time.
+            remaining_media = max(0.0, streamdetails.duration - streamdetails.seek_position)
+            window = min(window, remaining_media / playback_speed / 2)
         if window < MIN_CROSSFADE_DURATION:
             return CrossfadeMode.DISABLED, 0
         self.logger.debug(

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -272,6 +272,7 @@ class _RealtimeTailHold:
         self._audio_buffer = audio_buffer
         self._started: float | None = None
         self._content_bytes = 0
+        self._resident_at_anchor = 0.0
 
     def note_bytes(self, count: int) -> None:
         """
@@ -281,6 +282,11 @@ class _RealtimeTailHold:
         """
         if self._started is None:
             self._started = asyncio.get_event_loop().time()
+            # what the buffer already held is not new surplus: counting it would
+            # snap the hold to a lump the player pays for as an immediate stall
+            self._resident_at_anchor = (
+                self._audio_buffer.duration_available if self._audio_buffer is not None else 0.0
+            )
         self._content_bytes += count
 
     def hold_target(self, max_bytes: int, frame_size: int) -> int:
@@ -296,10 +302,17 @@ class _RealtimeTailHold:
         if audio_buffer is not None and audio_buffer.eof:
             # the source is done: everything left is resident, hold the full window
             return max_bytes
-        resident_seconds = audio_buffer.duration_available if audio_buffer is not None else 0.0
+        # net buffer change since the anchor: together with the bytes read, this
+        # is exactly what the source delivered since then, and delivery beyond
+        # the wall clock is the only audio that may be withheld
+        resident_delta = (
+            audio_buffer.duration_available - self._resident_at_anchor
+            if audio_buffer is not None
+            else 0.0
+        )
         elapsed = asyncio.get_event_loop().time() - self._started
         surplus_seconds = (
-            self._content_bytes / self._pcm_format.pcm_sample_size + resident_seconds - elapsed
+            self._content_bytes / self._pcm_format.pcm_sample_size + resident_delta - elapsed
         )
         # half the surplus: the other half keeps growing the player's lead, which
         # is what absorbs the source's own delivery wobble mid-track

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -326,8 +326,8 @@ async def _incoming_overlap_stream(
     collected: bytes,
     stream: AsyncGenerator[bytes],
     target_size: int,
-    fed: list[bytes],
     overshoot: bytearray,
+    on_pulled: Callable[[int], None],
 ) -> AsyncGenerator[bytes]:
     """
     Yield exactly the incoming track's overlap: what is in hand, then the live stream.
@@ -337,14 +337,14 @@ async def _incoming_overlap_stream(
         beyond the overlap are not lost (see ``overshoot``) and the stream itself
         stays open for the track's body.
     :param target_size: Exact number of overlap bytes to yield.
-    :param fed: Receives every yielded part, so the caller can account for them.
     :param overshoot: Receives bytes read beyond the overlap (they open the body).
+    :param on_pulled: Called with the size of every chunk taken off the stream here,
+        as it is taken - these bypass the caller's own read loop.
     """
     taken = 0
     if collected:
         part = collected[:target_size]
         overshoot.extend(collected[target_size:])
-        fed.append(part)
         taken = len(part)
         yield part
     while taken < target_size:
@@ -352,10 +352,10 @@ async def _incoming_overlap_stream(
             next_chunk = await anext(stream)
         except StopAsyncIteration:
             return
+        on_pulled(len(next_chunk))
         remaining = target_size - taken
         part = next_chunk[:remaining]
         overshoot.extend(next_chunk[remaining:])
-        fed.append(part)
         taken += len(part)
         yield part
 
@@ -2692,17 +2692,28 @@ class StreamsAudio:
                             # The mixer consumes the incoming overlap as it arrives and
                             # emits the blend at that same pace, so the transition
                             # streams instead of first collecting the whole overlap.
-                            # Everything handed to the mixer is kept for the
-                            # no-output fallback below.
-                            fed_to_mixer: list[bytes] = []
                             overlap_overshoot = bytearray()
                             mix_start_collected = len(crossfade_buffer)
+                            overlap_pulled = 0
+
+                            def _note_overlap_bytes(
+                                count: int, hold: _TailHold | None = tail_hold
+                            ) -> None:
+                                # the mixer reads the stream itself for the length of the
+                                # overlap; noting those bytes as they arrive keeps the
+                                # holdback's clock running, where one update afterwards
+                                # would read as a suspension and bank a false surplus
+                                nonlocal overlap_pulled
+                                overlap_pulled += count
+                                if hold is not None:
+                                    hold.note_bytes(count)
+
                             overlap_stream = _incoming_overlap_stream(
                                 bytes(crossfade_buffer),
                                 item_stream,
                                 incoming_crossfade_size,
-                                fed_to_mixer,
                                 overlap_overshoot,
+                                _note_overlap_bytes,
                             )
                             crossfade_buffer = bytearray()
                             # The mix output is split live as it flows: the first
@@ -2807,14 +2818,17 @@ class StreamsAudio:
                                     await asyncio.sleep(0)
                                 bytes_written += len(remaining_bytes)
                                 del remaining_bytes
-                            if tail_hold is not None:
-                                # bytes the mixer pulled from the stream bypassed the
-                                # loop's own counting; without them the surplus (and
-                                # so the next fade) would be under-measured
-                                pulled = sum(len(part) for part in fed_to_mixer) + len(
-                                    overlap_overshoot
-                                )
-                                tail_hold.note_bytes(max(0, pulled - mix_start_collected))
+                            # the position was reported for the planned overlap; an
+                            # incoming stream that ended short blended less than that,
+                            # and the track must not be reported past its own audio
+                            blended = max(
+                                0, mix_start_collected + overlap_pulled - len(overlap_overshoot)
+                            )
+                            queue_track.streamdetails.seek_position = min(
+                                queue_track.streamdetails.seek_position,
+                                raw_seek_position
+                                + blended / pcm_sample_size * track_playback_speed,
+                            )
                             last_fadeout_part = b""
                             last_streamdetails = None
                             last_queue_track = None

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -263,16 +263,17 @@ class _TailHold:
     # the player's supply must stay at least this far ahead of the wall clock
     _LEAD_RESERVE_S = 3.0
 
-    def __init__(self, pcm_format: AudioFormat, streamdetails: StreamDetails) -> None:
+    def __init__(self, pcm_format: AudioFormat, queue_item: QueueItem) -> None:
         """
         Initialize the tracker for one track's stream.
 
         :param pcm_format: PCM format of the stream's chunks.
-        :param streamdetails: Details of the track being streamed; its source buffer
-            is read at hold time, because opening the stream is what creates it.
+        :param queue_item: The item being streamed; its source buffer is resolved at
+            hold time, because opening the stream is what creates it - and a capacity
+            reselection can hand the item different details altogether.
         """
         self._pcm_format = pcm_format
-        self._streamdetails = streamdetails
+        self._queue_item = queue_item
         self._started: float | None = None
         self._last_noted = 0.0
         self._received_bytes = 0
@@ -304,7 +305,8 @@ class _TailHold:
         """
         if self._started is None:
             return 0
-        audio_buffer = cast("AudioBuffer | None", self._streamdetails.buffer)
+        streamdetails = self._queue_item.streamdetails
+        audio_buffer = cast("AudioBuffer | None", streamdetails.buffer) if streamdetails else None
         if audio_buffer is not None:
             if audio_buffer.has_error:
                 # a failed source is skipped without a fade, so its remaining audio
@@ -2024,7 +2026,7 @@ class StreamsAudio:
         # the holdback is grown out of the audio banked ahead of playback instead of
         # armed as one fixed window, so a source delivering near playback pace keeps
         # feeding the player
-        tail_hold = _TailHold(pcm_format, streamdetails) if crossfade_buffer_size > 0 else None
+        tail_hold = _TailHold(pcm_format, queue_item) if crossfade_buffer_size > 0 else None
         async for chunk in self.get_queue_item_stream(
             queue_item,
             pcm_format,
@@ -2584,7 +2586,7 @@ class StreamsAudio:
                 # of armed as one fixed window, so a source delivering near playback pace
                 # keeps feeding the player
                 tail_hold = (
-                    _TailHold(pcm_format, queue_track.streamdetails)
+                    _TailHold(pcm_format, queue_track)
                     if item_crossfade_mode != CrossfadeMode.DISABLED
                     else None
                 )

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -273,7 +273,12 @@ class _RealtimeTailHold:
         self._pcm_format = pcm_format
         self._audio_buffer = audio_buffer
         self._started: float | None = None
+        self._last_noted = 0.0
         self._received_bytes = 0
+
+    # an arrival gap this long is a suspension (pause, sink hold), not elapsed
+    # listening; counting it would wrongly erase the banked surplus for good
+    _SUSPEND_FORGIVE_S = 5.0
 
     def note_bytes(self, count: int) -> None:
         """
@@ -281,8 +286,12 @@ class _RealtimeTailHold:
 
         :param count: Number of PCM bytes received.
         """
+        now = asyncio.get_event_loop().time()
         if self._started is None:
-            self._started = asyncio.get_event_loop().time()
+            self._started = now
+        elif now - self._last_noted > self._SUSPEND_FORGIVE_S:
+            self._started += now - self._last_noted
+        self._last_noted = now
         self._received_bytes += count
 
     def hold_target(self, max_bytes: int, frame_size: int) -> int:
@@ -2201,26 +2210,31 @@ class StreamsAudio:
                     * pcm_format.pcm_sample_size
                 )
                 fadeout_share_bytes = (fadeout_share_bytes // frame_size) * frame_size
-                async for mix_chunk in self.smart_fades_mixer.mix(
+                mix_stream = self.smart_fades_mixer.mix(
                     smart_fade,
                     fade_in_part=_limited_fade_in(),
                     fade_out_part=fade_out_data,
                     pcm_format=pcm_format,
-                ):
-                    if first_part_written < fadeout_share_bytes:
-                        # split this chunk so A gets exactly fadeout_share_bytes
-                        remaining = fadeout_share_bytes - first_part_written
-                        if len(mix_chunk) > remaining:
-                            yield mix_chunk[:remaining]
-                            first_part_written += remaining
-                            bytes_written += remaining
-                            second_part_buf.extend(mix_chunk[remaining:])
+                )
+                # aclosing so an aborted stream tears the mix (and its feeder,
+                # which holds a read on the fade-in stream) down first
+                stack = aclosing(mix_stream)
+                async with stack:
+                    async for mix_chunk in mix_stream:
+                        if first_part_written < fadeout_share_bytes:
+                            # split this chunk so A gets exactly fadeout_share_bytes
+                            remaining = fadeout_share_bytes - first_part_written
+                            if len(mix_chunk) > remaining:
+                                yield mix_chunk[:remaining]
+                                first_part_written += remaining
+                                bytes_written += remaining
+                                second_part_buf.extend(mix_chunk[remaining:])
+                            else:
+                                yield mix_chunk
+                                first_part_written += len(mix_chunk)
+                                bytes_written += len(mix_chunk)
                         else:
-                            yield mix_chunk
-                            first_part_written += len(mix_chunk)
-                            bytes_written += len(mix_chunk)
-                    else:
-                        second_part_buf.extend(mix_chunk)
+                            second_part_buf.extend(mix_chunk)
                 # tail consumed by the mix but not credited to bytes_written
                 uncredited_tail_bytes = len(fade_out_data) - first_part_written
                 self._report_crossfade_mode(
@@ -2729,16 +2743,45 @@ class StreamsAudio:
                                 overlap_overshoot,
                             )
                             crossfade_buffer = bytearray()
+                            # The mix output is split live as it flows: the first
+                            # fadeout_share bytes are the outgoing track's (its held
+                            # tail, processed), the rest belong to this one. Credited
+                            # per chunk, because a single correction afterwards would
+                            # leave the queue's position mapping on the wrong track
+                            # for the whole (source-paced) duration of the blend. The
+                            # pre-counted tail makes way for that live credit.
+                            fadeout_share_seconds = (
+                                timing_info.pre_crossfade_duration + timing_info.crossfade_duration
+                            )
+                            fadeout_share = int(fadeout_share_seconds * pcm_sample_size)
+                            fadeout_share = (fadeout_share // frame_size) * frame_size
+                            assert last_play_log_entry.seconds_streamed is not None
+                            last_play_log_entry.seconds_streamed -= (
+                                len(last_fadeout_part) / pcm_sample_size
+                            )
+                            mix_stream = self.smart_fades_mixer.mix(
+                                crossfade_smart_fade,
+                                fade_in_part=overlap_stream,
+                                fade_out_part=last_fadeout_part,
+                                pcm_format=pcm_format,
+                            )
                             try:
                                 crossfade_bytes_written = 0
-                                async for mix_chunk in self.smart_fades_mixer.mix(
-                                    crossfade_smart_fade,
-                                    fade_in_part=overlap_stream,
-                                    fade_out_part=last_fadeout_part,
-                                    pcm_format=pcm_format,
-                                ):
-                                    yield mix_chunk
-                                    crossfade_bytes_written += len(mix_chunk)
+                                # closed before item_stream on an aborted flow: its
+                                # teardown stops the feeder that still holds a read
+                                # on item_stream, which must not be closed mid-read
+                                async with aclosing(mix_stream):
+                                    async for mix_chunk in mix_stream:
+                                        yield mix_chunk
+                                        outgoing_part = min(
+                                            len(mix_chunk),
+                                            max(0, fadeout_share - crossfade_bytes_written),
+                                        )
+                                        last_play_log_entry.seconds_streamed += (
+                                            outgoing_part / pcm_sample_size
+                                        )
+                                        bytes_written += len(mix_chunk) - outgoing_part
+                                        crossfade_bytes_written += len(mix_chunk)
                                 remaining_bytes = bytes(overlap_overshoot)
                             except Exception as mix_err:
                                 if crossfade_bytes_written:
@@ -2749,16 +2792,40 @@ class StreamsAudio:
                                     queue_track.name,
                                     mix_err,
                                 )
+                                # the tail was un-counted for the live credit above;
+                                # it now plays as ordinary outgoing audio
+                                last_play_log_entry.seconds_streamed += (
+                                    len(last_fadeout_part) / pcm_sample_size
+                                )
                                 for pcm_slice in iter_pcm_slices(
                                     last_fadeout_part, pcm_format, 1000
                                 ):
                                     yield pcm_slice
                                     await asyncio.sleep(0)
-                                # full tail was pre-counted and is now yielded as-is
                                 crossfade_bytes_written = 0
-                                remaining_bytes = b"".join(fed_to_mixer) + bytes(overlap_overshoot)
+                                remaining_bytes = b""
                                 # mix failed — undo the eager seek_position
                                 queue_track.streamdetails.seek_position = raw_seek_position
+                                # The mixer teardown cancels its feeder, which was
+                                # likely parked reading item_stream - that ends the
+                                # stream itself. Play the track from a fresh stream
+                                # (its buffer still holds what the mixer consumed)
+                                # rather than silently losing its body.
+                                await item_stream.aclose()
+                                fallback_stream = self.get_queue_item_stream(
+                                    queue_track,
+                                    pcm_format=pcm_format,
+                                    seek_position=int(raw_seek_position),
+                                    playback_speed=track_playback_speed,
+                                    raise_on_error=False,
+                                    session_id=flow_session_id,
+                                )
+                                async with aclosing(fallback_stream):
+                                    async for fallback_chunk in fallback_stream:
+                                        if _superseded():
+                                            return
+                                        yield fallback_chunk
+                                        bytes_written += len(fallback_chunk)
                             if crossfade_bytes_written:
                                 # the blend really played, so credit both of its sides with it
                                 for faded_item in (queue_track, outgoing_queue_track):
@@ -2772,22 +2839,6 @@ class StreamsAudio:
                                         flow_session_id,
                                         overlay_enabled=overlay_active(queue),
                                     )
-                                # Split mix output at end-of-overlap: PRE+CF to A, POST to B.
-                                fadeout_share_seconds = (
-                                    timing_info.pre_crossfade_duration
-                                    + timing_info.crossfade_duration
-                                )
-                                fadeout_share = int(fadeout_share_seconds * pcm_sample_size)
-                                fadeout_share = (fadeout_share // frame_size) * frame_size
-                                fadeout_share = min(fadeout_share, crossfade_bytes_written)
-                                fadein_share = crossfade_bytes_written - fadeout_share
-                                bytes_written += fadein_share
-                                if last_play_log_entry:
-                                    assert last_play_log_entry.seconds_streamed is not None
-                                    # correct pre-counted full tail to the timing-based share
-                                    last_play_log_entry.seconds_streamed += (
-                                        fadeout_share - len(last_fadeout_part)
-                                    ) / pcm_sample_size
                             if remaining_bytes:
                                 for pcm_slice in iter_pcm_slices(remaining_bytes, pcm_format, 1000):
                                     yield pcm_slice

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -242,16 +242,17 @@ def overlay_active(queue: PlayerQueue) -> bool:
     return queue.overlay_enabled and queue.overlay_source is not None
 
 
-class _RealtimeTailHold:
+class _TailHold:
     """
-    Grow a fade-out holdback for a realtime source without starving the player.
+    Grow a fade-out holdback out of what a source delivered ahead of playback.
 
-    A realtime source delivers barely above playback pace, so a fixed holdback
-    would starve the player. The only audio that may be withheld is what the
-    stream has received beyond the wall clock plus a safety reserve - that is
-    audio the player provably does not need to keep rendering in time - and
-    only half of that, so the player's own lead keeps growing too. Once the
-    source is done, the rest is resident and the full window is available.
+    Withholding a fixed window starves a source that delivers near playback pace
+    (a realtime session, a slow provider, a seek close to the end of a track). The
+    only audio that may be withheld is what the stream received beyond the wall
+    clock plus a safety reserve - audio the player provably does not need to keep
+    rendering in time - and only half of that, so the player's own lead keeps
+    growing too. Once the source is done, the rest is resident and the full window
+    is available.
     """
 
     # the player's supply must stay at least this far ahead of the wall clock
@@ -299,9 +300,14 @@ class _RealtimeTailHold:
         if self._started is None:
             return 0
         audio_buffer = self._audio_buffer
-        if audio_buffer is not None and audio_buffer.eof:
-            # the source is done: everything left is resident, hold the full window
-            return max_bytes
+        if audio_buffer is not None:
+            if audio_buffer.has_error:
+                # a failed source is skipped without a fade, so its remaining audio
+                # is better off played out than held back for one
+                return 0
+            if audio_buffer.eof:
+                # the source is done: everything left is resident, hold the full window
+                return max_bytes
         elapsed = asyncio.get_event_loop().time() - self._started
         received_seconds = self._received_bytes / self._pcm_format.pcm_sample_size
         spare_seconds = received_seconds - elapsed - self._LEAD_RESERVE_S
@@ -2003,13 +2009,13 @@ class StreamsAudio:
         warmup_size = int(pcm_format.pcm_sample_size * WARMUP_DURATION)
         warmup_bytes = 0
         total_chunks_received = 0
-        holdback_armed = False
         playback_speed = cast("float", queue_item.extra_attributes.get("playback_speed", 1.0))
-        # a realtime source's holdback is grown out of its banked surplus
-        # instead of armed as one fixed window
+        # the holdback is grown out of the audio banked ahead of playback instead of
+        # armed as one fixed window, so a source delivering near playback pace keeps
+        # feeding the player
         tail_hold = (
-            _RealtimeTailHold(pcm_format, cast("AudioBuffer | None", streamdetails.buffer))
-            if streamdetails.is_realtime and crossfade_buffer_size > 0
+            _TailHold(pcm_format, cast("AudioBuffer | None", streamdetails.buffer))
+            if crossfade_buffer_size > 0
             else None
         )
         async for chunk in self.get_queue_item_stream(
@@ -2033,25 +2039,12 @@ class StreamsAudio:
                 del chunk
                 continue
 
-            if tail_hold is None and not holdback_armed:
-                holdback_armed = self._crossfade_holdback_allowed(
-                    queue_item.streamdetails or streamdetails,
-                    crossfade_buffer_duration,
-                    playback_speed,
-                )
-                if not holdback_armed:
-                    # holding audio back now would only shrink the player's lead
-                    yield chunk
-                    bytes_written += len(chunk)
-                    del chunk
-                    continue
-
             buffer.extend(chunk)
             del chunk
             hold_target = (
                 tail_hold.hold_target(crossfade_buffer_size, frame_size)
                 if tail_hold is not None
-                else crossfade_buffer_size
+                else 0
             )
             if len(buffer) <= hold_target:
                 await asyncio.sleep(0)
@@ -2579,15 +2572,14 @@ class StreamsAudio:
                 crossfade_buffer = bytearray()
                 warmup_bytes = 0
                 first_chunk_received = False
-                holdback_armed = False
-                # a realtime source's holdback is grown out of its banked surplus
-                # instead of armed as one fixed window
+                # the holdback is grown out of the audio banked ahead of playback instead
+                # of armed as one fixed window, so a source delivering near playback pace
+                # keeps feeding the player
                 tail_hold = (
-                    _RealtimeTailHold(
+                    _TailHold(
                         pcm_format, cast("AudioBuffer | None", queue_track.streamdetails.buffer)
                     )
-                    if queue_track.streamdetails.is_realtime
-                    and item_crossfade_mode != CrossfadeMode.DISABLED
+                    if item_crossfade_mode != CrossfadeMode.DISABLED
                     else None
                 )
 
@@ -2648,19 +2640,6 @@ class StreamsAudio:
                             del chunk
                             continue
 
-                        if tail_hold is None and not last_fadeout_part and not holdback_armed:
-                            holdback_armed = self._crossfade_holdback_allowed(
-                                queue_track.streamdetails,
-                                crossfade_buffer_duration,
-                                track_playback_speed,
-                            )
-                            if not holdback_armed:
-                                # holding audio back now would only shrink the player's lead
-                                yield chunk
-                                bytes_written += len(chunk)
-                                del chunk
-                                continue
-
                         if not last_fadeout_part:
                             # the tail is being held back, so the audio the next transition
                             # blends in can be gathered alongside it instead of after it
@@ -2673,14 +2652,14 @@ class StreamsAudio:
 
                         # accumulate chunks in the crossfade buffer: the outgoing tail
                         # window, or (at a boundary) whatever of the incoming overlap
-                        # arrived before the mix starts. A realtime source's window is
-                        # whatever its banked surplus covers right now.
+                        # arrived before the mix starts. The window is whatever the
+                        # source has banked ahead of playback right now.
                         crossfade_buffer.extend(chunk)
                         del chunk
                         hold_target = (
                             tail_hold.hold_target(crossfade_buffer_size, frame_size)
                             if tail_hold is not None
-                            else crossfade_buffer_size
+                            else 0
                         )
                         if not last_fadeout_part and len(crossfade_buffer) <= hold_target:
                             await asyncio.sleep(0)
@@ -3859,34 +3838,6 @@ class StreamsAudio:
                 ffmpeg_proc.returncode,
                 streamdetails.uri,
             )
-
-    def _crossfade_holdback_allowed(
-        self, streamdetails: StreamDetails, tail_seconds: float, playback_speed: float = 1.0
-    ) -> bool:
-        """
-        Return whether the outgoing tail may be held back for a crossfade.
-
-        :param streamdetails: Stream details of the track being streamed.
-        :param tail_seconds: Length of the tail to hold back, in seconds of playback.
-        :param playback_speed: Playback-speed multiplier of the track.
-        """
-        if tail_seconds <= 0 or playback_speed <= 0:
-            return False
-        audio_buffer = cast("AudioBuffer | None", streamdetails.buffer)
-        if audio_buffer is None or audio_buffer.has_error:
-            # a failed source is skipped without a fade, so its remaining audio is
-            # better off played out than held back for one
-            return False
-        if streamdetails.is_realtime:
-            # a realtime source never arms a fixed window: its holdback is grown
-            # out of its banked surplus by the caller (see _RealtimeTailHold)
-            return False
-        # While the source is still delivering, it is what limits playback: withholding
-        # a tail on top of that eats into the lead the player needs. Once the source is
-        # done the remaining audio is resident, so the tail comes for free. A buffer that
-        # is too small to ever hold the tail is the exception - waiting for the source
-        # there would only lose the fade.
-        return audio_buffer.eof or audio_buffer.max_size_seconds / playback_speed < tail_seconds
 
     def _report_crossfade_mode(
         self,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -182,6 +182,10 @@ WARMUP_DURATION = 8
 # Minimum overlap used when the full incoming crossfade buffer was not prepared.
 MIN_CROSSFADE_FALLBACK_DURATION = 5
 
+# Minimum fade a realtime source's banked surplus must cover for the boundary to
+# be blended at all; below this the tail plays out and the boundary is a hard cut.
+MIN_REALTIME_CROSSFADE_DURATION = 3
+
 # Bounded wait at a boundary for a realtime incoming track to start delivering.
 # Its buffer only exists once its session produces audio, which happens around the
 # moment the outgoing track's audio ends; the wait trades a little of the player's
@@ -241,6 +245,64 @@ def _snap_supported_rate_down(target: int, supported_sample_rates: list[int]) ->
 def overlay_active(queue: PlayerQueue) -> bool:
     """Return True if the given queue has an audio overlay enabled and a source selected."""
     return queue.overlay_enabled and queue.overlay_source is not None
+
+
+class _RealtimeTailHold:
+    """
+    Grow a fade-out holdback for a realtime source out of its banked surplus.
+
+    A realtime source delivers barely above playback pace, so a fixed holdback
+    would starve the player at the start of a track. What can be withheld safely
+    is the surplus the source has delivered beyond the wall clock — which is also
+    exactly the audio a boundary can spend on a fade without the player ever
+    missing a byte. The window therefore starts at nothing and grows with the
+    source's overpace; once the source is done, the rest is resident and the
+    full window is available.
+    """
+
+    def __init__(self, pcm_format: AudioFormat, audio_buffer: AudioBuffer | None) -> None:
+        """
+        Initialize the tracker for one track's stream.
+
+        :param pcm_format: PCM format of the stream's chunks.
+        :param audio_buffer: The track's source buffer, if any; its resident audio
+            counts toward the surplus and its EOF releases the full window.
+        """
+        self._pcm_format = pcm_format
+        self._audio_buffer = audio_buffer
+        self._started: float | None = None
+        self._content_bytes = 0
+
+    def note_bytes(self, count: int) -> None:
+        """
+        Record stream bytes as they arrive (anchors the clock on the first ones).
+
+        :param count: Number of PCM bytes received.
+        """
+        if self._started is None:
+            self._started = asyncio.get_event_loop().time()
+        self._content_bytes += count
+
+    def hold_target(self, max_bytes: int, frame_size: int) -> int:
+        """
+        Return how many bytes of tail may currently be held back.
+
+        :param max_bytes: The full fade-out window (the cap).
+        :param frame_size: PCM frame size the target is aligned down to.
+        """
+        if self._started is None:
+            return 0
+        audio_buffer = self._audio_buffer
+        if audio_buffer is not None and audio_buffer.eof:
+            # the source is done: everything left is resident, hold the full window
+            return max_bytes
+        resident_seconds = audio_buffer.duration_available if audio_buffer is not None else 0.0
+        elapsed = asyncio.get_event_loop().time() - self._started
+        surplus_seconds = (
+            self._content_bytes / self._pcm_format.pcm_sample_size + resident_seconds - elapsed
+        )
+        surplus_bytes = int(max(0.0, surplus_seconds) * self._pcm_format.pcm_sample_size)
+        return min(max_bytes, surplus_bytes // frame_size * frame_size)
 
 
 async def _incoming_overlap_stream(
@@ -1939,6 +2001,13 @@ class StreamsAudio:
         total_chunks_received = 0
         holdback_armed = False
         playback_speed = cast("float", queue_item.extra_attributes.get("playback_speed", 1.0))
+        # a realtime source's holdback is grown out of its banked surplus
+        # instead of armed as one fixed window
+        tail_hold = (
+            _RealtimeTailHold(pcm_format, cast("AudioBuffer | None", streamdetails.buffer))
+            if streamdetails.is_realtime and crossfade_buffer_size > 0
+            else None
+        )
         async for chunk in self.get_queue_item_stream(
             queue_item,
             pcm_format,
@@ -1949,6 +2018,8 @@ class StreamsAudio:
             exact_seek=exact_buffer_seek,
         ):
             total_chunks_received += 1
+            if tail_hold is not None:
+                tail_hold.note_bytes(len(chunk))
 
             if warmup_bytes < warmup_size:
                 # warmup: yield directly, don't buffer
@@ -1958,7 +2029,7 @@ class StreamsAudio:
                 del chunk
                 continue
 
-            if not holdback_armed:
+            if tail_hold is None and not holdback_armed:
                 holdback_armed = self._crossfade_holdback_allowed(
                     queue_item.streamdetails or streamdetails,
                     crossfade_buffer_duration,
@@ -1973,11 +2044,16 @@ class StreamsAudio:
 
             buffer.extend(chunk)
             del chunk
-            if len(buffer) < crossfade_buffer_size:
+            hold_target = (
+                tail_hold.hold_target(crossfade_buffer_size, frame_size)
+                if tail_hold is not None
+                else crossfade_buffer_size
+            )
+            if len(buffer) <= hold_target:
                 await asyncio.sleep(0)
                 continue
-            # yield everything above the crossfade buffer
-            while len(buffer) > crossfade_buffer_size:
+            # yield everything above the current holdback window
+            while len(buffer) > hold_target:
                 yield bytes(buffer[: pcm_format.pcm_sample_size])
                 bytes_written += pcm_format.pcm_sample_size
                 del buffer[: pcm_format.pcm_sample_size]
@@ -2012,8 +2088,16 @@ class StreamsAudio:
         fade_in_buffer_duration = 0.0
         fade_in_playback_speed = 1.0
         # a fade needs enough of the outgoing track to overlap with; a holdback that
-        # armed late (or not at all) leaves less than that
-        min_fade_out_size = int(pcm_format.pcm_sample_size * MIN_CROSSFADE_FALLBACK_DURATION)
+        # armed late (or not at all) leaves less than that. A realtime tail is
+        # surplus-grown, so a smaller one is still worth blending.
+        min_fade_out_size = int(
+            pcm_format.pcm_sample_size
+            * (
+                MIN_REALTIME_CROSSFADE_DURATION
+                if streamdetails.is_realtime
+                else MIN_CROSSFADE_FALLBACK_DURATION
+            )
+        )
         if len(buffer) >= min_fade_out_size and next_queue_item and next_queue_item.streamdetails:
             fade_in_playback_speed = cast(
                 "float", next_queue_item.extra_attributes.get("playback_speed", 1.0)
@@ -2502,6 +2586,16 @@ class StreamsAudio:
                 warmup_bytes = 0
                 first_chunk_received = False
                 holdback_armed = False
+                # a realtime source's holdback is grown out of its banked surplus
+                # instead of armed as one fixed window
+                tail_hold = (
+                    _RealtimeTailHold(
+                        pcm_format, cast("AudioBuffer | None", queue_track.streamdetails.buffer)
+                    )
+                    if queue_track.streamdetails.is_realtime
+                    and item_crossfade_mode != CrossfadeMode.DISABLED
+                    else None
+                )
 
                 item_stream = await incoming_prefetcher.take(queue_track, int(raw_seek_position))
                 prefetched_size = incoming_prefetcher.collected_at_handover if item_stream else 0
@@ -2532,6 +2626,8 @@ class StreamsAudio:
                             )
                             return
                         total_chunks_received += 1
+                        if tail_hold is not None:
+                            tail_hold.note_bytes(len(chunk))
                         if not first_chunk_received:
                             first_chunk_received = True
                             # inform the queue that the track is now loaded in the buffer
@@ -2558,7 +2654,7 @@ class StreamsAudio:
                             del chunk
                             continue
 
-                        if not last_fadeout_part and not holdback_armed:
+                        if tail_hold is None and not last_fadeout_part and not holdback_armed:
                             holdback_armed = self._crossfade_holdback_allowed(
                                 queue_track.streamdetails,
                                 crossfade_buffer_duration,
@@ -2583,10 +2679,16 @@ class StreamsAudio:
 
                         # accumulate chunks in the crossfade buffer: the outgoing tail
                         # window, or (at a boundary) whatever of the incoming overlap
-                        # arrived before the mix starts
+                        # arrived before the mix starts. A realtime source's window is
+                        # whatever its banked surplus covers right now.
                         crossfade_buffer.extend(chunk)
                         del chunk
-                        if not last_fadeout_part and len(crossfade_buffer) < crossfade_buffer_size:
+                        hold_target = (
+                            tail_hold.hold_target(crossfade_buffer_size, frame_size)
+                            if tail_hold is not None
+                            else crossfade_buffer_size
+                        )
+                        if not last_fadeout_part and len(crossfade_buffer) <= hold_target:
                             await asyncio.sleep(0)
                             continue
                         # handle crossfade of previous track and new track
@@ -2613,6 +2715,7 @@ class StreamsAudio:
                             # no-output fallback below.
                             fed_to_mixer: list[bytes] = []
                             overlap_overshoot = bytearray()
+                            mix_start_collected = len(crossfade_buffer)
                             overlap_stream = _incoming_overlap_stream(
                                 bytes(crossfade_buffer),
                                 item_stream,
@@ -2686,14 +2789,22 @@ class StreamsAudio:
                                     await asyncio.sleep(0)
                                 bytes_written += len(remaining_bytes)
                                 del remaining_bytes
+                            if tail_hold is not None:
+                                # bytes the mixer pulled from the stream bypassed the
+                                # loop's own counting; without them the surplus (and
+                                # so the next fade) would be under-measured
+                                pulled = sum(len(part) for part in fed_to_mixer) + len(
+                                    overlap_overshoot
+                                )
+                                tail_hold.note_bytes(max(0, pulled - mix_start_collected))
                             last_fadeout_part = b""
                             last_streamdetails = None
                             last_queue_track = None
                             crossfade_buffer = bytearray()
                             warmup_bytes = 0
 
-                        # yield everything above the crossfade buffer size
-                        while len(crossfade_buffer) > crossfade_buffer_size:
+                        # yield everything above the current holdback window
+                        while len(crossfade_buffer) > hold_target:
                             yield bytes(crossfade_buffer[:pcm_sample_size])
                             bytes_written += pcm_sample_size
                             del crossfade_buffer[:pcm_sample_size]
@@ -2743,8 +2854,16 @@ class StreamsAudio:
                     # full tail was pre-counted and is now yielded as-is
                     last_fadeout_part = b""
                 # a fade needs enough of the outgoing track to overlap with; a holdback that
-                # armed late (or not at all) leaves less than that
-                min_fade_out_size = int(pcm_sample_size * MIN_CROSSFADE_FALLBACK_DURATION)
+                # armed late (or not at all) leaves less than that. A realtime tail is
+                # surplus-grown, so a smaller one is still worth blending.
+                min_fade_out_size = int(
+                    pcm_sample_size
+                    * (
+                        MIN_REALTIME_CROSSFADE_DURATION
+                        if queue_track.streamdetails.is_realtime
+                        else MIN_CROSSFADE_FALLBACK_DURATION
+                    )
+                )
                 if len(crossfade_buffer) >= min_fade_out_size and self.crossfade_allowed(
                     queue_track,
                     crossfade_mode=item_crossfade_mode,
@@ -3731,11 +3850,9 @@ class StreamsAudio:
             # better off played out than held back for one
             return False
         if streamdetails.is_realtime:
-            # a realtime source delivers at playback pace, so holding a tail back
-            # while it is still producing would starve the player; once it is done
-            # (which its overpaced read reaches ahead of the player) the remaining
-            # audio is resident and the tail comes for free
-            return audio_buffer.eof
+            # a realtime source never arms a fixed window: its holdback is grown
+            # out of its banked surplus by the caller (see _RealtimeTailHold)
+            return False
         # While the source is still delivering, it is what limits playback: withholding
         # a tail on top of that eats into the lead the player needs. Once the source is
         # done the remaining audio is resident, so the tail comes for free. A buffer that

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -15,7 +15,7 @@ import re
 import time
 from collections import deque
 from collections.abc import AsyncGenerator, Callable, Iterable
-from contextlib import aclosing, asynccontextmanager, nullcontext
+from contextlib import aclosing, asynccontextmanager, nullcontext, suppress
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, cast
@@ -182,6 +182,12 @@ WARMUP_DURATION = 8
 # Minimum overlap used when the full incoming crossfade buffer was not prepared.
 MIN_CROSSFADE_FALLBACK_DURATION = 5
 
+# Bounded wait at a boundary for a realtime incoming track to start delivering.
+# Its buffer only exists once its session produces audio, which happens around the
+# moment the outgoing track's audio ends; the wait trades a little of the player's
+# lead for the fade, and a source that never shows up loses only the fade.
+REALTIME_FADE_SOURCE_WAIT = 5.0
+
 # Chunk size for the realtime AudioSource path; small enough to keep ffmpeg→consumer
 # latency below ~50 ms while still amortising per-chunk overhead.
 AUDIO_SOURCE_CHUNK_SECONDS = 0.02
@@ -235,6 +241,44 @@ def _snap_supported_rate_down(target: int, supported_sample_rates: list[int]) ->
 def overlay_active(queue: PlayerQueue) -> bool:
     """Return True if the given queue has an audio overlay enabled and a source selected."""
     return queue.overlay_enabled and queue.overlay_source is not None
+
+
+async def _incoming_overlap_stream(
+    collected: bytes,
+    stream: AsyncGenerator[bytes],
+    target_size: int,
+    fed: list[bytes],
+    overshoot: bytearray,
+) -> AsyncGenerator[bytes]:
+    """
+    Yield exactly the incoming track's overlap: what is in hand, then the live stream.
+
+    :param collected: Overlap bytes already collected when the mix starts.
+    :param stream: The incoming track's stream, read further as needed; bytes read
+        beyond the overlap are not lost (see ``overshoot``) and the stream itself
+        stays open for the track's body.
+    :param target_size: Exact number of overlap bytes to yield.
+    :param fed: Receives every yielded part, for the mixer-failure fallback.
+    :param overshoot: Receives bytes read beyond the overlap (they open the body).
+    """
+    taken = 0
+    if collected:
+        part = collected[:target_size]
+        overshoot.extend(collected[target_size:])
+        fed.append(part)
+        taken = len(part)
+        yield part
+    while taken < target_size:
+        try:
+            next_chunk = await anext(stream)
+        except StopAsyncIteration:
+            return
+        remaining = target_size - taken
+        part = next_chunk[:remaining]
+        overshoot.extend(next_chunk[remaining:])
+        fed.append(part)
+        taken += len(part)
+        yield part
 
 
 class _IncomingFadePrefetcher:
@@ -299,7 +343,6 @@ class _IncomingFadePrefetcher:
             or next_item.queue_item_id == queue_item.queue_item_id
             or next_item.media_type != MediaType.TRACK
             or (streamdetails := next_item.streamdetails) is None
-            or streamdetails.is_realtime
             # without a duration the read below cannot be kept clear of the track's end
             or not streamdetails.duration
             or (audio_buffer := cast("AudioBuffer | None", streamdetails.buffer)) is None
@@ -1834,10 +1877,11 @@ class StreamsAudio:
 
         buffer = bytearray()
         bytes_written = 0
-        # calculate crossfade buffer size
+        # calculate crossfade buffer size; a realtime source never holds the smart
+        # window (45s of resident audio it cannot have), only the standard overlap
         crossfade_buffer_duration = (
             SMART_CROSSFADE_DURATION
-            if crossfade_mode == CrossfadeMode.SMART_CROSSFADE
+            if crossfade_mode == CrossfadeMode.SMART_CROSSFADE and not streamdetails.is_realtime
             else standard_crossfade_duration
         )
         crossfade_buffer_duration = min(
@@ -1989,6 +2033,9 @@ class StreamsAudio:
                 next_sample_rate=next_pcm.sample_rate,
             )
             if crossfade_allowed:
+                # a realtime incoming track has audio to read only once its session
+                # produces; give it a bounded chance to show up
+                await self._await_realtime_fade_source(next_queue_item.streamdetails)
                 transition_mode, fade_in_buffer_duration = self._select_buffered_crossfade(
                     next_queue_item.streamdetails,
                     crossfade_mode,
@@ -2299,16 +2346,17 @@ class StreamsAudio:
                         queue.display_name,
                     )
                     continue
-                # a realtime source delivers at playback pace, so it has no audio to spare
-                # for an overlap in either direction - but one that crossfades its own
-                # playback still does that boundary itself, inside the audio it hands over
-                item_crossfade_mode = (
-                    CrossfadeMode.DISABLED
-                    if queue_track.streamdetails.is_realtime
-                    else crossfade_mode
-                )
+                # a source that crossfades its own playback does that boundary itself,
+                # inside the audio it hands over - only then does MA step aside; a
+                # realtime source without that gets a fade decided from what its
+                # boundary can actually deliver (see _select_buffered_crossfade)
                 item_source_crossfade_mode = self.mass.streams.get_source_crossfade_mode(
                     queue, queue_track
+                )
+                item_crossfade_mode = (
+                    CrossfadeMode.DISABLED
+                    if item_source_crossfade_mode != CrossfadeMode.DISABLED
+                    else crossfade_mode
                 )
                 self.logger.debug(
                     "Start Streaming queue track: %s (%s) for queue %s",
@@ -2327,10 +2375,13 @@ class StreamsAudio:
                 track_playback_speed = cast(
                     "float", queue_track.extra_attributes.get("playback_speed", 1.0)
                 )
-                # calculate crossfade buffer size
+                # calculate crossfade buffer size; a realtime source never holds the
+                # smart window (45s of resident audio it cannot have), only the
+                # standard overlap
                 crossfade_buffer_duration = (
                     SMART_CROSSFADE_DURATION
                     if item_crossfade_mode == CrossfadeMode.SMART_CROSSFADE
+                    and not queue_track.streamdetails.is_realtime
                     else standard_crossfade_duration
                 )
                 crossfade_buffer_duration = min(
@@ -2357,7 +2408,6 @@ class StreamsAudio:
                 # Build eagerly so seek_position is set before PlayLogEntry is appended —
                 # consumer-paced mix() would otherwise let the queue briefly report 0.
                 crossfade_smart_fade: SmartFade | None = None
-                collect_started = 0.0
                 collect_resident = 0.0
                 incoming_crossfade_size = crossfade_buffer_size
                 incoming_audio_buffer: AudioBuffer | None = None
@@ -2368,6 +2418,9 @@ class StreamsAudio:
                 if last_fadeout_part and last_streamdetails:
                     incoming_duration = 0.0
                     if crossfade_buffer_size > 0 and item_crossfade_mode != CrossfadeMode.DISABLED:
+                        # a realtime incoming track has audio to read only once its
+                        # session produces; give it a bounded chance to show up
+                        await self._await_realtime_fade_source(queue_track.streamdetails)
                         transition_mode, incoming_duration = self._select_buffered_crossfade(
                             queue_track.streamdetails,
                             item_crossfade_mode,
@@ -2394,9 +2447,6 @@ class StreamsAudio:
                         incoming_crossfade_size = (
                             incoming_crossfade_size // frame_size
                         ) * frame_size
-                        # no audio is emitted while the incoming overlap is collected, so a
-                        # slow collection here is heard as a gap at the transition
-                        collect_started = asyncio.get_event_loop().time()
                         collect_resident = incoming_audio_buffer.duration_available
                         applied_mode = transition_mode
                         build_started = asyncio.get_event_loop().time()
@@ -2531,13 +2581,12 @@ class StreamsAudio:
                                 standard_crossfade_duration,
                             )
 
-                        # smart fades enabled: accumulate chunks in crossfade buffer
+                        # accumulate chunks in the crossfade buffer: the outgoing tail
+                        # window, or (at a boundary) whatever of the incoming overlap
+                        # arrived before the mix starts
                         crossfade_buffer.extend(chunk)
                         del chunk
-                        required_buffer_size = (
-                            incoming_crossfade_size if last_fadeout_part else crossfade_buffer_size
-                        )
-                        if len(crossfade_buffer) < required_buffer_size:
+                        if not last_fadeout_part and len(crossfade_buffer) < crossfade_buffer_size:
                             await asyncio.sleep(0)
                             continue
                         # handle crossfade of previous track and new track
@@ -2548,28 +2597,41 @@ class StreamsAudio:
                             and last_play_log_entry is not None
                         ):
                             self.logger.debug(
-                                "Collected %.1fs of incoming audio for the transition into %s"
-                                " in %.1fs (%.1fs prefetched, %.1fs build,"
-                                " %.1fs was resident when it started)",
-                                len(crossfade_buffer) / pcm_sample_size,
+                                "Starting the transition into %s with %.1fs of its overlap"
+                                " in hand (%.1fs prefetched, %.1fs build,"
+                                " %.1fs was resident at the boundary)",
                                 queue_track.name,
-                                asyncio.get_event_loop().time() - collect_started,
+                                len(crossfade_buffer) / pcm_sample_size,
                                 prefetched_size / pcm_sample_size,
                                 build_seconds,
                                 collect_resident,
                             )
-                            fadein_part = bytes(crossfade_buffer[:incoming_crossfade_size])
-                            remaining_bytes = bytes(crossfade_buffer[incoming_crossfade_size:])
+                            # The mixer consumes the incoming overlap as it arrives and
+                            # emits the blend at that same pace, so the transition
+                            # streams instead of first collecting the whole overlap.
+                            # Everything handed to the mixer is kept for the
+                            # no-output fallback below.
+                            fed_to_mixer: list[bytes] = []
+                            overlap_overshoot = bytearray()
+                            overlap_stream = _incoming_overlap_stream(
+                                bytes(crossfade_buffer),
+                                item_stream,
+                                incoming_crossfade_size,
+                                fed_to_mixer,
+                                overlap_overshoot,
+                            )
+                            crossfade_buffer = bytearray()
                             try:
                                 crossfade_bytes_written = 0
                                 async for mix_chunk in self.smart_fades_mixer.mix(
                                     crossfade_smart_fade,
-                                    fade_in_part=fadein_part,
+                                    fade_in_part=overlap_stream,
                                     fade_out_part=last_fadeout_part,
                                     pcm_format=pcm_format,
                                 ):
                                     yield mix_chunk
                                     crossfade_bytes_written += len(mix_chunk)
+                                remaining_bytes = bytes(overlap_overshoot)
                             except Exception as mix_err:
                                 if crossfade_bytes_written:
                                     # partial mix already played — concat'd tail would duplicate audio
@@ -2586,7 +2648,7 @@ class StreamsAudio:
                                     await asyncio.sleep(0)
                                 # full tail was pre-counted and is now yielded as-is
                                 crossfade_bytes_written = 0
-                                remaining_bytes = bytes(crossfade_buffer)
+                                remaining_bytes = b"".join(fed_to_mixer) + bytes(overlap_overshoot)
                                 # mix failed — undo the eager seek_position
                                 queue_track.streamdetails.seek_position = raw_seek_position
                             if crossfade_bytes_written:
@@ -3661,13 +3723,19 @@ class StreamsAudio:
         :param tail_seconds: Length of the tail to hold back, in seconds of playback.
         :param playback_speed: Playback-speed multiplier of the track.
         """
-        if tail_seconds <= 0 or playback_speed <= 0 or streamdetails.is_realtime:
+        if tail_seconds <= 0 or playback_speed <= 0:
             return False
         audio_buffer = cast("AudioBuffer | None", streamdetails.buffer)
         if audio_buffer is None or audio_buffer.has_error:
             # a failed source is skipped without a fade, so its remaining audio is
             # better off played out than held back for one
             return False
+        if streamdetails.is_realtime:
+            # a realtime source delivers at playback pace, so holding a tail back
+            # while it is still producing would starve the player; once it is done
+            # (which its overpaced read reaches ahead of the player) the remaining
+            # audio is resident and the tail comes for free
+            return audio_buffer.eof
         # While the source is still delivering, it is what limits playback: withholding
         # a tail on top of that eats into the lead the player needs. Once the source is
         # done the remaining audio is resident, so the tail comes for free. A buffer that
@@ -3713,6 +3781,29 @@ class StreamsAudio:
             alters_audio=queue_item.streamdetails.fade_in,
         )
 
+    async def _await_realtime_fade_source(self, streamdetails: StreamDetails) -> None:
+        """
+        Give a realtime incoming track a bounded chance to start delivering.
+
+        :param streamdetails: Stream details of the incoming (fade-in) track.
+        """
+        if not streamdetails.is_realtime:
+            return
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + REALTIME_FADE_SOURCE_WAIT
+        while True:
+            audio_buffer = cast("AudioBuffer | None", streamdetails.buffer)
+            if audio_buffer is not None:
+                if audio_buffer.has_error:
+                    return
+                with suppress(TimeoutError):
+                    await asyncio.wait_for(audio_buffer.ready.wait(), deadline - loop.time())
+                return
+            if loop.time() >= deadline:
+                return
+            # the buffer appears when the source's session starts producing
+            await asyncio.sleep(0.1)
+
     def _select_buffered_crossfade(
         self,
         streamdetails: StreamDetails,
@@ -3733,14 +3824,26 @@ class StreamsAudio:
         if (
             crossfade_mode == CrossfadeMode.DISABLED
             or playback_speed <= 0
-            # a realtime source has no more than its banked lead: fading in would spend
-            # that at the start of the track and leave nothing for the rest of it
-            or streamdetails.is_realtime
             or audio_buffer is None
             or audio_buffer.has_error
             or not audio_buffer.is_valid()
         ):
             return CrossfadeMode.DISABLED, 0
+
+        if streamdetails.is_realtime:
+            # A realtime source cannot bank the whole overlap up front, but it does
+            # not have to: the mix streams, so the blend flows at the source's own
+            # (overpaced) delivery rate. The resident audio only has to prove the
+            # source is actually delivering; a source that is not there yet means
+            # this boundary simply plays without a fade. Smart fades need their
+            # full analysis window resident, so a realtime source always gets the
+            # standard overlap.
+            if (
+                not audio_buffer.ready.is_set()
+                or standard_crossfade_duration < MIN_CROSSFADE_FALLBACK_DURATION
+            ):
+                return CrossfadeMode.DISABLED, 0
+            return CrossfadeMode.STANDARD_CROSSFADE, standard_crossfade_duration
 
         available_seconds = audio_buffer.duration_available / playback_speed
         if (

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2449,18 +2449,9 @@ class StreamsAudio:
                         queue.display_name,
                     )
                     continue
-                # a source that crossfades its own playback does that boundary itself,
-                # inside the audio it hands over - only then does MA step aside; a
-                # realtime source without that gets a fade decided from what its
-                # boundary can actually deliver (see _select_buffered_crossfade)
-                item_source_crossfade_mode = self.mass.streams.get_source_crossfade_mode(
-                    queue, queue_track
-                )
-                item_crossfade_mode = (
-                    CrossfadeMode.DISABLED
-                    if item_source_crossfade_mode != CrossfadeMode.DISABLED
-                    else crossfade_mode
-                )
+                # a realtime source gets a fade decided from what its boundary can
+                # actually deliver (see _select_buffered_crossfade)
+                item_crossfade_mode = crossfade_mode
                 self.logger.debug(
                     "Start Streaming queue track: %s (%s) for queue %s",
                     queue_track.streamdetails.uri,
@@ -2586,13 +2577,12 @@ class StreamsAudio:
                             + (timing_info.fadein_trimmed_duration + timing_info.crossfade_duration)
                             * track_playback_speed
                         )
-                # no fade is credited to this track until one is really rendered below,
-                # unless its own source is the one applying it
+                # no fade is credited to this track until one is really rendered below
                 self._report_crossfade_mode(
                     queue.queue_id,
                     queue_track,
                     pcm_format,
-                    item_source_crossfade_mode,
+                    CrossfadeMode.DISABLED,
                     flow_session_id,
                     overlay_enabled=overlay_active(queue),
                 )

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -113,10 +113,7 @@ from music_assistant.controllers.streams.constants import (
 from music_assistant.controllers.streams.ogg_handler import get_chained_ogg_stream
 from music_assistant.controllers.streams.smart_fades import SmartFadesMixer
 from music_assistant.controllers.streams.smart_fades.fades import SmartFade, StandardCrossFade
-from music_assistant.controllers.streams.smart_fades.helpers import (
-    MIN_EFFECTIVE_FADE_BUFFER,
-    SMART_CROSSFADE_DURATION,
-)
+from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
 from music_assistant.helpers import ssl as ssl_util
 from music_assistant.helpers.aiohttp_client import encoded_request_url
 from music_assistant.helpers.audio import (
@@ -179,12 +176,10 @@ if TYPE_CHECKING:
 # Seconds of PCM at the start of a track that are yielded straight to the player,
 # never held back for a crossfade.
 WARMUP_DURATION = 8
-# Minimum overlap used when the full incoming crossfade buffer was not prepared.
-MIN_CROSSFADE_FALLBACK_DURATION = 5
-
-# Minimum fade a realtime source's banked surplus must cover for the boundary to
-# be blended at all; below this the tail plays out and the boundary is a hard cut.
-MIN_REALTIME_CROSSFADE_DURATION = 3
+# Minimum overlap worth blending; below this the tail plays out and the boundary
+# is a hard cut. The configured mode picks the fade, this only decides whether a
+# boundary can carry one at all.
+MIN_CROSSFADE_DURATION = 3
 
 # Bounded wait at a boundary for a realtime incoming track to start delivering.
 # Its buffer only exists once its session produces audio, which happens around the
@@ -1962,7 +1957,7 @@ class StreamsAudio:
             else crossfade_buffer_duration,
         )
         # skip crossfade if buffer would be too small to be meaningful
-        if crossfade_buffer_duration < MIN_CROSSFADE_FALLBACK_DURATION:
+        if crossfade_buffer_duration < MIN_CROSSFADE_DURATION:
             crossfade_buffer_duration = 0
         # Ensure crossfade buffer size is aligned to frame boundaries
         # Frame size = bytes_per_sample * channels
@@ -2101,16 +2096,8 @@ class StreamsAudio:
         fade_in_buffer_duration = 0.0
         fade_in_playback_speed = 1.0
         # a fade needs enough of the outgoing track to overlap with; a holdback that
-        # armed late (or not at all) leaves less than that. A realtime tail is
-        # surplus-grown, so a smaller one is still worth blending.
-        min_fade_out_size = int(
-            pcm_format.pcm_sample_size
-            * (
-                MIN_REALTIME_CROSSFADE_DURATION
-                if streamdetails.is_realtime
-                else MIN_CROSSFADE_FALLBACK_DURATION
-            )
-        )
+        # armed late (or not at all) leaves less than that
+        min_fade_out_size = int(pcm_format.pcm_sample_size * MIN_CROSSFADE_DURATION)
         if len(buffer) >= min_fade_out_size and next_queue_item and next_queue_item.streamdetails:
             fade_in_playback_speed = cast(
                 "float", next_queue_item.extra_attributes.get("playback_speed", 1.0)
@@ -2137,7 +2124,6 @@ class StreamsAudio:
                     next_queue_item.streamdetails,
                     crossfade_mode,
                     standard_crossfade_duration,
-                    fade_in_playback_speed,
                     fade_out_seconds=len(buffer) / pcm_format.pcm_sample_size,
                 )
                 crossfade_allowed = transition_mode != CrossfadeMode.DISABLED
@@ -2484,7 +2470,7 @@ class StreamsAudio:
                     else crossfade_buffer_duration,
                 )
                 # skip crossfade if buffer would be too small to be meaningful
-                if crossfade_buffer_duration < MIN_CROSSFADE_FALLBACK_DURATION:
+                if crossfade_buffer_duration < MIN_CROSSFADE_DURATION:
                     crossfade_buffer_duration = 0
                 # Ensure crossfade buffer size is aligned to frame boundaries
                 # Frame size = bytes_per_sample * channels
@@ -2518,7 +2504,6 @@ class StreamsAudio:
                             queue_track.streamdetails,
                             item_crossfade_mode,
                             standard_crossfade_duration,
-                            track_playback_speed,
                             fade_out_seconds=len(last_fadeout_part) / pcm_sample_size,
                         )
                     if transition_mode == CrossfadeMode.DISABLED:
@@ -2905,16 +2890,8 @@ class StreamsAudio:
                     # full tail was pre-counted and is now yielded as-is
                     last_fadeout_part = b""
                 # a fade needs enough of the outgoing track to overlap with; a holdback that
-                # armed late (or not at all) leaves less than that. A realtime tail is
-                # surplus-grown, so a smaller one is still worth blending.
-                min_fade_out_size = int(
-                    pcm_sample_size
-                    * (
-                        MIN_REALTIME_CROSSFADE_DURATION
-                        if queue_track.streamdetails.is_realtime
-                        else MIN_CROSSFADE_FALLBACK_DURATION
-                    )
-                )
+                # armed late (or not at all) leaves less than that
+                min_fade_out_size = int(pcm_sample_size * MIN_CROSSFADE_DURATION)
                 if len(crossfade_buffer) >= min_fade_out_size and self.crossfade_allowed(
                     queue_track,
                     crossfade_mode=item_crossfade_mode,
@@ -3977,79 +3954,48 @@ class StreamsAudio:
         streamdetails: StreamDetails,
         crossfade_mode: CrossfadeMode,
         standard_crossfade_duration: int,
-        playback_speed: float = 1.0,
-        fade_out_seconds: float | None = None,
+        fade_out_seconds: float,
     ) -> tuple[CrossfadeMode, float]:
         """
-        Select a crossfade that can be completed from resident incoming PCM.
+        Select the crossfade this boundary can carry.
 
-        What the boundary has in hand picks the rung: a smart fade on whatever
-        window both sides can carry (the full smart window is a ceiling, its
-        effective minimum the floor), a standard fade otherwise, none when there
-        is not enough to blend at all.
+        The configured mode picks the fade; the held-back outgoing tail sizes its
+        window, up to that mode's ceiling. Too short a tail to blend at all means no
+        fade rather than a different one.
 
         :param streamdetails: Incoming track stream details.
         :param crossfade_mode: Requested crossfade mode.
         :param standard_crossfade_duration: Configured standard overlap in seconds.
-        :param playback_speed: Incoming track playback-speed multiplier.
-        :param fade_out_seconds: Held-back outgoing tail in seconds, when known;
-            a smart fade needs its effective minimum on that side too.
-        :return: Effective mode and resident fade-in duration in seconds.
+        :param fade_out_seconds: Held-back outgoing tail in seconds.
+        :return: Effective mode and fade-in duration in seconds.
         """
         audio_buffer = streamdetails.buffer
         if (
             crossfade_mode == CrossfadeMode.DISABLED
-            or playback_speed <= 0
             or audio_buffer is None
             or audio_buffer.has_error
             or not audio_buffer.is_valid()
+            or not audio_buffer.ready.is_set()
         ):
             return CrossfadeMode.DISABLED, 0
 
-        available_seconds = audio_buffer.duration_available / playback_speed
-        if (
-            crossfade_mode == CrossfadeMode.SMART_CROSSFADE
-            and audio_buffer.ready.is_set()
-            and (fade_out_seconds is None or fade_out_seconds >= MIN_EFFECTIVE_FADE_BUFFER)
-        ):
-            if streamdetails.is_realtime and fade_out_seconds is not None:
-                # The blend streams, so the incoming window does not have to be
-                # resident - it arrives at the source's own (overpaced) delivery
-                # rate while the blend plays. The held-back outgoing tail is what
-                # bounds the window a boundary can carry.
-                return crossfade_mode, min(SMART_CROSSFADE_DURATION, fade_out_seconds)
-            if available_seconds >= MIN_EFFECTIVE_FADE_BUFFER:
-                return crossfade_mode, min(SMART_CROSSFADE_DURATION, available_seconds)
-
-        if streamdetails.is_realtime:
-            # A realtime source cannot bank the whole standard overlap up front,
-            # but it does not have to: the standard mix streams too. The resident
-            # audio only has to prove the source is actually delivering; a source
-            # that is not there yet means this boundary simply plays without a fade.
-            if (
-                not audio_buffer.ready.is_set()
-                or standard_crossfade_duration < MIN_CROSSFADE_FALLBACK_DURATION
-            ):
-                return CrossfadeMode.DISABLED, 0
-            return CrossfadeMode.STANDARD_CROSSFADE, standard_crossfade_duration
-
-        if (
-            crossfade_mode == CrossfadeMode.STANDARD_CROSSFADE
-            and standard_crossfade_duration >= MIN_CROSSFADE_FALLBACK_DURATION
-            and audio_buffer.ready.is_set()
-            and available_seconds >= standard_crossfade_duration
-        ):
-            return crossfade_mode, standard_crossfade_duration
-
-        fallback_duration = min(standard_crossfade_duration, available_seconds)
-        if fallback_duration < MIN_CROSSFADE_FALLBACK_DURATION:
+        # The blend streams, so the incoming window does not have to be resident:
+        # it arrives while the blend plays. The tail we held back is what bounds it.
+        window = min(
+            SMART_CROSSFADE_DURATION
+            if crossfade_mode == CrossfadeMode.SMART_CROSSFADE
+            else standard_crossfade_duration,
+            fade_out_seconds,
+        )
+        if window < MIN_CROSSFADE_DURATION:
             return CrossfadeMode.DISABLED, 0
         self.logger.debug(
-            "Using %s second standard crossfade for %s from resident audio",
-            fallback_duration,
+            "Using a %.1f second %s for %s",
+            window,
+            crossfade_mode.value,
             streamdetails.uri,
         )
-        return CrossfadeMode.STANDARD_CROSSFADE, fallback_duration
+        return crossfade_mode, window
 
     async def _resolve_media_stream_source(
         self,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -3968,20 +3968,22 @@ class StreamsAudio:
         if (
             crossfade_mode == CrossfadeMode.SMART_CROSSFADE
             and audio_buffer.ready.is_set()
-            and available_seconds >= MIN_EFFECTIVE_FADE_BUFFER
             and (fade_out_seconds is None or fade_out_seconds >= MIN_EFFECTIVE_FADE_BUFFER)
         ):
-            return crossfade_mode, min(SMART_CROSSFADE_DURATION, available_seconds)
+            if streamdetails.is_realtime and fade_out_seconds is not None:
+                # The blend streams, so the incoming window does not have to be
+                # resident - it arrives at the source's own (overpaced) delivery
+                # rate while the blend plays. The held-back outgoing tail is what
+                # bounds the window a boundary can carry.
+                return crossfade_mode, min(SMART_CROSSFADE_DURATION, fade_out_seconds)
+            if available_seconds >= MIN_EFFECTIVE_FADE_BUFFER:
+                return crossfade_mode, min(SMART_CROSSFADE_DURATION, available_seconds)
 
         if streamdetails.is_realtime:
             # A realtime source cannot bank the whole standard overlap up front,
-            # but it does not have to: the standard mix streams, so the blend
-            # flows at the source's own (overpaced) delivery rate. The resident
+            # but it does not have to: the standard mix streams too. The resident
             # audio only has to prove the source is actually delivering; a source
-            # that is not there yet means this boundary simply plays without a
-            # fade. The smart rung above stays out of reach for now: a strictly
-            # sequential session cannot have the incoming window resident at the
-            # boundary, and the smart chain does not stream yet.
+            # that is not there yet means this boundary simply plays without a fade.
             if (
                 not audio_buffer.ready.is_set()
                 or standard_crossfade_duration < MIN_CROSSFADE_FALLBACK_DURATION

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -249,30 +249,31 @@ def overlay_active(queue: PlayerQueue) -> bool:
 
 class _RealtimeTailHold:
     """
-    Grow a fade-out holdback for a realtime source out of its banked surplus.
+    Grow a fade-out holdback for a realtime source without starving the player.
 
     A realtime source delivers barely above playback pace, so a fixed holdback
-    would starve the player at the start of a track. What can be withheld safely
-    is the surplus the source has delivered beyond the wall clock — which is also
-    exactly the audio a boundary can spend on a fade without the player ever
-    missing a byte. The window therefore starts at nothing and grows with the
-    source's overpace; once the source is done, the rest is resident and the
-    full window is available.
+    would starve the player. The only audio that may be withheld is what the
+    stream has received beyond the wall clock plus a safety reserve - that is
+    audio the player provably does not need to keep rendering in time - and
+    only half of that, so the player's own lead keeps growing too. Once the
+    source is done, the rest is resident and the full window is available.
     """
+
+    # the player's supply must stay at least this far ahead of the wall clock
+    _LEAD_RESERVE_S = 3.0
 
     def __init__(self, pcm_format: AudioFormat, audio_buffer: AudioBuffer | None) -> None:
         """
         Initialize the tracker for one track's stream.
 
         :param pcm_format: PCM format of the stream's chunks.
-        :param audio_buffer: The track's source buffer, if any; its resident audio
-            counts toward the surplus and its EOF releases the full window.
+        :param audio_buffer: The track's source buffer, if any; its EOF releases
+            the full window.
         """
         self._pcm_format = pcm_format
         self._audio_buffer = audio_buffer
         self._started: float | None = None
-        self._content_bytes = 0
-        self._resident_at_anchor = 0.0
+        self._received_bytes = 0
 
     def note_bytes(self, count: int) -> None:
         """
@@ -282,12 +283,7 @@ class _RealtimeTailHold:
         """
         if self._started is None:
             self._started = asyncio.get_event_loop().time()
-            # what the buffer already held is not new surplus: counting it would
-            # snap the hold to a lump the player pays for as an immediate stall
-            self._resident_at_anchor = (
-                self._audio_buffer.duration_available if self._audio_buffer is not None else 0.0
-            )
-        self._content_bytes += count
+        self._received_bytes += count
 
     def hold_target(self, max_bytes: int, frame_size: int) -> int:
         """
@@ -302,21 +298,10 @@ class _RealtimeTailHold:
         if audio_buffer is not None and audio_buffer.eof:
             # the source is done: everything left is resident, hold the full window
             return max_bytes
-        # net buffer change since the anchor: together with the bytes read, this
-        # is exactly what the source delivered since then, and delivery beyond
-        # the wall clock is the only audio that may be withheld
-        resident_delta = (
-            audio_buffer.duration_available - self._resident_at_anchor
-            if audio_buffer is not None
-            else 0.0
-        )
         elapsed = asyncio.get_event_loop().time() - self._started
-        surplus_seconds = (
-            self._content_bytes / self._pcm_format.pcm_sample_size + resident_delta - elapsed
-        )
-        # half the surplus: the other half keeps growing the player's lead, which
-        # is what absorbs the source's own delivery wobble mid-track
-        surplus_bytes = int(max(0.0, surplus_seconds) * self._pcm_format.pcm_sample_size) // 2
+        received_seconds = self._received_bytes / self._pcm_format.pcm_sample_size
+        spare_seconds = received_seconds - elapsed - self._LEAD_RESERVE_S
+        surplus_bytes = int(max(0.0, spare_seconds) * self._pcm_format.pcm_sample_size) // 2
         return min(max_bytes, surplus_bytes // frame_size * frame_size)
 
 
@@ -2033,6 +2018,8 @@ class StreamsAudio:
             exact_seek=exact_buffer_seek,
         ):
             total_chunks_received += 1
+            if tail_hold is not None:
+                tail_hold.note_bytes(len(chunk))
 
             if warmup_bytes < warmup_size:
                 # warmup: yield directly, don't buffer
@@ -2041,11 +2028,6 @@ class StreamsAudio:
                 bytes_written += len(chunk)
                 del chunk
                 continue
-
-            if tail_hold is not None:
-                # counted from warmup end on purpose: what the warmup banked
-                # stays with the player as its lead
-                tail_hold.note_bytes(len(chunk))
 
             if tail_hold is None and not holdback_armed:
                 holdback_armed = self._crossfade_holdback_allowed(
@@ -2645,6 +2627,8 @@ class StreamsAudio:
                             )
                             return
                         total_chunks_received += 1
+                        if tail_hold is not None:
+                            tail_hold.note_bytes(len(chunk))
                         if not first_chunk_received:
                             first_chunk_received = True
                             # inform the queue that the track is now loaded in the buffer
@@ -2670,11 +2654,6 @@ class StreamsAudio:
                             bytes_written += len(chunk)
                             del chunk
                             continue
-
-                        if tail_hold is not None:
-                            # counted from warmup end on purpose: what the warmup banked
-                            # stays with the player as its lead
-                            tail_hold.note_bytes(len(chunk))
 
                         if tail_hold is None and not last_fadeout_part and not holdback_armed:
                             holdback_armed = self._crossfade_holdback_allowed(

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -491,9 +491,10 @@ class AudioBuffer:
             # A realtime source fills the buffer at playback pace, so every second of
             # audio asked for here is a second of extra startup delay - on a seek or a
             # track change as much as on a start. The queue's crossfade setting buys
-            # nothing for such a source, because MA's own crossfade is force-disabled
-            # for it (it has no audio to spare for an overlap), so only dynamic
-            # normalization, which genuinely needs lookahead, raises this.
+            # nothing for such a source, because its fade streams in as it arrives and
+            # is sized by the tail the outgoing track banked, not by what is resident
+            # here. Only dynamic normalization, which genuinely needs lookahead, raises
+            # this.
             ready_threshold = 2 if dynamic_normalization else 1
         elif crossfade_enabled:
             ready_threshold = 8

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -792,9 +792,10 @@ class StreamsController(CoreController):
             )
             if queue_item.media_type != MediaType.TRACK:
                 crossfade_mode = CrossfadeMode.DISABLED
-            elif queue_item.streamdetails.is_realtime:
-                # a realtime source delivers at playback pace, so it has no audio to
-                # spare for an overlap in either direction
+            elif self.get_source_crossfade_mode(queue, queue_item) != CrossfadeMode.DISABLED:
+                # the item's own source fades its boundaries, inside the audio it
+                # hands over; a realtime source without that gets a fade decided
+                # from what its boundary can actually deliver
                 crossfade_mode = CrossfadeMode.DISABLED
             else:
                 crossfade_mode = self.get_crossfade_mode(queue)

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -374,38 +374,6 @@ class StreamsController(CoreController):
             streamdetails
         )
 
-    def get_source_crossfade_mode(self, queue: PlayerQueue, queue_item: QueueItem) -> CrossfadeMode:
-        """
-        Return the crossfade an item's own source applies, or DISABLED when none does.
-
-        A source that crossfades its own playback is handed the queue's crossfade
-        setting instead of Music Assistant mixing the overlap. This only answers for
-        audio we do not mix ourselves, and only for tracks - the same limit as applies
-        to a fade of our own.
-
-        A source already serving this item's queue answers for the item's own
-        boundaries. Before it does, the answer can only be the setting it will be
-        handed together with a boundary it would own both sides of.
-
-        :param queue: Queue the item is played from.
-        :param queue_item: Queue item to report the fade for.
-        """
-        if queue_item.media_type != MediaType.TRACK or queue_item.streamdetails is None:
-            return CrossfadeMode.DISABLED
-        if not queue_item.streamdetails.is_realtime:
-            # we mix this item's overlap ourselves, so the source's is not in play
-            return CrossfadeMode.DISABLED
-        provider = self.mass.get_provider(queue_item.streamdetails.provider)
-        if not isinstance(provider, MusicProvider):
-            return CrossfadeMode.DISABLED
-        source_fades = provider.delivers_crossfaded_audio(queue_item.streamdetails)
-        if source_fades is None:
-            # the source is not serving this queue yet, so the setting it will be
-            # handed and a boundary it would own are all there is to go on
-            queue_fades = self.get_crossfade_mode(queue) != CrossfadeMode.DISABLED
-            source_fades = queue_fades and self._source_fades_an_adjacent_item(queue, queue_item)
-        return CrossfadeMode.SOURCE if source_fades else CrossfadeMode.DISABLED
-
     def is_smart_fades_active(self, queue: PlayerQueue) -> bool:
         """Return whether the queue's effective crossfade mode is smart crossfade."""
         return self.get_crossfade_mode(queue) == CrossfadeMode.SMART_CROSSFADE
@@ -792,12 +760,9 @@ class StreamsController(CoreController):
             )
             if queue_item.media_type != MediaType.TRACK:
                 crossfade_mode = CrossfadeMode.DISABLED
-            elif self.get_source_crossfade_mode(queue, queue_item) != CrossfadeMode.DISABLED:
-                # the item's own source fades its boundaries, inside the audio it
-                # hands over; a realtime source without that gets a fade decided
-                # from what its boundary can actually deliver
-                crossfade_mode = CrossfadeMode.DISABLED
             else:
+                # a realtime source gets a fade decided from what its boundary
+                # can actually deliver (see _select_buffered_crossfade)
                 crossfade_mode = self.get_crossfade_mode(queue)
             if (
                 crossfade_mode != CrossfadeMode.DISABLED
@@ -877,7 +842,6 @@ class StreamsController(CoreController):
                 session_id=session_id,
                 # a crossfade the source performs itself is never mixed here, so it
                 # is reported apart from the mode that drives our own mixer
-                source_crossfade_mode=self.get_source_crossfade_mode(queue, queue_item),
             )
 
             if crossfade_mode != CrossfadeMode.DISABLED:
@@ -1581,7 +1545,6 @@ class StreamsController(CoreController):
                         queue_item.media_type == MediaType.RADIO and overlay_active(queue)
                     ),
                     session_id=queue_session_id,
-                    source_crossfade_mode=self.get_source_crossfade_mode(queue, queue_item),
                 )
             inner_stream = self.audio.get_queue_item_stream(
                 queue_item=queue_item,
@@ -2013,31 +1976,6 @@ class StreamsController(CoreController):
                     queue_id,
                 )
 
-    def _source_fades_an_adjacent_item(self, queue: PlayerQueue, queue_item: QueueItem) -> bool:
-        """
-        Return whether the same source serves an item next to this one.
-
-        Stands in for a source that is not serving this queue yet and so cannot answer
-        for the item itself: a source can only fade across a boundary it owns both
-        sides of, which makes this a necessary condition rather than proof of a fade.
-        Both neighbours count, the same way one of our own fades credits both of its
-        sides - the last track of a queue is still the side that was faded into.
-
-        :param queue: Queue the item is played from.
-        :param queue_item: Queue item whose neighbours to check.
-        """
-        assert queue_item.streamdetails is not None  # guaranteed by the caller
-        controller = self.mass.player_queues
-        queue_id = queue.queue_id
-        neighbours = [controller.get_next_item(queue_id, queue_item.queue_item_id)]
-        index = controller.index_by_id(queue_id, queue_item.queue_item_id)
-        if index is not None and index > 0:
-            neighbours.append(controller.get_item(queue_id, index - 1))
-        return any(
-            self._served_by(neighbour, queue_item.streamdetails.provider)
-            for neighbour in neighbours
-        )
-
     def _served_by(self, queue_item: QueueItem | None, provider_instance: str) -> bool:
         """
         Return whether a queue item is a track the given provider instance serves.
@@ -2064,7 +2002,6 @@ class StreamsController(CoreController):
         pcm_format: AudioFormat,
         overlay_enabled: bool,
         session_id: str | None = None,
-        source_crossfade_mode: CrossfadeMode = CrossfadeMode.DISABLED,
     ) -> None:
         """
         Store the shared processing context selected for a queue item.
@@ -2079,7 +2016,6 @@ class StreamsController(CoreController):
         :param pcm_format: Shared PCM format leaving queue processing.
         :param overlay_enabled: Whether an overlay is mixed into this stream.
         :param session_id: Queue session that owns processing-detail updates.
-        :param source_crossfade_mode: Crossfade the item's own source applies, if any.
         """
         if queue_item.streamdetails is None:
             return
@@ -2101,7 +2037,7 @@ class StreamsController(CoreController):
                     "float",
                     queue_item.extra_attributes.get("playback_speed", 1.0),
                 ),
-                crossfade_mode=source_crossfade_mode,
+                crossfade_mode=CrossfadeMode.DISABLED,
                 overlay_active=overlay_enabled,
             ),
             alters_audio=queue_item.streamdetails.fade_in,

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -840,8 +840,6 @@ class StreamsController(CoreController):
                     queue_item.media_type == MediaType.RADIO and overlay_active(queue)
                 ),
                 session_id=session_id,
-                # a crossfade the source performs itself is never mixed here, so it
-                # is reported apart from the mode that drives our own mixer
             )
 
             if crossfade_mode != CrossfadeMode.DISABLED:

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -64,7 +64,7 @@ def _feed_pipe_blocking(write_fd: int, payload: bytes) -> None:
         while view:
             written = os.write(write_fd, view[: 1024 * 1024])
             view = view[written:]
-    except BrokenPipeError, OSError:
+    except OSError:
         pass
     finally:
         os.close(write_fd)

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -64,10 +64,32 @@ def _feed_pipe_blocking(write_fd: int, payload: bytes) -> None:
         while view:
             written = os.write(write_fd, view[: 1024 * 1024])
             view = view[written:]
-    except OSError:
+    except BrokenPipeError:
+        # ffmpeg stopped reading (its filter took all it needed, or it exited)
         pass
     finally:
         os.close(write_fd)
+
+
+async def _feed_ffmpeg_stdin(
+    proc: AsyncProcess, fade_in_part: bytes | AsyncGenerator[bytes]
+) -> None:
+    """
+    Write the incoming track's head to the mixer, always ending with an EOF.
+
+    :param proc: The mixer process to feed.
+    :param fade_in_part: Raw PCM bytes, or a stream delivering them.
+    """
+    try:
+        if isinstance(fade_in_part, bytes):
+            await proc.write(fade_in_part)
+        else:
+            async for fade_chunk in fade_in_part:
+                await proc.write(fade_chunk)
+    finally:
+        # a feed that stops without an EOF leaves ffmpeg waiting for input
+        # while its consumer waits for output
+        await proc.write_eof()
 
 
 class SmartFade(ABC):
@@ -140,14 +162,6 @@ class SmartFade(ABC):
                 os.close(fadeout_read_fd)
                 fadeout_read_fd = -1
 
-                async def _feed_stdin() -> None:
-                    if isinstance(fade_in_part, bytes):
-                        await proc.write(fade_in_part)
-                    else:
-                        async for fade_chunk in fade_in_part:
-                            await proc.write(fade_chunk)
-                    await proc.write_eof()
-
                 async def _drain_stderr() -> None:
                     """Read stderr to prevent pipe deadlock."""
                     async for line in proc.iter_stderr():
@@ -157,7 +171,7 @@ class SmartFade(ABC):
                     asyncio.to_thread(_feed_pipe_blocking, fadeout_write_fd, fade_out_part)
                 )
                 fadeout_write_fd = -1  # the feeder owns and closes it now
-                feed_task = asyncio.create_task(_feed_stdin())
+                feed_task = asyncio.create_task(_feed_ffmpeg_stdin(proc, fade_in_part))
                 stderr_task = asyncio.create_task(_drain_stderr())
                 try:
                     async for chunk in proc.iter_any():

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -13,7 +13,10 @@ import aiofiles
 import shortuuid
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
-from music_assistant.controllers.streams.smart_fades.filters import CrossfadeFilter, Filter
+from music_assistant.controllers.streams.smart_fades.filters import (
+    Filter,
+    StreamingCrossfadeFilter,
+)
 from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
 from music_assistant.controllers.streams.smart_fades.models import (
     CrossfadeTimingInfo,
@@ -103,7 +106,13 @@ class SmartFade(ABC):
             pcm_format.content_type.value,
             "-i",
             fadeout_filename,
-            # Input 2: fade_in part (stdin)
+            # Input 2: fade_in part (stdin). The format is fully specified, so kill
+            # the raw demuxer's probe buffer: it would swallow seconds of a
+            # streamed fade-in before the filter graph produces its first frame.
+            "-probesize",
+            "32",
+            "-analyzeduration",
+            "0",
             "-acodec",
             pcm_format.content_type.name.lower(),
             *get_ffmpeg_channel_args(pcm_format),
@@ -318,8 +327,10 @@ class StandardCrossFade(SmartFade):
             fadein_trimmed_duration=0.0,
             post_crossfade_duration=max(0.0, fade_in_seconds - effective_cf),
         )
+        # the streaming variant, so a fade-in that is still arriving (realtime
+        # source) is blended and delivered as it comes in
         self.filters = [
-            CrossfadeFilter(logger=self.logger, crossfade_samples=crossfade_samples),
+            StreamingCrossfadeFilter(logger=self.logger, crossfade_samples=crossfade_samples),
         ]
 
     async def apply(
@@ -355,44 +366,45 @@ class StandardCrossFade(SmartFade):
                     for pcm_slice in iter_pcm_slices(chunk, pcm_format, 1000):
                         yield pcm_slice
             return
-        # Pre-crossfade: outgoing track minus the crossfaded portion
+        # Pre-crossfade: outgoing track minus the crossfaded portion. Emitted
+        # before the incoming side is touched at all: with a streamed fade-in the
+        # overlap is still arriving, and the player keeps playing this meanwhile.
         split = len(fade_out_part) - crossfade_size
         pre_crossfade = fade_out_part[:split]
         adjusted_fade_out_part = fade_out_part[split:]
-
-        # Collect only the crossfade portion from fade_in, keep the rest as a generator
-        if isinstance(fade_in_part, bytes):
-            adjusted_fade_in_part = fade_in_part[:crossfade_size]
-            post_crossfade: bytes | AsyncGenerator[bytes] = fade_in_part[crossfade_size:]
-        else:
-            # read exactly crossfade_size bytes from the generator
-            buf = bytearray()
-            async for chunk in fade_in_part:
-                buf.extend(chunk)
-                if len(buf) >= crossfade_size:
-                    break
-            adjusted_fade_in_part = bytes(buf[:crossfade_size])
-            # anything beyond crossfade_size plus the remaining generator is post_crossfade
-            leftover = bytes(buf[crossfade_size:])
-
-            async def _post_crossfade() -> AsyncGenerator[bytes]:
-                if leftover:
-                    for pcm_slice in iter_pcm_slices(leftover, pcm_format, 1000):
-                        yield pcm_slice
-                async for remaining_chunk in fade_in_part:
-                    for pcm_slice in iter_pcm_slices(remaining_chunk, pcm_format, 1000):
-                        yield pcm_slice
-
-            post_crossfade = _post_crossfade()
-
-        # Yield pre-crossfade, crossfaded section, and post-crossfade
         for pcm_slice in iter_pcm_slices(pre_crossfade, pcm_format, 1000):
             yield pcm_slice
-        async for chunk in super().apply(adjusted_fade_out_part, adjusted_fade_in_part, pcm_format):
-            yield chunk
-        if isinstance(post_crossfade, bytes):
-            for pcm_slice in iter_pcm_slices(post_crossfade, pcm_format, 1000):
-                yield pcm_slice
-        else:
-            async for chunk in post_crossfade:
+
+        if isinstance(fade_in_part, bytes):
+            async for chunk in super().apply(
+                adjusted_fade_out_part, fade_in_part[:crossfade_size], pcm_format
+            ):
                 yield chunk
+            for pcm_slice in iter_pcm_slices(fade_in_part[crossfade_size:], pcm_format, 1000):
+                yield pcm_slice
+            return
+
+        # Generator fade-in: hand exactly the overlap to the (streaming) blend as
+        # it arrives; whatever the last chunk carried beyond it opens the post part
+        overshoot = bytearray()
+
+        async def _overlap_stream() -> AsyncGenerator[bytes]:
+            taken = 0
+            async for chunk in fade_in_part:
+                remaining = crossfade_size - taken
+                if len(chunk) >= remaining:
+                    taken += remaining
+                    overshoot.extend(chunk[remaining:])
+                    yield chunk[:remaining]
+                    return
+                taken += len(chunk)
+                yield chunk
+
+        async for chunk in super().apply(adjusted_fade_out_part, _overlap_stream(), pcm_format):
+            yield chunk
+        if overshoot:
+            for pcm_slice in iter_pcm_slices(bytes(overshoot), pcm_format, 1000):
+                yield pcm_slice
+        async for remaining_chunk in fade_in_part:
+            for pcm_slice in iter_pcm_slices(remaining_chunk, pcm_format, 1000):
+                yield pcm_slice

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from contextlib import suppress
 from typing import TYPE_CHECKING
-
-import aiofiles
-import shortuuid
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.controllers.streams.smart_fades.filters import (
@@ -28,7 +26,6 @@ from music_assistant.controllers.streams.smart_fades.renderer import TransitionR
 from music_assistant.helpers.audio import iter_pcm_slices
 from music_assistant.helpers.ffmpeg import get_ffmpeg_channel_args
 from music_assistant.helpers.process import AsyncProcess
-from music_assistant.helpers.util import remove_file
 
 if TYPE_CHECKING:
     from music_assistant_models.media_items import AudioFormat
@@ -42,6 +39,35 @@ __all__ = [
     "SmartFadeNotApplicable",
     "StandardCrossFade",
 ]
+
+
+def _close_if_open(*fds: int) -> None:
+    """Close the given fds, ignoring ones already handed off (marked -1)."""
+    for fd in fds:
+        if fd != -1:
+            os.close(fd)
+
+
+def _feed_pipe_blocking(write_fd: int, payload: bytes) -> None:
+    """
+    Write a payload into a pipe fd with plain blocking writes, then close it.
+
+    Blocking on purpose (run in a thread): the pipe applies the backpressure,
+    and a consumer that went away surfaces as a broken pipe, which simply ends
+    the feed — the consumer's own exit status tells the story.
+
+    :param write_fd: Write end of the pipe; closed when done, whatever happens.
+    :param payload: The bytes to deliver.
+    """
+    try:
+        view = memoryview(payload)
+        while view:
+            written = os.write(write_fd, view[: 1024 * 1024])
+            view = view[written:]
+    except BrokenPipeError, OSError:
+        pass
+    finally:
+        os.close(write_fd)
 
 
 class SmartFade(ABC):
@@ -86,70 +112,33 @@ class SmartFade(ABC):
         :param fade_in_part: Raw PCM bytes or async generator for the incoming track's head.
         :param pcm_format: Audio format of both input parts and the output.
         """
-        # Write the fade_out_part to a temporary file
-        fadeout_filename = f"/tmp/{shortuuid.random(20)}.pcm"  # noqa: S108
-        async with aiofiles.open(fadeout_filename, "wb") as outfile:
-            await outfile.write(fade_out_part)
+        # The fade-out side goes in through its own pipe: ffmpeg takes any number
+        # of pipe:<fd> inputs, so no temp file has to touch the disk. The pipe far
+        # exceeds the kernel buffer, so it is fed alongside the stdin feeder below.
+        fadeout_read_fd, fadeout_write_fd = os.pipe()
 
-        args = [
-            "ffmpeg",
-            "-hide_banner",
-            "-loglevel",
-            "error",
-            # Input 1: fadeout part (as file)
-            "-acodec",
-            pcm_format.content_type.name.lower(),  # e.g., "pcm_f32le" not just "f32le"
-            *get_ffmpeg_channel_args(pcm_format),
-            "-ar",
-            str(pcm_format.sample_rate),
-            "-f",
-            pcm_format.content_type.value,
-            "-i",
-            fadeout_filename,
-            # Input 2: fade_in part (stdin). The format is fully specified, so kill
-            # the raw demuxer's probe buffer: it would swallow seconds of a
-            # streamed fade-in before the filter graph produces its first frame.
-            "-probesize",
-            "32",
-            "-analyzeduration",
-            "0",
-            "-acodec",
-            pcm_format.content_type.name.lower(),
-            *get_ffmpeg_channel_args(pcm_format),
-            "-ar",
-            str(pcm_format.sample_rate),
-            "-f",
-            pcm_format.content_type.value,
-            "-i",
-            "-",
-        ]
-        smart_fade_filters = self._get_ffmpeg_filters()
         self.logger.debug(
             "Applying smartfade: %s",
             self,
         )
-        args.extend(
-            [
-                "-filter_complex",
-                ";".join(smart_fade_filters),
-                # Output format specification - must match input codec format
-                "-acodec",
-                pcm_format.content_type.name.lower(),
-                *get_ffmpeg_channel_args(pcm_format),
-                "-ar",
-                str(pcm_format.sample_rate),
-                "-f",
-                pcm_format.content_type.value,
-                "-",
-            ]
-        )
+        args = self._mix_ffmpeg_args(pcm_format, fadeout_read_fd)
         self.logger.log(VERBOSE_LOG_LEVEL, "FFmpeg command args: %s", " ".join(args))
 
         got_output = False
         stderr_lines: list[str] = []
         try:
-            proc = AsyncProcess(args, stdin=True, stdout=True, stderr=True, name="smartfade")
+            proc = AsyncProcess(
+                args,
+                stdin=True,
+                stdout=True,
+                stderr=True,
+                name="smartfade",
+                pass_fds=(fadeout_read_fd,),
+            )
             async with proc:
+                # the child holds its own copy of the read end now
+                os.close(fadeout_read_fd)
+                fadeout_read_fd = -1
 
                 async def _feed_stdin() -> None:
                     if isinstance(fade_in_part, bytes):
@@ -164,6 +153,10 @@ class SmartFade(ABC):
                     async for line in proc.iter_stderr():
                         stderr_lines.append(line)
 
+                fadeout_task = asyncio.create_task(
+                    asyncio.to_thread(_feed_pipe_blocking, fadeout_write_fd, fade_out_part)
+                )
+                fadeout_write_fd = -1  # the feeder owns and closes it now
                 feed_task = asyncio.create_task(_feed_stdin())
                 stderr_task = asyncio.create_task(_drain_stderr())
                 try:
@@ -175,6 +168,12 @@ class SmartFade(ABC):
                         feed_task.cancel()
                     with suppress(asyncio.CancelledError):
                         await feed_task
+                    # Bounded wait: on consumer abort a paused-but-alive ffmpeg can
+                    # leave the writer blocked on a full pipe until proc.close()
+                    # (in __aexit__, after this finally) breaks it — the orphaned
+                    # thread then ends on its own, a completed write closed already.
+                    with suppress(TimeoutError, asyncio.CancelledError):
+                        await asyncio.wait_for(fadeout_task, timeout=2)
                     # Bounded wait on stderr_task so its output is still captured
                     # for error reporting on the happy/error paths, but we don't
                     # hang on consumer abort — ffmpeg is still alive then and
@@ -193,8 +192,8 @@ class SmartFade(ABC):
                     msg += f": {'; '.join(stderr_lines)}"
                 raise RuntimeError(msg)
         finally:
-            # Always cleanup temp file, even if ffmpeg fails
-            await remove_file(fadeout_filename)
+            # close whichever pipe ends this coroutine still owns (spawn failures)
+            _close_if_open(fadeout_read_fd, fadeout_write_fd)
 
     def __repr__(self) -> str:
         """Return string representation of SmartFade showing the filter chain."""
@@ -203,6 +202,54 @@ class SmartFade(ABC):
 
         chain = " → ".join(repr(f) for f in self.filters)
         return f"<{self.__class__.__name__}: {len(self.filters)} filters> {chain}"
+
+    def _mix_ffmpeg_args(self, pcm_format: AudioFormat, fadeout_read_fd: int) -> list[str]:
+        """
+        Build the mix's ffmpeg argv: fade-out on its own pipe, fade-in on stdin.
+
+        Both inputs are fully specified raw PCM, so the demuxer's probe buffer is
+        disabled — it would otherwise swallow seconds of a streamed fade-in
+        before the filter graph produces its first frame.
+
+        :param pcm_format: Audio format of both inputs and the output.
+        :param fadeout_read_fd: Read end of the fade-out pipe (passed to the child).
+        """
+        input_format = [
+            "-probesize",
+            "32",
+            "-analyzeduration",
+            "0",
+            "-acodec",
+            pcm_format.content_type.name.lower(),  # e.g., "pcm_f32le" not just "f32le"
+            *get_ffmpeg_channel_args(pcm_format),
+            "-ar",
+            str(pcm_format.sample_rate),
+            "-f",
+            pcm_format.content_type.value,
+        ]
+        return [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            *input_format,
+            "-i",
+            f"pipe:{fadeout_read_fd}",
+            *input_format,
+            "-i",
+            "-",
+            "-filter_complex",
+            ";".join(self._get_ffmpeg_filters()),
+            # output format matches the input codec format
+            "-acodec",
+            pcm_format.content_type.name.lower(),
+            *get_ffmpeg_channel_args(pcm_format),
+            "-ar",
+            str(pcm_format.sample_rate),
+            "-f",
+            pcm_format.content_type.value,
+            "-",
+        ]
 
     def _get_ffmpeg_filters(
         self,

--- a/music_assistant/controllers/streams/smart_fades/filters.py
+++ b/music_assistant/controllers/streams/smart_fades/filters.py
@@ -340,13 +340,15 @@ class StreamingCrossfadeFilter(Filter):
     def apply(self, input_fadein_label: str, input_fadeout_label: str) -> list[str]:
         """Apply the afade+amix filter chain."""
         ns = self.crossfade_samples
-        # equal-power qsin curves; the default tri/tri dips ~3dB mid-fade on uncorrelated material
+        # equal-power qsin curves; the default tri/tri dips ~3dB mid-fade on uncorrelated
+        # material. The final output stays unlabeled: this filter ends the chain and an
+        # unconnected named output fails the whole graph.
         return [
             f"{input_fadeout_label}afade=t=out:start_sample=0:nb_samples={ns}:"
             f"curve={self.fadeout_curve}[xfade_out]",
             f"{input_fadein_label}afade=t=in:start_sample=0:nb_samples={ns}:"
             f"curve={self.fadein_curve}[xfade_in]",
-            f"[xfade_out][xfade_in]amix=inputs=2:normalize=0[{self.output_fadeout_label}]",
+            "[xfade_out][xfade_in]amix=inputs=2:normalize=0",
         ]
 
     def __repr__(self) -> str:

--- a/music_assistant/controllers/streams/smart_fades/filters.py
+++ b/music_assistant/controllers/streams/smart_fades/filters.py
@@ -247,70 +247,21 @@ class PeakFilter(Filter):
         return f"Peak({self.frequency}Hz {self.stream_type} {gains})"
 
 
-class CrossfadeFilter(Filter):
-    """Filter that applies the final crossfade between fadeout and fadein streams."""
-
-    output_fadeout_label: str = "crossfade"
-    output_fadein_label: str = "crossfade"
-
-    def __init__(
-        self,
-        logger: logging.Logger,
-        crossfade_duration: float | None = None,
-        crossfade_samples: int | None = None,
-        *,
-        fadeout_curve: str = "qsin",
-        fadein_curve: str = "qsin",
-    ):
-        """
-        Initialize crossfade filter.
-
-        :param crossfade_duration: Overlap length in seconds (emits acrossfade ``d=``).
-        :param crossfade_samples: Overlap length in PCM samples (emits acrossfade ``ns=``).
-            Prefer this when the inputs are pre-trimmed to exactly the overlap region:
-            acrossfade silently emits nothing when its requested length exceeds the
-            buffer it is fed, and a fractional ``d`` can round just past a
-            frame-aligned buffer. A sample count cannot.
-        :param fadeout_curve: acrossfade ``c1`` curve applied to the outgoing stream.
-        :param fadein_curve: acrossfade ``c2`` curve applied to the incoming stream.
-        """
-        if (crossfade_duration is None) == (crossfade_samples is None):
-            raise ValueError("Provide exactly one of crossfade_duration or crossfade_samples")
-        self.crossfade_duration = crossfade_duration
-        self.crossfade_samples = crossfade_samples
-        self.fadeout_curve = fadeout_curve
-        self.fadein_curve = fadein_curve
-        super().__init__(logger)
-
-    def apply(self, input_fadein_label: str, input_fadeout_label: str) -> list[str]:
-        """Apply the acrossfade filter."""
-        overlap = (
-            f"ns={self.crossfade_samples}"
-            if self.crossfade_samples is not None
-            else f"d={self.crossfade_duration}"
-        )
-        # equal-power qsin curves; the default tri/tri dips ~3dB mid-fade on uncorrelated material
-        return [
-            f"{input_fadeout_label}{input_fadein_label}acrossfade={overlap}:"
-            f"c1={self.fadeout_curve}:c2={self.fadein_curve}"
-        ]
-
-    def __repr__(self) -> str:
-        """Return string representation of CrossfadeFilter."""
-        if self.crossfade_samples is not None:
-            return f"Crossfade(ns={self.crossfade_samples})"
-        return f"Crossfade(d={self.crossfade_duration:.1f}s)"
-
-
 class StreamingCrossfadeFilter(Filter):
     """
     Crossfade that emits blended output while the fade-in input is still arriving.
 
-    Same math as ``CrossfadeFilter`` (a faded-out and a faded-in stream, summed),
-    but built from afade+amix, which produce a frame as soon as both inputs have
-    one — acrossfade holds all output back until its second input hits EOF, which
-    stalls a fade against a realtime source for the whole overlap. Both inputs
-    must be pre-trimmed to exactly the overlap region.
+    Same math as ffmpeg's acrossfade (a faded-out and a faded-in stream, summed),
+    but built from afade+adelay+amix, which produce a frame as soon as both inputs
+    have one — acrossfade holds all output back until its second input hits EOF,
+    which stalls a fade against a realtime source for the whole overlap.
+
+    With ``pre_crossfade_samples`` the blend is positioned: the outgoing stream
+    plays that long untouched (the incoming side is delayed silence there), fades
+    over the overlap, and is cut hard at the planned end — a time-stretched
+    branch may land slightly off its planned length, and the cut keeps such
+    drift out of the incoming track's audio. Without it, both inputs must hold
+    exactly the overlap.
     """
 
     output_fadeout_label: str = "crossfade"
@@ -321,36 +272,47 @@ class StreamingCrossfadeFilter(Filter):
         logger: logging.Logger,
         crossfade_samples: int,
         *,
+        pre_crossfade_samples: int = 0,
         fadeout_curve: str = "qsin",
         fadein_curve: str = "qsin",
     ):
         """
         Initialize streaming crossfade filter.
 
-        :param crossfade_samples: Overlap length in PCM samples; both inputs must
-            hold exactly this many samples.
+        :param crossfade_samples: Overlap length in PCM samples.
+        :param pre_crossfade_samples: Samples of the outgoing stream played
+            untouched before the overlap begins.
         :param fadeout_curve: afade curve applied to the outgoing stream.
         :param fadein_curve: afade curve applied to the incoming stream.
         """
         self.crossfade_samples = crossfade_samples
+        self.pre_crossfade_samples = pre_crossfade_samples
         self.fadeout_curve = fadeout_curve
         self.fadein_curve = fadein_curve
         super().__init__(logger)
 
     def apply(self, input_fadein_label: str, input_fadeout_label: str) -> list[str]:
-        """Apply the afade+amix filter chain."""
+        """Apply the afade+adelay+amix filter chain."""
         ns = self.crossfade_samples
+        pre = self.pre_crossfade_samples
+        fadeout_chain = f"afade=t=out:start_sample={pre}:nb_samples={ns}:curve={self.fadeout_curve}"
+        fadein_chain = f"afade=t=in:start_sample=0:nb_samples={ns}:curve={self.fadein_curve}"
+        if pre:
+            fadeout_chain += f",atrim=end_sample={pre + ns}"
+            fadein_chain += f",adelay={pre}S:all=1"
         # equal-power qsin curves; the default tri/tri dips ~3dB mid-fade on uncorrelated
         # material. The final output stays unlabeled: this filter ends the chain and an
         # unconnected named output fails the whole graph.
         return [
-            f"{input_fadeout_label}afade=t=out:start_sample=0:nb_samples={ns}:"
-            f"curve={self.fadeout_curve}[xfade_out]",
-            f"{input_fadein_label}afade=t=in:start_sample=0:nb_samples={ns}:"
-            f"curve={self.fadein_curve}[xfade_in]",
+            f"{input_fadeout_label}{fadeout_chain}[xfade_out]",
+            f"{input_fadein_label}{fadein_chain}[xfade_in]",
             "[xfade_out][xfade_in]amix=inputs=2:normalize=0",
         ]
 
     def __repr__(self) -> str:
         """Return string representation of StreamingCrossfadeFilter."""
+        if self.pre_crossfade_samples:
+            return (
+                f"StreamingCrossfade(pre={self.pre_crossfade_samples}, ns={self.crossfade_samples})"
+            )
         return f"StreamingCrossfade(ns={self.crossfade_samples})"

--- a/music_assistant/controllers/streams/smart_fades/filters.py
+++ b/music_assistant/controllers/streams/smart_fades/filters.py
@@ -300,3 +300,55 @@ class CrossfadeFilter(Filter):
         if self.crossfade_samples is not None:
             return f"Crossfade(ns={self.crossfade_samples})"
         return f"Crossfade(d={self.crossfade_duration:.1f}s)"
+
+
+class StreamingCrossfadeFilter(Filter):
+    """
+    Crossfade that emits blended output while the fade-in input is still arriving.
+
+    Same math as ``CrossfadeFilter`` (a faded-out and a faded-in stream, summed),
+    but built from afade+amix, which produce a frame as soon as both inputs have
+    one — acrossfade holds all output back until its second input hits EOF, which
+    stalls a fade against a realtime source for the whole overlap. Both inputs
+    must be pre-trimmed to exactly the overlap region.
+    """
+
+    output_fadeout_label: str = "crossfade"
+    output_fadein_label: str = "crossfade"
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        crossfade_samples: int,
+        *,
+        fadeout_curve: str = "qsin",
+        fadein_curve: str = "qsin",
+    ):
+        """
+        Initialize streaming crossfade filter.
+
+        :param crossfade_samples: Overlap length in PCM samples; both inputs must
+            hold exactly this many samples.
+        :param fadeout_curve: afade curve applied to the outgoing stream.
+        :param fadein_curve: afade curve applied to the incoming stream.
+        """
+        self.crossfade_samples = crossfade_samples
+        self.fadeout_curve = fadeout_curve
+        self.fadein_curve = fadein_curve
+        super().__init__(logger)
+
+    def apply(self, input_fadein_label: str, input_fadeout_label: str) -> list[str]:
+        """Apply the afade+amix filter chain."""
+        ns = self.crossfade_samples
+        # equal-power qsin curves; the default tri/tri dips ~3dB mid-fade on uncorrelated material
+        return [
+            f"{input_fadeout_label}afade=t=out:start_sample=0:nb_samples={ns}:"
+            f"curve={self.fadeout_curve}[xfade_out]",
+            f"{input_fadein_label}afade=t=in:start_sample=0:nb_samples={ns}:"
+            f"curve={self.fadein_curve}[xfade_in]",
+            f"[xfade_out][xfade_in]amix=inputs=2:normalize=0[{self.output_fadeout_label}]",
+        ]
+
+    def __repr__(self) -> str:
+        """Return string representation of StreamingCrossfadeFilter."""
+        return f"StreamingCrossfade(ns={self.crossfade_samples})"

--- a/music_assistant/controllers/streams/smart_fades/helpers.py
+++ b/music_assistant/controllers/streams/smart_fades/helpers.py
@@ -11,8 +11,8 @@ if TYPE_CHECKING:
 # Buffer size in seconds for crossfade analysis
 SMART_CROSSFADE_DURATION = 45
 
-# Below this many seconds of audible tail, a smart crossfade is pointless;
-# the caller should fall back to a standard fade (which strips silence).
+# Below this many seconds of audible tail there is no room to place a musical
+# blend; the planner degrades such a boundary to a standard fade.
 MIN_EFFECTIVE_FADE_BUFFER = 8.0
 
 # Fraction of sustained (median-active) energy below which the outro no longer

--- a/music_assistant/controllers/streams/smart_fades/helpers.py
+++ b/music_assistant/controllers/streams/smart_fades/helpers.py
@@ -13,7 +13,7 @@ SMART_CROSSFADE_DURATION = 45
 
 # Below this many seconds of audible tail, a smart crossfade is pointless;
 # the caller should fall back to a standard fade (which strips silence).
-MIN_EFFECTIVE_FADE_BUFFER = 10.0
+MIN_EFFECTIVE_FADE_BUFFER = 8.0
 
 # Fraction of sustained (median-active) energy below which the outro no longer
 # carries the groove; the crossfade should end at or before this point.

--- a/music_assistant/controllers/streams/smart_fades/renderer.py
+++ b/music_assistant/controllers/streams/smart_fades/renderer.py
@@ -5,7 +5,7 @@ The renderer is the DJ's hands: it picks the tools from the filter toolset
 (``filters.py``) that realize a ``TransitionPlan``, and produces the
 ``CrossfadeTimingInfo`` breakdown.  This is the only place where bytes
 re-enter: the plan is sized in seconds, the renderer reconciles it with the
-actual buffer lengths and drives both the acrossfade overlap and the timing
+actual buffer lengths and drives both the blend overlap and the timing
 bookkeeping from that one reconciled value.
 """
 
@@ -15,7 +15,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from music_assistant.controllers.streams.smart_fades.filters import (
-    CrossfadeFilter,
     FadeInTrimFilter,
     FadeOutTrimFilter,
     Filter,
@@ -23,6 +22,7 @@ from music_assistant.controllers.streams.smart_fades.filters import (
     PeakFilter,
     ShelfFilter,
     ShelfType,
+    StreamingCrossfadeFilter,
 )
 from music_assistant.controllers.streams.smart_fades.models import (
     CrossfadeTimingInfo,
@@ -69,7 +69,10 @@ class TransitionRenderer:
             * pcm_format.sample_rate
         )
         crossfade_seconds = crossfade_samples / pcm_format.sample_rate
-        filters = self._build_filters(plan, crossfade_samples)
+        pre_crossfade_samples = int(
+            max(0.0, fade_out_seconds - crossfade_seconds) * pcm_format.sample_rate
+        )
+        filters = self._build_filters(plan, crossfade_samples, pre_crossfade_samples)
         timing = CrossfadeTimingInfo(
             pre_crossfade_duration=max(0.0, fade_out_seconds - crossfade_seconds),
             crossfade_duration=crossfade_seconds,
@@ -78,7 +81,9 @@ class TransitionRenderer:
         )
         return filters, timing
 
-    def _build_filters(self, plan: TransitionPlan, crossfade_samples: int) -> list[Filter]:
+    def _build_filters(
+        self, plan: TransitionPlan, crossfade_samples: int, pre_crossfade_samples: int
+    ) -> list[Filter]:
         """Assemble the ordered filter chain from the plan."""
         filters: list[Filter] = []
         # FadeOutTrim first: its cut point is on the untrimmed input timeline
@@ -103,10 +108,14 @@ class TransitionRenderer:
         self._append_shelf(filters, plan.eq_plan.low_in, "fadein")
         self._append_shelf(filters, plan.eq_plan.high_in, "fadein")
         self._append_shelf(filters, plan.eq_plan.mid_in, "fadein")
+        # the streaming blend is positioned at the planned pre-point, so it can
+        # emit while the incoming window is still arriving; the hard cut at the
+        # planned end keeps any time-stretch drift out of the incoming audio
         filters.append(
-            CrossfadeFilter(
+            StreamingCrossfadeFilter(
                 logger=self.logger,
                 crossfade_samples=crossfade_samples,
+                pre_crossfade_samples=pre_crossfade_samples,
                 fadeout_curve=plan.fadeout_curve,
             )
         )

--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -61,6 +61,7 @@ class AsyncProcess:
         stderr: bool | int | None = False,
         name: str | None = None,
         env: dict[str, str] | None = None,
+        pass_fds: tuple[int, ...] = (),
     ) -> None:
         """
         Initialize AsyncProcess.
@@ -71,6 +72,8 @@ class AsyncProcess:
         :param stderr: Stderr configuration (True for PIPE, False for DEVNULL, or custom).
         :param name: Process name for logging.
         :param env: Environment variables for the subprocess (None inherits parent env).
+        :param pass_fds: Extra file descriptors kept open in the child (e.g. an
+            input pipe the command reads as ``pipe:<fd>``); the caller owns them.
         """
         self.proc: asyncio.subprocess.Process | None = None
         if name is None:
@@ -82,6 +85,7 @@ class AsyncProcess:
         self._stdout = None if stdout is False else stdout
         self._stderr = asyncio.subprocess.DEVNULL if stderr is False else stderr
         self._env = get_subprocess_env(env)
+        self._pass_fds = pass_fds
         self._stderr_lock = asyncio.Lock()
         self._stdout_lock = asyncio.Lock()
         self._stdin_lock = asyncio.Lock()
@@ -130,6 +134,7 @@ class AsyncProcess:
             stderr=asyncio.subprocess.PIPE if self._stderr is True else self._stderr,
             env=self._env,
             bufsize=0,
+            pass_fds=self._pass_fds,
         )
         self.logger.log(
             VERBOSE_LOG_LEVEL, "Process %s started with PID %s", self.name, self.proc.pid

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -197,21 +197,6 @@ class MusicProvider(Provider):
         """
         return False
 
-    def delivers_crossfaded_audio(self, streamdetails: StreamDetails) -> bool | None:
-        """
-        Return whether this provider crossfades the playback it is serving.
-
-        True means the source applies the overlap at a boundary of this item itself,
-        so Music Assistant hands its crossfade setting over instead of mixing one.
-        None means the provider is not serving this item's queue yet, in which case
-        the queue's own setting answers instead. Only say True when the source really
-        does fade this item: nothing downstream verifies it.
-
-        :param streamdetails: Stream details of the item being asked about, whose
-            boundaries the answer is about.
-        """
-        return False
-
     @property
     def max_concurrent_streams(self) -> int | None:
         """

--- a/music_assistant/providers/spotify/README.md
+++ b/music_assistant/providers/spotify/README.md
@@ -58,12 +58,11 @@ audio prefs, wire models) is shared infrastructure owned by the Spotify Connect 
   — and that one continuous audio stream is split into ordinary per-item streams: an
   item's stream ends where the session reports moving on, and the next item's stream
   begins there. Played back to back the items reproduce the session's audio sample for
-  sample, so the cut position does not matter and Spotify's crossfade simply lives
-  inside the bytes. Only consecutive tracks are stitched; a podcast episode or audiobook
-  chapter is played on its own.
+  sample, so the cut position does not matter. Only consecutive tracks are stitched; a
+  podcast episode or audiobook chapter is played on its own.
 - **Use the engine's transport before respawning it.** A next-track lands on the item
-  that was fed one ahead, so the engine is told to skip to it and the session (with its
-  crossfade) survives. Tearing a session down and spawning another costs a login, an
+  that was fed one ahead, so the engine is told to skip to it and the session
+  survives. Tearing a session down and spawning another costs a login, an
   activate and a re-feed, which is seconds — and the daemon never exits on its own, so
   nothing is gained by waiting for it either: it is closed straight away.
 - **A session in use is never cut short**: the engine allows one session, so an item
@@ -90,9 +89,9 @@ audio prefs, wire models) is shared infrastructure owned by the Spotify Connect 
     a skip in the app lands there, which is also where the queue goes next, so the
     two stay in step. The engine's own autoplay and the item it restores at startup
     both fail the `mid_play` test, which is what keeps them out of it. Note the
-    last `crossfade + 10s` of an item is a blind spot by design: judging a boundary
-    needs that allowance, so a takeover inside it is missed rather than risking a
-    false one on every track.
+    last 10s of an item is a blind spot by design: judging a boundary needs that
+    allowance, so a takeover inside it is missed rather than risking a false one on
+    every track.
   - **Pause**, which is put back a couple of times (an accidental tap) and then
     taken at face value.
 
@@ -107,18 +106,12 @@ audio prefs, wire models) is shared infrastructure owned by the Spotify Connect 
   item's audio does not exist until the session gets there. The session calls
   `prepare_next_audio_buffer()` when it does, identifying the item **by URI** (a queue
   reorder may have moved it).
-- **Crossfade comes from the queue**: Music Assistant cannot crossfade audio it is not
-  mixing, so the queue's own crossfade preference is written into the engine's prefs
-  before every spawn. Its unit is milliseconds and sub-second values silently disable
-  crossfade, which the seconds-based queue setting can never produce. Changing the
-  setting mid-playback takes effect on the next playback, which is also why
-  `delivers_crossfaded_audio(streamdetails)` reports the captured value of the session
-  serving *that item's* queue rather than the current setting. It answers per boundary:
-  a fade is only reported where the engine plays across the cut. Nothing is faded *into*
-  the item a session starts on, one it was jumped to, or one it was handed but has not
-  reached; those are credited only if the engine plays on out of them. Likewise nothing
-  is faded out of an item whose follower this session can no longer serve — a drained
-  channel or a repeat starts a fresh session, so that boundary is a hard cut.
+- **The engine never crossfades**: its own crossfade is written off in the prefs before
+  every spawn, so each track's audio arrives clean from its first sample. Music Assistant
+  mixes the boundary itself from the tail it holds back, which is what keeps waveforms,
+  beat grids and light sync aligned with what is heard — a fade baked into the bytes
+  would shift every track's start against its analysis. It also means smart fades work
+  on Spotify audio.
 - **Pacing**: the capture FIFO is reader-clocked — how fast it is read *is* how fast
   the engine plays, because the pipe sink applies no rate limit of its own (read
   unpaced, PulseAudio renders silence rather than pushing back, and the session runs
@@ -138,9 +131,8 @@ audio prefs, wire models) is shared infrastructure owned by the Spotify Connect 
   through one place (`_apply_sink_state`).
 - **Delimiting**: the FIFO never ends on its own (the sink keeps rendering silence), so
   WebSocket state delimits the items. An item stream is deliberately **not** capped at
-  the item duration — with crossfade it carries the head of the next track — but it is
-  bounded, and completeness is validated against the furthest playback position the
-  engine reported for it, with the crossfade added to the tolerance. The **last** item
+  the item duration, but it is bounded, and completeness is validated against the
+  furthest playback position the engine reported for it. The **last** item
   of a run gets no track change to cut it on, so a stop/idle/pause snapshot at its own
   end arms a bounded tail drain instead; a pause part-way through is treated as app
   interference, and the engine resuming cancels the drain. A channel is served **once**:

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -541,8 +541,8 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     return session, item
                 if not seek_position and (pending := session.pending_item(spotify_uri)) is not None:
                     # skipped to the item that was fed next: the engine can jump
-                    # there itself, which keeps the session and its crossfade
-                    # instead of paying a whole respawn
+                    # there itself, which keeps the session instead of paying a
+                    # whole respawn
                     # claimed only once the engine is there: a refused skip
                     # would otherwise leave the channel claimed for good, and
                     # the session busy and unable to expire
@@ -773,8 +773,8 @@ class _SoloistSession:
         """
         Return the channel of an item that was fed but has not started yet.
 
-        The engine can be told to jump to it, which keeps the session (and its
-        crossfade) instead of paying a fresh spawn.
+        The engine can be told to jump to it, which keeps the session instead of
+        paying a fresh spawn.
 
         :param spotify_uri: The canonical Spotify URI to check.
         """
@@ -1669,9 +1669,9 @@ class _SoloistSession:
         Follow the engine to the item it reports as current, cutting the previous one.
 
         The cut lands wherever the engine says it moved on: an item's stream
-        carries whatever was read up to that point (including the head of a
-        crossfade) and the next item's stream continues from there, so the two
-        together still reproduce the session's audio exactly.
+        carries whatever was read up to that point and the next item's stream
+        continues from there, so the two together still reproduce the session's
+        audio exactly.
         """
         current = self._current
         if current is not None and current.uri == uri:
@@ -1898,9 +1898,9 @@ class _ItemAudio:
         Return whether the engine reported this item played (nearly) to its end.
 
         Tells a run that genuinely finished apart from someone pausing in the
-        Spotify app part-way through the last track. No crossfade allowance:
-        this judges the run's *last* item, which crossfades into nothing (see
-        ``mid_play``, which judges a boundary and therefore needs one).
+        Spotify app part-way through the last track. Where ``mid_play`` judges a
+        boundary the engine drove, this judges the run's *last* item, which no
+        boundary follows.
         """
         if self.duration_ms is None or self.last_position_ms is None:
             # nothing to judge by: treat a stop as the end rather than hanging
@@ -1913,10 +1913,10 @@ class _ItemAudio:
         Return whether the engine is part-way through this item.
 
         Distinguishes the engine being pulled off an item from it moving on at
-        the item's own end, which is an ordinary boundary — and with crossfade
-        that boundary falls a crossfade short of the duration. Answers False
-        whenever there is nothing to judge by, so an unknown position is never
-        read as an interruption.
+        the item's own end, which is an ordinary boundary — one the engine reaches
+        within the usual tolerance of the item's duration. Answers False whenever
+        there is nothing to judge by, so an unknown position is never read as an
+        interruption.
         """
         if not self.started.is_set() or self._closed or self.draining:
             return False

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -1092,6 +1092,11 @@ class _SoloistSession:
                 # the engine acted on the command before the failure got back to
                 # us, so it does play on into this item after all
                 return True
+            if isinstance(err, TimeoutError):
+                # the command may have landed engine-side regardless; keeping the
+                # channel makes the retry settle on it instead of queueing the
+                # same track a second time
+                return False
             del self._items[next_uri]
             with suppress(ValueError):
                 self._pending.remove(next_uri)

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -1064,10 +1064,19 @@ class _SoloistSession:
         next_uri = self._feedable_follower_uri(streamdetails)
         if next_uri is None:
             return False
-        if next_uri in self._items:
+        existing = self._items.get(next_uri)
+        if existing is not None and (
+            existing.claimed or existing is self._current or not existing.spent
+        ):
             # nothing left to send, so whether the engine plays on rests entirely on
             # the channel this session already holds for it
             return self._engine_plays_on_into(next_uri, spotify_uri)
+        if existing is not None:
+            # a channel left from an earlier play of the same track: its audio was
+            # handed over already, so this occurrence needs its own feed and channel
+            del self._items[next_uri]
+            with suppress(ValueError):
+                self._pending.remove(next_uri)
         # Registered before the command goes out: the engine can reach the item
         # while it is still in flight, and the events task has to find its
         # channel rather than mistake it for something nobody asked for.
@@ -1131,6 +1140,12 @@ class _SoloistSession:
         queue_id = self.queue_id
         queue = self.mass.player_queues.get(queue_id) if queue_id else None
         if queue is None or queue_id is None or queue.current_index is None:
+            self.logger.debug(
+                "No follower for %s: queue=%s current_index=%s",
+                streamdetails.uri,
+                queue_id,
+                queue.current_index if queue else None,
+            )
             return None
         controller = self.mass.player_queues
         # the item being streamed is the one playing or one of the few ahead of
@@ -1142,6 +1157,16 @@ class _SoloistSession:
                 break
             if item.streamdetails is streamdetails:
                 return controller.get_next_item(queue_id, item.queue_item_id)
+        self.logger.debug(
+            "No follower for %s: no identity match from index %s (%s)",
+            streamdetails.uri,
+            queue.current_index,
+            ", ".join(
+                f"{item.name}:{'same' if item.streamdetails is streamdetails else 'other'}"
+                for offset in range(_FOLLOWER_SEARCH_DEPTH)
+                if (item := controller.get_item(queue_id, queue.current_index + offset)) is not None
+            ),
+        )
         return None
 
     def _track_uri(self, queue_item: QueueItem) -> str | None:

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -177,6 +177,8 @@ _MAX_RETAINED_S: Final[float] = 20.0
 _RESUME_RETAINED_S: Final[float] = 10.0
 # how often the tail drain checks whether the item's own audio has all arrived
 _DRAIN_POLL_S: Final[float] = 0.1
+# how often an unsettled boundary re-asks the queue for the follower to feed
+_FEED_RETRY_INTERVAL_S: Final[float] = 2.0
 # the engine's "no repeat" value for its playback options
 _REPEAT_OFF: Final[str] = "off"
 # The engine allows one daemon per data directory and refuses to start otherwise,
@@ -418,11 +420,21 @@ class SoloistBackend(SpotifyPlaybackBackend):
         queue_id = streamdetails.queue_id if streamdetails is not None else None
         session, item = await self._acquire(spotify_uri, seek_position, queue_id)
         try:
-            # feed before the first byte is handed over: the item's own stream
-            # must not be able to reach its end before the next one is queued
-            if streamdetails is not None:
-                await session.feed_after(streamdetails, spotify_uri)
+            # Feed before the first byte is handed over: the item's own stream
+            # must not be able to reach its end before the next one is queued.
+            # A follower that is not knowable yet (the queue's index still
+            # settling on a fresh start, or the next item still being resolved)
+            # is asked for again while the item streams.
+            boundary_settled = streamdetails is None or await session.feed_after(
+                streamdetails, spotify_uri
+            )
+            next_feed_attempt = 0.0
             async for chunk in item.read():
+                if not boundary_settled and streamdetails is not None:
+                    now = time.monotonic()
+                    if now >= next_feed_attempt:
+                        next_feed_attempt = now + _FEED_RETRY_INTERVAL_S
+                        boundary_settled = await session.feed_after(streamdetails, spotify_uri)
                 yield chunk
         finally:
             item.release()
@@ -891,7 +903,7 @@ class _SoloistSession:
         await self._apply_sink_state(engine_playing=item.status == "playing")
         return item
 
-    async def feed_after(self, streamdetails: StreamDetails, spotify_uri: str) -> None:
+    async def feed_after(self, streamdetails: StreamDetails, spotify_uri: str) -> bool:
         """
         Hand the engine the item that follows the one being streamed, if any.
 
@@ -902,8 +914,10 @@ class _SoloistSession:
         :param streamdetails: The StreamDetails of the item being streamed, used
             to locate it in the queue.
         :param spotify_uri: The URI being streamed (only tracks are fed ahead).
+        :return: Whether the boundary is settled; False means the follower was
+            not knowable yet and asking again later may still feed it.
         """
-        await self._feed_follower(streamdetails, spotify_uri)
+        return await self._feed_follower(streamdetails, spotify_uri)
 
     async def validate_item(self, item: _ItemAudio) -> None:
         """

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -3,13 +3,14 @@ Spotify Soloist playback backend for the Spotify music provider.
 
 Runs one continuous session of ``soloist``, Spotify's official headless client,
 and feeds it one track ahead so the engine plays consecutive tracks without a
-break — with Spotify's own crossfade at the boundaries. The session renders into
-a private PulseAudio capture sink whose FIFO is read back slightly above
-realtime pace, and that one continuous audio stream is handed to Music Assistant
-as ordinary per-item streams: an item's stream ends where the session moves on to
-the next track, and the next item's stream begins there. Played back to back the
-items reproduce the session's audio sample for sample, so the cut position does
-not matter and a crossfade simply lives inside the bytes.
+break. The session renders into a private PulseAudio capture sink whose FIFO is
+read back slightly above realtime pace, and that one continuous audio stream is
+handed to Music Assistant as ordinary per-item streams: an item's stream ends
+where the session moves on to the next track, and the next item's stream begins
+there. Played back to back the items reproduce the session's audio sample for
+sample. The engine itself never crossfades — Music Assistant mixes the queue's
+crossfade, so every item's audio starts at its first sample and stays aligned
+with its analysis.
 
 SECURITY NOTE: the daemon takes the user's personal API key on its command
 line; nothing in this module may ever log the process argv.
@@ -40,8 +41,6 @@ from music_assistant_models.errors import AudioError, LoginFailed, MusicAssistan
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.constants import (
-    CONF_CROSSFADE_DURATION,
-    CONF_PLAYER_QUEUES,
     CONF_VALUE_DISABLED,
     CONF_VALUE_ENABLED,
     CONF_VOLUME_NORMALIZATION,
@@ -155,9 +154,9 @@ _DRAIN_TIMEOUT_S: Final[float] = 2.0
 # and showing as a playing device in the Spotify app - while the gap it exists to
 # cover is the handover between two items, which is milliseconds.
 _IDLE_TIMEOUT_S: Final[float] = 5.0
-# an item's stream may run past its nominal duration (it carries the head of the
-# crossfade into the next track), but never unboundedly: without the session
-# reporting a track change by then, something is wrong and the item fails
+# an item's stream may run past its nominal duration (reported durations are
+# approximate), but never unboundedly: without the session reporting a track
+# change by then, something is wrong and the item fails
 _ITEM_OVERRUN_S: Final[float] = 30.0
 # how far ahead of the playing item to look for the one being streamed: a flow
 # stream runs ahead of the player, a per-item stream is the playing item or its
@@ -355,18 +354,6 @@ class SoloistBackend(SpotifyPlaybackBackend):
         """
         session = self._session_for(streamdetails)
         return session.engine_normalizes if session is not None else None
-
-    def session_crossfades(self, streamdetails: StreamDetails) -> bool | None:
-        """
-        Return whether the session serving this item's queue fades one of its boundaries.
-
-        None when no session serves that queue, in which case the queue's own setting
-        is the only thing to go on.
-
-        :param streamdetails: Stream details of the item being asked about.
-        """
-        session = self._session_for(streamdetails)
-        return session.fades_a_boundary_of(streamdetails) if session is not None else None
 
     async def setup(self) -> None:
         """
@@ -641,11 +628,10 @@ class SoloistBackend(SpotifyPlaybackBackend):
         """Return whether the data dir holds a stored (paired) session (blocking)."""
         return soloist_session_present(self._data_dir)
 
-    def _prepare_data_dir(self, crossfade_ms: int, *, normalize: bool) -> None:
+    def _prepare_data_dir(self, *, normalize: bool) -> None:
         """
         Prepare the data dir for a fresh session spawn (blocking).
 
-        :param crossfade_ms: Crossfade duration to configure the engine with.
         :param normalize: Whether the engine should normalize loudness itself.
         """
         self._data_dir.mkdir(parents=True, exist_ok=True)
@@ -658,10 +644,13 @@ class SoloistBackend(SpotifyPlaybackBackend):
         # doing it the provider declares the audio pre-normalized, which takes
         # MA's own normalization out of the path (see
         # SpotifyProvider.delivers_normalized_audio).
+        # crossfade 0: Music Assistant mixes the queue's crossfade itself, so the
+        # engine plays every track clean from its first sample and an item's
+        # delivered audio lines up with its analysis (waveform, beat grid, light sync)
         if not write_audio_prefs(
             self._data_dir,
             self.logger,
-            crossfade_ms=crossfade_ms,
+            crossfade_ms=0,
             loudness_normalization=normalize,
             audio_quality=self._audio_quality,
         ):
@@ -723,7 +712,6 @@ class _SoloistSession:
         self.queue_id = queue_id
         self.mass = backend.mass
         self.logger: logging.Logger = backend.logger
-        self.crossfade_ms = 0
         # what the engine was actually told at spawn, which is what the streams
         # core has to agree with - the setting may be toggled while this plays
         self.engine_normalizes = False
@@ -861,10 +849,9 @@ class _SoloistSession:
         server = backend._server
         assert server is not None
         assert backend._binary is not None
-        self.crossfade_ms = self._queue_crossfade_ms()
         self.engine_normalizes = self._engine_normalization_enabled()
         await asyncio.to_thread(
-            partial(backend._prepare_data_dir, self.crossfade_ms, normalize=self.engine_normalizes)
+            partial(backend._prepare_data_dir, normalize=self.engine_normalizes)
         )
         self._sink = sink = await PipeSink.create(server, backend._sink_prefix)
         # unity gain so the FIFO carries the engine's PCM unaltered; the sink
@@ -909,50 +896,14 @@ class _SoloistSession:
         Hand the engine the item that follows the one being streamed, if any.
 
         Only consecutive tracks are stitched: the engine's queue command takes
-        track URIs, and a podcast episode or audiobook chapter gains nothing
-        from a crossfade anyway. Whether the feed landed also settles what
-        happens at the streamed item's end, which ``fades_a_boundary_of`` reports.
+        track URIs, and a podcast episode or audiobook chapter would not gain
+        anything from being fed ahead.
 
         :param streamdetails: The StreamDetails of the item being streamed, used
             to locate it in the queue.
         :param spotify_uri: The URI being streamed (only tracks are fed ahead).
         """
-        plays_on = await self._feed_follower(streamdetails, spotify_uri)
-        if (item := self._items.get(spotify_uri)) is not None:
-            item.fades_out = plays_on and self.crossfade_ms > 0
-
-    def fades_a_boundary_of(self, streamdetails: StreamDetails) -> bool:
-        """
-        Return whether this session fades one of an item's two boundaries.
-
-        Either side counts: an item's audio carries the overlap whether it was faded
-        into or out of. The engine has to play across the cut for that overlap to
-        exist, so nothing is faded into the item a session starts on, nor into one
-        the engine is jumped to.
-
-        :param streamdetails: Stream details of the item whose boundaries to report.
-        """
-        if self.crossfade_ms == 0 or streamdetails.media_type != MediaType.TRACK:
-            return False
-        uri = f"spotify:track:{streamdetails.item_id}"
-        if uri in self._pending:
-            # the engine has not played on to this item, so it is reached by a jump -
-            # which drops the overlap already rendered for it
-            return False
-        # Channels are keyed by track, so an entry left from an earlier play of the
-        # same one says nothing about this play: only the channel the engine is on
-        # can answer for its own boundaries.
-        if (item := self._items.get(uri)) is not None and item is self._current:
-            if item.faded_in:
-                return True
-            if item.fades_out is not None:
-                return item.fades_out
-        # what happens at this item's end is not settled yet, so the follower the
-        # engine would be fed is what the boundary rests on
-        next_uri = self._feedable_follower_uri(streamdetails)
-        if next_uri is None:
-            return False
-        return next_uri not in self._items or self._engine_plays_on_into(next_uri, uri)
+        await self._feed_follower(streamdetails, spotify_uri)
 
     async def validate_item(self, item: _ItemAudio) -> None:
         """
@@ -971,12 +922,7 @@ class _SoloistSession:
             raise AudioError(f"Spotify Soloist never started playing {item.uri}")
         if item.duration_ms is None:
             return
-        # with crossfade the engine starts the next track before this one ends,
-        # so the last position reported for it falls a crossfade short by design
-        tolerance_ms = min(
-            max(_INCOMPLETE_TOLERANCE_MS, self.crossfade_ms + _INCOMPLETE_TOLERANCE_MS),
-            item.duration_ms // 2,
-        )
+        tolerance_ms = min(_INCOMPLETE_TOLERANCE_MS, item.duration_ms // 2)
         if item.last_position_ms is None or item.last_position_ms + tolerance_ms < item.duration_ms:
             raise AudioError(
                 f"Spotify Soloist delivered incomplete audio for {item.uri} "
@@ -1071,23 +1017,6 @@ class _SoloistSession:
             item.started.set()
             item.close()
         self.mass.create_task(self.backend.discard_session, self)
-
-    def _queue_crossfade_ms(self) -> int:
-        """
-        Return the crossfade the engine should apply, from the queue's own preference.
-
-        Music Assistant cannot crossfade audio it is not mixing, so its queue
-        setting is handed to the engine instead. The pref is in milliseconds and
-        sub-second values silently disable crossfade, which the seconds-based
-        queue setting can never produce.
-        """
-        queue = self.mass.player_queues.get(self.queue_id) if self.queue_id else None
-        if queue is None or not queue.crossfade_enabled:
-            return 0
-        seconds = self.mass.config.get_raw_core_config_value(
-            CONF_PLAYER_QUEUES, CONF_CROSSFADE_DURATION, 8
-        )
-        return int(seconds) * 1000
 
     def _engine_normalization_enabled(self) -> bool:
         """
@@ -1732,7 +1661,6 @@ class _SoloistSession:
             item.spent = True
         if duration_ms:
             item.duration_ms = duration_ms
-        was_fed = uri in self._pending
         with suppress(ValueError):
             self._pending.remove(uri)
         self._current = item
@@ -1746,10 +1674,6 @@ class _SoloistSession:
             # is still on its way here and belongs to the item being left
             # behind - drop that, so it cannot open this one.
             self._stale_budget = self._stale_bytes()
-        elif was_fed and self.crossfade_ms > 0:
-            # reached by the engine playing on rather than by a jump, so this
-            # channel opens inside the overlap with the item before it
-            item.faded_in = True
         item.started.set()
         if current is not None and current.started.is_set():
             # Only an item that was actually playing has a boundary to cut at.
@@ -1911,12 +1835,6 @@ class _ItemAudio:
         self.claimed = False
         # served once already: its audio was handed over and cannot be replayed
         self.spent = False
-        # the engine played on into this channel, so its audio opens inside the
-        # overlap with the item before it
-        self.faded_in = False
-        # whether the engine plays on into another item at this one's end; None
-        # until the feed that decides it has been attempted
-        self.fades_out: bool | None = None
         self.drain_task: asyncio.Task[None] | None = None
         self._last_write = 0.0
         self._chunks: deque[bytes] = deque()
@@ -1970,10 +1888,9 @@ class _ItemAudio:
             return False
         # Uncapped on purpose, unlike validate_item's half-duration clamp: on an
         # item shorter than the allowance this answers False throughout, so a
-        # takeover there is missed rather than every crossfade boundary on it
+        # takeover there is missed rather than every ordinary boundary on it
         # being called one.
-        end_of_item_ms = self.session.crossfade_ms + _INCOMPLETE_TOLERANCE_MS
-        return self.last_position_ms + end_of_item_ms < self.duration_ms
+        return self.last_position_ms + _INCOMPLETE_TOLERANCE_MS < self.duration_ms
 
     @property
     def tail_complete(self) -> bool:
@@ -2126,9 +2043,7 @@ class _ItemAudio:
         """Return the byte count past which this item is considered stuck."""
         if (own_audio := self._duration_bytes()) is None:
             return None
-        return own_audio + int(
-            (self.session.crossfade_ms / 1000 + _ITEM_OVERRUN_S) * _BYTES_PER_SECOND
-        )
+        return own_audio + int(_ITEM_OVERRUN_S * _BYTES_PER_SECOND)
 
 
 def _decorated_duration_ms(item: object) -> int | None:

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -1140,12 +1140,6 @@ class _SoloistSession:
         queue_id = self.queue_id
         queue = self.mass.player_queues.get(queue_id) if queue_id else None
         if queue is None or queue_id is None or queue.current_index is None:
-            self.logger.debug(
-                "No follower for %s: queue=%s current_index=%s",
-                streamdetails.uri,
-                queue_id,
-                queue.current_index if queue else None,
-            )
             return None
         controller = self.mass.player_queues
         # the item being streamed is the one playing or one of the few ahead of
@@ -1157,15 +1151,13 @@ class _SoloistSession:
                 break
             if item.streamdetails is streamdetails:
                 return controller.get_next_item(queue_id, item.queue_item_id)
+        # commonly a queue index that has not settled yet (fresh play start);
+        # the caller keeps asking while the item streams
         self.logger.debug(
-            "No follower for %s: no identity match from index %s (%s)",
+            "No follower for %s: item not within %s of queue index %s",
             streamdetails.uri,
+            _FOLLOWER_SEARCH_DEPTH,
             queue.current_index,
-            ", ".join(
-                f"{item.name}:{'same' if item.streamdetails is streamdetails else 'other'}"
-                for offset in range(_FOLLOWER_SEARCH_DEPTH)
-                if (item := controller.get_item(queue_id, queue.current_index + offset)) is not None
-            ),
         )
         return None
 

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -262,17 +262,13 @@ class SpotifyProvider(MusicProvider):
         """
         Return whether Spotify's own engine crossfades this playback.
 
-        Only the soloist backend can: it keeps one session across items and is handed
-        the queue's crossfade duration when that session starts, so the overlap lives
-        in the audio it delivers. librespot fetches every track on its own. The session
-        serving this item's queue answers for the item's own boundaries, because it read
-        that duration once - a setting changed mid-playback applies to the next session,
-        not to the audio this one is still serving.
+        It never does: Music Assistant mixes the queue's crossfade itself, so every
+        track is delivered clean from its first sample and its audio stays aligned
+        with its analysis (waveform, beat grid, light sync).
 
         :param streamdetails: Stream details of the item being asked about.
         """
-        backend = self._soloist_backend
-        return backend.session_crossfades(streamdetails) if backend is not None else False
+        return False
 
     @property
     def max_concurrent_streams(self) -> int:

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -258,18 +258,6 @@ class SpotifyProvider(MusicProvider):
             return live
         return self.spotify_normalization_configured
 
-    def delivers_crossfaded_audio(self, streamdetails: StreamDetails) -> bool | None:
-        """
-        Return whether Spotify's own engine crossfades this playback.
-
-        It never does: Music Assistant mixes the queue's crossfade itself, so every
-        track is delivered clean from its first sample and its audio stays aligned
-        with its analysis (waveform, beat grid, light sync).
-
-        :param streamdetails: Stream details of the item being asked about.
-        """
-        return False
-
     @property
     def max_concurrent_streams(self) -> int:
         """

--- a/tests/controllers/streams/smart_fades/test_filters.py
+++ b/tests/controllers/streams/smart_fades/test_filters.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import logging
 
-import pytest
-
 from music_assistant.controllers.streams.smart_fades.filters import (
-    CrossfadeFilter,
     FadeOutTrimFilter,
     PeakFilter,
     ShelfFilter,
     ShelfType,
+    StreamingCrossfadeFilter,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -35,41 +33,54 @@ def test_fadeout_trim_trims_fadeout_and_passes_fadein_through() -> None:
     assert passthrough.endswith(f"[{fadeout_trim.output_fadein_label}]")
 
 
-def test_crossfade_uses_equal_power_curves() -> None:
-    """The level crossfade must use equal-power curves, not ffmpeg's default tri/tri."""
-    crossfade = CrossfadeFilter(logger=LOGGER, crossfade_duration=12.5)
+def test_streaming_crossfade_blends_the_exact_overlap() -> None:
+    """
+    The blend fades both streams over the sample-exact overlap and sums them.
+
+    afade+amix instead of acrossfade on purpose: acrossfade holds all output
+    back until its second input hits EOF, which would stall a fade whose
+    incoming side is still arriving. Equal-power qsin curves, not ffmpeg's
+    default tri/tri. The final output stays unlabeled: an unconnected named
+    output fails the whole graph.
+    """
+    crossfade = StreamingCrossfadeFilter(logger=LOGGER, crossfade_samples=441000)
     filter_strings = crossfade.apply("[fadein]", "[fadeout]")
-    assert filter_strings == ["[fadeout][fadein]acrossfade=d=12.5:c1=qsin:c2=qsin"]
+    assert filter_strings == [
+        "[fadeout]afade=t=out:start_sample=0:nb_samples=441000:curve=qsin[xfade_out]",
+        "[fadein]afade=t=in:start_sample=0:nb_samples=441000:curve=qsin[xfade_in]",
+        "[xfade_out][xfade_in]amix=inputs=2:normalize=0",
+    ]
 
 
-def test_crossfade_emits_the_given_curves() -> None:
+def test_streaming_crossfade_emits_the_given_curves() -> None:
     """Explicit fadeout/fadein curves override the default qsin:qsin pair."""
-    crossfade = CrossfadeFilter(
-        logger=LOGGER, crossfade_duration=12.5, fadeout_curve="nofade", fadein_curve="tri"
+    crossfade = StreamingCrossfadeFilter(
+        logger=LOGGER, crossfade_samples=441000, fadeout_curve="nofade", fadein_curve="tri"
     )
     filter_strings = crossfade.apply("[fadein]", "[fadeout]")
-    assert filter_strings == ["[fadeout][fadein]acrossfade=d=12.5:c1=nofade:c2=tri"]
+    assert "curve=nofade" in filter_strings[0]
+    assert "curve=tri" in filter_strings[1]
 
 
-def test_crossfade_sample_count_uses_ns() -> None:
+def test_streaming_crossfade_positions_the_blend() -> None:
     """
-    A sample-count crossfade must emit ``acrossfade=ns=`` rather than ``d=``.
+    A positioned blend delays the incoming stream and hard-cuts the outgoing one.
 
-    ffmpeg's ``acrossfade`` silently produces no output when its requested length
-    overruns the buffer it is fed; an integer sample count matches a frame-aligned
-    buffer exactly, where a fractional ``d`` can round just past it.
+    The pre-point places the fade on the outgoing stream, adelay (sample-exact,
+    ``S`` suffix) aligns the incoming stream under it, and the trim at the
+    planned end keeps any time-stretch drift out of the incoming audio.
     """
-    crossfade = CrossfadeFilter(logger=LOGGER, crossfade_samples=441000)
+    crossfade = StreamingCrossfadeFilter(
+        logger=LOGGER, crossfade_samples=441000, pre_crossfade_samples=882000
+    )
     filter_strings = crossfade.apply("[fadein]", "[fadeout]")
-    assert filter_strings == ["[fadeout][fadein]acrossfade=ns=441000:c1=qsin:c2=qsin"]
-
-
-def test_crossfade_requires_exactly_one_length() -> None:
-    """CrossfadeFilter must reject ambiguous or missing length specifications."""
-    with pytest.raises(ValueError, match="exactly one"):
-        CrossfadeFilter(logger=LOGGER)
-    with pytest.raises(ValueError, match="exactly one"):
-        CrossfadeFilter(logger=LOGGER, crossfade_duration=5.0, crossfade_samples=220500)
+    assert filter_strings == [
+        "[fadeout]afade=t=out:start_sample=882000:nb_samples=441000:curve=qsin,"
+        "atrim=end_sample=1323000[xfade_out]",
+        "[fadein]afade=t=in:start_sample=0:nb_samples=441000:curve=qsin,"
+        "adelay=882000S:all=1[xfade_in]",
+        "[xfade_out][xfade_in]amix=inputs=2:normalize=0",
+    ]
 
 
 class TestShelfFilter:

--- a/tests/controllers/streams/smart_fades/test_render_integration.py
+++ b/tests/controllers/streams/smart_fades/test_render_integration.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections.abc import AsyncGenerator
 
 import numpy as np
 import pytest
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
-from music_assistant.controllers.streams.smart_fades.fades import SmartCrossFade
+from music_assistant.controllers.streams.smart_fades.fades import SmartCrossFade, StandardCrossFade
 from music_assistant.models.audio_analysis import AudioAnalysisData
 
 PCM = AudioFormat(content_type=ContentType.PCM_F32LE, sample_rate=44100, bit_depth=32, channels=2)
@@ -173,3 +175,28 @@ async def test_mid_swaps_between_tracks() -> None:
     open_early = _cf_slice(open_mix, open_, 0.05, 0.3)
     assert _band_rms(gated_late, 950, 1050) < 0.7 * _band_rms(open_late, 950, 1050)
     assert _band_rms(gated_early, 1950, 2050) < 0.7 * _band_rms(open_early, 1950, 2050)
+
+
+@pytest.mark.asyncio
+async def test_a_failing_fade_in_ends_the_mix_instead_of_hanging() -> None:
+    """An incoming stream that dies mid-overlap must not leave ffmpeg waiting for input."""
+    fade_out = _tone(220.0, 6.0).tobytes()
+    delivered = _tone(440.0, 1.0).tobytes()
+
+    async def _dying_fade_in() -> AsyncGenerator[bytes]:
+        yield delivered
+        raise RuntimeError("incoming source died")
+
+    fade = StandardCrossFade(logging.getLogger(), crossfade_duration=2)
+    fade.build(len(fade_out), len(_tone(440.0, 4.0).tobytes()), PCM)
+
+    async def _drain_mix() -> None:
+        # the timeout only bounds the failure: without the EOF the mix hangs here
+        async with asyncio.timeout(30):
+            async for _chunk in fade.apply(fade_out, _dying_fade_in(), PCM):
+                pass
+
+    started = asyncio.get_event_loop().time()
+    with pytest.raises(RuntimeError, match="incoming source died"):
+        await _drain_mix()
+    assert asyncio.get_event_loop().time() - started < 10

--- a/tests/controllers/streams/smart_fades/test_renderer.py
+++ b/tests/controllers/streams/smart_fades/test_renderer.py
@@ -9,13 +9,13 @@ from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.controllers.streams.smart_fades.filters import (
-    CrossfadeFilter,
     FadeInTrimFilter,
     FadeOutTrimFilter,
     GradualTimeStretchFilter,
     PeakFilter,
     ShelfFilter,
     ShelfType,
+    StreamingCrossfadeFilter,
 )
 from music_assistant.controllers.streams.smart_fades.models import (
     EqPlan,
@@ -75,7 +75,7 @@ class TestTransitionRenderer:
             FadeInTrimFilter,
             ShelfFilter,  # B low
             ShelfFilter,  # B high
-            CrossfadeFilter,
+            StreamingCrossfadeFilter,
         ]
 
     def test_minimal_chain_is_shelves_then_crossfade(self) -> None:
@@ -86,7 +86,7 @@ class TestTransitionRenderer:
             ShelfFilter,
             ShelfFilter,
             ShelfFilter,
-            CrossfadeFilter,
+            StreamingCrossfadeFilter,
         ]
 
     def test_bypassed_low_shelves_are_skipped(self) -> None:
@@ -98,7 +98,7 @@ class TestTransitionRenderer:
         assert [type(f) for f in filters] == [
             ShelfFilter,  # A high
             ShelfFilter,  # B high
-            CrossfadeFilter,
+            StreamingCrossfadeFilter,
         ]
 
     def test_all_shelves_bypassed_leaves_only_crossfade(self) -> None:
@@ -109,7 +109,7 @@ class TestTransitionRenderer:
         eq_plan.high_out = None
         eq_plan.high_in = None
         filters, _ = TransitionRenderer(LOGGER).render(_plan(eq_plan=eq_plan), PCM, _seconds(45))
-        assert [type(f) for f in filters] == [CrossfadeFilter]
+        assert [type(f) for f in filters] == [StreamingCrossfadeFilter]
 
     def test_timing_accounts_for_both_tracks(self) -> None:
         """PRE+CF spans the fade-out, TRIM+CF+POST spans the fade-in."""
@@ -143,7 +143,7 @@ class TestTransitionRenderer:
         plan = _plan(crossfade_duration=10.0, fadein_trim_start=1.0)
         filters, timing = TransitionRenderer(LOGGER).render(plan, PCM, _seconds(5))
         crossfade = filters[-1]
-        assert isinstance(crossfade, CrossfadeFilter)
+        assert isinstance(crossfade, StreamingCrossfadeFilter)
         # 5s buffer minus the 1s trim leaves 4s of incoming audio
         assert crossfade.crossfade_samples == 4 * PCM.sample_rate
         assert timing.crossfade_duration == pytest.approx(4.0)
@@ -152,17 +152,17 @@ class TestTransitionRenderer:
         """With full buffers the filter carries the plan duration, frame-exact."""
         filters, timing = TransitionRenderer(LOGGER).render(_plan(), PCM, _seconds(45))
         crossfade = filters[-1]
-        assert isinstance(crossfade, CrossfadeFilter)
+        assert isinstance(crossfade, StreamingCrossfadeFilter)
         assert crossfade.crossfade_samples == 10 * PCM.sample_rate
         assert timing.crossfade_duration == pytest.approx(10.0)
 
     def test_fadeout_curve_flows_into_the_crossfade_filter(self) -> None:
-        """The plan's fadeout_curve becomes the acrossfade filter's c1 curve."""
+        """The plan's fadeout_curve becomes the outgoing stream's fade curve."""
         plan = _plan(fadeout_curve="nofade")
         filters, _ = TransitionRenderer(LOGGER).render(plan, PCM, _seconds(45))
         crossfade = filters[-1]
-        assert isinstance(crossfade, CrossfadeFilter)
-        assert "c1=nofade" in crossfade.apply("[fadein]", "[fadeout]")[0]
+        assert isinstance(crossfade, StreamingCrossfadeFilter)
+        assert "curve=nofade" in crossfade.apply("[fadein]", "[fadeout]")[0]
 
     def test_stretch_savings_shorten_fadeout_accounting(self) -> None:
         """A speed-up ramp removes time from the rendered fade-out total."""
@@ -190,7 +190,7 @@ class TestMidSwapRendering:
             ShelfFilter,  # B low
             ShelfFilter,  # B high
             PeakFilter,  # B mid
-            CrossfadeFilter,
+            StreamingCrossfadeFilter,
         ]
 
     def test_mid_none_is_skipped(self) -> None:

--- a/tests/controllers/streams/smart_fades/test_vocal_aware.py
+++ b/tests/controllers/streams/smart_fades/test_vocal_aware.py
@@ -16,7 +16,7 @@ import pytest
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
-from music_assistant.controllers.streams.smart_fades.filters import CrossfadeFilter
+from music_assistant.controllers.streams.smart_fades.filters import StreamingCrossfadeFilter
 from music_assistant.controllers.streams.smart_fades.mixer import SmartFadesMixer
 from music_assistant.controllers.streams.smart_fades.models import (
     TransitionPlan,
@@ -208,7 +208,7 @@ class TestShortVocalHandoff:
         assert eq.mid_in is None
 
     def test_handoff_still_uses_the_qsin_crossfade_filter(self) -> None:
-        """The handoff plan renders through the same equal-power CrossfadeFilter as any other."""
+        """The handoff plan renders through the same equal-power StreamingCrossfadeFilter as any other."""
         out = _with_vocal_activity(_analysis(120.0, duration=240.0), [(200.0, 239.9)])
         inc = _with_vocal_activity(_analysis(120.0, duration=240.0), [(0.0, 40.0)])
         plan = _plan(out, inc)
@@ -220,7 +220,7 @@ class TestShortVocalHandoff:
         filters, _timing = TransitionRenderer(LOGGER).render(
             plan, pcm_format, fade_in_bytes_len=int(45.0 * pcm_format.pcm_sample_size)
         )
-        crossfade_filters = [f for f in filters if isinstance(f, CrossfadeFilter)]
+        crossfade_filters = [f for f in filters if isinstance(f, StreamingCrossfadeFilter)]
         assert len(crossfade_filters) == 1
 
 

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -1253,8 +1253,11 @@ async def test_flow_zero_audio_skip_restores_seek_position(
         pass
 
     build.assert_awaited_once()
-    # a source that hands over nothing is reopened, and both opens see the eager position
-    assert eager_seek_positions == [32, 32]
+    # the prefetcher's early open sees the raw position; the reopen after the failed
+    # handover sees the eager (crossfade-adjusted) one
+    assert len(eager_seek_positions) == 2
+    assert eager_seek_positions[-1] == 32
+    # ... and the zero-audio skip restores the raw position afterwards
     assert skipped_streamdetails.seek_position == raw_seek_position
 
 

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -1208,6 +1208,7 @@ async def test_flow_zero_audio_skip_restores_seek_position(
     mass.player_queues.get.return_value = queue
     mass.player_queues.get_next_item.return_value = skipped_item
     mass.streams.get_crossfade_mode.return_value = CrossfadeMode.STANDARD_CROSSFADE
+    mass.streams.get_source_crossfade_mode.return_value = CrossfadeMode.DISABLED
     mass.config.get_raw_core_config_value.return_value = 8
     mass.streams.audio_processing.update_item_context = MagicMock()
     mass.player_queues.queue_buffer_completed = MagicMock()

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -1176,6 +1176,7 @@ async def test_flow_zero_audio_skip_restores_seek_position(
             has_error=False,
             is_valid=lambda *_args: True,
             duration_available=16,
+            eof=False,
             ready=SimpleNamespace(is_set=lambda: True),
         ),
         fade_in=False,

--- a/tests/controllers/streams/test_crossfade_capacity.py
+++ b/tests/controllers/streams/test_crossfade_capacity.py
@@ -318,7 +318,9 @@ async def test_crossfade_reads_its_window_past_the_resident_buffer(
     assert incoming_seconds_read > resident_media_duration
     crossfade_data = audio._crossfade_data["queue-1"]
     assert crossfade_data.queue_item_id == "next"
+    # the window is stream time, so fast playback reaches the incoming track's
+    # half-duration cap sooner: at 2x an 8s overlap would eat this whole track
+    expected_window = min(crossfade_duration, next_details.duration / playback_speed / 2)
     # the next track resumes at the media time the blend already played
-    assert crossfade_data.fade_in_media_duration == pytest.approx(
-        crossfade_duration * playback_speed
-    )
+    assert crossfade_data.fade_in_media_duration == pytest.approx(expected_window * playback_speed)
+    assert crossfade_data.fade_in_media_duration <= next_details.duration / 2

--- a/tests/controllers/streams/test_crossfade_capacity.py
+++ b/tests/controllers/streams/test_crossfade_capacity.py
@@ -35,12 +35,13 @@ def _streamdetails(audio_buffer: AudioBuffer | None) -> StreamDetails:
     return streamdetails
 
 
-def _buffer(duration_available: float, ready: bool) -> AudioBuffer:
+def _buffer(duration_available: float, ready: bool, eof: bool = False) -> AudioBuffer:
     """Build a valid buffer with the requested resident duration."""
     audio_buffer = MagicMock(spec=AudioBuffer)
     audio_buffer.has_error = False
     audio_buffer.is_valid.return_value = True
     audio_buffer.duration_available = duration_available
+    audio_buffer.eof = eof
     audio_buffer.ready = MagicMock()
     audio_buffer.ready.is_set.return_value = ready
     return audio_buffer

--- a/tests/controllers/streams/test_crossfade_capacity.py
+++ b/tests/controllers/streams/test_crossfade_capacity.py
@@ -13,7 +13,7 @@ from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.controllers.streams.audio import (
-    MIN_CROSSFADE_FALLBACK_DURATION,
+    MIN_CROSSFADE_DURATION,
     StreamsAudio,
 )
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
@@ -52,66 +52,68 @@ def _delivered_buffer() -> SimpleNamespace:
 
 
 def test_ready_incoming_buffer_keeps_smart_crossfade() -> None:
-    """A fully resident incoming buffer keeps the requested Smart Fade."""
+    """A tail that carries the full smart window keeps the requested Smart Fade."""
     audio = StreamsAudio(MagicMock())
 
     mode, duration = audio._select_buffered_crossfade(
         _streamdetails(_buffer(SMART_CROSSFADE_DURATION, ready=True)),
         CrossfadeMode.SMART_CROSSFADE,
         standard_crossfade_duration=8,
+        fade_out_seconds=SMART_CROSSFADE_DURATION,
     )
 
     assert mode == CrossfadeMode.SMART_CROSSFADE
     assert duration == SMART_CROSSFADE_DURATION
 
 
-def test_partial_incoming_buffer_degrades_to_short_standard_crossfade() -> None:
-    """Five resident seconds are crossfaded without waiting for more source PCM."""
-    audio = StreamsAudio(MagicMock())
-    available_seconds = MIN_CROSSFADE_FALLBACK_DURATION + 2
-
-    mode, duration = audio._select_buffered_crossfade(
-        _streamdetails(_buffer(available_seconds, ready=False)),
-        CrossfadeMode.SMART_CROSSFADE,
-        standard_crossfade_duration=8,
-    )
-
-    assert mode == CrossfadeMode.STANDARD_CROSSFADE
-    assert duration == available_seconds
-
-
-def test_crossfade_resident_duration_accounts_for_playback_speed() -> None:
-    """Fast playback cannot claim more post-filter overlap than resident PCM can produce."""
+def test_a_partly_resident_incoming_buffer_keeps_the_full_window() -> None:
+    """The incoming side streams in while the blend plays, so residency does not cap it."""
     audio = StreamsAudio(MagicMock())
 
     mode, duration = audio._select_buffered_crossfade(
-        _streamdetails(_buffer(8, ready=False)),
+        _streamdetails(_buffer(2, ready=True)),
         CrossfadeMode.SMART_CROSSFADE,
         standard_crossfade_duration=8,
-        playback_speed=2.0,
+        fade_out_seconds=SMART_CROSSFADE_DURATION,
     )
 
-    assert mode == CrossfadeMode.DISABLED
-    assert duration == 0
+    assert mode == CrossfadeMode.SMART_CROSSFADE
+    assert duration == SMART_CROSSFADE_DURATION
 
 
 @pytest.mark.parametrize(
     "audio_buffer",
     [
         None,
-        _buffer(MIN_CROSSFADE_FALLBACK_DURATION - 0.5, ready=False),
+        _buffer(30, ready=False),
     ],
 )
 def test_unprepared_incoming_buffer_disables_crossfade(
     audio_buffer: AudioBuffer | None,
 ) -> None:
-    """An unusable incoming buffer falls back to gapless/no-crossfade playback."""
+    """An incoming source that is not delivering yet falls back to playback without a fade."""
     audio = StreamsAudio(MagicMock())
 
     mode, duration = audio._select_buffered_crossfade(
         _streamdetails(audio_buffer),
         CrossfadeMode.SMART_CROSSFADE,
         standard_crossfade_duration=8,
+        fade_out_seconds=SMART_CROSSFADE_DURATION,
+    )
+
+    assert mode == CrossfadeMode.DISABLED
+    assert duration == 0
+
+
+def test_a_tail_below_the_minimum_disables_the_crossfade() -> None:
+    """Too short a held tail is played out instead of blended."""
+    audio = StreamsAudio(MagicMock())
+
+    mode, duration = audio._select_buffered_crossfade(
+        _streamdetails(_buffer(30, ready=True)),
+        CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+        fade_out_seconds=MIN_CROSSFADE_DURATION - 0.5,
     )
 
     assert mode == CrossfadeMode.DISABLED
@@ -202,22 +204,19 @@ async def test_unprepared_next_track_flushes_outgoing_tail_without_opening_sourc
     build.assert_not_awaited()
 
 
-@pytest.mark.parametrize(
-    ("playback_speed", "resident_media_duration"),
-    [(0.5, 2.5), (2.0, 10.0)],
-)
-async def test_partial_crossfade_resumes_at_consumed_media_time(
+@pytest.mark.parametrize("playback_speed", [0.5, 2.0])
+async def test_crossfade_reads_its_window_past_the_resident_buffer(
     monkeypatch: pytest.MonkeyPatch,
     playback_speed: float,
-    resident_media_duration: float,
 ) -> None:
-    """Crossfade output bytes resume the raw source at the matching media-time position."""
+    """The blend consumes its whole window as it arrives, and hands on the media time used."""
     pcm_format = AudioFormat(
         content_type=ContentType.PCM_S16LE,
         sample_rate=8000,
         bit_depth=16,
         channels=2,
     )
+    resident_media_duration = 2.0
     current_details = SimpleNamespace(
         duration=16,
         seek_position=0,
@@ -228,7 +227,7 @@ async def test_partial_crossfade_resumes_at_consumed_media_time(
     )
     next_details = SimpleNamespace(
         audio_format=pcm_format,
-        buffer=_buffer(resident_media_duration, ready=False),
+        buffer=_buffer(resident_media_duration, ready=True),
         duration=16,
         seek_position=0,
         uri="test://next",
@@ -264,10 +263,11 @@ async def test_partial_crossfade_resumes_at_consumed_media_time(
     audio.setup()
     audio.select_pcm_format = AsyncMock(return_value=pcm_format)  # type: ignore[method-assign]
     audio.crossfade_allowed = MagicMock(return_value=True)  # type: ignore[method-assign]
+    crossfade_duration = 8
     smart_fade = SimpleNamespace(
         timing_info=SimpleNamespace(
-            pre_crossfade_duration=3,
-            crossfade_duration=5,
+            pre_crossfade_duration=0,
+            crossfade_duration=crossfade_duration,
             fadein_trimmed_duration=0,
         )
     )
@@ -287,23 +287,22 @@ async def test_partial_crossfade_resumes_at_consumed_media_time(
             yield chunk
 
     monkeypatch.setattr(audio.smart_fades_mixer, "mix", _mix)
-    requested_beyond_resident = False
-    seek_positions: list[float | None] = []
+    incoming_seconds_read = 0
 
     async def _item_stream(
         queue_item: object,
         *_args: object,
-        **kwargs: object,
+        **_kwargs: object,
     ) -> AsyncGenerator[bytes]:
-        nonlocal requested_beyond_resident
+        nonlocal incoming_seconds_read
         if queue_item is current_item:
             yield bytes(pcm_format.pcm_sample_size * 8)
             yield bytes(pcm_format.pcm_sample_size * 8)
             return
-        seek_positions.append(cast("float | None", kwargs.get("seek_position")))
-        yield bytes(pcm_format.pcm_sample_size * MIN_CROSSFADE_FALLBACK_DURATION)
-        requested_beyond_resident = True
-        pytest.fail("Crossfade requested audio beyond the resident buffer")
+        # the incoming source keeps delivering beyond what was resident at the boundary
+        for _ in range(20):
+            incoming_seconds_read += 1
+            yield bytes(pcm_format.pcm_sample_size)
 
     monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
     stream = audio.get_queue_item_stream_with_smartfade(
@@ -311,25 +310,15 @@ async def test_partial_crossfade_resumes_at_consumed_media_time(
         cast("Any", current_item),
         pcm_format,
         crossfade_mode=CrossfadeMode.STANDARD_CROSSFADE,
-        standard_crossfade_duration=8,
+        standard_crossfade_duration=crossfade_duration,
     )
 
     _ = [chunk async for chunk in stream]
 
-    assert not requested_beyond_resident
+    assert incoming_seconds_read > resident_media_duration
     crossfade_data = audio._crossfade_data["queue-1"]
-    assert crossfade_data.fade_in_media_duration == resident_media_duration
-    assert crossfade_data.elapsed_time_offset == 5 * playback_speed
-
-    next_stream = audio.get_queue_item_stream_with_smartfade(
-        cast("Any", player),
-        cast("Any", next_item),
-        pcm_format,
-        crossfade_mode=CrossfadeMode.STANDARD_CROSSFADE,
-        standard_crossfade_duration=8,
+    assert crossfade_data.queue_item_id == "next"
+    # the next track resumes at the media time the blend already played
+    assert crossfade_data.fade_in_media_duration == pytest.approx(
+        crossfade_duration * playback_speed
     )
-    await anext(next_stream)
-    await next_stream.aclose()
-
-    assert seek_positions == [None, resident_media_duration]
-    assert next_details.seek_position == 5 * playback_speed

--- a/tests/controllers/streams/test_crossfade_transition.py
+++ b/tests/controllers/streams/test_crossfade_transition.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from collections.abc import AsyncGenerator
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
@@ -12,6 +13,7 @@ from music_assistant_models.enums import ContentType, CrossfadeMode, MediaType
 from music_assistant_models.errors import QueueEmpty
 from music_assistant_models.media_items import AudioFormat
 
+from music_assistant.controllers.streams import audio as audio_module
 from music_assistant.controllers.streams.audio import StreamsAudio
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
 from music_assistant.controllers.streams.smart_fades.fades import StandardCrossFade
@@ -510,3 +512,35 @@ async def test_flow_keeps_the_prefetch_clear_of_the_end_after_a_seek(
     # half of the 10s that remain, so the source is never read to its end in the background
     assert exhausted_at["item-1"]["item-2"] <= TEST_PCM_FORMAT.pcm_sample_size * 5 + CHUNK_SIZE
     assert opened.count("item-2") == 1
+
+
+async def test_prefetch_handover_gives_up_on_a_stalled_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A source that stopped delivering must not hold the handover open."""
+    monkeypatch.setattr(audio_module, "PREFETCH_HANDOVER_TIMEOUT", 0.1)
+    prefetcher = audio_module._IncomingFadePrefetcher(
+        cast("Any", MagicMock()), TEST_PCM_FORMAT, "session-1"
+    )
+    stalled = asyncio.Event()
+
+    async def _stalled_stream() -> AsyncGenerator[bytes]:
+        # the source went quiet: the collector blocks here, never seeing a new target
+        await stalled.wait()
+        yield b""
+
+    streamdetails = SimpleNamespace(stream_error=False)
+    queue_item = SimpleNamespace(queue_item_id="item-2", streamdetails=streamdetails)
+    stream = _stalled_stream()
+    prefetcher._queue_item_id = "item-2"
+    prefetcher._streamdetails = cast("Any", streamdetails)
+    prefetcher._seek_position = 0
+    prefetcher._stream = stream
+    prefetcher._chunks = deque()
+    prefetcher._target = TEST_PCM_FORMAT.pcm_sample_size * 45
+    prefetcher._task = asyncio.create_task(prefetcher._collect(stream, prefetcher._chunks))
+
+    # the flow stream opens the track itself rather than waiting on a dead prefetch;
+    # the timeout keeps a regression here a failure instead of a hung test run
+    async with asyncio.timeout(10):
+        assert await prefetcher.take(cast("Any", queue_item), 0) is None

--- a/tests/controllers/streams/test_crossfade_transition.py
+++ b/tests/controllers/streams/test_crossfade_transition.py
@@ -127,13 +127,17 @@ def _flow_audio(
     async def _concat_mix(
         _smart_fade: object,
         *,
-        fade_in_part: bytes,
+        fade_in_part: bytes | AsyncGenerator[bytes],
         fade_out_part: bytes,
         **_kwargs: object,
     ) -> AsyncGenerator[bytes]:
         # a lossless stand-in for the mixer, so the emitted total stays checkable
         yield fade_out_part
-        yield fade_in_part
+        if isinstance(fade_in_part, bytes):
+            yield fade_in_part
+        else:
+            async for fade_in_chunk in fade_in_part:
+                yield fade_in_chunk
 
     monkeypatch.setattr(audio.smart_fades_mixer, "mix", _concat_mix)
     return audio, queue, mass

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -28,7 +28,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.queue_item import QueueItem
 from music_assistant_models.streamdetails import StreamDetails
 
-from music_assistant.controllers.streams.audio import StreamsAudio
+from music_assistant.controllers.streams.audio import StreamsAudio, _RealtimeTailHold
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
 from music_assistant.controllers.streams.constants import BufferSize
 from music_assistant.controllers.streams.controller import StreamsController
@@ -297,24 +297,44 @@ def test_holdback_rejected_when_crossfade_buffer_size_is_zero() -> None:
     assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 0) is False
 
 
-def test_holdback_for_realtime_source_arms_only_at_eof() -> None:
-    """A realtime source's tail is held back only once the source is done delivering."""
+def test_holdback_never_arms_a_fixed_window_for_a_realtime_source() -> None:
+    """A realtime source's holdback is surplus-grown (_RealtimeTailHold), never fixed."""
     audio = StreamsAudio(MagicMock())
-    delivering = SimpleNamespace(
-        is_realtime=True, buffer=SimpleNamespace(eof=False, has_error=False, max_size_seconds=300)
-    )
-    done = SimpleNamespace(
-        is_realtime=True, buffer=SimpleNamespace(eof=True, has_error=False, max_size_seconds=300)
-    )
-    # the small-buffer exception must not apply: holding back against a
-    # still-delivering realtime source would starve the player
-    small = SimpleNamespace(
-        is_realtime=True, buffer=SimpleNamespace(eof=False, has_error=False, max_size_seconds=15)
-    )
+    for eof in (False, True):
+        streamdetails = SimpleNamespace(
+            is_realtime=True,
+            buffer=SimpleNamespace(eof=eof, has_error=False, max_size_seconds=300),
+        )
+        assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
 
-    assert audio._crossfade_holdback_allowed(cast("Any", delivering), 10) is False
-    assert audio._crossfade_holdback_allowed(cast("Any", done), 10) is True
-    assert audio._crossfade_holdback_allowed(cast("Any", small), 45) is False
+
+async def test_realtime_tail_hold_grows_with_the_banked_surplus() -> None:
+    """The holdback window covers exactly what the source delivered beyond the clock."""
+    pcm_format = TEST_PCM_FORMAT
+    frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
+    audio_buffer = SimpleNamespace(eof=False, duration_available=2.0)
+    hold = _RealtimeTailHold(pcm_format, cast("Any", audio_buffer))
+
+    # nothing arrived yet: nothing may be held
+    assert hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size) == 0
+
+    # 11s of content arrived; pretend ~4s of wall time passed since the first byte
+    hold.note_bytes(11 * pcm_format.pcm_sample_size)
+    hold._started = asyncio.get_event_loop().time() - 4.0
+    target = hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size)
+    # surplus = 11 (content) + 2 (resident) - 4 (elapsed) = 9s => capped at the window
+    assert target == 8 * pcm_format.pcm_sample_size
+    # a larger window is bounded by the surplus itself, frame-aligned
+    larger = hold.hold_target(45 * pcm_format.pcm_sample_size, frame_size)
+    assert larger % frame_size == 0
+    assert int(8.5 * pcm_format.pcm_sample_size) < larger <= 9 * pcm_format.pcm_sample_size
+
+    # once the source is done, the rest is resident: full window regardless
+    audio_buffer.eof = True
+    assert (
+        hold.hold_target(45 * pcm_format.pcm_sample_size, frame_size)
+        == 45 * pcm_format.pcm_sample_size
+    )
 
 
 def test_holdback_rejected_without_a_buffer() -> None:

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -309,7 +309,7 @@ def test_holdback_never_arms_a_fixed_window_for_a_realtime_source() -> None:
 
 
 async def test_realtime_tail_hold_grows_with_the_banked_surplus() -> None:
-    """The holdback window covers exactly what the source delivered beyond the clock."""
+    """The holdback takes half of what arrived beyond the wall clock plus a reserve."""
     pcm_format = TEST_PCM_FORMAT
     frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
     audio_buffer = SimpleNamespace(eof=False, duration_available=2.0)
@@ -318,20 +318,21 @@ async def test_realtime_tail_hold_grows_with_the_banked_surplus() -> None:
     # nothing arrived yet: nothing may be held
     assert hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size) == 0
 
-    # 22s of content arrived; pretend ~4s of wall time passed since the first byte.
-    # The 2s the buffer held at the anchor is NOT surplus (it predates the anchor);
-    # 2s more arriving into the buffer since then is.
-    hold.note_bytes(22 * pcm_format.pcm_sample_size)
+    # 27s arrived in ~4s of wall time: 27 - 4 - 3 (reserve) = 20s is spare, half
+    # of which may be held (the rest keeps growing the player's lead)
+    hold.note_bytes(27 * pcm_format.pcm_sample_size)
     hold._started = asyncio.get_event_loop().time() - 4.0
-    audio_buffer.duration_available = 4.0
     target = hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size)
-    # surplus = 22 (content) + 2 (buffer delta) - 4 (elapsed) = 20s; half of it may
-    # be held (the rest keeps growing the player's lead) => capped at the window
     assert target == 8 * pcm_format.pcm_sample_size
-    # a larger window is bounded by half the surplus, frame-aligned
     larger = hold.hold_target(45 * pcm_format.pcm_sample_size, frame_size)
     assert larger % frame_size == 0
     assert int(9.5 * pcm_format.pcm_sample_size) < larger <= 10 * pcm_format.pcm_sample_size
+
+    # barely above realtime: within the reserve nothing may be held at all
+    fresh = _RealtimeTailHold(pcm_format, cast("Any", audio_buffer))
+    fresh.note_bytes(6 * pcm_format.pcm_sample_size)
+    fresh._started = asyncio.get_event_loop().time() - 4.0
+    assert fresh.hold_target(8 * pcm_format.pcm_sample_size, frame_size) == 0
 
     # once the source is done, the rest is resident: full window regardless
     audio_buffer.eof = True

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -414,15 +414,15 @@ def test_realtime_incoming_source_climbs_the_fade_ladder_by_residency() -> None:
     )
     assert (mode, duration) == (CrossfadeMode.STANDARD_CROSSFADE, 8)
 
-    # a resident smart window (however it got there) earns the smart fade,
-    # sized by what is actually in hand rather than the full ceiling
+    # with a held tail that can carry the window, the smart fade applies and is
+    # sized by that tail: the incoming side streams in while the blend plays
     mode, duration = audio._select_buffered_crossfade(
-        _streamdetails_for_crossfade(_buffer(15, ready=True), is_realtime=True),
+        _streamdetails_for_crossfade(_buffer(2, ready=True), is_realtime=True),
         CrossfadeMode.SMART_CROSSFADE,
         standard_crossfade_duration=8,
         fade_out_seconds=20,
     )
-    assert (mode, duration) == (CrossfadeMode.SMART_CROSSFADE, 15)
+    assert (mode, duration) == (CrossfadeMode.SMART_CROSSFADE, 20)
 
     # ... but not when the outgoing tail cannot carry its half of the window
     mode, duration = audio._select_buffered_crossfade(

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -296,8 +296,8 @@ async def test_tail_hold_grows_with_the_banked_surplus() -> None:
     pcm_format = TEST_PCM_FORMAT
     frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
     audio_buffer = SimpleNamespace(eof=False, has_error=False, duration_available=2.0)
-    streamdetails = SimpleNamespace(buffer=audio_buffer)
-    hold = _TailHold(pcm_format, cast("Any", streamdetails))
+    queue_item = SimpleNamespace(streamdetails=SimpleNamespace(buffer=audio_buffer))
+    hold = _TailHold(pcm_format, cast("Any", queue_item))
 
     # nothing arrived yet: nothing may be held
     assert hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size) == 0
@@ -313,7 +313,7 @@ async def test_tail_hold_grows_with_the_banked_surplus() -> None:
     assert int(9.5 * pcm_format.pcm_sample_size) < larger <= 10 * pcm_format.pcm_sample_size
 
     # barely above realtime: within the reserve nothing may be held at all
-    fresh = _TailHold(pcm_format, cast("Any", streamdetails))
+    fresh = _TailHold(pcm_format, cast("Any", queue_item))
     fresh.note_bytes(6 * pcm_format.pcm_sample_size)
     fresh._started = asyncio.get_event_loop().time() - 4.0
     assert fresh.hold_target(8 * pcm_format.pcm_sample_size, frame_size) == 0
@@ -332,7 +332,7 @@ async def test_tail_hold_sees_a_buffer_attached_after_it_was_created() -> None:
     frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
     # the tracker is built before the stream is opened, so there is no buffer yet
     streamdetails = SimpleNamespace(buffer=None)
-    hold = _TailHold(pcm_format, cast("Any", streamdetails))
+    hold = _TailHold(pcm_format, cast("Any", SimpleNamespace(streamdetails=streamdetails)))
     hold.note_bytes(pcm_format.pcm_sample_size)
     hold._started = asyncio.get_event_loop().time()
 
@@ -345,12 +345,32 @@ async def test_tail_hold_sees_a_buffer_attached_after_it_was_created() -> None:
     )
 
 
+async def test_tail_hold_follows_a_capacity_reselection() -> None:
+    """A reselection hands the item different details; the tracker must follow them."""
+    pcm_format = TEST_PCM_FORMAT
+    frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
+    queue_item = SimpleNamespace(streamdetails=SimpleNamespace(buffer=None))
+    hold = _TailHold(pcm_format, cast("Any", queue_item))
+    hold.note_bytes(pcm_format.pcm_sample_size)
+    hold._started = asyncio.get_event_loop().time()
+
+    # the source was reselected: the item carries a different streamdetails now
+    queue_item.streamdetails = SimpleNamespace(buffer=SimpleNamespace(eof=True, has_error=False))
+
+    assert (
+        hold.hold_target(45 * pcm_format.pcm_sample_size, frame_size)
+        == 45 * pcm_format.pcm_sample_size
+    )
+
+
 async def test_tail_hold_releases_everything_for_a_failed_source() -> None:
     """A failed source is skipped without a fade, so its remaining audio is played out."""
     pcm_format = TEST_PCM_FORMAT
     frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
     audio_buffer = SimpleNamespace(eof=True, has_error=True, duration_available=30.0)
-    hold = _TailHold(pcm_format, cast("Any", SimpleNamespace(buffer=audio_buffer)))
+    hold = _TailHold(
+        pcm_format, cast("Any", SimpleNamespace(streamdetails=SimpleNamespace(buffer=audio_buffer)))
+    )
     hold.note_bytes(27 * pcm_format.pcm_sample_size)
     hold._started = asyncio.get_event_loop().time() - 4.0
 
@@ -362,7 +382,9 @@ async def test_tail_hold_forgives_a_suspended_source() -> None:
     pcm_format = TEST_PCM_FORMAT
     frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
     audio_buffer = SimpleNamespace(eof=False, has_error=False, duration_available=2.0)
-    hold = _TailHold(pcm_format, cast("Any", SimpleNamespace(buffer=audio_buffer)))
+    hold = _TailHold(
+        pcm_format, cast("Any", SimpleNamespace(streamdetails=SimpleNamespace(buffer=audio_buffer)))
+    )
 
     hold.note_bytes(27 * pcm_format.pcm_sample_size)
     hold._started = asyncio.get_event_loop().time() - 4.0
@@ -377,7 +399,9 @@ async def test_tail_hold_works_without_a_source_buffer() -> None:
     """A source without a buffer still banks a holdback out of what it delivered."""
     pcm_format = TEST_PCM_FORMAT
     frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
-    hold = _TailHold(pcm_format, cast("Any", SimpleNamespace(buffer=None)))
+    hold = _TailHold(
+        pcm_format, cast("Any", SimpleNamespace(streamdetails=SimpleNamespace(buffer=None)))
+    )
 
     hold.note_bytes(27 * pcm_format.pcm_sample_size)
     hold._started = asyncio.get_event_loop().time() - 4.0

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -134,12 +134,13 @@ async def _empty_mix(*_args: object, **_kwargs: object) -> AsyncGenerator[bytes]
         yield chunk
 
 
-def _buffer(duration_available: float, ready: bool) -> AudioBuffer:
+def _buffer(duration_available: float, ready: bool, eof: bool = False) -> AudioBuffer:
     """Build a valid buffer with the requested resident duration."""
     audio_buffer = MagicMock(spec=AudioBuffer)
     audio_buffer.has_error = False
     audio_buffer.is_valid.return_value = True
     audio_buffer.duration_available = duration_available
+    audio_buffer.eof = eof
     audio_buffer.ready = MagicMock()
     audio_buffer.ready.is_set.return_value = ready
     return audio_buffer
@@ -418,6 +419,20 @@ def test_the_held_tail_sizes_the_fade_the_configured_mode_picks() -> None:
         fade_out_seconds=20,
     )
     assert (mode, duration) == (CrossfadeMode.STANDARD_CROSSFADE, 8)
+
+
+def test_a_finished_incoming_source_caps_the_window_at_what_it_holds() -> None:
+    """A source that already ended has no more audio than what is resident."""
+    audio = StreamsAudio(MagicMock())
+
+    mode, duration = audio._select_buffered_crossfade(
+        _streamdetails_for_crossfade(_buffer(6, ready=True, eof=True), is_realtime=True),
+        CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+        fade_out_seconds=45,
+    )
+
+    assert (mode, duration) == (CrossfadeMode.SMART_CROSSFADE, 6)
 
 
 def test_a_short_incoming_track_caps_the_window() -> None:

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -295,7 +295,8 @@ async def test_tail_hold_grows_with_the_banked_surplus() -> None:
     pcm_format = TEST_PCM_FORMAT
     frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
     audio_buffer = SimpleNamespace(eof=False, has_error=False, duration_available=2.0)
-    hold = _TailHold(pcm_format, cast("Any", audio_buffer))
+    streamdetails = SimpleNamespace(buffer=audio_buffer)
+    hold = _TailHold(pcm_format, cast("Any", streamdetails))
 
     # nothing arrived yet: nothing may be held
     assert hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size) == 0
@@ -311,7 +312,7 @@ async def test_tail_hold_grows_with_the_banked_surplus() -> None:
     assert int(9.5 * pcm_format.pcm_sample_size) < larger <= 10 * pcm_format.pcm_sample_size
 
     # barely above realtime: within the reserve nothing may be held at all
-    fresh = _TailHold(pcm_format, cast("Any", audio_buffer))
+    fresh = _TailHold(pcm_format, cast("Any", streamdetails))
     fresh.note_bytes(6 * pcm_format.pcm_sample_size)
     fresh._started = asyncio.get_event_loop().time() - 4.0
     assert fresh.hold_target(8 * pcm_format.pcm_sample_size, frame_size) == 0
@@ -324,12 +325,31 @@ async def test_tail_hold_grows_with_the_banked_surplus() -> None:
     )
 
 
+async def test_tail_hold_sees_a_buffer_attached_after_it_was_created() -> None:
+    """Opening the stream is what creates the buffer, so its EOF must still be seen."""
+    pcm_format = TEST_PCM_FORMAT
+    frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
+    # the tracker is built before the stream is opened, so there is no buffer yet
+    streamdetails = SimpleNamespace(buffer=None)
+    hold = _TailHold(pcm_format, cast("Any", streamdetails))
+    hold.note_bytes(pcm_format.pcm_sample_size)
+    hold._started = asyncio.get_event_loop().time()
+
+    # a source that finished delivering releases the full window
+    streamdetails.buffer = SimpleNamespace(eof=True, has_error=False)
+
+    assert (
+        hold.hold_target(45 * pcm_format.pcm_sample_size, frame_size)
+        == 45 * pcm_format.pcm_sample_size
+    )
+
+
 async def test_tail_hold_releases_everything_for_a_failed_source() -> None:
     """A failed source is skipped without a fade, so its remaining audio is played out."""
     pcm_format = TEST_PCM_FORMAT
     frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
     audio_buffer = SimpleNamespace(eof=True, has_error=True, duration_available=30.0)
-    hold = _TailHold(pcm_format, cast("Any", audio_buffer))
+    hold = _TailHold(pcm_format, cast("Any", SimpleNamespace(buffer=audio_buffer)))
     hold.note_bytes(27 * pcm_format.pcm_sample_size)
     hold._started = asyncio.get_event_loop().time() - 4.0
 
@@ -341,7 +361,7 @@ async def test_tail_hold_forgives_a_suspended_source() -> None:
     pcm_format = TEST_PCM_FORMAT
     frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
     audio_buffer = SimpleNamespace(eof=False, has_error=False, duration_available=2.0)
-    hold = _TailHold(pcm_format, cast("Any", audio_buffer))
+    hold = _TailHold(pcm_format, cast("Any", SimpleNamespace(buffer=audio_buffer)))
 
     hold.note_bytes(27 * pcm_format.pcm_sample_size)
     hold._started = asyncio.get_event_loop().time() - 4.0
@@ -356,7 +376,7 @@ async def test_tail_hold_works_without_a_source_buffer() -> None:
     """A source without a buffer still banks a holdback out of what it delivered."""
     pcm_format = TEST_PCM_FORMAT
     frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
-    hold = _TailHold(pcm_format, None)
+    hold = _TailHold(pcm_format, cast("Any", SimpleNamespace(buffer=None)))
 
     hold.note_bytes(27 * pcm_format.pcm_sample_size)
     hold._started = asyncio.get_event_loop().time() - 4.0

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -31,7 +31,7 @@ from music_assistant_models.streamdetails import StreamDetails
 from music_assistant.controllers.streams.audio import (
     MIN_CROSSFADE_DURATION,
     StreamsAudio,
-    _RealtimeTailHold,
+    _TailHold,
 )
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
 from music_assistant.controllers.streams.constants import BufferSize
@@ -287,36 +287,15 @@ async def test_eof_reflects_producer_completion() -> None:
     assert buf.eof
 
 
-# -- StreamsAudio._crossfade_holdback_allowed --
+# -- _TailHold --
 
 
-def test_holdback_rejected_when_crossfade_buffer_size_is_zero() -> None:
-    """A zero-size crossfade buffer has nothing to hold back."""
-    audio = StreamsAudio(MagicMock())
-    streamdetails = SimpleNamespace(
-        is_realtime=False, buffer=SimpleNamespace(eof=True, has_error=False, max_size_seconds=300)
-    )
-
-    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 0) is False
-
-
-def test_holdback_never_arms_a_fixed_window_for_a_realtime_source() -> None:
-    """A realtime source's holdback is surplus-grown (_RealtimeTailHold), never fixed."""
-    audio = StreamsAudio(MagicMock())
-    for eof in (False, True):
-        streamdetails = SimpleNamespace(
-            is_realtime=True,
-            buffer=SimpleNamespace(eof=eof, has_error=False, max_size_seconds=300),
-        )
-        assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
-
-
-async def test_realtime_tail_hold_grows_with_the_banked_surplus() -> None:
+async def test_tail_hold_grows_with_the_banked_surplus() -> None:
     """The holdback takes half of what arrived beyond the wall clock plus a reserve."""
     pcm_format = TEST_PCM_FORMAT
     frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
-    audio_buffer = SimpleNamespace(eof=False, duration_available=2.0)
-    hold = _RealtimeTailHold(pcm_format, cast("Any", audio_buffer))
+    audio_buffer = SimpleNamespace(eof=False, has_error=False, duration_available=2.0)
+    hold = _TailHold(pcm_format, cast("Any", audio_buffer))
 
     # nothing arrived yet: nothing may be held
     assert hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size) == 0
@@ -332,7 +311,7 @@ async def test_realtime_tail_hold_grows_with_the_banked_surplus() -> None:
     assert int(9.5 * pcm_format.pcm_sample_size) < larger <= 10 * pcm_format.pcm_sample_size
 
     # barely above realtime: within the reserve nothing may be held at all
-    fresh = _RealtimeTailHold(pcm_format, cast("Any", audio_buffer))
+    fresh = _TailHold(pcm_format, cast("Any", audio_buffer))
     fresh.note_bytes(6 * pcm_format.pcm_sample_size)
     fresh._started = asyncio.get_event_loop().time() - 4.0
     assert fresh.hold_target(8 * pcm_format.pcm_sample_size, frame_size) == 0
@@ -345,65 +324,44 @@ async def test_realtime_tail_hold_grows_with_the_banked_surplus() -> None:
     )
 
 
-def test_holdback_rejected_without_a_buffer() -> None:
-    """A source with no buffer yet has nothing to hold back."""
-    audio = StreamsAudio(MagicMock())
-    streamdetails = SimpleNamespace(is_realtime=False, buffer=None)
+async def test_tail_hold_releases_everything_for_a_failed_source() -> None:
+    """A failed source is skipped without a fade, so its remaining audio is played out."""
+    pcm_format = TEST_PCM_FORMAT
+    frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
+    audio_buffer = SimpleNamespace(eof=True, has_error=True, duration_available=30.0)
+    hold = _TailHold(pcm_format, cast("Any", audio_buffer))
+    hold.note_bytes(27 * pcm_format.pcm_sample_size)
+    hold._started = asyncio.get_event_loop().time() - 4.0
 
-    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
-
-
-def test_holdback_rejected_before_source_reaches_eof() -> None:
-    """A still-filling buffer keeps limiting playback, so its tail is not held back yet."""
-    audio = StreamsAudio(MagicMock())
-    streamdetails = SimpleNamespace(
-        is_realtime=False, buffer=SimpleNamespace(eof=False, has_error=False, max_size_seconds=300)
-    )
-
-    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
+    assert hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size) == 0
 
 
-def test_holdback_allowed_once_source_reaches_eof() -> None:
-    """A fully delivered, non-realtime source may hold back its tail for a crossfade."""
-    audio = StreamsAudio(MagicMock())
-    streamdetails = SimpleNamespace(
-        is_realtime=False, buffer=SimpleNamespace(eof=True, has_error=False, max_size_seconds=300)
-    )
+async def test_tail_hold_forgives_a_suspended_source() -> None:
+    """A pause is not elapsed listening, so it does not erase the banked surplus."""
+    pcm_format = TEST_PCM_FORMAT
+    frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
+    audio_buffer = SimpleNamespace(eof=False, has_error=False, duration_available=2.0)
+    hold = _TailHold(pcm_format, cast("Any", audio_buffer))
 
-    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is True
+    hold.note_bytes(27 * pcm_format.pcm_sample_size)
+    hold._started = asyncio.get_event_loop().time() - 4.0
+    # the source went quiet for a while, then resumed
+    hold._last_noted = asyncio.get_event_loop().time() - 30.0
+    hold.note_bytes(pcm_format.pcm_sample_size)
 
-
-def test_holdback_rejected_for_a_failed_source() -> None:
-    """A source that failed is skipped without a fade, so its tail is played out instead."""
-    audio = StreamsAudio(MagicMock())
-    streamdetails = SimpleNamespace(
-        is_realtime=False,
-        buffer=SimpleNamespace(eof=True, has_error=True, max_size_seconds=300),
-    )
-
-    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
+    assert hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size) > 0
 
 
-def test_holdback_allowed_when_the_buffer_can_never_hold_the_tail() -> None:
-    """A buffer smaller than the tail collects it while the source runs, or loses the fade."""
-    audio = StreamsAudio(MagicMock())
-    streamdetails = SimpleNamespace(
-        is_realtime=False, buffer=SimpleNamespace(eof=False, has_error=False, max_size_seconds=15)
-    )
+async def test_tail_hold_works_without_a_source_buffer() -> None:
+    """A source without a buffer still banks a holdback out of what it delivered."""
+    pcm_format = TEST_PCM_FORMAT
+    frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
+    hold = _TailHold(pcm_format, None)
 
-    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 45) is True
-    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
+    hold.note_bytes(27 * pcm_format.pcm_sample_size)
+    hold._started = asyncio.get_event_loop().time() - 4.0
 
-
-def test_holdback_capacity_accounts_for_playback_speed() -> None:
-    """Buffer capacity is source time, so faster playback leaves fewer seconds to fade with."""
-    audio = StreamsAudio(MagicMock())
-    streamdetails = SimpleNamespace(
-        is_realtime=False, buffer=SimpleNamespace(eof=False, has_error=False, max_size_seconds=60)
-    )
-
-    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 45) is False
-    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 45, 2.0) is True
+    assert hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size) > 0
 
 
 # -- StreamsAudio._select_buffered_crossfade --
@@ -586,10 +544,10 @@ async def test_smartfade_realtime_current_item_fades_once_its_source_is_done(
     assert crossfade_data.queue_item_id == "next"
 
 
-async def test_smartfade_still_filling_buffer_yields_all_audio_without_crossfade(
+async def test_smartfade_still_filling_source_fades_from_what_it_banked(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A non-realtime source that has not yet reached EOF is also never held back for a fade."""
+    """A source still delivering fades from the audio it banked ahead of playback."""
     pcm_format = AudioFormat(
         content_type=ContentType.PCM_S16LE,
         sample_rate=8000,
@@ -610,6 +568,7 @@ async def test_smartfade_still_filling_buffer_yields_all_audio_without_crossfade
         duration=16,
         seek_position=0,
         uri="test://next",
+        volume_normalization_mode=None,
         is_realtime=False,
     )
     current_item = SimpleNamespace(
@@ -639,20 +598,41 @@ async def test_smartfade_still_filling_buffer_yields_all_audio_without_crossfade
     mass.player_queues.index_by_id.return_value = 1
     audio = StreamsAudio(cast("Any", mass))
     audio.setup()
-    build = AsyncMock()
+    audio.select_pcm_format = AsyncMock(return_value=pcm_format)  # type: ignore[method-assign]
+    audio.crossfade_allowed = MagicMock(return_value=True)  # type: ignore[method-assign]
+    build = AsyncMock(
+        return_value=SimpleNamespace(
+            timing_info=SimpleNamespace(
+                fadein_trimmed_duration=0.0,
+                crossfade_duration=8.0,
+                pre_crossfade_duration=0.0,
+            )
+        )
+    )
     monkeypatch.setattr(audio.smart_fades_mixer, "build", build)
 
-    async def _current_stream(
-        queue_item: object,
+    async def _concat_mix(
+        _smart_fade: object,
+        *,
+        fade_in_part: AsyncGenerator[bytes],
+        fade_out_part: bytes,
+        **_kwargs: object,
+    ) -> AsyncGenerator[bytes]:
+        yield fade_out_part
+        async for fade_in_chunk in fade_in_part:
+            yield fade_in_chunk
+
+    monkeypatch.setattr(audio.smart_fades_mixer, "mix", _concat_mix)
+
+    async def _item_stream(
+        _queue_item: object,
         *_args: object,
         **_kwargs: object,
     ) -> AsyncGenerator[bytes]:
-        if queue_item is not current_item:
-            pytest.fail("The incoming source was opened while the current buffer was still open")
         yield bytes(pcm_format.pcm_sample_size * 8)
         yield bytes(pcm_format.pcm_sample_size * 8)
 
-    monkeypatch.setattr(audio, "get_queue_item_stream", _current_stream)
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
     stream = audio.get_queue_item_stream_with_smartfade(
         cast("Any", player),
         cast("Any", current_item),
@@ -663,9 +643,13 @@ async def test_smartfade_still_filling_buffer_yields_all_audio_without_crossfade
 
     output = b"".join([chunk async for chunk in stream])
 
-    assert len(output) == pcm_format.pcm_sample_size * 16
-    build.assert_not_awaited()
-    assert "queue-1" not in audio._crossfade_data
+    # how much tail the holdback banked depends on the wall clock, so only the
+    # invariants are asserted: the source's own audio is all there, and it faded
+    assert len(output) >= pcm_format.pcm_sample_size * 16
+    build.assert_awaited_once()
+    crossfade_data = audio._crossfade_data.get("queue-1")
+    assert crossfade_data is not None
+    assert crossfade_data.queue_item_id == "next"
 
 
 # -- Path level: get_queue_flow_stream --

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -318,12 +318,15 @@ async def test_realtime_tail_hold_grows_with_the_banked_surplus() -> None:
     # nothing arrived yet: nothing may be held
     assert hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size) == 0
 
-    # 22s of content arrived; pretend ~4s of wall time passed since the first byte
+    # 22s of content arrived; pretend ~4s of wall time passed since the first byte.
+    # The 2s the buffer held at the anchor is NOT surplus (it predates the anchor);
+    # 2s more arriving into the buffer since then is.
     hold.note_bytes(22 * pcm_format.pcm_sample_size)
     hold._started = asyncio.get_event_loop().time() - 4.0
+    audio_buffer.duration_available = 4.0
     target = hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size)
-    # surplus = 22 (content) + 2 (resident) - 4 (elapsed) = 20s; half of it may be
-    # held (the rest keeps growing the player's lead) => capped at the window
+    # surplus = 22 (content) + 2 (buffer delta) - 4 (elapsed) = 20s; half of it may
+    # be held (the rest keeps growing the player's lead) => capped at the window
     assert target == 8 * pcm_format.pcm_sample_size
     # a larger window is bounded by half the surplus, frame-aligned
     larger = hold.hold_target(45 * pcm_format.pcm_sample_size, frame_size)
@@ -467,7 +470,9 @@ async def test_smartfade_realtime_current_item_fades_once_its_source_is_done(
         seek_position=0,
         seconds_streamed=0,
         uri="test://current",
-        buffer=SimpleNamespace(eof=True, cancelled=False, has_error=False, max_size_seconds=300),
+        buffer=SimpleNamespace(
+            eof=True, cancelled=False, has_error=False, max_size_seconds=300, duration_available=0.0
+        ),
         is_realtime=True,
     )
     next_details = SimpleNamespace(

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -318,16 +318,17 @@ async def test_realtime_tail_hold_grows_with_the_banked_surplus() -> None:
     # nothing arrived yet: nothing may be held
     assert hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size) == 0
 
-    # 11s of content arrived; pretend ~4s of wall time passed since the first byte
-    hold.note_bytes(11 * pcm_format.pcm_sample_size)
+    # 22s of content arrived; pretend ~4s of wall time passed since the first byte
+    hold.note_bytes(22 * pcm_format.pcm_sample_size)
     hold._started = asyncio.get_event_loop().time() - 4.0
     target = hold.hold_target(8 * pcm_format.pcm_sample_size, frame_size)
-    # surplus = 11 (content) + 2 (resident) - 4 (elapsed) = 9s => capped at the window
+    # surplus = 22 (content) + 2 (resident) - 4 (elapsed) = 20s; half of it may be
+    # held (the rest keeps growing the player's lead) => capped at the window
     assert target == 8 * pcm_format.pcm_sample_size
-    # a larger window is bounded by the surplus itself, frame-aligned
+    # a larger window is bounded by half the surplus, frame-aligned
     larger = hold.hold_target(45 * pcm_format.pcm_sample_size, frame_size)
     assert larger % frame_size == 0
-    assert int(8.5 * pcm_format.pcm_sample_size) < larger <= 9 * pcm_format.pcm_sample_size
+    assert int(9.5 * pcm_format.pcm_sample_size) < larger <= 10 * pcm_format.pcm_sample_size
 
     # once the source is done, the rest is resident: full window regardless
     audio_buffer.eof = True
@@ -401,20 +402,36 @@ def test_holdback_capacity_accounts_for_playback_speed() -> None:
 # -- StreamsAudio._select_buffered_crossfade --
 
 
-def test_realtime_incoming_source_gets_a_standard_fade_once_delivering() -> None:
-    """A delivering realtime source gets the standard overlap; smart needs its full window."""
+def test_realtime_incoming_source_climbs_the_fade_ladder_by_residency() -> None:
+    """What is resident picks the rung: smart with the window in hand, standard without."""
     audio = StreamsAudio(MagicMock())
 
+    # barely delivering: the streaming standard mix covers the overlap as it arrives
     mode, duration = audio._select_buffered_crossfade(
-        _streamdetails_for_crossfade(
-            _buffer(SMART_CROSSFADE_DURATION, ready=True), is_realtime=True
-        ),
+        _streamdetails_for_crossfade(_buffer(2, ready=True), is_realtime=True),
         CrossfadeMode.SMART_CROSSFADE,
         standard_crossfade_duration=8,
     )
+    assert (mode, duration) == (CrossfadeMode.STANDARD_CROSSFADE, 8)
 
-    assert mode == CrossfadeMode.STANDARD_CROSSFADE
-    assert duration == 8
+    # a resident smart window (however it got there) earns the smart fade,
+    # sized by what is actually in hand rather than the full ceiling
+    mode, duration = audio._select_buffered_crossfade(
+        _streamdetails_for_crossfade(_buffer(15, ready=True), is_realtime=True),
+        CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+        fade_out_seconds=20,
+    )
+    assert (mode, duration) == (CrossfadeMode.SMART_CROSSFADE, 15)
+
+    # ... but not when the outgoing tail cannot carry its half of the window
+    mode, duration = audio._select_buffered_crossfade(
+        _streamdetails_for_crossfade(_buffer(15, ready=True), is_realtime=True),
+        CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+        fade_out_seconds=6,
+    )
+    assert (mode, duration) == (CrossfadeMode.STANDARD_CROSSFADE, 8)
 
 
 def test_realtime_incoming_source_not_yet_delivering_skips_the_fade() -> None:

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -297,14 +297,24 @@ def test_holdback_rejected_when_crossfade_buffer_size_is_zero() -> None:
     assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 0) is False
 
 
-def test_holdback_rejected_for_realtime_source() -> None:
-    """A realtime source's tail is never held back, even once its buffer reaches EOF."""
+def test_holdback_for_realtime_source_arms_only_at_eof() -> None:
+    """A realtime source's tail is held back only once the source is done delivering."""
     audio = StreamsAudio(MagicMock())
-    streamdetails = SimpleNamespace(
+    delivering = SimpleNamespace(
+        is_realtime=True, buffer=SimpleNamespace(eof=False, has_error=False, max_size_seconds=300)
+    )
+    done = SimpleNamespace(
         is_realtime=True, buffer=SimpleNamespace(eof=True, has_error=False, max_size_seconds=300)
     )
+    # the small-buffer exception must not apply: holding back against a
+    # still-delivering realtime source would starve the player
+    small = SimpleNamespace(
+        is_realtime=True, buffer=SimpleNamespace(eof=False, has_error=False, max_size_seconds=15)
+    )
 
-    assert audio._crossfade_holdback_allowed(cast("Any", streamdetails), 10) is False
+    assert audio._crossfade_holdback_allowed(cast("Any", delivering), 10) is False
+    assert audio._crossfade_holdback_allowed(cast("Any", done), 10) is True
+    assert audio._crossfade_holdback_allowed(cast("Any", small), 45) is False
 
 
 def test_holdback_rejected_without_a_buffer() -> None:
@@ -371,8 +381,8 @@ def test_holdback_capacity_accounts_for_playback_speed() -> None:
 # -- StreamsAudio._select_buffered_crossfade --
 
 
-def test_realtime_incoming_source_disables_crossfade_even_when_ready() -> None:
-    """A realtime incoming source never gets a fade-in, no matter how ready its buffer is."""
+def test_realtime_incoming_source_gets_a_standard_fade_once_delivering() -> None:
+    """A delivering realtime source gets the standard overlap; smart needs its full window."""
     audio = StreamsAudio(MagicMock())
 
     mode, duration = audio._select_buffered_crossfade(
@@ -383,6 +393,20 @@ def test_realtime_incoming_source_disables_crossfade_even_when_ready() -> None:
         standard_crossfade_duration=8,
     )
 
+    assert mode == CrossfadeMode.STANDARD_CROSSFADE
+    assert duration == 8
+
+
+def test_realtime_incoming_source_not_yet_delivering_skips_the_fade() -> None:
+    """A realtime source whose buffer is not ready yet means the boundary plays clean."""
+    audio = StreamsAudio(MagicMock())
+
+    mode, duration = audio._select_buffered_crossfade(
+        _streamdetails_for_crossfade(_buffer(0, ready=False), is_realtime=True),
+        CrossfadeMode.STANDARD_CROSSFADE,
+        standard_crossfade_duration=8,
+    )
+
     assert mode == CrossfadeMode.DISABLED
     assert duration == 0
 
@@ -390,17 +414,17 @@ def test_realtime_incoming_source_disables_crossfade_even_when_ready() -> None:
 # -- Path level: get_queue_item_stream_with_smartfade --
 
 
-async def test_smartfade_realtime_current_item_yields_all_audio_without_crossfade(
+async def test_smartfade_realtime_current_item_fades_once_its_source_is_done(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A realtime current item streams straight through; nothing is held back for a fade."""
+    """A realtime item whose source finished delivering holds its tail and fades."""
     pcm_format = AudioFormat(
         content_type=ContentType.PCM_S16LE,
         sample_rate=8000,
         bit_depth=16,
         channels=2,
     )
-    # the source is done delivering, so only the realtime flag can deny the holdback
+    # the source is done delivering, which is what arms the realtime holdback
     current_details = SimpleNamespace(
         duration=16,
         seek_position=0,
@@ -409,8 +433,6 @@ async def test_smartfade_realtime_current_item_yields_all_audio_without_crossfad
         buffer=SimpleNamespace(eof=True, cancelled=False, has_error=False, max_size_seconds=300),
         is_realtime=True,
     )
-    # a fully resident, ready incoming buffer - the realtime flag on the outgoing
-    # track must be what blocks the fade, not an unprepared next item
     next_details = SimpleNamespace(
         audio_format=pcm_format,
         buffer=_buffer(SMART_CROSSFADE_DURATION, ready=True),
@@ -418,6 +440,7 @@ async def test_smartfade_realtime_current_item_yields_all_audio_without_crossfad
         seek_position=0,
         uri="test://next",
         is_realtime=False,
+        volume_normalization_mode=None,
     )
     current_item = SimpleNamespace(
         queue_id="queue-1",
@@ -446,20 +469,41 @@ async def test_smartfade_realtime_current_item_yields_all_audio_without_crossfad
     mass.player_queues.index_by_id.return_value = 1
     audio = StreamsAudio(cast("Any", mass))
     audio.setup()
-    build = AsyncMock()
+    audio.select_pcm_format = AsyncMock(return_value=pcm_format)  # type: ignore[method-assign]
+    audio.crossfade_allowed = MagicMock(return_value=True)  # type: ignore[method-assign]
+    build = AsyncMock(
+        return_value=SimpleNamespace(
+            timing_info=SimpleNamespace(
+                fadein_trimmed_duration=0.0,
+                crossfade_duration=8.0,
+                pre_crossfade_duration=0.0,
+            )
+        )
+    )
     monkeypatch.setattr(audio.smart_fades_mixer, "build", build)
 
-    async def _current_stream(
-        queue_item: object,
+    async def _concat_mix(
+        _smart_fade: object,
+        *,
+        fade_in_part: AsyncGenerator[bytes],
+        fade_out_part: bytes,
+        **_kwargs: object,
+    ) -> AsyncGenerator[bytes]:
+        yield fade_out_part
+        async for fade_in_chunk in fade_in_part:
+            yield fade_in_chunk
+
+    monkeypatch.setattr(audio.smart_fades_mixer, "mix", _concat_mix)
+
+    async def _item_stream(
+        _queue_item: object,
         *_args: object,
         **_kwargs: object,
     ) -> AsyncGenerator[bytes]:
-        if queue_item is not current_item:
-            pytest.fail("The incoming source was opened while the current item was realtime")
         yield bytes(pcm_format.pcm_sample_size * 8)
         yield bytes(pcm_format.pcm_sample_size * 8)
 
-    monkeypatch.setattr(audio, "get_queue_item_stream", _current_stream)
+    monkeypatch.setattr(audio, "get_queue_item_stream", _item_stream)
     stream = audio.get_queue_item_stream_with_smartfade(
         cast("Any", player),
         cast("Any", current_item),
@@ -470,9 +514,13 @@ async def test_smartfade_realtime_current_item_yields_all_audio_without_crossfad
 
     output = b"".join([chunk async for chunk in stream])
 
+    # 8s warmup + 8s of mix output (pre+overlap); the incoming share of the mix
+    # is buffered as crossfade data for the next item's own stream
     assert len(output) == pcm_format.pcm_sample_size * 16
-    build.assert_not_awaited()
-    assert "queue-1" not in audio._crossfade_data
+    build.assert_awaited_once()
+    crossfade_data = audio._crossfade_data.get("queue-1")
+    assert crossfade_data is not None
+    assert crossfade_data.queue_item_id == "next"
 
 
 async def test_smartfade_still_filling_buffer_yields_all_audio_without_crossfade(
@@ -1181,9 +1229,21 @@ def _single_item_handler(*, is_realtime: bool) -> tuple[Any, MagicMock, dict[str
     return controller, request, seen
 
 
-async def test_single_item_handler_skips_crossfade_for_a_realtime_item() -> None:
-    """A realtime item is never steered into the crossfaded single-item stream."""
+async def test_single_item_handler_keeps_crossfade_for_a_realtime_item() -> None:
+    """A realtime item whose source does not fade keeps the queue's crossfade."""
     controller, request, seen = _single_item_handler(is_realtime=True)
+
+    with pytest.raises(_PcmFormatRequested):
+        await controller.serve_queue_item_stream(request)
+
+    assert seen["crossfade_enabled"] is True
+    controller.get_crossfade_mode.assert_called_once()
+
+
+async def test_single_item_handler_steps_aside_for_a_source_that_fades() -> None:
+    """An item whose own source fades its boundaries is served without an MA fade."""
+    controller, request, seen = _single_item_handler(is_realtime=True)
+    controller.get_source_crossfade_mode = MagicMock(return_value=CrossfadeMode.SOURCE)
 
     with pytest.raises(_PcmFormatRequested):
         await controller.serve_queue_item_stream(request)

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -188,9 +188,9 @@ def _queue_item_with_mapping(media_item_cls: type) -> QueueItem:
     [
         pytest.param(True, False, None, MediaType.RADIO, 1, id="realtime_base"),
         pytest.param(True, False, None, MediaType.AUDIO_SOURCE, 1, id="realtime_audio_source"),
-        # the queue's crossfade setting buys nothing for a realtime source: MA's own
-        # crossfade is force-disabled for one, so a second of audio here would only
-        # be a second of extra startup delay
+        # the queue's crossfade setting buys nothing for a realtime source: its fade
+        # streams in as it arrives, so a second of audio here would only be a second
+        # of extra startup delay
         pytest.param(True, True, None, MediaType.TRACK, 1, id="realtime_crossfade"),
         pytest.param(
             True,
@@ -398,6 +398,22 @@ def test_the_held_tail_sizes_the_fade_the_configured_mode_picks() -> None:
         fade_out_seconds=20,
     )
     assert (mode, duration) == (CrossfadeMode.STANDARD_CROSSFADE, 8)
+
+
+def test_a_short_incoming_track_caps_the_window() -> None:
+    """A long tail cannot claim more overlap than the next track can supply."""
+    audio = StreamsAudio(MagicMock())
+    streamdetails = _streamdetails_for_crossfade(_buffer(2, ready=True), is_realtime=True)
+    streamdetails.duration = 20
+
+    mode, duration = audio._select_buffered_crossfade(
+        streamdetails,
+        CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+        fade_out_seconds=45,
+    )
+
+    assert (mode, duration) == (CrossfadeMode.SMART_CROSSFADE, 10)
 
 
 def test_a_tail_too_short_to_blend_skips_the_fade() -> None:

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -28,7 +28,11 @@ from music_assistant_models.media_items import (
 from music_assistant_models.queue_item import QueueItem
 from music_assistant_models.streamdetails import StreamDetails
 
-from music_assistant.controllers.streams.audio import StreamsAudio, _RealtimeTailHold
+from music_assistant.controllers.streams.audio import (
+    MIN_CROSSFADE_DURATION,
+    StreamsAudio,
+    _RealtimeTailHold,
+)
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
 from music_assistant.controllers.streams.constants import BufferSize
 from music_assistant.controllers.streams.controller import StreamsController
@@ -405,20 +409,12 @@ def test_holdback_capacity_accounts_for_playback_speed() -> None:
 # -- StreamsAudio._select_buffered_crossfade --
 
 
-def test_realtime_incoming_source_climbs_the_fade_ladder_by_residency() -> None:
-    """What is resident picks the rung: smart with the window in hand, standard without."""
+def test_the_held_tail_sizes_the_fade_the_configured_mode_picks() -> None:
+    """The mode decides which fade is applied; the held tail only sizes its window."""
     audio = StreamsAudio(MagicMock())
 
-    # barely delivering: the streaming standard mix covers the overlap as it arrives
-    mode, duration = audio._select_buffered_crossfade(
-        _streamdetails_for_crossfade(_buffer(2, ready=True), is_realtime=True),
-        CrossfadeMode.SMART_CROSSFADE,
-        standard_crossfade_duration=8,
-    )
-    assert (mode, duration) == (CrossfadeMode.STANDARD_CROSSFADE, 8)
-
-    # with a held tail that can carry the window, the smart fade applies and is
-    # sized by that tail: the incoming side streams in while the blend plays
+    # a realtime source barely delivers, yet the tail it banked carries the window:
+    # the incoming side streams in while the blend plays
     mode, duration = audio._select_buffered_crossfade(
         _streamdetails_for_crossfade(_buffer(2, ready=True), is_realtime=True),
         CrossfadeMode.SMART_CROSSFADE,
@@ -427,14 +423,38 @@ def test_realtime_incoming_source_climbs_the_fade_ladder_by_residency() -> None:
     )
     assert (mode, duration) == (CrossfadeMode.SMART_CROSSFADE, 20)
 
-    # ... but not when the outgoing tail cannot carry its half of the window
+    # a shorter tail keeps the smart fade, on a shorter window
     mode, duration = audio._select_buffered_crossfade(
-        _streamdetails_for_crossfade(_buffer(15, ready=True), is_realtime=True),
+        _streamdetails_for_crossfade(_buffer(2, ready=True), is_realtime=True),
         CrossfadeMode.SMART_CROSSFADE,
         standard_crossfade_duration=8,
         fade_out_seconds=6,
     )
+    assert (mode, duration) == (CrossfadeMode.SMART_CROSSFADE, 6)
+
+    # a standard fade never exceeds the configured overlap
+    mode, duration = audio._select_buffered_crossfade(
+        _streamdetails_for_crossfade(_buffer(2, ready=True), is_realtime=True),
+        CrossfadeMode.STANDARD_CROSSFADE,
+        standard_crossfade_duration=8,
+        fade_out_seconds=20,
+    )
     assert (mode, duration) == (CrossfadeMode.STANDARD_CROSSFADE, 8)
+
+
+def test_a_tail_too_short_to_blend_skips_the_fade() -> None:
+    """Below the minimum overlap the tail plays out and the boundary is a hard cut."""
+    audio = StreamsAudio(MagicMock())
+
+    mode, duration = audio._select_buffered_crossfade(
+        _streamdetails_for_crossfade(_buffer(20, ready=True), is_realtime=True),
+        CrossfadeMode.SMART_CROSSFADE,
+        standard_crossfade_duration=8,
+        fade_out_seconds=MIN_CROSSFADE_DURATION - 0.5,
+    )
+
+    assert mode == CrossfadeMode.DISABLED
+    assert duration == 0
 
 
 def test_realtime_incoming_source_not_yet_delivering_skips_the_fade() -> None:
@@ -445,6 +465,7 @@ def test_realtime_incoming_source_not_yet_delivering_skips_the_fade() -> None:
         _streamdetails_for_crossfade(_buffer(0, ready=False), is_realtime=True),
         CrossfadeMode.STANDARD_CROSSFADE,
         standard_crossfade_duration=8,
+        fade_out_seconds=8,
     )
 
     assert mode == CrossfadeMode.DISABLED

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -34,7 +34,6 @@ from music_assistant.controllers.streams.constants import BufferSize
 from music_assistant.controllers.streams.controller import StreamsController
 from music_assistant.controllers.streams.smart_fades.fades import StandardCrossFade
 from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
-from music_assistant.models.music_provider import MusicProvider
 
 # Standard test PCM format: 44100Hz, 16-bit, stereo
 TEST_PCM_FORMAT = AudioFormat(
@@ -1016,16 +1015,14 @@ async def test_smartfade_stub_remainder_does_not_crossfade(
     build.assert_not_awaited()
 
 
-@pytest.mark.parametrize("source_crossfade_mode", [CrossfadeMode.DISABLED, CrossfadeMode.SOURCE])
-async def test_flow_reports_the_crossfade_a_realtime_item_really_gets(
+async def test_flow_reports_no_fade_for_a_realtime_item_until_one_renders(
     monkeypatch: pytest.MonkeyPatch,
-    source_crossfade_mode: CrossfadeMode,
 ) -> None:
     """
-    A realtime item is credited with its source's fade, never one of ours.
+    A realtime item is not credited with any fade up front.
 
-    Music Assistant has no audio to spare for an overlap on either side of such an
-    item, so the only fade it can report is the one the source applies itself.
+    A fade is only reported once one is really rendered at its boundary; the
+    source-delegation reporting is gone along with the delegation itself.
     """
     pcm_format = AudioFormat(
         content_type=ContentType.PCM_S16LE,
@@ -1068,7 +1065,6 @@ async def test_flow_reports_the_crossfade_a_realtime_item_really_gets(
     mass.player_queues.load_next_queue_item = AsyncMock(side_effect=QueueEmpty)
     mass.player_queues.get.return_value = queue
     mass.streams.get_crossfade_mode.return_value = CrossfadeMode.SMART_CROSSFADE
-    mass.streams.get_source_crossfade_mode.return_value = source_crossfade_mode
     mass.config.get_raw_core_config_value.return_value = 8
     update_item_context = MagicMock()
     mass.streams.audio_processing.update_item_context = update_item_context
@@ -1092,7 +1088,7 @@ async def test_flow_reports_the_crossfade_a_realtime_item_really_gets(
 
     update_item_context.assert_called()
     reported = update_item_context.call_args.kwargs["queue_processing"]
-    assert reported.crossfade_mode == source_crossfade_mode
+    assert reported.crossfade_mode == CrossfadeMode.DISABLED
 
 
 async def test_flow_standard_fade_only_holds_back_its_overlap(
@@ -1283,18 +1279,6 @@ async def test_single_item_handler_keeps_crossfade_for_a_realtime_item() -> None
     controller.get_crossfade_mode.assert_called_once()
 
 
-async def test_single_item_handler_steps_aside_for_a_source_that_fades() -> None:
-    """An item whose own source fades its boundaries is served without an MA fade."""
-    controller, request, seen = _single_item_handler(is_realtime=True)
-    controller.get_source_crossfade_mode = MagicMock(return_value=CrossfadeMode.SOURCE)
-
-    with pytest.raises(_PcmFormatRequested):
-        await controller.serve_queue_item_stream(request)
-
-    assert seen["crossfade_enabled"] is False
-    controller.get_crossfade_mode.assert_not_called()
-
-
 async def test_single_item_handler_keeps_crossfade_for_a_buffered_item() -> None:
     """A buffered item still gets the queue's configured crossfade."""
     controller, request, seen = _single_item_handler(is_realtime=False)
@@ -1304,317 +1288,6 @@ async def test_single_item_handler_keeps_crossfade_for_a_buffered_item() -> None
 
     assert seen["crossfade_enabled"] is True
     controller.get_crossfade_mode.assert_called_once()
-
-
-# -- StreamsController.get_source_crossfade_mode --
-
-
-class _CrossfadingProvider(MusicProvider):
-    """A music provider whose running source crossfades this item's boundary."""
-
-    def delivers_crossfaded_audio(self, streamdetails: StreamDetails) -> bool | None:
-        """Declare the source fade."""
-        return True
-
-
-class _NonCrossfadingServingProvider(MusicProvider):
-    """A music provider serving this item, whose session fades neither of its boundaries."""
-
-    def delivers_crossfaded_audio(self, streamdetails: StreamDetails) -> bool | None:
-        """Deny the source fade for this item."""
-        return False
-
-
-class _UndecidedCrossfadingProvider(MusicProvider):
-    """A music provider that can crossfade its own playback but serves nothing yet."""
-
-    def delivers_crossfaded_audio(self, streamdetails: StreamDetails) -> bool | None:
-        """Leave the answer to the queue's own setting."""
-        return None
-
-
-@pytest.mark.parametrize(
-    ("queue_crossfade_mode", "provider", "expected"),
-    [
-        # with no session running the queue preference is all there is to go on
-        (
-            CrossfadeMode.DISABLED,
-            object.__new__(_UndecidedCrossfadingProvider),
-            CrossfadeMode.DISABLED,
-        ),
-        (
-            CrossfadeMode.SMART_CROSSFADE,
-            object.__new__(_UndecidedCrossfadingProvider),
-            CrossfadeMode.SOURCE,
-        ),
-        # a running source answers for itself, whatever the setting says now
-        (
-            CrossfadeMode.DISABLED,
-            object.__new__(_CrossfadingProvider),
-            CrossfadeMode.SOURCE,
-        ),
-        # a provider that does not fade its own playback, and a plugin-served item
-        (CrossfadeMode.SMART_CROSSFADE, object.__new__(MusicProvider), CrossfadeMode.DISABLED),
-        (CrossfadeMode.SMART_CROSSFADE, None, CrossfadeMode.DISABLED),
-    ],
-)
-def test_only_a_declared_source_fade_is_reported_as_such(
-    queue_crossfade_mode: CrossfadeMode,
-    provider: Any,
-    expected: CrossfadeMode,
-) -> None:
-    """Only a provider that says it crossfades its own playback is credited with one."""
-    controller = _source_crossfade_controller(provider, queue_crossfade_mode)
-
-    assert controller.get_source_crossfade_mode(MagicMock(), _realtime_track()) == expected
-
-
-@pytest.mark.parametrize(
-    ("media_type", "is_realtime"),
-    [
-        # our own mixer owns both of these, so the source's fade is not in play
-        (MediaType.TRACK, False),
-        (MediaType.AUDIOBOOK, True),
-    ],
-)
-def test_no_source_fade_for_audio_we_mix_ourselves(
-    media_type: MediaType, is_realtime: bool
-) -> None:
-    """A source fade is only reported for audio Music Assistant does not mix."""
-    controller = _source_crossfade_controller(
-        object.__new__(_CrossfadingProvider), CrossfadeMode.SMART_CROSSFADE
-    )
-    controller.mass.player_queues.get_next_item.return_value = _follower("same-provider")
-    queue_item = SimpleNamespace(
-        queue_item_id="item-1",
-        media_type=media_type,
-        streamdetails=_make_stream_details(media_type, is_realtime=is_realtime),
-    )
-
-    assert controller.get_source_crossfade_mode(MagicMock(), queue_item) == CrossfadeMode.DISABLED
-
-
-@pytest.mark.parametrize(
-    ("neighbour_kind", "expected"),
-    [
-        # a boundary the source owns both sides of, as a provider item and as a
-        # library item that carries the source in its mappings instead
-        ("same-provider", CrossfadeMode.SOURCE),
-        ("library-mapped", CrossfadeMode.SOURCE),
-        # nothing next to it, so there is no boundary at all
-        ("none", CrossfadeMode.DISABLED),
-        # the source plays the current item out at any of these, so the cut is hard
-        ("other-provider", CrossfadeMode.DISABLED),
-        ("not-a-track", CrossfadeMode.DISABLED),
-        ("unresolvable", CrossfadeMode.DISABLED),
-    ],
-)
-@pytest.mark.parametrize("side", ["follower", "predecessor"])
-def test_an_undecided_source_needs_a_boundary_it_would_own(
-    neighbour_kind: str, side: str, expected: CrossfadeMode
-) -> None:
-    """
-    A source that is not serving this queue yet is credited only where it could fade.
-
-    It cannot answer for the item, so the boundary stands in: either side counts,
-    the same way one of our own fades credits both of its sides. Reporting a fade
-    anywhere else would describe an overlap nobody rendered - we do not mix a
-    realtime item's boundaries either, so it is a hard cut.
-    """
-    controller = _source_crossfade_controller(
-        object.__new__(_UndecidedCrossfadingProvider), CrossfadeMode.SMART_CROSSFADE
-    )
-    queues = controller.mass.player_queues
-    neighbour = _follower(neighbour_kind)
-    if side == "follower":
-        queues.get_next_item.return_value = neighbour
-    else:
-        queues.get_next_item.return_value = None
-        queues.index_by_id.return_value = 1
-        queues.get_item.return_value = neighbour
-    queue_item = SimpleNamespace(
-        queue_item_id="item-1",
-        media_type=MediaType.TRACK,
-        streamdetails=_make_stream_details(MediaType.TRACK, is_realtime=True),
-    )
-
-    assert controller.get_source_crossfade_mode(MagicMock(), queue_item) == expected
-
-
-@pytest.mark.parametrize(
-    ("provider", "neighbour_kind", "expected"),
-    [
-        # the source says it fades this item, so its own boundary answer stands even
-        # where the queue offers nothing to fade against
-        (_CrossfadingProvider, "none", CrossfadeMode.SOURCE),
-        # and it says it does not, so the neighbour it happens to own is not credited:
-        # a list predecessor that never played is exactly this case
-        (_NonCrossfadingServingProvider, "same-provider", CrossfadeMode.DISABLED),
-    ],
-)
-def test_a_serving_source_is_not_second_guessed_by_the_queue(
-    provider: type[MusicProvider], neighbour_kind: str, expected: CrossfadeMode
-) -> None:
-    """
-    A source already serving the item answers for its boundaries, and that answer stands.
-
-    It knows what it fed and what it played across; the neighbour check is only a
-    necessary condition, so applying it on top would both deny fades that happened
-    and credit ones that did not.
-    """
-    controller = _source_crossfade_controller(
-        object.__new__(provider), CrossfadeMode.SMART_CROSSFADE
-    )
-    controller.mass.player_queues.get_next_item.return_value = _follower(neighbour_kind)
-
-    assert controller.get_source_crossfade_mode(MagicMock(), _realtime_track()) == expected
-
-
-def test_the_raw_pcm_path_reports_a_source_fade_too() -> None:
-    """
-    A source fade reaches the processing details on the raw-PCM entry point as well.
-
-    Gapless players are served per item straight from ``get_stream`` rather than over
-    the http route, so leaving it out there would report nothing for most players.
-    """
-    queue_item = SimpleNamespace(
-        queue_id="queue-1",
-        queue_item_id="item-1",
-        name="Track",
-        media_type=MediaType.TRACK,
-        media_item=None,
-        streamdetails=_make_stream_details(MediaType.TRACK, is_realtime=True),
-        extra_attributes={},
-        image=None,
-    )
-    queue = SimpleNamespace(
-        queue_id="queue-1",
-        display_name="Queue",
-        crossfade_enabled=True,
-        overlay_enabled=False,
-        overlay_source=None,
-    )
-    controller = cast("Any", object.__new__(StreamsController))
-    controller.mass = MagicMock()
-    controller.mass.player_queues.get.return_value = queue
-    controller.mass.player_queues.get_item.return_value = queue_item
-    controller.mass.players.get_player.return_value = None
-    controller.logger = MagicMock()
-    controller.audio = MagicMock()
-    controller._update_audio_processing_context = MagicMock()
-    controller.get_source_crossfade_mode = MagicMock(return_value=CrossfadeMode.SOURCE)
-    media = SimpleNamespace(
-        media_type=MediaType.TRACK,
-        source_id="queue-1",
-        queue_item_id="item-1",
-        queue_session_id="session-1",
-        uri="",
-    )
-
-    controller.get_stream(cast("Any", media), TEST_PCM_FORMAT)
-
-    assert (
-        controller._update_audio_processing_context.call_args.kwargs["source_crossfade_mode"]
-        == CrossfadeMode.SOURCE
-    )
-
-
-def test_a_music_provider_declares_no_source_fade_by_default() -> None:
-    """The declaration is opt-in: nothing downstream verifies it."""
-    assert (
-        object.__new__(MusicProvider).delivers_crossfaded_audio(
-            _make_stream_details(MediaType.TRACK, is_realtime=True)
-        )
-        is False
-    )
-
-
-def _source_crossfade_controller(provider: Any, queue_crossfade_mode: CrossfadeMode) -> Any:
-    """
-    Return a controller resolving source fades against one provider and setting.
-
-    The queue follows on with another item of the same source, so only the provider
-    and the setting decide; the boundary cases are covered on their own.
-    """
-    controller = cast("Any", object.__new__(StreamsController))
-    controller.mass = MagicMock()
-    controller.mass.get_provider.return_value = provider
-    controller.mass.player_queues.get_next_item.return_value = _follower("same-provider")
-    # first in the queue, so nothing precedes it and only the follower decides
-    controller.mass.player_queues.index_by_id.return_value = 0
-    controller.get_crossfade_mode = MagicMock(return_value=queue_crossfade_mode)
-    return controller
-
-
-def _follower(kind: str) -> Any:
-    """Return the queue item that follows, in each shape the resolver has to handle."""
-    if kind == "none":
-        return None
-    if kind == "not-a-track":
-        return SimpleNamespace(media_type=MediaType.AUDIOBOOK, streamdetails=None, media_item=None)
-    if kind == "same-provider":
-        # already resolved to the provider that will serve it
-        return SimpleNamespace(
-            media_type=MediaType.TRACK,
-            streamdetails=_make_stream_details(MediaType.TRACK, is_realtime=True),
-            media_item=None,
-        )
-    if kind == "other-provider":
-        other = _make_stream_details(MediaType.TRACK, is_realtime=True)
-        other.provider = "other--1"
-        return SimpleNamespace(media_type=MediaType.TRACK, streamdetails=other, media_item=None)
-    if kind == "library-mapped":
-        return SimpleNamespace(
-            media_type=MediaType.TRACK,
-            streamdetails=None,
-            media_item=SimpleNamespace(
-                provider="library",
-                provider_mappings=[SimpleNamespace(provider_instance="builtin")],
-            ),
-        )
-    # nothing to resolve it with at all
-    return SimpleNamespace(media_type=MediaType.TRACK, streamdetails=None, media_item=None)
-
-
-def _realtime_track() -> Any:
-    """Return a queue item whose track arrives at playback pace."""
-    return SimpleNamespace(
-        queue_item_id="item-1",
-        media_type=MediaType.TRACK,
-        streamdetails=_make_stream_details(MediaType.TRACK, is_realtime=True),
-    )
-
-
-def test_the_context_update_carries_a_source_fade_the_audio_layer_never_sees() -> None:
-    """
-    A crossfade performed by the source is published with the item's context.
-
-    Our own mixer reports the fades it renders, but it renders none here, so this is
-    the only place the source's fade can reach the processing details.
-    """
-    controller = cast("Any", object.__new__(StreamsController))
-    controller.mass = MagicMock()
-    controller.mass.player_queues.queue_data_or_none.return_value = SimpleNamespace(
-        session_id="session-1"
-    )
-    controller.audio_processing = MagicMock()
-    queue_item = SimpleNamespace(
-        queue_item_id="item-1",
-        streamdetails=_make_stream_details(MediaType.TRACK, is_realtime=True),
-        extra_attributes={},
-    )
-
-    controller._update_audio_processing_context(
-        queue=SimpleNamespace(queue_id="queue-1"),
-        queue_item=queue_item,
-        pcm_format=TEST_PCM_FORMAT,
-        overlay_enabled=False,
-        session_id="session-1",
-        source_crossfade_mode=CrossfadeMode.SOURCE,
-    )
-
-    reported = controller.audio_processing.update_item_context.call_args.kwargs["queue_processing"]
-    assert reported.crossfade_mode == CrossfadeMode.SOURCE
 
 
 # -- StreamsAudio.get_stream_details --

--- a/tests/controllers/streams/test_realtime_sources.py
+++ b/tests/controllers/streams/test_realtime_sources.py
@@ -345,6 +345,26 @@ async def test_tail_hold_sees_a_buffer_attached_after_it_was_created() -> None:
     )
 
 
+async def test_tail_hold_counts_a_long_mix_as_listening_time() -> None:
+    """Bytes noted across a long overlap must not read as a suspension and bank a surplus."""
+    pcm_format = TEST_PCM_FORMAT
+    frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
+    queue_item = SimpleNamespace(
+        streamdetails=SimpleNamespace(buffer=SimpleNamespace(eof=False, has_error=False))
+    )
+    hold = _TailHold(pcm_format, cast("Any", queue_item))
+
+    # 20s of audio arrives over 20s of wall clock: the source is keeping pace, so
+    # there is no surplus to hold back
+    hold.note_bytes(pcm_format.pcm_sample_size)
+    now = asyncio.get_event_loop().time()
+    hold._started = now - 20.0
+    hold._last_noted = now
+    hold._received_bytes = 20 * pcm_format.pcm_sample_size
+
+    assert hold.hold_target(45 * pcm_format.pcm_sample_size, frame_size) == 0
+
+
 async def test_tail_hold_follows_a_capacity_reselection() -> None:
     """A reselection hands the item different details; the tracker must follow them."""
     pcm_format = TEST_PCM_FORMAT

--- a/tests/controllers/streams/test_smartfade_transition_timings.py
+++ b/tests/controllers/streams/test_smartfade_transition_timings.py
@@ -36,9 +36,9 @@ from music_assistant.controllers.streams.smart_fades.fades import (
     StandardCrossFade,
 )
 from music_assistant.controllers.streams.smart_fades.filters import (
-    CrossfadeFilter,
     FadeOutTrimFilter,
     GradualTimeStretchFilter,
+    StreamingCrossfadeFilter,
 )
 from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
 from music_assistant.controllers.streams.smart_fades.mixer import SmartFadesMixer
@@ -233,18 +233,18 @@ class TestStandardCrossFadeBuild:
         assert timing.post_crossfade_duration == pytest.approx(17.0)
 
     def test_filter_duration_matches_clamped_timing(self) -> None:
-        """The acrossfade filter must use the clamped duration, not the configured one."""
+        """The crossfade filter must use the clamped duration, not the configured one."""
         fade = StandardCrossFade(logger=logging.getLogger(), crossfade_duration=10.0)
         # only 6s of (stripped) fade-out audio available
         fade.build(_seconds(6), _seconds(45), PCM)
         assert fade.timing_info.crossfade_duration == pytest.approx(6.0)
         crossfade_filter = fade.filters[0]
-        assert isinstance(crossfade_filter, CrossfadeFilter)
+        assert isinstance(crossfade_filter, StreamingCrossfadeFilter)
         assert crossfade_filter.crossfade_samples == int(6.0 * PCM.sample_rate)
 
     def test_fractional_overlap_keeps_filter_aligned_to_buffer(self) -> None:
         """
-        A non-integer clamped overlap keeps acrossfade ``ns=`` aligned to the buffer.
+        A non-integer clamped overlap keeps the filter's sample count aligned to the buffer.
 
         Regression for the silent "FFmpeg produced no output" fallback: a fractional
         effective crossfade made the byte slice a fraction of a sample shorter than the
@@ -257,10 +257,10 @@ class TestStandardCrossFadeBuild:
         fade = StandardCrossFade(logger=logging.getLogger(), crossfade_duration=10.0)
         fade.build(fade_out_len, _seconds(45), PCM)
         crossfade_filter = fade.filters[0]
-        assert isinstance(crossfade_filter, CrossfadeFilter)
+        assert isinstance(crossfade_filter, StreamingCrossfadeFilter)
         # the source-of-truth byte size is frame-aligned ...
         assert fade.crossfade_size % frame_size == 0
-        # ... and the acrossfade sample count is exactly that buffer, in samples
+        # ... and the filter's sample count is exactly that buffer, in samples
         assert crossfade_filter.crossfade_samples == fade.crossfade_size // frame_size
         # the timing duration round-trips from the same integer, never the other way
         assert fade.timing_info.crossfade_duration == pytest.approx(
@@ -308,10 +308,11 @@ class TestStandardCrossFadeApplySlicing:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """
-        apply() must feed the base mixer exactly the acrossfade ``ns=`` sample count.
+        apply() must feed the base mixer exactly the filter's sample count.
 
-        Otherwise ffmpeg's acrossfade receives fewer samples than requested and emits
-        nothing — the silent crossfade failure this regression guards against.
+        Otherwise ffmpeg receives fewer samples than the filter was built for and the
+        overlap comes out short — the silent crossfade failure this regression guards
+        against.
         """
         captured: dict[str, bytes] = {}
 
@@ -333,7 +334,7 @@ class TestStandardCrossFadeApplySlicing:
         fade = StandardCrossFade(logger=logging.getLogger(), crossfade_duration=10.0)
         fade.build(fade_out_len, _seconds(45), PCM)
         crossfade_filter = fade.filters[0]
-        assert isinstance(crossfade_filter, CrossfadeFilter)
+        assert isinstance(crossfade_filter, StreamingCrossfadeFilter)
         assert crossfade_filter.crossfade_samples is not None
         async for _ in fade.apply(b"\x00" * fade_out_len, b"\x11" * _seconds(45), PCM):
             pass

--- a/tests/providers/spotify/test_backends.py
+++ b/tests/providers/spotify/test_backends.py
@@ -99,20 +99,6 @@ def test_only_the_soloist_backend_declares_normalized_audio() -> None:
     assert prov.delivers_normalized_audio(_streamdetails()) is False
 
 
-def test_no_backend_declares_crossfaded_audio() -> None:
-    """
-    Music Assistant mixes the queue's crossfade itself on either backend.
-
-    Librespot fetches every track on its own, and the soloist engine is spawned
-    with its own crossfade off, so no delivered audio ever carries an overlap.
-    """
-    prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
-    prov.backend = SoloistBackend(prov)
-    assert prov.delivers_crossfaded_audio(_streamdetails()) is False
-    prov.backend = LibrespotBackend(prov)
-    assert prov.delivers_crossfaded_audio(_streamdetails()) is False
-
-
 @pytest.mark.parametrize("normalizes", [True, False])
 def test_another_queues_session_does_not_answer_for_normalization(normalizes: bool) -> None:
     """

--- a/tests/providers/spotify/test_backends.py
+++ b/tests/providers/spotify/test_backends.py
@@ -99,61 +99,38 @@ def test_only_the_soloist_backend_declares_normalized_audio() -> None:
     assert prov.delivers_normalized_audio(_streamdetails()) is False
 
 
-def test_only_the_soloist_backend_can_declare_crossfaded_audio() -> None:
+def test_no_backend_declares_crossfaded_audio() -> None:
     """
-    Librespot fetches every track on its own, so it has nothing to fade into.
+    Music Assistant mixes the queue's crossfade itself on either backend.
 
-    With no soloist session running yet there is nothing to report either, and the
-    queue's own setting answers instead.
+    Librespot fetches every track on its own, and the soloist engine is spawned
+    with its own crossfade off, so no delivered audio ever carries an overlap.
     """
     prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
     prov.backend = SoloistBackend(prov)
-    assert prov.delivers_crossfaded_audio(_streamdetails()) is None
+    assert prov.delivers_crossfaded_audio(_streamdetails()) is False
     prov.backend = LibrespotBackend(prov)
     assert prov.delivers_crossfaded_audio(_streamdetails()) is False
 
 
-@pytest.mark.parametrize("expected", [True, False])
-def test_a_running_session_answers_for_the_boundary_it_is_asked_about(
-    expected: bool,
-) -> None:
-    """
-    The engine reads the crossfade once, at spawn, so the session answers for itself.
-
-    Following the current setting instead would claim a fade the running engine is
-    not applying, or deny the one it still is.
-    """
-    prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
-    backend = SoloistBackend(prov)
-    prov.backend = backend
-    streamdetails = _streamdetails(queue_id="queue-1")
-    backend._session = _session(queue_id="queue-1", fades=expected)
-
-    assert backend.session_crossfades(streamdetails) is expected
-    assert prov.delivers_crossfaded_audio(streamdetails) is expected
-
-
 @pytest.mark.parametrize("normalizes", [True, False])
-def test_another_queues_session_answers_for_neither_hook(normalizes: bool) -> None:
+def test_another_queues_session_does_not_answer_for_normalization(normalizes: bool) -> None:
     """
     A session serves one queue, so it says nothing about an item played on another.
 
-    Reading it anyway would hand the asking queue the other one's answers: MA
+    Reading it anyway would hand the asking queue the other one's answer: MA
     normalization applied on top of the engine's, or skipped when nobody applies it.
     """
     prov = _make_provider({CONF_PLAYBACK_BACKEND: BACKEND_SOLOIST})
     cast("MagicMock", prov.config).get_value = MagicMock(return_value=normalizes)
     backend = SoloistBackend(prov)
     prov.backend = backend
-    backend._session = _session(queue_id="queue-1", fades=True, normalizes=not normalizes)
+    backend._session = _session(queue_id="queue-1", normalizes=not normalizes)
     other_queue = _streamdetails(queue_id="queue-2")
 
     assert backend.session_normalizes(other_queue) is None
-    assert backend.session_crossfades(other_queue) is None
-    # so the configuration answers for normalization, and the queue's own setting
-    # (resolved by the streams core) for the crossfade
+    # so the configuration answers for normalization
     assert prov.delivers_normalized_audio(other_queue) is normalizes
-    assert prov.delivers_crossfaded_audio(other_queue) is None
 
 
 def test_turning_spotify_normalization_off_hands_it_back_to_ma() -> None:
@@ -172,7 +149,7 @@ def test_the_engine_is_told_who_normalizes(tmp_path: Path, normalize: bool) -> N
     cast("MagicMock", prov.mass).cache_path = str(tmp_path / "cache")
     backend = SoloistBackend(prov)
     prov.backend = backend
-    backend._prepare_data_dir(0, normalize=normalize)
+    backend._prepare_data_dir(normalize=normalize)
     prefs = (backend._data_dir / "settings" / "prefs").read_text(encoding="utf-8")
     assert f"audio.normalize_v2={'true' if normalize else 'false'}" in prefs
 
@@ -271,13 +248,12 @@ def _streamdetails(*, queue_id: str | None = None, item_id: str = "track-1") -> 
     )
 
 
-def _session(*, queue_id: str, fades: bool, normalizes: bool = True) -> MagicMock:
+def _session(*, queue_id: str, normalizes: bool = True) -> MagicMock:
     """Return a stand-in for a running soloist session serving one queue."""
     session = MagicMock()
     session.usable = True
     session.queue_id = queue_id
     session.engine_normalizes = normalizes
-    session.fades_a_boundary_of = MagicMock(return_value=fades)
     return session
 
 

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -1041,19 +1041,6 @@ async def test_the_engine_moving_on_at_a_track_end_is_not_a_takeover(tmp_path: P
     assert session.item_for("spotify:track:autoplay") is None
 
 
-async def test_a_long_crossfade_boundary_is_not_a_takeover(tmp_path: Path) -> None:
-    """With crossfade the engine moves on a crossfade short of the duration."""
-    session = _make_session(tmp_path)
-    session.crossfade_ms = 15_000
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
-    await session._observe_current(TRACK_A, 200_000)
-    # the last position reported before the engine crossfades into the next track
-    item.observe_position(200_000 - session.crossfade_ms)
-
-    await session._observe_current("spotify:track:autoplay", 180_000)
-    assert session.usable is True
-
-
 async def test_an_ended_item_says_what_the_app_did(tmp_path: Path) -> None:
     """The item's stream fails with the takeover, not a generic session error."""
     session = _make_session(tmp_path)
@@ -1458,282 +1445,11 @@ def test_a_running_session_answers_for_what_the_engine_is_doing(tmp_path: Path) 
     )
 
 
-def test_crossfade_comes_from_the_queue_preference(tmp_path: Path) -> None:
-    """The queue's crossfade setting is handed to the engine, in milliseconds."""
+def test_engine_never_crossfades(tmp_path: Path) -> None:
+    """MA mixes the queue's crossfade itself, so the provider never claims a source fade."""
     session = _make_session(tmp_path, queue_id="player1")
-    _queues_of(session).get.return_value = MagicMock(queue_id="player1", crossfade_enabled=True)
-    cast("MagicMock", session.mass.config).get_raw_core_config_value = MagicMock(return_value=6)
-    assert session._queue_crossfade_ms() == 6000
-
-
-def test_crossfade_off_is_zero(tmp_path: Path) -> None:
-    """A queue with crossfade disabled gets an explicit zero (which clears the pref)."""
-    session = _make_session(tmp_path, queue_id="player1")
-    _queues_of(session).get.return_value = MagicMock(crossfade_enabled=False)
-    assert session._queue_crossfade_ms() == 0
-
-
-def test_no_queue_means_no_crossfade(tmp_path: Path) -> None:
-    """Without a queue to read the preference from, the engine gets no crossfade."""
-    session = _make_session(tmp_path, queue_id=None)
-    assert session._queue_crossfade_ms() == 0
-
-
-async def test_a_fed_boundary_the_engine_played_across_is_reported(tmp_path: Path) -> None:
-    """The engine playing on into a fed item is what puts the overlap in its audio."""
-    session = _make_session(tmp_path, queue_id="player1")
-    session.crossfade_ms = 8000
-    streamdetails = _streamdetails_for(uri=TRACK_B)
-    session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
-    session._pending.append(TRACK_B)
-    queues = _queues_of(session)
-    queues.get.return_value = MagicMock(current_index=0)
-    queues.get_item.return_value = None
-
-    # fed but not reached, so MA arriving here now means a jump - not a fade
-    assert session.fades_a_boundary_of(streamdetails) is False
-
-    await session._observe_current(TRACK_B, 200_000)
-
-    assert session._items[TRACK_B].faded_in is True
-    assert session.fades_a_boundary_of(streamdetails) is True
-
-
-async def test_a_jumped_to_item_opens_on_a_hard_cut(tmp_path: Path) -> None:
-    """A skip discards the overlap the engine rendered, so no fade reaches the item."""
-    session = _make_session(tmp_path, queue_id="player1")
-    session.crossfade_ms = 8000
-    session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
-    session._pending.append(TRACK_B)
-    session._discard_until = TRACK_B
-    queues = _queues_of(session)
-    queues.get.return_value = MagicMock(current_index=0)
-    queues.get_item.return_value = None
-
-    await session._observe_current(TRACK_B, 200_000)
-
-    assert session._items[TRACK_B].faded_in is False
-    assert session.fades_a_boundary_of(_streamdetails_for(uri=TRACK_B)) is False
-
-
-async def test_a_feed_the_engine_acted_on_before_failing_still_fades(tmp_path: Path) -> None:
-    """
-    The engine can reach a fed item and the command still fail on the way back.
-
-    The channel is kept for it in that case, because the reader is already writing
-    there - so the boundary was played across and denying the fade would describe a
-    cut the engine never made.
-    """
-    session = _make_session(tmp_path, queue_id="player1")
-    session.crossfade_ms = 8000
-    streamdetails = _streamdetails_for(uri=TRACK_A)
-    playing = _queue_item(TRACK_A, streamdetails=streamdetails)
-    streamed = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
-    streamed.started.set()
-    session._current = streamed
-    queues = _queues_of(session)
-    queues.get.return_value = MagicMock(current_index=0)
-    queues.get_item.side_effect = lambda _queue_id, index: playing if index == 0 else None
-    queues.get_next_item.return_value = _queue_item(TRACK_B)
-
-    async def _reached_then_failed(_uri: str, **_kwargs: Any) -> None:
-        await session._observe_current(TRACK_B, 200_000)
-        raise TimeoutError
-
-    _client_of(session).add_to_queue.side_effect = _reached_then_failed
-
-    await session.feed_after(streamdetails, TRACK_A)
-
-    # the channel survived because the engine is playing it, so the fade is real
-    assert session._items[TRACK_B].faded_in is True
-    assert streamed.fades_out is True
-
-
-async def test_an_item_only_fed_is_reached_by_a_jump(tmp_path: Path) -> None:
-    """
-    An item MA opens before the engine gets to it is jumped to, so no fade reaches it.
-
-    Its own follower would otherwise stand in and claim one, which is why being handed
-    over but not reached has to answer first.
-    """
-    session = _make_session(tmp_path, queue_id="player1")
-    session.crossfade_ms = 8000
-    streamdetails = _streamdetails_for(uri=TRACK_B)
-    playing = _queue_item(TRACK_B, streamdetails=streamdetails)
-    session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
-    session._pending.append(TRACK_B)
-    queues = _queues_of(session)
-    queues.get.return_value = MagicMock(current_index=1)
-    queues.get_item.side_effect = lambda _queue_id, index: playing if index == 1 else None
-    # a follower it could be fed, so only the pending state can produce the hard cut
-    queues.get_next_item.return_value = _queue_item(TRACK_A)
-
-    assert session.fades_a_boundary_of(streamdetails) is False
-
-
-async def test_an_item_the_engine_reached_unfed_carries_no_fade(tmp_path: Path) -> None:
-    """
-    Only an item handed to the engine can be played on into.
-
-    The engine also reports items nobody asked for - the session it restores at
-    startup, its own autoplay - and crediting those would claim an overlap that
-    was never rendered.
-    """
-    session = _make_session(tmp_path, queue_id="player1")
-    session.crossfade_ms = 8000
-
-    await session._observe_current("spotify:track:restored", 200_000)
-
-    assert session._items["spotify:track:restored"].faded_in is False
-
-
-async def test_an_earlier_play_of_a_track_does_not_answer_for_a_later_one(
-    tmp_path: Path,
-) -> None:
-    """
-    Channels are keyed by track, so a repeated one must not read the first play's fades.
-
-    In an A-B-A queue the first A faded out into B, but the last A plays on a fresh
-    session with nothing after it, so both of its boundaries are hard cuts.
-    """
-    session = _make_session(tmp_path, queue_id="player1")
-    session.crossfade_ms = 8000
-    first_a = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
-    first_a.started.set()
-    first_a.spent = True
-    first_a.fades_out = True
-    playing_b = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
-    playing_b.started.set()
-    playing_b.faded_in = True
-    session._current = playing_b
-    last_a = _streamdetails_for(uri=TRACK_A)
-    queues = _queues_of(session)
-    queues.get.return_value = MagicMock(current_index=2)
-    queues.get_item.side_effect = lambda _queue_id, index: (
-        _queue_item(TRACK_A, streamdetails=last_a) if index == 2 else None
-    )
-    queues.get_next_item.return_value = None
-
-    assert session.fades_a_boundary_of(last_a) is False
-
-
-async def test_a_fresh_sessions_first_item_rests_on_its_own_follower(tmp_path: Path) -> None:
-    """
-    Nothing was faded into the item a session starts on, so only its end can be faded.
-
-    A single-track play from the middle of a list is exactly this: the item before it
-    never played, so crediting that boundary would report an overlap nobody rendered.
-    """
-    session = _make_session(tmp_path, queue_id="player1")
-    session.crossfade_ms = 8000
-    streamdetails = _streamdetails_for(uri=TRACK_A)
-    playing = _queue_item(TRACK_A, streamdetails=streamdetails)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
-    item.started.set()
-    queues = _queues_of(session)
-    queues.get.return_value = MagicMock(current_index=0)
-    queues.get_item.side_effect = lambda _queue_id, index: playing if index == 0 else None
-
-    queues.get_next_item.return_value = None
-    assert session.fades_a_boundary_of(streamdetails) is False
-
-    queues.get_next_item.return_value = _queue_item(TRACK_B)
-    assert session.fades_a_boundary_of(streamdetails) is True
-
-
-@pytest.mark.parametrize(
-    ("crossfade_ms", "feed_fails", "expected"),
-    [
-        (8000, False, True),
-        # a feed that did not land costs the crossfade at exactly that boundary
-        (8000, True, False),
-        # and an engine started without crossfade cuts hard whatever it was fed
-        (0, False, False),
-    ],
-)
-async def test_feeding_the_follower_settles_the_boundary_at_the_items_end(
-    tmp_path: Path, crossfade_ms: int, feed_fails: bool, expected: bool
-) -> None:
-    """Once the feed has been attempted, its outcome is what the boundary rests on."""
-    session = _make_session(tmp_path, queue_id="player1")
-    session.crossfade_ms = crossfade_ms
-    streamdetails = _streamdetails_for(uri=TRACK_A)
-    playing = _queue_item(TRACK_A, streamdetails=streamdetails)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
-    item.started.set()
-    session._current = item
-    queues = _queues_of(session)
-    queues.get.return_value = MagicMock(current_index=0)
-    queues.get_item.side_effect = lambda _queue_id, index: playing if index == 0 else None
-    queues.get_next_item.return_value = _queue_item(TRACK_B)
-    if feed_fails:
-        _client_of(session).add_to_queue.side_effect = TimeoutError
-
-    await session.feed_after(streamdetails, TRACK_A)
-
-    assert item.fades_out is expected
-    assert session.fades_a_boundary_of(streamdetails) is expected
-
-
-@pytest.mark.parametrize(
-    ("follower_state", "expected"),
-    [
-        # handed over and waiting: the engine reaches it by playing on
-        ("pending", True),
-        # the engine is already there, ahead of the stream MA is still reading
-        ("current", True),
-        # served once already, so the next play of it starts a fresh session - an
-        # A-B-A queue reaches this after jumping to B
-        ("drained", False),
-    ],
-)
-async def test_a_follower_the_session_already_holds_decides_the_boundary(
-    tmp_path: Path, follower_state: str, expected: bool
-) -> None:
-    """
-    With nothing left to feed, the channel already there is what the boundary rests on.
-
-    A drained channel cannot be replayed, so crediting it would report an overlap the
-    engine never renders - and the answer has to be the same before and after the feed
-    that finds nothing to send.
-    """
-    session = _make_session(tmp_path, queue_id="player1")
-    session.crossfade_ms = 8000
-    streamdetails = _streamdetails_for(uri=TRACK_B)
-    playing = _queue_item(TRACK_B, streamdetails=streamdetails)
-    streamed = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
-    streamed.started.set()
-    session._current = streamed
-    follower = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
-    if follower_state == "pending":
-        session._pending.append(TRACK_A)
-    else:
-        follower.started.set()
-        if follower_state == "current":
-            session._current = follower
-        else:
-            follower.spent = True
-    queues = _queues_of(session)
-    queues.get.return_value = MagicMock(current_index=1)
-    queues.get_item.side_effect = lambda _queue_id, index: playing if index == 1 else None
-    queues.get_next_item.return_value = _queue_item(TRACK_A)
-
-    assert session.fades_a_boundary_of(streamdetails) is expected
-
-    await session.feed_after(streamdetails, TRACK_B)
-
-    _client_of(session).add_to_queue.assert_not_awaited()
-    assert streamed.fades_out is expected
-    assert session.fades_a_boundary_of(streamdetails) is expected
-
-
-async def test_only_a_track_can_carry_a_source_fade(tmp_path: Path) -> None:
-    """A podcast episode is never stitched, so both of its boundaries are hard cuts."""
-    session = _make_session(tmp_path, queue_id="player1")
-    session.crossfade_ms = 8000
-    episode = _streamdetails_for(uri="spotify:episode:xyz", media_type=MediaType.PODCAST_EPISODE)
-
-    assert session.fades_a_boundary_of(episode) is False
+    provider = session.backend.provider
+    assert provider.delivers_crossfaded_audio(_streamdetails_for(queue_id="player1")) is False
 
 
 async def test_short_delivery_is_rejected_as_incomplete(tmp_path: Path) -> None:
@@ -1745,18 +1461,6 @@ async def test_short_delivery_is_rejected_as_incomplete(tmp_path: Path) -> None:
     item.last_position_ms = 100_000
     with pytest.raises(AudioError, match="incomplete"):
         await session.validate_item(item)
-
-
-async def test_a_crossfade_shortfall_is_tolerated(tmp_path: Path) -> None:
-    """With crossfade the engine reports the item short by design; that is not a failure."""
-    session = _make_session(tmp_path)
-    session.crossfade_ms = 12_000
-    item = _ItemAudio(TRACK_A, session)
-    item.playing_seen = True
-    item.duration_ms = 200_000
-    # 12s of crossfade plus the ordinary tolerance
-    item.last_position_ms = 200_000 - 21_000
-    await session.validate_item(item)
 
 
 async def test_missing_position_is_rejected_as_incomplete(tmp_path: Path) -> None:
@@ -1969,12 +1673,12 @@ def test_the_engine_is_told_not_to_normalize(tmp_path: Path) -> None:
     prefs = backend._data_dir / "settings" / "Users" / "alice-user" / "prefs"
     prefs.parent.mkdir(parents=True)
     prefs.write_text("some.engine.key=1\n", encoding="utf-8")
-    backend._prepare_data_dir(8000, normalize=False)
+    backend._prepare_data_dir(normalize=False)
     content = prefs.read_text(encoding="utf-8").splitlines()
     assert "some.engine.key=1" in content
     assert "audio.normalize_v2=false" in content
-    assert "audio.crossfade_v2=true" in content
-    assert "audio.crossfade.time_v2=8000" in content
+    # MA mixes the queue's crossfade itself, so the engine's own is always off
+    assert "audio.crossfade_v2=false" in content
     # the ceiling is stated rather than left to the engine's own default
     assert "audio.play_bitrate_enumeration=5" in content
     assert "audio.play_bitrate_non_metered_enumeration=5" in content
@@ -1987,7 +1691,7 @@ def test_disabling_crossfade_writes_the_boolean(tmp_path: Path) -> None:
     prefs = backend._data_dir / "settings" / "prefs"
     prefs.parent.mkdir(parents=True)
     prefs.write_text("audio.crossfade_v2=true\naudio.crossfade.time_v2=8000\n", encoding="utf-8")
-    backend._prepare_data_dir(0, normalize=False)
+    backend._prepare_data_dir(normalize=False)
     content = prefs.read_text(encoding="utf-8").splitlines()
     assert "audio.crossfade_v2=false" in content
     assert not any(line.startswith("audio.crossfade.time_v2") for line in content)

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -1445,13 +1445,6 @@ def test_a_running_session_answers_for_what_the_engine_is_doing(tmp_path: Path) 
     )
 
 
-def test_engine_never_crossfades(tmp_path: Path) -> None:
-    """MA mixes the queue's crossfade itself, so the provider never claims a source fade."""
-    session = _make_session(tmp_path, queue_id="player1")
-    provider = session.backend.provider
-    assert provider.delivers_crossfaded_audio(_streamdetails_for(queue_id="player1")) is False
-
-
 async def test_short_delivery_is_rejected_as_incomplete(tmp_path: Path) -> None:
     """PCM that stops well short of the item's duration is rejected."""
     session = _make_session(tmp_path)


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant now mixes crossfades itself for Spotify (and any other realtime source), instead of delegating them to Spotify's engine. Every track's audio is delivered clean from its first sample, so waveforms, beat grids and light sync stay aligned with what you hear — and smart fades work on Spotify streams for the first time.

- The Spotify Soloist engine always plays with its own crossfade off; MA blends the boundary from the audio it holds.
- A realtime source's fade sizes itself from banked headroom: only audio delivered beyond the wall clock (plus a safety reserve) may be held back for the fade, and only half of it — playback continuity always wins over the fade.
- Crossfades stream: blended audio is delivered while the incoming track is still arriving (afade+amix replaces acrossfade, which buffers until its second input ends).
- Smart fades act on a dynamic window: 8s floor, 45s ceiling, sized by what the boundary can carry — and the whole smart chain (tempo ramp, EQ shelves, positioned blend) streams too.
- The mixer no longer writes a temp file: the outgoing tail is fed to ffmpeg through its own pipe.
- The engine's follower feed retries while a track streams, so a fresh queue start or a replayed track can no longer silently lose the next-track handover.
- The queue's track/progress display now follows the audio exactly through a mixed boundary.
- The old source-delegated crossfade path (a provider declaring its audio arrives pre-faded) is removed from the streaming logic; `CrossfadeMode.SOURCE` stays for a source to report its own fade to the UI.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
