### PR TITLE
Let audio analysis notice players that are not served over HTTP

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -237,7 +237,8 @@ class StreamsController(CoreController):
         self.audio = StreamsAudio(mass)
         self.audio_processing = AudioProcessingManager(mass)
         self._audio_analysis = AudioAnalysisController(self)
-        # Number of queue streams (single item or flow) actively serving a player right now.
+        # Number of queue streams (single item or flow) actively serving a player right now,
+        # counted for both entry points: the http routes and the raw-PCM get_stream helper.
         # Audio analysis reads this (via audio_analysis.playback_active) to yield CPU while a
         # queue stream is live. Announcements are a separate path that never runs analysis.
         self._active_output_streams = 0
@@ -1474,8 +1475,10 @@ class StreamsController(CoreController):
                 raise AudioError(
                     f"Unknown (or invalid) audio source session: {media.queue_session_id}"
                 )
-            return self._get_audio_source_session_stream(
-                session, pcm_format, player_id or media.source_id
+            return self._count_as_output_stream(
+                self._get_audio_source_session_stream(
+                    session, pcm_format, player_id or media.source_id
+                )
             )
         if media.source_id and media.queue_item_id:
             # Queue stream request - determine flow_mode based on player capabilities
@@ -1530,7 +1533,7 @@ class StreamsController(CoreController):
                     flow_stream = self.audio.get_overlay_mixed_stream(
                         queue, flow_stream, pcm_format
                     )
-                return flow_stream
+                return self._count_as_output_stream(flow_stream)
             # single item stream (e.g. radio or non-flow mode)
             queue_item = self.mass.player_queues.get_item(media.source_id, media.queue_item_id)
             assert queue_item
@@ -1569,12 +1572,12 @@ class StreamsController(CoreController):
                 queue_item.media_item is not None
                 and queue_item.media_item.media_type == MediaType.AUDIO_SOURCE
             ):
