### PR TITLE
Count album plays started from a streaming service's own listings

### DIFF
--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -772,15 +772,18 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
             )
             if prev_album == album:
                 return None
-        return enqueued
+        # credit the album the track carries, which is the library one whenever the album is
+        # in the library, so the play lands on the row an explicit library play writes instead
+        # of a second provider-scoped one.
+        return album if isinstance(album, Album) else enqueued
 
     def _is_user_initiated_play(
         self, queue_data: PlayerQueueData, media_item: MediaItemType
     ) -> bool:
         """Return whether a played item was explicitly chosen by the user."""
-        # a played item is the library one where the enqueued item may still be the provider
-        # one it was picked from. The media type is compared alongside it because the library
-        # numbers each type from one, so ids collide freely across types.
+        # a played item is reported in its library shape while the enqueued item may still be
+        # the provider one it was picked from. The media type is compared alongside it because
+        # the library numbers each type from one, so ids collide freely across types.
         return any(
             item.media_type == media_item.media_type and compare_item_ids(item, media_item)
             for item in queue_data.enqueued_media_items

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -47,6 +47,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
     set_current_user,
 )
 from music_assistant.helpers.audio import resolve_output_player_ids
+from music_assistant.helpers.compare import compare_item_ids
 from music_assistant.helpers.util import get_changed_keys, percentage
 from music_assistant.models.player import Player
 
@@ -747,11 +748,14 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
         album = getattr(media_item, "album", None)
         if album is None:
             return None
+        # the album the user pressed play on keeps the shape of the listing it was picked
+        # from, while the queue's tracks carry the library album. Matching on the provider
+        # mappings recognises both shapes as the same album.
         enqueued = next(
             (
                 item
                 for item in queue_data.enqueued_media_items
-                if isinstance(item, Album) and item == album
+                if isinstance(item, Album) and compare_item_ids(item, album)
             ),
             None,
         )
@@ -774,7 +778,13 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
         self, queue_data: PlayerQueueData, media_item: MediaItemType
     ) -> bool:
         """Return whether a played item was explicitly chosen by the user."""
