### PR TITLE
Add optional blog post link to release notes

### DIFF
--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Important notes to display at the top (breaking changes, critical info, etc.)'
     required: false
     default: ''
+  blog-post-url:
+    description: 'URL of the accompanying blog post, linked at the top of the release notes'
+    required: false
+    default: ''
 outputs:
   release-notes:
     description: 'The complete generated release notes including frontend changes'
@@ -55,6 +59,7 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_SERVER_URL: ${{ github.server_url }}
         IMPORTANT_NOTES: ${{ inputs.important-notes }}
+        BLOG_POST_URL: ${{ inputs.blog-post-url }}
       run: |
         cd "${{ inputs.repository-path }}"
         chmod +x ${{ github.action_path }}/generate_notes.py

--- a/.github/actions/generate-release-notes/generate_notes.py
+++ b/.github/actions/generate-release-notes/generate_notes.py
@@ -278,9 +278,20 @@ def generate_release_notes(  # noqa: PLR0915
     previous_tag,
     frontend_changes=None,
     important_notes=None,
+    blog_post_url=None,
 ) -> str:
     """Generate the formatted release notes."""
     lines = []
+
+    banner = None
+    if blog_post_url and blog_post_url.strip():
+        version = os.environ.get("VERSION", "")
+        match = re.match(r"^(\d+)\.(\d+)", version)
+        release = f"{match.group(1)}.{match.group(2)}" if match else version
+        banner = (
+            f"> 🎉 **Music Assistant {release} is here!** "
+            f"Read the [release announcement]({blog_post_url.strip()}) on our blog."
+        )
 
     # Add important notes section first if provided
     if important_notes and important_notes.strip():