-                return self._wrap_with_audio_source_lifecycle(
+                inner_stream = self._wrap_with_audio_source_lifecycle(
                     inner=inner_stream,
                     queue_item=queue_item,
                     player_id=player_id or media.source_id,
                 )
-            return inner_stream
+            return self._count_as_output_stream(inner_stream)
         # assume url or some other direct path
         # NOTE: this will fail if its an uri not playable by ffmpeg
         return get_ffmpeg_stream(
@@ -1973,6 +1976,27 @@ class StreamsController(CoreController):
                     source_id,
                     queue_id,
                 )
+
+    async def _count_as_output_stream(self, inner: AsyncGenerator[bytes]) -> AsyncGenerator[bytes]:
+        """
+        Forward a queue stream while it counts towards the active-output-stream gauge.
+
+        Direct-PCM consumers (AirPlay, Snapcast, Sendspin, Squeezelite, UGP, ...) call
+        ``get_stream`` instead of going through the HTTP route, so without this they never
+        register as playing and audio analysis keeps its idle CPU budget while they stream.
+
+        :param inner: The queue (flow or single item) stream to forward.
+        """
+        self._active_output_streams += 1
+        try:
+            # aclosing guarantees the generator (and thus the ffmpeg process chain behind
+            # it) is torn down when the consumer stops iterating; an async for does not
+            # close its iterator on its own.
+            async with aclosing(inner):
+                async for chunk in inner:
+                    yield chunk
+        finally:
+            self._active_output_streams -= 1
 
     def _served_by(self, queue_item: QueueItem | None, provider_instance: str) -> bool:
         """

--- a/music_assistant/providers/squeezelite/multi_client_stream.py
+++ b/music_assistant/providers/squeezelite/multi_client_stream.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import AsyncGenerator, Sequence
-from contextlib import suppress
+from contextlib import aclosing, suppress
 from typing import TYPE_CHECKING
 
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
@@ -97,16 +97,19 @@ class MultiClientStream:
             len(self.subscribers),
             self.expected_clients,
         )
-        async for chunk in self.audio_source:
-            fail_count = 0
-            while len(self.subscribers) == 0:
-                await asyncio.sleep(0.1)
-                fail_count += 1
-                if fail_count > 50:
-                    LOGGER.warning("No clients connected, stopping stream")
-                    return
-            await asyncio.gather(
-                *[sub.put(chunk) for sub in self.subscribers], return_exceptions=True
-            )
+        # aclosing so giving up below tears the source down; returning out of an async for
+        # leaves it suspended, and this object keeps it referenced so nothing collects it
+        async with aclosing(self.audio_source):
+            async for chunk in self.audio_source:
+                fail_count = 0
+                while len(self.subscribers) == 0:
+                    await asyncio.sleep(0.1)
+                    fail_count += 1
+                    if fail_count > 50:
+                        LOGGER.warning("No clients connected, stopping stream")
+                        return
+                await asyncio.gather(
+                    *[sub.put(chunk) for sub in self.subscribers], return_exceptions=True
+                )
         # EOF: send empty chunk
         await asyncio.gather(*[sub.put(b"") for sub in self.subscribers], return_exceptions=True)

--- a/tests/controllers/streams/test_audio_source_route.py
+++ b/tests/controllers/streams/test_audio_source_route.py
@@ -44,6 +44,7 @@ def _controller(session: AudioSourceSession | None) -> tuple[Any, MagicMock, Mag
     ctrl = StreamsController.__new__(StreamsController)
     ctrl.mass = MagicMock()
     ctrl.logger = MagicMock()
+    ctrl._active_output_streams = 0
     # a truthy MagicMock here would send _log_request down the verbose path
     ctrl.logger.isEnabledFor = MagicMock(return_value=False)
     provider = MagicMock(spec=PluginProvider)
@@ -164,11 +165,15 @@ def test_a_direct_pcm_request_from_a_superseded_session_is_refused() -> None:
         )
 
 
-def test_a_direct_pcm_request_carrying_the_live_token_is_served() -> None:
+async def test_a_direct_pcm_request_carrying_the_live_token_is_served() -> None:
     """A consumer naming the session that is playing gets its stream."""
     session = _session()
     ctrl, _provider, _player = _controller(session)
-    ctrl._get_audio_source_session_stream = MagicMock(return_value="pcm-stream")
+
+    async def _session_stream() -> AsyncGenerator[bytes]:
+        yield b"pcm-stream"
+
+    ctrl._get_audio_source_session_stream = MagicMock(return_value=_session_stream())
 
     result = ctrl.get_stream(
         PlayerMedia(
@@ -181,7 +186,7 @@ def test_a_direct_pcm_request_carrying_the_live_token_is_served() -> None:
         player_id=CONSUMER_ID,
     )
 
-    assert result == "pcm-stream"
+    assert [chunk async for chunk in result] == [b"pcm-stream"]
     ctrl._get_audio_source_session_stream.assert_called_once_with(
         session, AudioFormat(), CONSUMER_ID
     )

--- a/tests/controllers/streams/test_direct_pcm_stream.py
+++ b/tests/controllers/streams/test_direct_pcm_stream.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import AsyncGenerator
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -90,3 +91,63 @@ def test_single_item_stream_forwards_the_seek_position(seek_position: int) -> No
     )
 
     assert call_kwargs["seek_position"] == seek_position
+
+
+async def _pcm_chunks() -> AsyncGenerator[bytes]:
+    """Yield two PCM chunks so the gauge can be observed mid-stream."""
+    yield b"chunk-1"
+    yield b"chunk-2"
+
+
+def _pcm_stream_controller() -> StreamsController:
+    """Build a controller whose single item stream yields real PCM chunks."""
+    controller, _ = _controller(_queue_item(0))
+    audio = cast("Any", controller.audio)
+    audio.get_queue_item_stream.side_effect = lambda **_kwargs: _pcm_chunks()
+    return controller
+
+
+@pytest.mark.asyncio
+async def test_direct_pcm_stream_counts_as_an_active_output_stream() -> None:
+    """A player consuming raw PCM registers as playing, so analysis yields CPU to it."""
+    controller = _pcm_stream_controller()
+
+    stream = controller.get_stream(
+        PlayerMedia(
+            uri="library://audiobook/1",
+            media_type=MediaType.AUDIOBOOK,
+            source_id=QUEUE_ID,
+            queue_item_id=QUEUE_ITEM_ID,
+        ),
+        PCM_FORMAT,
+    )
+    assert controller.output_stream_active() is False
+
+    chunks = []
+    async for chunk in stream:
+        chunks.append(chunk)
+        assert controller.output_stream_active() is True
+
+    assert chunks == [b"chunk-1", b"chunk-2"]
+    assert controller.output_stream_active() is False
+
+
+@pytest.mark.asyncio
+async def test_abandoned_direct_pcm_stream_releases_the_gauge() -> None:
+    """A consumer that stops mid-stream releases its count, so analysis regains its budget."""
+    controller = _pcm_stream_controller()
+
+    stream = controller.get_stream(
+        PlayerMedia(
+            uri="library://audiobook/1",
+            media_type=MediaType.AUDIOBOOK,
+            source_id=QUEUE_ID,
+            queue_item_id=QUEUE_ITEM_ID,
+        ),
+        PCM_FORMAT,
+    )
+    assert await anext(stream) == b"chunk-1"
+    assert controller.output_stream_active() is True
+
+    await stream.aclose()
+    assert controller.output_stream_active() is False

--- a/tests/providers/squeezelite/test_multi_client_stream.py
+++ b/tests/providers/squeezelite/test_multi_client_stream.py
@@ -1,0 +1,59 @@
+"""Tests for the squeezelite multi-client stream task."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
+
+from music_assistant.providers.squeezelite.multi_client_stream import MultiClientStream
+
+PCM_FORMAT = AudioFormat(
+    content_type=ContentType.PCM_S16LE,
+    sample_rate=44100,
+    bit_depth=16,
+    channels=2,
+)
+
+
+@pytest.fixture(name="instant_sleep")
+def instant_sleep_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the runner's retry delays elapse immediately while still yielding control."""
+    real_sleep = asyncio.sleep
+
+    async def _sleep(_delay: float, *args: Any, **kwargs: Any) -> Any:
+        return await real_sleep(0, *args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+
+
+@pytest.mark.usefixtures("instant_sleep")
+async def test_runner_closes_the_source_when_no_client_connects() -> None:
+    """
+    Giving up on a stream nobody subscribed to tears the source down.
+
+    The source counts as active playback for as long as it is open, so leaving it
+    suspended here would hold audio analysis in its reduced-CPU mode indefinitely.
+    """
+    closed = asyncio.Event()
+
+    async def _source() -> AsyncGenerator[bytes]:
+        try:
+            while True:
+                yield b"chunk"
+        finally:
+            closed.set()
+
+    stream = MultiClientStream(
+        audio_source=_source(),
+        audio_format=PCM_FORMAT,
+        queue_id="queue-1",
+        session_id="session-1",
+    )
+    await stream.task
+
+    assert closed.is_set()


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant lowers the CPU that audio analysis may use while a player is streaming, so
playback keeps priority. That check only ever noticed players served over HTTP. Every player
that takes raw audio directly — AirPlay, Snapcast, Sendspin, Squeezelite, Universal Group and
the MSX bridge — never counted as playing, so analysis kept running at its full idle budget
underneath them.

Found while measuring the analysis CPU profile during the Spotify Soloist stutter testing.

## Changes

- Raw audio streams handed to a player now count as active playback for as long as they run.
- Squeezelite: a group stream that gives up because no player ever connected now closes its
  audio source instead of leaving it (and its ffmpeg chain) open.
- Added tests covering a stream that plays out, one the player abandons halfway, and the
  squeezelite give-up path.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
