### PR TITLE
Show bit-perfect playback for external sources

### DIFF
--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -86,6 +86,7 @@ class _AudioSourceProcessingSession:
 
     session_id: str
     context_ready: bool = False
+    pcm_format: AudioFormat | None = None
     crossfade_mode: CrossfadeMode = CrossfadeMode.UNKNOWN
     volume_normalization_mode: VolumeNormalizationMode = VolumeNormalizationMode.UNKNOWN
     outputs: dict[str | None, dict[str, _AudioOutputEntry]] = field(default_factory=dict)
@@ -205,6 +206,7 @@ class AudioProcessingManager:
         player_id: str,
         session_id: str,
         *,
+        pcm_format: AudioFormat,
         crossfade_enabled: bool | None,
         volume_normalization_enabled: bool | None,
     ) -> None:
@@ -213,6 +215,7 @@ class AudioProcessingManager:
 
         :param player_id: Player that owns the source selection.
         :param session_id: Source playback session that owns the update.
+        :param pcm_format: PCM format the source's audio is decoded to.
         :param crossfade_enabled: Whether the source applies crossfade, or None if unknown.
         :param volume_normalization_enabled: Whether the source normalizes, or None if unknown.
         """
@@ -220,6 +223,7 @@ class AudioProcessingManager:
         if session is None:
             return
         session.context_ready = True
+        session.pcm_format = deepcopy(pcm_format)
         if crossfade_enabled is None:
             session.crossfade_mode = CrossfadeMode.UNKNOWN
         elif crossfade_enabled:
@@ -251,9 +255,10 @@ class AudioProcessingManager:
         :param output_plan: Effective output processing and private intermediate formats.
         :param shared_player_ids: Additional players receiving this identical output path.
             An empty iterable marks a path that can gain shared destinations later.
-        :param queue_id: Queue identifier that owns the output.
-        :param session_id: Queue session identifier that owns the output.
-        :param queue_item_id: Queue item for single-item output, or None for flow output.
+        :param queue_id: Queue that owns the output, or the player holding a live source.
+        :param session_id: Queue session or source playback session that owns the output.
+        :param queue_item_id: Queue item for single-item output, or None for flow output
+            and for a live source.
         :return: Whether the effective output changed.
         """
         source_session = (
@@ -529,6 +534,7 @@ class AudioProcessingManager:
             outputs=self._group_outputs(
                 streamdetails,
                 self._get_outputs(processing, None),
+                item=_source_processing_item(processing),
             ),
         )
         if source_session.active_source_audio == details:
@@ -582,24 +588,14 @@ class AudioProcessingManager:
         self,
         streamdetails: StreamDetails,
         player_outputs: dict[str, _AudioOutputEntry],
-        *,
-        item: _AudioProcessingItem | None = None,
+        item: _AudioProcessingItem,
     ) -> list[AudioOutputDetails]:
         """Group players with identical effective output processing."""
         grouped: list[AudioOutputDetails] = []
         for player_id, entry in sorted(player_outputs.items()):
             output = deepcopy(entry.details)
             output.player_ids = [player_id]
-            output.fidelity = (
-                _get_output_fidelity(streamdetails, item, entry)
-                if item is not None
-                else AudioFidelity(
-                    quality=_get_effective_quality(
-                        streamdetails.audio_format,
-                        output.output_format,
-                    )
-                )
-            )
+            output.fidelity = _get_output_fidelity(streamdetails, item, entry)
             for existing in grouped:
                 if _output_details_equal_ignoring_players(existing, output):
                     existing.player_ids.append(player_id)
@@ -733,6 +729,35 @@ def get_normalization_details(
         target_lufs=streamdetails.target_loudness,
         measured_lufs=measured_lufs,
         applied_gain_db=applied_gain_db,
+    )
+
+
+def _source_processing_item(
+    processing: _AudioSourceProcessingSession,
+) -> _AudioProcessingItem:
+    """
+    Describe a live source's audio path in the shared processing shape.
+
+    :param processing: Runtime processing state of the live source selection.
+    """
+    # Music Assistant mixes nothing into a live source: it neither crossfades,
+    # normalizes, changes speed nor overlays one. Only a step the source reported
+    # applying is carried over, and one it did not report counts as none: either
+    # way it reaches us already mixed and leaves our own path untouched.
+    return _AudioProcessingItem(
+        queue_processing=AudioQueueProcessing(
+            pcm_format=processing.pcm_format,
+            normalization=(
+                AudioNormalizationDetails(mode=VolumeNormalizationMode.SOURCE)
+                if processing.volume_normalization_mode == VolumeNormalizationMode.SOURCE
+                else None
+            ),
+            crossfade_mode=(
+                CrossfadeMode.SOURCE
+                if processing.crossfade_mode == CrossfadeMode.SOURCE
+                else CrossfadeMode.DISABLED
+            ),
+        ),
     )
 
 

