### PR TITLE
Fix announcement volume and mute handling on AirPlay speakers

### DIFF
--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -474,8 +474,10 @@ class AnnouncementsMixin:
                 for muted_player in muted_players:
                     tg.create_task(self._set_announcement_mute(muted_player, False))
             announcement_volume = self.get_announcement_volume(player.player_id, volume_level)
-            if announcement_volume is not None and not self._output_owns_volume(
-                player, announce_player
+            if (
+                announcement_volume is not None
+                and not announce_player.applies_announcement_volume
+                and not self._output_owns_volume(player, announce_player)
             ):
                 # The level is resolved on the scale of the control that owns the player's
                 # volume, so an output that does not own it cannot apply it: whatever that

--- a/music_assistant/controllers/players/announcements.py
+++ b/music_assistant/controllers/players/announcements.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from music_assistant import MusicAssistant
+    from music_assistant.controllers.streams.announcements import AnnouncementRender
 
 # the caller waits for this command and it holds the player's playback lock while it runs,
 # so a wedged engine must give up well before the generic (background) engine timeout
@@ -268,7 +269,7 @@ class AnnouncementsMixin:
                 pre_announce,
                 url,
             )
-            announce_player = self._resolve_announce_player(player)
+            announce_player = await self._resolve_ready_announce_player(player, render, url)
             native_announce_support = announce_player is not None
             if announce_player is None:
                 announce_player = player
@@ -285,14 +286,6 @@ class AnnouncementsMixin:
             )
             # handle native announce support (player or linked protocol)
             if native_announce_support:
-                # hand the url to the player as soon as there is audio to serve from;
-                # its exact length is resolved further downstream, while it plays
-                if not await render.wait_ready():
-                    self.logger.warning(
-                        "Announcement to player %s - no audio available for %s",
-                        player.state.name,
-                        url,
-                    )
                 await self._play_native_announcement(
                     player, announce_player, announcement, volume_level
                 )
@@ -406,6 +399,36 @@ class AnnouncementsMixin:
                 require_active=False,
             )
         return None
+
+    async def _resolve_ready_announce_player(
+        self, player: Player, render: AnnouncementRender, url: str
+    ) -> Player | None:
+        """
+        Return the player that plays the announcement natively, once its audio is ready.
+
+        Returns None when nothing in the chain announces natively (any more), so the
+        caller has to fall back to the default implementation.
+
+        :param player: The player the announcement is played on.
+        :param render: The announcement audio being rendered.
+        :param url: URL of the announcement, for logging.
+        """
+        if (announce_player := self._resolve_announce_player(player)) is None:
+            return None
+        # hand the url to the player as soon as there is audio to serve from;
+        # its exact length is resolved further downstream, while it plays
+        if not await render.wait_ready():
+            self.logger.warning(
+                "Announcement to player %s - no audio available for %s",
+                player.state.name,
+                url,
+            )
+        if PlayerFeature.PLAY_ANNOUNCEMENT not in announce_player.supported_features:
+            # Rendering the audio can take a while. An output that announces by mixing
+            # the clip into what it is already playing stops offering the feature once
+            # that playback ended, and the default implementation takes over.
+            return None
+        return announce_player
 
     async def _render_announcement_message(
         self, message: str, tts_engine: str | None, language: str | None

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -942,6 +942,18 @@ class Player(ABC):
             "enqueue_next_media needs to be implemented when PlayerFeature.ENQUEUE is set"
         )
 
+    @property
+    def applies_announcement_volume(self) -> bool:
+        """
+        Return True if the player applies the announcement volume itself.
+
+        A player that mixes an announcement into audio it is already playing knows when
+        the clip becomes audible, so it applies and restores the level at that moment -
+        through the volume control that owns its output. The players controller then
+        leaves the volume alone instead of raising it before the announcement starts.
+        """
+        return False
+
     async def play_announcement(
         self, announcement: PlayerMedia, volume_level: int | None = None
     ) -> None:

--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -286,7 +286,7 @@ gets the generic announcement handling from the players controller instead.
 The clip file is wrapped in ducked silence, because the binary holds the duck for the
 whole file:
 
-| | |
+| Part | What happens |
 |---|---|
 | lead-in | music already ducked, nothing said yet — the announcement volume is raised here |
 | clip | the announcement itself, at the announcement volume |

--- a/music_assistant/providers/airplay/README.md
+++ b/music_assistant/providers/airplay/README.md
@@ -275,6 +275,29 @@ AirPlay uses **flow mode** streaming, which means:
 - Supports crossfade between tracks
 - Once started, the stream continues until explicitly stopped
 
