### PR TITLE
Show audio quality for external sources

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 57
+API_SCHEMA_VERSION: Final[int] = 58
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -23,6 +23,7 @@ from music_assistant_models.enums import ProviderFeature, RepeatMode
 from music_assistant.models.plugin import PluginProvider
 
 if TYPE_CHECKING:
+    from music_assistant_models.audio_processing import ActiveSourceAudioDetails
     from music_assistant_models.media_items import AudioSource
     from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 
@@ -51,6 +52,7 @@ class AudioSourceSession:
     playback_session_id: str = field(default_factory=lambda: uuid4().hex)
     started_at: float = field(default_factory=time.time)
     streamdetails: StreamDetails | None = None
+    active_source_audio: ActiveSourceAudioDetails | None = None
     stream_metadata: StreamMetadata | None = None
     stream_metadata_last_updated: float | None = None
     # an adopted placeholder stays replaceable by a later one, a report does not
@@ -291,10 +293,17 @@ class AudioSourceMixin:
             and session.source_id == source.item_id
             and session.provider_instance_id == provider_instance_id
         ):
+            self.mass.streams.audio_processing.clear_source(
+                player_id,
+                session.playback_session_id,
+                preserve_details=True,
+            )
             session.source = source
             session.playback_session_id = uuid4().hex
             session.stream_session_id = None
             return session
+        if session is not None:
+            self.mass.streams.audio_processing.clear_source(player_id, session.playback_session_id)
         # a source plays on one player at a time, so it leaves whichever other player
         # was holding it: two players both reporting it would let a command on the one
         # that lost it drive the one that has it
@@ -304,6 +313,7 @@ class AudioSourceMixin:
                 and other.source_id == source.item_id
                 and other.provider_instance_id == provider_instance_id
             ):