--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -740,10 +740,10 @@ def _source_processing_item(
 
     :param processing: Runtime processing state of the live source selection.
     """
-    # Music Assistant mixes nothing into a live source: it neither crossfades,
-    # normalizes, changes speed nor overlays one. Only a step the source reported
-    # applying is carried over, and one it did not report counts as none: either
-    # way it reaches us already mixed and leaves our own path untouched.
+    # Music Assistant mixes nothing into a live source: whatever the source
+    # reported applying reaches us already mixed, and a step it did not report
+    # counts as none. Both are recorded as what they are rather than flattened,
+    # so the shared check stays the one deciding what a source-applied step costs.
     return _AudioProcessingItem(
         queue_processing=AudioQueueProcessing(
             pcm_format=processing.pcm_format,

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1826,7 +1826,7 @@ class StreamsController(CoreController):
             queue_id=session.player_id,
             session_id=session.playback_session_id,
         ).filter_params
-        self._update_audio_source_processing_context(session, provider)
+        self._update_audio_source_processing_context(session, provider, pcm_format)
         if (
             output_format.content_type == ContentType.WAV
             and not filter_params
@@ -1901,7 +1901,7 @@ class StreamsController(CoreController):
                     session.source_id, MediaType.AUDIO_SOURCE
                 )
                 session.attach_streamdetails(streamdetails)
-            self._update_audio_source_processing_context(session, prov)
+            self._update_audio_source_processing_context(session, prov, pcm_format)
             serving = True
             async for chunk in self.audio.get_audio_source_stream(
                 streamdetails=streamdetails,
@@ -2076,18 +2076,21 @@ class StreamsController(CoreController):
         self,
         session: AudioSourceSession,
         provider: PluginProvider,
+        pcm_format: AudioFormat,
     ) -> None:
         """
         Publish source-owned processing for a live AudioSource.
 
         :param session: Active source session to publish.
         :param provider: Plugin delivering the live source.
+        :param pcm_format: PCM format the source's audio is decoded to.
         """
         if session.streamdetails is None:
             return
         self.audio_processing.update_source_context(
             session.player_id,
             session.playback_session_id,
+            pcm_format=pcm_format,
             crossfade_enabled=provider.delivers_crossfaded_audio(session.streamdetails),
             volume_normalization_enabled=provider.delivers_normalized_audio(session.streamdetails),
         )

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -421,6 +421,36 @@ def test_unreported_source_processing_does_not_cost_the_bit_perfect_badge() -> N
     assert details.outputs[0].fidelity.bit_perfect is True
 
 
+def test_a_player_that_cannot_take_the_source_rate_is_not_bit_perfect() -> None:
+    """A source rate the player cannot take is snapped down, which loses samples."""
+    manager, _mass, source_session, lossless_plan, _pcm_format = _source_manager_context()
+    # the source arrives at 96 kHz but the player tops out at 48 kHz
+    snapped = _format(ContentType.PCM_S24LE, 48000, 24)
+    lossless_plan.input_format = snapped
+    lossless_plan.output_details.output_format = _format(ContentType.FLAC, 48000, 24)
+    manager.update_output(
+        "player-1",
+        lossless_plan,
+        queue_id="source-player",
+        session_id="source-session",
+    )
+
+    manager.update_source_context(
+        "source-player",
+        "source-session",
+        pcm_format=snapped,
+        crossfade_enabled=False,
+        volume_normalization_enabled=False,
+    )
+
+    details = cast(
+        "ActiveSourceAudioDetails | None",
+        source_session.active_source_audio,
+    )
+    assert details is not None
+    assert details.outputs[0].fidelity.bit_perfect is False
+
+
 def test_a_live_source_output_narrower_than_the_source_is_not_bit_perfect() -> None:
     """Dropping a 24-bit source to a 16-bit output loses bits for a live source too."""
     manager, _mass, source_session, lossless_plan, pcm_format = _source_manager_context()

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -308,11 +308,12 @@ def test_shared_output_destinations_are_registered_atomically() -> None:
 
 def test_live_source_context_publishes_input_and_source_processing() -> None:
     """A live source publishes its input and the processing it applies itself."""
-    manager, mass, source_session, _lossless_plan = _source_manager_context()
+    manager, mass, source_session, _lossless_plan, pcm_format = _source_manager_context()
 
     manager.update_source_context(
         "source-player",
         "source-session",
+        pcm_format=pcm_format,
         crossfade_enabled=True,
         volume_normalization_enabled=True,
     )
@@ -332,7 +333,7 @@ def test_live_source_context_publishes_input_and_source_processing() -> None:
 
 def test_live_source_output_registered_before_context_is_published() -> None:
     """An output prepared before source details arrive is retained and published."""
-    manager, _mass, source_session, lossless_plan = _source_manager_context()
+    manager, _mass, source_session, lossless_plan, pcm_format = _source_manager_context()
 
     assert manager.update_output(
         "player-1",
@@ -346,6 +347,7 @@ def test_live_source_output_registered_before_context_is_published() -> None:
     manager.update_source_context(
         "source-player",
         "source-session",
+        pcm_format=pcm_format,
         crossfade_enabled=False,
         volume_normalization_enabled=None,
     )
@@ -361,16 +363,99 @@ def test_live_source_output_registered_before_context_is_published() -> None:
     assert details.outputs[0].player_ids == ["player-1", "player-2"]
     assert details.outputs[0].output_format == lossless_plan.output_details.output_format
     assert details.outputs[0].fidelity.quality == AudioQuality.HI_RES
-    assert details.outputs[0].fidelity.bit_perfect is None
+    assert details.outputs[0].fidelity.bit_perfect is True
+
+
+def test_a_source_that_crossfades_itself_stays_bit_perfect() -> None:
+    """A fade the source mixed itself reaches us already mixed, so nothing is lost."""
+    manager, _mass, source_session, lossless_plan, pcm_format = _source_manager_context()
+    manager.update_output(
+        "player-1",
+        lossless_plan,
+        queue_id="source-player",
+        session_id="source-session",
+    )
+
+    manager.update_source_context(
+        "source-player",
+        "source-session",
+        pcm_format=pcm_format,
+        crossfade_enabled=True,
+        volume_normalization_enabled=True,
+    )
+
+    details = cast(
+        "ActiveSourceAudioDetails | None",
+        source_session.active_source_audio,
+    )
+    assert details is not None
+    assert details.crossfade_mode is CrossfadeMode.SOURCE
+    assert details.outputs[0].fidelity.bit_perfect is True
+
+
+def test_unreported_source_processing_does_not_cost_the_bit_perfect_badge() -> None:
+    """A source that never says what it applies still hands us its samples untouched."""
+    manager, _mass, source_session, lossless_plan, pcm_format = _source_manager_context()
+    manager.update_output(
+        "player-1",
+        lossless_plan,
+        queue_id="source-player",
+        session_id="source-session",
+    )
+
+    manager.update_source_context(
+        "source-player",
+        "source-session",
+        pcm_format=pcm_format,
+        crossfade_enabled=None,
+        volume_normalization_enabled=None,
+    )
+
+    details = cast(
+        "ActiveSourceAudioDetails | None",
+        source_session.active_source_audio,
+    )
+    assert details is not None
+    assert details.crossfade_mode is CrossfadeMode.UNKNOWN
+    assert details.volume_normalization_mode is VolumeNormalizationMode.UNKNOWN
+    assert details.outputs[0].fidelity.bit_perfect is True
+
+
+def test_a_live_source_output_narrower_than_the_source_is_not_bit_perfect() -> None:
+    """Dropping a 24-bit source to a 16-bit output loses bits for a live source too."""
+    manager, _mass, source_session, lossless_plan, pcm_format = _source_manager_context()
+    lossless_plan.output_details.output_format = _format(ContentType.FLAC, 96000, 16)
+    manager.update_output(
+        "player-1",
+        lossless_plan,
+        queue_id="source-player",
+        session_id="source-session",
+    )
+
+    manager.update_source_context(
+        "source-player",
+        "source-session",
+        pcm_format=pcm_format,
+        crossfade_enabled=False,
+        volume_normalization_enabled=False,
+    )
+
+    details = cast(
+        "ActiveSourceAudioDetails | None",
+        source_session.active_source_audio,
+    )
+    assert details is not None
+    assert details.outputs[0].fidelity.bit_perfect is False
 
 
 def test_stale_live_source_updates_are_rejected() -> None:
     """A superseded source session cannot publish context or outputs."""
-    manager, _mass, source_session, lossless_plan = _source_manager_context()
+    manager, _mass, source_session, lossless_plan, pcm_format = _source_manager_context()
 
     manager.update_source_context(
         "source-player",
         "stale-session",
+        pcm_format=pcm_format,
         crossfade_enabled=True,
         volume_normalization_enabled=True,
     )
@@ -386,10 +471,11 @@ def test_stale_live_source_updates_are_rejected() -> None:
 
 def test_clearing_live_source_processing_removes_the_snapshot() -> None:
     """Ending a source selection clears its published audio details."""
-    manager, mass, source_session, _lossless_plan = _source_manager_context()
+    manager, mass, source_session, _lossless_plan, pcm_format = _source_manager_context()
     manager.update_source_context(
         "source-player",
         "source-session",
+        pcm_format=pcm_format,
         crossfade_enabled=False,
         volume_normalization_enabled=False,
     )
@@ -403,7 +489,7 @@ def test_clearing_live_source_processing_removes_the_snapshot() -> None:
 
 def test_live_source_outputs_follow_current_group_members() -> None:
     """A departed group member is removed from the live source output snapshot."""
-    manager, mass, source_session, lossless_plan = _source_manager_context()
+    manager, mass, source_session, lossless_plan, pcm_format = _source_manager_context()
     manager.update_output(
         "player-1",
         lossless_plan,
@@ -414,6 +500,7 @@ def test_live_source_outputs_follow_current_group_members() -> None:
     manager.update_source_context(
         "source-player",
         "source-session",
+        pcm_format=pcm_format,
         crossfade_enabled=False,
         volume_normalization_enabled=False,
     )
@@ -1525,8 +1612,9 @@ def _source_manager_context() -> tuple[
     MagicMock,
     Any,
     AudioOutputPlan,
+    AudioFormat,
 ]:
-    """Return one active live source and a lossless output plan."""
+    """Return one active live source, a lossless output plan and its PCM format."""
     mass = MagicMock()
     streamdetails = StreamDetails(
         provider="source-provider",
@@ -1543,15 +1631,16 @@ def _source_manager_context() -> tuple[
         source_session if player_id == "source-player" else None
     )
     manager = AudioProcessingManager(mass)
+    pcm_format = _format(ContentType.PCM_S24LE, 96000, 24)
     output_plan = AudioOutputPlan(
         filter_params=[],
         output_details=AudioOutputDetails(
             dsp=AudioDSPDetails(state=DSPState.DISABLED),
             output_format=_format(ContentType.FLAC, 96000, 24),
         ),
-        input_format=_format(ContentType.PCM_S24LE, 96000, 24),
+        input_format=pcm_format,
     )
-    return manager, mass, source_session, output_plan
+    return manager, mass, source_session, output_plan, pcm_format
 
 
 def _source_handled_soloist_item(

--- a/tests/controllers/streams/test_audio_source_route.py
+++ b/tests/controllers/streams/test_audio_source_route.py
@@ -367,12 +367,14 @@ async def test_direct_pcm_stream_stops_when_the_session_is_reselected() -> None:
         yield b"stale"
 
     ctrl.audio.get_audio_source_stream = MagicMock(return_value=chunks())
-    stream = ctrl._get_audio_source_session_stream(session, AudioFormat(), CONSUMER_ID)
+    pcm_format = AudioFormat()
+    stream = ctrl._get_audio_source_session_stream(session, pcm_format, CONSUMER_ID)
 
     assert await anext(stream) == b"first"
     ctrl.audio_processing.update_source_context.assert_called_once_with(
         OWNER_ID,
         session.playback_session_id,
+        pcm_format=pcm_format,
         crossfade_enabled=provider.delivers_crossfaded_audio.return_value,
         volume_normalization_enabled=provider.delivers_normalized_audio.return_value,
     )


### PR DESCRIPTION
# What does this implement/fix?

Playback through a live external source (Spotify Connect, and any other plugin source) never got a bit-perfect verdict: the quality details always read "bit perfect: unknown", even for a lossless Connect session sent to a lossless output. #5963 published the input quality and the outputs for those sources, but the fidelity check that decides the bit-perfect badge only ran for queue items.

- run the same fidelity check for a live source as for a queue item
- record the PCM format the source's audio is decoded to, which that check needs
- a fade or loudness correction the source applied itself reaches us already mixed, so it no longer costs the badge

**Related issue (if applicable):**

- follow-up on #5963

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