-        return media_item in queue_data.enqueued_media_items
+        # a played item is the library one where the enqueued item may still be the provider
+        # one it was picked from. The media type is compared alongside it because the library
+        # numbers each type from one, so ids collide freely across types.
+        return any(
+            item.media_type == media_item.media_type and compare_item_ids(item, media_item)
+            for item in queue_data.enqueued_media_items
+        )
 
     async def _mark_album_played(
         self, album: Album, track: MediaItemType, queue_data: PlayerQueueData

--- a/tests/controllers/music/test_artist_play_credit.py
+++ b/tests/controllers/music/test_artist_play_credit.py
@@ -195,3 +195,59 @@ def test_enqueued_album_decision() -> None:
     assert tracker._enqueued_album_for_track(data, items[1], t2) is None
     # a track whose album was never enqueued -> not credited
     assert tracker._enqueued_album_for_track(data, items[2], t3) is None
+
+
+def test_enqueued_provider_album_credits_its_library_tracks() -> None:
+    """An album picked from a provider listing is credited, though its tracks are library ones."""
+    mapping = ProviderMapping(
+        item_id="album-prov-1", provider_domain="spotify", provider_instance="spotify--abc"
+    )
+    # the album object a provider listing hands to play_media
+    provider_album = Album(
+        item_id="album-prov-1",
+        provider="spotify--abc",
+        name="Kind of Blue",
+        provider_mappings={mapping},
+        album_type=AlbumType.ALBUM,
+    )
+    # the album its tracks carry, because the album is also in the library
+    library_album = Album(
+        item_id="7",
+        provider="library",
+        name="Kind of Blue",
+        provider_mappings={mapping},
+        album_type=AlbumType.ALBUM,
+    )
+    other_album = Album(
+        item_id="8",
+        provider="library",
+        name="Sketches of Spain",
+        provider_mappings={
+            ProviderMapping(
+                item_id="album-prov-2",
+                provider_domain="spotify",
+                provider_instance="spotify--abc",
+            )
+        },
+        album_type=AlbumType.ALBUM,
+    )
+    t1 = Track(item_id="t1", provider="library", name="T1", provider_mappings=set())
+    t2 = Track(item_id="t2", provider="library", name="T2", provider_mappings=set())
+    t3 = Track(item_id="t3", provider="library", name="T3", provider_mappings=set())
+    items = [QueueItem.from_media_item("q1", track) for track in (t1, t2, t3)]
+    # loading an item for playback puts the full library album on it
+    t1.album = library_album
+    t2.album = library_album
+    t3.album = other_album
+
+    tracker = PlayerQueuesController.__new__(PlayerQueuesController)
+    queue = cast("PlayerQueue", Mock(queue_id="q1"))
+    data = PlayerQueueData(queue=queue, items=items, enqueued_media_items=[provider_album])
+    tracker._queue_data = {"q1": data}
+
+    # the enqueued album is credited on the first track of its run
+    assert tracker._enqueued_album_for_track(data, items[0], t1) is provider_album
+    # and only once for that run
+    assert tracker._enqueued_album_for_track(data, items[1], t2) is None
+    # a track from an album the user never enqueued is not credited
+    assert tracker._enqueued_album_for_track(data, items[2], t3) is None

--- a/tests/controllers/music/test_artist_play_credit.py
+++ b/tests/controllers/music/test_artist_play_credit.py
@@ -13,7 +13,7 @@ from unittest.mock import Mock
 from uuid import uuid4
 
 from music_assistant_models.enums import AlbumType, MediaType
-from music_assistant_models.media_items import Album, Artist, ProviderMapping, Track
+from music_assistant_models.media_items import Album, Artist, ItemMapping, ProviderMapping, Track
 from music_assistant_models.queue_item import QueueItem
 from music_assistant_models.unique_list import UniqueList
 
@@ -245,9 +245,38 @@ def test_enqueued_provider_album_credits_its_library_tracks() -> None:
     data = PlayerQueueData(queue=queue, items=items, enqueued_media_items=[provider_album])
     tracker._queue_data = {"q1": data}
 
-    # the enqueued album is credited on the first track of its run
-    assert tracker._enqueued_album_for_track(data, items[0], t1) is provider_album
+    # the enqueued album is credited on the first track of its run, under the library
+    # identity so it shares the row an explicit library play writes
+    assert tracker._enqueued_album_for_track(data, items[0], t1) is library_album
     # and only once for that run
     assert tracker._enqueued_album_for_track(data, items[1], t2) is None
     # a track from an album the user never enqueued is not credited
     assert tracker._enqueued_album_for_track(data, items[2], t3) is None
+
+
+def test_album_outside_the_library_is_credited_as_the_provider_album() -> None:
+    """An album that is not in the library is credited under the provider identity."""
+    provider_album = Album(
+        item_id="album-prov-1",
+        provider="spotify--abc",
+        name="Kind of Blue",
+        provider_mappings={
+            ProviderMapping(
+                item_id="album-prov-1",
+                provider_domain="spotify",
+                provider_instance="spotify--abc",
+            )
+        },
+        album_type=AlbumType.ALBUM,
+    )
+    track = Track(item_id="t1", provider="spotify--abc", name="T1", provider_mappings=set())
+    items = [QueueItem.from_media_item("q1", track)]
+    # with no library album to swap in, the track keeps the provider album as a mapping
+    track.album = ItemMapping.from_item(provider_album)
+
+    tracker = PlayerQueuesController.__new__(PlayerQueuesController)
+    queue = cast("PlayerQueue", Mock(queue_id="q1"))
+    data = PlayerQueueData(queue=queue, items=items, enqueued_media_items=[provider_album])
+    tracker._queue_data = {"q1": data}
+
+    assert tracker._enqueued_album_for_track(data, items[0], track) is provider_album

--- a/tests/controllers/player_queues/test_user_initiated_plays.py
+++ b/tests/controllers/player_queues/test_user_initiated_plays.py
@@ -190,3 +190,39 @@ async def test_enqueued_item_mapping_counts_as_user_initiated() -> None:
     enqueued = ctrl._queue_data["q1"].enqueued_media_items
     assert enqueued == [track]
     assert ctrl._is_user_initiated_play(ctrl._queue_data["q1"], track) is True
+
+
+def test_track_picked_from_a_provider_listing_is_user_initiated() -> None:
+    """A track picked from a provider listing counts as explicit once it resolves to the library."""
+    mapping = ProviderMapping(
+        item_id="track-prov-1", provider_domain="spotify", provider_instance="spotify--abc"
+    )
+    # the track object a provider listing hands to play_media
+    provider_track = Track(
+        item_id="track-prov-1",
+        provider="spotify--abc",
+        name="T",
+        provider_mappings={mapping},
+    )
+    # the same track as it is reported once loaded for playback
+    library_track = Track(item_id="12", provider="library", name="T", provider_mappings={mapping})
+    data = cast("PlayerQueueData", Mock(enqueued_media_items=[provider_track]))
+
+    tracker = PlayerQueuesController.__new__(PlayerQueuesController)
+    assert tracker._is_user_initiated_play(data, library_track) is True
+
+
+def test_library_ids_are_not_matched_across_media_types() -> None:
+    """The library numbers each media type from one, so an album id never matches a track id."""
+    album = Album(
+        item_id="7",
+        provider="library",
+        name="A",
+        provider_mappings=set(),
+        album_type=AlbumType.ALBUM,
+    )
+    track = Track(item_id="7", provider="library", name="T", provider_mappings=set())
+    data = cast("PlayerQueueData", Mock(enqueued_media_items=[album]))
+
+    tracker = PlayerQueuesController.__new__(PlayerQueuesController)
+    assert tracker._is_user_initiated_play(data, track) is False


### PR DESCRIPTION
# What does this implement/fix?

Playing an album from a streaming service's own browse or search results never
counted as an album play, so its play count stayed at zero and it never showed up
in "Recently played".

The album you press play on is that provider's album, but the tracks that end up in
the queue carry the library album (any album in your library resolves that way).
Comparing the two objects said "different album", so the play was dropped. Picking a
single track that way hit the same mismatch and was recorded as if it had started on
its own, which also keeps it out of "Recently played".

Both now match on the album's provider mappings, which recognises the two shapes as
the same item, and the album play is recorded against your library album so it shares
the same entry as playing it from the library. Playing from the library was never
affected.

**Related issue (if applicable):**

- n/a — found while reviewing the check, not from a user report.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
