### PR TITLE
Use album loudness only when tracks really play as part of an album

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1375,7 +1375,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                 # we only allow 10 retries to prevent infinite loops
                 raise QueueEmpty("No more (playable) tracks left in the queue.")
             try:
-                await self._load_item(queue_item, next_index)
+                await self._load_item(queue_item, self._get_next_index(queue_id, next_index))
                 # we're all set, this is our next item
                 next_item = queue_item
                 break

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -64,6 +64,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
     set_current_user,
 )
 from music_assistant.helpers.audio import get_probed_duration, store_probed_duration
+from music_assistant.helpers.compare import compare_item_ids
 from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
 from music_assistant.models.music_provider import MusicProvider
 
@@ -313,38 +314,13 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         if not queue_item.available:
             raise MediaNotFoundError(f"Item {queue_item.uri} is not available")
 
-        # work out if we are playing an album and if we should prefer album
-        # loudness
-        next_track_from_same_album = (
-            next_index is not None
-            and (next_item := self.get_item(queue_id, next_index))
-            and (
-                queue_item.media_item
-                and hasattr(queue_item.media_item, "album")
-                and queue_item.media_item.album
-                and next_item.media_item
-                and hasattr(next_item.media_item, "album")
-                and next_item.media_item.album
-                and queue_item.media_item.album.item_id == next_item.media_item.album.item_id
-            )
-        )
+        # an item is played as part of its album when the item before or after it belongs
+        # to that same album, in which case the album loudness is the one to normalize on
         current_index = self.index_by_id(queue_id, queue_item.queue_item_id)
-        if current_index is None:
-            previous_track_from_same_album = False
-        else:
-            previous_index = max(current_index - 1, 0)
-            previous_track_from_same_album = (
-                previous_index > 0
-                and (previous_item := self.get_item(queue_id, previous_index)) is not None
-                and previous_item.media_item is not None
-                and hasattr(previous_item.media_item, "album")
-                and previous_item.media_item.album is not None
-                and queue_item.media_item is not None
-                and hasattr(queue_item.media_item, "album")
-                and queue_item.media_item.album is not None
-                and queue_item.media_item.album.item_id == previous_item.media_item.album.item_id
-            )
-        playing_album_tracks = next_track_from_same_album or previous_track_from_same_album
+        previous_index = current_index - 1 if current_index is not None else None
+        playing_album_tracks = self._is_same_album(queue_item, next_index) or self._is_same_album(
+            queue_item, previous_index
+        )
         if queue_item.media_item and isinstance(queue_item.media_item, Track):
             album = queue_item.media_item.album
             # prefer the full library media item so we have all metadata and provider(quality) info
@@ -393,7 +369,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             queue_item=queue_item,
             seek_position=seek_position,
             fade_in=fade_in,
-            prefer_album_loudness=bool(playing_album_tracks),
+            prefer_album_loudness=playing_album_tracks,
         )
         # update queue_item.duration from streamdetails if we got a better value
         self._apply_probed_duration(queue_item)
@@ -412,6 +388,26 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             # the first chunk is in, so the source has been probed and a duration the
             # provider did not report is known before playback starts
             self._apply_probed_duration(queue_item)
+
+    def _is_same_album(self, queue_item: QueueItem, other_index: int | None) -> bool:
+        """
+        Check whether the queue item at the given index holds a track from the same album.
+
+        :param queue_item: The queue item to compare against.
+        :param other_index: Index of the neighbouring queue item, if there is one.
+        """
+        if other_index is None or other_index < 0:
+            return False
+        if (other_item := self.get_item(queue_item.queue_id, other_index)) is None:
+            return False
+        album = getattr(queue_item.media_item, "album", None)
+        other_album = getattr(other_item.media_item, "album", None)
+        if album is None or other_album is None:
+            return False
+        # an item picks up its library album only once it is loaded, so the neighbour may hold
+        # a different representation of the same album. Matching on the provider mappings
+        # recognises both shapes, plain item_id equality does not.
+        return compare_item_ids(album, other_album)
 
     def _apply_probed_duration(self, queue_item: QueueItem) -> None:
         """

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -322,12 +322,14 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         if not queue_item.available:
             raise MediaNotFoundError(f"Item {queue_item.uri} is not available")
 
-        # an item is played as part of its album when the item before or after it belongs
-        # to that same album, in which case the album loudness is the one to normalize on
+        # an item is played as part of its album when the item before or after it belongs to
+        # that same album, in which case the album loudness is the one to normalize on. A single
+        # track on repeat never is, no matter which album its queue neighbours belong to.
         current_index = self.index_by_id(queue_id, queue_item.queue_item_id)
         previous_index = current_index - 1 if current_index is not None else None
-        playing_album_tracks = self._is_same_album(queue_item, next_index) or self._is_same_album(
-            queue_item, previous_index
+        playing_album_tracks = queue.repeat_mode != RepeatMode.ONE and (
+            self._is_same_album(queue_item, next_index)
+            or self._is_same_album(queue_item, previous_index)
         )
         if queue_item.media_item and isinstance(queue_item.media_item, Track):
             album = queue_item.media_item.album
@@ -406,9 +408,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         """
         if other_index is None or other_index < 0:
             return False
