### PR TITLE
Bump hass-client to 1.3.1

### DIFF
--- a/music_assistant/providers/hass/manifest.json
+++ b/music_assistant/providers/hass/manifest.json
@@ -10,5 +10,5 @@
   "multi_instance": false,
   "builtin": false,
   "icon": "md:webhook",
-  "requirements": ["hass-client==1.3.0"]
+  "requirements": ["hass-client==1.3.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -38,7 +38,7 @@ duration-parser==1.0.1
 fastmcp==3.4.7
 getmac==0.9.5
 gql[all]==4.0.0
-hass-client==1.3.0
+hass-client==1.3.1
 hue-entertainment==0.1.2
 huggingface-hub==1.26.1
 ibroadcastaio==0.8.0


### PR DESCRIPTION
# What does this implement/fix?

Bumps `hass-client` from 1.3.0 to 1.3.1 for the Home Assistant provider.

The new release is bugfix-only, no API changes:

- Fixes a hang when disconnecting before the listener task has started.
- Fixes bare tracebacks in the log when an event subscription callback raises.
- Fixes error noise in the log when the Home Assistant connection drops.

Changes:

- Bump the pin in `music_assistant/providers/hass/manifest.json`.
- Regenerate `requirements_all.txt`.

Verified locally against 1.3.1: `tests/providers/hass` and `tests/providers/hass_players` both green (148 passed), `pre-commit run --all-files` clean. No new tests, since this only moves a pin.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