@@ -305,7 +316,13 @@ def generate_release_notes(  # noqa: PLR0915
         if channel:
             lines.append(f"## 📦 {channel} Release")
             lines.append("")
+        if banner:
+            lines.append(banner)
+            lines.append("")
         lines.append(f"_Changes since [{previous_tag}]({repo_url}/releases/tag/{previous_tag})_")
+        lines.append("")
+    elif banner:
+        lines.append(banner)
         lines.append("")
 
     # Add categorized PRs - first pass: categories without "after-other" flag
@@ -398,7 +415,7 @@ def generate_release_notes(  # noqa: PLR0915
     return "\n".join(lines)
 
 
-def main() -> None:
+def main() -> None:  # noqa: PLR0915
     """Generate release notes for the target version."""
     # Get environment variables
     github_token = os.environ.get("GITHUB_TOKEN")
@@ -408,6 +425,7 @@ def main() -> None:
     channel = os.environ.get("CHANNEL")
     repo_name = os.environ.get("GITHUB_REPOSITORY")
     important_notes = os.environ.get("IMPORTANT_NOTES", "")
+    blog_post_url = os.environ.get("BLOG_POST_URL", "")
 
     if not all([github_token, version, head_sha, channel, repo_name]):
         print("Error: Missing required environment variables")  # noqa: T201
@@ -466,6 +484,7 @@ def main() -> None:
             previous_tag,
             frontend_changes_list,
             important_notes,
+            blog_post_url=blog_post_url,
         )
 
     # Output to GitHub Actions

--- a/.github/workflows/RELEASE_NOTES_GENERATION.md
+++ b/.github/workflows/RELEASE_NOTES_GENERATION.md
@@ -36,6 +36,8 @@ contributors. The generator:
 4. Extracts notes from frontend dependency-update pull requests in the same comparison.
 5. Merges and deduplicates server and frontend contributors.
 6. Places manually supplied important notes first.
+7. Renders an optional blog post link as a banner between the channel header and the
+   changes-since line.
 
 The resulting body is finalized on the matching draft before publication. Reruns may
 refresh draft notes, but release assets and the source SHA must remain exact. After

--- a/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
+++ b/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
@@ -71,7 +71,9 @@ The scheduled workflow checks nightly releases automatically. For a manual versi
 Auto-release calculates the next version and invokes **Create Release** with its captured
 source SHA. **Create Release** can also be dispatched directly with an explicit version;
 for direct runs it resolves and freezes the current channel branch head itself unless you
-pass `source_sha` to recover an exact draft or published release source.
+pass `source_sha` to recover an exact draft or published release source. For big releases
+dispatched this way, `blog_post_url` links the announcement at the top of the release
+notes; the workflow verifies the URL is live before releasing.
 
 Do not create or publish a GitHub release manually. A draft created outside the workflow
 is accepted only when its exact tag name and target SHA match; conflicting tags,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ on:
       important_notes:
         description: "Important notes (breaking changes, critical info, etc.)"
         required: false
+      blog_post_url:
+        description: "URL of the accompanying blog post, shown at the top of the release notes"
+        required: false
   workflow_call:
     inputs:
       version:
@@ -39,6 +42,10 @@ on:
         type: string
       important_notes:
         description: "Important notes (breaking changes, critical info, etc.)"
+        required: false
+        type: string
+      blog_post_url:
+        description: "URL of the accompanying blog post, shown at the top of the release notes"
         required: false
         type: string
     secrets:
@@ -155,6 +162,22 @@ jobs:
               echo "base_image_version=${{ env.BASE_IMAGE_VERSION_NIGHTLY }}" >> "$GITHUB_OUTPUT"
               ;;
           esac
+
+      - name: Verify blog post URL
+        if: inputs.blog_post_url != ''
+        env:
+          BLOG_POST_URL: ${{ inputs.blog_post_url }}
+        run: |
+          if [[ "$BLOG_POST_URL" != https://* ]]; then
+            echo "blog_post_url must start with https://" >&2
+            exit 1
+          fi
+          status=$(curl -sSL -o /dev/null -w '%{http_code}' \
+            --retry 3 --max-time 30 "$BLOG_POST_URL")
+          if [ "$status" != "200" ]; then
+            echo "blog_post_url returned HTTP $status" >&2
+            exit 1
+          fi
 
       - name: Create immutable-settings token
         id: immutable_token
@@ -568,6 +591,7 @@ jobs:
           channel: ${{ inputs.channel }}
           github-token: ${{ github.token }}
           important-notes: ${{ inputs.important_notes }}
+          blog-post-url: ${{ inputs.blog_post_url }}
 
       - name: Format release title
         id: title

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -188,3 +188,32 @@ def test_minor_release_with_diverged_previous_tag(
     prs = generate_notes.get_prs_between_tags(repo, "2.8.9", "headsha")
 
     assert [pr.number for pr in prs] == [100, 120]
+
+
+def test_blog_post_url_banner_renders_below_channel_header(
+    generate_notes: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blog post URL renders between the channel header and the changes-since line."""
+    monkeypatch.setenv("VERSION", "2.10.0")
+    monkeypatch.setenv("CHANNEL", "stable")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "music-assistant/server")
+
+    notes = generate_notes.generate_release_notes(
+        config={"categories": []},
+        categories={},
+        uncategorized=[],
+        contributors=[],
+        previous_tag="2.9.9",
+        frontend_changes=None,
+        important_notes="Something breaking",
+        blog_post_url="https://music-assistant.io/blog/2-10/",
+    )
+
+    banner = (
+        "> 🎉 **Music Assistant 2.10 is here!** "
+        "Read the [release announcement](https://music-assistant.io/blog/2-10/) on our blog."
+    )
+    header_pos = notes.index("## 📦 Stable Release")
+    assert notes.index("## ⚠️ Important Notes") < header_pos
+    assert header_pos < notes.index(banner) < notes.index("_Changes since")


### PR DESCRIPTION
# What does this implement/fix?

Every big release (e.g. 2.9.x -> 2.10.0) is accompanied by a blog post, and until now the link had to be pasted into the release notes by hand. This adds an optional `blog_post_url` input to the manually dispatched Create Release workflow.

- New optional `blog_post_url` input on `release.yml` (`workflow_dispatch` and `workflow_call`)
- The `resolve` job verifies the URL is `https://` and returns HTTP 200 before anything is built
- The release notes render the link as a banner between the channel header and the "Changes since" line
- Regression test for the banner placement

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