-        other_item = self.get_item(queue_item.queue_id, other_index)
-        # repeat single points back at the item itself, which is no album to speak of
-        if other_item is None or other_item.queue_item_id == queue_item.queue_item_id:
+        if (other_item := self.get_item(queue_item.queue_id, other_index)) is None:
             return False
         album = getattr(queue_item.media_item, "album", None)
         other_album = getattr(other_item.media_item, "album", None)

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -408,7 +408,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         """
         if other_index is None or other_index < 0:
             return False
-        if (other_item := self.get_item(queue_item.queue_id, other_index)) is None:
+        other_item = self.get_item(queue_item.queue_id, other_index)
+        # repeating a single item, or a one-item queue, wraps right back onto this item
+        if other_item is None or other_item.queue_item_id == queue_item.queue_item_id:
             return False
         album = getattr(queue_item.media_item, "album", None)
         other_album = getattr(other_item.media_item, "album", None)

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -297,7 +297,15 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         seek_position: int = 0,
         fade_in: bool = False,
     ) -> None:
-        """Try to load the stream details for the given queue item."""
+        """
+        Try to load the stream details for the given queue item.
+
+        :param queue_item: The queue item to load.
+        :param next_index: Index of the item that plays after this one, if any.
+        :param is_start: Whether this item starts playback, rather than following another item.
+        :param seek_position: Position (in seconds) to start playback from.
+        :param fade_in: Whether to fade in the audio.
+        """
         queue_id = queue_item.queue_id
         queue = self._queue_data[queue_id].queue
 
@@ -398,7 +406,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         """
         if other_index is None or other_index < 0:
             return False
-        if (other_item := self.get_item(queue_item.queue_id, other_index)) is None:
+        other_item = self.get_item(queue_item.queue_id, other_index)
+        # repeat single points back at the item itself, which is no album to speak of
+        if other_item is None or other_item.queue_item_id == queue_item.queue_item_id:
             return False
         album = getattr(queue_item.media_item, "album", None)
         other_album = getattr(other_item.media_item, "album", None)

--- a/tests/controllers/player_queues/test_prefer_album_loudness.py
+++ b/tests/controllers/player_queues/test_prefer_album_loudness.py
@@ -166,3 +166,13 @@ async def test_track_on_repeat_single_is_not_an_album() -> None:
     """A track repeating on its own is not played as part of its album."""
     items = [_queue_item("track-1", PROVIDER_ALBUM)]
     assert not await _prefer_album_loudness(items, current_index=0, repeat_mode=RepeatMode.ONE)
+
+
+async def test_repeat_single_ignores_the_album_around_it() -> None:
+    """Repeating one track of an album does not play the rest of that album."""
+    items = [
+        _queue_item("track-1", PROVIDER_ALBUM),
+        _queue_item("track-2", PROVIDER_ALBUM),
+        _queue_item("track-3", PROVIDER_ALBUM),
+    ]
+    assert not await _prefer_album_loudness(items, current_index=1, repeat_mode=RepeatMode.ONE)

--- a/tests/controllers/player_queues/test_prefer_album_loudness.py
+++ b/tests/controllers/player_queues/test_prefer_album_loudness.py
@@ -176,3 +176,9 @@ async def test_repeat_single_ignores_the_album_around_it() -> None:
         _queue_item("track-3", PROVIDER_ALBUM),
     ]
     assert not await _prefer_album_loudness(items, current_index=1, repeat_mode=RepeatMode.ONE)
+
+
+async def test_single_track_on_repeat_all_is_not_an_album() -> None:
+    """Repeating a one-item queue wraps onto the item itself, which is no album."""
+    items = [_queue_item("track-1", PROVIDER_ALBUM)]
+    assert not await _prefer_album_loudness(items, current_index=0, repeat_mode=RepeatMode.ALL)

