### PR TITLE
Fix mid-track silence on AirPlay receivers that need an explicit progress anchor

### DIFF
--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -841,11 +841,12 @@ class AirPlayStream:
                             self._artwork_render_generations.discard(metadata_generation)
                         return
                     self._metadata_text_checksum = text_checksum
-                    # the push resets a changed track to position zero (a
-                    # same-item refinement carries the current position), so
-                    # the correction below only follows when playback is
-                    # actually elsewhere (mid-track start, tag refinement)
-                    self._last_progress_sent = 0
+                    # every identity push is followed by one explicit progress
+                    # anchor, even at position zero: some receivers (WiiM Amp)
+                    # mute a flushed-and-restarted session mid-track when no
+                    # PROGRESS ever follows the SENDMETA, and un-mute on the
+                    # first one that arrives
+                    self._last_progress_sent = None
                     if artwork_file:
                         # the bundle delivered the artwork: settle it and stand
                         # down the ARTWORK follow-up

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2313,10 +2313,11 @@ async def test_initial_metadata_skips_artwork() -> None:
     ):
         await stream.send_metadata(0, metadata, send_artwork=False)
 
-    # the metadata push resets the device position to zero, so a push at the
-    # start of a track needs no separate progress correction
-    assert send_command.await_count == 1
+    # the metadata push is followed by an explicit progress anchor, even at
+    # zero (receivers like the WiiM Amp gate their rendering on it)
+    assert send_command.await_count == 2
     assert "TITLE=Track" in send_command.await_args_list[0].args[0]
+    assert send_command.await_args_list[1].args[0].endswith("PROGRESS=0")
     assert stream._last_progress_sent == 0
     send_artwork.assert_not_awaited()
 
@@ -2857,8 +2858,8 @@ async def test_concurrent_metadata_updates_only_send_latest_artwork() -> None:
     commands = [call.args[0].decode() for call in write_command.await_args_list]
     assert any("TITLE=New track" in command for command in commands)
     assert not any("ARTWORK=old.jpg" in command for command in commands)
-    assert "ARTWORKFILE=new.jpg\n" in commands[-1]
-    assert commands[-1].endswith("ACTION=SENDMETA\n")
+    last_bundle = [command for command in commands if command.endswith("ACTION=SENDMETA\n")][-1]
+    assert "ARTWORKFILE=new.jpg\n" in last_bundle
 
 
 @pytest.mark.asyncio
@@ -3050,8 +3051,8 @@ async def test_repeated_metadata_retries_superseded_artwork() -> None:
     assert "ARTWORK=b-stale.jpg\n" not in commands
     assert "ARTWORK=c.jpg\n" not in commands
     # the final B render completed within the budget, so it rides the bundle
-    assert "ARTWORKFILE=b-final.jpg\n" in commands[-1]
-    assert commands[-1].endswith("ACTION=SENDMETA\n")
+    last_bundle = [command for command in commands if command.endswith("ACTION=SENDMETA\n")][-1]
+    assert "ARTWORKFILE=b-final.jpg\n" in last_bundle
     assert stream._metadata_artwork_checksum == "b-image"
 
 
@@ -3099,13 +3100,14 @@ async def test_track_change_bundles_ready_artwork_into_a_single_push() -> None:
     ):
         await stream.send_metadata(0, metadata)
 
-    assert write_command.await_count == 1
+    assert write_command.await_count == 2
     lines = write_command.await_args_list[0].args[0].decode().splitlines()
     assert "TITLE=Track" in lines
     assert "ITEMID=item-1" in lines
     # the artwork is staged before the SENDMETA applies the whole bundle
     assert lines[-2:] == ["ARTWORKFILE=/cache/art.jpg", "ACTION=SENDMETA"]
-    # the push resets the device position to zero: no PROGRESS correction
+    # the bundle is one write; the explicit progress anchor follows separately
+    assert write_command.await_args_list[1].args[0].decode().endswith("PROGRESS=0\n")
     assert stream._last_progress_sent == 0
     assert stream._metadata_artwork_checksum == "image"
 
