### PR TITLE
Fix slow player response after pausing an external source

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -3843,8 +3843,14 @@ class StreamsAudio:
             logger.warning("\n".join(list(ffmpeg_proc.log_history)[-10:]))
             raise AudioError(f"Error while streaming: {err}") from err
         finally:
-            # always ensure close is called which also handles all cleanup
-            await ffmpeg_proc.close()
+            # a clean end still has buffered output worth draining; a teardown or error
+            # leaves ffmpeg wedged on an input that will never deliver again, where the
+            # drain costs 12s (5s stdout + 5s stderr + 2s communicate) of a held player
+            # lock before the SIGKILL that was always coming
+            if finished:
+                await ffmpeg_proc.close()
+            else:
+                await ffmpeg_proc.kill()
             # determine how many seconds we've received
             # for pcm output we can calculate this easily
             seconds_received = bytes_sent / pcm_format.pcm_sample_size if bytes_sent else 0

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -3843,11 +3843,11 @@ class StreamsAudio:
             logger.warning("\n".join(list(ffmpeg_proc.log_history)[-10:]))
             raise AudioError(f"Error while streaming: {err}") from err
         finally:
-            # a clean end still has buffered output worth draining; a teardown or error
-            # leaves ffmpeg wedged on an input that will never deliver again, where the
-            # drain costs 12s (5s stdout + 5s stderr + 2s communicate) of a held player
-            # lock before the SIGKILL that was always coming
-            if finished:
+            # ffmpeg wedged on an input that will never deliver again pays close()'s
+            # full drain (5s stdout + 5s stderr + 2s communicate) under a held player
+            # lock before the SIGKILL that was always coming. Once the process is gone
+            # close() is free, and it is the only path that cancels the stdin feeder.
+            if finished or ffmpeg_proc.returncode is not None:
                 await ffmpeg_proc.close()
             else:
                 await ffmpeg_proc.kill()

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -3845,8 +3845,9 @@ class StreamsAudio:
         finally:
             # ffmpeg wedged on an input that will never deliver again pays close()'s
             # full drain (5s stdout + 5s stderr + 2s communicate) under a held player
-            # lock before the SIGKILL that was always coming. Once the process is gone
-            # close() is free, and it is the only path that cancels the stdin feeder.
+            # lock before the SIGKILL that was always coming. Once the process has
+            # exited close() is free, and kill() would return before cleaning up the
+            # stdin feeder behind it.
             if finished or ffmpeg_proc.returncode is not None:
                 await ffmpeg_proc.close()
             else:

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -3843,12 +3843,11 @@ class StreamsAudio:
             logger.warning("\n".join(list(ffmpeg_proc.log_history)[-10:]))
             raise AudioError(f"Error while streaming: {err}") from err
         finally:
-            # ffmpeg wedged on an input that will never deliver again pays close()'s
-            # full drain (5s stdout + 5s stderr + 2s communicate) under a held player
-            # lock before the SIGKILL that was always coming. Once the process has
-            # exited close() is free, and kill() would return before cleaning up the
-            # stdin feeder behind it.
-            if finished or ffmpeg_proc.returncode is not None:
+            # An ffmpeg wedged on an input that will never deliver again pays close()'s
+            # full drain - some 12 seconds in practice - under a held player lock,
+            # before the SIGKILL that was always coming. Once the process has exited
+            # close() is free, and it is what cleans up the stdin feeder behind it.
+            if ffmpeg_proc.returncode is not None:
                 await ffmpeg_proc.close()
             else:
                 await ffmpeg_proc.kill()

--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -406,7 +406,7 @@ class AsyncProcess:
             except Exception as err:
                 LOGGER.warning("Process stdin feeder task ended with error: %s", err)
 
-        # Cancel stderr reader task if any
+        # Same for the stderr reader task
         if self._stderr_reader_task:
             if not self._stderr_reader_task.done():
                 self._stderr_reader_task.cancel()
@@ -429,6 +429,16 @@ class AsyncProcess:
         self.logger.debug("Killing process %s with PID %s", self.name, pid)
         with suppress(ProcessLookupError, OSError):
             os.kill(pid, 9)  # SIGKILL = 9