--- a/tests/controllers/player_queues/test_prefer_album_loudness.py
+++ b/tests/controllers/player_queues/test_prefer_album_loudness.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
-from music_assistant_models.enums import MediaType
+from music_assistant_models.enums import MediaType, RepeatMode
 from music_assistant_models.media_items import Album, ItemMapping, ProviderMapping, Track
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
@@ -90,9 +90,12 @@ def _controller(items: list[QueueItem]) -> PlayerQueuesController:
     return controller
 
 
-async def _prefer_album_loudness(items: list[QueueItem], current_index: int) -> bool:
+async def _prefer_album_loudness(
+    items: list[QueueItem], current_index: int, repeat_mode: RepeatMode = RepeatMode.OFF
+) -> bool:
     """Load the item after the given index the way a player asks for it, and read the decision."""
     controller = _controller(items)
+    controller._queue_data[QUEUE_ID].queue.repeat_mode = repeat_mode
     await controller.load_next_queue_item(QUEUE_ID, items[current_index].queue_item_id)
     get_stream_details = cast("AsyncMock", controller.mass.streams.audio.get_stream_details)
     return cast("bool", get_stream_details.call_args.kwargs["prefer_album_loudness"])
@@ -147,3 +150,19 @@ async def test_different_albums_use_track_loudness() -> None:
         _queue_item("track-3", PROVIDER_ALBUM),
     ]
     assert not await _prefer_album_loudness(items, current_index=0)
+
+
+async def test_first_item_of_the_queue_has_no_previous_item() -> None:
+    """Repeating the queue wraps back to its first item, which nothing plays before."""
+    items = [
+        _queue_item("track-1", OTHER_PROVIDER_ALBUM),
+        _queue_item("track-2", PROVIDER_ALBUM),
+        _queue_item("track-3", OTHER_PROVIDER_ALBUM),
+    ]
+    assert not await _prefer_album_loudness(items, current_index=2, repeat_mode=RepeatMode.ALL)
+
+
+async def test_track_on_repeat_single_is_not_an_album() -> None:
+    """A track repeating on its own is not played as part of its album."""
+    items = [_queue_item("track-1", PROVIDER_ALBUM)]
+    assert not await _prefer_album_loudness(items, current_index=0, repeat_mode=RepeatMode.ONE)

