### PR TITLE
Announcements use the speaker's own announcement feature first

### DIFF
--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -374,22 +374,22 @@ class AnnouncementsMixin:
 
         :param player: The player the announcement is played on.
         """
+        if PlayerFeature.PLAY_ANNOUNCEMENT in player.supported_features:
+            # The device's own announcement handler is built for exactly this and
+            # overlays the clip on whatever the speaker is playing - including the
+            # stream a linked protocol renders into it (e.g. Sonos audioClip while
+            # the Sonos plays through its AirPlay child), so it always wins.
+            return player
         if announce_player := self._get_control_target(
             player,
             required_feature=PlayerFeature.PLAY_ANNOUNCEMENT,
             require_active=True,
         ):
-            # The output that is ACTIVELY rendering can announce: the
-            # announcement rides the same audio path as the music (e.g. a
-            # Sonos playing through its AirPlay child gets the clip mixed
-            # into that live stream, in sync with the rest of the group)
-            # instead of a second mechanism firing beside the playback.
+            # No native handler, so the output that is ACTIVELY rendering announces:
+            # the announcement rides the same audio path as the music (mixed into
+            # that live stream, in sync with the rest of the group) instead of a
+            # second mechanism firing beside the playback.
             return announce_player
-        if PlayerFeature.PLAY_ANNOUNCEMENT in player.supported_features:
-            # Not playing through an announce-capable output: the player's
-            # own native support (e.g. Sonos audioClip, which overlays the
-            # clip on whatever source is playing) is the next-best path.
-            return player
         if player.state.playback_state != PlaybackState.PLAYING:
             # An idle player may announce through any linked protocol. A
             # PLAYING player deliberately gets no such fallback: routing to

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -2081,9 +2081,9 @@ class ProtocolLinkingMixin:
         """
         Get the best player(protocol) to send audio-path commands to.
 
-        Resolves commands that travel with the audio (enqueue, pause, announcements),
-        so the output that renders the audio outranks the native player. Volume and
-        mute are control-plane instead and resolve through
+        Resolves commands that travel with the audio (enqueue, pause), so the output
+        that renders the audio outranks the native player. Volume and mute are
+        control-plane instead and resolve through
         :meth:`Player._get_protocol_player_for_feature`, which orders differently.
 
         :param player: The player the command was issued on.

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -2081,10 +2081,11 @@ class ProtocolLinkingMixin:
         """
         Get the best player(protocol) to send audio-path commands to.
 
-        Resolves commands that travel with the audio (enqueue, pause), so the output
-        that renders the audio outranks the native player. Volume and mute are
-        control-plane instead and resolve through
-        :meth:`Player._get_protocol_player_for_feature`, which orders differently.
+        Resolves commands that travel with the audio (enqueue, pause, and an
+        announcement the player cannot handle itself), so the output that renders the
+        audio outranks the native player. Volume and mute are control-plane instead
+        and resolve through :meth:`Player._get_protocol_player_for_feature`, which
+        orders differently.
 
         :param player: The player the command was issued on.
         :param required_feature: The feature the resolved target has to support.

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -4841,22 +4841,37 @@ class TestNativeAnnouncementRouting:
         native_path.assert_awaited_once()
         assert native_path.call_args.args[1] is proto
 
-    async def test_active_protocol_child_beats_own_native_support(
+    async def test_own_native_support_beats_the_active_protocol_child(
         self, mock_mass: MagicMock
     ) -> None:
         """
-        The output that is actively rendering wins over the player's own support.
+        The player's own announcement handler wins over the output rendering the audio.
 
-        E.g. a Sonos playing through its AirPlay child: the announcement rides
-        the same audio path as the music (mixed into the live stream, in sync
-        with the rest of a group) instead of a second mechanism firing beside
-        the playback.
+        E.g. a Sonos playing through its AirPlay child announces with audioClip,
+        which overlays the clip on that stream.
         """
-        controller, _player, proto, native_path, _generic_path = (
+        controller, player, _proto, native_path, _generic_path = (
             self._make_player_with_linked_child(
                 mock_mass,
                 PlaybackState.PLAYING,
                 parent_supports_announce=True,
+                active_protocol="proto_1",
+            )
+        )
+
+        await controller.play_announcement("player_1", "http://test/announcement.mp3")
+
+        native_path.assert_awaited_once()
+        assert native_path.call_args.args[1] is player
+
+    async def test_active_protocol_child_announces_without_own_support(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player that cannot announce itself announces through its rendering output."""
+        controller, _player, proto, native_path, _generic_path = (
+            self._make_player_with_linked_child(
+                mock_mass,
+                PlaybackState.PLAYING,
                 active_protocol="proto_1",
             )
         )


### PR DESCRIPTION
# What does this implement/fix?

A speaker that can play announcements itself was skipped whenever it was playing through a linked output. For example a Sonos playing over AirPlay: the announcement went to the AirPlay interface instead of the Sonos' own announcement feature, which is the one built for it and overlays the message on whatever is playing.

The speaker's own announcement feature now always wins. Only a speaker that has none falls back to the output that is rendering the music, and idle speakers keep announcing through a linked output as before.

- Announcement routing prefers the player's native announcement support over the active output protocol
- Tests updated for the new order, plus one for a speaker without its own support

Deliberate trade-off: when such a speaker is grouped with speakers of another brand over AirPlay, the announcement no longer travels with the group's audio, so it plays in that speaker's own room on its own timing.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