+### Announcements
+
+An announcement is mixed into the audio the player is already rendering: the binary
+overlays the clip on the outgoing stream with the music ducked underneath, without a
+flush or a re-anchor, so the group timeline is untouched. Native announcement support
+is therefore only offered while there is live playback to mix into — an idle player
+gets the generic announcement handling from the players controller instead.
+
+The clip file is wrapped in ducked silence, because the binary holds the duck for the
+whole file:
+
+| | |
+|---|---|
+| lead-in | music already ducked, nothing said yet — the announcement volume is raised here |
+| clip | the announcement itself, at the announcement volume |
+| tail | music still ducked — the volume is put back here |
+
+Both volume changes are timed on the audible instant the binary acks, and they travel
+through the players controller so they land on whichever control owns the output (see
+[Volume Ownership](#volume-ownership)). Neither is ever heard as the music changing
+level. The duck is deepened by exactly the size of the volume bump, so the music keeps
+the same perceived level underneath while the clip gets louder.
+
 
 ## Multi-Room Synchronization
 
@@ -350,11 +373,13 @@ Handled in `_handle_dacp_request()` in [provider.py](provider.py):
 
 An AirPlay volume command sets the receiver's own volume, and that level stays behind on the device after the session ends. Music Assistant therefore only sends one when nothing else owns the volume of this output: on a device that is also reachable through a native provider or another protocol (a Sonos speaker, an AV receiver), the stream simply plays at the level the device is already set to, and volume stays with that provider.
 
-A volume is still sent when the AirPlay output itself is the resolved volume control, when a mute has to travel with the stream, and when a session asks for a specific level (an announcement).
+A volume is still sent when the AirPlay output itself is the resolved volume control, and when a mute has to travel with the stream.
 
 ### Volume Feedback
 
 Devices can report their own volume changes back over DACP; Music Assistant applies them unless `ignore_volume` is set. Genuine Apple devices are auto-set to ignore these reports (they manage volume internally).
+
+A receiver also echoes back every level it is handed, and an echo that arrives after the next level was sent would be read as the user reaching for the volume and written straight back to the device. Reports are therefore ignored for a short window after Music Assistant sends a volume itself, and for the whole span of an announcement.
 
 **Config option**: `ignore_volume` (default: `False`, auto-enabled for Apple devices)
 - Useful when device volume reports are unreliable

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -432,20 +432,30 @@ def _member_duck_db(member: AirPlayPlayer, volume_level: int | None) -> float:
     """
     Return the music duck (dB) for one member, compensated for its volume bump.
 
-    The announcement volume raises the music bed together with the clip. The
-    AirPlay volume scale is linear dB (see AIRPLAY_VOLUME_DB_PER_POINT), so that
-    rise is exactly known and the duck is deepened by the same amount - the music
-    keeps its configured perceived duck depth while the clip plays at the
-    configured announcement loudness. A bump DOWN (a night-mode announcement
-    quieter than the music) symmetrically shallows the duck, and the result never
-    leaves the binary's usable range.
+    The announcement volume raises the music bed together with the clip, so the duck
+    is deepened by that same rise and the music keeps its configured perceived duck
+    depth while the clip plays at the configured announcement loudness. A bump DOWN
+    (a night-mode announcement quieter than the music) symmetrically shallows the
+    duck, and the result never leaves the binary's usable range.
+
+    The rise is read off the AirPlay volume scale, which is linear dB (see
+    AIRPLAY_VOLUME_DB_PER_POINT). A level that lands on another control (the native
+    volume of the device this output renders for) follows that control's own taper,
+    so there the compensation is an approximation - still far closer than leaving the
+    bed to ride up with the clip.
     """
     duck_db = float(AIRPLAY_ANNOUNCE_DUCK_DB)
     if volume_level is None:
         return duck_db
-    if (prev_volume := _volume_target(member).state.volume_level) is None:
+    target = _volume_target(member)
+    if (prev_volume := target.state.volume_level) is None:
         return duck_db
-    bump_db = (volume_level - prev_volume) * AIRPLAY_VOLUME_DB_PER_POINT
+    # the levels are logical, and the volume limits configured on the target decide
+    # what they land on: the device levels are what the rise is actually made of
+    scale = member.mass.players.scale_volume_to_device
+    bump_db = (
+        scale(target.player_id, volume_level) - scale(target.player_id, prev_volume)
+    ) * AIRPLAY_VOLUME_DB_PER_POINT
     return min(0.0, max(-60.0, duck_db - bump_db))
 
 

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -5,8 +5,13 @@ The cliairplay binary mixes a raw-PCM clip over the outgoing music with the musi
 ducked underneath - no flush, no re-anchor, the group timeline stays untouched. This
 module renders the shared announcement clip once per member stdin format, arms every
 member of the live session at one shared audible instant and tracks the per-member
-outcome. Whenever there is no live playback to mix into (idle or parked player), the
-announcement runs as a dedicated stream session instead, leaving the player idle.
+outcome. Native announcements are only offered while there is live playback to mix
+into; without it the player controller plays the announcement its own way.
+
+The clip is wrapped in ducked silence: the binary holds the music duck for the whole
+file, so the lead-in is a window in which the music is already quiet and nothing is
+being said yet. That is where the announcement volume is raised, and the trailing
+silence is where it is put back - neither change is ever heard on the music itself.
 
 Targeting semantics: a player addressed individually announces alone - over its own
 ducked copy of the group's music, while the other rooms play on untouched - whenever
@@ -32,41 +37,36 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-from music_assistant_models.enums import ContentType, PlaybackState
+from music_assistant_models.enums import ContentType
 from music_assistant_models.errors import PlayerCommandFailed
 
 from .constants import (
     AIRPLAY_ANNOUNCE_AT_MARGIN_MS,
     AIRPLAY_ANNOUNCE_DONE_TIMEOUT_MS,
     AIRPLAY_ANNOUNCE_DUCK_DB,
+    AIRPLAY_ANNOUNCE_DUCK_LEAD_S,
     AIRPLAY_ANNOUNCE_DUCK_TAIL_S,
     AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS,
-    AIRPLAY_ANNOUNCE_SESSION_DRAIN_S,
     AIRPLAY_ANNOUNCE_STARTED_TIMEOUT_MS,
     AIRPLAY_ANNOUNCE_VOLUME_BUMP_DELAY_MS,
     AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS,
     AIRPLAY_VOLUME_DB_PER_POINT,
+    AIRPLAY_VOLUME_ECHO_GRACE_S,
 )
-from .stream_session import AirPlayStreamSession
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Iterable
+    from collections.abc import Iterable
 
     from music_assistant_models.media_items import AudioFormat
     from music_assistant_models.player import PlayerMedia
 
     from music_assistant.controllers.players.helpers import AnnounceData
     from music_assistant.controllers.streams.announcements import AnnouncementRender
+    from music_assistant.models.player import Player
 
     from .player import AirPlayPlayer
     from .provider import AirPlayProvider
     from .stream import AirPlayStream
-
-# Scheduled announcement-volume changes of one member: the previous level and
-# the timer task ids that apply/restore the announcement volume around the
-# clip (mass.call_later tracks its timers by task id, and only cancel_timer
-# releases a tracked entry that never fired).
-_VolumeSchedule = tuple["AirPlayPlayer", int, list[str]]
 
 
 async def play_announcement(
@@ -75,11 +75,10 @@ async def play_announcement(
     """
     Play an announcement on the player (and, for an ad-hoc leader, its members).
 
-    A live playing session mixes the clip over the music without interrupting
-    it; an idle player plays the announcement as a dedicated stream session and
-    ends idle. A group-entity announcement is forwarded per member by the
-    controller; the members share one audible instant through the provider's
-    announce-plan registry so every room renders the clip in sync.
+    The clip is mixed over the live playing session without interrupting it. A
+    group-entity announcement is forwarded per member by the controller; the
+    members share one audible instant through the provider's announce-plan
+    registry so every room renders the clip in sync.
 
     :param player: The player the announcement targets.
     :param announcement: The announcement to play.
@@ -93,27 +92,25 @@ async def play_announcement(
     renderer = player.mass.streams.announcement_renderer
     render = renderer.acquire(announce_data)
     try:
-        await _run_announcement(player, announcement, render, volume_level)
+        await _run_announcement(player, render, volume_level)
     finally:
         await renderer.release(render)
 
 
 async def _run_announcement(
     player: AirPlayPlayer,
-    announcement: PlayerMedia,
     render: AnnouncementRender,
     volume_level: int | None,
 ) -> None:
     """
-    Render the clip, then mix it over live playback or play it as its own session.
+    Render the clip and mix it over the live playing session.
 
     :param player: The player the announcement targets.
-    :param announcement: The announcement to play.
     :param render: The announcement render to play.
     :param volume_level: Optional volume level for the announcement.
     """
-    # The whole clip is rendered up front: the live path hands the binary a
-    # complete file, and the exact duration bounds every wait below.
+    # The whole clip is rendered up front: the binary is handed a complete file,
+    # and the exact duration bounds every wait below.
     duration = await render.wait_finished()
     if duration is None:
         duration = render.duration
@@ -122,9 +119,7 @@ async def _run_announcement(
             "Announcement for %s produced no audio; nothing to play", player.display_name
         )
         return
-    if await _announce_over_live_session(player, render, duration, volume_level):
-        return
-    await _announce_with_session(player, announcement, render, duration, volume_level)
+    await _announce_over_live_session(player, render, duration, volume_level)
 
 
 async def _announce_over_live_session(
@@ -132,7 +127,7 @@ async def _announce_over_live_session(
     render: AnnouncementRender,
     duration: float,
     volume_level: int | None,
-) -> bool:
+) -> None:
     """
     Mix the clip over the live playing session.
 
@@ -140,15 +135,11 @@ async def _announce_over_live_session(
     :param render: The (finished) announcement render to play.
     :param duration: Exact clip duration in seconds.
     :param volume_level: Optional volume level for the announcement.
-    :return: True when at least one member played the clip; False when there is
-        no live playback to mix into, so the caller runs the dedicated
-        announcement session instead.
-    :raises PlayerCommandFailed: If there was live playback but no member armed
-        the clip (tearing the playing session down for a fallback would trade
-        the user's music for the announcement).
+    :raises PlayerCommandFailed: If the player stopped playing before the clip
+        could be armed, or if no member armed it.
     """
     clip_files: dict[str, str] = {}
-    volume_schedules: list[_VolumeSchedule] = []
+    bumped: dict[str, int] = {}
     try:
         # The dispatch decision and the arming run under the player lock - the
         # same lock play_media holds to mutate the session - while the
@@ -164,7 +155,11 @@ async def _announce_over_live_session(
         async with player._lock:
             members = _live_members(player)
             if not members:
-                return False
+                # the feature is only advertised while there is live audio to mix
+                # into, so this is playback that ended since the controller resolved it
+                raise PlayerCommandFailed(
+                    f"Cannot announce on {player.display_name}: the player stopped playing"
+                )
             streams: dict[str, AirPlayStream] = {}
             for member in members:
                 assert member.stream is not None  # guaranteed by _live_members
@@ -213,53 +208,15 @@ async def _announce_over_live_session(
             if ack is not None
         }
         if not started:
-            # Music keeps playing on every member, so falling back to a
-            # dedicated announcement session would stop the user's playback
-            # over a clip that could not be mixed anyway. Silently ignoring
-            # the unknown arm command is exactly what an outdated cliairplay
-            # build does.
+            # Music keeps playing on every member, so failing here leaves the
+            # user's playback untouched. Silently ignoring the unknown arm
+            # command is exactly what an outdated cliairplay build does.
             raise PlayerCommandFailed(
                 f"No member of {player.display_name} armed the announcement; "
                 "the running cliairplay binary may not support announcements yet "
                 "(version mismatch)"
             )
-        if volume_level is not None:
-            for member in members:
-                if (ack := started.get(member.player_id)) is None:
-                    continue
-                ack_at_unix_ms, ack_duration_ms = ack
-                # The binary-reported duration includes the ducked silence
-                # tail appended to the clip file; the restore must land INSIDE
-                # that cushion, so it is timed on the content length alone.
-                content_seconds = (
-                    max(0.0, ack_duration_ms / 1000 - AIRPLAY_ANNOUNCE_DUCK_TAIL_S)
-                    if ack_duration_ms
-                    else duration
-                )
-                if schedule := _schedule_member_volume(
-                    member,
-                    volume_level,
-                    ack_at_unix_ms or at_unix_ms,
-                    content_seconds,
-                ):
-                    volume_schedules.append(schedule)
-        padded_duration = duration + AIRPLAY_ANNOUNCE_DUCK_TAIL_S
-        done_results = await asyncio.gather(
-            *[
-                streams[member_id].wait_announce_done(
-                    max(0.0, (ack_at or at_unix_ms) / 1000 - time.time())
-                    + (ack_duration / 1000 if ack_duration else padded_duration)
-                    + AIRPLAY_ANNOUNCE_DONE_TIMEOUT_MS / 1000
-                )
-                for member_id, (ack_at, ack_duration) in started.items()
-            ]
-        )
-        for member_id, done in zip(started, done_results, strict=True):
-            if not done:
-                player.logger.debug(
-                    "Announcement on member %s was cut short or its completion went unreported",
-                    member_id,
-                )
+        armed = [member for member in members if member.player_id in started]
         if failed := [m.display_name for m in members if m.player_id not in started]:
             player.logger.warning(
                 "Announcement was not played on %d member(s) of %s: %s",
@@ -267,148 +224,71 @@ async def _announce_over_live_session(
                 player.display_name,
                 ", ".join(failed),
             )
+        # Every instant below is derived from the acked start of the clip FILE,
+        # which opens with the ducked lead-in: the music is already ducked there
+        # while the announcement itself has not started yet.
+        file_seconds = AIRPLAY_ANNOUNCE_DUCK_LEAD_S + duration + AIRPLAY_ANNOUNCE_DUCK_TAIL_S
+        earliest_at_unix_ms = min(ack_at or at_unix_ms for ack_at, _ in started.values())
+        content_end_unix_ms = (
+            max(ack_at or at_unix_ms for ack_at, _ in started.values())
+            + (AIRPLAY_ANNOUNCE_DUCK_LEAD_S + duration) * 1000
+        )
+        latest_end_unix_ms = max(
+            (ack_at or at_unix_ms) + (ack_duration or int(file_seconds * 1000))
+            for ack_at, ack_duration in started.values()
+        )
+        # the receiver echoes every level it is given, and those echoes must not be
+        # read as the user reaching for the volume mid-announcement
+        for member in armed:
+            member.suppress_volume_reports(
+                max(0.0, latest_end_unix_ms / 1000 - time.time()) + AIRPLAY_VOLUME_ECHO_GRACE_S
+            )
+        # the done reports arrive while the volume timeline below runs its course
+        done_task = asyncio.gather(
+            *[
+                streams[member_id].wait_announce_done(
+                    max(0.0, (ack_at or at_unix_ms) / 1000 - time.time())
+                    + (ack_duration / 1000 if ack_duration else file_seconds)
+                    + AIRPLAY_ANNOUNCE_DONE_TIMEOUT_MS / 1000
+                )
+                for member_id, (ack_at, ack_duration) in started.items()
+            ]
+        )
+        try:
+            if volume_level is not None:
+                await _volume_around_clip(
+                    player,
+                    armed,
+                    volume_level,
+                    earliest_at_unix_ms,
+                    content_end_unix_ms,
+                    bumped,
+                )
+            done_results = await done_task
+        except BaseException:
+            done_task.cancel()
+            raise
+        for member_id, done in zip(started, done_results, strict=True):
+            if not done:
+                player.logger.debug(
+                    "Announcement on member %s was cut short or its completion went unreported",
+                    member_id,
+                )
         # announce_done fires when the clip is fully MIXED at the delivery
         # head - up to a member's span BEFORE it is audible. Returning then
         # would let the caller restore mutes (and arm a follow-up
         # announcement) over the audible tail, so hold the return until the
         # latest audible end across the started members.
-        latest_end_unix_ms = max(
-            (ack_at or at_unix_ms) + (ack_duration or int(padded_duration * 1000))
-            for ack_at, ack_duration in started.values()
-        )
-        await asyncio.sleep(
-            max(0.0, latest_end_unix_ms / 1000 - time.time())
-            + AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS / 1000
-        )
-        return True
-    except BaseException:
-        # The scheduled volume changes belong to an announcement that is no
-        # longer being tracked: cancel them and restore the previous levels
-        # right away (a restore of an unchanged level is a harmless re-send).
-        # This path leaves the music session running, so the restore still
-        # reaches the receiver from its own task - unlike the dedicated
-        # session, which has to be restored before it is torn down.
-        for member, prev_volume, task_ids in volume_schedules:
-            for task_id in task_ids:
-                member.mass.cancel_timer(task_id)
-            player.mass.create_task(member.volume_set(prev_volume))
-        raise
+        await _hold_until(latest_end_unix_ms + AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS)
     finally:
+        if bumped:
+            # A failed or cancelled announcement leaves the music playing, so whatever
+            # the timeline above did not put back still has to be restored - from its
+            # own task, since an await here is cancelled along with this one.
+            player.mass.create_task(_restore_announcement_volume(player, bumped))
         for path in clip_files.values():
             with suppress(OSError):
                 Path(path).unlink()
-
-
-async def _announce_with_session(
-    player: AirPlayPlayer,
-    announcement: PlayerMedia,
-    render: AnnouncementRender,
-    duration: float,
-    volume_level: int | None,
-) -> None:
-    """
-    Play the announcement as a dedicated stream session.
-
-    Any existing (parked) session led by this player is stopped first. The
-    player ends idle - the same end state the generic announcement flow leaves
-    a non-playing player in; the queue keeps its resume position server-side.
-
-    Known limitation: a synced member of a group without live playback is
-    refused here - its stream belongs to the leader's shared (parked) session,
-    which must not be torn down for a single-member announcement, so that
-    announcement simply does not play. Announcing over a parked session
-    without stopping it needs binary-side support (announce while in
-    STANDBY), which is the planned proper fix.
-
-    :param player: The player the announcement targets.
-    :param announcement: The announcement media, owning the session's metadata.
-    :param render: The (finished) announcement render to play.
-    :param duration: Exact clip duration in seconds.
-    :param volume_level: Optional volume level for the announcement.
-    :raises PlayerCommandFailed: If the player is a synced group member or is
-        streamed to by its Sendspin bridge - both own no session this path may
-        replace.
-    """
-    provider = cast("AirPlayProvider", player.provider)
-    if player.synced_to:
-        # The controller's group-forward runs the member calls in a
-        # TaskManager, which does not cancel siblings on a failure, so raising
-        # here cannot take the leader's in-flight announcement down with it.
-        raise PlayerCommandFailed(
-            f"Cannot announce on {player.display_name}: a grouped AirPlay player "
-            "without live playback cannot announce natively"
-        )
-    bridge = provider.bridge_manager.get_bridge(player.player_id)
-    if bridge is not None and bridge.owns_airplay_stream:
-        # The bridge is actively streaming to the device; a dedicated
-        # announcement session would seize it from the Sendspin side with
-        # nothing restoring that playback. Only reachable in a race (the live
-        # mix path handles a playing bridge stream). A bridge that is merely
-        # configured but idle is a bystander: the fallback then behaves
-        # exactly as it does for an unbridged player.
-        raise PlayerCommandFailed(
-            f"Cannot announce on {player.display_name}: the player is being streamed "
-            "to by its Sendspin bridge"
-        )
-    prev_volumes: dict[AirPlayPlayer, int] = {}
-    session: AirPlayStreamSession | None = None
-    try:
-        # Session teardown and setup mirror play_media's cold path, under the
-        # same player lock; the clip wait below runs outside it.
-        async with player._lock:
-            if player.stream and player.stream.running and player.stream.session:
-                player._transitioning = True
-                await player.stream.session.stop()
-                player.stream = None
-            sync_clients = player._get_sync_clients()
-            session_pcm_format = await player._get_session_pcm_format(sync_clients, announcement)
-            if volume_level is not None:
-                for member in sync_clients:
-                    prev_volume = member.volume_level
-                    if prev_volume is not None and prev_volume != volume_level:
-                        prev_volumes[member] = prev_volume
-                        await member.volume_set(volume_level)
-            session = AirPlayStreamSession(
-                provider,
-                sync_clients,
-                session_pcm_format,
-                announcement,
-                requested_volume=volume_level,
-            )
-            # The clip is served with its silence tail: the legacy RAOP flow
-            # reports end of stream the moment the last fed sample is audible,
-            # and a volume command is dropped once a stream has ended - so
-            # without the tail the restore below never reaches the speaker.
-            await session.start(_clip_with_tail(render, session_pcm_format))
-            player._transitioning = False
-        # The clip is anchored: wait out the start lead plus the clip, then the
-        # pad that covers the jitter between the anchored and the true audible
-        # end, so the restore below does not land on the announcement's own
-        # tail. Restoring at the end of the drain instead would be a coin flip:
-        # the binary reports its own end of stream on that same margin, and the
-        # server treats that report as the end of the stream.
-        restore_pad = AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS / 1000
-        await asyncio.sleep(max(0.0, session.start_time - time.time()) + duration + restore_pad)
-        await _restore_member_volumes(prev_volumes)
-        # Let the receiver play out what it still has buffered before the stop.
-        # The source ends after the clip, so the session usually ends cleanly on
-        # its own and that stop is cleanup only.
-        await asyncio.sleep(max(0.0, AIRPLAY_ANNOUNCE_SESSION_DRAIN_S - restore_pad))
-    finally:
-        player._transitioning = False
-        try:
-            # Whatever the restore above did not reach (a cancelled
-            # announcement) still goes back while the session is up. A session that
-            # failed to START has already stopped itself, so there the restore
-            # only settles our own state and the device is corrected by the
-            # volume the next stream pushes.
-            await _restore_member_volumes(prev_volumes)
-        finally:
-            if session is not None:
-                await session.stop()
-                # like player.stop(): an idle player must not keep showing media
-                player._attr_current_media = None
-                player.update_state()
 
 
 def _live_members(player: AirPlayPlayer) -> list[AirPlayPlayer]:
@@ -419,11 +299,10 @@ def _live_members(player: AirPlayPlayer) -> list[AirPlayPlayer]:
     covers every member of its session. Only a PLAYING session can mix a clip -
     a parked (paused) or idle player has no live timeline to mix into.
     """
-    if player.playback_state != PlaybackState.PLAYING:
+    if not player.has_live_audio:
         return []
     stream = player.stream
-    if stream is None or not stream.running or not stream.connected:
-        return []
+    assert stream is not None  # guaranteed by has_live_audio
     if player.synced_to:
         return [player]
     if stream.session is None:
@@ -533,103 +412,151 @@ def _member_span_ms(stream: AirPlayStream) -> int:
     return AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS
 
 
+def _volume_target(member: AirPlayPlayer) -> Player:
+    """
+    Return the player whose volume control owns this member's output.
+
+    An AirPlay volume writes the receiver's own level, so it may only be set when
+    nothing else owns it; on a device that is also reachable through a native
+    provider the announcement volume belongs on that parent instead.
+    """
+    if (parent_id := member.protocol_parent_id) and (
+        parent := member.mass.players.get_player(parent_id)
+    ):
+        return parent
+    return member
+
+
 def _member_duck_db(member: AirPlayPlayer, volume_level: int | None) -> float:
     """
     Return the music duck (dB) for one member, compensated for its volume bump.
 
-    The announcement volume is applied as DEVICE volume, which raises the music
-    bed together with the clip. The AirPlay volume scale is linear dB (see
-    AIRPLAY_VOLUME_DB_PER_POINT), so that rise is exactly known and the duck is
-    deepened by the same amount - the music keeps its configured perceived duck
-    depth while the clip plays at the configured announcement loudness. A bump
-    DOWN (a night-mode announcement quieter than the music) symmetrically
-    shallows the duck, and the result never leaves the binary's usable range.
+    The announcement volume raises the music bed together with the clip. The
+    AirPlay volume scale is linear dB (see AIRPLAY_VOLUME_DB_PER_POINT), so that
+    rise is exactly known and the duck is deepened by the same amount - the music
+    keeps its configured perceived duck depth while the clip plays at the
+    configured announcement loudness. A bump DOWN (a night-mode announcement
+    quieter than the music) symmetrically shallows the duck, and the result never
+    leaves the binary's usable range.
     """
     duck_db = float(AIRPLAY_ANNOUNCE_DUCK_DB)
-    if volume_level is None or member.volume_level is None:
+    if volume_level is None:
         return duck_db
-    bump_db = (volume_level - member.volume_level) * AIRPLAY_VOLUME_DB_PER_POINT
+    if (prev_volume := _volume_target(member).state.volume_level) is None:
+        return duck_db
+    bump_db = (volume_level - prev_volume) * AIRPLAY_VOLUME_DB_PER_POINT
     return min(0.0, max(-60.0, duck_db - bump_db))
 
 
-def _schedule_member_volume(
-    member: AirPlayPlayer, volume_level: int, at_unix_ms: int, clip_seconds: float
-) -> _VolumeSchedule | None:
+async def _volume_around_clip(
+    player: AirPlayPlayer,
+    armed: list[AirPlayPlayer],
+    volume_level: int,
+    lead_in_unix_ms: float,
+    content_end_unix_ms: float,
+    bumped: dict[str, int],
+) -> None:
     """
-    Schedule the announcement volume around one member's audible clip window.
+    Move the volume to the announcement level and back, inside the ducked silence.
 
-    Both changes are wall-clock timers on the acked instant: the done report
-    arrives when the clip is fully MIXED (at the delivery head), which is ahead
-    of it being heard, so neither change can key off it.
+    Both changes are timed on the acked instant of the clip file: the done report
+    arrives when the clip is fully MIXED (at the delivery head), which is ahead of
+    it being heard, so neither change can key off it.
 
-    :param member: The member whose volume is bumped and restored.
+    :param player: The player the announcement targets.
+    :param armed: The members playing the clip.
     :param volume_level: The announcement volume level.
-    :param at_unix_ms: The acked audible instant of the clip on this member.
-    :param clip_seconds: The clip duration in seconds.
-    :return: The schedule to track (None when there is nothing to change).
+    :param lead_in_unix_ms: Start of the earliest member's ducked lead-in.
+    :param content_end_unix_ms: End of the latest member's announcement audio.
+    :param bumped: Mapping that tracks which players still need restoring.
     """
-    prev_volume = member.volume_level
-    if prev_volume is None or prev_volume == volume_level:
-        return None
-    delay = max(0.0, at_unix_ms / 1000 - time.time())
-    # The bump is biased INTO the clip: a receiver that plays out later than
-    # the reported instant would otherwise get louder while the old music is
-    # still sounding. The duck ramp (and the pre-announce chime) masks the
-    # late bump; short clips cap the bias at their midpoint.
-    bump_delay = delay + min(AIRPLAY_ANNOUNCE_VOLUME_BUMP_DELAY_MS / 1000, clip_seconds / 2)
-    # Deterministic task ids: cancel_timer is the only way to release a tracked
-    # timer that never fires, and reusing the ids also cancels stale timers of
-    # a replaced announcement on the same member.
-    task_ids = [
-        f"airplay_announce_volume_bump_{member.player_id}",
-        f"airplay_announce_volume_restore_{member.player_id}",
-    ]
-    member.mass.call_later(bump_delay, member.volume_set, volume_level, task_id=task_ids[0])
-    member.mass.call_later(
-        delay + clip_seconds + AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS / 1000,
-        member.volume_set,
-        prev_volume,
-        task_id=task_ids[1],
+    await _hold_until(lead_in_unix_ms + AIRPLAY_ANNOUNCE_VOLUME_BUMP_DELAY_MS)
+    await _apply_announcement_volume(armed, volume_level, bumped)
+    await _hold_until(content_end_unix_ms + AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS)
+    await _restore_announcement_volume(player, bumped)
+
+
+async def _apply_announcement_volume(
+    members: list[AirPlayPlayer], volume_level: int, bumped: dict[str, int]
+) -> None:
+    """
+    Put every member on the announcement volume.
+
+    :param members: The members playing the clip.
+    :param volume_level: The announcement volume level.
+    :param bumped: Mapping that is filled in-place with the previous level per player
+        id, so the caller restores exactly what was changed even if this call fails.
+    """
+    targets: list[Player] = []
+    for member in members:
+        target = _volume_target(member)
+        prev_volume = target.state.volume_level
+        if prev_volume is None or prev_volume == volume_level or target.player_id in bumped:
+            continue
+        bumped[target.player_id] = prev_volume
+        targets.append(target)
+    # the command travels through the controller so it lands on the control that owns
+    # the output, on that control's own scale
+    results = await asyncio.gather(
+        *[target.mass.players.cmd_volume_set(target.player_id, volume_level) for target in targets],
+        return_exceptions=True,
     )
-    return (member, prev_volume, task_ids)
+    for target, result in zip(targets, results, strict=True):
+        if isinstance(result, BaseException):
+            target.logger.warning(
+                "Could not set the announcement volume on %s: %r", target.display_name, result
+            )
+
+
+async def _restore_announcement_volume(player: AirPlayPlayer, bumped: dict[str, int]) -> None:
+    """
+    Put every bumped player back on the level it had before the announcement.
+
+    An entry is dropped only once its player is restored, so a later call covers
+    exactly what this one did not reach.
+
+    :param player: The player the announcement targets.
+    :param bumped: The level each player carried before the announcement.
+    """
+    for player_id in list(bumped):
+        try:
+            await player.mass.players.cmd_volume_set(player_id, bumped[player_id])
+        except Exception as err:
+            player.logger.warning(
+                "Could not restore the volume of %s after the announcement: %r", player_id, err
+            )
+            continue
+        del bumped[player_id]
+
+
+async def _hold_until(unix_ms: float) -> None:
+    """Wait for the given wall-clock instant (unix ms) to arrive."""
+    await asyncio.sleep(max(0.0, unix_ms / 1000 - time.time()))
 
 
 async def _render_clip_file(render: AnnouncementRender, pcm_format: AudioFormat) -> str:
     """
     Render the announcement clip into a temp file of raw PCM in the given format.
 
-    A ducked-silence tail is appended: the binary holds the music duck for the
-    whole file, so the music stays ducked briefly past the announcement and the
-    volume restore has a safe window to land in.
+    The clip is wrapped in ducked silence: the binary holds the music duck for the
+    whole file, so the music is already ducked before the announcement starts and
+    stays ducked briefly past it - the window in which the announcement volume is
+    raised and put back.
 
     The caller owns the file and removes it once every member is done with it.
 
     :param render: The (finished) announcement render to read.
     :param pcm_format: The raw PCM format the file must carry.
     """
-    clip = bytearray()
+    clip = bytearray(_clip_silence(pcm_format, AIRPLAY_ANNOUNCE_DUCK_LEAD_S))
     async for chunk in render.get_stream(pcm_format):
         clip.extend(chunk)
-    clip.extend(_clip_silence_tail(pcm_format))
+    clip.extend(_clip_silence(pcm_format, AIRPLAY_ANNOUNCE_DUCK_TAIL_S))
     return await asyncio.to_thread(_write_clip_file, clip)
 
 
-async def _clip_with_tail(
-    render: AnnouncementRender, pcm_format: AudioFormat
-) -> AsyncGenerator[bytes]:
-    """
-    Yield the announcement clip followed by the trailing silence.
-
-    :param render: The (finished) announcement render to read.
-    :param pcm_format: The raw PCM format to yield.
-    """
-    async for chunk in render.get_stream(pcm_format):
-        yield chunk
-    yield _clip_silence_tail(pcm_format)
-
-
-def _clip_silence_tail(pcm_format: AudioFormat) -> bytes:
-    """Return the silence tail appended to an announcement clip, in the given PCM format."""
+def _clip_silence(pcm_format: AudioFormat, seconds: float) -> bytes:
+    """Return the silence an announcement clip is wrapped in, in the given PCM format."""
     # Wire sizes come from the content type: at 24-bit the stdin carrier is
     # s32le while bit_depth stays 24, so bit_depth-derived sizes are wrong.
     bytes_per_sample = {
@@ -638,8 +565,8 @@ def _clip_silence_tail(pcm_format: AudioFormat) -> bytes:
         ContentType.PCM_S32LE: 4,
         ContentType.PCM_F32LE: 4,
     }.get(pcm_format.content_type, pcm_format.bit_depth // 8)
-    trail_frames = int(pcm_format.sample_rate * AIRPLAY_ANNOUNCE_DUCK_TAIL_S)
-    return bytes(trail_frames * bytes_per_sample * pcm_format.channels)
+    frames = int(pcm_format.sample_rate * seconds)
+    return bytes(frames * bytes_per_sample * pcm_format.channels)
 
 
 def _write_clip_file(data: bytes | bytearray) -> str:
@@ -648,25 +575,6 @@ def _write_clip_file(data: bytes | bytearray) -> str:
     with os.fdopen(fd, "wb") as clip_file:
         clip_file.write(data)
     return path
-
-
-async def _restore_member_volumes(prev_volumes: dict[AirPlayPlayer, int]) -> None:
-    """
-    Put every bumped member back on its pre-announcement volume.
-
-    An AirPlay volume command only reaches the receiver over a running stream,
-    so this has to be called while the announcement session is still up:
-    afterwards it only settles our own state and leaves the speaker sitting at
-    the announcement level.
-
-    An entry is dropped only once its member is restored, so a later call
-    covers exactly what this one did not reach.
-
-    :param prev_volumes: The level each member carried before the announcement.
-    """
-    for member in list(prev_volumes):
-        await member.volume_set(prev_volumes[member])
-        del prev_volumes[member]
 
 
 async def _no_announce_ack() -> tuple[int, int] | None:

--- a/music_assistant/providers/airplay/announce.py
+++ b/music_assistant/providers/airplay/announce.py
@@ -155,10 +155,11 @@ async def _announce_over_live_session(
         async with player._lock:
             members = _live_members(player)
             if not members:
-                # the feature is only advertised while there is live audio to mix
-                # into, so this is playback that ended since the controller resolved it
+                # the feature is only advertised while there is live audio to mix into,
+                # so by now that playback ended or moved to a stream we do not own
                 raise PlayerCommandFailed(
-                    f"Cannot announce on {player.display_name}: the player stopped playing"
+                    f"Cannot announce on {player.display_name}: "
+                    "there is no live playback to mix the announcement into"
                 )
             streams: dict[str, AirPlayStream] = {}
             for member in members:

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -233,13 +233,17 @@ AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS: Final[int] = 2000
 # and out itself. <= -60 mutes the music entirely. -18 dB puts the music
 # clearly in the background under speech (-12 was field-judged too shallow).
 AIRPLAY_ANNOUNCE_DUCK_DB: Final[int] = -18
+# Silence prepended to every announcement clip. The binary holds the music duck
+# for the whole clip file, so this is a window in which the music is already
+# ducked and the announcement has not started yet: the announcement volume is
+# raised inside it, where it cannot be heard as the music getting louder. It
+# has to cover the duck's ramp plus the round trip of the volume command.
+AIRPLAY_ANNOUNCE_DUCK_LEAD_S: Final[float] = 0.5
 # Silence appended to every announcement clip, so the volume restore has a
-# cushion to land in. Mixed over live playback the binary holds the duck for
-# the whole clip, so the restore lands while the music is still ducked instead
-# of racing the duck's 200 ms tail ramp (a restore that lands after the ramp
-# plays a moment of full-level music at the still-bumped device volume). On a
-# dedicated announcement session it keeps the stream alive past the clip, which
-# is what a volume command needs to reach the receiver at all.
+# cushion to land in. The binary holds the duck for the whole clip, so the
+# restore lands while the music is still ducked instead of racing the duck's
+# 200 ms tail ramp (a restore that lands after the ramp plays a moment of
+# full-level music at the still-bumped device volume).
 AIRPLAY_ANNOUNCE_DUCK_TAIL_S: Final[float] = 1.0
 # On top of the lead to the commanded instant: how long to wait for a member's
 # announce_started before treating that member as not announcing. An outdated
@@ -253,11 +257,10 @@ AIRPLAY_ANNOUNCE_DONE_TIMEOUT_MS: Final[int] = 5000
 # Pad after the clip's audible end before the pre-announcement volume is
 # restored: covers the jitter between the acked instant and true audibility.
 AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS: Final[int] = 500
-# Delay of the announcement-volume bump past the clip's audible start: a bump
-# that lands early (a receiver playing out later than the reported instant)
-# raises the still-playing music, so it is biased into the clip where the duck
-# ramp masks it - the pre-announce chime covers the first moments anyway.
-AIRPLAY_ANNOUNCE_VOLUME_BUMP_DELAY_MS: Final[int] = 300
+# Where inside the ducked lead-in the announcement volume is raised: past the
+# duck's own ramp, with the rest of the lead left for the command to reach the
+# receiver before the announcement itself becomes audible.
+AIRPLAY_ANNOUNCE_VOLUME_BUMP_DELAY_MS: Final[int] = 200
 # The AirPlay volume parameter is linear dB: 0..100 maps onto -30..0 dB on
 # every flow (libraop raopcl_float_volume, reused verbatim by the native AP2
 # SET_PARAMETER path), so one volume point is exactly 0.3 dB of output. This
@@ -265,9 +268,6 @@ AIRPLAY_ANNOUNCE_VOLUME_BUMP_DELAY_MS: Final[int] = 300
 # the duck is deepened by the same amount to keep the music's perceived level
 # at the configured duck depth.
 AIRPLAY_VOLUME_DB_PER_POINT: Final[float] = 0.3
-# Drain margin for a dedicated announcement session: covers the receiver
-# playing out its buffered audio after the clip's last byte was fed.
-AIRPLAY_ANNOUNCE_SESSION_DRAIN_S: Final[float] = 2.0
 
 # Cover art is rendered to a local JPEG for the binary to embed (the binary
 # does not fetch URLs). 512px keeps the SET_PARAMETER payload small while still
@@ -303,6 +303,11 @@ CONF_PAIR_NOW: Final[str] = "pair_now"
 
 FALLBACK_VOLUME: Final[int] = 20
 AIRPLAY_VOLUME_MUTE: Final[float] = -144.0
+# How long a volume we sent ourselves keeps the device's own volume reports from
+# being acted on. A receiver echoes every level it is given back over DACP, and
+# an echo that arrives after the next level was already sent would otherwise be
+# read as the user turning the knob and written straight back to the device.
+AIRPLAY_VOLUME_ECHO_GRACE_S: Final[float] = 2.0
 
 AIRPLAY_PCM_FORMAT = AudioFormat(
     content_type=ContentType.from_bit_depth(16), sample_rate=44100, bit_depth=16

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -247,8 +247,8 @@ AIRPLAY_ANNOUNCE_DUCK_LEAD_S: Final[float] = 0.5
 AIRPLAY_ANNOUNCE_DUCK_TAIL_S: Final[float] = 1.0
 # On top of the lead to the commanded instant: how long to wait for a member's
 # announce_started before treating that member as not announcing. An outdated
-# binary silently ignores the unknown command, so this bounded wait is also
-# what detects that and routes the announcement to the fallback path.
+# binary silently ignores the unknown command, so this bounded wait is also what
+# detects that, and the announcement then fails instead of playing nowhere.
 AIRPLAY_ANNOUNCE_STARTED_TIMEOUT_MS: Final[int] = 3000
 # On top of the clip's audible end: how long to wait for announce_done. The
 # wait stays bounded because a queue that ends mid-clip emits its eof, which

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -606,14 +606,14 @@ class AirPlayPlayer(Player):
         self, announcement: PlayerMedia, volume_level: int | None = None
     ) -> None:
         """
-        Play an announcement natively: mixed over live playback, or as its own session.
+        Play an announcement natively, mixed over the audio the player is rendering.
 
         :param announcement: Details of the announcement that needs to be played.
         :param volume_level: Optional volume level for the announcement.
         """
-        # The lock windows live inside the orchestration: the dispatch decision
-        # and session mutations hold self._lock like play_media does, while the
-        # multi-second clip waits run outside it (see announce.py).
+        # The lock windows live inside the orchestration: the dispatch decision and
+        # the arming hold self._lock like play_media does, while the multi-second
+        # clip waits run outside it (see announce.py).
         await announce.play_announcement(self, announcement, volume_level)
 
     async def volume_set(self, volume_level: int) -> None:
@@ -787,7 +787,7 @@ class AirPlayPlayer(Player):
 
         cur_volume = self.volume_level or 0
         if abs(cur_volume - volume) > 1 or (time.time() - self.last_command_sent) > 3:
-            self.mass.create_task(self.volume_set(volume))
+            self.mass.create_task(self._adopt_device_volume(volume))
         else:
             self._attr_volume_level = volume
             self.mass.config.set_raw_player_config_value(self.player_id, CONF_STORED_VOLUME, volume)
@@ -978,6 +978,18 @@ class AirPlayPlayer(Player):
             return
         progress = int(metadata.corrected_elapsed_time or 0)
         self.mass.create_task(self.stream.send_metadata(progress, metadata))
+
+    async def _adopt_device_volume(self, volume: int) -> None:
+        """
+        Take over a level the device set itself.
+
+        :param volume: The level the device reported.
+        """
+        await self.volume_set(volume)
+        # Writing the level back is a volume command like any other and opens the echo
+        # window, but this one only hands the device its own level: leaving the window
+        # open would swallow the rest of a volume the user is still turning up.
+        self._volume_reports_ignored_until = 0.0
 
     def _control_routes_to_self(self, control: str) -> bool:
         """Return True if the given (resolved) control routes to this player."""

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -985,11 +985,14 @@ class AirPlayPlayer(Player):
 
         :param volume: The level the device reported.
         """
+        ignored_until = self._volume_reports_ignored_until
         await self.volume_set(volume)
         # Writing the level back is a volume command like any other and opens the echo
         # window, but this one only hands the device its own level: leaving the window
-        # open would swallow the rest of a volume the user is still turning up.
-        self._volume_reports_ignored_until = 0.0
+        # open would swallow the rest of a volume the user is still turning up. A longer
+        # window opened while this was in flight (an announcement) still stands.
+        if self._volume_reports_ignored_until <= time.time() + AIRPLAY_VOLUME_ECHO_GRACE_S:
+            self._volume_reports_ignored_until = ignored_until
 
     def _control_routes_to_self(self, control: str) -> bool:
         """Return True if the given (resolved) control routes to this player."""

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -34,6 +34,7 @@ from .constants import (
     AIRPLAY_HIRES_SAMPLE_RATES,
     AIRPLAY_PCM_FORMAT,
     AIRPLAY_REJOIN_ATTEMPT_DELAYS,
+    AIRPLAY_VOLUME_ECHO_GRACE_S,
     BASE_PLAYER_FEATURES,
     CONF_AIRPLAY_CREDENTIALS,
     CONF_BUFFER_DEPTH,
@@ -110,6 +111,7 @@ class AirPlayPlayer(Player):
         self.address = address
         self.stream: AirPlayStream | None = None
         self.last_command_sent = 0.0
+        self._volume_reports_ignored_until = 0.0
         self._lock = asyncio.Lock()
         self._transitioning = False  # Set during stream replacement to ignore stale DACP messages
         self._rejoin_task: asyncio.Task[None] | None = None
@@ -310,22 +312,25 @@ class AirPlayPlayer(Player):
         # an AirPlay receiver), which only pauses the sync leader while the other
         # members keep playing.
         features = {*BASE_PLAYER_FEATURES, PlayerFeature.PAUSE}
-        # A player with a Sendspin bridge CONFIGURED still announces natively
-        # whenever there is a stream to mix into: its own (session-backed)
-        # AirPlay stream, or the bridge's stream while Sendspin plays through
-        # it. Only a bridged player with neither hides the feature - a
-        # dedicated announcement session on it would race the bridge for the
-        # device, so those announcements keep their existing routing (the
-        # generic flow via the Sendspin parent).
-        prov = cast("AirPlayProvider", self.provider)
-        bridge = prov.bridge_manager.get_bridge(self.player_id)
-        if (
-            bridge is not None
-            and not bridge.owns_airplay_stream
-            and not (self.stream is not None and self.stream.running and self.stream.session)
-        ):
+        # An announcement is mixed into the audio the player is already rendering, so
+        # the feature is only offered while there is live playback to mix into. Without
+        # it the players controller plays the announcement its own way, which leaves
+        # the device to whatever else may be streaming to it.
+        if not self.has_live_audio:
             features.discard(PlayerFeature.PLAY_ANNOUNCEMENT)
         return features
+
+    @property
+    def has_live_audio(self) -> bool:
+        """Return True if the player is rendering audio an announcement can mix into."""
+        if self.playback_state != PlaybackState.PLAYING:
+            return False
+        return self.stream is not None and self.stream.running and self.stream.connected
+
+    @property
+    def applies_announcement_volume(self) -> bool:
+        """Return True: the announcement volume is applied around the mixed clip."""
+        return True
 
     @property
     def can_group_with(self) -> set[str]:
@@ -753,14 +758,31 @@ class AirPlayPlayer(Player):
             # always update the state after modifying group members
             self.update_state()
 
-    def update_volume_from_device(self, volume: int) -> None:
-        """Update volume from device feedback."""
-        ignore_volume_report = (
+    @property
+    def ignore_volume_reports(self) -> bool:
+        """Return True if the device's own volume reports must not be acted on."""
+        if self._volume_reports_ignored_until > time.time():
+            # a level we sent ourselves is still echoing back
+            return True
+        return bool(
             self.config.get_value(CONF_IGNORE_VOLUME)
             or self.device_info.manufacturer.lower() == "apple"
         )
 
-        if ignore_volume_report:
+    def suppress_volume_reports(self, seconds: float = AIRPLAY_VOLUME_ECHO_GRACE_S) -> None:
+        """
+        Ignore the device's own volume reports for the given time.
+
+        :param seconds: How long from now the reports are ignored; a window that is
+            already open is only ever extended.
+        """
+        self._volume_reports_ignored_until = max(
+            self._volume_reports_ignored_until, time.time() + seconds
+        )
+
+    def update_volume_from_device(self, volume: int) -> None:
+        """Update volume from device feedback."""
+        if self.ignore_volume_reports:
             return
 
         cur_volume = self.volume_level or 0

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -41,7 +41,6 @@ from .constants import (
     AIRPLAY_VOLUME_MUTE,
     CLI_PROBLEM_MARKERS,
     COMPANION_DISCOVERY_TYPE,
-    CONF_IGNORE_VOLUME,
     CONF_PASSWORD_INVALID,
     CONF_PASSWORD_MARKERS_REVIEWED,
     CONF_STORED_VOLUME,
@@ -1049,10 +1048,6 @@ class AirPlayProvider(PlayerProvider):
                 parent_player = player
 
             player_id = player.player_id
-            ignore_volume_report = (
-                self.mass.config.get_raw_player_config_value(player_id, CONF_IGNORE_VOLUME, False)
-                or player.device_info.manufacturer.lower() == "apple"
-            )
             if path == "/ctrl-int/1/nextitem":
                 self.handle_remote_command(player, AirPlayRemoteCommand.NEXT)
             elif path == "/ctrl-int/1/previtem":
@@ -1089,7 +1084,7 @@ class AirPlayProvider(PlayerProvider):
                         player_id,
                         task_id=f"debounced_pause_{player_id}",
                     )
-            elif "dmcp.device-volume=" in path and not ignore_volume_report:
+            elif "dmcp.device-volume=" in path and not player.ignore_volume_reports:
                 # This is a bit annoying as this can be either the device confirming a new volume
                 # we've sent or the device requesting a new volume itself.
                 # In case of a small rounding difference, we ignore this,

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -359,13 +359,8 @@ class AirPlayStream:
         # An AirPlay volume command writes the receiver's own volume and persists there
         # after the session ends, so it is only sent when nothing else owns this output's
         # volume: otherwise the device keeps playing at the level its own app or remote is
-        # set to. A latched mute would start the stream silent, and a volume explicitly
-        # requested for this session (an announcement) is not an unsolicited push.
-        if (
-            self.player.owns_volume
-            or self.player.volume_muted
-            or (self.session is not None and self.session.requested_volume is not None)
-        ):
+        # set to. A latched mute would start the stream silent, so it does travel along.
+        if self.player.owns_volume or self.player.volume_muted:
             # Repeat after 2 seconds because some players ignore the first volume command
             # (https://github.com/music-assistant/support/issues/3330). The repeat reads
             # the level when it fires, so it never replays a value that changed since.

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -1769,6 +1769,9 @@ class AirPlayStream:
         command_delivered = await self.commands_pipe.write(command.encode("utf-8"))
         if command_delivered:
             self.player.last_command_sent = time.time()
+            if command.startswith("VOLUME="):
+                # the receiver echoes every level it is handed back over DACP
+                self.player.suppress_volume_reports()
         return command_delivered
 
     def _check_password_preflight(self) -> None:

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -65,7 +65,6 @@ class AirPlayStreamSession:
         sync_clients: list[AirPlayPlayer],
         pcm_format: AudioFormat,
         media: PlayerMedia,
-        requested_volume: int | None = None,
     ) -> None:
         """
         Initialize AirPlayStreamSession.
@@ -74,16 +73,12 @@ class AirPlayStreamSession:
         :param sync_clients: List of AirPlay players to stream to.
         :param pcm_format: PCM format of the input stream.
         :param media: Queue media that owns the stream session.
-        :param requested_volume: Volume level explicitly requested for this session (an
-            announcement volume), already applied to its members. Omit for a regular
-            stream, which only carries a volume when this output owns it.
         """
         assert sync_clients
         self.prov = airplay_provider
         self.mass = airplay_provider.mass
         self.pcm_format = pcm_format
         self.media = media
-        self.requested_volume = requested_volume
         self.sync_clients = sync_clients
         self._audio_source_task: asyncio.Task[None] | None = None
         self._player_ffmpeg: dict[str, FFMpeg] = {}

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -16,7 +16,7 @@ import time
 from collections.abc import AsyncIterator, Callable, Iterator
 from types import SimpleNamespace
 from typing import Any, NamedTuple, cast
-from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
 from music_assistant_models.auth import User, UserRole
@@ -4375,6 +4375,38 @@ class TestNativeAnnouncementVolumeRouting:
 
         # the output cannot attenuate what another control is already attenuating,
         # so the level goes through that control and the output announces at unity
+        assert setup.volume_set.await_args_list == [
+            call("parent", self.ANNOUNCE_VOLUME),
+            call("parent", 20),
+        ]
+        setup.play_announcement.assert_awaited_once_with(ANY, None)
+
+    async def test_output_that_applies_the_volume_itself_gets_it_handed_down(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        An output that applies the announcement volume itself is left to do so.
+
+        A player that mixes the clip into audio it is already playing knows when the
+        clip becomes audible; setting the level up front would raise the music that
+        is still playing instead. Any other output has it applied before it starts.
+        """
+        setup = self._make_setup(mock_mass, "sibling")
+
+        with patch.object(
+            type(setup.output),
+            "applies_announcement_volume",
+            new_callable=PropertyMock,
+            return_value=True,
+        ):
+            await self._announce(setup)
+
+        setup.volume_set.assert_not_awaited()
+        setup.play_announcement.assert_awaited_once_with(ANY, self.ANNOUNCE_VOLUME)
+        setup.play_announcement.reset_mock()
+
+        await self._announce(setup)
+
         assert setup.volume_set.await_args_list == [
             call("parent", self.ANNOUNCE_VOLUME),
             call("parent", 20),

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -4291,6 +4291,64 @@ class TestPlayAnnouncementCleanup:
         render.wait_ready.assert_awaited_once()
         render.wait_finished.assert_not_awaited()
 
+    async def test_feature_still_offered_after_the_render_keeps_the_native_path(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A player still offering the feature once its audio is ready announces natively."""
+        announcements: dict[str, object] = {}
+        controller, _player, render = self._make_player(mock_mass, announcements)
+        order: list[str] = []
+
+        async def _wait_ready() -> bool:
+            order.append("render")
+            return True
+
+        async def _native(*_args: object, **_kwargs: object) -> None:
+            order.append("native")
+
+        render.wait_ready = AsyncMock(side_effect=_wait_ready)
+
+        with (
+            patch.object(controller, "_play_native_announcement", side_effect=_native) as native,
+            patch.object(controller, "_play_announcement") as fallback,
+        ):
+            await controller.play_announcement("player_1", "http://test/announcement.mp3")
+
+        native.assert_awaited_once()
+        fallback.assert_not_awaited()
+        assert order == ["render", "native"]
+
+    async def test_feature_lost_during_the_render_falls_back_to_the_default(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A player that stopped offering the feature while its audio rendered is not handed it.
+
+        Rendering speech takes seconds, and an output that announces by mixing the clip
+        into what it is already playing stops offering the feature the moment that
+        playback ends - so the default implementation has to take over.
+        """
+        announcements: dict[str, object] = {}
+        controller, player, render = self._make_player(mock_mass, announcements)
+
+        async def _wait_ready() -> bool:
+            player._attr_supported_features.discard(PlayerFeature.PLAY_ANNOUNCEMENT)
+            return True
+
+        render.wait_ready = AsyncMock(side_effect=_wait_ready)
+
+        with (
+            patch.object(controller, "_play_native_announcement") as native,
+            patch.object(controller, "_play_announcement") as fallback,
+        ):
+            await controller.play_announcement("player_1", "http://test/announcement.mp3")
+
+        native.assert_not_awaited()
+        fallback.assert_awaited_once()
+        # nothing renders the clip natively, so the announcement is not tagged for it
+        registered = mock_mass.streams.announcement_renderer.register.call_args.args[1]
+        assert registered["announce_player_id"] is None
+
 
 class _AnnounceSetup(NamedTuple):
     """A player announcing through a linked protocol output, with the calls it makes mocked."""

--- a/tests/providers/airplay/dacp/conftest.py
+++ b/tests/providers/airplay/dacp/conftest.py
@@ -118,6 +118,7 @@ def make_player(  # noqa: PLR0913
     player.state.playback_state = state
     player.state.active_group = None
     player.device_info.manufacturer = manufacturer
+    player.ignore_volume_reports = manufacturer.lower() == "apple"
     player.volume_muted = False
     player.volume_level = 50
     if has_stream:

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import time
-from collections.abc import AsyncGenerator, Iterator
+from collections.abc import AsyncGenerator, Coroutine, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -88,6 +88,10 @@ def _make_player(player_id: str, stream: MagicMock | None = None) -> MagicMock:
         side_effect=lambda coro, *_args, **_kwargs: asyncio.get_running_loop().create_task(coro)
     )
     player.mass.players.cmd_volume_set = AsyncMock()
+    # what the controller's scaling returns for the default 0/100 volume limits
+    player.mass.players.scale_volume_to_device = MagicMock(
+        side_effect=lambda _player_id, level: level
+    )
     player.provider._announce_plans = {}
     player.provider.bridge_manager.get_bridge = MagicMock(return_value=None)
     renderer = player.mass.streams.announcement_renderer
@@ -109,6 +113,26 @@ def _make_playing_group(*streams: MagicMock) -> list[MagicMock]:
 def _make_announcement() -> MagicMock:
     """Build the announcement PlayerMedia handed down by the player controller."""
     return MagicMock(custom_data=dict(ANNOUNCE_DATA))
+
+
+def _record_spawned_tasks(player: MagicMock) -> list[asyncio.Task[None]]:
+    """
+    Make the player's task spawner record what it starts, and return that record.
+
+    :param player: The player the announcement targets; the restore its teardown
+        falls back on runs from a task of its own.
+    """
+    tasks: list[asyncio.Task[None]] = []
+
+    def create_task(
+        coro: Coroutine[Any, Any, None], *_args: Any, **_kwargs: Any
+    ) -> asyncio.Task[None]:
+        task = asyncio.get_running_loop().create_task(coro)
+        tasks.append(task)
+        return task
+
+    player.mass.create_task = MagicMock(side_effect=create_task)
+    return tasks
 
 
 @contextmanager
@@ -420,6 +444,25 @@ def test_member_duck_compensates_the_volume_target_bump() -> None:
     assert announce._member_duck_db(member, 61) == pytest.approx(-24.9)
 
 
+def test_member_duck_compensates_the_bump_the_device_actually_gets() -> None:
+    """
+    The compensation is made of the DEVICE levels, not the logical ones.
+
+    A volume limit configured on the target scales every logical level down before it
+    reaches the device, so the music rises by less than the logical delta says and a
+    duck deepened by that delta would bury it.
+    """
+    member = _make_player("m")
+    member.state.volume_level = 30
+    # max_volume 60: logical 30 lands on device 18, logical 55 on device 33
+    member.mass.players.scale_volume_to_device = MagicMock(
+        side_effect=lambda _player_id, level: (level * 60) // 100
+    )
+
+    # +15 device points is +4.5 dB, where the logical +25 would read as +7.5 dB
+    assert announce._member_duck_db(member, 55) == pytest.approx(-22.5)
+
+
 def test_volume_target_is_the_protocol_parent() -> None:
     """The volume of a member with a protocol parent is owned by that parent."""
     member = _make_player("child")
@@ -441,6 +484,94 @@ async def test_no_volume_level_leaves_the_volume_alone() -> None:
     await announce.play_announcement(members[0], _make_announcement(), None)
 
     members[0].mass.players.cmd_volume_set.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_announcement_hands_the_bumped_volume_back() -> None:
+    """
+    An announcement cancelled after the raise still puts the previous level back.
+
+    The music plays on, so the speaker must not be left sitting at the announcement
+    level. The restore runs from a task of its own, since an await in the cancelled
+    call would be cancelled right along with it.
+    """
+    (member,) = _make_playing_group(_make_stream())
+    spawned = _record_spawned_tasks(member)
+    raised = asyncio.Event()
+    parked = asyncio.Event()
+    member.mass.players.cmd_volume_set = AsyncMock(side_effect=lambda *_args: raised.set())
+
+    async def hold_until(_unix_ms: float) -> None:
+        if not raised.is_set():
+            return
+        # the hold in the ducked tail, where the cancel lands
+        parked.set()
+        await asyncio.Event().wait()
+
+    with patch.object(announce, "_hold_until", hold_until):
+        announcing = asyncio.create_task(
+            announce.play_announcement(member, _make_announcement(), 55)
+        )
+        await parked.wait()
+        announcing.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await announcing
+    await asyncio.gather(*spawned)
+
+    assert member.mass.players.cmd_volume_set.await_args_list == [
+        call("member_0", 55),
+        call("member_0", 30),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_completed_announcement_leaves_nothing_to_restore() -> None:
+    """
+    An announcement that ran its course needs no restore behind it.
+
+    Its own timeline put the level back inline, so the teardown's safety net finds
+    nothing left to hand over and never spawns a second restore.
+    """
+    (member,) = _make_playing_group(_make_stream())
+    spawned = _record_spawned_tasks(member)
+
+    with _timeline(member):
+        await announce.play_announcement(member, _make_announcement(), 55)
+
+    assert spawned == []
+    assert member.mass.players.cmd_volume_set.await_args_list == [
+        call("member_0", 55),
+        call("member_0", 30),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_restore_keeps_its_level_for_a_retry(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A level that could not be restored stays behind for a later call, and is logged.
+
+    Dropping it would leave the speaker at the announcement level with nothing left
+    that knows what to put back.
+    """
+    player = _make_player("solo")
+    bumped = {"solo": 30, "other": 40}
+    player.mass.players.cmd_volume_set = AsyncMock(
+        side_effect=[RuntimeError("device unreachable"), None]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await announce._restore_announcement_volume(player, bumped)
+
+    assert bumped == {"solo": 30}
+    assert "Could not restore the volume of solo" in caplog.text
+
+    player.mass.players.cmd_volume_set = AsyncMock()
+    await announce._restore_announcement_volume(player, bumped)
+
+    assert bumped == {}
+    player.mass.players.cmd_volume_set.assert_awaited_once_with("solo", 30)
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -231,7 +231,7 @@ async def test_player_without_live_audio_is_refused() -> None:
     """Without audio to mix into the announcement is refused, releasing the render."""
     player = _make_player("solo")
 
-    with pytest.raises(PlayerCommandFailed, match="stopped playing"):
+    with pytest.raises(PlayerCommandFailed, match="no live playback"):
         await announce.play_announcement(player, _make_announcement(), 40)
 
     player.mass.streams.announcement_renderer.release.assert_awaited_once()
@@ -563,7 +563,7 @@ async def test_synced_member_without_live_playback_is_refused() -> None:
     parked_session = parked_stream.session
     parked_session.stop = AsyncMock()
 
-    with pytest.raises(PlayerCommandFailed, match="stopped playing"):
+    with pytest.raises(PlayerCommandFailed, match="no live playback"):
         await announce.play_announcement(member, _make_announcement(), None)
 
     parked_stream.announce.assert_not_awaited()
@@ -641,7 +641,7 @@ async def test_bridged_player_without_a_stream_to_mix_into_is_refused() -> None:
     bridge = MagicMock(owns_airplay_stream=False)
     player.provider.bridge_manager.get_bridge = MagicMock(return_value=bridge)
 
-    with pytest.raises(PlayerCommandFailed, match="stopped playing"):
+    with pytest.raises(PlayerCommandFailed, match="no live playback"):
         await announce.play_announcement(player, _make_announcement(), None)
 
     stream.announce.assert_not_awaited()

--- a/tests/providers/airplay/test_announce.py
+++ b/tests/providers/airplay/test_announce.py
@@ -4,11 +4,13 @@ import asyncio
 import logging
 import time
 from collections.abc import AsyncGenerator, Iterator
+from contextlib import contextmanager
+from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
-from music_assistant_models.enums import ContentType, PlaybackState
+from music_assistant_models.enums import ContentType
 from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import AudioFormat
 
@@ -16,9 +18,12 @@ from music_assistant.providers.airplay import announce
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_ANNOUNCE_AT_MARGIN_MS,
     AIRPLAY_ANNOUNCE_DUCK_DB,
+    AIRPLAY_ANNOUNCE_DUCK_LEAD_S,
     AIRPLAY_ANNOUNCE_DUCK_TAIL_S,
     AIRPLAY_ANNOUNCE_FALLBACK_SPAN_MS,
+    AIRPLAY_ANNOUNCE_VOLUME_BUMP_DELAY_MS,
     AIRPLAY_PCM_FORMAT,
+    AIRPLAY_VOLUME_ECHO_GRACE_S,
 )
 
 ANNOUNCE_DATA = {
@@ -28,20 +33,6 @@ ANNOUNCE_DATA = {
     "announce_player_id": None,
 }
 HIRES_PCM_FORMAT = AudioFormat(content_type=ContentType.PCM_S32LE, sample_rate=48000, bit_depth=24)
-
-
-@pytest.fixture(autouse=True)
-def _zero_restore_pad() -> Iterator[None]:
-    """
-    Zero the audible-end pad for every test.
-
-    Both paths hold the volume restore until the clip's audible end plus this
-    pad - the live path holds its return with it too; the streams below ack a
-    long-past instant, so only the pad would otherwise add real wall-clock time
-    to every test. The tests that assert on that timing override it themselves.
-    """
-    with patch.object(announce, "AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS", 0):
-        yield
 
 
 def _make_render(duration: float = 1.5) -> MagicMock:
@@ -65,8 +56,8 @@ def _make_stream(
     """
     Build a mock member stream whose announce arm resolves with the given ack.
 
-    The default ack reports a long-past audible instant, so the audible-end
-    hold at the end of the live path resolves without waiting.
+    The default ack reports a long-past audible instant, so every wait the
+    announcement holds for resolves without spending wall-clock time.
     """
     stream = MagicMock()
     stream.running = True
@@ -87,16 +78,16 @@ def _make_player(player_id: str, stream: MagicMock | None = None) -> MagicMock:
     player.display_name = player_id
     player.synced_to = None
     player.state.active_group = None
+    player.state.volume_level = 30
     player.protocol_parent_id = None
-    player.playback_state = PlaybackState.PLAYING
-    player.volume_level = 30
-    player.volume_set = AsyncMock()
+    player.has_live_audio = stream is not None
     player.stream = stream
     player._lock = asyncio.Lock()
     player.logger = logging.getLogger("test.airplay.announce")
     player.mass.create_task = MagicMock(
         side_effect=lambda coro, *_args, **_kwargs: asyncio.get_running_loop().create_task(coro)
     )
+    player.mass.players.cmd_volume_set = AsyncMock()
     player.provider._announce_plans = {}
     player.provider.bridge_manager.get_bridge = MagicMock(return_value=None)
     renderer = player.mass.streams.announcement_renderer
@@ -118,6 +109,30 @@ def _make_playing_group(*streams: MagicMock) -> list[MagicMock]:
 def _make_announcement() -> MagicMock:
     """Build the announcement PlayerMedia handed down by the player controller."""
     return MagicMock(custom_data=dict(ANNOUNCE_DATA))
+
+
+@contextmanager
+def _timeline(player: MagicMock) -> Iterator[list[tuple[str, float]]]:
+    """
+    Record the announcement's volume timeline without spending its waits.
+
+    Yields the ordered log of the instants (unix ms) the announcement holds for and
+    the volume levels it sets, so a test can assert the ORDER of both volume changes
+    against the clip's own instants without reading the wall clock.
+
+    :param player: The player the announcement targets; its controller is the one
+        every volume command travels through.
+    """
+    events: list[tuple[str, float]] = []
+
+    async def hold_until(unix_ms: float) -> None:
+        events.append(("hold", unix_ms))
+
+    player.mass.players.cmd_volume_set = AsyncMock(
+        side_effect=lambda _player_id, level: events.append(("volume", level))
+    )
+    with patch.object(announce, "_hold_until", hold_until):
+        yield events
 
 
 def test_member_span_prefers_the_warm_lead() -> None:
@@ -166,10 +181,8 @@ async def test_live_announcement_arms_every_member_at_one_shared_instant() -> No
     members = _make_playing_group(*streams)
     leader = members[0]
 
-    with patch.object(announce, "_announce_with_session", new_callable=AsyncMock) as session_path:
-        await announce.play_announcement(leader, _make_announcement(), None)
+    await announce.play_announcement(leader, _make_announcement(), None)
 
-    session_path.assert_not_awaited()
     arms = [stream.announce.call_args for stream in streams]
     for arm in arms:
         assert arm is not None
@@ -190,29 +203,38 @@ async def test_live_announcement_renders_one_clip_per_distinct_format() -> None:
     streams = [_make_stream(), _make_stream(pcm_format=HIRES_PCM_FORMAT)]
     members = _make_playing_group(*streams)
 
-    with patch.object(announce, "_announce_with_session", new_callable=AsyncMock):
-        await announce.play_announcement(members[0], _make_announcement(), None)
+    await announce.play_announcement(members[0], _make_announcement(), None)
 
     clip_paths = {stream.announce.call_args.args[0] for stream in streams}
     assert len(clip_paths) == 2
 
 
 @pytest.mark.asyncio
-async def test_idle_player_takes_the_session_path() -> None:
-    """Without live playback the announcement runs as its own stream session."""
+async def test_clip_file_wraps_the_audio_in_ducked_silence() -> None:
+    """The clip file is lead-in silence, then the announcement audio, then tail silence."""
+    clip_path = await announce._render_clip_file(_make_render(), HIRES_PCM_FORMAT)
+    try:
+        clip = Path(clip_path).read_bytes()
+    finally:
+        Path(clip_path).unlink()
+
+    # the silence is sized on the content type: this format carries 24 bit over an
+    # s32le wire, so a bit_depth-derived size would come out a quarter short
+    frame_bytes = 4 * HIRES_PCM_FORMAT.channels
+    lead_bytes = int(HIRES_PCM_FORMAT.sample_rate * AIRPLAY_ANNOUNCE_DUCK_LEAD_S) * frame_bytes
+    tail_bytes = int(HIRES_PCM_FORMAT.sample_rate * AIRPLAY_ANNOUNCE_DUCK_TAIL_S) * frame_bytes
+    assert clip == bytes(lead_bytes) + b"\xff" * 64 + bytes(tail_bytes)
+
+
+@pytest.mark.asyncio
+async def test_player_without_live_audio_is_refused() -> None:
+    """Without audio to mix into the announcement is refused, releasing the render."""
     player = _make_player("solo")
-    player.playback_state = PlaybackState.IDLE
-    announcement = _make_announcement()
 
-    with patch.object(announce, "_announce_with_session", new_callable=AsyncMock) as session_path:
-        await announce.play_announcement(player, announcement, 40)
+    with pytest.raises(PlayerCommandFailed, match="stopped playing"):
+        await announce.play_announcement(player, _make_announcement(), 40)
 
-    session_path.assert_awaited_once()
-    args = session_path.call_args.args
-    assert args[0] is player
-    assert args[1] is announcement
-    assert args[3] == 1.5  # the render's exact duration bounds the session waits
-    assert args[4] == 40
+    player.mass.streams.announcement_renderer.release.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -220,85 +242,147 @@ async def test_no_member_arming_fails_without_killing_the_music() -> None:
     """
     Live members that never arm the clip fail the announcement, not the music.
 
-    An outdated cliairplay silently ignores the arm command; a fallback session
-    would stop the user's playing session over a clip that could not be mixed.
+    An outdated cliairplay silently ignores the arm command: nothing is said, but
+    the session every member is playing from is left exactly as it was.
     """
     streams = [_make_stream(ack=None), _make_stream(ack=None)]
     members = _make_playing_group(*streams)
     live_session = streams[0].session
     live_session.stop = AsyncMock()
 
-    with (
-        patch.object(announce, "_announce_with_session", new_callable=AsyncMock) as session_path,
-        pytest.raises(PlayerCommandFailed, match="may not support announcements"),
-    ):
+    with pytest.raises(PlayerCommandFailed, match="may not support announcements"):
         await announce.play_announcement(members[0], _make_announcement(), None)
 
     for stream in streams:
         stream.announce.assert_awaited_once()
         stream.wait_announce_done.assert_not_awaited()
-    session_path.assert_not_awaited()
     live_session.stop.assert_not_awaited()
     members[0].mass.streams.announcement_renderer.release.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_partial_success_warns_and_does_not_fall_back(
+async def test_partial_success_warns_about_the_members_that_stayed_silent(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """One member playing the clip is a success; the members that did not are named."""
     streams = [_make_stream(), _make_stream(ack=None)]
     members = _make_playing_group(*streams)
 
-    with (
-        patch.object(announce, "_announce_with_session", new_callable=AsyncMock) as session_path,
-        caplog.at_level(logging.WARNING),
-    ):
+    with caplog.at_level(logging.WARNING):
         await announce.play_announcement(members[0], _make_announcement(), None)
 
-    session_path.assert_not_awaited()
     assert "member_1" in caplog.text
     streams[0].wait_announce_done.assert_awaited_once()
     streams[1].wait_announce_done.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_volume_is_scheduled_on_the_acked_instant() -> None:
-    """The volume bump lands at the acked audible instant, the restore after the clip."""
-    ack_at_unix_ms = int(time.time() * 1000) + 200
-    # the acked duration includes the 1s ducked-silence tail: 0.8s of content,
-    # which keeps the bias out of the short-clip cap while the audible-end hold
-    # this call ends on stays short
-    stream = _make_stream(ack=(ack_at_unix_ms, 1800))
-    members = _make_playing_group(stream)
-    member = members[0]
-    member.volume_level = 30
-    # both delays count down from the moment they are scheduled, which the
-    # clock reads either side of it bracket exactly: the audible-end hold this
-    # call ends on runs for seconds past that moment
-    scheduled_at: list[float] = []
-    member.mass.call_later = MagicMock(
-        side_effect=lambda *_args, **_kwargs: scheduled_at.append(time.time())
-    )
+async def test_volume_moves_inside_the_ducked_silence() -> None:
+    """
+    The volume is raised in the ducked lead-in and restored in the ducked tail.
 
-    before_s = time.time()
-    with patch.object(announce, "_announce_with_session", new_callable=AsyncMock):
+    Both changes are timed on the acked start of the clip FILE: the raise lands
+    after that start but before the announcement audio at the end of the lead-in,
+    and the restore after that audio but before the file ends - so neither is ever
+    heard on the music, which is ducked for the whole file.
+    """
+    duration = 1.5
+    file_ms = int((AIRPLAY_ANNOUNCE_DUCK_LEAD_S + duration + AIRPLAY_ANNOUNCE_DUCK_TAIL_S) * 1000)
+    ack_at_unix_ms = 1_700_000_000_000
+    (member,) = _make_playing_group(_make_stream(ack=(ack_at_unix_ms, file_ms)))
+
+    with _timeline(member) as events:
         await announce.play_announcement(member, _make_announcement(), 55)
 
-    scheduled = member.mass.call_later.call_args_list
-    assert len(scheduled) == 2
-    bump, restore = scheduled
-    assert bump.args[1:] == (member.volume_set, 55)
-    assert restore.args[1:] == (member.volume_set, 30)
-    # the bump lands on what was left of the acked instant when it was
-    # scheduled (0.2s out here), plus the 0.3s into-the-clip bias; the restore
-    # follows the CONTENT length (the acked duration minus the silence tail)
-    # plus the (zeroed) pad, so it lands inside the ducked cushion - 0.5s
-    # after the bump here
-    left_at_least = max(0.0, ack_at_unix_ms / 1000 - scheduled_at[0])
-    left_at_most = max(0.0, ack_at_unix_ms / 1000 - before_s)
-    assert left_at_least + 0.3 <= bump.args[0] <= left_at_most + 0.3
-    assert restore.args[0] - bump.args[0] == pytest.approx(0.5)
+    assert [name for name, _ in events] == ["hold", "volume", "hold", "volume", "hold"]
+    assert events[1][1] == 55
+    assert events[3][1] == 30  # the level the volume target carried before
+    raised_at, restored_at = events[0][1], events[2][1]
+    assert raised_at == ack_at_unix_ms + AIRPLAY_ANNOUNCE_VOLUME_BUMP_DELAY_MS
+    # inside the lead-in: the music is already ducked, nothing is being said yet
+    assert ack_at_unix_ms < raised_at < ack_at_unix_ms + AIRPLAY_ANNOUNCE_DUCK_LEAD_S * 1000
+    # inside the tail: the announcement is over, the clip file is not
+    assert (
+        ack_at_unix_ms + (AIRPLAY_ANNOUNCE_DUCK_LEAD_S + duration) * 1000
+        <= restored_at
+        < ack_at_unix_ms + file_ms
+    )
+
+
+@pytest.mark.asyncio
+async def test_short_clip_is_fully_covered_by_the_announcement_volume() -> None:
+    """
+    A clip shorter than the ducked lead-in still plays at the announcement volume.
+
+    The raise is timed on the lead-in, never on the clip's own length, so a short
+    announcement is at the announcement level from its first word (the regression
+    heard as a short announcement not playing at all).
+    """
+    duration = 0.4
+    file_ms = int((AIRPLAY_ANNOUNCE_DUCK_LEAD_S + duration + AIRPLAY_ANNOUNCE_DUCK_TAIL_S) * 1000)
+    ack_at_unix_ms = 1_700_000_000_000
+    (member,) = _make_playing_group(_make_stream(ack=(ack_at_unix_ms, file_ms)))
+    member.mass.streams.announcement_renderer.acquire = MagicMock(
+        return_value=_make_render(duration)
+    )
+
+    with _timeline(member) as events:
+        await announce.play_announcement(member, _make_announcement(), 55)
+
+    assert [name for name, _ in events] == ["hold", "volume", "hold", "volume", "hold"]
+    raised_at, restored_at = events[0][1], events[2][1]
+    # the raise still lands before a word is said, the restore only after the last
+    assert raised_at < ack_at_unix_ms + AIRPLAY_ANNOUNCE_DUCK_LEAD_S * 1000
+    assert restored_at >= ack_at_unix_ms + (AIRPLAY_ANNOUNCE_DUCK_LEAD_S + duration) * 1000
+
+
+@pytest.mark.asyncio
+async def test_announcement_volume_lands_on_the_protocol_parent() -> None:
+    """
+    The announcement volume is set on the control that owns the member's output.
+
+    An AirPlay child of a native player must not write the receiver's own level:
+    the command travels through the controller to the parent, on the parent's scale.
+    """
+    (member,) = _make_playing_group(_make_stream())
+    parent = _make_player("parent")
+    parent.state.volume_level = 20
+    parent.mass = member.mass
+    member.protocol_parent_id = "parent"
+    member.mass.players.get_player = MagicMock(return_value=parent)
+
+    with _timeline(member):
+        await announce.play_announcement(member, _make_announcement(), 55)
+
+    # the parent's own level is bumped and restored; the child is never addressed
+    assert member.mass.players.cmd_volume_set.await_args_list == [
+        call("parent", 55),
+        call("parent", 20),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_armed_members_ignore_their_own_volume_echoes() -> None:
+    """
+    Every armed member ignores the device's volume reports until its clip is over.
+
+    The receiver echoes each level it is handed back over DACP; an echo read as the
+    user reaching for the volume would be written straight back to the device.
+    """
+    # taken WITH the wall clock the ack is built from, so the window below is
+    # bracketed exactly however slow the run itself is
+    now_ms = int(time.time() * 1000)
+    file_ms = 3000
+    (member,) = _make_playing_group(_make_stream(ack=(now_ms + 300, file_ms)))
+
+    with _timeline(member):
+        await announce.play_announcement(member, _make_announcement(), 55)
+    elapsed = time.time() - now_ms / 1000
+
+    audible_end_s = (300 + file_ms) / 1000
+    window = member.suppress_volume_reports.call_args.args[0]
+    assert audible_end_s + AIRPLAY_VOLUME_ECHO_GRACE_S - elapsed <= window
+    assert window <= audible_end_s + AIRPLAY_VOLUME_ECHO_GRACE_S
 
 
 def test_member_duck_compensates_the_volume_bump() -> None:
@@ -311,175 +395,52 @@ def test_member_duck_compensates_the_volume_bump() -> None:
     down shallows it symmetrically, and without a bump the base duck applies.
     """
     member = _make_player("m")
-    member.volume_level = 38
+    member.state.volume_level = 38
     assert announce._member_duck_db(member, 61) == pytest.approx(-24.9)
     assert announce._member_duck_db(member, 18) == pytest.approx(-12.0)
     assert announce._member_duck_db(member, None) == pytest.approx(-18.0)
     assert announce._member_duck_db(member, 38) == pytest.approx(-18.0)
     # extreme bumps clamp to the binary's usable range (never boost the music)
-    member.volume_level = 0
+    member.state.volume_level = 0
     assert announce._member_duck_db(member, 100) == pytest.approx(-48.0)
     assert announce._member_duck_db(member, 0) == pytest.approx(-18.0)
-    member.volume_level = 100
+    member.state.volume_level = 100
     assert announce._member_duck_db(member, 0) == pytest.approx(0.0)
+
+
+def test_member_duck_compensates_the_volume_target_bump() -> None:
+    """The compensation follows the level of the control the bump is applied to."""
+    member = _make_player("child")
+    member.state.volume_level = 100
+    parent = _make_player("parent")
+    parent.state.volume_level = 38
+    member.protocol_parent_id = "parent"
+    member.mass.players.get_player = MagicMock(return_value=parent)
+
+    assert announce._member_duck_db(member, 61) == pytest.approx(-24.9)
+
+
+def test_volume_target_is_the_protocol_parent() -> None:
+    """The volume of a member with a protocol parent is owned by that parent."""
+    member = _make_player("child")
+    parent = _make_player("parent")
+    member.protocol_parent_id = "parent"
+    member.mass.players.get_player = MagicMock(return_value=parent)
+
+    assert announce._volume_target(member) is parent
+    # a member without one owns its own volume
+    member.protocol_parent_id = None
+    assert announce._volume_target(member) is member
 
 
 @pytest.mark.asyncio
 async def test_no_volume_level_leaves_the_volume_alone() -> None:
-    """Without an announcement volume nothing is scheduled on any member."""
+    """Without an announcement volume no level is touched on any member."""
     members = _make_playing_group(_make_stream())
 
-    with patch.object(announce, "_announce_with_session", new_callable=AsyncMock):
-        await announce.play_announcement(members[0], _make_announcement(), None)
+    await announce.play_announcement(members[0], _make_announcement(), None)
 
-    members[0].mass.call_later.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_session_path_plays_the_clip_and_restores_the_volume() -> None:
-    """The dedicated session serves the clip to the configured group at the given volume."""
-    player = _make_player("solo")
-    player.playback_state = PlaybackState.IDLE
-    player.volume_level = 25
-    player._get_sync_clients = MagicMock(return_value=[player])
-    player._get_session_pcm_format = AsyncMock(return_value=AIRPLAY_PCM_FORMAT)
-    announcement = _make_announcement()
-    render = _make_render(duration=0.01)
-    player.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
-    events: list[tuple[str, float]] = []
-
-    with (
-        patch.object(announce, "AirPlayStreamSession") as session_cls,
-        patch.object(announce, "AIRPLAY_ANNOUNCE_VOLUME_RESTORE_PAD_MS", 100),
-        patch.object(announce, "AIRPLAY_ANNOUNCE_SESSION_DRAIN_S", 0.4),
-    ):
-        started = time.monotonic()
-        player.volume_set = AsyncMock(
-            side_effect=lambda level: events.append((f"volume={level}", time.monotonic() - started))
-        )
-        session = session_cls.return_value
-        session.start = AsyncMock()
-        session.stop = AsyncMock(
-            side_effect=lambda: events.append(("stop", time.monotonic() - started))
-        )
-        session.start_time = 0.0
-        await announce.play_announcement(player, announcement, 60)
-
-    assert session_cls.call_args.args == (
-        player.provider,
-        [player],
-        AIRPLAY_PCM_FORMAT,
-        announcement,
-    )
-    session.start.assert_awaited_once()
-    session.stop.assert_awaited_once()
-    # An AirPlay volume only reaches the receiver over a running stream, so the
-    # restore has to land on the clip's audible end (+ the 0.1s pad), well
-    # inside the 0.4s drain the session is stopped after.
-    assert [name for name, _ in events] == ["volume=60", "volume=25", "stop"]
-    _, restored_at = events[1]
-    _, stopped_at = events[2]
-    assert 0.1 <= restored_at < 0.3
-    assert stopped_at >= 0.4
-    # the player ends idle without still showing media (like player.stop())
-    assert player._attr_current_media is None
-    player.update_state.assert_called()
-
-
-@pytest.mark.asyncio
-async def test_session_path_restores_the_volume_when_the_clip_is_cut_short() -> None:
-    """An announcement cancelled mid-clip hands the speaker back its own volume."""
-    player = _make_player("solo")
-    player.playback_state = PlaybackState.IDLE
-    player.volume_level = 25
-    player._get_sync_clients = MagicMock(return_value=[player])
-    player._get_session_pcm_format = AsyncMock(return_value=AIRPLAY_PCM_FORMAT)
-    render = _make_render(duration=30)
-    player.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
-    events: list[str] = []
-    player.volume_set = AsyncMock(side_effect=lambda level: events.append(f"volume={level}"))
-
-    with patch.object(announce, "AirPlayStreamSession") as session_cls:
-        started = asyncio.Event()
-        session = session_cls.return_value
-        session.start = AsyncMock(side_effect=lambda _source: started.set())
-        session.stop = AsyncMock(side_effect=lambda: events.append("stop"))
-        session.start_time = 0.0
-        announcing = asyncio.create_task(
-            announce.play_announcement(player, _make_announcement(), 60)
-        )
-        # the session is up; the cancel lands in the clip wait that follows
-        await started.wait()
-        announcing.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await announcing
-
-    # the session is still up here, so the restore reaches the receiver
-    assert events == ["volume=60", "volume=25", "stop"]
-
-
-@pytest.mark.asyncio
-async def test_session_path_serves_the_clip_with_its_silence_tail() -> None:
-    """The dedicated session keeps feeding past the clip, so the volume restore lands in time."""
-    player = _make_player("solo")
-    player.playback_state = PlaybackState.IDLE
-    player._get_sync_clients = MagicMock(return_value=[player])
-    player._get_session_pcm_format = AsyncMock(return_value=HIRES_PCM_FORMAT)
-    render = _make_render(duration=0.01)
-    player.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
-    served = bytearray()
-
-    with (
-        patch.object(announce, "AirPlayStreamSession") as session_cls,
-        patch.object(announce, "AIRPLAY_ANNOUNCE_SESSION_DRAIN_S", 0.0),
-    ):
-
-        async def start(source: AsyncGenerator[bytes]) -> None:
-            async for chunk in source:
-                served.extend(chunk)
-
-        session = session_cls.return_value
-        session.start = AsyncMock(side_effect=start)
-        session.stop = AsyncMock()
-        session.start_time = 0.0
-        await announce.play_announcement(player, _make_announcement(), None)
-
-    # the tail is sized on the content type: this format carries 24 bit over an
-    # s32le wire, so a bit_depth-derived size would come out a quarter short
-    tail_bytes = (
-        int(HIRES_PCM_FORMAT.sample_rate * AIRPLAY_ANNOUNCE_DUCK_TAIL_S)
-        * 4
-        * HIRES_PCM_FORMAT.channels
-    )
-    assert served == b"\xff" * 64 + bytes(tail_bytes)
-
-
-@pytest.mark.asyncio
-async def test_session_path_stops_a_parked_session_first() -> None:
-    """A parked (paused) session is stopped before the dedicated announcement session."""
-    parked_stream = _make_stream()
-    player = _make_player("solo", stream=parked_stream)
-    player.playback_state = PlaybackState.PAUSED
-    player._get_sync_clients = MagicMock(return_value=[player])
-    player._get_session_pcm_format = AsyncMock(return_value=AIRPLAY_PCM_FORMAT)
-    parked_session = parked_stream.session
-    parked_session.stop = AsyncMock()
-    render = _make_render(duration=0.01)
-    player.mass.streams.announcement_renderer.acquire = MagicMock(return_value=render)
-
-    with (
-        patch.object(announce, "AirPlayStreamSession") as session_cls,
-        patch.object(announce, "AIRPLAY_ANNOUNCE_SESSION_DRAIN_S", 0.0),
-    ):
-        session = session_cls.return_value
-        session.start = AsyncMock()
-        session.stop = AsyncMock()
-        session.start_time = 0.0
-        await announce.play_announcement(player, _make_announcement(), None)
-
-    parked_session.stop.assert_awaited_once()
-    assert player.stream is None
-    session.start.assert_awaited_once()
+    members[0].mass.players.cmd_volume_set.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -589,22 +550,23 @@ async def test_member_announced_directly_arms_itself() -> None:
 @pytest.mark.asyncio
 async def test_synced_member_without_live_playback_is_refused() -> None:
     """
-    A parked group member must not announce by tearing down the shared session.
+    A parked group member has nothing to mix into, so its announcement is refused.
 
-    Its stream belongs to the leader's parked session; stopping that for a
-    single-member announcement would silence every room in the group.
+    Its stream belongs to the leader's parked session, which is left untouched:
+    stopping it for a single-member announcement would silence the whole group.
     """
     parked_stream = _make_stream()
     members = _make_playing_group(parked_stream)
     member = members[0]
     member.synced_to = "some_leader"
-    member.playback_state = PlaybackState.PAUSED
+    member.has_live_audio = False
     parked_session = parked_stream.session
     parked_session.stop = AsyncMock()
 
-    with pytest.raises(PlayerCommandFailed, match="without live playback"):
+    with pytest.raises(PlayerCommandFailed, match="stopped playing"):
         await announce.play_announcement(member, _make_announcement(), None)
 
+    parked_stream.announce.assert_not_awaited()
     parked_session.stop.assert_not_awaited()
 
 
@@ -666,20 +628,23 @@ async def test_bridge_configured_player_mixes_over_its_own_session() -> None:
 
 
 @pytest.mark.asyncio
-async def test_bridge_streaming_player_never_runs_a_session_fallback() -> None:
-    """A player whose bridge owns the live stream fails instead of seizing the device."""
-    player = _make_player("bridged")
-    player.playback_state = PlaybackState.IDLE
-    bridge = MagicMock(owns_airplay_stream=True)
+async def test_bridged_player_without_a_stream_to_mix_into_is_refused() -> None:
+    """
+    A bridged player Sendspin is not streaming through is refused, not seized.
+
+    Neither its own session nor the bridge is rendering audio here, so there is
+    nothing to mix the clip into and the device is left to whatever owns it.
+    """
+    stream = _make_stream()
+    stream.session = None
+    player = _make_player("bridged", stream=stream)
+    bridge = MagicMock(owns_airplay_stream=False)
     player.provider.bridge_manager.get_bridge = MagicMock(return_value=bridge)
 
-    with (
-        patch.object(announce, "AirPlayStreamSession") as session_cls,
-        pytest.raises(PlayerCommandFailed, match="Sendspin bridge"),
-    ):
+    with pytest.raises(PlayerCommandFailed, match="stopped playing"):
         await announce.play_announcement(player, _make_announcement(), None)
 
-    session_cls.assert_not_called()
+    stream.announce.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -1065,6 +1065,34 @@ async def test_adopting_a_device_level_keeps_the_next_report_visible(
 
 
 @pytest.mark.asyncio
+async def test_adopting_a_device_level_keeps_an_announcement_window(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """
+    Adopting a device level leaves a longer window opened meanwhile in place.
+
+    An announcement holds the reports off for its whole span; a write-back that lands
+    inside it must clear only the moment its own command opened, not that span.
+    """
+    airplay_player.config.get_value.return_value = False  # type: ignore[attr-defined]
+    airplay_player._attr_volume_level = 30
+    stream = MagicMock(running=True)
+    # an announcement arms its own span while the write-back is in flight
+    stream.send_cli_command = AsyncMock(
+        side_effect=lambda _command: airplay_player.suppress_volume_reports(30)
+    )
+    airplay_player.stream = stream
+    adoptions: list[Coroutine[Any, Any, None]] = []
+    airplay_player.mass.create_task = MagicMock(side_effect=adoptions.append)  # type: ignore[method-assign]
+
+    airplay_player.update_volume_from_device(55)
+    while adoptions:
+        await adoptions.pop()
+
+    assert airplay_player.ignore_volume_reports is True
+
+
+@pytest.mark.asyncio
 async def test_single_player_play_sends_action_play(airplay_player: AirPlayPlayer) -> None:
     """An unsynced player resumes its paused stream in place with ACTION=PLAY."""
     airplay_player._attr_group_members = []

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -3,7 +3,8 @@
 import asyncio
 import logging
 import time
-from typing import cast
+from collections.abc import Coroutine
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -1024,6 +1025,43 @@ def test_volume_report_suppression_expires(airplay_player: AirPlayPlayer) -> Non
         assert airplay_player.ignore_volume_reports is True
     with patch("music_assistant.providers.airplay.player.time.time", return_value=expired):
         assert airplay_player.ignore_volume_reports is False
+
+
+@pytest.mark.asyncio
+async def test_adopting_a_device_level_keeps_the_next_report_visible(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """
+    Writing a device-reported level back does not blind us to the reports after it.
+
+    That write is a volume command like any other and so arms the echo grace, but it
+    only hands the device its own level: left armed it would swallow the rest of a
+    volume the user is still turning up.
+    """
+    airplay_player.config.get_value.return_value = False  # type: ignore[attr-defined]
+    airplay_player._attr_volume_level = 30
+    stream = MagicMock(running=True)
+    # the running stream arms the grace for every level it delivers
+    stream.send_cli_command = AsyncMock(
+        side_effect=lambda _command: airplay_player.suppress_volume_reports()
+    )
+    airplay_player.stream = stream
+    adoptions: list[Coroutine[Any, Any, None]] = []
+    airplay_player.mass.create_task = MagicMock(side_effect=adoptions.append)  # type: ignore[method-assign]
+
+    airplay_player.update_volume_from_device(55)
+    while adoptions:
+        await adoptions.pop()
+
+    assert airplay_player._attr_volume_level == 55
+    stream.send_cli_command.assert_awaited_once_with("VOLUME=55")
+
+    # the user keeps turning the knob: the report that follows is acted on
+    airplay_player.update_volume_from_device(70)
+    while adoptions:
+        await adoptions.pop()
+
+    assert airplay_player._attr_volume_level == 70
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -957,31 +957,73 @@ def test_supported_features_always_includes_pause(airplay_player: AirPlayPlayer)
     assert PlayerFeature.PAUSE in airplay_player.supported_features
 
 
-def test_bridged_player_advertises_announcements_only_while_streaming(
+def test_announcements_are_advertised_only_with_live_audio(
     airplay_player: AirPlayPlayer,
 ) -> None:
     """
-    A Sendspin-bridged player advertises PLAY_ANNOUNCEMENT only while streaming.
+    PLAY_ANNOUNCEMENT is advertised only while there is audio to mix a clip into.
 
-    The bridge's live stream is a regular AirPlayStream the clip mixes into, so
-    the feature stays available then. An idle bridged player must not advertise
-    it - a dedicated announcement session would fight the bridge for the
-    device, so those announcements keep their existing routing.
+    A clip is mixed over the live stream, so without one the players controller
+    has to announce its own way - which leaves the device to whatever else may be
+    streaming to it (a Sendspin bridge, for one).
     """
+    airplay_player._attr_playback_state = PlaybackState.PLAYING
+    assert airplay_player.stream is None
+    assert PlayerFeature.PLAY_ANNOUNCEMENT not in airplay_player.supported_features
+    # a stream that is up but not yet connected renders nothing
+    airplay_player.stream = MagicMock(running=True, connected=False)
+    assert PlayerFeature.PLAY_ANNOUNCEMENT not in airplay_player.supported_features
+    airplay_player.stream = MagicMock(running=True, connected=True)
+    assert PlayerFeature.PLAY_ANNOUNCEMENT in airplay_player.supported_features
+    # the bridge's own stream is a regular AirPlayStream the clip mixes into, so a
+    # Sendspin-bridged player streaming through it keeps the feature
     bridge_manager = cast("AirPlayProvider", airplay_player.provider).bridge_manager
-    with patch.object(bridge_manager, "get_bridge", return_value=None):
+    with patch.object(bridge_manager, "get_bridge", return_value=MagicMock()):
         assert PlayerFeature.PLAY_ANNOUNCEMENT in airplay_player.supported_features
-    streaming_bridge = MagicMock(owns_airplay_stream=True)
-    with patch.object(bridge_manager, "get_bridge", return_value=streaming_bridge):
-        assert PlayerFeature.PLAY_ANNOUNCEMENT in airplay_player.supported_features
-    idle_bridge = MagicMock(owns_airplay_stream=False)
-    with patch.object(bridge_manager, "get_bridge", return_value=idle_bridge):
-        assert PlayerFeature.PLAY_ANNOUNCEMENT not in airplay_player.supported_features
-        # ... but a configured-yet-idle bridge never hides the feature while the
-        # player runs its own session-backed stream (playing over AirPlay itself)
-        airplay_player.stream = MagicMock(running=True, session=MagicMock())
-        assert PlayerFeature.PLAY_ANNOUNCEMENT in airplay_player.supported_features
-        airplay_player.stream = None
+    airplay_player._attr_playback_state = PlaybackState.PAUSED
+    assert PlayerFeature.PLAY_ANNOUNCEMENT not in airplay_player.supported_features
+
+
+def test_player_applies_the_announcement_volume_itself(airplay_player: AirPlayPlayer) -> None:
+    """The clip is mixed into live audio, so the level is moved around it, not before it."""
+    assert airplay_player.applies_announcement_volume is True
+
+
+def test_volume_reports_are_ignored_while_our_own_level_echoes(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """
+    A level we sent ourselves is ignored when the receiver echoes it back.
+
+    Every level handed to a receiver comes back over DACP; taken at face value that
+    echo reads as the user turning the knob and is written straight back out.
+    """
+    airplay_player.config.get_value.return_value = False  # type: ignore[attr-defined]
+    airplay_player._attr_volume_level = 30
+
+    airplay_player.suppress_volume_reports(10)
+
+    assert airplay_player.ignore_volume_reports is True
+    with patch.object(AirPlayPlayer, "update_state") as mock_update:
+        airplay_player.update_volume_from_device(55)
+    assert airplay_player._attr_volume_level == 30
+    mock_update.assert_not_called()
+    airplay_player.mass.create_task.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_volume_report_suppression_expires(airplay_player: AirPlayPlayer) -> None:
+    """Past its window the device's own volume reports are acted on again."""
+    airplay_player.config.get_value.return_value = False  # type: ignore[attr-defined]
+    expired = time.time() + 10
+
+    airplay_player.suppress_volume_reports(5)
+    # a shorter window never shortens the one already open
+    airplay_player.suppress_volume_reports(1)
+
+    with patch("music_assistant.providers.airplay.player.time.time", return_value=expired - 6):
+        assert airplay_player.ignore_volume_reports is True
+    with patch("music_assistant.providers.airplay.player.time.time", return_value=expired):
+        assert airplay_player.ignore_volume_reports is False
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2458,27 +2458,6 @@ async def test_wait_for_connection_sends_volume_when_muted_without_ownership() -
 
 
 @pytest.mark.asyncio
-async def test_wait_for_connection_sends_volume_for_a_requested_session_volume() -> None:
-    """A volume explicitly requested for the session is pushed, even without ownership."""
-    player = _make_player()
-    player.owns_volume = False
-    player.volume_muted = False
-    stream = AirPlayStream(player)
-    stream._connected.set()
-    stream.session = MagicMock(requested_volume=85)
-
-    with (
-        patch.object(stream, "_cli_proc", MagicMock()),
-        patch.object(stream.commands_pipe, "wait_for_reader", new=AsyncMock(return_value=True)),
-        patch.object(stream, "_send_current_metadata", new_callable=AsyncMock),
-        patch.object(stream, "send_cli_command", new_callable=AsyncMock) as send_command,
-    ):
-        await stream.wait_for_connection()
-
-    send_command.assert_awaited_with(f"VOLUME={player.volume_level}")
-
-
-@pytest.mark.asyncio
 async def test_wait_for_connection_fails_on_an_unread_command_pipe() -> None:
     """A binary that never attaches to the command pipe can never be anchored: fail the connect."""
     player = _make_player()

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -1203,6 +1203,50 @@ async def test_cli_command_preserves_timestamp_when_delivery_raises() -> None:
 
 
 @pytest.mark.asyncio
+async def test_delivered_volume_command_arms_the_echo_grace() -> None:
+    """
+    A delivered volume command makes the player ignore the echo of it.
+
+    The receiver reports every level it is handed back over DACP; read at face value
+    that echo is the user reaching for the volume and is written straight back out.
+    """
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream._cli_proc = _make_cli_proc()
+
+    with patch.object(stream.commands_pipe, "write", new=AsyncMock(return_value=True)):
+        assert await stream.send_cli_command("VOLUME=40") is True
+
+    player.suppress_volume_reports.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_delivered_other_command_leaves_the_echo_grace_alone() -> None:
+    """A command that is not a level cannot come back as one, so it blinds nothing."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream._cli_proc = _make_cli_proc()
+
+    with patch.object(stream.commands_pipe, "write", new=AsyncMock(return_value=True)):
+        assert await stream.send_cli_command("ACTION=STANDBY") is True
+
+    player.suppress_volume_reports.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dropped_volume_command_leaves_the_echo_grace_alone() -> None:
+    """A volume command the binary never got is never echoed, so the reports stay live."""
+    player = _make_player()
+    stream = AirPlayStream(player)
+    stream._cli_proc = _make_cli_proc()
+
+    with patch.object(stream.commands_pipe, "write", new=AsyncMock(return_value=False)):
+        assert await stream.send_cli_command("VOLUME=40") is False
+
+    player.suppress_volume_reports.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_connect_does_not_write_before_the_binary_can_read() -> None:
     """Connecting lays out the command pipe and starts cliairplay, pushing nothing into it."""
     player = _make_player()


### PR DESCRIPTION
# What does this implement/fix?

Announcements over AirPlay happened in the wrong order. The volume went up while the music
was still playing at full level, and a short announcement (just "test") was over before the
volume had actually risen, so it was barely audible or seemed not to play at all. A speaker
that was muted beforehand could also end up un-muted again afterwards.

The announcement clip is now wrapped in a moment of silence on both sides. Because the
music stays ducked for the whole clip, the volume can move inside that silence, where it
cannot be heard as the music changing level: the music ducks first, the volume goes up,
then the announcement is spoken, and the volume is back before the music comes up again.

Changes:

- Duck the music first, then raise the volume, then play the announcement - and restore in
  the same order.
- Short announcements now play at the announcement volume from the first word.
- Set the announcement volume on the control that actually owns the speaker, so a WiiM or
  Sonos playing over AirPlay no longer gets it turned up before the announcement starts.
- Ignore the receiver's own volume reports for a moment after Music Assistant sets a level,
  so its echo can no longer un-mute a muted speaker or write the announcement volume back.
- Only offer native AirPlay announcements while there is music to mix into; without it the
  standard announcement handling is used.

**Related issue (if applicable):**

- n/a (reported directly)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) - `bugfix`
- [ ] New feature (non-breaking change which adds functionality) - `new-feature`
- [ ] Enhancement to an existing feature - `enhancement`
- [ ] New music/player/metadata/plugin provider - `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) - `breaking-change`
- [ ] Refactor (no behaviour change) - `refactor`
- [ ] Documentation only - `documentation`
- [ ] Maintenance / chore - `maintenance`
- [ ] CI / workflow change - `ci`
- [ ] Dependencies bump - `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
