### PR TITLE
Support next/previous controls on Google Cast devices

### DIFF
--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -920,11 +920,15 @@ class ChromecastPlayer(Player):
 
         :param command: Either "next" or "previous".
         """
+        if self.mass.closing:
+            return
         queue_command = (
             self.mass.player_queues.next if command == "next" else self.mass.player_queues.previous
         )
 
         def dispatch() -> None:
+            if self.mass.closing:
+                return
             # A stopped queue still reports active=True, so also reject IDLE or a
             # press on a dashboard-only session would start playback.
             queue = self.mass.players.get_active_queue(self)

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -920,22 +920,21 @@ class ChromecastPlayer(Player):
 
         :param command: Either "next" or "previous".
         """
-        # Same resolution as _flow_stream_underrun: a Cast group child mirrors the
-        # group's queue, and a Cast exposed as a protocol player is wrapped by a
-        # universal player that owns the queue.
-        queue_id = self.active_cast_group or self.protocol_parent_id or self.player_id
         queue_command = (
             self.mass.player_queues.next if command == "next" else self.mass.player_queues.previous
         )
 
         def dispatch() -> None:
-            # Read queue state on the event loop thread, not the socket thread the
-            # command arrives on: a dashboard-only session (no active MA queue) would
-            # otherwise raise InvalidCommand and spam the log on every button press.
-            queue = self.mass.player_queues.get(queue_id)
+            # Resolve the queue on the event loop thread, not the socket thread the
+            # command arrives on. get_active_queue follows sync/group/protocol parents;
+            # a dashboard-only session (no active queue anywhere up the chain) is
+            # dropped instead of raising InvalidCommand on every button press.
+            queue = self.mass.players.get_active_queue(self)
             if queue is None or not queue.active:
-                self.logger.debug("Ignoring %s command: queue %s is not active", command, queue_id)
+                self.logger.debug(
+                    "Ignoring %s command: no active queue for %s", command, self.display_name
+                )
                 return
-            self.mass.create_task(queue_command(queue_id))
+            self.mass.create_task(queue_command(queue.queue_id))
 
         self.mass.loop.call_soon_threadsafe(dispatch)

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -46,6 +46,7 @@ from .constants import (
     SENDSPIN_CAST_APP_ID,
 )
 from .helpers import CastStatusListener, ChromecastInfo
+from .receiver_commands import MassCastCommandController
 
 if TYPE_CHECKING:
     from pychromecast import Chromecast
@@ -88,6 +89,7 @@ class ChromecastPlayer(Player):
         self.status_listener: CastStatusListener | None
         self.cast_info = cast_info
         self.mz_controller: MultizoneController | None = None
+        self.command_controller: MassCastCommandController | None = None
         self.on_app_status_changed: Callable[[str | None], None] | None = None
         self.last_poll = 0.0
         self.last_multichannel_check = 0.0
@@ -138,6 +140,9 @@ class ChromecastPlayer(Player):
             mz_controller = MultizoneController(cast_info.uuid)
             self.cc.register_handler(mz_controller)
             self.mz_controller = mz_controller
+        command_controller = MassCastCommandController(self._handle_receiver_command)
+        self.cc.register_handler(command_controller)
+        self.command_controller = command_controller
 
     async def async_setup(self) -> None:
         """Start the chromecast socket client (must be called after __init__)."""
@@ -289,6 +294,9 @@ class ChromecastPlayer(Player):
         if self.status_listener is not None:
             self.status_listener.invalidate()
         self.status_listener = None
+        if self.command_controller is not None:
+            self.cc.unregister_handler(self.command_controller)
+            self.command_controller = None
         self.logger.debug("Disconnecting from chromecast socket %s", self.display_name)
         if self.mass.closing:
             # Non-blocking disconnect: close socket, don't wait for thread.
@@ -903,3 +911,20 @@ class ChromecastPlayer(Player):
         # player that owns the queue. Only a native/standalone Cast owns its own queue.
         queue_id = self.active_cast_group or self.protocol_parent_id or self.player_id
         return self.mass.player_queues.flow_stream_finished(queue_id)