+
+        # SIGKILL leaves whatever the child already wrote in the pipes, and the reap
+        # below only completes once they disconnect - so drain them here rather than
+        # waiting that out for output nobody is going to read
+        try:
+            await asyncio.wait_for(self.proc.communicate(), 2)
+        except TimeoutError:
+            pass  # the escalation below takes over
+        except Exception as err:
+            self.logger.warning("Failed to drain the pipes of PID %s: %s", pid, err)
 
         # Wait for process to actually terminate
         try:

--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -392,17 +392,30 @@ class AsyncProcess:
 
         pid = self.proc.pid
 
-        # Cancel stdin feeder task if any
-        if self._stdin_feeder_task and not self._stdin_feeder_task.done():
-            self._stdin_feeder_task.cancel()
-            with suppress(asyncio.CancelledError, Exception):
+        # Cancel stdin feeder task if any. A task that already finished is still
+        # awaited, so an exception it ended with is retrieved rather than reported
+        # as unhandled once it is garbage collected - and logged, so retrieving it
+        # does not swallow the only trace of the failure.
+        if self._stdin_feeder_task:
+            if not self._stdin_feeder_task.done():
+                self._stdin_feeder_task.cancel()
+            try:
                 await self._stdin_feeder_task
+            except asyncio.CancelledError:
+                pass  # Expected when we cancel the task
+            except Exception as err:
+                LOGGER.warning("Process stdin feeder task ended with error: %s", err)
 
         # Cancel stderr reader task if any
-        if self._stderr_reader_task and not self._stderr_reader_task.done():
-            self._stderr_reader_task.cancel()
-            with suppress(asyncio.CancelledError, Exception):
+        if self._stderr_reader_task:
+            if not self._stderr_reader_task.done():
+                self._stderr_reader_task.cancel()
+            try:
                 await self._stderr_reader_task
+            except asyncio.CancelledError:
+                pass  # Expected when we cancel the task
+            except Exception as err:
+                LOGGER.warning("Process stderr reader task ended with error: %s", err)
 
         # Close stdin to signal we're done sending data
         # Note: Don't manually call feed_eof() on stdout/stderr - this causes

--- a/music_assistant/providers/spotify_connect/base.py
+++ b/music_assistant/providers/spotify_connect/base.py
@@ -108,8 +108,8 @@ class SpotifyConnectBackend(ABC):
         """
         Whether the audio stream reaches a clean end when playback pauses.
 
-        Pipe-fed backends never reach one; the provider then stops the player
-        actively on the paused state event.
+        A backend returning False never reaches one; the provider then stops the
+        player actively on the paused state event.
         """
         return True
 

--- a/music_assistant/providers/spotify_connect/base.py
+++ b/music_assistant/providers/spotify_connect/base.py
@@ -108,8 +108,8 @@ class SpotifyConnectBackend(ABC):
         """
         Whether the audio stream reaches a clean end when playback pauses.
 
-        Pipe-fed backends deliver silence on pause instead; the provider then
-        stops the player actively on the paused state event.
+        Pipe-fed backends never reach one; the provider then stops the player
+        actively on the paused state event.
         """
         return True
 

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -897,7 +897,7 @@ class SpotifyConnectProvider(PluginProvider):
             # stop and ends the stream (clean EOF), so the player leaves the playing
             # state; the next 'playing' event re-fires play_media to resume.
             self._cancel_pending_play_media()
-            # A pipe-fed backend keeps delivering silence on pause (no EOF), so
+            # A backend without a stream end on pause never signals EOF, so
             # the player must be stopped actively; the claim stays so the next
             # 'playing' event resumes playback like the EOF path does. Only the
             # playing→paused transition fires it: the backend reports a pause

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -893,9 +893,10 @@ class SpotifyConnectProvider(PluginProvider):
             was_playing = self._playing
             self._playing = False
             # A pause/stop is the definitive "don't start": cancel a deferred fire