--- a/tests/controllers/player_queues/test_prefer_album_loudness.py
+++ b/tests/controllers/player_queues/test_prefer_album_loudness.py
@@ -1,0 +1,149 @@
+"""Tests for the album-loudness decision taken while loading a queue item."""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import Album, ItemMapping, ProviderMapping, Track
+from music_assistant_models.player_queue import PlayerQueue
+from music_assistant_models.queue_item import QueueItem
+
+from music_assistant.controllers.player_queues.controller import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+
+QUEUE_ID = "queue-1"
+
+PROVIDER_ALBUM = ItemMapping(
+    media_type=MediaType.ALBUM,
+    item_id="album-prov-1",
+    provider="spotify--abc",
+    name="Kind of Blue",
+)
+OTHER_PROVIDER_ALBUM = ItemMapping(
+    media_type=MediaType.ALBUM,
+    item_id="album-prov-2",
+    provider="spotify--abc",
+    name="Sketches of Spain",
+)
+LIBRARY_ALBUM = Album(
+    item_id="7",
+    provider="library",
+    name="Kind of Blue",
+    provider_mappings={
+        ProviderMapping(
+            item_id="album-prov-1",
+            provider_domain="spotify",
+            provider_instance="spotify--abc",
+        )
+    },
+)
+
+
+def _queue_item(item_id: str, album: Album | ItemMapping) -> QueueItem:
+    """Build a queue item holding a track on the given album."""
+    return QueueItem(
+        queue_id=QUEUE_ID,
+        queue_item_id=item_id,
+        name=item_id,
+        duration=300,
+        media_item=Track(
+            item_id=item_id,
+            provider="spotify--abc",
+            name=item_id,
+            duration=300,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=item_id,
+                    provider_domain="spotify",
+                    provider_instance="spotify--abc",
+                )
+            },
+            album=album,
+        ),
+    )
+
+
+def _controller(items: list[QueueItem]) -> PlayerQueuesController:
+    """Build a bare controller whose queue holds the given items."""
+    controller = PlayerQueuesController.__new__(PlayerQueuesController)
+    controller.logger = MagicMock()
+    controller._queue_data = {
+        QUEUE_ID: PlayerQueueData(
+            queue=PlayerQueue(
+                queue_id=QUEUE_ID,
+                active=True,
+                display_name="Test queue",
+                available=True,
+                items=len(items),
+            ),
+            items=items,
+        )
+    }
+    tracks_by_uri = {item.uri: item.media_item for item in items}
+    mass = MagicMock()
+    mass.music.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    mass.music.get_item_by_uri = AsyncMock(side_effect=lambda uri: tracks_by_uri[uri])
+    mass.streams.audio.get_stream_details = AsyncMock(return_value=MagicMock(duration=None))
+    controller.mass = mass
+    return controller
+
+
+async def _prefer_album_loudness(items: list[QueueItem], current_index: int) -> bool:
+    """Load the item after the given index the way a player asks for it, and read the decision."""
+    controller = _controller(items)
+    await controller.load_next_queue_item(QUEUE_ID, items[current_index].queue_item_id)
+    get_stream_details = cast("AsyncMock", controller.mass.streams.audio.get_stream_details)
+    return cast("bool", get_stream_details.call_args.kwargs["prefer_album_loudness"])
+
+
+async def test_standalone_track_uses_track_loudness() -> None:
+    """A track surrounded by other albums is normalized on its own loudness."""
+    items = [
+        _queue_item("track-1", OTHER_PROVIDER_ALBUM),
+        _queue_item("track-2", PROVIDER_ALBUM),
+    ]
+    assert not await _prefer_album_loudness(items, current_index=0)
+
+
+async def test_second_track_of_an_album_uses_album_loudness() -> None:
+    """The track right after the first one of an album is still part of that album."""
+    items = [
+        _queue_item("track-1", PROVIDER_ALBUM),
+        _queue_item("track-2", PROVIDER_ALBUM),
+    ]
+    assert await _prefer_album_loudness(items, current_index=0)
+
+
+async def test_library_album_matches_provider_album_of_previous_item() -> None:
+    """
+    A loaded previous item carries the library album while the item being loaded has the provider one.
+
+    Both describe the same album, so the album loudness applies.
+    """
+    items = [
+        _queue_item("track-1", LIBRARY_ALBUM),
+        _queue_item("track-2", PROVIDER_ALBUM),
+    ]
+    assert await _prefer_album_loudness(items, current_index=0)
+
+
+async def test_library_album_matches_provider_album_of_next_item() -> None:
+    """The same album seen from both representations is recognised on the next-item side too."""
+    items = [
+        _queue_item("track-1", OTHER_PROVIDER_ALBUM),
+        _queue_item("track-2", PROVIDER_ALBUM),
+        _queue_item("track-3", LIBRARY_ALBUM),
+    ]
+    assert await _prefer_album_loudness(items, current_index=0)
+
+
+async def test_different_albums_use_track_loudness() -> None:
+    """Neighbouring tracks from genuinely different albums do not form an album."""
+    items = [
+        _queue_item("track-1", PROVIDER_ALBUM),
+        _queue_item("track-2", OTHER_PROVIDER_ALBUM),
+        _queue_item("track-3", PROVIDER_ALBUM),
+    ]
+    assert not await _prefer_album_loudness(items, current_index=0)

--- a/tests/controllers/player_queues/test_prefer_album_loudness.py
+++ b/tests/controllers/player_queues/test_prefer_album_loudness.py
@@ -153,13 +153,16 @@ async def test_different_albums_use_track_loudness() -> None:
 
 
 async def test_first_item_of_the_queue_has_no_previous_item() -> None:
-    """Repeating the queue wraps back to its first item, which nothing plays before."""
+    """Starting at the first item, nothing plays before it, least of all the end of the queue."""
     items = [
         _queue_item("track-1", OTHER_PROVIDER_ALBUM),
         _queue_item("track-2", PROVIDER_ALBUM),
         _queue_item("track-3", OTHER_PROVIDER_ALBUM),
     ]
-    assert not await _prefer_album_loudness(items, current_index=2, repeat_mode=RepeatMode.ALL)
+    controller = _controller(items)
+    await controller._load_item(items[0], next_index=1)
+    get_stream_details = cast("AsyncMock", controller.mass.streams.audio.get_stream_details)
+    assert not get_stream_details.call_args.kwargs["prefer_album_loudness"]
 
 
 async def test_track_on_repeat_single_is_not_an_album() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Volume normalization used the **album** loudness for nearly every track, because the check for "does the next track belong to the same album?" ended up comparing a track with itself. Single tracks in a shuffled queue, a playlist or radio were levelled against an album they were not being played as part of, so they came out louder or quieter than intended.

Two smaller problems in the same check are fixed along with it, so the album case it is meant to catch now actually works.

- The check now looks at the track that really comes next, instead of at the track itself.
- The second track of an album now sees the first one (the first queue position was skipped).
- Albums are matched on their provider mappings, so a track that already carries its library album still matches the same album on the track next to it.
- A single track looping on repeat no longer counts as album playback.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