+
+    def _handle_receiver_command(self, command: str) -> None:
+        """
+        Handle a playback command forwarded by the Cast receiver app.
+
+        Called from the pychromecast socket thread.
+
+        :param command: Either "next" or "previous".
+        """
+        # Same resolution as _flow_stream_underrun: a Cast group child mirrors the
+        # group's queue, and a Cast exposed as a protocol player is wrapped by a
+        # universal player that owns the queue.
+        queue_id = self.active_cast_group or self.protocol_parent_id or self.player_id
+        queue_command = (
+            self.mass.player_queues.next if command == "next" else self.mass.player_queues.previous
+        )
+        self.mass.loop.call_soon_threadsafe(lambda: self.mass.create_task(queue_command(queue_id)))

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -925,14 +925,12 @@ class ChromecastPlayer(Player):
         )
 
         def dispatch() -> None:
-            # Resolve the queue on the event loop thread, not the socket thread the
-            # command arrives on. get_active_queue follows sync/group/protocol parents;
-            # a dashboard-only session (no active queue anywhere up the chain) is
-            # dropped instead of raising InvalidCommand on every button press.
+            # A stopped queue still reports active=True, so also reject IDLE or a
+            # press on a dashboard-only session would start playback.
             queue = self.mass.players.get_active_queue(self)
-            if queue is None or not queue.active:
+            if queue is None or not queue.active or queue.state == PlaybackState.IDLE:
                 self.logger.debug(
-                    "Ignoring %s command: no active queue for %s", command, self.display_name
+                    "Ignoring %s command: no playing queue for %s", command, self.display_name
                 )
                 return
             self.mass.create_task(queue_command(queue.queue_id))

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -927,4 +927,15 @@ class ChromecastPlayer(Player):
         queue_command = (
             self.mass.player_queues.next if command == "next" else self.mass.player_queues.previous
         )
-        self.mass.loop.call_soon_threadsafe(lambda: self.mass.create_task(queue_command(queue_id)))
+
+        def dispatch() -> None:
+            # Read queue state on the event loop thread, not the socket thread the
+            # command arrives on: a dashboard-only session (no active MA queue) would
+            # otherwise raise InvalidCommand and spam the log on every button press.
+            queue = self.mass.player_queues.get(queue_id)
+            if queue is None or not queue.active:
+                self.logger.debug("Ignoring %s command: queue %s is not active", command, queue_id)
+                return
+            self.mass.create_task(queue_command(queue_id))
+
+        self.mass.loop.call_soon_threadsafe(dispatch)