-            # from a now-stale 'playing'. The active get_audio_stream sees the PCM
-            # stop and ends the stream (clean EOF), so the player leaves the playing
-            # state; the next 'playing' event re-fires play_media to resume.
+            # from a now-stale 'playing'. On a backend whose stream ends on pause the
+            # active get_audio_stream sees the PCM stop and ends the stream (clean
+            # EOF), so the player leaves the playing state and the next 'playing'
+            # event re-fires play_media to resume.
             self._cancel_pending_play_media()
             # A backend without a stream end on pause never signals EOF, so
             # the player must be stopped actively; the claim stays so the next

--- a/music_assistant/providers/spotify_connect/soloist/README.md
+++ b/music_assistant/providers/spotify_connect/soloist/README.md
@@ -65,9 +65,12 @@ a FIFO. The daemon is spawned with `PULSE_SERVER`/`PULSE_SINK` pointing at its s
   recreation always respawns the soloist daemon (it holds the sink name in its spawn env).
 - Failed sink volume operations **fail closed**: sink and daemon are torn down and rebuilt
   rather than risking audio through a sink with an unknown gain.
-- The pipe-sink emits **silence when paused** (no EOF), so `stream_ends_on_pause` is
-  False: the provider actively stops the MA player on a `PAUSED` event (bounded, replaced
-  by a quick resume).
+- The pipe-sink **never signals end of stream**, so `stream_ends_on_pause` is False: the
+  provider actively stops the MA player on a `PAUSED` event (bounded, replaced by a quick
+  resume). The sink renders only while a client is connected — it emits silence while the
+  daemon holds its stream open and nothing at all once the daemon drops it, and suspending
+  the sink does not produce an EOF either. A reader that outlives the pause blocks until
+  the stall timeout, so MA must end the stream itself.
 
 ## Volume modes
 

--- a/music_assistant/providers/spotify_connect/soloist/backend.py
+++ b/music_assistant/providers/spotify_connect/soloist/backend.py
@@ -257,7 +257,10 @@ class SoloistBackend(SpotifyConnectBackend):
 
     @property
     def stream_ends_on_pause(self) -> bool:
-        """The pipe sink delivers silence on pause; the provider stops the player."""
+        """The pipe sink never signals end of stream; the provider stops the player."""
+        # the sink renders only while a client is connected: silence while the daemon
+        # holds its stream open, nothing at all once the daemon drops it. A reader
+        # therefore sees neither audio nor EOF, so MA has to end the stream itself.
         return False
 
     @property

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -50,6 +50,9 @@ class _FakeFFMpeg:
         self.log_history: list[str] = []
         self.proc = MagicMock(pid=1234)
         self.stdin_feeder_exception: Exception | None = None
+        # records which teardown the stream picked: a clean end drains, anything
+        # else kills outright
+        self.torn_down_via: str | None = None
         type(self).last_instance = self
 
     async def start(self) -> None:
@@ -64,7 +67,10 @@ class _FakeFFMpeg:
         return None
 
     async def close(self) -> None:
-        return None
+        self.torn_down_via = "close"
+
+    async def kill(self) -> None:
+        self.torn_down_via = "kill"
 
 
 @pytest.fixture
