### PR TITLE
Speed up the slowest AirPlay announcement test

### DIFF
--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -266,8 +266,10 @@ async def test_partial_success_warns_and_does_not_fall_back(
 async def test_volume_is_scheduled_on_the_acked_instant() -> None:
     """The volume bump lands at the acked audible instant, the restore after the clip."""
     ack_at_unix_ms = int(time.time() * 1000) + 200
-    # the acked duration includes the 1s ducked-silence tail: 2s of content
-    stream = _make_stream(ack=(ack_at_unix_ms, 3000))
+    # the acked duration includes the 1s ducked-silence tail: 0.8s of content,
+    # which keeps the bias out of the short-clip cap while the audible-end hold
+    # this call ends on stays short
+    stream = _make_stream(ack=(ack_at_unix_ms, 1800))
     members = _make_playing_group(stream)
     member = members[0]
     member.volume_level = 30
@@ -291,12 +293,12 @@ async def test_volume_is_scheduled_on_the_acked_instant() -> None:
     # the bump lands on what was left of the acked instant when it was
     # scheduled (0.2s out here), plus the 0.3s into-the-clip bias; the restore
     # follows the CONTENT length (the acked duration minus the silence tail)
-    # plus the (zeroed) pad, so it lands inside the ducked cushion - 1.7s
+    # plus the (zeroed) pad, so it lands inside the ducked cushion - 0.5s
     # after the bump here
     left_at_least = max(0.0, ack_at_unix_ms / 1000 - scheduled_at[0])
     left_at_most = max(0.0, ack_at_unix_ms / 1000 - before_s)
     assert left_at_least + 0.3 <= bump.args[0] <= left_at_most + 0.3
-    assert restore.args[0] - bump.args[0] == pytest.approx(1.7)
+    assert restore.args[0] - bump.args[0] == pytest.approx(0.5)
 
 
 def test_member_duck_compensates_the_volume_bump() -> None:


### PR DESCRIPTION
# What does this implement/fix?

`test_volume_is_scheduled_on_the_acked_instant` was the slowest test in the AirPlay
announcement suite: it acked a 3s clip, and the live announcement path holds its return
until the acked audible end, so the test spent ~3.2s doing nothing but waiting.

- Ack a 1.8s clip instead of 3s: 0.8s of content plus the 1s ducked-silence tail
- Updated the pinned bump/restore gap to match (0.5s instead of 1.7s)
- Test now runs in ~2s instead of ~3.2s, with no loss of coverage

The 0.8s of content deliberately stays above the 0.6s point where the short-clip bump cap
takes over, so the test keeps pinning the normal 0.3s into-the-clip bias. Verified it still
fails against the mutations it exists to catch (ignoring the acked instant, dropping the
bias, and biasing the bump late).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