--- a/music_assistant/providers/chromecast/receiver_commands.py
+++ b/music_assistant/providers/chromecast/receiver_commands.py
@@ -1,0 +1,45 @@
+"""Inbound custom-namespace messages from the Music Assistant Cast receiver app."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pychromecast.controllers import BaseController
+
+from .constants import DASHBOARD_NAMESPACE
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pychromecast.generated.cast_channel_pb2 import CastMessage
+
+PLAYER_COMMANDS = ("next", "previous")
+
+
+class MassCastCommandController(BaseController):
+    """Handles playback commands the Music Assistant Cast receiver app forwards."""
+
+    def __init__(self, on_command: Callable[[str], None]) -> None:
+        """
+        Initialize the controller.
+
+        :param on_command: Called with "next" or "previous" when the device's own
+            UI (Google Home app, touch controls, remote) asks for a queue jump.
+        """
+        super().__init__(DASHBOARD_NAMESPACE)
+        self._on_command = on_command
+
+    def receive_message(self, _message: CastMessage, data: dict[str, Any]) -> bool:
+        """
+        Handle an incoming message on the Music Assistant Cast namespace.
+
+        :param _message: The raw Cast protocol message.
+        :param data: The parsed JSON payload.
+        """
+        if data.get("type") != "player_command":
+            return False
+        command = data.get("command")
+        if command not in PLAYER_COMMANDS:
+            return False
+        self._on_command(command)
+        return True

--- a/tests/providers/chromecast/test_receiver_commands.py
+++ b/tests/providers/chromecast/test_receiver_commands.py
@@ -8,11 +8,13 @@ this controller turns them back into MA queue commands.
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 
 from music_assistant.providers.chromecast.constants import DASHBOARD_NAMESPACE
+from music_assistant.providers.chromecast.player import ChromecastPlayer
 from music_assistant.providers.chromecast.receiver_commands import MassCastCommandController
 
 
@@ -53,3 +55,54 @@ def test_unhandled_messages_are_ignored(data: dict[str, object]) -> None:
 
     assert controller.receive_message(MagicMock(), data) is False
     on_command.assert_not_called()
+
+
+### Dispatch into the queue controller
+
+
+def _fake_cast(
+    *,
+    player_id: str = "cast_id",
+    protocol_parent_id: str | None = None,
+    active_cast_group: str | None = None,
+) -> MagicMock:
+    """Build a MagicMock Cast that records the coroutine passed to the event loop."""
+    fake = MagicMock()
+    fake.player_id = player_id
+    fake.protocol_parent_id = protocol_parent_id
+    fake.active_cast_group = active_cast_group
+    # call_soon_threadsafe runs the callback inline so the call is observable
+    fake.mass.loop.call_soon_threadsafe = MagicMock(side_effect=lambda func, *args: func(*args))
+    return fake
+
+
+def _dispatch(fake: MagicMock, command: str) -> None:
+    ChromecastPlayer._handle_receiver_command(cast("ChromecastPlayer", fake), command)
+
+
+def test_next_command_targets_the_queue_owner() -> None:
+    """A Cast wrapped by a universal player forwards next to the parent's queue."""
+    fake = _fake_cast(protocol_parent_id="up_universal")
+
+    _dispatch(fake, "next")
+
+    fake.mass.create_task.assert_called_once()
+    fake.mass.player_queues.next.assert_called_once_with("up_universal")
+
+
+def test_previous_command_targets_the_queue_owner() -> None:
+    """Previous is routed to the same resolved queue id."""
+    fake = _fake_cast()
+
+    _dispatch(fake, "previous")
+
+    fake.mass.player_queues.previous.assert_called_once_with("cast_id")
+
+
+def test_command_prefers_the_active_cast_group() -> None:
+    """A Cast group child mirrors the group's queue, taking precedence."""
+    fake = _fake_cast(protocol_parent_id="up_universal", active_cast_group="cast_group")
+
+    _dispatch(fake, "next")
+
+    fake.mass.player_queues.next.assert_called_once_with("cast_group")

--- a/tests/providers/chromecast/test_receiver_commands.py
+++ b/tests/providers/chromecast/test_receiver_commands.py
@@ -66,13 +66,16 @@ def _fake_cast(
     protocol_parent_id: str | None = None,
     active_cast_group: str | None = None,
 ) -> MagicMock:
-    """Build a MagicMock Cast that records the coroutine passed to the event loop."""
+    """Build a MagicMock Cast whose call_soon_threadsafe hop runs the callback inline."""
     fake = MagicMock()
     fake.player_id = player_id
     fake.protocol_parent_id = protocol_parent_id
     fake.active_cast_group = active_cast_group
-    # call_soon_threadsafe runs the callback inline so the call is observable
+    # call_soon_threadsafe runs the callback inline so the dispatch is observable
     fake.mass.loop.call_soon_threadsafe = MagicMock(side_effect=lambda func, *args: func(*args))
+    # deliberately active: the resolved queue must exist and be active for a
+    # command to reach player_queues.next/previous, see test_inactive_queue_is_ignored
+    fake.mass.player_queues.get.return_value.active = True
     return fake
 
 
@@ -86,6 +89,7 @@ def test_next_command_targets_the_queue_owner() -> None:
 
     _dispatch(fake, "next")
 