@@ -330,6 +336,49 @@ async def test_get_media_stream_raises_when_source_stalls(
     audio = _make_audio_controller()
     with pytest.raises(AudioError):
         await _drain(audio.get_media_stream(_flac_streamdetails(), _make_pcm_format()))
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_kills_ffmpeg_when_source_stalls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stalled source kills ffmpeg outright instead of waiting out the pipe drains."""
+    monkeypatch.setattr(audio_mod, "FFMpeg", _StallingFFMpeg)
+    monkeypatch.setattr(audio_mod, "STREAM_START_TIMEOUT", 0.1)
+    monkeypatch.setattr(audio_mod, "STREAM_STALL_TIMEOUT", 0.1)
+
+    audio = _make_audio_controller()
+    with pytest.raises(AudioError):
+        await _drain(audio.get_media_stream(_flac_streamdetails(), _make_pcm_format()))
+
+    assert _StallingFFMpeg.last_instance is not None
+    assert _StallingFFMpeg.last_instance.torn_down_via == "kill"
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_kills_ffmpeg_when_cancelled(
+    patch_ffmpeg: type[_FakeFFMpeg],
+) -> None:
+    """A consumer that walks away mid-stream kills ffmpeg rather than draining it."""
+    audio = _make_audio_controller()
+    stream = audio.get_media_stream(_flac_streamdetails(), _make_pcm_format())
+    await anext(stream)
+    await stream.aclose()
+
+    assert patch_ffmpeg.last_instance is not None
+    assert patch_ffmpeg.last_instance.torn_down_via == "kill"
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_closes_ffmpeg_on_clean_end(
+    patch_ffmpeg: type[_FakeFFMpeg],
+) -> None:
+    """A stream that reaches its end still drains ffmpeg, so no trailing audio is lost."""
+    audio = _make_audio_controller()
+    await _drain(audio.get_media_stream(_flac_streamdetails(), _make_pcm_format()))
+
+    assert patch_ffmpeg.last_instance is not None
+    assert patch_ffmpeg.last_instance.torn_down_via == "close"
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -29,6 +29,8 @@ class _FakeFFMpeg:
     """FFMpeg test double that records the arguments it was constructed with."""
 
     last_instance: _FakeFFMpeg | None = None
+    # exit code the process is reaped with; None while it is still running
+    exit_code: int = 0
 
     def __init__(
         self,
@@ -46,7 +48,8 @@ class _FakeFFMpeg:
         self.input_format = input_format
         self._probed_codec_type = ContentType.FLAC  # arbitrary, distinct from PCM/OGG
         self.parsed_duration: int | None = None
-        self.returncode: int | None = 0
+        # mirrors the real FFMpeg: unset while the process runs, filled in on reap
+        self.returncode: int | None = None
         self.log_history: list[str] = []
         self.proc = MagicMock(pid=1234)
         self.stdin_feeder_exception: Exception | None = None
@@ -64,13 +67,15 @@ class _FakeFFMpeg:
         yield b"\x00\x01" * 256
 
     async def wait_with_timeout(self, _timeout: float) -> None:
-        return None
+        self.returncode = self.exit_code
 
     async def close(self) -> None:
         self.torn_down_via = "close"
+        self.returncode = self.exit_code
 
     async def kill(self) -> None:
         self.torn_down_via = "kill"
+        self.returncode = -9
 
 
 @pytest.fixture
@@ -206,6 +211,12 @@ class _TwoMinuteFFMpeg(_FakeFFMpeg):
     async def iter_chunked(self, _chunk_size: int) -> AsyncGenerator[bytes]:
         for _ in range(self.seconds_emitted):
             yield b"\x00" * _PCM_SAMPLE_SIZE
+
+
+class _AlreadyExitedFFMpeg(_FakeFFMpeg):
+    """FFMpeg double whose process exited with an error code before teardown."""
+
+    exit_code = 1
 
 
 class _FailingStartFFMpeg(_FakeFFMpeg):
@@ -346,6 +357,7 @@ async def test_get_media_stream_kills_ffmpeg_when_source_stalls(
     monkeypatch.setattr(audio_mod, "FFMpeg", _StallingFFMpeg)
     monkeypatch.setattr(audio_mod, "STREAM_START_TIMEOUT", 0.1)
     monkeypatch.setattr(audio_mod, "STREAM_STALL_TIMEOUT", 0.1)
+    monkeypatch.setattr(_StallingFFMpeg, "last_instance", None)
 
     audio = _make_audio_controller()
     with pytest.raises(AudioError):
@@ -367,6 +379,22 @@ async def test_get_media_stream_kills_ffmpeg_when_cancelled(
 
     assert patch_ffmpeg.last_instance is not None
     assert patch_ffmpeg.last_instance.torn_down_via == "kill"
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_closes_ffmpeg_that_already_exited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ffmpeg that already exited is closed, so its stdin feeder is still cancelled."""
+    monkeypatch.setattr(audio_mod, "FFMpeg", _AlreadyExitedFFMpeg)
+    monkeypatch.setattr(_AlreadyExitedFFMpeg, "last_instance", None)
+
+    audio = _make_audio_controller()
+    with pytest.raises(AudioError):
+        await _drain(audio.get_media_stream(_flac_streamdetails(), _make_pcm_format()))
+
+    assert _AlreadyExitedFFMpeg.last_instance is not None
+    assert _AlreadyExitedFFMpeg.last_instance.torn_down_via == "close"
 
 
 @pytest.mark.asyncio

--- a/tests/helpers/test_process.py
+++ b/tests/helpers/test_process.py
@@ -213,6 +213,35 @@ async def test_second_close_returns_without_waiting_out_the_stream_locks() -> No
 
 
 @pytest.mark.asyncio
+async def test_kill_retrieves_the_exception_of_a_finished_stdin_feeder(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A stdin feeder that already failed is awaited and its failure logged.
+
+    Awaiting only a still-pending task leaves the exception of one that already
+    ended unretrieved, which asyncio reports as unhandled when it is collected;
+    retrieving it without logging would drop the only trace of the failure.
+    """
+
+    async def _failing_feeder() -> None:
+        raise RuntimeError("feeder blew up")
+
+    proc = AsyncProcess(["sh", "-c", "sleep 30"], stdout=True, stderr=asyncio.subprocess.STDOUT)
+    await proc.start()
+    feeder = asyncio.create_task(_failing_feeder())
+    await asyncio.wait([feeder])  # let it fail without retrieving the exception
+    proc._stdin_feeder_task = feeder
+
+    await proc.kill()
+
+    # asyncio clears this flag once the exception has been retrieved; while it is
+    # set the task is the one that triggers "Task exception was never retrieved"
+    assert feeder._log_traceback is False
+    assert "feeder blew up" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_close_reaps_a_child_that_never_closes_its_pipes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/helpers/test_process.py
+++ b/tests/helpers/test_process.py
@@ -25,6 +25,12 @@ _WEDGED_CHILD = (
     "sys.stdout.write('ready\\n'); sys.stdout.flush(); time.sleep(30)"
 )
 
+# Writes more than a pipe buffer holds and never exits, so its output is still
+# undelivered when the process is killed.
+_NOISY_CHILD = (
+    "import sys, time; sys.stdout.write('x' * 300000); sys.stdout.flush(); time.sleep(30)"
+)
+
 
 @pytest.fixture(name="piped_process")
 async def piped_process_fixture() -> AsyncGenerator[tuple[AsyncProcess, int]]:
@@ -239,6 +245,25 @@ async def test_kill_retrieves_the_exception_of_a_finished_stdin_feeder(
     # set the task is the one that triggers "Task exception was never retrieved"
     assert feeder._log_traceback is False
     assert "feeder blew up" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_kill_returns_promptly_with_output_left_in_the_pipes() -> None:
+    """
+    Killing a process whose pipes still hold output returns without delay.
+
+    The reap only completes once every pipe has disconnected, and nothing reads
+    them after a kill, so the pipes have to be drained for it to finish.
+    """
+    proc = AsyncProcess([sys.executable, "-c", _NOISY_CHILD], stdout=True, stderr=True)
+    await proc.start()
+    await asyncio.sleep(0.5)
+
+    started = time.monotonic()
+    await proc.kill()
+
+    assert proc.returncode is not None
+    assert time.monotonic() - started < 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Pausing an external source (Spotify Connect) left the audio process that reads the capture pipe running, and the cleanup that eventually stopped it took a fixed 12 seconds. That cleanup runs while the player is locked, so pressing play again shortly after a pause could sit waiting for several seconds before anything happened.

When a stream ends normally we still drain the audio process, so no trailing audio is lost. When it ends because it was stopped or ran into an error, the process is blocked on input that will never arrive again — draining it only waits out three timeouts before the kill that was always coming, so it is now stopped straight away.

- Stop draining ffmpeg's pipes when a stream ends by teardown or error, and kill it instead. A clean end still drains as before.
- Correct the Soloist notes: the capture sink only produces audio while a client is connected, so it never signals end of stream — not on pause, and not when suspended.
- Tests for kill-on-teardown, kill-on-cancel and drain-on-clean-end.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
