### PR TITLE
Fix flaky AirPlay announcement timing tests

### DIFF
--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -271,6 +271,13 @@ async def test_volume_is_scheduled_on_the_acked_instant() -> None:
     members = _make_playing_group(stream)
     member = members[0]
     member.volume_level = 30
+    # both delays count down from the moment they are scheduled, so that
+    # moment - not a clock read after the call - is what they are checked
+    # against: the audible-end hold at the end of the call takes seconds
+    scheduled_at_ms: list[float] = []
+    member.mass.call_later = MagicMock(
+        side_effect=lambda *_args, **_kwargs: scheduled_at_ms.append(time.time() * 1000)
+    )
 
     with patch.object(announce, "_announce_with_session", new_callable=AsyncMock):
         await announce.play_announcement(member, _make_announcement(), 55)
@@ -280,11 +287,13 @@ async def test_volume_is_scheduled_on_the_acked_instant() -> None:
     bump, restore = scheduled
     assert bump.args[1:] == (member.volume_set, 55)
     assert restore.args[1:] == (member.volume_set, 30)
-    # the bump derives from the acked instant (~0.2s out) plus the 0.3s
-    # into-the-clip bias; the restore follows the CONTENT length (the acked
-    # duration minus the silence tail) plus the (zeroed) pad, so it lands
-    # inside the ducked cushion - 1.7s after the bump here
-    assert 0.2 < bump.args[0] <= 0.5
+    # the bump lands on what was left of the acked instant when it was
+    # scheduled (0.2s out here), plus the 0.3s into-the-clip bias; the restore
+    # follows the CONTENT length (the acked duration minus the silence tail)
+    # plus the (zeroed) pad, so it lands inside the ducked cushion - 1.7s
+    # after the bump here
+    remaining_s = max(0.0, (ack_at_unix_ms - scheduled_at_ms[0]) / 1000)
+    assert bump.args[0] == pytest.approx(remaining_s + 0.3, abs=0.01)
     assert restore.args[0] - bump.args[0] == pytest.approx(1.7)
 
 
@@ -489,16 +498,19 @@ async def test_group_entity_fanout_arms_each_member_at_one_shared_instant() -> N
         if member is not leader:
             member.synced_to = leader.player_id
         member.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
-    # the second member reports a far larger span: the shared instant must
-    # clear it for every sibling arm
-    streams[1].latency_lead_ms = 2000
+    # the second member reports a span past the fallback the others assume:
+    # the shared instant must clear the LARGEST one for every sibling arm
+    largest_span_ms = AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS + 1000
+    streams[1].latency_lead_ms = largest_span_ms
     announcement = _make_announcement()
 
+    before_ms = int(time.time() * 1000)
     await asyncio.gather(
         announce.play_announcement(leader, announcement, None),
         announce.play_announcement(member_1, announcement, None),
         announce.play_announcement(member_2, announcement, None),
     )
+    after_ms = time.time() * 1000
 
     instants = set()
     for stream in streams:
@@ -506,8 +518,10 @@ async def test_group_entity_fanout_arms_each_member_at_one_shared_instant() -> N
         stream.wait_announce_done.assert_awaited_once()
         instants.add(stream.announce.await_args.args[1])
     assert len(instants) == 1
-    # the shared instant cleared the largest member span (2s + margin)
-    assert next(iter(instants)) >= int(time.time() * 1000) + 2000
+    # the lead is measured from the clock the fan-out was scheduled against,
+    # not from a freshly read one, so a slow runner cannot eat into it
+    expected_lead = largest_span_ms + AIRPLAY_ANNOUNCE_AT_MARGIN_MS
+    assert before_ms + expected_lead <= next(iter(instants)) <= after_ms + expected_lead
 
 
 @pytest.mark.asyncio