+    fake.mass.loop.call_soon_threadsafe.assert_called_once()
     fake.mass.create_task.assert_called_once()
     fake.mass.player_queues.next.assert_called_once_with("up_universal")
 
@@ -96,6 +100,7 @@ def test_previous_command_targets_the_queue_owner() -> None:
 
     _dispatch(fake, "previous")
 
+    fake.mass.loop.call_soon_threadsafe.assert_called_once()
     fake.mass.player_queues.previous.assert_called_once_with("cast_id")
 
 
@@ -105,4 +110,16 @@ def test_command_prefers_the_active_cast_group() -> None:
 
     _dispatch(fake, "next")
 
+    fake.mass.loop.call_soon_threadsafe.assert_called_once()
     fake.mass.player_queues.next.assert_called_once_with("cast_group")
+
+
+def test_inactive_queue_is_ignored() -> None:
+    """A command on a dashboard-only session (no active MA queue) is dropped, not dispatched."""
+    fake = _fake_cast()
+    fake.mass.player_queues.get.return_value.active = False
+
+    _dispatch(fake, "next")
+
+    fake.mass.player_queues.next.assert_not_called()
+    fake.mass.create_task.assert_not_called()

--- a/tests/providers/chromecast/test_receiver_commands.py
+++ b/tests/providers/chromecast/test_receiver_commands.py
@@ -1,0 +1,55 @@
+"""
+Tests for the inbound half of the Music Assistant Cast namespace.
+
+The receiver app forwards the device's own next/previous button presses as
+custom messages (see https://github.com/music-assistant/support/issues/2969);
+this controller turns them back into MA queue commands.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from music_assistant.providers.chromecast.constants import DASHBOARD_NAMESPACE
+from music_assistant.providers.chromecast.receiver_commands import MassCastCommandController
+
+
+def test_controller_uses_the_mass_cast_namespace() -> None:
+    """The controller listens on the same namespace the receiver replies on."""
+    controller = MassCastCommandController(MagicMock())
+
+    assert controller.namespace == DASHBOARD_NAMESPACE
+
+
+@pytest.mark.parametrize("command", ["next", "previous"])
+def test_player_command_is_forwarded(command: str) -> None:
+    """A player_command message invokes the callback and is marked handled."""
+    on_command = MagicMock()
+    controller = MassCastCommandController(on_command)
+
+    handled = controller.receive_message(
+        MagicMock(), {"type": "player_command", "command": command}
+    )
+
+    assert handled is True
+    on_command.assert_called_once_with(command)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"type": "receiver_status", "connected": True},
+        {"type": "player_command", "command": "shuffle"},
+        {"type": "player_command"},
+        {},
+    ],
+)
+def test_unhandled_messages_are_ignored(data: dict[str, object]) -> None:
+    """Other namespace traffic is left for other handlers and never dispatched."""
+    on_command = MagicMock()
+    controller = MassCastCommandController(on_command)
+
+    assert controller.receive_message(MagicMock(), data) is False
+    on_command.assert_not_called()

--- a/tests/providers/chromecast/test_receiver_commands.py
+++ b/tests/providers/chromecast/test_receiver_commands.py
@@ -70,6 +70,7 @@ def _fake_cast(
     """Build a MagicMock Cast whose call_soon_threadsafe hop runs the callback inline."""
     fake = MagicMock()
     fake.display_name = "Fake Cast"
+    fake.mass.closing = False
     # call_soon_threadsafe runs the callback inline so the dispatch is observable
     fake.mass.loop.call_soon_threadsafe = MagicMock(side_effect=lambda func, *args: func(*args))
     if queue_id is None:
@@ -136,6 +137,17 @@ def test_idle_queue_is_ignored() -> None:
     _dispatch(fake, "next")
 
     fake.mass.player_queues.next.assert_not_called()
+    fake.mass.create_task.assert_not_called()
+
+
+def test_commands_are_ignored_during_shutdown() -> None:
+    """A press racing MusicAssistant.stop() must not schedule a new queue task."""
+    fake = _fake_cast()
+    fake.mass.closing = True
+
+    _dispatch(fake, "next")
+
+    fake.mass.loop.call_soon_threadsafe.assert_not_called()
     fake.mass.create_task.assert_not_called()
 
 

--- a/tests/providers/chromecast/test_receiver_commands.py
+++ b/tests/providers/chromecast/test_receiver_commands.py
@@ -12,6 +12,7 @@ from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
+from music_assistant_models.enums import PlaybackState
 
 from music_assistant.providers.chromecast.constants import DASHBOARD_NAMESPACE
 from music_assistant.providers.chromecast.player import ChromecastPlayer
@@ -60,7 +61,12 @@ def test_unhandled_messages_are_ignored(data: dict[str, object]) -> None:
 ### Dispatch into the queue controller
 
 
-def _fake_cast(*, queue_id: str | None = "cast_queue", queue_active: bool = True) -> MagicMock:
+def _fake_cast(
+    *,
+    queue_id: str | None = "cast_queue",
+    queue_active: bool = True,
+    queue_state: PlaybackState = PlaybackState.PLAYING,
+) -> MagicMock:
     """Build a MagicMock Cast whose call_soon_threadsafe hop runs the callback inline."""
     fake = MagicMock()
     fake.display_name = "Fake Cast"
@@ -72,6 +78,7 @@ def _fake_cast(*, queue_id: str | None = "cast_queue", queue_active: bool = True
         queue = MagicMock()
         queue.queue_id = queue_id
         queue.active = queue_active
+        queue.state = queue_state
         fake.mass.players.get_active_queue.return_value = queue
     return fake
 
@@ -120,3 +127,22 @@ def test_inactive_queue_is_ignored() -> None:
 
     fake.mass.player_queues.next.assert_not_called()
     fake.mass.create_task.assert_not_called()
+
+
+def test_idle_queue_is_ignored() -> None:
+    """An idle queue still reports active=True; a press must not start playback."""
+    fake = _fake_cast(queue_state=PlaybackState.IDLE)
+
+    _dispatch(fake, "next")
+
+    fake.mass.player_queues.next.assert_not_called()
+    fake.mass.create_task.assert_not_called()
+
+
+def test_paused_queue_is_dispatched() -> None:
+    """Next while paused is a legitimate command and goes through."""
+    fake = _fake_cast(queue_state=PlaybackState.PAUSED)
+
+    _dispatch(fake, "next")
+
+    fake.mass.player_queues.next.assert_called_once_with("cast_queue")

--- a/tests/providers/chromecast/test_receiver_commands.py
+++ b/tests/providers/chromecast/test_receiver_commands.py
@@ -60,22 +60,19 @@ def test_unhandled_messages_are_ignored(data: dict[str, object]) -> None:
 ### Dispatch into the queue controller
 
 
-def _fake_cast(
-    *,
-    player_id: str = "cast_id",
-    protocol_parent_id: str | None = None,
-    active_cast_group: str | None = None,
-) -> MagicMock:
+def _fake_cast(*, queue_id: str | None = "cast_queue", queue_active: bool = True) -> MagicMock:
     """Build a MagicMock Cast whose call_soon_threadsafe hop runs the callback inline."""
     fake = MagicMock()
-    fake.player_id = player_id
-    fake.protocol_parent_id = protocol_parent_id
-    fake.active_cast_group = active_cast_group
+    fake.display_name = "Fake Cast"
     # call_soon_threadsafe runs the callback inline so the dispatch is observable
     fake.mass.loop.call_soon_threadsafe = MagicMock(side_effect=lambda func, *args: func(*args))
-    # deliberately active: the resolved queue must exist and be active for a
-    # command to reach player_queues.next/previous, see test_inactive_queue_is_ignored
-    fake.mass.player_queues.get.return_value.active = True
+    if queue_id is None:
+        fake.mass.players.get_active_queue.return_value = None
+    else:
+        queue = MagicMock()
+        queue.queue_id = queue_id
+        queue.active = queue_active
+        fake.mass.players.get_active_queue.return_value = queue
     return fake
 
 
@@ -83,41 +80,41 @@ def _dispatch(fake: MagicMock, command: str) -> None:
     ChromecastPlayer._handle_receiver_command(cast("ChromecastPlayer", fake), command)
 
 
-def test_next_command_targets_the_queue_owner() -> None:
-    """A Cast wrapped by a universal player forwards next to the parent's queue."""
-    fake = _fake_cast(protocol_parent_id="up_universal")
+def test_next_command_targets_the_active_queue() -> None:
+    """Next is dispatched to the queue that get_active_queue resolves for this player."""
+    fake = _fake_cast(queue_id="up_universal")
 
     _dispatch(fake, "next")
 
     fake.mass.loop.call_soon_threadsafe.assert_called_once()
