### PR TITLE
Tidy up process cleanup code

### DIFF
--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -189,26 +189,9 @@ class FFMpeg(AsyncProcess):
     ) -> tuple[bytes, bytes]:
         """Override communicate to avoid blocking."""
         if self._stdin_feeder_task:
-            if not self._stdin_feeder_task.done():
-                self._stdin_feeder_task.cancel()
-            # Always await the task to consume any exception and prevent
-            # "Task exception was never retrieved" errors.
-            try:
-                await self._stdin_feeder_task
-            except asyncio.CancelledError:
-                pass  # Expected when we cancel the task
-            except Exception as err:
-                # Log unexpected exceptions from the stdin feeder before suppressing
-                # The audio source may have failed, and we need visibility into this
-                self.logger.warning(
-                    "FFMpeg stdin feeder task ended with error: %s",
-                    err,
-                )
+            await self._cancel_and_await(self._stdin_feeder_task, "stdin feeder")
         if self._stderr_reader_task:
-            if not self._stderr_reader_task.done():
-                self._stderr_reader_task.cancel()
-            with suppress(asyncio.CancelledError, Exception):
-                await self._stderr_reader_task
+            await self._cancel_and_await(self._stderr_reader_task, "stderr reader")
         return await super().communicate(input, timeout)
 
     async def _log_reader_task(self) -> None:

--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -296,22 +296,8 @@ class AsyncProcess:
         if not self.proc:
             return
 
-        # cancel existing stdin feeder task if any
         if self._stdin_feeder_task:
-            if not self._stdin_feeder_task.done():
-                self._stdin_feeder_task.cancel()
-            # Always await the task to consume any exception and prevent
-            # "Task exception was never retrieved" errors.
-            try:
-                await self._stdin_feeder_task
-            except asyncio.CancelledError:
-                pass  # Expected when we cancel the task
-            except Exception as err:
-                # Log unexpected exceptions from the stdin feeder before suppressing
-                LOGGER.warning(
-                    "Process stdin feeder task ended with error: %s",
-                    err,
-                )
+            await self._cancel_and_await(self._stdin_feeder_task, "stdin feeder")
 
         # close stdin to signal we're done sending data
         with suppress(TimeoutError, asyncio.CancelledError):
@@ -392,30 +378,10 @@ class AsyncProcess:
 
         pid = self.proc.pid
 
-        # Cancel stdin feeder task if any. A task that already finished is still
-        # awaited, so an exception it ended with is retrieved rather than reported
-        # as unhandled once it is garbage collected - and logged, so retrieving it
-        # does not swallow the only trace of the failure.
         if self._stdin_feeder_task:
-            if not self._stdin_feeder_task.done():
-                self._stdin_feeder_task.cancel()
-            try:
-                await self._stdin_feeder_task
-            except asyncio.CancelledError:
-                pass  # Expected when we cancel the task
-            except Exception as err:
-                LOGGER.warning("Process stdin feeder task ended with error: %s", err)
-
-        # Same for the stderr reader task
+            await self._cancel_and_await(self._stdin_feeder_task, "stdin feeder")
         if self._stderr_reader_task:
-            if not self._stderr_reader_task.done():
-                self._stderr_reader_task.cancel()
-            try:
-                await self._stderr_reader_task
-            except asyncio.CancelledError:
-                pass  # Expected when we cancel the task
-            except Exception as err:
-                LOGGER.warning("Process stderr reader task ended with error: %s", err)
+            await self._cancel_and_await(self._stderr_reader_task, "stderr reader")
 
         # Close stdin to signal we're done sending data
         # Note: Don't manually call feed_eof() on stdout/stderr - this causes
@@ -543,6 +509,28 @@ class AsyncProcess:
             with suppress(RuntimeError):
                 transport.set_write_buffer_limits(high=high, low=low)
         return True
+
+    async def _cancel_and_await(self, task: asyncio.Task[None], description: str) -> None:
+        """
+        Cancel one of this process' helper tasks and wait for it to end.
+
+        A task that already finished is awaited too, so it is never left with an
+        unretrieved exception. An unexpected error is logged rather than raised.
+
+        :param task: The task to cancel and await.
+        :param description: How the task is named when logging an unexpected error.
+        """
+        if not task.done():
+            task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass  # expected when we cancel the task
+        except Exception as err:
+            # retrieving the failure is what keeps asyncio from reporting it as
+            # unhandled once the task is collected, so log it here rather than
+            # dropping the only trace of it
+            self.logger.warning("The %s task ended with error: %s", description, err)
 
 
 async def check_output(


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5961. Cancelling a background helper task and waiting for it had been copy-pasted four times across `AsyncProcess.close()`, `AsyncProcess.kill()` and `FFMpeg.communicate()`, so a fix to one of them (like #5961) had to be repeated everywhere by hand. Collapsed into a single private helper.

No user-visible change.

**Related issue (if applicable):**

- follow-up to #5961

## Changes

- Added `AsyncProcess._cancel_and_await()`: cancels the task if it is still pending, always awaits it, ignores the cancellation and logs anything else.
- `close()`, `kill()` and `FFMpeg.communicate()` now call it instead of their own copies.
- One small side effect: an unexpected error from ffmpeg's stderr reader is now logged instead of silently discarded.
- `close()`'s stderr handling is left as it was - it waits for the reader to finish on its own rather than cancelling it, so it is a different thing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
