### PR TITLE
Keep tracks of the same album gapless when crossfade is on

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -133,6 +133,7 @@ from music_assistant.helpers.audio import (
     resample_pcm_audio,
     resolve_output_player_ids,
 )
+from music_assistant.helpers.compare import compare_item_ids
 from music_assistant.helpers.dsp import ComplexFilter, filter_to_ffmpeg_params
 from music_assistant.helpers.ffmpeg import (
     FFMpeg,
@@ -3050,12 +3051,16 @@ class StreamsAudio:
         if next_item.media_type != MediaType.TRACK:
             self.logger.debug("Skipping crossfade: next item is not a track")
             return False
+        # an item picks up its library album only once it is loaded, so a queue fed straight
+        # from a provider can hold the provider album on the side that is not loaded yet.
+        # Matching on the provider mappings recognises both shapes as the same album; the
+        # uri-based equality of the album objects does not.
         if (
             isinstance(queue_item.media_item, Track)
             and isinstance(next_item.media_item, Track)
             and queue_item.media_item.album
             and next_item.media_item.album
-            and queue_item.media_item.album == next_item.media_item.album
+            and compare_item_ids(queue_item.media_item.album, next_item.media_item.album)
             and not self.mass.config.get_raw_core_config_value(
                 "streams", CONF_ALLOW_CROSSFADE_SAME_ALBUM, False
             )

--- a/tests/controllers/streams/test_crossfade_same_album.py
+++ b/tests/controllers/streams/test_crossfade_same_album.py
@@ -1,0 +1,114 @@
+"""Tests for the crossfade guard that keeps tracks of one album gapless."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+from music_assistant_models.enums import CrossfadeMode, MediaType
+from music_assistant_models.media_items import Album, ItemMapping, ProviderMapping, Track
+from music_assistant_models.queue_item import QueueItem
+
+from music_assistant.controllers.streams.audio import StreamsAudio
+
+PROVIDER_ALBUM = ItemMapping(
+    media_type=MediaType.ALBUM,
+    item_id="album-prov-1",
+    provider="spotify--abc",
+    name="Kind of Blue",
+)
+OTHER_PROVIDER_ALBUM = ItemMapping(
+    media_type=MediaType.ALBUM,
+    item_id="album-prov-2",
+    provider="spotify--abc",
+    name="Sketches of Spain",
+)
+LIBRARY_ALBUM = Album(
+    item_id="7",
+    provider="library",
+    name="Kind of Blue",
+    provider_mappings={
+        ProviderMapping(
+            item_id="album-prov-1",
+            provider_domain="spotify",
+            provider_instance="spotify--abc",
+        )
+    },
+)
+
+
+def _queue_item(item_id: str, album: Album | ItemMapping) -> QueueItem:
+    """Build a queue item holding a track on the given album."""
+    return QueueItem(
+        queue_id="queue-1",
+        queue_item_id=item_id,
+        name=item_id,
+        duration=300,
+        media_item=Track(
+            item_id=item_id,
+            provider="spotify--abc",
+            name=item_id,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=item_id,
+                    provider_domain="spotify",
+                    provider_instance="spotify--abc",
+                )
+            },
+            album=album,
+        ),
+    )
+
+
+def _audio(next_item: QueueItem, allow_same_album: bool = False) -> StreamsAudio:
+    """Build a StreamsAudio whose queue reports the given (unloaded) next item."""
+    mass = MagicMock()
+    mass.player_queues.get.return_value = MagicMock()
+    mass.players.get_player.return_value = MagicMock()
+    mass.player_queues.get_next_item.return_value = next_item
+    mass.config.get_raw_core_config_value.return_value = allow_same_album
+    return StreamsAudio(cast("Any", mass))
+
+
+def _crossfade_allowed(current: QueueItem, next_item: QueueItem, **kwargs: Any) -> bool:
+    """Run the guard the way the flow stream does: only the current item is loaded."""
+    return _audio(next_item, **kwargs).crossfade_allowed(
+        current,
+        crossfade_mode=CrossfadeMode.STANDARD_CROSSFADE,
+        player_id="queue-1",
+        flow_mode=True,
+    )
+
+
+def test_same_album_from_one_provider_is_not_crossfaded() -> None:
+    """Two tracks that both still carry the provider album are recognised as one album."""
+    assert not _crossfade_allowed(
+        _queue_item("track-1", PROVIDER_ALBUM), _queue_item("track-2", PROVIDER_ALBUM)
+    )
+
+
+def test_library_album_matches_the_provider_album_of_an_unloaded_next_item() -> None:
+    """
+    A loaded item carries the library album while the next item still carries the provider one.
+
+    Both describe the same album, so the boundary must stay gapless.
+    """
+    assert not _crossfade_allowed(
+        _queue_item("track-1", LIBRARY_ALBUM), _queue_item("track-2", PROVIDER_ALBUM)
+    )
+
+
+def test_different_albums_are_crossfaded() -> None:
+    """A boundary between two genuinely different albums still gets its crossfade."""
+    assert _crossfade_allowed(
+        _queue_item("track-1", LIBRARY_ALBUM), _queue_item("track-2", OTHER_PROVIDER_ALBUM)
+    )
+
+
+def test_same_album_is_crossfaded_when_the_user_allows_it() -> None:
+    """The same-album guard stays overridable by the streams config option."""
+    assert _crossfade_allowed(
+        _queue_item("track-1", LIBRARY_ALBUM),
+        _queue_item("track-2", PROVIDER_ALBUM),
+        allow_same_album=True,
+    )


### PR DESCRIPTION
# What does this implement/fix?

Music Assistant does not crossfade between two tracks of the same album, so an album stays gapless. That check could miss and fade anyway.

A queue item swaps in its library album as soon as it is loaded for playback, and at a track boundary only one of the two items is guaranteed to have been loaded. The same album was then held as two different objects — the library one on one side, the provider one on the other — and comparing those objects said "different album". It needs the next track to still be unloaded at the boundary, so it shows up on short tracks (interludes, segues, movements), which is exactly the material the gapless rule is there for.

Matching on the album's provider mappings recognises both shapes as the same album. No extra database lookup, so nothing is added to the track-boundary hot path.

**Related issue (if applicable):**

- n/a — found while reviewing the check, not from a user report.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