+    fake.mass.players.get_active_queue.assert_called_once_with(fake)
     fake.mass.create_task.assert_called_once()
     fake.mass.player_queues.next.assert_called_once_with("up_universal")
 
 
-def test_previous_command_targets_the_queue_owner() -> None:
+def test_previous_command_targets_the_active_queue() -> None:
     """Previous is routed to the same resolved queue id."""
     fake = _fake_cast()
 
     _dispatch(fake, "previous")
 
     fake.mass.loop.call_soon_threadsafe.assert_called_once()
-    fake.mass.player_queues.previous.assert_called_once_with("cast_id")
+    fake.mass.player_queues.previous.assert_called_once_with("cast_queue")
 
 
-def test_command_prefers_the_active_cast_group() -> None:
-    """A Cast group child mirrors the group's queue, taking precedence."""
-    fake = _fake_cast(protocol_parent_id="up_universal", active_cast_group="cast_group")
+def test_no_active_queue_is_ignored() -> None:
+    """A command without any resolvable queue (dashboard-only session) is dropped."""
+    fake = _fake_cast(queue_id=None)
 
     _dispatch(fake, "next")
 
-    fake.mass.loop.call_soon_threadsafe.assert_called_once()
-    fake.mass.player_queues.next.assert_called_once_with("cast_group")
+    fake.mass.player_queues.next.assert_not_called()
+    fake.mass.create_task.assert_not_called()
 
 
 def test_inactive_queue_is_ignored() -> None:
-    """A command on a dashboard-only session (no active MA queue) is dropped, not dispatched."""
-    fake = _fake_cast()
-    fake.mass.player_queues.get.return_value.active = False
+    """A command whose resolved queue is not active is dropped, not dispatched."""
+    fake = _fake_cast(queue_active=False)
 
     _dispatch(fake, "next")
 


### PR DESCRIPTION
# What does this implement/fix?

Google Cast devices show no next/previous track buttons while Music Assistant is playing (Google Home app, Nest Hub touch controls, Android TV remotes). The receiver never advertises the `QUEUE_NEXT`/`QUEUE_PREV` media commands, so the Cast UI never draws the buttons.

This is the server half of the fix. The companion receiver PR (music-assistant/cast-receiver#4) makes the receiver app advertise those commands and forward button presses as a `player_command` message on the existing `urn:x-cast:io.music-assistant.cast` namespace. This PR receives that message and drives the MA queue, keeping MA the single source of truth (works in flow mode too, where there is no real Cast queue).

- Add `MassCastCommandController` on the MA cast namespace, parsing forwarded `next`/`previous` commands
- Register it on every Cast player, unregister on unload
- Dispatch to `player_queues.next/previous` via the event loop, resolving the queue owner (cast group / universal player wrap) like `_flow_stream_underrun`
- Ignore commands when the resolved queue is not active (e.g. dashboard-only sessions)

Inert until the receiver app ships: the production receiver never sends `player_command`. **Merge order matters**: this must be in a published release before the receiver PR deploys, otherwise devices show buttons that do nothing and Assistant voice skip breaks on older servers.

Verified on hardware (Nest Hub): buttons and voice, next and previous, flow and non-flow mode.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/2969

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.