@@ -3199,7 +3201,15 @@ async def test_pending_start_interrupts_the_artwork_wait() -> None:
     commands = [args.args[0] for args in write_command.await_args_list]
     assert commands[0].endswith("ACTION=SENDMETA\n")
     assert "ARTWORKFILE" not in commands[0]
-    assert commands[1].startswith(f"START_UNIX_MS={START_UNIX_MS}")
+    # the START may only queue behind the push's quick pipe writes (the
+    # progress anchor), never behind the artwork render itself
+    start_index = next(
+        index
+        for index, command in enumerate(commands)
+        if command.startswith(f"START_UNIX_MS={START_UNIX_MS}")
+    )
+    assert start_index <= 2
+    assert not any("late.jpg" in command for command in commands[:start_index])
 
 
 @pytest.mark.asyncio
@@ -3229,6 +3239,40 @@ async def test_track_change_starting_mid_track_sends_a_progress_correction() -> 
     # corrected right after
     assert commands[1].endswith("PROGRESS=120\n")
     assert stream._last_progress_sent == 120
+
+
+@pytest.mark.asyncio
+async def test_track_change_at_position_zero_still_sends_a_progress_anchor() -> None:
+    """
+    A track starting at zero still gets an explicit PROGRESS anchor.
+
+    Some receivers gate their rendering on an explicit timeline anchor: a WiiM
+    Amp mutes a flushed-and-restarted session a couple of minutes in when no
+    PROGRESS ever follows the metadata push, and un-mutes the instant one
+    arrives. Relying on SENDMETA's implicit reset to zero is not enough.
+    """
+    stream = AirPlayStream(_make_player())
+    stream._cli_proc = _make_cli_proc()
+    metadata = MagicMock(
+        queue_item_id="item-1",
+        duration=180,
+        title="Track",
+        artist="Artist",
+        album="Album",
+        image_url="image",
+    )
+
+    with (
+        patch.object(stream.commands_pipe, "write", new_callable=AsyncMock) as write_command,
+        patch.object(stream, "_prepare_artwork", new=AsyncMock(return_value="/cache/art.jpg")),
+    ):
+        await stream.send_metadata(0, metadata)
+
+    commands = [args.args[0].decode() for args in write_command.await_args_list]
+    assert len(commands) == 2
+    assert commands[0].endswith("ACTION=SENDMETA\n")
+    assert commands[1].endswith("PROGRESS=0\n")
+    assert stream._last_progress_sent == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Some AirPlay receivers gate their rendering on an explicit timeline anchor. A WiiM Amp that got a flush-and-restart mid-session (play_media on a live session, which is also the path every skip and seek takes) reported itself STOPPED, kept rendering for about two minutes, then muted. It stayed silent while the server streamed loud audio into a healthy RTP session, and un-muted within 100 ms of the first `progress:` SET_PARAMETER that arrived, at the next track boundary.

The receiver never got that anchor earlier because of a gap in `send_metadata`: after a SENDMETA identity push, `_last_progress_sent` was set to 0 on the assumption that the push itself resets the device position to zero. For a track starting at position 0 the follow-up progress correction (the post-anchor media-updated nudge) then never cleared the >= 2s dedup gate, so a restarted track never sent PROGRESS at all. During crossfaded playback the boundary offset (~17s) happened to pass the gate every track, which is why steady playback was fine and only the restart path starved the device.

The fix sets `_last_progress_sent` to `None` after every identity push, so exactly one explicit PROGRESS anchor follows each SENDMETA, position 0 included. Dedup takes over again after that one push. Pre-anchor pushes stay harmless: cliraop drops PROGRESS while the session is not yet streaming (`raopcl_set_progress` returns early below `RAOP_STREAMING`).

- `send_metadata` now owes one explicit PROGRESS after every SENDMETA instead of assuming the implicit reset to zero is enough
- regression test: a track change landing at position 0 is followed by `PROGRESS=0`
- updated the tests that pinned the old "no PROGRESS at zero" behavior and the positional command indexes the extra write shifted

**Related issue (if applicable):**

- related issue N/A (diagnosed from live server logs, 2.10.0.dev2026082503)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