+                self.mass.streams.audio_processing.clear_source(other_id, other.playback_session_id)
                 del self._source_sessions[other_id]
                 self.trigger_player_update(other_id)
         session = AudioSourceSession(
@@ -324,4 +334,7 @@ class AudioSourceMixin:
         :param player_id: The player whose session ended.
         :return: The session that was ended, or None if there was none.
         """
+        session = self._source_sessions.get(player_id)
+        if session is not None:
+            self.mass.streams.audio_processing.clear_source(player_id, session.playback_session_id)
         return self._source_sessions.pop(player_id, None)

--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -1,4 +1,4 @@
-"""Runtime audio processing details for queue streams."""
+"""Runtime audio processing details for queue and live source streams."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
 
 from music_assistant_models.audio_processing import (
+    ActiveSourceAudioDetails,
     AudioFidelity,
     AudioNormalizationDetails,
     AudioNormalizationMeasurementSource,
@@ -79,8 +80,20 @@ class _AudioProcessingSession:
     shared_output_templates: dict[str | None, _AudioOutputEntry] = field(default_factory=dict)
 
 
+@dataclass(slots=True)
+class _AudioSourceProcessingSession:
+    """Runtime processing state for one live AudioSource selection."""
+
+    session_id: str
+    context_ready: bool = False
+    crossfade_mode: CrossfadeMode = CrossfadeMode.UNKNOWN
+    volume_normalization_mode: VolumeNormalizationMode = VolumeNormalizationMode.UNKNOWN
+    outputs: dict[str | None, dict[str, _AudioOutputEntry]] = field(default_factory=dict)
+    shared_output_templates: dict[str | None, _AudioOutputEntry] = field(default_factory=dict)
+
+
 class AudioProcessingManager:
-    """Build and attach effective audio processing chains to stream details."""
+    """Build effective audio processing details for active playback."""
 
     def __init__(self, mass: MusicAssistant) -> None:
         """
@@ -90,6 +103,7 @@ class AudioProcessingManager:
         """
         self.mass = mass
         self._sessions: dict[str, _AudioProcessingSession] = {}
+        self._source_sessions: dict[str, _AudioSourceProcessingSession] = {}
 
     def start_session(self, queue_id: str, session_id: str) -> None:
         """
@@ -186,6 +200,40 @@ class AudioProcessingManager:
         item.alters_audio = item.alters_audio or alters_audio
         self._publish_item(queue_id, queue_item_id, session)
 
+    def update_source_context(
+        self,
+        player_id: str,
+        session_id: str,
+        *,
+        crossfade_enabled: bool | None,
+        volume_normalization_enabled: bool | None,
+    ) -> None:
+        """
+        Store the source-owned processing active for a live AudioSource.
+
+        :param player_id: Player that owns the source selection.
+        :param session_id: Source playback session that owns the update.
+        :param crossfade_enabled: Whether the source applies crossfade, or None if unknown.
+        :param volume_normalization_enabled: Whether the source normalizes, or None if unknown.
+        """
+        session = self._get_source_session(player_id, session_id, create=True)
+        if session is None:
+            return
+        session.context_ready = True
+        if crossfade_enabled is None:
+            session.crossfade_mode = CrossfadeMode.UNKNOWN
+        elif crossfade_enabled:
+            session.crossfade_mode = CrossfadeMode.SOURCE
+        else:
+            session.crossfade_mode = CrossfadeMode.DISABLED
+        if volume_normalization_enabled is None:
+            session.volume_normalization_mode = VolumeNormalizationMode.UNKNOWN
+        elif volume_normalization_enabled:
+            session.volume_normalization_mode = VolumeNormalizationMode.SOURCE
+        else:
+            session.volume_normalization_mode = VolumeNormalizationMode.DISABLED
+        self._publish_source(player_id, session)
+
     def update_output(
         self,
         player_id: str,
@@ -208,12 +256,22 @@ class AudioProcessingManager:
         :param queue_item_id: Queue item for single-item output, or None for flow output.
         :return: Whether the effective output changed.
         """
-        session = self._get_session(queue_id, session_id)
-        if session is None:
-            return False
-        self._prune_played_items(queue_id, session)
-        if queue_item_id is not None and self._is_played_item(queue_id, queue_item_id):
-            return False
+        source_session = (
+            self._get_source_session(queue_id, session_id, create=True)
+            if queue_item_id is None
+            else None
+        )
+        queue_session: _AudioProcessingSession | None = None
+        if source_session is not None:
+            session: _AudioProcessingSession | _AudioSourceProcessingSession = source_session
+        else:
+            queue_session = self._get_session(queue_id, session_id)
+            if queue_session is None:
+                return False
+            self._prune_played_items(queue_id, queue_session)
+            if queue_item_id is not None and self._is_played_item(queue_id, queue_item_id):
+                return False
+            session = queue_session
 
         destination_player_ids = {player_id}
         if shared_player_ids is not None:
@@ -244,7 +302,11 @@ class AudioProcessingManager:
         if not changed_entries:
             return False
         item_outputs.update(changed_entries)
-        current_changed = self._publish_all(queue_id, session)
+        if source_session is not None:
+            self._publish_source(queue_id, source_session)
+            return True
+        assert queue_session is not None
+        current_changed = self._publish_all(queue_id, queue_session)
         queue = self.mass.player_queues.get(queue_id)
         if current_changed or (
             queue
@@ -294,6 +356,36 @@ class AudioProcessingManager:
             self.mass.player_queues.signal_update(queue_id)
         return current_changed
 
+    def clear_source(
+        self,
+        player_id: str,
+        session_id: str | None = None,
+        *,
+        preserve_details: bool = False,
+    ) -> None:
+        """
+        Clear processing details for a live AudioSource.
+
+        :param player_id: Player that owns the source selection.
+        :param session_id: Only clear when this playback session is still active.
+        :param preserve_details: Keep the last published snapshot until its replacement arrives.
+        """
+        processing = self._source_sessions.get(player_id)
+        if processing is None or (session_id is not None and processing.session_id != session_id):
+            return
+        del self._source_sessions[player_id]
+        if preserve_details:
+            return
+        source_session = self.mass.players.get_audio_source_session(player_id)
+        if (
+            source_session is None
+            or source_session.active_source_audio is None
+            or (session_id is not None and source_session.playback_session_id != session_id)
+        ):
+            return
+        source_session.active_source_audio = None
+        self.mass.players.trigger_player_update(player_id)
+
     def update_player_dsp_preset(self, player_id: str, preset_id: str | None) -> None:
         """
         Update preset identity where the effective DSP config remains unchanged.
@@ -301,21 +393,14 @@ class AudioProcessingManager:
         :param player_id: Player whose persisted DSP config changed.
         :param preset_id: Selected preset identifier, or None when cleared.
         """
-        for queue_id, session in tuple(self._sessions.items()):
-            changed = False
-            for outputs in session.outputs.values():
-                for entry in outputs.values():
-                    if (
-                        entry.dsp_config_id == player_id
-                        and entry.details.dsp.preset_id != preset_id
-                    ):
-                        entry.details.dsp.preset_id = preset_id
-                        changed = True
-            for entry in session.shared_output_templates.values():
-                if entry.dsp_config_id == player_id:
-                    entry.details.dsp.preset_id = preset_id
-            if changed and self._publish_all(queue_id, session):
+        for queue_id, queue_session in tuple(self._sessions.items()):
+            if self._update_session_dsp_preset(queue_session, player_id, preset_id) and (
+                self._publish_all(queue_id, queue_session)
+            ):
                 self.mass.player_queues.signal_update(queue_id)
+        for source_player_id, source_session in tuple(self._source_sessions.items()):
+            if self._update_session_dsp_preset(source_session, player_id, preset_id):
+                self._publish_source(source_player_id, source_session)
 
     def clear(self, queue_id: str, session_id: str | None = None) -> None:
         """
@@ -350,6 +435,44 @@ class AudioProcessingManager:
             return None
         return session
 
+    def _get_source_session(
+        self,
+        player_id: str,
+        session_id: str,
+        *,
+        create: bool,
+    ) -> _AudioSourceProcessingSession | None:
+        """Return processing state only when the producer owns the source selection."""
+        source_session = self.mass.players.get_audio_source_session(player_id)
+        if source_session is None or source_session.playback_session_id != session_id:
+            return None
+        processing = self._source_sessions.get(player_id)
+        if processing is not None and processing.session_id == session_id:
+            return processing
+        if not create:
+            return None
+        processing = _AudioSourceProcessingSession(session_id=session_id)
+        self._source_sessions[player_id] = processing
+        return processing
+
+    @staticmethod
+    def _update_session_dsp_preset(
+        session: _AudioProcessingSession | _AudioSourceProcessingSession,
+        player_id: str,
+        preset_id: str | None,
+    ) -> bool:
+        """Update a player's preset identity in cached output details."""
+        changed = False
+        for outputs in session.outputs.values():
+            for entry in outputs.values():
+                if entry.dsp_config_id == player_id and entry.details.dsp.preset_id != preset_id:
+                    entry.details.dsp.preset_id = preset_id
+                    changed = True
+        for entry in session.shared_output_templates.values():
+            if entry.dsp_config_id == player_id:
+                entry.details.dsp.preset_id = preset_id
+        return changed
+
     def _publish_all(self, queue_id: str, session: _AudioProcessingSession) -> bool:
         """Attach complete chains for every prepared item."""
         queue = self.mass.player_queues.get(queue_id)
@@ -360,6 +483,37 @@ class AudioProcessingManager:
             if self._publish_item(queue_id, queue_item_id, session, signal_update=False):
                 current_changed |= queue_item_id == current_item_id
         return current_changed
+
+    def _publish_source(
+        self,
+        player_id: str,
+        processing: _AudioSourceProcessingSession,
+    ) -> bool:
+        """Attach live source audio details to the active source session."""
+        source_session = self.mass.players.get_audio_source_session(player_id)
+        if (
+            source_session is None
+            or source_session.playback_session_id != processing.session_id
+            or source_session.streamdetails is None
+            or not processing.context_ready
+        ):
+            return False
+        streamdetails = source_session.streamdetails
+        details = ActiveSourceAudioDetails(
+            input_format=deepcopy(streamdetails.audio_format),
+            input_fidelity=AudioFidelity(quality=get_audio_quality(streamdetails.audio_format)),
+            crossfade_mode=processing.crossfade_mode,
+            volume_normalization_mode=processing.volume_normalization_mode,
+            outputs=self._group_outputs(
+                streamdetails,
+                self._get_outputs(processing, None),
+            ),
+        )
+        if source_session.active_source_audio == details:
+            return False
+        source_session.active_source_audio = details
+        self.mass.players.trigger_player_update(player_id)
+        return True
 
     def _publish_item(
         self,
@@ -384,8 +538,8 @@ class AudioProcessingManager:
                 queue_processing=deepcopy(item.queue_processing),
                 outputs=self._group_outputs(
                     queue_item.streamdetails,
-                    item,
                     output_entries,
+                    item=item,
                 ),
             )
         previous = queue_item.streamdetails.audio_processing
@@ -405,15 +559,25 @@ class AudioProcessingManager:
     def _group_outputs(
         self,
         streamdetails: StreamDetails,
-        item: _AudioProcessingItem,
         player_outputs: dict[str, _AudioOutputEntry],
+        *,
+        item: _AudioProcessingItem | None = None,
     ) -> list[AudioOutputDetails]:
         """Group players with identical effective output processing."""
         grouped: list[AudioOutputDetails] = []
         for player_id, entry in sorted(player_outputs.items()):
             output = deepcopy(entry.details)
             output.player_ids = [player_id]
-            output.fidelity = _get_output_fidelity(streamdetails, item, entry)
+            output.fidelity = (
+                _get_output_fidelity(streamdetails, item, entry)
+                if item is not None
+                else AudioFidelity(
+                    quality=_get_effective_quality(
+                        streamdetails.audio_format,
+                        output.output_format,
+                    )
+                )
+            )
             for existing in grouped:
                 if _output_details_equal_ignoring_players(existing, output):
                     existing.player_ids.append(player_id)
@@ -424,7 +588,7 @@ class AudioProcessingManager:
 
     @staticmethod
     def _get_outputs(
-        session: _AudioProcessingSession,
+        session: _AudioProcessingSession | _AudioSourceProcessingSession,
         queue_item_id: str | None,
     ) -> dict[str, _AudioOutputEntry]:
         """Return shared outputs overlaid with queue-item-specific outputs."""
@@ -556,16 +720,25 @@ def _get_output_fidelity(
     output: _AudioOutputEntry,
 ) -> AudioFidelity:
     """Return effective quality and bit-perfect state for an output."""
-    input_quality = get_audio_quality(streamdetails.audio_format)
-    output_quality = get_audio_quality(output.details.output_format)
-    if AudioQuality.UNKNOWN in (input_quality, output_quality):
-        quality = AudioQuality.UNKNOWN
-    else:
-        quality = min((input_quality, output_quality), key=_QUALITY_RANK.__getitem__)
     return AudioFidelity(
-        quality=quality,
+        quality=_get_effective_quality(
+            streamdetails.audio_format,
+            output.details.output_format,
+        ),
         bit_perfect=_is_bit_perfect(streamdetails, item, output),
     )
+
+
+def _get_effective_quality(
+    input_format: AudioFormat,
+    output_format: AudioFormat | None,
+) -> AudioQuality:
+    """Return the effective quality after the known output format."""
+    input_quality = get_audio_quality(input_format)
+    output_quality = get_audio_quality(output_format)
+    if AudioQuality.UNKNOWN in (input_quality, output_quality):
+        return AudioQuality.UNKNOWN
+    return min((input_quality, output_quality), key=_QUALITY_RANK.__getitem__)
 
 
 def _is_bit_perfect(

--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -318,42 +318,33 @@ class AudioProcessingManager:
 
     def retain_outputs(self, queue_id: str, player_ids: set[str]) -> bool:
         """
-        Reconcile outputs with players attached to a queue.
+        Reconcile processing outputs with the current playback destinations.
 
         :param queue_id: Queue identifier.
         :param player_ids: Player identifiers that belong to the output.
         :return: Whether reconciliation published an updated current chain.
         """
-        session = self._sessions.get(queue_id)
-        if session is None:
-            return False
-        changed = False
-        for queue_item_id, outputs in list(session.outputs.items()):
-            retained = {
-                player_id: output
-                for player_id, output in outputs.items()
-                if player_id in player_ids
-            }
-            if template := session.shared_output_templates.get(queue_item_id):
-                added_player_ids = player_ids - retained.keys()
-                if queue_id not in outputs:
-                    added_player_ids.discard(queue_id)
-                for player_id in sorted(added_player_ids):
-                    retained[player_id] = deepcopy(template)
-                    retained[player_id].details.player_ids = [player_id]
-            if retained == outputs:
-                continue
-            changed = True
-            if retained:
-                session.outputs[queue_item_id] = retained
-            else:
-                del session.outputs[queue_item_id]
-                session.shared_output_templates.pop(queue_item_id, None)
-        if not changed:
-            return False
-        current_changed = self._publish_all(queue_id, session)
-        if current_changed:
-            self.mass.player_queues.signal_update(queue_id)
+        queue_session = self._sessions.get(queue_id)
+        queue_changed = queue_session is not None and self._retain_session_outputs(
+            queue_session,
+            queue_id,
+            player_ids,
+        )
+        source_session = self._source_sessions.get(queue_id)
+        source_changed = source_session is not None and self._retain_session_outputs(
+            source_session,
+            queue_id,
+            player_ids,
+        )
+        current_changed = False
+        if queue_changed:
+            assert queue_session is not None
+            current_changed = self._publish_all(queue_id, queue_session)
+            if current_changed:
+                self.mass.player_queues.signal_update(queue_id)
+        if source_changed:
+            assert source_session is not None
+            self._publish_source(queue_id, source_session)
         return current_changed
 
     def clear_source(
@@ -454,6 +445,37 @@ class AudioProcessingManager:
         processing = _AudioSourceProcessingSession(session_id=session_id)
         self._source_sessions[player_id] = processing
         return processing
+
+    @staticmethod
+    def _retain_session_outputs(
+        session: _AudioProcessingSession | _AudioSourceProcessingSession,
+        owner_id: str,
+        player_ids: set[str],
+    ) -> bool:
+        """Reconcile one processing session with its current destinations."""
+        changed = False
+        for queue_item_id, outputs in list(session.outputs.items()):
+            retained = {
+                player_id: output
+                for player_id, output in outputs.items()
+                if player_id in player_ids
+            }
+            if template := session.shared_output_templates.get(queue_item_id):
+                added_player_ids = player_ids - retained.keys()
+                if owner_id not in outputs:
+                    added_player_ids.discard(owner_id)
+                for player_id in sorted(added_player_ids):
+                    retained[player_id] = deepcopy(template)
+                    retained[player_id].details.player_ids = [player_id]
+            if retained == outputs:
+                continue
+            changed = True
+            if retained:
+                session.outputs[queue_item_id] = retained
+            else:
+                del session.outputs[queue_item_id]
+                session.shared_output_templates.pop(queue_item_id, None)
+        return changed
 
     @staticmethod
     def _update_session_dsp_preset(

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1087,6 +1087,7 @@ class StreamsController(CoreController):
                 player=player,
                 session=session,
                 streamdetails=streamdetails,
+                provider=prov,
             )
             serving = True
             self._active_output_streams += 1
@@ -1772,6 +1773,7 @@ class StreamsController(CoreController):
         player: Player,
         session: AudioSourceSession,
         streamdetails: StreamDetails,
+        provider: PluginProvider,
     ) -> tuple[web.StreamResponse, AsyncGenerator[bytes]]:
         """
         Open the response for a live audio source and build the audio behind it.
@@ -1780,6 +1782,7 @@ class StreamsController(CoreController):
         :param player: The player consuming this stream.
         :param session: The session whose source is being streamed.
         :param streamdetails: The stream details resolved for that source.
+        :param provider: Plugin delivering the live source.
         :return: The prepared response and the encoded audio to write to it.
         """
         pcm_format = await self.audio.select_pcm_format(
@@ -1820,7 +1823,10 @@ class StreamsController(CoreController):
             input_format=pcm_format,
             output_format=output_format,
             shared_player_ids=player.state.group_members,
+            queue_id=session.player_id,
+            session_id=session.playback_session_id,
         ).filter_params
+        self._update_audio_source_processing_context(session, provider)
         if (
             output_format.content_type == ContentType.WAV
             and not filter_params
@@ -1895,6 +1901,7 @@ class StreamsController(CoreController):
                     session.source_id, MediaType.AUDIO_SOURCE
                 )
                 session.attach_streamdetails(streamdetails)
+            self._update_audio_source_processing_context(session, prov)
             serving = True
             async for chunk in self.audio.get_audio_source_stream(
                 streamdetails=streamdetails,
@@ -2063,6 +2070,26 @@ class StreamsController(CoreController):
                 overlay_active=overlay_enabled,
             ),
             alters_audio=queue_item.streamdetails.fade_in,
+        )
+
+    def _update_audio_source_processing_context(
+        self,
+        session: AudioSourceSession,
+        provider: PluginProvider,
+    ) -> None:
+        """
+        Publish source-owned processing for a live AudioSource.
+
+        :param session: Active source session to publish.
+        :param provider: Plugin delivering the live source.
+        """
+        if session.streamdetails is None:
+            return
+        self.audio_processing.update_source_context(
+            session.player_id,
+            session.playback_session_id,
+            crossfade_enabled=provider.delivers_crossfaded_audio(session.streamdetails),
+            volume_normalization_enabled=provider.delivers_normalized_audio(session.streamdetails),
         )
 
     def _get_announcement_http_profile(self, player_id: str, announce_data: AnnounceData) -> str:

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -68,6 +68,7 @@ from music_assistant.helpers.player import get_default_player_icon
 from music_assistant.helpers.util import html_to_markdown
 
 if TYPE_CHECKING:
+    from music_assistant_models.audio_processing import ActiveSourceAudioDetails
     from music_assistant_models.config_entries import (
         ConfigActionResult,
         ConfigEntry,
@@ -302,6 +303,11 @@ def _state_fingerprint(state: PlayerState) -> dict[str, Any]:
         "synced_to": state.synced_to,
         "active_sound_mode": state.active_sound_mode,
         "active_source": state.active_source,
+        "active_source_audio": (
+            _freeze(state.active_source_audio.to_dict())
+            if state.active_source_audio is not None
+            else None
+        ),
         "active_group": state.active_group,
         "enabled": state.enabled,
         "hide_in_ui": state.hide_in_ui,
@@ -2554,6 +2560,7 @@ class Player(ABC):
             can_group_with=self.__final_can_group_with,
             synced_to=self.__final_synced_to,
             active_source=self.__final_active_source,
+            active_source_audio=self.__final_active_source_audio,
             source_list=self.__final_source_list,
             active_group=self.__final_active_group,
             current_media=self.__final_current_media,
@@ -2829,6 +2836,23 @@ class Player(ABC):
                 continue
             if self.player_id in group_player.state.group_members:
                 return group_player.player_id
+        return None
+
+    @cached_property
+    @final
+    def __final_active_source_audio(self) -> ActiveSourceAudioDetails | None:
+        """Return audio details for the FINAL active external source."""
+        if parent_player_id := (self.__final_active_group or self.__final_synced_to):
+            if parent_player_id != self.player_id and (
+                parent_player := self.mass.players.get_player(parent_player_id)
+            ):
+                return parent_player.state.active_source_audio
+            return None
+        if self.type == PlayerType.PROTOCOL and self.__attr_protocol_parent_id:
+            if parent_player := self.mass.players.get_player(self.__attr_protocol_parent_id):
+                return parent_player.state.active_source_audio
+        if (session := self.mass.players.get_audio_source_session(self.player_id)) is not None:
+            return session.active_source_audio
         return None
 
     @cached_property

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -164,6 +164,22 @@ class PluginProvider(Provider):
         # a stray empty chunk to the downstream consumer first.
         yield b""  # type: ignore[unreachable]
 
+    def delivers_normalized_audio(self, streamdetails: StreamDetails) -> bool | None:
+        """
+        Return whether this plugin normalizes the live audio it delivers, if known.
+
+        :param streamdetails: Stream details of the active AudioSource.
+        """
+        return None
+
+    def delivers_crossfaded_audio(self, streamdetails: StreamDetails) -> bool | None:
+        """
+        Return whether this plugin crossfades the live audio it delivers, if known.
+
+        :param streamdetails: Stream details of the active AudioSource.
+        """
+        return None
+
     async def on_source_control(
         self,
         source_id: str,

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -348,6 +348,22 @@ class SpotifyConnectProvider(PluginProvider):
                 return  # audio pipe closed (backend exited / restarting)
             yield chunk
 
+    def delivers_normalized_audio(self, streamdetails: StreamDetails) -> bool:
+        """
+        Return whether Spotify applies loudness normalization to this source.
+
+        :param streamdetails: Stream details of the active Spotify Connect source.
+        """
+        return self._resolve_loudness_normalization()
+
+    def delivers_crossfaded_audio(self, streamdetails: StreamDetails) -> bool:
+        """
+        Return whether Spotify applies crossfade to this source.
+
+        :param streamdetails: Stream details of the active Spotify Connect source.
+        """
+        return self._resolve_crossfade_ms() > 0
+
     async def on_source_selected(
         self,
         source_id: str,

--- a/tests/controllers/config/test_setup_flows.py
+++ b/tests/controllers/config/test_setup_flows.py
@@ -1462,6 +1462,7 @@ async def test_player_setup_reason_in_state_fingerprint() -> None:
 async def test_has_setup_flow_serialized_for_own_flow() -> None:
     """A player implementing its own flow serializes has_setup_flow (regardless of needs_setup)."""
     provider = MockProvider("sendspin", instance_id="sendspin")
+    provider.mass.players.get_audio_source_session.return_value = None
     plain = MockPlayer(provider, "plain_player", "Plain Player")
     player = _FlowPlayer(provider, "flow_player", "Flow Player")
     assert plain.has_setup_flow is False
@@ -1478,6 +1479,7 @@ async def test_has_setup_flow_serialized_for_own_flow() -> None:
 async def test_has_setup_flow_serialized_for_protocol_child() -> None:
     """A wrapper player inherits has_setup_flow from a linked protocol child with a flow."""
     parent_provider = MockProvider("universal_player", instance_id="universal_player")
+    parent_provider.mass.players.get_audio_source_session.return_value = None
     child_provider = MockProvider("airplay", instance_id="airplay")
     parent = MockPlayer(parent_provider, "up_parent", "Hallway")
     child = _ProtocolChildPlayer(child_provider, "ap_child", "Hallway AirPlay")

--- a/tests/controllers/players/test_audio_source_session.py
+++ b/tests/controllers/players/test_audio_source_session.py
@@ -6,6 +6,7 @@ without any of it living in a queue item. Nothing produces a session yet, so
 these tests drive the mixin directly.
 """
 
+from typing import cast
 from unittest.mock import MagicMock
 
 from music_assistant_models.enums import ContentType, MediaType, ProviderFeature, StreamType
@@ -106,12 +107,15 @@ def test_started_session_resolves_source_and_provider() -> None:
 def test_starting_a_second_session_replaces_the_first() -> None:
     """A player outputs one source at a time, so a new session replaces the old."""
     ctrl = _Controller(_plugin_provider())
-    ctrl._start_audio_source_session(PLAYER_ID, _audio_source("first"), PROVIDER_INSTANCE)
+    first = ctrl._start_audio_source_session(PLAYER_ID, _audio_source("first"), PROVIDER_INSTANCE)
     second = ctrl._start_audio_source_session(PLAYER_ID, _audio_source("second"), PROVIDER_INSTANCE)
 
     current = ctrl.get_audio_source_session(PLAYER_ID)
     assert current is second
     assert current.source_id == "second"
+    cast("MagicMock", ctrl.mass.streams.audio_processing.clear_source).assert_called_once_with(
+        PLAYER_ID, first.playback_session_id
+    )
 
 
 def test_ending_a_session_drops_and_returns_it() -> None:
@@ -120,6 +124,9 @@ def test_ending_a_session_drops_and_returns_it() -> None:
     session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
 
     assert ctrl._end_audio_source_session(PLAYER_ID) is session
+    cast("MagicMock", ctrl.mass.streams.audio_processing.clear_source).assert_called_once_with(
+        PLAYER_ID, session.playback_session_id
+    )
     assert ctrl.get_audio_source_session(PLAYER_ID) is None
     # ending twice is harmless
     assert ctrl._end_audio_source_session(PLAYER_ID) is None
@@ -232,6 +239,9 @@ def test_reconnecting_the_same_source_keeps_its_metadata() -> None:
     ctrl = _Controller(_plugin_provider())
     source = _audio_source()
     first = ctrl._start_audio_source_session(PLAYER_ID, source, PROVIDER_INSTANCE)
+    audio_details = MagicMock()
+    first.active_source_audio = audio_details
+    first_session_id = first.playback_session_id
     ctrl.update_source_metadata(
         PLAYER_ID, SOURCE_ID, PROVIDER_INSTANCE, StreamMetadata(title="Take Five")
     )
@@ -242,6 +252,12 @@ def test_reconnecting_the_same_source_keeps_its_metadata() -> None:
     assert again.stream_metadata is not None
     assert again.stream_metadata.title == "Take Five"
     assert again.started_at == first.started_at
+    assert again.active_source_audio is audio_details
+    cast("MagicMock", ctrl.mass.streams.audio_processing.clear_source).assert_called_once_with(
+        PLAYER_ID,
+        first_session_id,
+        preserve_details=True,
+    )
 
 
 def test_selecting_a_different_source_does_not_keep_the_old_metadata() -> None:

--- a/tests/controllers/players/test_player_protocol_state.py
+++ b/tests/controllers/players/test_player_protocol_state.py
@@ -11,7 +11,9 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
-from music_assistant_models.enums import PlaybackState, PlayerType
+from music_assistant_models.audio_processing import ActiveSourceAudioDetails
+from music_assistant_models.enums import ContentType, PlaybackState, PlayerType
+from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.controllers.players import PlayerController
 from tests.common import MockPlayer, MockProvider
@@ -103,6 +105,30 @@ class TestFinalPlaybackStateWithActiveProtocol:
         player.refresh_state(signal_event=False)
 
         assert player.state.playback_state == PlaybackState.IDLE
+
+    def test_protocol_player_inherits_parent_source_audio(
+        self,
+        provider: MockProvider,
+        controller: PlayerController,
+    ) -> None:
+        """A protocol player publishes the live source audio details of its parent."""
+        details = ActiveSourceAudioDetails(
+            input_format=AudioFormat(
+                content_type=ContentType.FLAC,
+                sample_rate=44100,
+                bit_depth=16,
+                channels=2,
+            )
+        )
+        parent = MockPlayer(provider, "player_1", "Player")
+        parent._state.active_source_audio = details
+        protocol_player = MockPlayer(provider, "ap_1", "AirPlay", player_type=PlayerType.PROTOCOL)
+        controller._players = {"player_1": parent, "ap_1": protocol_player}
+        protocol_player.set_protocol_parent_id("player_1")
+
+        protocol_player.refresh_state(signal_event=False)
+
+        assert protocol_player.state.active_source_audio == details
 
     def test_no_active_protocol_uses_native_state(
         self,

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.audio_processing import (
+    ActiveSourceAudioDetails,
     AudioDSPDetails,
     AudioFidelity,
     AudioNormalizationDetails,
@@ -303,6 +304,101 @@ def test_shared_output_destinations_are_registered_atomically() -> None:
         queue_item_id="item-1",
     )
     mass.player_queues.signal_update.assert_not_called()
+
+
+def test_live_source_context_publishes_input_and_source_processing() -> None:
+    """A live source publishes its input and the processing it applies itself."""
+    manager, mass, source_session, _lossless_plan = _source_manager_context()
+
+    manager.update_source_context(
+        "source-player",
+        "source-session",
+        crossfade_enabled=True,
+        volume_normalization_enabled=True,
+    )
+
+    details = cast(
+        "ActiveSourceAudioDetails | None",
+        source_session.active_source_audio,
+    )
+    assert details is not None
+    assert details.input_format == source_session.streamdetails.audio_format
+    assert details.input_fidelity.quality == AudioQuality.HI_RES
+    assert details.crossfade_mode is CrossfadeMode.SOURCE
+    assert details.volume_normalization_mode is VolumeNormalizationMode.SOURCE
+    assert details.outputs == []
+    mass.players.trigger_player_update.assert_called_once_with("source-player")
+
+
+def test_live_source_output_registered_before_context_is_published() -> None:
+    """An output prepared before source details arrive is retained and published."""
+    manager, _mass, source_session, lossless_plan = _source_manager_context()
+
+    assert manager.update_output(
+        "player-1",
+        lossless_plan,
+        shared_player_ids={"player-2"},
+        queue_id="source-player",
+        session_id="source-session",
+    )
+    assert source_session.active_source_audio is None
+
+    manager.update_source_context(
+        "source-player",
+        "source-session",
+        crossfade_enabled=False,
+        volume_normalization_enabled=None,
+    )
+
+    details = cast(
+        "ActiveSourceAudioDetails | None",
+        source_session.active_source_audio,
+    )
+    assert details is not None
+    assert details.crossfade_mode is CrossfadeMode.DISABLED
+    assert details.volume_normalization_mode is VolumeNormalizationMode.UNKNOWN
+    assert len(details.outputs) == 1
+    assert details.outputs[0].player_ids == ["player-1", "player-2"]
+    assert details.outputs[0].output_format == lossless_plan.output_details.output_format
+    assert details.outputs[0].fidelity.quality == AudioQuality.HI_RES
+    assert details.outputs[0].fidelity.bit_perfect is None
+
+
+def test_stale_live_source_updates_are_rejected() -> None:
+    """A superseded source session cannot publish context or outputs."""
+    manager, _mass, source_session, lossless_plan = _source_manager_context()
+
+    manager.update_source_context(
+        "source-player",
+        "stale-session",
+        crossfade_enabled=True,
+        volume_normalization_enabled=True,
+    )
+
+    assert not manager.update_output(
+        "player-1",
+        lossless_plan,
+        queue_id="source-player",
+        session_id="stale-session",
+    )
+    assert source_session.active_source_audio is None
+
+
+def test_clearing_live_source_processing_removes_the_snapshot() -> None:
+    """Ending a source selection clears its published audio details."""
+    manager, mass, source_session, _lossless_plan = _source_manager_context()
+    manager.update_source_context(
+        "source-player",
+        "source-session",
+        crossfade_enabled=False,
+        volume_normalization_enabled=False,
+    )
+    mass.players.trigger_player_update.reset_mock()
+
+    manager.clear_source("source-player", "source-session")
+
+    assert source_session.active_source_audio is None
+    mass.players.trigger_player_update.assert_called_once_with("source-player")
 
 
 def test_shared_output_adds_member_without_stream_restart() -> None:
@@ -1392,6 +1488,40 @@ def _manager_context(
         input_format=pcm_format,
     )
     return manager, mass, queue_data, streamdetails, lossless_plan, lossy_plan
+
+
+def _source_manager_context() -> tuple[
+    AudioProcessingManager,
+    MagicMock,
+    Any,
+    AudioOutputPlan,
+]:
+    """Return one active live source and a lossless output plan."""
+    mass = MagicMock()
+    streamdetails = StreamDetails(
+        provider="source-provider",
+        item_id="main",
+        audio_format=_format(ContentType.FLAC, 96000, 24, bit_rate=3200),
+        media_type=MediaType.AUDIO_SOURCE,
+    )
+    source_session: Any = SimpleNamespace(
+        playback_session_id="source-session",
+        streamdetails=streamdetails,
+        active_source_audio=None,
+    )
+    mass.players.get_audio_source_session.side_effect = lambda player_id: (
+        source_session if player_id == "source-player" else None
+    )
+    manager = AudioProcessingManager(mass)
+    output_plan = AudioOutputPlan(
+        filter_params=[],
+        output_details=AudioOutputDetails(
+            dsp=AudioDSPDetails(state=DSPState.DISABLED),
+            output_format=_format(ContentType.FLAC, 96000, 24),
+        ),
+        input_format=_format(ContentType.PCM_S24LE, 96000, 24),
+    )
+    return manager, mass, source_session, output_plan
 
 
 def _source_handled_soloist_item(

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -401,6 +401,36 @@ def test_clearing_live_source_processing_removes_the_snapshot() -> None:
     mass.players.trigger_player_update.assert_called_once_with("source-player")
 
 
+def test_live_source_outputs_follow_current_group_members() -> None:
+    """A departed group member is removed from the live source output snapshot."""
+    manager, mass, source_session, lossless_plan = _source_manager_context()
+    manager.update_output(
+        "player-1",
+        lossless_plan,
+        shared_player_ids={"player-2"},
+        queue_id="source-player",
+        session_id="source-session",
+    )
+    manager.update_source_context(
+        "source-player",
+        "source-session",
+        crossfade_enabled=False,
+        volume_normalization_enabled=False,
+    )
+    mass.players.trigger_player_update.reset_mock()
+
+    manager.retain_outputs("source-player", {"player-1"})
+
+    details = cast(
+        "ActiveSourceAudioDetails | None",
+        source_session.active_source_audio,
+    )
+    assert details is not None
+    assert len(details.outputs) == 1
+    assert details.outputs[0].player_ids == ["player-1"]
+    mass.players.trigger_player_update.assert_called_once_with("source-player")
+
+
 def test_shared_output_adds_member_without_stream_restart() -> None:
     """A late native-sync member inherits the active shared output path."""
     manager, mass, _queue_data, streamdetails, output_plan, _lossy_plan = _manager_context()

--- a/tests/controllers/streams/test_audio_source_route.py
+++ b/tests/controllers/streams/test_audio_source_route.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import web
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import ContentType, MediaType
 from music_assistant_models.errors import AudioError
 from music_assistant_models.media_items import AudioFormat, AudioSource
 
@@ -51,6 +51,8 @@ def _controller(session: AudioSourceSession | None) -> tuple[Any, MagicMock, Mag
     provider.instance_id = INSTANCE_ID
     provider.on_source_selected = AsyncMock()
     provider.on_source_unselected = AsyncMock()
+    provider.delivers_crossfaded_audio.return_value = True
+    provider.delivers_normalized_audio.return_value = False
     ctrl.mass.get_provider = MagicMock(return_value=provider)
     ctrl.mass.players.get_audio_source_session = MagicMock(
         return_value=session, side_effect=lambda pid: session if pid == OWNER_ID else None
@@ -59,6 +61,7 @@ def _controller(session: AudioSourceSession | None) -> tuple[Any, MagicMock, Mag
     player.player_id = CONSUMER_ID
     ctrl.mass.players.get_player = MagicMock(return_value=player)
     ctrl.mass.players.deselect_source = AsyncMock()
+    ctrl.audio_processing = MagicMock()
     return ctrl, provider, player
 
 
@@ -140,6 +143,59 @@ async def test_a_head_probe_does_not_trigger_the_plugin() -> None:
 
     assert result == "head-response"
     provider.on_source_selected.assert_not_awaited()
+
+
+async def test_http_output_is_registered_to_the_source_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The HTTP output plan is owned by the live source playback session."""
+    session = _session()
+    ctrl, provider, player = _controller(session)
+    ctrl.audio = MagicMock()
+    pcm_format = AudioFormat(
+        content_type=ContentType.PCM_S24LE,
+        sample_rate=48000,
+        bit_depth=24,
+        channels=2,
+    )
+    output_format = AudioFormat(
+        content_type=ContentType.FLAC,
+        sample_rate=48000,
+        bit_depth=24,
+        channels=2,
+    )
+    ctrl.audio.select_pcm_format = AsyncMock(return_value=pcm_format)
+    ctrl.audio.get_output_format = AsyncMock(return_value=output_format)
+    ctrl.audio.get_audio_source_stream.return_value = "audio-input"
+    ctrl.audio.get_player_output_plan.return_value = SimpleNamespace(filter_params=[])
+    player.state.group_members = ["member-1"]
+    player.get_config_value.return_value = "default"
+    response = MagicMock()
+    response.prepare = AsyncMock()
+    monkeypatch.setattr(web, "StreamResponse", MagicMock(return_value=response))
+    monkeypatch.setattr(
+        "music_assistant.controllers.streams.controller.get_ffmpeg_stream",
+        MagicMock(return_value="encoded-audio"),
+    )
+    request = SimpleNamespace(match_info={"fmt": "flac"})
+
+    result = await ctrl._prepare_audio_source_stream(
+        request,
+        player,
+        session,
+        MagicMock(),
+        provider,
+    )
+
+    assert result == (response, "encoded-audio")
+    ctrl.audio.get_player_output_plan.assert_called_once_with(
+        player_id=player.player_id,
+        input_format=pcm_format,
+        output_format=output_format,
+        shared_player_ids=player.state.group_members,
+        queue_id=session.player_id,
+        session_id=session.playback_session_id,
+    )
 
 
 def test_a_direct_pcm_request_from_a_superseded_session_is_refused() -> None:
@@ -303,7 +359,7 @@ async def test_direct_pcm_stream_stops_when_the_session_is_reselected() -> None:
     """A running PCM stream ends before yielding audio for a newer selection."""
     session = _session()
     session.streamdetails = MagicMock()
-    ctrl, _provider, _player = _controller(session)
+    ctrl, provider, _player = _controller(session)
     ctrl.audio = MagicMock()
 
     async def chunks() -> AsyncGenerator[bytes]:
@@ -314,6 +370,12 @@ async def test_direct_pcm_stream_stops_when_the_session_is_reselected() -> None:
     stream = ctrl._get_audio_source_session_stream(session, AudioFormat(), CONSUMER_ID)
 
     assert await anext(stream) == b"first"
+    ctrl.audio_processing.update_source_context.assert_called_once_with(
+        OWNER_ID,
+        session.playback_session_id,
+        crossfade_enabled=provider.delivers_crossfaded_audio.return_value,
+        volume_normalization_enabled=provider.delivers_normalized_audio.return_value,
+    )
     session.playback_session_id = "replacement-session"
 
     with pytest.raises(StopAsyncIteration):

--- a/tests/models/test_player_state_updates.py
+++ b/tests/models/test_player_state_updates.py
@@ -8,7 +8,18 @@ from statistics import median
 from unittest.mock import MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import MediaType, PlaybackState
+from music_assistant_models.audio_processing import (
+    ActiveSourceAudioDetails,
+    AudioFidelity,
+    AudioQuality,
+)
+from music_assistant_models.enums import (
+    ContentType,
+    CrossfadeMode,
+    MediaType,
+    PlaybackState,
+    VolumeNormalizationMode,
+)
 from music_assistant_models.media_items import AudioFormat, AudioSource
 from music_assistant_models.media_items.provider_mapping import ProviderMapping
 from music_assistant_models.player_queue import PlayerQueue
@@ -547,6 +558,101 @@ class TestLiveSourcePosition:
         assert media.source_id == "player_1"
         # no queue item: this is not playing out of a queue
         assert media.queue_item_id is None
+
+
+class TestLiveSourceAudioDetails:
+    """Audio details published for a live external source."""
+
+    @staticmethod
+    def _details(quality: AudioQuality = AudioQuality.LOSSLESS) -> ActiveSourceAudioDetails:
+        """Return source audio details with a known lossless input."""
+        return ActiveSourceAudioDetails(
+            input_format=AudioFormat(
+                content_type=ContentType.FLAC,
+                sample_rate=44100,
+                bit_depth=16,
+                channels=2,
+            ),
+            input_fidelity=AudioFidelity(quality=quality),
+            crossfade_mode=CrossfadeMode.SOURCE,
+            volume_normalization_mode=VolumeNormalizationMode.SOURCE,
+        )
+
+    def test_source_audio_details_reach_player_state(self, mock_mass: MagicMock) -> None:
+        """The source session's audio snapshot is part of the published player state."""
+        details = self._details()
+        source = AudioSource(
+            item_id="main",
+            provider="test_instance",
+            name="Spotify Connect",
+            provider_mappings=set(),
+        )
+        session = AudioSourceSession(
+            player_id="player_1",
+            source=source,
+            provider_instance_id="test_instance",
+            active_source_audio=details,
+        )
+        mock_mass.players.get_audio_source_session.return_value = session
+        player = MockPlayer(MockProvider("test_provider", mass=mock_mass), "player_1", "Player")
+
+        player.update_state(signal_event=False)
+
+        assert player.state.active_source_audio == details
+
+    def test_replacing_source_audio_details_signals_player_update(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Replacing the snapshot is detected even when no player-owned input changed."""
+        first = self._details()
+        source = AudioSource(
+            item_id="main",
+            provider="test_instance",
+            name="Spotify Connect",
+            provider_mappings=set(),
+        )
+        session = AudioSourceSession(
+            player_id="player_1",
+            source=source,
+            provider_instance_id="test_instance",
+            active_source_audio=first,
+        )
+        mock_mass.players.get_audio_source_session.return_value = session
+        player = MockPlayer(MockProvider("test_provider", mass=mock_mass), "player_1", "Player")
+        player.update_state(signal_event=False)
+        mock_mass.players.signal_player_state_update.reset_mock()
+        session.active_source_audio = self._details(AudioQuality.STANDARD)
+
+        player.mark_state_dirty()
+        player.update_state()
+
+        assert player.state.active_source_audio is not None
+        assert player.state.active_source_audio.input_fidelity.quality is AudioQuality.STANDARD
+        mock_mass.players.signal_player_state_update.assert_called_once()
+
+    def test_ending_source_session_clears_player_audio_details(self, mock_mass: MagicMock) -> None:
+        """A player no longer owning the source publishes no source audio snapshot."""
+        source = AudioSource(
+            item_id="main",
+            provider="test_instance",
+            name="Spotify Connect",
+            provider_mappings=set(),
+        )
+        session = AudioSourceSession(
+            player_id="player_1",
+            source=source,
+            provider_instance_id="test_instance",
+            active_source_audio=self._details(),
+        )
+        mock_mass.players.get_audio_source_session.return_value = session
+        player = MockPlayer(MockProvider("test_provider", mass=mock_mass), "player_1", "Player")
+        player.update_state(signal_event=False)
+        mock_mass.players.get_audio_source_session.return_value = None
+
+        player.mark_state_dirty()
+        player.update_state(signal_event=False)
+
+        assert player.state.active_source_audio is None
 
 
 class TestMediaUpdatedCallback:

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -396,6 +396,32 @@ def test_audio_behavior_values_reach_the_backend(tmp_path: Path) -> None:
     assert backend._audio_quality == AUDIO_QUALITY_HIGH
 
 
+def test_source_processing_defaults_are_reported(tmp_path: Path) -> None:
+    """Spotify reports its default source processing as normalization only."""
+    provider = _provider_with_stored_config({}, tmp_path)
+
+    assert provider.delivers_crossfaded_audio(MagicMock()) is False
+    assert provider.delivers_normalized_audio(MagicMock()) is True
+
+
+def test_source_processing_config_is_reported(tmp_path: Path) -> None:
+    """Spotify reports the source processing configured for its backend."""
+    provider = _provider_with_stored_config({}, tmp_path)
+    provider.config.values[CONF_CROSSFADE_DURATION] = ConfigEntry(
+        key=CONF_CROSSFADE_DURATION,
+        type=ConfigEntryType.INTEGER,
+        value=8,
+    )
+    provider.config.values[CONF_LOUDNESS_NORMALIZATION] = ConfigEntry(
+        key=CONF_LOUDNESS_NORMALIZATION,
+        type=ConfigEntryType.BOOLEAN,
+        value=False,
+    )
+
+    assert provider.delivers_crossfaded_audio(MagicMock()) is True
+    assert provider.delivers_normalized_audio(MagicMock()) is False
+
+
 def test_write_config_carries_the_audio_behavior_keys(tmp_path: Path) -> None:
     """The generated config.yml carries crossfade_duration (ms) and normalisation_disabled."""
     backend = object.__new__(GoLibrespotBackend)


### PR DESCRIPTION
# What does this implement/fix?

Live external sources such as Spotify Connect play outside the queue, so their input quality and audio processing were never published to clients.

- Publish input format and quality for the active external source
- Report source-controlled crossfade and volume normalization when known
- Include known grouped output formats for HTTP and direct-PCM playback paths
- Keep details across pauses and reconnects while rejecting stale session updates

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked: music-assistant/models#379.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: music-assistant/frontend#2628.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.