@@ -598,14 +612,16 @@ async def test_return_holds_until_the_audible_end() -> None:
     announce_done reports MIX completion at the delivery head - ahead of
     audibility - and the caller re-mutes muted players the moment this returns.
     """
+    # taken WITH the wall clock the ack is built from, so the hold is measured
+    # from that same instant however slow the setup below runs
+    started = time.monotonic()
     now_unix_ms = int(time.time() * 1000)
     stream = _make_stream(ack=(now_unix_ms + 250, 100))
     members = _make_playing_group(stream)
 
     with patch.object(announce, "AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS", 100):
-        started = time.monotonic()
         await announce.play_announcement(members[0], _make_announcement(), None)
-        elapsed = time.monotonic() - started
+    elapsed = time.monotonic() - started
 
     # audible end = acked instant + clip duration (0.35s out) + the 0.1s pad
     assert elapsed >= 0.4

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -271,14 +271,15 @@ async def test_volume_is_scheduled_on_the_acked_instant() -> None:
     members = _make_playing_group(stream)
     member = members[0]
     member.volume_level = 30
-    # both delays count down from the moment they are scheduled, so that
-    # moment - not a clock read after the call - is what they are checked
-    # against: the audible-end hold at the end of the call takes seconds
-    scheduled_at_ms: list[float] = []
+    # both delays count down from the moment they are scheduled, which the
+    # clock reads either side of it bracket exactly: the audible-end hold this
+    # call ends on runs for seconds past that moment
+    scheduled_at: list[float] = []
     member.mass.call_later = MagicMock(
-        side_effect=lambda *_args, **_kwargs: scheduled_at_ms.append(time.time() * 1000)
+        side_effect=lambda *_args, **_kwargs: scheduled_at.append(time.time())
     )
 
+    before_s = time.time()
     with patch.object(announce, "_announce_with_session", new_callable=AsyncMock):
         await announce.play_announcement(member, _make_announcement(), 55)
 
@@ -292,8 +293,9 @@ async def test_volume_is_scheduled_on_the_acked_instant() -> None:
     # follows the CONTENT length (the acked duration minus the silence tail)
     # plus the (zeroed) pad, so it lands inside the ducked cushion - 1.7s
     # after the bump here
-    remaining_s = max(0.0, (ack_at_unix_ms - scheduled_at_ms[0]) / 1000)
-    assert bump.args[0] == pytest.approx(remaining_s + 0.3, abs=0.01)
+    left_at_least = max(0.0, ack_at_unix_ms / 1000 - scheduled_at[0])
+    left_at_most = max(0.0, ack_at_unix_ms / 1000 - before_s)
+    assert left_at_least + 0.3 <= bump.args[0] <= left_at_most + 0.3
     assert restore.args[0] - bump.args[0] == pytest.approx(1.7)
 
 
@@ -518,8 +520,8 @@ async def test_group_entity_fanout_arms_each_member_at_one_shared_instant() -> N
         stream.wait_announce_done.assert_awaited_once()
         instants.add(stream.announce.await_args.args[1])
     assert len(instants) == 1
-    # the lead is measured from the clock the fan-out was scheduled against,
-    # not from a freshly read one, so a slow runner cannot eat into it
+    # the instant is computed inside the call, so the clock reads either side
+    # of it bracket the lead however long the fan-out itself takes
     expected_lead = largest_span_ms + AIRPLAY_ANNOUNCE_AT_MARGIN_MS
     assert before_ms + expected_lead <= next(iter(instants)) <= after_ms + expected_lead
 


### PR DESCRIPTION
# What does this implement/fix?

`test_group_entity_fanout_arms_each_member_at_one_shared_instant` compared a value computed *during* the call against a clock read at assertion time, so wall-clock time passing in between ate into its 300 ms margin. On a loaded CI runner it failed intermittently and passed on a plain re-run — most recently blocking an unrelated PR (#5960). Reviewing its siblings turned up one more test of the same shape, plus one whose bound could never fail at all.

Every one of these assertions now measures against the reference it was actually scheduled from, so the outcome no longer depends on how fast the runner is. The bounds stay tight rather than widened — dropping the fan-out margin, taking the smallest member span instead of the largest, ignoring the acked instant, or dropping the into-the-clip bias or the audible-end pad each still fail the tests.

## Changes

- Group fan-out test (the one that was failing on CI): bracket the shared instant between clock reads either side of the fan-out, instead of comparing it to a freshly read clock.
- That test's "larger span" member was set to exactly the fallback span the other members assume, so its "clears the largest span" claim was never actually exercised — it now reports a genuinely larger one.
- Audible-end hold test: take the elapsed-time reference together with the wall clock the ack is built from, rather than after it — the gap between the two only had 50 ms of slack.
- Volume-schedule test: its bump bound could never fail (the delay is floored at zero, so the value could not drop below it). It is now bracketed around the moment the timer is scheduled, which does catch a bump that ignores the acked instant.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
