### PR TITLE
Match imported playlist tracks against other providers when their source is gone

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -659,13 +659,13 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         allowed_provider_instances: set[str] | None = None,
     ) -> SearchResults:
         """
-        Search one available provider through the cached, timeout-bounded path.
+        Search one provider within the allowed scope.
 
         :param search_query: Search query.
         :param provider_instance_id_or_domain: Provider instance ID or domain.
         :param media_types: Media types to include.
         :param limit: Maximum results per media type.
-        :param allowed_provider_instances: Explicit provider scope for deferred work.
+        :param allowed_provider_instances: Provider instances allowed for this search.
         """
         domain_in_scope = False
         if allowed_provider_instances is not None:
@@ -681,9 +681,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 )
                 and provider.instance_id == provider_instance_id
             ]
-            # a domain is "in scope" once any allowed instance resolves to it, even if
-            # every one of them is currently unavailable - that is a temporary outage
-            # of an account the user actually has, not an absent provider
+            # Treat any allowed sibling of this domain as in scope, even if all are down.
             domain_in_scope = any(
                 provider.domain == provider_instance_id_or_domain for provider in allowed_providers
             )

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -32,6 +32,7 @@ from music_assistant_models.errors import (
     InvalidProviderURI,
     MediaNotFoundError,
     MusicAssistantError,
+    ResourceTemporarilyUnavailable,
     UnsupportedFeaturedException,
 )
 from music_assistant_models.helpers import get_global_cache_value
@@ -646,6 +647,72 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         if all_results_complete:
             await self._cache_search_results(
                 cache_key, result, SEARCH_CACHE_EXPIRATION_COMBINED, self.domain
+            )
+        return result
+
+    async def search_provider(
+        self,
+        search_query: str,
+        provider_instance_id_or_domain: str,
+        media_types: list[MediaType],
+        limit: int = 10,
+        allowed_provider_instances: set[str] | None = None,
+    ) -> SearchResults:
+        """
+        Search one available provider through the cached, timeout-bounded path.
+
+        :param search_query: Search query.
+        :param provider_instance_id_or_domain: Provider instance ID or domain.
+        :param media_types: Media types to include.
+        :param limit: Maximum results per media type.
+        :param allowed_provider_instances: Explicit provider scope for deferred work.
+        """
+        if allowed_provider_instances is not None:
+            available_providers = [
+                provider
+                for provider_instance_id in sorted(allowed_provider_instances)
+                if isinstance(
+                    provider := self.mass.get_provider(
+                        provider_instance_id,
+                        return_unavailable=True,
+                    ),
+                    MusicProvider,
+                )
+                and provider.instance_id == provider_instance_id
+                and provider.available
+            ]
+        else:
+            available_providers = self.providers
+        provider = next(
+            (
+                item
+                for item in available_providers
+                if item.instance_id == provider_instance_id_or_domain
+            ),
+            None,
+        ) or next(
+            (item for item in available_providers if item.domain == provider_instance_id_or_domain),
+            None,
+        )
+        if provider is None:
+            if (
+                allowed_provider_instances is not None
+                and provider_instance_id_or_domain in allowed_provider_instances
+            ):
+                raise ResourceTemporarilyUnavailable(
+                    f"Provider {provider_instance_id_or_domain} is unavailable"
+                )
+            return SearchResults()
+        result = await self._search_provider(
+            search_query,
+            provider.instance_id,
+            media_types,
+            limit=limit,
+            strict_provider_instance=True,
+        )
+        if result is None:
+            raise ResourceTemporarilyUnavailable(
+                f"Search on provider {provider.name} failed or timed out"
             )
         return result
 
@@ -2552,6 +2619,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         media_types: list[MediaType],
         limit: int = 10,
         skip_item_ids: set[tuple[MediaType, str, str]] | None = None,
+        strict_provider_instance: bool = False,
     ) -> SearchResults | None:
         """
         Perform search on given provider, returns None if the search failed or timed out.
@@ -2563,10 +2631,18 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param limit: number of items to return in the search (per type).
         :param skip_item_ids: Optional set of (media_type, provider_domain, item_id)
                               tuples to filter out of the results.
+        :param strict_provider_instance: Do not fall back to another provider instance.
         """
-        prov = self.mass.get_provider(provider_instance_id_or_domain, provider_type=MusicProvider)
-        if not prov:
-            return SearchResults()
+        prov = self.mass.get_provider(
+            provider_instance_id_or_domain,
+            return_unavailable=strict_provider_instance,
+            provider_type=MusicProvider,
+        )
+        if not prov or (
+            strict_provider_instance
+            and (prov.instance_id != provider_instance_id_or_domain or not prov.available)
+        ):
+            return None if strict_provider_instance else SearchResults()
         if ProviderFeature.SEARCH not in prov.supported_features:
             return SearchResults()
 

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -667,8 +667,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param limit: Maximum results per media type.
         :param allowed_provider_instances: Explicit provider scope for deferred work.
         """
+        domain_in_scope = False
         if allowed_provider_instances is not None:
-            available_providers = [
+            allowed_providers = [
                 provider
                 for provider_instance_id in sorted(allowed_provider_instances)
                 if isinstance(
@@ -679,8 +680,14 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                     MusicProvider,
                 )
                 and provider.instance_id == provider_instance_id
-                and provider.available
             ]
+            # a domain is "in scope" once any allowed instance resolves to it, even if
+            # every one of them is currently unavailable - that is a temporary outage
+            # of an account the user actually has, not an absent provider
+            domain_in_scope = any(
+                provider.domain == provider_instance_id_or_domain for provider in allowed_providers
+            )
+            available_providers = [provider for provider in allowed_providers if provider.available]
         else:
             available_providers = self.providers
         provider = next(
@@ -691,13 +698,16 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             ),
             None,
         ) or next(
-            (item for item in available_providers if item.domain == provider_instance_id_or_domain),
+            (
+                item
+                for item in available_providers
+                if item.domain == provider_instance_id_or_domain and item.available
+            ),
             None,
         )
         if provider is None:
-            if (
-                allowed_provider_instances is not None
-                and provider_instance_id_or_domain in allowed_provider_instances
+            if allowed_provider_instances is not None and (
+                provider_instance_id_or_domain in allowed_provider_instances or domain_in_scope
             ):
                 raise ResourceTemporarilyUnavailable(
                     f"Provider {provider_instance_id_or_domain} is unavailable"

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -1001,10 +1001,10 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
 
         :param item_id: Provider item ID.
         :param provider_instance_id_or_domain: Provider instance ID or domain.
-        :param force_refresh: Bypass cached provider details.
-        :param fallback: Preferred fallback when the provider no longer resolves the ID.
-        :param allow_fallback: Return supplied or stored fallback details after a provider miss.
-        :param strict_provider_instance: Do not fall back to another provider instance.
+        :param force_refresh: Force a fresh provider lookup.
+        :param fallback: Details to return if the provider no longer resolves the ID.
+        :param allow_fallback: Allow fallback details after a provider miss.
+        :param strict_provider_instance: Require this exact provider instance.
         """
         if provider_instance_id_or_domain == "library":
             return await self.get_library_item(item_id)

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -993,32 +993,55 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         provider_instance_id_or_domain: str,
         force_refresh: bool = False,
         fallback: ItemMapping | ItemCls | None = None,
+        allow_fallback: bool = True,
+        strict_provider_instance: bool = False,
     ) -> ItemCls:
-        """Return item details for the given provider item id."""
+        """
+        Return item details for the given provider item ID.
+
+        :param item_id: Provider item ID.
+        :param provider_instance_id_or_domain: Provider instance ID or domain.
+        :param force_refresh: Bypass cached provider details.
+        :param fallback: Preferred fallback when the provider no longer resolves the ID.
+        :param allow_fallback: Return supplied or stored fallback details after a provider miss.
+        :param strict_provider_instance: Do not fall back to another provider instance.
+        """
         if provider_instance_id_or_domain == "library":
             return await self.get_library_item(item_id)
-        if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
+        provider = self.mass.get_provider(
+            provider_instance_id_or_domain,
+            return_unavailable=strict_provider_instance,
+        )
+        if provider is None or (
+            strict_provider_instance
+            and (provider.instance_id != provider_instance_id_or_domain or not provider.available)
+        ):
             raise ProviderUnavailableError(f"{provider_instance_id_or_domain} is not available")
-        if provider := self.mass.get_provider(provider_instance_id_or_domain):
-            provider = cast("MusicProvider | PluginProvider", provider)
-            with suppress(MediaNotFoundError):
-                async with self.mass.cache.handle_refresh(force_refresh):
-                    if self.media_type == MediaType.PLAYLIST:
-                        return cast("ItemCls", await provider.get_playlist(item_id))
-                    if self.media_type == MediaType.RADIO:
-                        return cast("ItemCls", await provider.get_radio(item_id))
-                    music_prov = cast("MusicProvider", provider)
-                    if self.media_type == MediaType.ARTIST:
-                        return cast("ItemCls", await music_prov.get_artist(item_id))
-                    if self.media_type == MediaType.ALBUM:
-                        return cast("ItemCls", await music_prov.get_album(item_id))
-                    if self.media_type == MediaType.TRACK:
-                        return cast("ItemCls", await music_prov.get_track(item_id))
-                    if self.media_type == MediaType.AUDIOBOOK:
-                        return cast("ItemCls", await music_prov.get_audiobook(item_id))
-                    if self.media_type == MediaType.PODCAST:
-                        return cast("ItemCls", await music_prov.get_podcast(item_id))
+        provider = cast("MusicProvider | PluginProvider", provider)
+        with suppress(MediaNotFoundError):
+            async with self.mass.cache.handle_refresh(force_refresh):
+                if self.media_type == MediaType.PLAYLIST:
+                    return cast("ItemCls", await provider.get_playlist(item_id))
+                if self.media_type == MediaType.RADIO:
+                    return cast("ItemCls", await provider.get_radio(item_id))
+                music_prov = cast("MusicProvider", provider)
+                if self.media_type == MediaType.ARTIST:
+                    return cast("ItemCls", await music_prov.get_artist(item_id))
+                if self.media_type == MediaType.ALBUM:
+                    return cast("ItemCls", await music_prov.get_album(item_id))
+                if self.media_type == MediaType.TRACK:
+                    return cast("ItemCls", await music_prov.get_track(item_id))
+                if self.media_type == MediaType.AUDIOBOOK:
+                    return cast("ItemCls", await music_prov.get_audiobook(item_id))
+                if self.media_type == MediaType.PODCAST:
+                    return cast("ItemCls", await music_prov.get_podcast(item_id))
         # if we reach this point all possibilities failed and the item could not be found.
+        if not allow_fallback:
+            msg = (
+                f"{self.media_type.value}://{item_id} not "
+                f"found on provider {provider_instance_id_or_domain}"
+            )
+            raise MediaNotFoundError(msg)
         # There is a possibility that the (streaming) provider changed the id of the item
         # so we return the previous details (if we have any) marked as unavailable, so
         # at least we have the possibility to sort out the new id through matching logic.

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -375,7 +375,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         if not provider or not isinstance(provider, MusicProvider):
             raise ProviderUnavailableError("Builtin provider is not available")
         builtin_prov = cast("BuiltinProvider", provider)
-        playlist = await builtin_prov.import_playlist(m3u_data)
+        playlist, playlist_generation = await builtin_prov.import_playlist(m3u_data)
         for prov_mapping in playlist.provider_mappings:
             prov_mapping.in_library = True
         db_playlist = await self.add_item_to_library(playlist, False)
@@ -425,6 +425,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 name=f"Import playlist {db_playlist.name}",
                 handler=lambda: builtin_prov.match_imported_playlist_tracks(
                     prov_playlist_id,
+                    playlist_generation,
                     effective_match_policy,
                     tuple(sorted(allowed_provider_instances.items())),
                     tuple(sorted(search_provider_instances)),

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Sequence
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Final, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import (
@@ -28,7 +28,6 @@ from music_assistant.controllers.tasks.context import (
     update_current_task_progress_text,
 )
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
-from music_assistant.helpers.compare import TrackMatchConfidence
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.helpers.playlists import (
@@ -68,25 +67,6 @@ def _update_stage_progress(
         return
     progress = start + int((current * (end - start)) / total)
     update_current_task_progress(min(progress, end), text)
-
-
-# minimum TrackMatchConfidence accepted for each policy tier.
-#
-# EXACT requires release-track evidence (e.g. a MusicBrainz track/release ID) pinning a
-# specific release, not just the underlying recording. M3U playlists exported by a current
-# Music Assistant persist this evidence when the source track carries it, so imports of
-# those files can reach EXACT; legacy or third-party M3U files typically only carry an ISRC
-# or recording ID and cap out at SAME_RECORDING or BEST_EFFORT.
-_MATCH_POLICY_MINIMUM_CONFIDENCE: Final[dict[PlaylistMatchPolicy, TrackMatchConfidence]] = {
-    PlaylistMatchPolicy.EXACT: TrackMatchConfidence.EXACT,
-    PlaylistMatchPolicy.SAME_RECORDING: TrackMatchConfidence.LIKELY,
-    PlaylistMatchPolicy.BEST_EFFORT: TrackMatchConfidence.LOOSE,
-}
-
-
-def match_policy_minimum_confidence(match_policy: PlaylistMatchPolicy) -> TrackMatchConfidence:
-    """Return the minimum track-match confidence accepted by a match policy."""
-    return _MATCH_POLICY_MINIMUM_CONFIDENCE[match_policy]
 
 
 class PlaylistController(MediaControllerBase[Playlist]):

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -336,20 +336,15 @@ class PlaylistController(MediaControllerBase[Playlist]):
         """
         Import a playlist from M3U8 format.
 
-        Creates a new builtin playlist from the provided M3U data. Entries whose original
-        source is confirmed still playable - available and, once probed, still
-        resolvable, or merely unreachable right now - are kept as-is; a background task
-        then searches other providers for a substitute for entries whose original source
-        is confirmed missing, when requested.
+        Creates a builtin playlist from the supplied M3U data. When matching is enabled,
+        entries confirmed missing are matched in a background task.
 
         :param m3u_data: The M3U8 playlist data as a string.
-        :param library_matching: Deprecated, use match_policy instead. When True and
-            match_policy is not set, matching runs at PlaylistMatchPolicy.BEST_EFFORT.
-        :param match_providers: Optional list of provider instance IDs or domains to search
-            when matching runs. Defaults to all providers available to the current user.
-        :param match_policy: Lowest track-match confidence accepted for a substitute when
-            an entry's original source is confirmed missing. Leave unset together with
-            library_matching=False to skip matching and leave those entries unresolved.
+        :param library_matching: Deprecated; when True and match_policy is unset, use
+            PlaylistMatchPolicy.BEST_EFFORT.
+        :param match_providers: Provider instances or domains to search when matching runs.
+        :param match_policy: Minimum substitute confidence. Leave unset with
+            ``library_matching=False`` to skip matching.
         """
         provider = self.mass.get_provider("builtin")
         if not provider or not isinstance(provider, MusicProvider):
@@ -365,18 +360,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
         if effective_match_policy is not None:
             prov_playlist_id = playlist.item_id
             user = get_current_user()
-            # snapshot the current user's allowed provider instances now: the matching
-            # itself runs later in an unattended background task, without the request's
-            # user context, so provider-instance isolation must be captured up front.
-            # Source ownership is checked against every provider instance the user has
-            # configured and enabled, not just the ones currently loaded, so a provider
-            # that failed setup or is temporarily down is not mistaken for one the user
-            # removed. The same configured-and-enabled snapshot also backs the search
-            # target set below, since the deferred task resolves each instance to a
-            # provider object again once it actually runs.
-            # Each instance is snapshotted together with its domain so a domain-only
-            # reference can also be expanded from this configured set, independent of
-            # whether that instance happens to be loaded right now.
+            # Snapshot the user's enabled music providers for the deferred task,
+            # including unavailable instances and each instance's domain.
             user_provider_filter = user.provider_filter if user else None
             configured_providers = await self.mass.config.get_provider_configs(
                 provider_type=ProviderType.MUSIC
@@ -387,18 +372,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 if conf.enabled
                 and (not user_provider_filter or conf.instance_id in user_provider_filter)
             }
-            # the builtin provider hosts the playlist itself; it is not a streaming
-            # provider choice a restricted user's filter opts in or out of, so a bare
-            # HTTP/file entry's original source must always be authoritatively probable
+            # Include builtin so bare HTTP/file entries can still be validated.
             allowed_provider_instances[builtin_prov.instance_id] = builtin_prov.domain
-            # match_providers only narrows which providers are searched for a substitute;
-            # it must not narrow source validation, or a playable original on a provider
-            # outside that list would look unavailable and get replaced unnecessarily.
-            # An explicit empty list (all providers deselected) must narrow the search
-            # to nothing, so it is checked against None rather than emptiness. The
-            # builtin instance is excluded from the search set - it exists in the
-            # allowed snapshot only to authoritatively validate a bare HTTP/file
-            # original, it is never itself a substitute-search target.
+            # Only narrow substitute search, not original-source validation.
+            # Exclude builtin from search targets.
             searchable_instances = {
                 instance_id: domain
                 for instance_id, domain in allowed_provider_instances.items()

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -367,8 +367,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
         Import a playlist from M3U8 format.
 
         Creates a new builtin playlist from the provided M3U data. Entries whose original
-        provider is still available are kept as-is; a background task then searches other
-        providers for a substitute for the remaining entries, when requested.
+        source is confirmed still playable - available and, once probed, still
+        resolvable, or merely unreachable right now - are kept as-is; a background task
+        then searches other providers for a substitute for entries whose original source
+        is confirmed missing, when requested.
 
         :param m3u_data: The M3U8 playlist data as a string.
         :param library_matching: Deprecated, use match_policy instead. When True and
@@ -376,7 +378,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         :param match_providers: Optional list of provider instance IDs or domains to search
             when matching runs. Defaults to all providers available to the current user.
         :param match_policy: Lowest track-match confidence accepted for a substitute when
-            an entry's original provider is unavailable. Leave unset together with
+            an entry's original source is confirmed missing. Leave unset together with
             library_matching=False to skip matching and leave those entries unresolved.
         """
         provider = self.mass.get_provider("builtin")

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Sequence
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, cast
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import MediaType, ProviderFeature
@@ -23,6 +24,7 @@ from music_assistant.controllers.tasks.context import (
     update_current_task_progress_text,
 )
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
+from music_assistant.helpers.compare import TrackMatchConfidence
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.helpers.playlists import (
@@ -62,6 +64,33 @@ def _update_stage_progress(
         return
     progress = start + int((current * (end - start)) / total)
     update_current_task_progress(min(progress, end), text)
+
+
+class PlaylistMatchPolicy(StrEnum):
+    """
+    Allowed fallback depth when matching a playlist track on another provider.
+
+    Shared between playlist import and (future) playlist migration: both only fall back to a
+    provider search once a track's own reference (its original URI, or its library mapping)
+    is no longer available.
+    """
+
+    EXACT = "exact"
+    SAME_RECORDING = "same_recording"
+    BEST_EFFORT = "best_effort"
+
+
+# minimum TrackMatchConfidence accepted for each policy tier
+_MATCH_POLICY_MINIMUM_CONFIDENCE: Final[dict[PlaylistMatchPolicy, TrackMatchConfidence]] = {
+    PlaylistMatchPolicy.EXACT: TrackMatchConfidence.EXACT,
+    PlaylistMatchPolicy.SAME_RECORDING: TrackMatchConfidence.LIKELY,
+    PlaylistMatchPolicy.BEST_EFFORT: TrackMatchConfidence.LOOSE,
+}
+
+
+def match_policy_minimum_confidence(match_policy: PlaylistMatchPolicy) -> TrackMatchConfidence:
+    """Return the minimum track-match confidence accepted by a match policy."""
+    return _MATCH_POLICY_MINIMUM_CONFIDENCE[match_policy]
 
 
 class PlaylistController(MediaControllerBase[Playlist]):
@@ -324,20 +353,22 @@ class PlaylistController(MediaControllerBase[Playlist]):
     async def import_playlist(
         self,
         m3u_data: str,
-        library_matching: bool = False,
+        match_policy: PlaylistMatchPolicy | None = None,
         match_providers: list[str] | None = None,
     ) -> Playlist:
         """
         Import a playlist from M3U8 format.
 
-        Creates a new builtin playlist from the provided M3U data.
+        Creates a new builtin playlist from the provided M3U data. Entries whose original
+        provider is still available are kept as-is; a background task then searches other
+        providers for a substitute for the remaining entries, when requested.
 
         :param m3u_data: The M3U8 playlist data as a string.
-        :param library_matching: When True, attempt to find tracks by searching
-            providers using metadata when the original URI's provider is not
-            available. Defaults to False.
-        :param match_providers: Optional list of provider instance IDs or domains
-            to search when library_matching is enabled.
+        :param match_policy: Lowest track-match confidence accepted for a substitute when
+            an entry's original provider is unavailable. Omit to skip matching entirely and
+            leave those entries unresolved.
+        :param match_providers: Optional list of provider instance IDs or domains to search
+            when match_policy is set. Defaults to all providers available to the current user.
         """
         provider = self.mass.get_provider("builtin")
         if not provider or not isinstance(provider, MusicProvider):
@@ -347,13 +378,25 @@ class PlaylistController(MediaControllerBase[Playlist]):
         for prov_mapping in playlist.provider_mappings:
             prov_mapping.in_library = True
         db_playlist = await self.add_item_to_library(playlist, False)
-        if library_matching:
+        if match_policy is not None:
             prov_playlist_id = playlist.item_id
             user = get_current_user()
+            # snapshot the current user's allowed provider instances now: the matching
+            # itself runs later in an unattended background task, without the request's
+            # user context, so provider-instance isolation must be captured up front
+            allowed_provider_instances = {item.instance_id for item in self.mass.music.providers}
+            if match_providers:
+                allowed_provider_instances &= {
+                    item.instance_id
+                    for item in self.mass.music.providers
+                    if item.instance_id in match_providers or item.domain in match_providers
+                }
             self.mass.tasks.run_background_task(
                 name=f"Import playlist {db_playlist.name}",
                 handler=lambda: builtin_prov.match_imported_playlist_tracks(
-                    prov_playlist_id, match_providers
+                    prov_playlist_id,
+                    match_policy,
+                    tuple(sorted(allowed_provider_instances)),
                 ),
                 translation_key="import_playlist_matching",
                 translation_owner=self.translation_owner,
@@ -363,6 +406,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     "task_domain": "playlist_import_matching",
                     "playlist_id": str(db_playlist.item_id),
                     "playlist_name": db_playlist.name,
+                    "match_policy": match_policy.value,
                 },
                 allow_retry=True,
                 allow_cancel=True,

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -353,8 +353,9 @@ class PlaylistController(MediaControllerBase[Playlist]):
     async def import_playlist(
         self,
         m3u_data: str,
-        match_policy: PlaylistMatchPolicy | None = None,
+        library_matching: bool = False,
         match_providers: list[str] | None = None,
+        match_policy: PlaylistMatchPolicy | None = None,
     ) -> Playlist:
         """
         Import a playlist from M3U8 format.
@@ -364,11 +365,13 @@ class PlaylistController(MediaControllerBase[Playlist]):
         providers for a substitute for the remaining entries, when requested.
 
         :param m3u_data: The M3U8 playlist data as a string.
-        :param match_policy: Lowest track-match confidence accepted for a substitute when
-            an entry's original provider is unavailable. Omit to skip matching entirely and
-            leave those entries unresolved.
+        :param library_matching: Deprecated, use match_policy instead. When True and
+            match_policy is not set, matching runs at PlaylistMatchPolicy.BEST_EFFORT.
         :param match_providers: Optional list of provider instance IDs or domains to search
-            when match_policy is set. Defaults to all providers available to the current user.
+            when matching runs. Defaults to all providers available to the current user.
+        :param match_policy: Lowest track-match confidence accepted for a substitute when
+            an entry's original provider is unavailable. Leave unset together with
+            library_matching=False to skip matching and leave those entries unresolved.
         """
         provider = self.mass.get_provider("builtin")
         if not provider or not isinstance(provider, MusicProvider):
@@ -378,7 +381,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
         for prov_mapping in playlist.provider_mappings:
             prov_mapping.in_library = True
         db_playlist = await self.add_item_to_library(playlist, False)
-        if match_policy is not None:
+        effective_match_policy = match_policy or (
+            PlaylistMatchPolicy.BEST_EFFORT if library_matching else None
+        )
+        if effective_match_policy is not None:
             prov_playlist_id = playlist.item_id
             user = get_current_user()
             # snapshot the current user's allowed provider instances now: the matching
@@ -395,7 +401,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 name=f"Import playlist {db_playlist.name}",
                 handler=lambda: builtin_prov.match_imported_playlist_tracks(
                     prov_playlist_id,
-                    match_policy,
+                    effective_match_policy,
                     tuple(sorted(allowed_provider_instances)),
                 ),
                 translation_key="import_playlist_matching",
@@ -406,7 +412,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     "task_domain": "playlist_import_matching",
                     "playlist_id": str(db_playlist.item_id),
                     "playlist_name": db_playlist.name,
-                    "match_policy": match_policy.value,
+                    "match_policy": effective_match_policy.value,
                 },
                 allow_retry=True,
                 allow_cancel=True,

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -415,6 +415,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 if conf.enabled
                 and (not user_provider_filter or conf.instance_id in user_provider_filter)
             }
+            # the builtin provider hosts the playlist itself; it is not a streaming
+            # provider choice a restricted user's filter opts in or out of, so a bare
+            # HTTP/file entry's original source must always be authoritatively probable
+            allowed_provider_instances[builtin_prov.instance_id] = builtin_prov.domain
             # match_providers only narrows which providers are searched for a substitute;
             # it must not narrow source validation, or a playable original on a provider
             # outside that list would look unavailable and get replaced unnecessarily.

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -397,8 +397,12 @@ class PlaylistController(MediaControllerBase[Playlist]):
             # itself runs later in an unattended background task, without the request's
             # user context, so provider-instance isolation must be captured up front
             allowed_provider_instances = {item.instance_id for item in self.mass.music.providers}
+            # match_providers only narrows which providers are searched for a substitute;
+            # it must not narrow source validation, or a playable original on a provider
+            # outside that list would look unavailable and get replaced unnecessarily
+            search_provider_instances = allowed_provider_instances
             if match_providers:
-                allowed_provider_instances &= {
+                search_provider_instances = {
                     item.instance_id
                     for item in self.mass.music.providers
                     if item.instance_id in match_providers or item.domain in match_providers
@@ -409,6 +413,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                     prov_playlist_id,
                     effective_match_policy,
                     tuple(sorted(allowed_provider_instances)),
+                    tuple(sorted(search_provider_instances)),
                 ),
                 translation_key="import_playlist_matching",
                 translation_owner=self.translation_owner,

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -8,7 +8,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from music_assistant_models.auth import Scope
-from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.enums import MediaType, ProviderFeature, ProviderType
 from music_assistant_models.errors import (
     InvalidDataError,
     InvalidProviderURI,
@@ -395,12 +395,25 @@ class PlaylistController(MediaControllerBase[Playlist]):
             user = get_current_user()
             # snapshot the current user's allowed provider instances now: the matching
             # itself runs later in an unattended background task, without the request's
-            # user context, so provider-instance isolation must be captured up front
-            allowed_provider_instances = {item.instance_id for item in self.mass.music.providers}
+            # user context, so provider-instance isolation must be captured up front.
+            # Source ownership is checked against every provider instance the user has
+            # configured and enabled, not just the ones currently loaded, so a provider
+            # that failed setup or is temporarily down is not mistaken for one the user
+            # removed - only actually searching for a substitute needs a loaded provider.
+            user_provider_filter = user.provider_filter if user else None
+            configured_providers = await self.mass.config.get_provider_configs(
+                provider_type=ProviderType.MUSIC
+            )
+            allowed_provider_instances = {
+                conf.instance_id
+                for conf in configured_providers
+                if conf.enabled
+                and (not user_provider_filter or conf.instance_id in user_provider_filter)
+            }
             # match_providers only narrows which providers are searched for a substitute;
             # it must not narrow source validation, or a playable original on a provider
             # outside that list would look unavailable and get replaced unnecessarily
-            search_provider_instances = allowed_provider_instances
+            search_provider_instances = {item.instance_id for item in self.mass.music.providers}
             if match_providers:
                 search_provider_instances = {
                     item.instance_id

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -391,7 +391,9 @@ class PlaylistController(MediaControllerBase[Playlist]):
             # Source ownership is checked against every provider instance the user has
             # configured and enabled, not just the ones currently loaded, so a provider
             # that failed setup or is temporarily down is not mistaken for one the user
-            # removed - only actually searching for a substitute needs a loaded provider.
+            # removed. The same configured-and-enabled snapshot also backs the search
+            # target set below, since the deferred task resolves each instance to a
+            # provider object again once it actually runs.
             # Each instance is snapshotted together with its domain so a domain-only
             # reference can also be expanded from this configured set, independent of
             # whether that instance happens to be loaded right now.
@@ -413,13 +415,21 @@ class PlaylistController(MediaControllerBase[Playlist]):
             # it must not narrow source validation, or a playable original on a provider
             # outside that list would look unavailable and get replaced unnecessarily.
             # An explicit empty list (all providers deselected) must narrow the search
-            # to nothing, so it is checked against None rather than emptiness.
-            search_provider_instances = {item.instance_id for item in self.mass.music.providers}
+            # to nothing, so it is checked against None rather than emptiness. The
+            # builtin instance is excluded from the search set - it exists in the
+            # allowed snapshot only to authoritatively validate a bare HTTP/file
+            # original, it is never itself a substitute-search target.
+            searchable_instances = {
+                instance_id: domain
+                for instance_id, domain in allowed_provider_instances.items()
+                if instance_id != builtin_prov.instance_id
+            }
+            search_provider_instances = set(searchable_instances)
             if match_providers is not None:
                 search_provider_instances = {
-                    item.instance_id
-                    for item in self.mass.music.providers
-                    if item.instance_id in match_providers or item.domain in match_providers
+                    instance_id
+                    for instance_id, domain in searchable_instances.items()
+                    if instance_id in match_providers or domain in match_providers
                 }
             self.mass.tasks.run_background_task(
                 name=f"Import playlist {db_playlist.name}",

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -73,6 +73,12 @@ class PlaylistMatchPolicy(StrEnum):
     Shared between playlist import and (future) playlist migration: both only fall back to a
     provider search once a track's own reference (its original URI, or its library mapping)
     is no longer available.
+
+    EXACT requires release-track evidence (e.g. a MusicBrainz track/release ID) pinning a
+    specific release, not just the underlying recording. M3U playlists exported by a current
+    Music Assistant persist this evidence when the source track carries it, so imports of
+    those files can reach EXACT; legacy or third-party M3U files typically only carry an ISRC
+    or recording ID and cap out at SAME_RECORDING or BEST_EFFORT.
     """
 
     EXACT = "exact"

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -400,12 +400,15 @@ class PlaylistController(MediaControllerBase[Playlist]):
             # configured and enabled, not just the ones currently loaded, so a provider
             # that failed setup or is temporarily down is not mistaken for one the user
             # removed - only actually searching for a substitute needs a loaded provider.
+            # Each instance is snapshotted together with its domain so a domain-only
+            # reference can also be expanded from this configured set, independent of
+            # whether that instance happens to be loaded right now.
             user_provider_filter = user.provider_filter if user else None
             configured_providers = await self.mass.config.get_provider_configs(
                 provider_type=ProviderType.MUSIC
             )
             allowed_provider_instances = {
-                conf.instance_id
+                conf.instance_id: conf.domain
                 for conf in configured_providers
                 if conf.enabled
                 and (not user_provider_filter or conf.instance_id in user_provider_filter)
@@ -425,7 +428,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 handler=lambda: builtin_prov.match_imported_playlist_tracks(
                     prov_playlist_id,
                     effective_match_policy,
-                    tuple(sorted(allowed_provider_instances)),
+                    tuple(sorted(allowed_provider_instances.items())),
                     tuple(sorted(search_provider_instances)),
                 ),
                 translation_key="import_playlist_matching",

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -417,9 +417,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
             }
             # match_providers only narrows which providers are searched for a substitute;
             # it must not narrow source validation, or a playable original on a provider
-            # outside that list would look unavailable and get replaced unnecessarily
+            # outside that list would look unavailable and get replaced unnecessarily.
+            # An explicit empty list (all providers deselected) must narrow the search
+            # to nothing, so it is checked against None rather than emptiness.
             search_provider_instances = {item.instance_id for item in self.mass.music.providers}
-            if match_providers:
+            if match_providers is not None:
                 search_provider_instances = {
                     item.instance_id
                     for item in self.mass.music.providers

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Sequence
 from contextlib import suppress
-from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from music_assistant_models.auth import Scope
-from music_assistant_models.enums import MediaType, ProviderFeature, ProviderType
+from music_assistant_models.enums import (
+    MediaType,
+    PlaylistMatchPolicy,
+    ProviderFeature,
+    ProviderType,
+)
 from music_assistant_models.errors import (
     InvalidDataError,
     InvalidProviderURI,
@@ -66,27 +70,13 @@ def _update_stage_progress(
     update_current_task_progress(min(progress, end), text)
 
 
-class PlaylistMatchPolicy(StrEnum):
-    """
-    Allowed fallback depth when matching a playlist track on another provider.
-
-    Shared between playlist import and (future) playlist migration: both only fall back to a
-    provider search once a track's own reference (its original URI, or its library mapping)
-    is no longer available.
-
-    EXACT requires release-track evidence (e.g. a MusicBrainz track/release ID) pinning a
-    specific release, not just the underlying recording. M3U playlists exported by a current
-    Music Assistant persist this evidence when the source track carries it, so imports of
-    those files can reach EXACT; legacy or third-party M3U files typically only carry an ISRC
-    or recording ID and cap out at SAME_RECORDING or BEST_EFFORT.
-    """
-
-    EXACT = "exact"
-    SAME_RECORDING = "same_recording"
-    BEST_EFFORT = "best_effort"
-
-
-# minimum TrackMatchConfidence accepted for each policy tier
+# minimum TrackMatchConfidence accepted for each policy tier.
+#
+# EXACT requires release-track evidence (e.g. a MusicBrainz track/release ID) pinning a
+# specific release, not just the underlying recording. M3U playlists exported by a current
+# Music Assistant persist this evidence when the source track carries it, so imports of
+# those files can reach EXACT; legacy or third-party M3U files typically only carry an ISRC
+# or recording ID and cap out at SAME_RECORDING or BEST_EFFORT.
 _MATCH_POLICY_MINIMUM_CONFIDENCE: Final[dict[PlaylistMatchPolicy, TrackMatchConfidence]] = {
     PlaylistMatchPolicy.EXACT: TrackMatchConfidence.EXACT,
     PlaylistMatchPolicy.SAME_RECORDING: TrackMatchConfidence.LIKELY,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -983,12 +983,6 @@ class TracksController(MediaControllerBase[Track]):
                 seen_candidates.add(candidate_key)
                 if not compare_track_title(base_track.name, search_result.name):
                     continue
-                if not compare_artists(
-                    base_track.artists,
-                    search_result.artists,
-                    any_match=True,
-                ):
-                    continue
                 try:
                     candidate = await self.get_provider_item(
                         search_result.item_id,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -715,7 +715,9 @@ class TracksController(MediaControllerBase[Track]):
                     allow_fallback=False,
                     strict_provider_instance=True,
                 )
-            except MediaNotFoundError:
+            except MediaNotFoundError, InvalidDataError:
+                # a stale mapping (deleted catalog id, unreadable stream) is not fatal -
+                # fall through to a fresh search below instead of aborting the provider
                 mapped_candidate = None
             if mapped_candidate:
                 confidence, resolved_base_album = await self._get_match_confidence(
@@ -1039,7 +1041,9 @@ class TracksController(MediaControllerBase[Track]):
                         allow_fallback=False,
                         strict_provider_instance=True,
                     )
-                except MediaNotFoundError:
+                except MediaNotFoundError, InvalidDataError:
+                    # this hydrated search result is unusable - skip it, other
+                    # candidates from this same search are still worth trying
                     continue
                 except (
                     ResourceTemporarilyUnavailable,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -81,11 +81,7 @@ class TrackProviderMatch:
     track: Track
     mapping: ProviderMapping
     confidence: TrackMatchConfidence
-    # the full hydrated album used to establish this candidate's own confidence,
-    # when album-level release evidence was needed for that; None if confidence
-    # was decided without hydrating an album (e.g. direct item-id/MB_TRACK match),
-    # so a later pairwise compatibility check reuses the same evidence rather than
-    # degrading to the track's raw, unhydrated album reference
+    # Hydrated album evidence, if album-level comparison was needed.
     album: Album | ItemMapping | None = None
 
 
@@ -95,9 +91,7 @@ class TrackProviderMatchResult:
 
     match: TrackProviderMatch | None = None
     ambiguous: bool = False
-    # the confidence tier at which this provider's own candidates could not be told
-    # apart, so a caller resolving several providers together can tell that a weaker
-    # tier from another provider isn't actually a safe, uncontested answer either
+    # Highest confidence tier this provider could not disambiguate.
     ambiguous_confidence: TrackMatchConfidence | None = None
 
 
@@ -704,11 +698,11 @@ class TracksController(MediaControllerBase[Track]):
         :param provider: Target provider.
         :param minimum_confidence: Lowest confidence that may be returned.
         :param base_album: Optional full reference album for release evidence.
-        :param mapping_source: Optional library track whose mappings may be reused as candidates.
-        :param allowed_provider_instances: Provider instances available to the initiating user.
-        :param trust_base_mapping: Treat a direct base-track mapping as exact provider identity.
-        :param known_dead_mappings: ``(instance_id, item_id)`` pairs a caller has already
-            authoritatively confirmed unresolvable, so they are not hydrated again here.
+        :param mapping_source: Optional track whose mappings may be reused as candidates.
+        :param allowed_provider_instances: Provider instances allowed for album evidence.
+        :param trust_base_mapping: Treat a direct base-track mapping as exact identity.
+        :param known_dead_mappings: Exact ``(instance_id, item_id)`` pairs already
+            confirmed unresolvable.
         """
         resolved_base_album = base_album
         mapped_match: TrackProviderMatch | None = None
@@ -725,27 +719,20 @@ class TracksController(MediaControllerBase[Track]):
             if known_dead_mappings and (provider.instance_id, mapping.item_id) in (
                 known_dead_mappings
             ):
-                # a caller already authoritatively confirmed this exact candidate dead
-                # moments ago - hydrating it again here would double its provider
-                # traffic for nothing, so fall through to a fresh search straight away
+                # Skip a candidate the caller already proved dead.
                 mapped_candidate = None
             else:
                 try:
                     mapped_candidate = await self.get_provider_item(
                         mapping.item_id,
                         provider.instance_id,
-                        # an untrusted mapping (trust_base_mapping=False) may have just
-                        # been proven dead by an authoritative caller-side probe - a
-                        # cached hit here must not resurrect it as a confident match,
-                        # so bypass the provider cache the same way that probe did
+                        # Revalidate untrusted mappings against the provider, not cache.
                         force_refresh=not trust_base_mapping,
                         allow_fallback=False,
                         strict_provider_instance=True,
                     )
                 except MediaNotFoundError, InvalidDataError, InvalidProviderID:
-                    # a stale mapping (deleted catalog id, unreadable stream, malformed
-                    # id) is not fatal - fall through to a fresh search below instead
-                    # of aborting
+                    # Ignore stale mappings and fall back to search.
                     mapped_candidate = None
             if mapped_candidate:
                 confidence, resolved_base_album, candidate_album = await self._get_match_confidence(
@@ -792,9 +779,7 @@ class TracksController(MediaControllerBase[Track]):
             (rank, match) for rank, match in candidates if match.confidence == best_confidence
         ]
         if not self._matches_are_compatible([match for _, match in best_matches], best_confidence):
-            # missing source evidence (e.g. no explicitness tag) can let unrelated
-            # candidates tie at the same confidence - checked at every tier, not just
-            # LOOSE, since a quality tie-break would otherwise pick one arbitrarily
+            # Treat tied top-tier candidates as ambiguous, not arbitrary.
             return TrackProviderMatchResult(ambiguous=True, ambiguous_confidence=best_confidence)
         _, best_match = max(
             best_matches,
@@ -823,19 +808,13 @@ class TracksController(MediaControllerBase[Track]):
         :param minimum_confidence: Lowest confidence that may be accepted.
         :param provider_instance_ids: Provider instances to search for a match.
         :param trust_track_mappings: Treat mappings attached to the source track as exact.
-        :param failed_provider_instances: Provider instances unavailable for the migration.
-        :param evidence_provider_instances: Provider instances available to the initiating
-            user, for authorizing release-evidence album hydration. Defaults to
-            ``provider_instance_ids`` when not given separately, so a narrower search scope
-            never also narrows which of the user's own accounts evidence may be hydrated
-            from.
-        :param known_dead_mappings: ``(instance_id, item_id)`` pairs a caller has already
-            authoritatively confirmed unresolvable, so they are not hydrated again here.
-        :param search_non_streaming_without_mapping: Search a non-streaming provider (e.g.
-            filesystem) even without a pre-existing mapping to it. Only safe when
-            ``provider_instance_ids`` is the caller's own deliberate, explicit selection of
-            match targets - otherwise a non-streaming provider is only ever confirmed
-            through a mapping it already carries, never blindly searched.
+        :param failed_provider_instances: Provider instances already known unavailable.
+        :param evidence_provider_instances: Provider instances allowed for album-evidence
+            hydration. Defaults to ``provider_instance_ids``.
+        :param known_dead_mappings: Exact ``(instance_id, item_id)`` pairs already
+            confirmed unresolvable.
+        :param search_non_streaming_without_mapping: Search non-streaming targets even
+            without an existing mapping. Only use with an explicit target set.
         """
         library_track = await self.get_library_match(track)
         enriched_track = deepcopy(track)
@@ -886,10 +865,7 @@ class TracksController(MediaControllerBase[Track]):
         if domain_ambiguous_confidence is not None and (
             ambiguous_confidence is None or domain_ambiguous_confidence > ambiguous_confidence
         ):
-            # a same-domain tie that could not be resolved (e.g. two personal
-            # accounts disagreeing) is evidence just as unresolved as a cross-provider
-            # tie - a weaker tier from another provider must not be quietly accepted
-            # over it either
+            # A same-domain tie blocks weaker matches from other providers too.
             ambiguous_confidence = domain_ambiguous_confidence
         accepted, tier_ambiguous_providers = self._resolve_confident_matches(
             provider_matches, unresolved_confidence=ambiguous_confidence
@@ -999,9 +975,8 @@ class TracksController(MediaControllerBase[Track]):
         """
         Return ranked provider candidates from every credited-artist search query.
 
-        :param known_dead_mappings: ``(instance_id, item_id)`` pairs a caller has
-            already authoritatively confirmed unresolvable, skipped here even if a
-            search result happens to hydrate the same pair from provider caches.
+        :param known_dead_mappings: Exact ``(instance_id, item_id)`` pairs already
+            confirmed unresolvable.
         """
         search_queries = list(
             dict.fromkeys(f"{artist.name} - {base_track.name}" for artist in base_track.artists)
@@ -1031,9 +1006,7 @@ class TracksController(MediaControllerBase[Track]):
                     continue
                 seen_candidates.add(candidate_key)
                 if known_dead_mappings and candidate_key in known_dead_mappings:
-                    # a caller already authoritatively confirmed this exact
-                    # (instance, item id) pair dead moments ago - a stale cached
-                    # hit here must not resurrect it as a confident substitute
+                    # Ignore stale cached hits the caller already proved dead.
                     continue
                 if not compare_track_title(base_track.name, search_result.name):
                     continue
@@ -1045,8 +1018,7 @@ class TracksController(MediaControllerBase[Track]):
                         strict_provider_instance=True,
                     )
                 except MediaNotFoundError, InvalidDataError, InvalidProviderID:
-                    # this hydrated search result is unusable - skip it, other
-                    # candidates from this same search are still worth trying
+                    # Skip unusable results but keep the rest of this search.
                     continue
                 except (
                     ResourceTemporarilyUnavailable,
@@ -1055,12 +1027,8 @@ class TracksController(MediaControllerBase[Track]):
                     OSError,
                     TimeoutError,
                 ):
-                    # unlike a search-request failure (which only loses queries not
-                    # yet attempted), a failed hydration mid-loop still leaves
-                    # unseen candidates - possibly stronger or ambiguity-triggering
-                    # ones - among the already-fetched search results; propagate so
-                    # the caller reports this provider as failed rather than
-                    # silently accepting an incomplete candidate set
+                    # Propagate mid-loop hydration failures so the provider is reported
+                    # as incomplete rather than silently accepted.
                     raise
                 confidence, base_album, candidate_album = await self._get_match_confidence(
                     base_track,
@@ -1091,16 +1059,7 @@ class TracksController(MediaControllerBase[Track]):
         allow_item_id_match: bool = True,
         allowed_provider_instances: set[str] | None = None,
     ) -> tuple[TrackMatchConfidence, Album | ItemMapping | None, Album | ItemMapping | None]:
-        """
-        Return candidate confidence with full album evidence when needed.
-
-        The returned candidate album is the hydrated album actually used to decide
-        the confidence, or ``None`` when no album evidence was needed for the
-        verdict (e.g. a direct item-id/MB_TRACK match) - callers that persist a
-        match should keep this value so a later re-comparison against a sibling
-        candidate reuses the same evidence instead of falling back to the track's
-        raw, unhydrated album reference.
-        """
+        """Return confidence and any hydrated album evidence used to score it."""
         confidence = compare_track_evidence(
             base_track,
             candidate,
@@ -1132,9 +1091,7 @@ class TracksController(MediaControllerBase[Track]):
     def _get_provider_mapping(track: Track, provider: MusicProvider) -> ProviderMapping | None:
         """Return an available mapping suitable for the provider instance."""
         domain_mapping: ProviderMapping | None = None
-        # provider_mappings is a set, so its iteration order is not guaranteed stable
-        # across runs; tie-break equal-quality mappings by identity so the chosen
-        # mapping is deterministic instead of process-dependent
+        # Sort deterministically before picking the best mapping.
         sorted_mappings = sorted(
             track.provider_mappings,
             key=lambda item: (
@@ -1149,10 +1106,7 @@ class TracksController(MediaControllerBase[Track]):
                 continue
             if mapping.provider_instance == provider.instance_id:
                 return mapping
-            # is_unique=None means "use the provider's default", and non-streaming
-            # providers (e.g. filesystem) default to instance-unique - mirror that
-            # same effective-uniqueness rule here, or a falsy-but-unset value could
-            # wrongly expand an instance-unique mapping across a different instance
+            # Treat unset uniqueness like the provider default.
             effective_is_unique = mapping.is_unique or not provider.is_streaming_provider
             if (
                 mapping.provider_domain == provider.domain
@@ -1166,18 +1120,10 @@ class TracksController(MediaControllerBase[Track]):
 
     def _domain_is_streaming(self, domain: str, allowed_provider_instances: set[str]) -> bool:
         """
-        Return whether providers of this domain share a single portable catalog.
-
-        Every instance of a domain shares the same provider class and therefore the
-        same ``is_streaming_provider`` trait, so any one allowed instance of it is
-        representative. Defaults to ``False`` when no instance of this domain can be
-        resolved at all - unlike liveness checks elsewhere, this gates whether a
-        sibling instance's album is trusted as release evidence, so an unresolvable
-        domain must not be assumed portable.
+        Return whether a domain's item ids are portable across its instances.
 
         :param domain: The provider domain to check.
-        :param allowed_provider_instances: Instance ids to search for a representative
-            instance of this domain.
+        :param allowed_provider_instances: Instance ids to search for a representative.
         """
         for allowed_id in allowed_provider_instances:
             if (
@@ -1195,9 +1141,8 @@ class TracksController(MediaControllerBase[Track]):
         Return full album details when they are available.
 
         :param track: Track whose album should be hydrated.
-        :param allowed_provider_instances: Provider instances available to the
-            initiating user. When set, an album on a domain that resolves outside
-            this set is left as the unhydrated mapping instead of being fetched.
+        :param allowed_provider_instances: Provider instances allowed for album
+            hydration. Out-of-scope albums stay as mappings.
         """
         if not track.album or isinstance(track.album, Album):
             return track.album
@@ -1214,14 +1159,8 @@ class TracksController(MediaControllerBase[Track]):
             ):
                 candidate_instances = [provider.instance_id]
             else:
-                # a bare domain resolves to its first registered instance, which may
-                # not be the one this user is allowed to use even though a sibling
-                # instance of the same domain is; try every allowed instance of that
-                # domain instead of giving up on that single, arbitrary first match -
-                # but only for a genuinely portable (streaming) catalog, since a
-                # non-streaming domain (e.g. filesystem) mints its own local ids per
-                # instance and a sibling's coincidentally-matching id would supply
-                # false release evidence for an unrelated album
+                # For a domain-only or foreign instance, try allowed siblings only on
+                # portable domains.
                 domain = provider.domain if provider is not None else provider_instance_id_or_domain
                 candidate_instances = (
                     [
@@ -1238,15 +1177,14 @@ class TracksController(MediaControllerBase[Track]):
                     else []
                 )
                 if not candidate_instances:
-                    # can't verify this account is one the initiating user has access to
+                    # No allowed instance can verify this album.
                     return track.album
         for candidate_instance in candidate_instances:
             try:
                 if library_item := await self.mass.music.albums.get_library_item_by_prov_id(
                     track.album.item_id, candidate_instance
                 ):
-                    # prefer the library's own copy over a fresh provider fetch,
-                    # matching the library-first preference of the shared get()
+                    # Prefer the library copy over a fresh provider fetch.
                     return library_item
                 return await self.mass.music.albums.get_provider_item(
                     track.album.item_id,
@@ -1264,10 +1202,7 @@ class TracksController(MediaControllerBase[Track]):
                 OSError,
                 TimeoutError,
             ) as err:
-                # this candidate could not supply the album; a missing/unavailable
-                # account, or a malformed id (e.g. reconstructed from imported M3U
-                # metadata), must not block a sibling instance of the same domain
-                # from still supplying the release evidence
+                # Keep trying sibling instances of the same domain for album evidence.
                 self.logger.debug(
                     "Could not load album details for track %s on %s: %s",
                     track.name,
@@ -1281,18 +1216,10 @@ class TracksController(MediaControllerBase[Track]):
         matches: list[TrackProviderMatch], tier: TrackMatchConfidence
     ) -> bool:
         """
-        Return whether tied matches at the given confidence tier identify the same release.
+        Return whether tied matches can coexist at this confidence tier.
 
-        An EXACT tier requires every pair to compare as EXACT: a looser recording-level
-        agreement (e.g. matching ISRC but a different MB_TRACK/release) must not tie at
-        EXACT, since that would let the importer persist one candidate's release evidence
-        while the Exact policy is free to later select a conflicting one. Lower tiers only
-        require agreement at LIKELY, since that is already their "same recording" floor.
-
-        Each match's own hydrated album (when one was needed to establish its
-        confidence) is reused for this pairwise check, so two candidates that were
-        individually confirmed EXACT via release evidence do not degrade to a lower
-        tier here for lacking that same evidence against each other.
+        EXACT requires exact release agreement; lower tiers require LIKELY
+        compatibility. Reuses any hydrated album evidence stored on the matches.
         """
         required = (
             TrackMatchConfidence.EXACT
@@ -1319,15 +1246,8 @@ class TracksController(MediaControllerBase[Track]):
         """
         Reduce matches from multiple instances of the same provider domain to one.
 
-        Evaluating every allowed instance can surface more than one acceptable match for
-        the same domain (e.g. two personal accounts on the same service), but only one
-        mapping can be stored per domain. The highest-confidence match is kept; tied
-        top-confidence candidates that disagree with each other are reported as
-        ambiguous, and compatible ties are resolved by mapping quality rather than
-        picked arbitrarily by instance order. The highest confidence tier discarded to
-        an unresolved same-domain tie is also returned, so a caller combining this with
-        cross-provider ambiguity does not let a weaker tier from another domain be
-        quietly accepted over evidence that is itself unresolved at a higher tier.
+        Compatible top-tier ties are resolved by mapping quality; incompatible ones are
+        reported as ambiguous instead of picked arbitrarily.
         """
         best: list[tuple[MusicProvider, TrackProviderMatch]] = []
         ambiguous_providers: list[str] = []
@@ -1356,20 +1276,10 @@ class TracksController(MediaControllerBase[Track]):
         """
         Accept provider matches confidence tier by confidence tier.
 
-        Resolves the highest-confidence candidates first, so a stronger match is
-        preferred over a weaker one that conflicts with it regardless of which
-        provider was visited first, and rejects a whole confidence tier as
-        ambiguous when its own candidates disagree with each other - missing
-        source evidence (e.g. no explicitness tag) can otherwise let unrelated
-        recordings tie and get merged or picked arbitrarily. Resolution stops at
-        the first ambiguous tier: once the strongest remaining evidence can't be
-        told apart, a weaker tier can't settle that disagreement either, so it
-        would be wrong to quietly substitute it in as if it were the answer.
+        Stop at the first ambiguous tier or tier blocked by unresolved stronger
+        evidence.
 
-        :param unresolved_confidence: The highest tier at which some other
-            provider's own candidates already tied ambiguously, if any. A tier at
-            or below it is rejected too rather than accepted, since it cannot be
-            trusted over evidence that is itself unresolved at that level.
+        :param unresolved_confidence: Highest tier already left unresolved elsewhere.
         """
         accepted: list[tuple[MusicProvider, TrackProviderMatch]] = []
         ambiguous_providers: list[str] = []
@@ -1413,13 +1323,7 @@ class TracksController(MediaControllerBase[Track]):
         """
         Query every allowed provider for a match, deferring accept/reject decisions.
 
-        Every allowed instance is queried before any conflict is resolved, so a
-        disagreement (including between two instances of the same domain) is settled
-        by confidence rather than by which instance happened to be visited first.
-        Providers whose own candidates tied ambiguously contribute no match here;
-        the highest such tier is returned separately so a caller resolving several
-        providers together can tell that a weaker, uncontested-looking match from
-        another provider isn't actually a safe answer to that disagreement either.
+        Returns matches plus ambiguous providers and the highest ambiguous tier.
         """
         base_album: Album | ItemMapping | None = None
         base_album_loaded = False
@@ -1501,10 +1405,9 @@ class TracksController(MediaControllerBase[Track]):
         """
         Return the providers to query and any allowed instance that cannot be queried.
 
-        :param provider_instance_ids: Provider instances available to the initiating user,
-            or ``None`` to query every loaded provider.
-        :param failed_provider_instances: Provider instances to skip as already failed,
-            updated in place with any instance found unavailable here.
+        :param provider_instance_ids: Allowed provider instances, or ``None`` for all.
+        :param failed_provider_instances: Instances already known failed; updated in
+            place with any new failures found here.
         """
         if provider_instance_ids is None:
             return list(self.mass.music.providers), []
@@ -1515,9 +1418,7 @@ class TracksController(MediaControllerBase[Track]):
                 failed_provider_instances is not None
                 and provider_instance_id in failed_provider_instances
             ):
-                # already confirmed failed for an earlier entry in this pass - report it
-                # again here too, so a caller building a report attributes every entry
-                # this instance was skipped for, not just the one that first found it down
+                # Keep reporting a known-failed instance for each skipped entry.
                 failed_providers.append(provider_instance_id)
                 continue
             candidate = self.mass.get_provider(provider_instance_id, return_unavailable=True)
@@ -1525,17 +1426,13 @@ class TracksController(MediaControllerBase[Track]):
                 isinstance(candidate, MusicProvider)
                 and candidate.instance_id == provider_instance_id
             ):
-                # the instance has fully unloaded (no provider object left at all) -
-                # report it as failed too, using its instance id as display name,
-                # instead of silently dropping it and letting callers retry it forever
+                # Treat fully missing instances as failed instead of silently dropping them.
                 if failed_provider_instances is not None:
                     failed_provider_instances.add(provider_instance_id)
                 failed_providers.append(provider_instance_id)
                 continue
             if not candidate.available:
-                # allowed but currently unreachable - report it so a caller building a
-                # report can retry, instead of silently treating this as "no candidates
-                # found" for the rest of the pass
+                # Report unavailable instances so callers can retry them.
                 if failed_provider_instances is not None:
                     failed_provider_instances.add(candidate.instance_id)
                 failed_providers.append(candidate.name)

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1149,10 +1149,24 @@ class TracksController(MediaControllerBase[Track]):
             provider = self.mass.get_provider(
                 provider_instance_id_or_domain, return_unavailable=True
             )
-            if provider is None or provider.instance_id not in allowed_provider_instances:
-                # can't verify this account is one the initiating user has access to
-                return track.album
-            provider_instance_id_or_domain = provider.instance_id
+            if provider is not None and provider.instance_id in allowed_provider_instances:
+                provider_instance_id_or_domain = provider.instance_id
+            else:
+                # a bare domain resolves to its first registered instance, which may
+                # not be the one this user is allowed to use even though a sibling
+                # instance of the same domain is; try every allowed instance instead
+                # of giving up on that single, arbitrary first match
+                domain = provider.domain if provider is not None else provider_instance_id_or_domain
+                resolved_instance: str | None = None
+                for candidate_id in allowed_provider_instances:
+                    candidate = self.mass.get_provider(candidate_id, return_unavailable=True)
+                    if candidate is not None and candidate.domain == domain:
+                        resolved_instance = candidate.instance_id
+                        break
+                if resolved_instance is None:
+                    # can't verify this account is one the initiating user has access to
+                    return track.album
+                provider_instance_id_or_domain = resolved_instance
         try:
             return await self.mass.music.albums.get(
                 track.album.item_id,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from copy import deepcopy
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Never, cast
 
@@ -17,8 +19,10 @@ from music_assistant_models.enums import (
 )
 from music_assistant_models.errors import (
     InvalidDataError,
+    MediaNotFoundError,
     MusicAssistantError,
     ProviderUnavailableError,
+    ResourceTemporarilyUnavailable,
     UnsupportedFeaturedException,
 )
 from music_assistant_models.helpers import create_safe_string
@@ -45,9 +49,12 @@ from music_assistant.controllers.music.helpers import (
     search_name_match_clause,
 )
 from music_assistant.helpers.compare import (
+    TrackMatchConfidence,
     compare_artists,
     compare_media_item,
     compare_track,
+    compare_track_evidence,
+    compare_track_title,
     loose_compare_strings,
 )
 from music_assistant.helpers.database import UNSET
@@ -63,6 +70,34 @@ if TYPE_CHECKING:
     from music_assistant import MusicAssistant
     from music_assistant.models.metadata_provider import MetadataProvider
     from music_assistant.models.plugin import PluginProvider
+
+
+@dataclass(frozen=True, slots=True)
+class TrackProviderMatch:
+    """Matched provider track with its confidence and target mapping."""
+
+    track: Track
+    mapping: ProviderMapping
+    confidence: TrackMatchConfidence
+
+
+@dataclass(frozen=True, slots=True)
+class TrackProviderMatchResult:
+    """Result of resolving a track on one provider."""
+
+    match: TrackProviderMatch | None = None
+    ambiguous: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TrackProviderEnrichment:
+    """Track enriched with provider matches without changing the library."""
+
+    track: Track
+    matches: tuple[TrackProviderMatch, ...]
+    ambiguous_providers: tuple[str, ...]
+    failed_providers: tuple[str, ...]
+    used_library_item: bool
 
 
 class TracksController(MediaControllerBase[Track]):
@@ -629,6 +664,242 @@ class TracksController(MediaControllerBase[Track]):
             in_library_only=True,
         )
 
+    async def get_library_match(self, item: Track) -> Track | None:
+        """
+        Return an existing library track matching the provider track.
+
+        :param item: Provider track to resolve.
+        """
+        if library_item_id := await self._get_library_item_by_match(item):
+            return await self.get_library_item(library_item_id)
+        return None
+
+    async def find_provider_match(
+        self,
+        base_track: Track,
+        provider: MusicProvider,
+        minimum_confidence: TrackMatchConfidence = TrackMatchConfidence.LIKELY,
+        base_album: Album | ItemMapping | None = None,
+        mapping_source: Track | None = None,
+        allowed_provider_instances: set[str] | None = None,
+        trust_base_mapping: bool = True,
+    ) -> TrackProviderMatchResult:
+        """
+        Find the best track match on a music provider.
+
+        :param base_track: Reference track to match.
+        :param provider: Target provider.
+        :param minimum_confidence: Lowest confidence that may be returned.
+        :param base_album: Optional full reference album for release evidence.
+        :param mapping_source: Optional library track whose mappings may be reused as candidates.
+        :param allowed_provider_instances: Provider instances available to the initiating user.
+        :param trust_base_mapping: Treat a direct base-track mapping as exact provider identity.
+        """
+        resolved_base_album = base_album
+        mapped_match: TrackProviderMatch | None = None
+        mapping_source = mapping_source or base_track
+        if mapping := self._get_provider_mapping(mapping_source, provider):
+            if mapping_source is base_track and trust_base_mapping:
+                return TrackProviderMatchResult(
+                    match=TrackProviderMatch(
+                        track=base_track,
+                        mapping=mapping,
+                        confidence=TrackMatchConfidence.EXACT,
+                    )
+                )
+            try:
+                mapped_candidate = await self.get_provider_item(
+                    mapping.item_id,
+                    provider.instance_id,
+                    allow_fallback=False,
+                    strict_provider_instance=True,
+                )
+            except MediaNotFoundError:
+                mapped_candidate = None
+            if mapped_candidate:
+                confidence, resolved_base_album = await self._get_match_confidence(
+                    base_track,
+                    mapped_candidate,
+                    resolved_base_album,
+                    allow_item_id_match=trust_base_mapping,
+                )
+                if confidence >= minimum_confidence and (
+                    candidate_mapping := self._get_provider_mapping(
+                        mapped_candidate,
+                        provider,
+                    )
+                ):
+                    mapped_match = TrackProviderMatch(
+                        track=mapped_candidate,
+                        mapping=candidate_mapping,
+                        confidence=confidence,
+                    )
+                    if confidence == TrackMatchConfidence.EXACT:
+                        return TrackProviderMatchResult(match=mapped_match)
+        if ProviderFeature.SEARCH not in provider.supported_features:
+            return TrackProviderMatchResult(match=mapped_match)
+        if MediaType.TRACK not in provider.supported_media_types:
+            return TrackProviderMatchResult(match=mapped_match)
+        if not base_track.artists:
+            return TrackProviderMatchResult(match=mapped_match)
+
+        candidates = await self._search_provider_track_matches(
+            base_track,
+            provider,
+            minimum_confidence,
+            resolved_base_album,
+            allowed_provider_instances,
+            trust_base_mapping,
+            mapped_match,
+        )
+
+        if not candidates:
+            return TrackProviderMatchResult()
+        best_confidence = max(match.confidence for _, match in candidates)
+        best_matches = [
+            (rank, match) for rank, match in candidates if match.confidence == best_confidence
+        ]
+        if best_confidence == TrackMatchConfidence.LOOSE and not self._matches_are_compatible(
+            [match for _, match in best_matches]
+        ):
+            return TrackProviderMatchResult(ambiguous=True)
+        _, best_match = max(
+            best_matches,
+            key=lambda ranked_match: (
+                ranked_match[1].mapping.quality,
+                -ranked_match[0],
+            ),
+        )
+        return TrackProviderMatchResult(match=best_match)
+
+    async def enrich_provider_mappings(
+        self,
+        track: Track,
+        minimum_confidence: TrackMatchConfidence = TrackMatchConfidence.LIKELY,
+        provider_instance_ids: set[str] | None = None,
+        trust_track_mappings: bool = True,
+        failed_provider_instances: set[str] | None = None,
+    ) -> TrackProviderEnrichment:
+        """
+        Resolve missing streaming-provider mappings without updating the library.
+
+        :param track: Provider track to enrich.
+        :param minimum_confidence: Lowest confidence that may be accepted.
+        :param provider_instance_ids: Provider instances available to the initiating user.
+        :param trust_track_mappings: Treat mappings attached to the source track as exact.
+        :param failed_provider_instances: Provider instances unavailable for the migration.
+        """
+        library_track = await self.get_library_match(track)
+        enriched_track = deepcopy(track)
+        if provider_instance_ids is not None:
+            enriched_track.provider_mappings = {
+                mapping
+                for mapping in enriched_track.provider_mappings
+                if mapping.provider_instance in provider_instance_ids and mapping.available
+            }
+        existing_domains = (
+            {
+                mapping.provider_domain
+                for mapping in enriched_track.provider_mappings
+                if mapping.available
+            }
+            if trust_track_mappings
+            else set()
+        )
+        base_album: Album | ItemMapping | None = None
+        base_album_loaded = False
+        matches: list[TrackProviderMatch] = []
+        ambiguous_providers: list[str] = []
+        failed_providers: list[str] = []
+        providers = (
+            [
+                provider
+                for provider_instance_id in sorted(provider_instance_ids)
+                if isinstance(
+                    provider := self.mass.get_provider(
+                        provider_instance_id,
+                        return_unavailable=True,
+                    ),
+                    MusicProvider,
+                )
+                and provider.instance_id == provider_instance_id
+                and provider.available
+            ]
+            if provider_instance_ids is not None
+            else self.mass.music.providers
+        )
+        mapping_source = library_track or track
+        for provider in providers:
+            if (
+                failed_provider_instances is not None
+                and provider.instance_id in failed_provider_instances
+            ):
+                continue
+            if provider.domain in existing_domains:
+                continue
+            if not provider.is_streaming_provider and not (
+                self._get_provider_mapping(mapping_source, provider)
+            ):
+                continue
+            if not base_album_loaded:
+                base_album = await self._get_full_track_album(track)
+                base_album_loaded = True
+            try:
+                result = await self.find_provider_match(
+                    track,
+                    provider,
+                    minimum_confidence=minimum_confidence,
+                    base_album=base_album,
+                    mapping_source=mapping_source,
+                    allowed_provider_instances=provider_instance_ids,
+                    trust_base_mapping=trust_track_mappings,
+                )
+            except (
+                ResourceTemporarilyUnavailable,
+                ProviderUnavailableError,
+                ClientError,
+                OSError,
+                TimeoutError,
+            ) as err:
+                if failed_provider_instances is not None:
+                    failed_provider_instances.add(provider.instance_id)
+                self.logger.warning(
+                    "Failed to match %s on provider %s: %s",
+                    track.name,
+                    provider.name,
+                    err,
+                )
+                failed_providers.append(provider.name)
+                continue
+            except (InvalidDataError, MediaNotFoundError) as err:
+                self.logger.warning(
+                    "Failed to match %s on provider %s: %s",
+                    track.name,
+                    provider.name,
+                    err,
+                )
+                failed_providers.append(provider.name)
+                continue
+            if result.match:
+                enriched_track.provider_mappings = {
+                    mapping
+                    for mapping in enriched_track.provider_mappings
+                    if mapping.provider_domain != provider.domain
+                    or (trust_track_mappings and mapping.available)
+                }
+                enriched_track.provider_mappings.add(result.match.mapping)
+                matches.append(result.match)
+                existing_domains.add(provider.domain)
+            elif result.ambiguous:
+                ambiguous_providers.append(provider.name)
+        return TrackProviderEnrichment(
+            track=enriched_track,
+            matches=tuple(matches),
+            ambiguous_providers=tuple(ambiguous_providers),
+            failed_providers=tuple(failed_providers),
+            used_library_item=library_track is not None,
+        )
+
     async def match_provider(
         self,
         base_track: Track,
@@ -701,6 +972,177 @@ class TracksController(MediaControllerBase[Track]):
                 # 100% match, we update the db with the additional provider mapping(s)
                 await self.add_provider_mappings(db_track.item_id, match)
                 processed_domains.add(provider.domain)
+
+    async def _search_provider_track_matches(
+        self,
+        base_track: Track,
+        provider: MusicProvider,
+        minimum_confidence: TrackMatchConfidence,
+        base_album: Album | ItemMapping | None,
+        allowed_provider_instances: set[str] | None,
+        allow_item_id_match: bool,
+        mapped_match: TrackProviderMatch | None,
+    ) -> list[tuple[int, TrackProviderMatch]]:
+        """Return ranked provider candidates, stopping when an exact match is found."""
+        search_queries = list(
+            dict.fromkeys(f"{artist.name} - {base_track.name}" for artist in base_track.artists)
+        )
+        candidates: list[tuple[int, TrackProviderMatch]] = (
+            [(0, mapped_match)] if mapped_match else []
+        )
+        seen_candidates: set[tuple[str, str]] = set()
+        for search_query in search_queries:
+            try:
+                search_results = await self.mass.music.search_provider(
+                    search_query,
+                    provider.instance_id,
+                    [MediaType.TRACK],
+                    limit=5,
+                    allowed_provider_instances=allowed_provider_instances,
+                )
+            except ResourceTemporarilyUnavailable:
+                if candidates:
+                    break
+                raise
+            for search_result in search_results.tracks:
+                if not isinstance(search_result, Track):
+                    continue
+                candidate_key = (search_result.provider, search_result.item_id)
+                if candidate_key in seen_candidates or not search_result.available:
+                    continue
+                seen_candidates.add(candidate_key)
+                if not compare_track_title(base_track.name, search_result.name):
+                    continue
+                if not compare_artists(
+                    base_track.artists,
+                    search_result.artists,
+                    any_match=True,
+                ):
+                    continue
+                try:
+                    candidate = await self.get_provider_item(
+                        search_result.item_id,
+                        provider.instance_id,
+                        allow_fallback=False,
+                        strict_provider_instance=True,
+                    )
+                except MediaNotFoundError:
+                    continue
+                except (
+                    ResourceTemporarilyUnavailable,
+                    ProviderUnavailableError,
+                    ClientError,
+                    OSError,
+                    TimeoutError,
+                ):
+                    if candidates:
+                        return candidates
+                    raise
+                confidence, base_album = await self._get_match_confidence(
+                    base_track,
+                    candidate,
+                    base_album,
+                    allow_item_id_match=allow_item_id_match,
+                )
+                if confidence < minimum_confidence:
+                    continue
+                if not (mapping := self._get_provider_mapping(candidate, provider)):
+                    continue
+                candidate_match = TrackProviderMatch(
+                    track=candidate,
+                    mapping=mapping,
+                    confidence=confidence,
+                )
+                candidates.append((len(candidates), candidate_match))
+                if confidence == TrackMatchConfidence.EXACT:
+                    return candidates
+        return candidates
+
+    async def _get_match_confidence(
+        self,
+        base_track: Track,
+        candidate: Track,
+        base_album: Album | ItemMapping | None,
+        *,
+        allow_item_id_match: bool = True,
+    ) -> tuple[TrackMatchConfidence, Album | ItemMapping | None]:
+        """Return candidate confidence with full album evidence when needed."""
+        confidence = compare_track_evidence(
+            base_track,
+            candidate,
+            base_album=base_album,
+            allow_item_id_match=allow_item_id_match,
+        )
+        if confidence == TrackMatchConfidence.EXACT:
+            return confidence, base_album
+        if base_album is None:
+            base_album = await self._get_full_track_album(base_track)
+        candidate_album = await self._get_full_track_album(candidate)
+        return (
+            compare_track_evidence(
+                base_track,
+                candidate,
+                base_album=base_album,
+                compare_album_item=candidate_album,
+                allow_item_id_match=allow_item_id_match,
+            ),
+            base_album,
+        )
+
+    @staticmethod
+    def _get_provider_mapping(track: Track, provider: MusicProvider) -> ProviderMapping | None:
+        """Return an available mapping suitable for the provider instance."""
+        domain_mapping: ProviderMapping | None = None
+        for mapping in sorted(track.provider_mappings, key=lambda item: item.quality, reverse=True):
+            if not mapping.available:
+                continue
+            if mapping.provider_instance == provider.instance_id:
+                return mapping
+            if (
+                mapping.provider_domain == provider.domain
+                and not mapping.is_unique
+                and domain_mapping is None
+            ):
+                domain_mapping = mapping
+        if domain_mapping is None:
+            return None
+        return replace(domain_mapping, provider_instance=provider.instance_id)
+
+    async def _get_full_track_album(self, track: Track) -> Album | ItemMapping | None:
+        """Return full album details when they are available."""
+        if not track.album or isinstance(track.album, Album):
+            return track.album
+        try:
+            return await self.mass.music.albums.get(
+                track.album.item_id,
+                track.album.provider,
+                allow_update_metadata=False,
+            )
+        except (
+            InvalidDataError,
+            MediaNotFoundError,
+            ProviderUnavailableError,
+            ResourceTemporarilyUnavailable,
+            ClientError,
+            OSError,
+            TimeoutError,
+        ) as err:
+            self.logger.debug(
+                "Could not load album details for track %s: %s",
+                track.name,
+                err,
+            )
+            return track.album
+
+    @staticmethod
+    def _matches_are_compatible(matches: list[TrackProviderMatch]) -> bool:
+        """Return whether tied loose matches identify the same recording."""
+        return all(
+            compare_track_evidence(base_match.track, compare_match.track)
+            >= TrackMatchConfidence.LIKELY
+            for index, base_match in enumerate(matches)
+            for compare_match in matches[index + 1 :]
+        )
 
     async def _add_library_item(self, item: Track, overwrite_existing: bool = False) -> int:
         """Add a new item record to the database."""

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1116,7 +1116,19 @@ class TracksController(MediaControllerBase[Track]):
     def _get_provider_mapping(track: Track, provider: MusicProvider) -> ProviderMapping | None:
         """Return an available mapping suitable for the provider instance."""
         domain_mapping: ProviderMapping | None = None
-        for mapping in sorted(track.provider_mappings, key=lambda item: item.quality, reverse=True):
+        # provider_mappings is a set, so its iteration order is not guaranteed stable
+        # across runs; tie-break equal-quality mappings by identity so the chosen
+        # mapping is deterministic instead of process-dependent
+        sorted_mappings = sorted(
+            track.provider_mappings,
+            key=lambda item: (
+                -item.quality,
+                item.provider_domain,
+                item.provider_instance,
+                item.item_id,
+            ),
+        )
+        for mapping in sorted_mappings:
             if not mapping.available:
                 continue
             if mapping.provider_instance == provider.instance_id:

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -992,7 +992,7 @@ class TracksController(MediaControllerBase[Track]):
         allow_item_id_match: bool,
         mapped_match: TrackProviderMatch | None,
     ) -> list[tuple[int, TrackProviderMatch]]:
-        """Return ranked provider candidates, stopping once a search page yields an exact match."""
+        """Return ranked provider candidates from every credited-artist search query."""
         search_queries = list(
             dict.fromkeys(f"{artist.name} - {base_track.name}" for artist in base_track.artists)
         )
@@ -1013,7 +1013,6 @@ class TracksController(MediaControllerBase[Track]):
                 if candidates:
                     break
                 raise
-            found_exact = False
             for search_result in search_results.tracks:
                 if not isinstance(search_result, Track):
                     continue
@@ -1067,13 +1066,6 @@ class TracksController(MediaControllerBase[Track]):
                     confidence=confidence,
                 )
                 candidates.append((len(candidates), candidate_match))
-                if confidence == TrackMatchConfidence.EXACT:
-                    # an already-fetched page may hold another, conflicting exact
-                    # candidate, so the remaining results are still worth checking;
-                    # only further (costlier) search queries are skipped from here
-                    found_exact = True
-            if found_exact:
-                break
         return candidates
 
     async def _get_match_confidence(

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -759,9 +759,10 @@ class TracksController(MediaControllerBase[Track]):
         best_matches = [
             (rank, match) for rank, match in candidates if match.confidence == best_confidence
         ]
-        if best_confidence == TrackMatchConfidence.LOOSE and not self._matches_are_compatible(
-            [match for _, match in best_matches]
-        ):
+        if not self._matches_are_compatible([match for _, match in best_matches]):
+            # missing source evidence (e.g. no explicitness tag) can let unrelated
+            # candidates tie at the same confidence - checked at every tier, not just
+            # LOOSE, since a quality tie-break would otherwise pick one arbitrarily
             return TrackProviderMatchResult(ambiguous=True)
         _, best_match = max(
             best_matches,
@@ -881,6 +882,13 @@ class TracksController(MediaControllerBase[Track]):
                 failed_providers.append(provider.name)
                 continue
             if result.match:
+                if matches and not self._matches_are_compatible([*matches, result.match]):
+                    # this provider's match is not the same recording as a match
+                    # already accepted from another provider (missing source evidence,
+                    # e.g. no explicitness tag, can let unrelated candidates tie) -
+                    # treat it as ambiguous instead of merging conflicting mappings
+                    ambiguous_providers.append(provider.name)
+                    continue
                 enriched_track.provider_mappings = {
                     mapping
                     for mapping in enriched_track.provider_mappings

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -81,6 +81,12 @@ class TrackProviderMatch:
     track: Track
     mapping: ProviderMapping
     confidence: TrackMatchConfidence
+    # the full hydrated album used to establish this candidate's own confidence,
+    # when album-level release evidence was needed for that; None if confidence
+    # was decided without hydrating an album (e.g. direct item-id/MB_TRACK match),
+    # so a later pairwise compatibility check reuses the same evidence rather than
+    # degrading to the track's raw, unhydrated album reference
+    album: Album | ItemMapping | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -742,7 +748,7 @@ class TracksController(MediaControllerBase[Track]):
                     # of aborting
                     mapped_candidate = None
             if mapped_candidate:
-                confidence, resolved_base_album = await self._get_match_confidence(
+                confidence, resolved_base_album, candidate_album = await self._get_match_confidence(
                     base_track,
                     mapped_candidate,
                     resolved_base_album,
@@ -759,6 +765,7 @@ class TracksController(MediaControllerBase[Track]):
                         track=mapped_candidate,
                         mapping=candidate_mapping,
                         confidence=confidence,
+                        album=candidate_album,
                     )
         if ProviderFeature.SEARCH not in provider.supported_features:
             return TrackProviderMatchResult(match=mapped_match)
@@ -1055,7 +1062,7 @@ class TracksController(MediaControllerBase[Track]):
                     # the caller reports this provider as failed rather than
                     # silently accepting an incomplete candidate set
                     raise
-                confidence, base_album = await self._get_match_confidence(
+                confidence, base_album, candidate_album = await self._get_match_confidence(
                     base_track,
                     candidate,
                     base_album,
@@ -1070,6 +1077,7 @@ class TracksController(MediaControllerBase[Track]):
                     track=candidate,
                     mapping=mapping,
                     confidence=confidence,
+                    album=candidate_album,
                 )
                 candidates.append((len(candidates), candidate_match))
         return candidates
@@ -1082,8 +1090,17 @@ class TracksController(MediaControllerBase[Track]):
         *,
         allow_item_id_match: bool = True,
         allowed_provider_instances: set[str] | None = None,
-    ) -> tuple[TrackMatchConfidence, Album | ItemMapping | None]:
-        """Return candidate confidence with full album evidence when needed."""
+    ) -> tuple[TrackMatchConfidence, Album | ItemMapping | None, Album | ItemMapping | None]:
+        """
+        Return candidate confidence with full album evidence when needed.
+
+        The returned candidate album is the hydrated album actually used to decide
+        the confidence, or ``None`` when no album evidence was needed for the
+        verdict (e.g. a direct item-id/MB_TRACK match) - callers that persist a
+        match should keep this value so a later re-comparison against a sibling
+        candidate reuses the same evidence instead of falling back to the track's
+        raw, unhydrated album reference.
+        """
         confidence = compare_track_evidence(
             base_track,
             candidate,
@@ -1091,7 +1108,7 @@ class TracksController(MediaControllerBase[Track]):
             allow_item_id_match=allow_item_id_match,
         )
         if confidence == TrackMatchConfidence.EXACT:
-            return confidence, base_album
+            return confidence, base_album, None
         if base_album is None:
             base_album = await self._get_full_track_album(
                 base_track, allowed_provider_instances=allowed_provider_instances
@@ -1108,6 +1125,7 @@ class TracksController(MediaControllerBase[Track]):
                 allow_item_id_match=allow_item_id_match,
             ),
             base_album,
+            candidate_album,
         )
 
     @staticmethod
@@ -1236,6 +1254,11 @@ class TracksController(MediaControllerBase[Track]):
         EXACT, since that would let the importer persist one candidate's release evidence
         while the Exact policy is free to later select a conflicting one. Lower tiers only
         require agreement at LIKELY, since that is already their "same recording" floor.
+
+        Each match's own hydrated album (when one was needed to establish its
+        confidence) is reused for this pairwise check, so two candidates that were
+        individually confirmed EXACT via release evidence do not degrade to a lower
+        tier here for lacking that same evidence against each other.
         """
         required = (
             TrackMatchConfidence.EXACT
@@ -1243,7 +1266,13 @@ class TracksController(MediaControllerBase[Track]):
             else TrackMatchConfidence.LIKELY
         )
         return all(
-            compare_track_evidence(base_match.track, compare_match.track) >= required
+            compare_track_evidence(
+                base_match.track,
+                compare_match.track,
+                base_album=base_match.album,
+                compare_album_item=compare_match.album,
+            )
+            >= required
             for index, base_match in enumerate(matches)
             for compare_match in matches[index + 1 :]
         )

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1256,6 +1256,7 @@ class TracksController(MediaControllerBase[Track]):
                 )
             except (
                 InvalidDataError,
+                InvalidProviderID,
                 MediaNotFoundError,
                 ProviderUnavailableError,
                 ResourceTemporarilyUnavailable,
@@ -1263,9 +1264,10 @@ class TracksController(MediaControllerBase[Track]):
                 OSError,
                 TimeoutError,
             ) as err:
-                # this candidate could not supply the album; a missing or unavailable
-                # account must not block a sibling instance of the same domain from
-                # still supplying the release evidence
+                # this candidate could not supply the album; a missing/unavailable
+                # account, or a malformed id (e.g. reconstructed from imported M3U
+                # metadata), must not block a sibling instance of the same domain
+                # from still supplying the release evidence
                 self.logger.debug(
                     "Could not load album details for track %s on %s: %s",
                     track.name,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -20,6 +20,7 @@ from music_assistant_models.enums import (
 )
 from music_assistant_models.errors import (
     InvalidDataError,
+    InvalidProviderID,
     MediaNotFoundError,
     MusicAssistantError,
     ProviderUnavailableError,
@@ -735,9 +736,10 @@ class TracksController(MediaControllerBase[Track]):
                         allow_fallback=False,
                         strict_provider_instance=True,
                     )
-                except MediaNotFoundError, InvalidDataError:
-                    # a stale mapping (deleted catalog id, unreadable stream) is not
-                    # fatal - fall through to a fresh search below instead of aborting
+                except MediaNotFoundError, InvalidDataError, InvalidProviderID:
+                    # a stale mapping (deleted catalog id, unreadable stream, malformed
+                    # id) is not fatal - fall through to a fresh search below instead
+                    # of aborting
                     mapped_candidate = None
             if mapped_candidate:
                 confidence, resolved_base_album = await self._get_match_confidence(
@@ -1015,7 +1017,7 @@ class TracksController(MediaControllerBase[Track]):
                         allow_fallback=False,
                         strict_provider_instance=True,
                     )
-                except MediaNotFoundError, InvalidDataError:
+                except MediaNotFoundError, InvalidDataError, InvalidProviderID:
                     # this hydrated search result is unusable - skip it, other
                     # candidates from this same search are still worth trying
                     continue
@@ -1109,9 +1111,14 @@ class TracksController(MediaControllerBase[Track]):
                 continue
             if mapping.provider_instance == provider.instance_id:
                 return mapping
+            # is_unique=None means "use the provider's default", and non-streaming
+            # providers (e.g. filesystem) default to instance-unique - mirror that
+            # same effective-uniqueness rule here, or a falsy-but-unset value could
+            # wrongly expand an instance-unique mapping across a different instance
+            effective_is_unique = mapping.is_unique or not provider.is_streaming_provider
             if (
                 mapping.provider_domain == provider.domain
-                and not mapping.is_unique
+                and not effective_is_unique
                 and domain_mapping is None
             ):
                 domain_mapping = mapping

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -775,6 +775,7 @@ class TracksController(MediaControllerBase[Track]):
             allowed_provider_instances,
             trust_base_mapping,
             mapped_match,
+            known_dead_mappings,
         )
 
         if not candidates:
@@ -986,8 +987,15 @@ class TracksController(MediaControllerBase[Track]):
         allowed_provider_instances: set[str] | None,
         allow_item_id_match: bool,
         mapped_match: TrackProviderMatch | None,
+        known_dead_mappings: frozenset[tuple[str, str]] | None = None,
     ) -> list[tuple[int, TrackProviderMatch]]:
-        """Return ranked provider candidates from every credited-artist search query."""
+        """
+        Return ranked provider candidates from every credited-artist search query.
+
+        :param known_dead_mappings: ``(instance_id, item_id)`` pairs a caller has
+            already authoritatively confirmed unresolvable, skipped here even if a
+            search result happens to hydrate the same pair from provider caches.
+        """
         search_queries = list(
             dict.fromkeys(f"{artist.name} - {base_track.name}" for artist in base_track.artists)
         )
@@ -1015,6 +1023,11 @@ class TracksController(MediaControllerBase[Track]):
                 if candidate_key in seen_candidates or not search_result.available:
                     continue
                 seen_candidates.add(candidate_key)
+                if known_dead_mappings and candidate_key in known_dead_mappings:
+                    # a caller already authoritatively confirmed this exact
+                    # (instance, item id) pair dead moments ago - a stale cached
+                    # hit here must not resurrect it as a confident substitute
+                    continue
                 if not compare_track_title(base_track.name, search_result.name):
                     continue
                 try:

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -889,13 +889,16 @@ class TracksController(MediaControllerBase[Track]):
                 failed_providers.append(provider.name)
                 continue
             if result.match:
-                # defer accept/reject until every provider has been queried, so a
-                # conflict is resolved by confidence rather than by which provider
-                # happened to be visited first
+                # defer accept/reject until every allowed instance has been queried, so
+                # a conflict (including between two instances of the same domain) is
+                # resolved by confidence rather than by which one was visited first
                 provider_matches.append((provider, result.match))
-                existing_domains.add(provider.domain)
             elif result.ambiguous:
                 ambiguous_providers.append(provider.name)
+        provider_matches, domain_ambiguous_providers = self._select_best_match_per_domain(
+            provider_matches
+        )
+        ambiguous_providers.extend(domain_ambiguous_providers)
         accepted, tier_ambiguous_providers = self._resolve_confident_matches(provider_matches)
         ambiguous_providers.extend(tier_ambiguous_providers)
         for provider, match in accepted:
@@ -1184,6 +1187,34 @@ class TracksController(MediaControllerBase[Track]):
             for index, base_match in enumerate(matches)
             for compare_match in matches[index + 1 :]
         )
+
+    def _select_best_match_per_domain(
+        self, provider_matches: list[tuple[MusicProvider, TrackProviderMatch]]
+    ) -> tuple[list[tuple[MusicProvider, TrackProviderMatch]], list[str]]:
+        """
+        Reduce matches from multiple instances of the same provider domain to one.
+
+        Evaluating every allowed instance can surface more than one acceptable match for
+        the same domain (e.g. two personal accounts on the same service), but only one
+        mapping can be stored per domain. The highest-confidence match is kept; tied
+        top-confidence candidates that disagree with each other are reported as
+        ambiguous instead of picked arbitrarily by instance order.
+        """
+        best: list[tuple[MusicProvider, TrackProviderMatch]] = []
+        ambiguous_providers: list[str] = []
+        for _, domain_iter in groupby(
+            sorted(provider_matches, key=lambda pm: pm[0].domain), key=lambda pm: pm[0].domain
+        ):
+            domain_matches = list(domain_iter)
+            best_confidence = max(match.confidence for _, match in domain_matches)
+            top_tier = [pm for pm in domain_matches if pm[1].confidence == best_confidence]
+            if len(top_tier) > 1 and not self._matches_are_compatible(
+                [match for _, match in top_tier]
+            ):
+                ambiguous_providers.extend(provider.name for provider, _ in top_tier)
+                continue
+            best.append(top_tier[0])
+        return best, ambiguous_providers
 
     def _resolve_confident_matches(
         self, provider_matches: list[tuple[MusicProvider, TrackProviderMatch]]

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -738,8 +738,6 @@ class TracksController(MediaControllerBase[Track]):
                         mapping=candidate_mapping,
                         confidence=confidence,
                     )
-                    if confidence == TrackMatchConfidence.EXACT:
-                        return TrackProviderMatchResult(match=mapped_match)
         if ProviderFeature.SEARCH not in provider.supported_features:
             return TrackProviderMatchResult(match=mapped_match)
         if MediaType.TRACK not in provider.supported_media_types:
@@ -816,23 +814,8 @@ class TracksController(MediaControllerBase[Track]):
         matches: list[TrackProviderMatch] = []
         provider_matches: list[tuple[MusicProvider, TrackProviderMatch]] = []
         ambiguous_providers: list[str] = []
-        failed_providers: list[str] = []
-        providers = (
-            [
-                provider
-                for provider_instance_id in sorted(provider_instance_ids)
-                if isinstance(
-                    provider := self.mass.get_provider(
-                        provider_instance_id,
-                        return_unavailable=True,
-                    ),
-                    MusicProvider,
-                )
-                and provider.instance_id == provider_instance_id
-                and provider.available
-            ]
-            if provider_instance_ids is not None
-            else self.mass.music.providers
+        providers, failed_providers = self._resolve_allowed_providers(
+            provider_instance_ids, failed_provider_instances
         )
         mapping_source = library_track or track
         for provider in providers:
@@ -1001,7 +984,7 @@ class TracksController(MediaControllerBase[Track]):
         allow_item_id_match: bool,
         mapped_match: TrackProviderMatch | None,
     ) -> list[tuple[int, TrackProviderMatch]]:
-        """Return ranked provider candidates, stopping when an exact match is found."""
+        """Return ranked provider candidates, stopping once a search page yields an exact match."""
         search_queries = list(
             dict.fromkeys(f"{artist.name} - {base_track.name}" for artist in base_track.artists)
         )
@@ -1022,6 +1005,7 @@ class TracksController(MediaControllerBase[Track]):
                 if candidates:
                     break
                 raise
+            found_exact = False
             for search_result in search_results.tracks:
                 if not isinstance(search_result, Track):
                     continue
@@ -1076,7 +1060,12 @@ class TracksController(MediaControllerBase[Track]):
                 )
                 candidates.append((len(candidates), candidate_match))
                 if confidence == TrackMatchConfidence.EXACT:
-                    return candidates
+                    # an already-fetched page may hold another, conflicting exact
+                    # candidate, so the remaining results are still worth checking;
+                    # only further (costlier) search queries are skipped from here
+                    found_exact = True
+            if found_exact:
+                break
         return candidates
 
     async def _get_match_confidence(
@@ -1247,6 +1236,46 @@ class TracksController(MediaControllerBase[Track]):
                 continue
             accepted.extend(tier)
         return accepted, ambiguous_providers
+
+    def _resolve_allowed_providers(
+        self,
+        provider_instance_ids: set[str] | None,
+        failed_provider_instances: set[str] | None,
+    ) -> tuple[list[MusicProvider], list[str]]:
+        """
+        Return the providers to query and any allowed instance that cannot be queried.
+
+        :param provider_instance_ids: Provider instances available to the initiating user,
+            or ``None`` to query every loaded provider.
+        :param failed_provider_instances: Provider instances to skip as already failed,
+            updated in place with any instance found unavailable here.
+        """
+        if provider_instance_ids is None:
+            return list(self.mass.music.providers), []
+        providers: list[MusicProvider] = []
+        failed_providers: list[str] = []
+        for provider_instance_id in sorted(provider_instance_ids):
+            if (
+                failed_provider_instances is not None
+                and provider_instance_id in failed_provider_instances
+            ):
+                continue
+            candidate = self.mass.get_provider(provider_instance_id, return_unavailable=True)
+            if not (
+                isinstance(candidate, MusicProvider)
+                and candidate.instance_id == provider_instance_id
+            ):
+                continue
+            if not candidate.available:
+                # allowed but currently unreachable - report it so a caller building a
+                # report can retry, instead of silently treating this as "no candidates
+                # found" for the rest of the pass
+                if failed_provider_instances is not None:
+                    failed_provider_instances.add(candidate.instance_id)
+                failed_providers.append(candidate.name)
+                continue
+            providers.append(candidate)
+        return providers, failed_providers
 
     async def _add_library_item(self, item: Track, overwrite_existing: bool = False) -> int:
         """Add a new item record to the database."""

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1288,6 +1288,12 @@ class TracksController(MediaControllerBase[Track]):
                 isinstance(candidate, MusicProvider)
                 and candidate.instance_id == provider_instance_id
             ):
+                # the instance has fully unloaded (no provider object left at all) -
+                # report it as failed too, using its instance id as display name,
+                # instead of silently dropping it and letting callers retry it forever
+                if failed_provider_instances is not None:
+                    failed_provider_instances.add(provider_instance_id)
+                failed_providers.append(provider_instance_id)
                 continue
             if not candidate.available:
                 # allowed but currently unreachable - report it so a caller building a

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1162,7 +1162,11 @@ class TracksController(MediaControllerBase[Track]):
             provider = self.mass.get_provider(
                 provider_instance_id_or_domain, return_unavailable=True
             )
-            if provider is not None and provider.instance_id in allowed_provider_instances:
+            if (
+                provider is not None
+                and provider.instance_id == provider_instance_id_or_domain
+                and provider.instance_id in allowed_provider_instances
+            ):
                 candidate_instances = [provider.instance_id]
             else:
                 # a bare domain resolves to its first registered instance, which may
@@ -1267,7 +1271,10 @@ class TracksController(MediaControllerBase[Track]):
         provider was visited first, and rejects a whole confidence tier as
         ambiguous when its own candidates disagree with each other - missing
         source evidence (e.g. no explicitness tag) can otherwise let unrelated
-        recordings tie and get merged or picked arbitrarily.
+        recordings tie and get merged or picked arbitrarily. Resolution stops at
+        the first ambiguous tier: once the strongest remaining evidence can't be
+        told apart, a weaker tier can't settle that disagreement either, so it
+        would be wrong to quietly substitute it in as if it were the answer.
         """
         accepted: list[tuple[MusicProvider, TrackProviderMatch]] = []
         ambiguous_providers: list[str] = []
@@ -1284,7 +1291,7 @@ class TracksController(MediaControllerBase[Track]):
                 )
             ):
                 ambiguous_providers.extend(provider.name for provider, _ in tier)
-                continue
+                break
             accepted.extend(tier)
         return accepted, ambiguous_providers
 

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
+from itertools import groupby
 from typing import TYPE_CHECKING, Any, Never, cast
 
 from aiohttp import ClientError
@@ -722,6 +723,7 @@ class TracksController(MediaControllerBase[Track]):
                     mapped_candidate,
                     resolved_base_album,
                     allow_item_id_match=trust_base_mapping,
+                    allowed_provider_instances=allowed_provider_instances,
                 )
                 if confidence >= minimum_confidence and (
                     candidate_mapping := self._get_provider_mapping(
@@ -844,7 +846,9 @@ class TracksController(MediaControllerBase[Track]):
             ):
                 continue
             if not base_album_loaded:
-                base_album = await self._get_full_track_album(track)
+                base_album = await self._get_full_track_album(
+                    track, allowed_provider_instances=provider_instance_ids
+                )
                 base_album_loaded = True
             try:
                 result = await self.find_provider_match(
@@ -890,16 +894,9 @@ class TracksController(MediaControllerBase[Track]):
                 existing_domains.add(provider.domain)
             elif result.ambiguous:
                 ambiguous_providers.append(provider.name)
-        # resolve highest-confidence candidates first, so a stronger match from a
-        # later provider is preferred over a weaker one that was found earlier -
-        # missing source evidence (e.g. no explicitness tag) can otherwise let
-        # unrelated recordings tie and get merged or picked in visitation order
-        for provider, match in sorted(
-            provider_matches, key=lambda pm: pm[1].confidence, reverse=True
-        ):
-            if matches and not self._matches_are_compatible([*matches, match]):
-                ambiguous_providers.append(provider.name)
-                continue
+        accepted, tier_ambiguous_providers = self._resolve_confident_matches(provider_matches)
+        ambiguous_providers.extend(tier_ambiguous_providers)
+        for provider, match in accepted:
             enriched_track.provider_mappings = {
                 mapping
                 for mapping in enriched_track.provider_mappings
@@ -1059,6 +1056,7 @@ class TracksController(MediaControllerBase[Track]):
                     candidate,
                     base_album,
                     allow_item_id_match=allow_item_id_match,
+                    allowed_provider_instances=allowed_provider_instances,
                 )
                 if confidence < minimum_confidence:
                     continue
@@ -1081,6 +1079,7 @@ class TracksController(MediaControllerBase[Track]):
         base_album: Album | ItemMapping | None,
         *,
         allow_item_id_match: bool = True,
+        allowed_provider_instances: set[str] | None = None,
     ) -> tuple[TrackMatchConfidence, Album | ItemMapping | None]:
         """Return candidate confidence with full album evidence when needed."""
         confidence = compare_track_evidence(
@@ -1092,8 +1091,12 @@ class TracksController(MediaControllerBase[Track]):
         if confidence == TrackMatchConfidence.EXACT:
             return confidence, base_album
         if base_album is None:
-            base_album = await self._get_full_track_album(base_track)
-        candidate_album = await self._get_full_track_album(candidate)
+            base_album = await self._get_full_track_album(
+                base_track, allowed_provider_instances=allowed_provider_instances
+            )
+        candidate_album = await self._get_full_track_album(
+            candidate, allowed_provider_instances=allowed_provider_instances
+        )
         return (
             compare_track_evidence(
                 base_track,
@@ -1124,14 +1127,32 @@ class TracksController(MediaControllerBase[Track]):
             return None
         return replace(domain_mapping, provider_instance=provider.instance_id)
 
-    async def _get_full_track_album(self, track: Track) -> Album | ItemMapping | None:
-        """Return full album details when they are available."""
+    async def _get_full_track_album(
+        self, track: Track, allowed_provider_instances: set[str] | None = None
+    ) -> Album | ItemMapping | None:
+        """
+        Return full album details when they are available.
+
+        :param track: Track whose album should be hydrated.
+        :param allowed_provider_instances: Provider instances available to the
+            initiating user. When set, an album on a domain that resolves outside
+            this set is left as the unhydrated mapping instead of being fetched.
+        """
         if not track.album or isinstance(track.album, Album):
             return track.album
+        provider_instance_id_or_domain = track.album.provider
+        if allowed_provider_instances is not None and provider_instance_id_or_domain != "library":
+            provider = self.mass.get_provider(
+                provider_instance_id_or_domain, return_unavailable=True
+            )
+            if provider is None or provider.instance_id not in allowed_provider_instances:
+                # can't verify this account is one the initiating user has access to
+                return track.album
+            provider_instance_id_or_domain = provider.instance_id
         try:
             return await self.mass.music.albums.get(
                 track.album.item_id,
-                track.album.provider,
+                provider_instance_id_or_domain,
                 allow_update_metadata=False,
             )
         except (
@@ -1159,6 +1180,38 @@ class TracksController(MediaControllerBase[Track]):
             for index, base_match in enumerate(matches)
             for compare_match in matches[index + 1 :]
         )
+
+    def _resolve_confident_matches(
+        self, provider_matches: list[tuple[MusicProvider, TrackProviderMatch]]
+    ) -> tuple[list[tuple[MusicProvider, TrackProviderMatch]], list[str]]:
+        """
+        Accept provider matches confidence tier by confidence tier.
+
+        Resolves the highest-confidence candidates first, so a stronger match is
+        preferred over a weaker one that conflicts with it regardless of which
+        provider was visited first, and rejects a whole confidence tier as
+        ambiguous when its own candidates disagree with each other - missing
+        source evidence (e.g. no explicitness tag) can otherwise let unrelated
+        recordings tie and get merged or picked arbitrarily.
+        """
+        accepted: list[tuple[MusicProvider, TrackProviderMatch]] = []
+        ambiguous_providers: list[str] = []
+        for _, tier_iter in groupby(
+            sorted(provider_matches, key=lambda pm: pm[1].confidence, reverse=True),
+            key=lambda pm: pm[1].confidence,
+        ):
+            tier = list(tier_iter)
+            tier_matches = [match for _, match in tier]
+            if not self._matches_are_compatible(tier_matches) or (
+                accepted
+                and not self._matches_are_compatible(
+                    [*(match for _, match in accepted), *tier_matches]
+                )
+            ):
+                ambiguous_providers.extend(provider.name for provider, _ in tier)
+                continue
+            accepted.extend(tier)
+        return accepted, ambiguous_providers
 
     async def _add_library_item(self, item: Track, overwrite_existing: bool = False) -> int:
         """Add a new item record to the database."""

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1309,6 +1309,10 @@ class TracksController(MediaControllerBase[Track]):
                 failed_provider_instances is not None
                 and provider_instance_id in failed_provider_instances
             ):
+                # already confirmed failed for an earlier entry in this pass - report it
+                # again here too, so a caller building a report attributes every entry
+                # this instance was skipped for, not just the one that first found it down
+                failed_providers.append(provider_instance_id)
                 continue
             candidate = self.mass.get_provider(provider_instance_id, return_unavailable=True)
             if not (

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -806,9 +806,10 @@ class TracksController(MediaControllerBase[Track]):
         failed_provider_instances: set[str] | None = None,
         evidence_provider_instances: set[str] | None = None,
         known_dead_mappings: frozenset[tuple[str, str]] | None = None,
+        search_non_streaming_without_mapping: bool = False,
     ) -> TrackProviderEnrichment:
         """
-        Resolve missing streaming-provider mappings without updating the library.
+        Resolve missing provider mappings without updating the library.
 
         :param track: Provider track to enrich.
         :param minimum_confidence: Lowest confidence that may be accepted.
@@ -822,6 +823,11 @@ class TracksController(MediaControllerBase[Track]):
             from.
         :param known_dead_mappings: ``(instance_id, item_id)`` pairs a caller has already
             authoritatively confirmed unresolvable, so they are not hydrated again here.
+        :param search_non_streaming_without_mapping: Search a non-streaming provider (e.g.
+            filesystem) even without a pre-existing mapping to it. Only safe when
+            ``provider_instance_ids`` is the caller's own deliberate, explicit selection of
+            match targets - otherwise a non-streaming provider is only ever confirmed
+            through a mapping it already carries, never blindly searched.
         """
         library_track = await self.get_library_match(track)
         enriched_track = deepcopy(track)
@@ -861,6 +867,7 @@ class TracksController(MediaControllerBase[Track]):
             failed_provider_instances=failed_provider_instances,
             failed_providers=failed_providers,
             known_dead_mappings=known_dead_mappings,
+            search_non_streaming_without_mapping=search_non_streaming_without_mapping,
         )
         (
             provider_matches,
@@ -1311,7 +1318,7 @@ class TracksController(MediaControllerBase[Track]):
             accepted.extend(tier)
         return accepted, ambiguous_providers
 
-    async def _query_provider_matches(
+    async def _query_provider_matches(  # noqa: PLR0913
         self,
         track: Track,
         providers: list[MusicProvider],
@@ -1323,6 +1330,7 @@ class TracksController(MediaControllerBase[Track]):
         failed_provider_instances: set[str] | None,
         failed_providers: list[str],
         known_dead_mappings: frozenset[tuple[str, str]] | None = None,
+        search_non_streaming_without_mapping: bool = False,
     ) -> tuple[
         list[tuple[MusicProvider, TrackProviderMatch]], list[str], TrackMatchConfidence | None
     ]:
@@ -1350,8 +1358,10 @@ class TracksController(MediaControllerBase[Track]):
                 continue
             if provider.domain in existing_domains:
                 continue
-            if not provider.is_streaming_provider and not (
-                self._get_provider_mapping(mapping_source, provider)
+            if (
+                not provider.is_streaming_provider
+                and not search_non_streaming_without_mapping
+                and not self._get_provider_mapping(mapping_source, provider)
             ):
                 continue
             if not base_album_loaded:

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -782,15 +782,21 @@ class TracksController(MediaControllerBase[Track]):
         provider_instance_ids: set[str] | None = None,
         trust_track_mappings: bool = True,
         failed_provider_instances: set[str] | None = None,
+        evidence_provider_instances: set[str] | None = None,
     ) -> TrackProviderEnrichment:
         """
         Resolve missing streaming-provider mappings without updating the library.
 
         :param track: Provider track to enrich.
         :param minimum_confidence: Lowest confidence that may be accepted.
-        :param provider_instance_ids: Provider instances available to the initiating user.
+        :param provider_instance_ids: Provider instances to search for a match.
         :param trust_track_mappings: Treat mappings attached to the source track as exact.
         :param failed_provider_instances: Provider instances unavailable for the migration.
+        :param evidence_provider_instances: Provider instances available to the initiating
+            user, for authorizing release-evidence album hydration. Defaults to
+            ``provider_instance_ids`` when not given separately, so a narrower search scope
+            never also narrows which of the user's own accounts evidence may be hydrated
+            from.
         """
         library_track = await self.get_library_match(track)
         enriched_track = deepcopy(track)
@@ -809,6 +815,8 @@ class TracksController(MediaControllerBase[Track]):
             if trust_track_mappings
             else set()
         )
+        if evidence_provider_instances is None:
+            evidence_provider_instances = provider_instance_ids
         base_album: Album | ItemMapping | None = None
         base_album_loaded = False
         matches: list[TrackProviderMatch] = []
@@ -832,7 +840,7 @@ class TracksController(MediaControllerBase[Track]):
                 continue
             if not base_album_loaded:
                 base_album = await self._get_full_track_album(
-                    track, allowed_provider_instances=provider_instance_ids
+                    track, allowed_provider_instances=evidence_provider_instances
                 )
                 base_album_loaded = True
             try:
@@ -842,7 +850,7 @@ class TracksController(MediaControllerBase[Track]):
                     minimum_confidence=minimum_confidence,
                     base_album=base_album,
                     mapping_source=mapping_source,
-                    allowed_provider_instances=provider_instance_ids,
+                    allowed_provider_instances=evidence_provider_instances,
                     trust_base_mapping=trust_track_mappings,
                 )
             except (

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -766,7 +766,7 @@ class TracksController(MediaControllerBase[Track]):
         best_matches = [
             (rank, match) for rank, match in candidates if match.confidence == best_confidence
         ]
-        if not self._matches_are_compatible([match for _, match in best_matches]):
+        if not self._matches_are_compatible([match for _, match in best_matches], best_confidence):
             # missing source evidence (e.g. no explicitness tag) can let unrelated
             # candidates tie at the same confidence - checked at every tier, not just
             # LOOSE, since a quality tie-break would otherwise pick one arbitrarily
@@ -1219,11 +1219,25 @@ class TracksController(MediaControllerBase[Track]):
         return track.album
 
     @staticmethod
-    def _matches_are_compatible(matches: list[TrackProviderMatch]) -> bool:
-        """Return whether tied loose matches identify the same recording."""
+    def _matches_are_compatible(
+        matches: list[TrackProviderMatch], tier: TrackMatchConfidence
+    ) -> bool:
+        """
+        Return whether tied matches at the given confidence tier identify the same release.
+
+        An EXACT tier requires every pair to compare as EXACT: a looser recording-level
+        agreement (e.g. matching ISRC but a different MB_TRACK/release) must not tie at
+        EXACT, since that would let the importer persist one candidate's release evidence
+        while the Exact policy is free to later select a conflicting one. Lower tiers only
+        require agreement at LIKELY, since that is already their "same recording" floor.
+        """
+        required = (
+            TrackMatchConfidence.EXACT
+            if tier is TrackMatchConfidence.EXACT
+            else TrackMatchConfidence.LIKELY
+        )
         return all(
-            compare_track_evidence(base_match.track, compare_match.track)
-            >= TrackMatchConfidence.LIKELY
+            compare_track_evidence(base_match.track, compare_match.track) >= required
             for index, base_match in enumerate(matches)
             for compare_match in matches[index + 1 :]
         )
@@ -1250,7 +1264,7 @@ class TracksController(MediaControllerBase[Track]):
             best_confidence = max(match.confidence for _, match in domain_matches)
             top_tier = [pm for pm in domain_matches if pm[1].confidence == best_confidence]
             if len(top_tier) > 1 and not self._matches_are_compatible(
-                [match for _, match in top_tier]
+                [match for _, match in top_tier], best_confidence
             ):
                 ambiguous_providers.extend(provider.name for provider, _ in top_tier)
                 continue
@@ -1275,16 +1289,16 @@ class TracksController(MediaControllerBase[Track]):
         """
         accepted: list[tuple[MusicProvider, TrackProviderMatch]] = []
         ambiguous_providers: list[str] = []
-        for _, tier_iter in groupby(
+        for tier_confidence, tier_iter in groupby(
             sorted(provider_matches, key=lambda pm: pm[1].confidence, reverse=True),
             key=lambda pm: pm[1].confidence,
         ):
             tier = list(tier_iter)
             tier_matches = [match for _, match in tier]
-            if not self._matches_are_compatible(tier_matches) or (
+            if not self._matches_are_compatible(tier_matches, tier_confidence) or (
                 accepted
                 and not self._matches_are_compatible(
-                    [*(match for _, match in accepted), *tier_matches]
+                    [*(match for _, match in accepted), *tier_matches], tier_confidence
                 )
             ):
                 ambiguous_providers.extend(provider.name for provider, _ in tier)

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -712,6 +712,11 @@ class TracksController(MediaControllerBase[Track]):
                 mapped_candidate = await self.get_provider_item(
                     mapping.item_id,
                     provider.instance_id,
+                    # an untrusted mapping (trust_base_mapping=False) may have just been
+                    # proven dead by an authoritative caller-side probe - a cached hit
+                    # here must not resurrect it as a confident match, so bypass the
+                    # provider cache the same way that probe did
+                    force_refresh=not trust_base_mapping,
                     allow_fallback=False,
                     strict_provider_instance=True,
                 )

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1187,7 +1187,8 @@ class TracksController(MediaControllerBase[Track]):
         the same domain (e.g. two personal accounts on the same service), but only one
         mapping can be stored per domain. The highest-confidence match is kept; tied
         top-confidence candidates that disagree with each other are reported as
-        ambiguous instead of picked arbitrarily by instance order.
+        ambiguous, and compatible ties are resolved by mapping quality rather than
+        picked arbitrarily by instance order.
         """
         best: list[tuple[MusicProvider, TrackProviderMatch]] = []
         ambiguous_providers: list[str] = []
@@ -1202,7 +1203,7 @@ class TracksController(MediaControllerBase[Track]):
             ):
                 ambiguous_providers.extend(provider.name for provider, _ in top_tier)
                 continue
-            best.append(top_tier[0])
+            best.append(max(top_tier, key=lambda pm: pm[1].mapping.quality))
         return best, ambiguous_providers
 
     def _resolve_confident_matches(

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1185,10 +1185,17 @@ class TracksController(MediaControllerBase[Track]):
                     return track.album
         for candidate_instance in candidate_instances:
             try:
-                return await self.mass.music.albums.get(
+                if library_item := await self.mass.music.albums.get_library_item_by_prov_id(
+                    track.album.item_id, candidate_instance
+                ):
+                    # prefer the library's own copy over a fresh provider fetch,
+                    # matching the library-first preference of the shared get()
+                    return library_item
+                return await self.mass.music.albums.get_provider_item(
                     track.album.item_id,
                     candidate_instance,
-                    allow_update_metadata=False,
+                    allow_fallback=False,
+                    strict_provider_instance=True,
                 )
             except (
                 InvalidDataError,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1164,6 +1164,30 @@ class TracksController(MediaControllerBase[Track]):
             return None
         return replace(domain_mapping, provider_instance=provider.instance_id)
 
+    def _domain_is_streaming(self, domain: str, allowed_provider_instances: set[str]) -> bool:
+        """
+        Return whether providers of this domain share a single portable catalog.
+
+        Every instance of a domain shares the same provider class and therefore the
+        same ``is_streaming_provider`` trait, so any one allowed instance of it is
+        representative. Defaults to ``False`` when no instance of this domain can be
+        resolved at all - unlike liveness checks elsewhere, this gates whether a
+        sibling instance's album is trusted as release evidence, so an unresolvable
+        domain must not be assumed portable.
+
+        :param domain: The provider domain to check.
+        :param allowed_provider_instances: Instance ids to search for a representative
+            instance of this domain.
+        """
+        for allowed_id in allowed_provider_instances:
+            if (
+                allowed_provider := self.mass.get_provider(
+                    allowed_id, return_unavailable=True, provider_type=MusicProvider
+                )
+            ) and allowed_provider.domain == domain:
+                return allowed_provider.is_streaming_provider
+        return False
+
     async def _get_full_track_album(
         self, track: Track, allowed_provider_instances: set[str] | None = None
     ) -> Album | ItemMapping | None:
@@ -1193,18 +1217,26 @@ class TracksController(MediaControllerBase[Track]):
                 # a bare domain resolves to its first registered instance, which may
                 # not be the one this user is allowed to use even though a sibling
                 # instance of the same domain is; try every allowed instance of that
-                # domain instead of giving up on that single, arbitrary first match
+                # domain instead of giving up on that single, arbitrary first match -
+                # but only for a genuinely portable (streaming) catalog, since a
+                # non-streaming domain (e.g. filesystem) mints its own local ids per
+                # instance and a sibling's coincidentally-matching id would supply
+                # false release evidence for an unrelated album
                 domain = provider.domain if provider is not None else provider_instance_id_or_domain
-                candidate_instances = [
-                    allowed_provider.instance_id
-                    for allowed_id in sorted(allowed_provider_instances)
-                    if (
-                        allowed_provider := self.mass.get_provider(
-                            allowed_id, return_unavailable=True
+                candidate_instances = (
+                    [
+                        allowed_provider.instance_id
+                        for allowed_id in sorted(allowed_provider_instances)
+                        if (
+                            allowed_provider := self.mass.get_provider(
+                                allowed_id, return_unavailable=True
+                            )
                         )
-                    )
-                    and allowed_provider.domain == domain
-                ]
+                        and allowed_provider.domain == domain
+                    ]
+                    if self._domain_is_streaming(domain, allowed_provider_instances)
+                    else []
+                )
                 if not candidate_instances:
                     # can't verify this account is one the initiating user has access to
                     return track.album

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -860,10 +860,20 @@ class TracksController(MediaControllerBase[Track]):
             failed_providers=failed_providers,
             known_dead_mappings=known_dead_mappings,
         )
-        provider_matches, domain_ambiguous_providers = self._select_best_match_per_domain(
-            provider_matches
-        )
+        (
+            provider_matches,
+            domain_ambiguous_providers,
+            domain_ambiguous_confidence,
+        ) = self._select_best_match_per_domain(provider_matches)
         ambiguous_providers.extend(domain_ambiguous_providers)
+        if domain_ambiguous_confidence is not None and (
+            ambiguous_confidence is None or domain_ambiguous_confidence > ambiguous_confidence
+        ):
+            # a same-domain tie that could not be resolved (e.g. two personal
+            # accounts disagreeing) is evidence just as unresolved as a cross-provider
+            # tie - a weaker tier from another provider must not be quietly accepted
+            # over it either
+            ambiguous_confidence = domain_ambiguous_confidence
         accepted, tier_ambiguous_providers = self._resolve_confident_matches(
             provider_matches, unresolved_confidence=ambiguous_confidence
         )
@@ -1209,7 +1219,9 @@ class TracksController(MediaControllerBase[Track]):
 
     def _select_best_match_per_domain(
         self, provider_matches: list[tuple[MusicProvider, TrackProviderMatch]]
-    ) -> tuple[list[tuple[MusicProvider, TrackProviderMatch]], list[str]]:
+    ) -> tuple[
+        list[tuple[MusicProvider, TrackProviderMatch]], list[str], TrackMatchConfidence | None
+    ]:
         """
         Reduce matches from multiple instances of the same provider domain to one.
 
@@ -1218,10 +1230,14 @@ class TracksController(MediaControllerBase[Track]):
         mapping can be stored per domain. The highest-confidence match is kept; tied
         top-confidence candidates that disagree with each other are reported as
         ambiguous, and compatible ties are resolved by mapping quality rather than
-        picked arbitrarily by instance order.
+        picked arbitrarily by instance order. The highest confidence tier discarded to
+        an unresolved same-domain tie is also returned, so a caller combining this with
+        cross-provider ambiguity does not let a weaker tier from another domain be
+        quietly accepted over evidence that is itself unresolved at a higher tier.
         """
         best: list[tuple[MusicProvider, TrackProviderMatch]] = []
         ambiguous_providers: list[str] = []
+        ambiguous_confidence: TrackMatchConfidence | None = None
         for _, domain_iter in groupby(
             sorted(provider_matches, key=lambda pm: pm[0].domain), key=lambda pm: pm[0].domain
         ):
@@ -1232,9 +1248,11 @@ class TracksController(MediaControllerBase[Track]):
                 [match for _, match in top_tier], best_confidence
             ):
                 ambiguous_providers.extend(provider.name for provider, _ in top_tier)
+                if ambiguous_confidence is None or best_confidence > ambiguous_confidence:
+                    ambiguous_confidence = best_confidence
                 continue
             best.append(max(top_tier, key=lambda pm: pm[1].mapping.quality))
-        return best, ambiguous_providers
+        return best, ambiguous_providers, ambiguous_confidence
 
     def _resolve_confident_matches(
         self,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -810,6 +810,7 @@ class TracksController(MediaControllerBase[Track]):
         base_album: Album | ItemMapping | None = None
         base_album_loaded = False
         matches: list[TrackProviderMatch] = []
+        provider_matches: list[tuple[MusicProvider, TrackProviderMatch]] = []
         ambiguous_providers: list[str] = []
         failed_providers: list[str] = []
         providers = (
@@ -882,24 +883,31 @@ class TracksController(MediaControllerBase[Track]):
                 failed_providers.append(provider.name)
                 continue
             if result.match:
-                if matches and not self._matches_are_compatible([*matches, result.match]):
-                    # this provider's match is not the same recording as a match
-                    # already accepted from another provider (missing source evidence,
-                    # e.g. no explicitness tag, can let unrelated candidates tie) -
-                    # treat it as ambiguous instead of merging conflicting mappings
-                    ambiguous_providers.append(provider.name)
-                    continue
-                enriched_track.provider_mappings = {
-                    mapping
-                    for mapping in enriched_track.provider_mappings
-                    if mapping.provider_domain != provider.domain
-                    or (trust_track_mappings and mapping.available)
-                }
-                enriched_track.provider_mappings.add(result.match.mapping)
-                matches.append(result.match)
+                # defer accept/reject until every provider has been queried, so a
+                # conflict is resolved by confidence rather than by which provider
+                # happened to be visited first
+                provider_matches.append((provider, result.match))
                 existing_domains.add(provider.domain)
             elif result.ambiguous:
                 ambiguous_providers.append(provider.name)
+        # resolve highest-confidence candidates first, so a stronger match from a
+        # later provider is preferred over a weaker one that was found earlier -
+        # missing source evidence (e.g. no explicitness tag) can otherwise let
+        # unrelated recordings tie and get merged or picked in visitation order
+        for provider, match in sorted(
+            provider_matches, key=lambda pm: pm[1].confidence, reverse=True
+        ):
+            if matches and not self._matches_are_compatible([*matches, match]):
+                ambiguous_providers.append(provider.name)
+                continue
+            enriched_track.provider_mappings = {
+                mapping
+                for mapping in enriched_track.provider_mappings
+                if mapping.provider_domain != provider.domain
+                or (trust_track_mappings and mapping.available)
+            }
+            enriched_track.provider_mappings.add(match.mapping)
+            matches.append(match)
         return TrackProviderEnrichment(
             track=enriched_track,
             matches=tuple(matches),

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1026,8 +1026,12 @@ class TracksController(MediaControllerBase[Track]):
                     OSError,
                     TimeoutError,
                 ):
-                    if candidates:
-                        return candidates
+                    # unlike a search-request failure (which only loses queries not
+                    # yet attempted), a failed hydration mid-loop still leaves
+                    # unseen candidates - possibly stronger or ambiguity-triggering
+                    # ones - among the already-fetched search results; propagate so
+                    # the caller reports this provider as failed rather than
+                    # silently accepting an incomplete candidate set
                     raise
                 confidence, base_album = await self._get_match_confidence(
                     base_track,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -688,6 +688,7 @@ class TracksController(MediaControllerBase[Track]):
         mapping_source: Track | None = None,
         allowed_provider_instances: set[str] | None = None,
         trust_base_mapping: bool = True,
+        known_dead_mappings: frozenset[tuple[str, str]] | None = None,
     ) -> TrackProviderMatchResult:
         """
         Find the best track match on a music provider.
@@ -699,6 +700,8 @@ class TracksController(MediaControllerBase[Track]):
         :param mapping_source: Optional library track whose mappings may be reused as candidates.
         :param allowed_provider_instances: Provider instances available to the initiating user.
         :param trust_base_mapping: Treat a direct base-track mapping as exact provider identity.
+        :param known_dead_mappings: ``(instance_id, item_id)`` pairs a caller has already
+            authoritatively confirmed unresolvable, so they are not hydrated again here.
         """
         resolved_base_album = base_album
         mapped_match: TrackProviderMatch | None = None
@@ -712,22 +715,30 @@ class TracksController(MediaControllerBase[Track]):
                         confidence=TrackMatchConfidence.EXACT,
                     )
                 )
-            try:
-                mapped_candidate = await self.get_provider_item(
-                    mapping.item_id,
-                    provider.instance_id,
-                    # an untrusted mapping (trust_base_mapping=False) may have just been
-                    # proven dead by an authoritative caller-side probe - a cached hit
-                    # here must not resurrect it as a confident match, so bypass the
-                    # provider cache the same way that probe did
-                    force_refresh=not trust_base_mapping,
-                    allow_fallback=False,
-                    strict_provider_instance=True,
-                )
-            except MediaNotFoundError, InvalidDataError:
-                # a stale mapping (deleted catalog id, unreadable stream) is not fatal -
-                # fall through to a fresh search below instead of aborting the provider
+            if known_dead_mappings and (provider.instance_id, mapping.item_id) in (
+                known_dead_mappings
+            ):
+                # a caller already authoritatively confirmed this exact candidate dead
+                # moments ago - hydrating it again here would double its provider
+                # traffic for nothing, so fall through to a fresh search straight away
                 mapped_candidate = None
+            else:
+                try:
+                    mapped_candidate = await self.get_provider_item(
+                        mapping.item_id,
+                        provider.instance_id,
+                        # an untrusted mapping (trust_base_mapping=False) may have just
+                        # been proven dead by an authoritative caller-side probe - a
+                        # cached hit here must not resurrect it as a confident match,
+                        # so bypass the provider cache the same way that probe did
+                        force_refresh=not trust_base_mapping,
+                        allow_fallback=False,
+                        strict_provider_instance=True,
+                    )
+                except MediaNotFoundError, InvalidDataError:
+                    # a stale mapping (deleted catalog id, unreadable stream) is not
+                    # fatal - fall through to a fresh search below instead of aborting
+                    mapped_candidate = None
             if mapped_candidate:
                 confidence, resolved_base_album = await self._get_match_confidence(
                     base_track,
@@ -792,6 +803,7 @@ class TracksController(MediaControllerBase[Track]):
         trust_track_mappings: bool = True,
         failed_provider_instances: set[str] | None = None,
         evidence_provider_instances: set[str] | None = None,
+        known_dead_mappings: frozenset[tuple[str, str]] | None = None,
     ) -> TrackProviderEnrichment:
         """
         Resolve missing streaming-provider mappings without updating the library.
@@ -806,6 +818,8 @@ class TracksController(MediaControllerBase[Track]):
             ``provider_instance_ids`` when not given separately, so a narrower search scope
             never also narrows which of the user's own accounts evidence may be hydrated
             from.
+        :param known_dead_mappings: ``(instance_id, item_id)`` pairs a caller has already
+            authoritatively confirmed unresolvable, so they are not hydrated again here.
         """
         library_track = await self.get_library_match(track)
         enriched_track = deepcopy(track)
@@ -844,6 +858,7 @@ class TracksController(MediaControllerBase[Track]):
             existing_domains=existing_domains,
             failed_provider_instances=failed_provider_instances,
             failed_providers=failed_providers,
+            known_dead_mappings=known_dead_mappings,
         )
         provider_matches, domain_ambiguous_providers = self._select_best_match_per_domain(
             provider_matches
@@ -1278,6 +1293,7 @@ class TracksController(MediaControllerBase[Track]):
         existing_domains: set[str],
         failed_provider_instances: set[str] | None,
         failed_providers: list[str],
+        known_dead_mappings: frozenset[tuple[str, str]] | None = None,
     ) -> tuple[
         list[tuple[MusicProvider, TrackProviderMatch]], list[str], TrackMatchConfidence | None
     ]:
@@ -1323,6 +1339,7 @@ class TracksController(MediaControllerBase[Track]):
                     mapping_source=mapping_source,
                     allowed_provider_instances=evidence_provider_instances,
                     trust_base_mapping=trust_track_mappings,
+                    known_dead_mappings=known_dead_mappings,
                 )
             except (
                 ResourceTemporarilyUnavailable,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -88,6 +88,10 @@ class TrackProviderMatchResult:
 
     match: TrackProviderMatch | None = None
     ambiguous: bool = False
+    # the confidence tier at which this provider's own candidates could not be told
+    # apart, so a caller resolving several providers together can tell that a weaker
+    # tier from another provider isn't actually a safe, uncontested answer either
+    ambiguous_confidence: TrackMatchConfidence | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -770,7 +774,7 @@ class TracksController(MediaControllerBase[Track]):
             # missing source evidence (e.g. no explicitness tag) can let unrelated
             # candidates tie at the same confidence - checked at every tier, not just
             # LOOSE, since a quality tie-break would otherwise pick one arbitrarily
-            return TrackProviderMatchResult(ambiguous=True)
+            return TrackProviderMatchResult(ambiguous=True, ambiguous_confidence=best_confidence)
         _, best_match = max(
             best_matches,
             key=lambda ranked_match: (
@@ -822,80 +826,32 @@ class TracksController(MediaControllerBase[Track]):
         )
         if evidence_provider_instances is None:
             evidence_provider_instances = provider_instance_ids
-        base_album: Album | ItemMapping | None = None
-        base_album_loaded = False
         matches: list[TrackProviderMatch] = []
-        provider_matches: list[tuple[MusicProvider, TrackProviderMatch]] = []
-        ambiguous_providers: list[str] = []
         providers, failed_providers = self._resolve_allowed_providers(
             provider_instance_ids, failed_provider_instances
         )
-        mapping_source = library_track or track
-        for provider in providers:
-            if (
-                failed_provider_instances is not None
-                and provider.instance_id in failed_provider_instances
-            ):
-                continue
-            if provider.domain in existing_domains:
-                continue
-            if not provider.is_streaming_provider and not (
-                self._get_provider_mapping(mapping_source, provider)
-            ):
-                continue
-            if not base_album_loaded:
-                base_album = await self._get_full_track_album(
-                    track, allowed_provider_instances=evidence_provider_instances
-                )
-                base_album_loaded = True
-            try:
-                result = await self.find_provider_match(
-                    track,
-                    provider,
-                    minimum_confidence=minimum_confidence,
-                    base_album=base_album,
-                    mapping_source=mapping_source,
-                    allowed_provider_instances=evidence_provider_instances,
-                    trust_base_mapping=trust_track_mappings,
-                )
-            except (
-                ResourceTemporarilyUnavailable,
-                ProviderUnavailableError,
-                ClientError,
-                OSError,
-                TimeoutError,
-            ) as err:
-                if failed_provider_instances is not None:
-                    failed_provider_instances.add(provider.instance_id)
-                self.logger.warning(
-                    "Failed to match %s on provider %s: %s",
-                    track.name,
-                    provider.name,
-                    err,
-                )
-                failed_providers.append(provider.name)
-                continue
-            except (InvalidDataError, MediaNotFoundError) as err:
-                self.logger.warning(
-                    "Failed to match %s on provider %s: %s",
-                    track.name,
-                    provider.name,
-                    err,
-                )
-                failed_providers.append(provider.name)
-                continue
-            if result.match:
-                # defer accept/reject until every allowed instance has been queried, so
-                # a conflict (including between two instances of the same domain) is
-                # resolved by confidence rather than by which one was visited first
-                provider_matches.append((provider, result.match))
-            elif result.ambiguous:
-                ambiguous_providers.append(provider.name)
+        (
+            provider_matches,
+            ambiguous_providers,
+            ambiguous_confidence,
+        ) = await self._query_provider_matches(
+            track,
+            providers,
+            minimum_confidence=minimum_confidence,
+            mapping_source=library_track or track,
+            evidence_provider_instances=evidence_provider_instances,
+            trust_track_mappings=trust_track_mappings,
+            existing_domains=existing_domains,
+            failed_provider_instances=failed_provider_instances,
+            failed_providers=failed_providers,
+        )
         provider_matches, domain_ambiguous_providers = self._select_best_match_per_domain(
             provider_matches
         )
         ambiguous_providers.extend(domain_ambiguous_providers)
-        accepted, tier_ambiguous_providers = self._resolve_confident_matches(provider_matches)
+        accepted, tier_ambiguous_providers = self._resolve_confident_matches(
+            provider_matches, unresolved_confidence=ambiguous_confidence
+        )
         ambiguous_providers.extend(tier_ambiguous_providers)
         for provider, match in accepted:
             enriched_track.provider_mappings = {
@@ -1272,7 +1228,9 @@ class TracksController(MediaControllerBase[Track]):
         return best, ambiguous_providers
 
     def _resolve_confident_matches(
-        self, provider_matches: list[tuple[MusicProvider, TrackProviderMatch]]
+        self,
+        provider_matches: list[tuple[MusicProvider, TrackProviderMatch]],
+        unresolved_confidence: TrackMatchConfidence | None = None,
     ) -> tuple[list[tuple[MusicProvider, TrackProviderMatch]], list[str]]:
         """
         Accept provider matches confidence tier by confidence tier.
@@ -1286,6 +1244,11 @@ class TracksController(MediaControllerBase[Track]):
         the first ambiguous tier: once the strongest remaining evidence can't be
         told apart, a weaker tier can't settle that disagreement either, so it
         would be wrong to quietly substitute it in as if it were the answer.
+
+        :param unresolved_confidence: The highest tier at which some other
+            provider's own candidates already tied ambiguously, if any. A tier at
+            or below it is rejected too rather than accepted, since it cannot be
+            trusted over evidence that is itself unresolved at that level.
         """
         accepted: list[tuple[MusicProvider, TrackProviderMatch]] = []
         ambiguous_providers: list[str] = []
@@ -1295,16 +1258,114 @@ class TracksController(MediaControllerBase[Track]):
         ):
             tier = list(tier_iter)
             tier_matches = [match for _, match in tier]
-            if not self._matches_are_compatible(tier_matches, tier_confidence) or (
-                accepted
-                and not self._matches_are_compatible(
-                    [*(match for _, match in accepted), *tier_matches], tier_confidence
+            if (
+                (unresolved_confidence is not None and tier_confidence <= unresolved_confidence)
+                or not self._matches_are_compatible(tier_matches, tier_confidence)
+                or (
+                    accepted
+                    and not self._matches_are_compatible(
+                        [*(match for _, match in accepted), *tier_matches], tier_confidence
+                    )
                 )
             ):
                 ambiguous_providers.extend(provider.name for provider, _ in tier)
                 break
             accepted.extend(tier)
         return accepted, ambiguous_providers
+
+    async def _query_provider_matches(
+        self,
+        track: Track,
+        providers: list[MusicProvider],
+        minimum_confidence: TrackMatchConfidence,
+        mapping_source: Track,
+        evidence_provider_instances: set[str] | None,
+        trust_track_mappings: bool,
+        existing_domains: set[str],
+        failed_provider_instances: set[str] | None,
+        failed_providers: list[str],
+    ) -> tuple[
+        list[tuple[MusicProvider, TrackProviderMatch]], list[str], TrackMatchConfidence | None
+    ]:
+        """
+        Query every allowed provider for a match, deferring accept/reject decisions.
+
+        Every allowed instance is queried before any conflict is resolved, so a
+        disagreement (including between two instances of the same domain) is settled
+        by confidence rather than by which instance happened to be visited first.
+        Providers whose own candidates tied ambiguously contribute no match here;
+        the highest such tier is returned separately so a caller resolving several
+        providers together can tell that a weaker, uncontested-looking match from
+        another provider isn't actually a safe answer to that disagreement either.
+        """
+        base_album: Album | ItemMapping | None = None
+        base_album_loaded = False
+        provider_matches: list[tuple[MusicProvider, TrackProviderMatch]] = []
+        ambiguous_providers: list[str] = []
+        ambiguous_confidence: TrackMatchConfidence | None = None
+        for provider in providers:
+            if (
+                failed_provider_instances is not None
+                and provider.instance_id in failed_provider_instances
+            ):
+                continue
+            if provider.domain in existing_domains:
+                continue
+            if not provider.is_streaming_provider and not (
+                self._get_provider_mapping(mapping_source, provider)
+            ):
+                continue
+            if not base_album_loaded:
+                base_album = await self._get_full_track_album(
+                    track, allowed_provider_instances=evidence_provider_instances
+                )
+                base_album_loaded = True
+            try:
+                result = await self.find_provider_match(
+                    track,
+                    provider,
+                    minimum_confidence=minimum_confidence,
+                    base_album=base_album,
+                    mapping_source=mapping_source,
+                    allowed_provider_instances=evidence_provider_instances,
+                    trust_base_mapping=trust_track_mappings,
+                )
+            except (
+                ResourceTemporarilyUnavailable,
+                ProviderUnavailableError,
+                ClientError,
+                OSError,
+                TimeoutError,
+            ) as err:
+                if failed_provider_instances is not None:
+                    failed_provider_instances.add(provider.instance_id)
+                self.logger.warning(
+                    "Failed to match %s on provider %s: %s",
+                    track.name,
+                    provider.name,
+                    err,
+                )
+                failed_providers.append(provider.name)
+                continue
+            except (InvalidDataError, MediaNotFoundError) as err:
+                self.logger.warning(
+                    "Failed to match %s on provider %s: %s",
+                    track.name,
+                    provider.name,
+                    err,
+                )
+                failed_providers.append(provider.name)
+                continue
+            if result.match:
+                provider_matches.append((provider, result.match))
+            elif result.ambiguous:
+                ambiguous_providers.append(provider.name)
+                if result.ambiguous_confidence is not None and (
+                    ambiguous_confidence is None
+                    or result.ambiguous_confidence > ambiguous_confidence
+                ):
+                    ambiguous_confidence = result.ambiguous_confidence
+        return provider_matches, ambiguous_providers, ambiguous_confidence
 
     def _resolve_allowed_providers(
         self,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -1157,49 +1157,58 @@ class TracksController(MediaControllerBase[Track]):
         if not track.album or isinstance(track.album, Album):
             return track.album
         provider_instance_id_or_domain = track.album.provider
+        candidate_instances = [provider_instance_id_or_domain]
         if allowed_provider_instances is not None and provider_instance_id_or_domain != "library":
             provider = self.mass.get_provider(
                 provider_instance_id_or_domain, return_unavailable=True
             )
             if provider is not None and provider.instance_id in allowed_provider_instances:
-                provider_instance_id_or_domain = provider.instance_id
+                candidate_instances = [provider.instance_id]
             else:
                 # a bare domain resolves to its first registered instance, which may
                 # not be the one this user is allowed to use even though a sibling
-                # instance of the same domain is; try every allowed instance instead
-                # of giving up on that single, arbitrary first match
+                # instance of the same domain is; try every allowed instance of that
+                # domain instead of giving up on that single, arbitrary first match
                 domain = provider.domain if provider is not None else provider_instance_id_or_domain
-                resolved_instance: str | None = None
-                for candidate_id in allowed_provider_instances:
-                    candidate = self.mass.get_provider(candidate_id, return_unavailable=True)
-                    if candidate is not None and candidate.domain == domain:
-                        resolved_instance = candidate.instance_id
-                        break
-                if resolved_instance is None:
+                candidate_instances = [
+                    allowed_provider.instance_id
+                    for allowed_id in sorted(allowed_provider_instances)
+                    if (
+                        allowed_provider := self.mass.get_provider(
+                            allowed_id, return_unavailable=True
+                        )
+                    )
+                    and allowed_provider.domain == domain
+                ]
+                if not candidate_instances:
                     # can't verify this account is one the initiating user has access to
                     return track.album
-                provider_instance_id_or_domain = resolved_instance
-        try:
-            return await self.mass.music.albums.get(
-                track.album.item_id,
-                provider_instance_id_or_domain,
-                allow_update_metadata=False,
-            )
-        except (
-            InvalidDataError,
-            MediaNotFoundError,
-            ProviderUnavailableError,
-            ResourceTemporarilyUnavailable,
-            ClientError,
-            OSError,
-            TimeoutError,
-        ) as err:
-            self.logger.debug(
-                "Could not load album details for track %s: %s",
-                track.name,
-                err,
-            )
-            return track.album
+        for candidate_instance in candidate_instances:
+            try:
+                return await self.mass.music.albums.get(
+                    track.album.item_id,
+                    candidate_instance,
+                    allow_update_metadata=False,
+                )
+            except (
+                InvalidDataError,
+                MediaNotFoundError,
+                ProviderUnavailableError,
+                ResourceTemporarilyUnavailable,
+                ClientError,
+                OSError,
+                TimeoutError,
+            ) as err:
+                # this candidate could not supply the album; a missing or unavailable
+                # account must not block a sibling instance of the same domain from
+                # still supplying the release evidence
+                self.logger.debug(
+                    "Could not load album details for track %s on %s: %s",
+                    track.name,
+                    candidate_instance,
+                    err,
+                )
+        return track.album
 
     @staticmethod
     def _matches_are_compatible(matches: list[TrackProviderMatch]) -> bool:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -1090,8 +1090,14 @@ def _track_version(track: Track) -> str:
 
 def _track_artist_credits_match(base_track: Track, compare_track: Track) -> bool:
     """Return whether credited artists agree or one provider omitted credits."""
-    if not compare_artists(base_track.artists, compare_track.artists, any_match=True):
+    if not base_track.artists or not compare_track.artists:
         return False
+    # deliberately not gated on compare_artists: an exact per-artist match there
+    # only proves one credited artist is shared, which the primary-artist check
+    # below already treats as insufficient on its own - the credit-group coverage
+    # comparison is the one that must decide, so it must always run rather than
+    # being preempted by a list-level comparison that splits composite credits
+    # (e.g. "Artist A, Artist B" reconstructed as one M3U artist) differently
     base_credits = _track_artist_credit_groups(base_track)
     compare_credits = _track_artist_credit_groups(compare_track)
     if not (

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -10,7 +10,7 @@ from enum import Enum, IntEnum
 from functools import lru_cache
 from typing import Final
 
-from music_assistant_models.enums import ExternalID, MediaType
+from music_assistant_models.enums import ExternalID, MediaType, PlaylistMatchPolicy
 from music_assistant_models.helpers import create_safe_string
 from music_assistant_models.media_items import (
     Album,
@@ -124,6 +124,23 @@ class TrackMatchConfidence(IntEnum):
     LOOSE = 1
     LIKELY = 2
     EXACT = 3
+
+
+# EXACT requires release-track evidence (e.g. a MusicBrainz track/release ID) pinning a
+# specific release, not just the underlying recording. M3U playlists exported by a current
+# Music Assistant persist this evidence when the source track carries it, so imports of
+# those files can reach EXACT; legacy or third-party M3U files typically only carry an ISRC
+# or recording ID and cap out at SAME_RECORDING or BEST_EFFORT.
+_MATCH_POLICY_MINIMUM_CONFIDENCE: Final[dict[PlaylistMatchPolicy, TrackMatchConfidence]] = {
+    PlaylistMatchPolicy.EXACT: TrackMatchConfidence.EXACT,
+    PlaylistMatchPolicy.SAME_RECORDING: TrackMatchConfidence.LIKELY,
+    PlaylistMatchPolicy.BEST_EFFORT: TrackMatchConfidence.LOOSE,
+}
+
+
+def match_policy_minimum_confidence(match_policy: PlaylistMatchPolicy) -> TrackMatchConfidence:
+    """Return the minimum track-match confidence accepted by a match policy."""
+    return _MATCH_POLICY_MINIMUM_CONFIDENCE[match_policy]
 
 
 def compare_media_item(

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -248,6 +248,17 @@ def compare_album_evidence(
         return AlbumMatchEvidence.MATCH
 
     # return early on (un)matched authoritative external id
+    external_id_evidence = _compare_album_external_ids(base_item, compare_item)
+    if external_id_evidence is not None:
+        return external_id_evidence
+
+    return _compare_album_metadata(base_item, compare_item, strict, base_tracks, compare_tracks)
+
+
+def _compare_album_external_ids(
+    base_item: Album | ItemMapping, compare_item: Album | ItemMapping
+) -> AlbumMatchEvidence | None:
+    """Return decisive match evidence from an authoritative external id, if either has one."""
     for ext_id in (
         ExternalID.MB_ALBUM,
         ExternalID.DISCOGS,
@@ -258,7 +269,17 @@ def compare_album_evidence(
         )
         if external_id_match is not None:
             return AlbumMatchEvidence.MATCH if external_id_match else AlbumMatchEvidence.NO_MATCH
+    return None
 
+
+def _compare_album_metadata(
+    base_item: Album | ItemMapping,
+    compare_item: Album | ItemMapping,
+    strict: bool,
+    base_tracks: Sequence[Track] | None,
+    compare_tracks: Sequence[Track] | None,
+) -> AlbumMatchEvidence:
+    """Return match evidence from the albums' own metadata, without any identity checks."""
     # barcode/ASIN are shared across pressings and are non-unique corroboration only,
     # so they are never used on their own, only to resolve a year or edition ambiguity below
     secondary_external_id_match = any(
@@ -526,6 +547,32 @@ def _same_instance_item_match(
     return False
 
 
+def _same_album(
+    base_album: Album | ItemMapping | None,
+    compare_album_item: Album | ItemMapping | None,
+) -> bool:
+    """
+    Return whether two album references used as track evidence are the same album.
+
+    Mirrors ``compare_album(strict=False)`` but never widens shared-item-id identity
+    across sibling instances of a non-streaming provider domain - see
+    ``_same_instance_item_match`` - since a track's album is independently hydrated
+    per instance, and two unrelated albums on different non-streaming instances can
+    otherwise coincidentally share an id.
+    """
+    if base_album is None or compare_album_item is None:
+        return False
+    if _same_instance_item_match(base_album, compare_album_item):
+        return True
+    external_id_evidence = _compare_album_external_ids(base_album, compare_album_item)
+    if external_id_evidence is not None:
+        return external_id_evidence == AlbumMatchEvidence.MATCH
+    return (
+        _compare_album_metadata(base_album, compare_album_item, False, None, None)
+        == AlbumMatchEvidence.MATCH
+    )
+
+
 def _album_has_authoritative_release_evidence(
     base_album: Album | ItemMapping | None, compare_album_item: Album | ItemMapping | None
 ) -> bool:
@@ -604,7 +651,7 @@ def compare_track_evidence(
     same_album = (
         isinstance(base_album, Album)
         and isinstance(compare_album_item, Album)
-        and bool(compare_album(base_album, compare_album_item, strict=False))
+        and _same_album(base_album, compare_album_item)
     )
     if (
         mb_track_match is not False
@@ -1330,7 +1377,7 @@ def _same_album_position_conflicts(
     """Return whether tracks occupy different known positions on the same album."""
     if not isinstance(base_album, Album) or not isinstance(compare_album_item, Album):
         return False
-    if not compare_album(base_album, compare_album_item, strict=False):
+    if not _same_album(base_album, compare_album_item):
         return False
     if not base_track.track_number or not compare_track.track_number:
         return False

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -1094,10 +1094,17 @@ def _track_artist_credits_match(base_track: Track, compare_track: Track) -> bool
         return False
     base_credits = _track_artist_credit_groups(base_track)
     compare_credits = _track_artist_credit_groups(compare_track)
-    return _artist_credit_groups_cover(
-        base_credits,
-        compare_credits,
-    ) or _artist_credit_groups_cover(compare_credits, base_credits)
+    if not (
+        _artist_credit_groups_cover(base_credits, compare_credits)
+        or _artist_credit_groups_cover(compare_credits, base_credits)
+    ):
+        return False
+    # a shared featured artist alone is not enough to accept the match: each side's
+    # own primary artist must also be represented on the other side, or an unrelated
+    # track that merely happens to share a featured/guest artist could be substituted
+    return _artist_credited(base_track.artists[0].name, compare_credits) and _artist_credited(
+        compare_track.artists[0].name, base_credits
+    )
 
 
 def _track_artist_credit_groups(track: Track) -> set[frozenset[str]]:
@@ -1129,6 +1136,12 @@ def _artist_credit_groups_cover(
         group in target_groups or (len(group) > 1 and group.issubset(target_singletons))
         for group in source_groups
     )
+
+
+def _artist_credited(name: str, credit_groups: set[frozenset[str]]) -> bool:
+    """Return whether an artist name is represented, alone or within a group, among credits."""
+    key = _artist_credit_key(name)
+    return any(key in group for group in credit_groups)
 
 
 def _artist_credit_key(name: str) -> str:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -70,10 +70,7 @@ _FEATURED_ARTIST_SPLITTER = re.compile(
     r"\s*(?:,|&|\+|\band\b|\bwith\b)\s*",
     re.IGNORECASE,
 )
-# a comma unambiguously joins a list of independent artist names, unlike an ampersand,
-# "and", or "with", which are just as likely to be part of an official act's own name
-# (e.g. "Earth, Wind & Fire", "Simon & Garfunkel") - used only as a conservative
-# fallback for a structured artist credit, never for a title-embedded feature credit
+# Split structured artist lists conservatively; '&' and 'with' often belong to band names.
 _ARTIST_LIST_SPLITTER = re.compile(r"\s*,\s*")
 
 # retail suffixes a provider (notably Apple Music) appends to an EP/single title.
@@ -126,11 +123,7 @@ class TrackMatchConfidence(IntEnum):
     EXACT = 3
 
 
-# EXACT requires release-track evidence (e.g. a MusicBrainz track/release ID) pinning a
-# specific release, not just the underlying recording. M3U playlists exported by a current
-# Music Assistant persist this evidence when the source track carries it, so imports of
-# those files can reach EXACT; legacy or third-party M3U files typically only carry an ISRC
-# or recording ID and cap out at SAME_RECORDING or BEST_EFFORT.
+# EXACT needs release-level evidence; looser policies accept recording-level matches.
 _MATCH_POLICY_MINIMUM_CONFIDENCE: Final[dict[PlaylistMatchPolicy, TrackMatchConfidence]] = {
     PlaylistMatchPolicy.EXACT: TrackMatchConfidence.EXACT,
     PlaylistMatchPolicy.SAME_RECORDING: TrackMatchConfidence.LIKELY,
@@ -516,13 +509,7 @@ def _same_instance_item_match(
     """
     Return whether two items share the same provider instance and item id.
 
-    Unlike ``compare_item_ids``, this never widens the identity match across sibling
-    instances of the same domain. A shared item id there only proves catalog identity
-    for a genuinely portable (streaming) provider - for a non-streaming one (e.g.
-    filesystem), each instance mints its own local ids, so an id collision is
-    coincidence, not evidence. Confidence tiers built from this check have no way to
-    tell portable domains from non-portable ones here, so they only trust the
-    unambiguous case: the very same provider instance.
+    Unlike ``compare_item_ids``, this does not widen across sibling instances.
     """
     if not base_item.provider or not compare_item.provider:
         return False
@@ -554,11 +541,8 @@ def _same_album(
     """
     Return whether two album references used as track evidence are the same album.
 
-    Mirrors ``compare_album(strict=False)`` but never widens shared-item-id identity
-    across sibling instances of a non-streaming provider domain - see
-    ``_same_instance_item_match`` - since a track's album is independently hydrated
-    per instance, and two unrelated albums on different non-streaming instances can
-    otherwise coincidentally share an id.
+    Unlike ``compare_album(strict=False)``, this does not widen across sibling
+    instances of non-streaming domains.
     """
     if base_album is None or compare_album_item is None:
         return False
@@ -579,11 +563,7 @@ def _album_has_authoritative_release_evidence(
     """
     Return whether two album references share decisive, release-level evidence.
 
-    Mirrors the external ids ``compare_album_evidence`` already treats as decisive on
-    their own (a shared item identity, or a MusicBrainz release id, Discogs, or
-    TheAudioDB match) - as opposed to a barcode/ASIN, which is shared across pressings
-    and only ever corroborates an otherwise ambiguous edition, never release identity
-    by itself.
+    Barcode and ASIN matches do not qualify on their own.
     """
     if base_album is None or compare_album_item is None:
         return False
@@ -661,10 +641,7 @@ def compare_track_evidence(
         and versions_match
         and _same_album_position_matches(base_item, compare_item)
     ):
-        # metadata agreement alone (title/artists/version/position on a nominally
-        # matching album) is provider drift risk, not proof of the same recording;
-        # only decisive release-level evidence earns EXACT here, otherwise this is
-        # still strong corroboration but only to LIKELY
+        # Matching metadata on the same album is only EXACT with release-level evidence.
         return (
             TrackMatchConfidence.EXACT
             if _album_has_authoritative_release_evidence(base_album, compare_album_item)
@@ -703,8 +680,7 @@ def compare_track_evidence(
     if _track_durations_match(base_item, compare_item, _LOOSE_TRACK_DURATION_TOLERANCE):
         return TrackMatchConfidence.LOOSE
     if not _track_durations_conflict(base_item, compare_item, _LOOSE_TRACK_DURATION_TOLERANCE):
-        # title and artist already matched above; a duration that is merely unknown on
-        # one side (e.g. an M3U entry with no #EXTINF length) isn't evidence against it
+        # Unknown duration on one side is not evidence against the match.
         return TrackMatchConfidence.LOOSE
     return TrackMatchConfidence.NO_MATCH
 
@@ -1229,12 +1205,7 @@ def _track_artist_credits_match(base_track: Track, compare_track: Track) -> bool
     """Return whether credited artists agree or one provider omitted credits."""
     if not base_track.artists or not compare_track.artists:
         return False
-    # deliberately not gated on compare_artists: an exact per-artist match there
-    # only proves one credited artist is shared, which the primary-artist check
-    # below already treats as insufficient on its own - the credit-group coverage
-    # comparison is the one that must decide, so it must always run rather than
-    # being preempted by a list-level comparison that splits composite credits
-    # (e.g. "Artist A, Artist B" reconstructed as one M3U artist) differently
+    # Always compare full credit groups; list-level artist matches are too weak here.
     base_credits, base_list_groups = _track_artist_credit_groups(base_track)
     compare_credits, compare_list_groups = _track_artist_credit_groups(compare_track)
     if not (
@@ -1242,9 +1213,7 @@ def _track_artist_credits_match(base_track: Track, compare_track: Track) -> bool
         or _artist_credit_groups_cover(compare_credits, base_credits, compare_list_groups)
     ):
         return False
-    # a shared featured artist alone is not enough to accept the match: each side's
-    # own primary artist must also be represented on the other side, or an unrelated
-    # track that merely happens to share a featured/guest artist could be substituted
+    # Shared featured artists are not enough without matching primary artists.
     return _artist_credited(base_track.artists[0].name, compare_credits) and _artist_credited(
         compare_track.artists[0].name, base_credits
     )
@@ -1256,10 +1225,7 @@ def _track_artist_credit_groups(
     """
     Return normalized structured and title-embedded artist credits.
 
-    Also returns a per-structured-credit comma-only decomposition, keyed by its
-    normal (full-splitter) group, for ``_artist_credit_groups_cover``'s conservative
-    multi-artist fallback - a title-embedded feature credit needs no such entry, since
-    it only ever uses the full splitter it was already extracted with.
+    Also returns comma-only splits for structured credits used by the coverage fallback.
     """
     artist_credits: set[frozenset[str]] = set()
     list_groups: dict[frozenset[str], frozenset[str]] = {}
@@ -1298,12 +1264,8 @@ def _artist_credit_groups_cover(
     """
     Return whether target credits contain every complete source credit.
 
-    A multi-artist source credit with no matching combined group among the targets
-    can still be considered covered when every one of its components is separately
-    credited there - using ``source_list_groups``'s comma-only decomposition for that
-    fallback where available, instead of the same full splitter used for the direct
-    equality check just above, so that an official act's own name is never mistaken
-    for a list of unrelated artists that happen to share its individual words.
+    A combined source credit can also match when all of its comma-split members are
+    credited separately.
     """
     target_singletons = {next(iter(group)) for group in target_groups if len(group) == 1}
     for group in source_groups:
@@ -1321,9 +1283,7 @@ def _artist_credited(name: str, credit_groups: set[frozenset[str]]) -> bool:
     key = _artist_credit_key(name)
     if any(key in group for group in credit_groups):
         return True
-    # a composite band name (e.g. "Simon & Garfunkel") splits into several credited
-    # components; it is still represented when the credits carry that same combined
-    # group, or every one of its components separately
+    # Composite band names still count if their group, or all comma-split parts, appear.
     own_group = _artist_credit_group(name)
     own_list_group = _artist_credit_list_group(name)
     return len(own_group) > 1 and _artist_credit_groups_cover(

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -6,7 +6,7 @@ import re
 import unicodedata
 from collections.abc import Sequence
 from difflib import SequenceMatcher
-from enum import Enum
+from enum import Enum, IntEnum
 from functools import lru_cache
 from typing import Final
 
@@ -27,6 +27,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.helpers.external_ids import is_valid_isrc, normalize_external_id
+from music_assistant.helpers.util import extract_title_artist_credits, parse_title_and_version
 
 IGNORE_VERSIONS = (
     "explicit",  # explicit is matched separately
@@ -65,6 +66,10 @@ _RECORDING_CONFLICT_VERSION_TOKENS = {
     "remix",
     "session",
 }
+_FEATURED_ARTIST_SPLITTER = re.compile(
+    r"\s*(?:,|&|\+|\band\b|\bwith\b)\s*",
+    re.IGNORECASE,
+)
 
 # retail suffixes a provider (notably Apple Music) appends to an EP/single title.
 # Entries must be a single ASCII alphanumeric word: album_retail_suffix_sql_match matches
@@ -95,6 +100,8 @@ ALBUM_RETAIL_SUFFIX_KEYS: Final = tuple(
 # match allows more duration drift than a bare title/version fallback
 _ISRC_DURATION_TOLERANCE = 8
 _FALLBACK_DURATION_TOLERANCE = 2
+_TRACK_DURATION_TOLERANCE = 3
+_LOOSE_TRACK_DURATION_TOLERANCE = 5
 
 
 class AlbumMatchEvidence(Enum):
@@ -103,6 +110,15 @@ class AlbumMatchEvidence(Enum):
     MATCH = "match"
     NO_MATCH = "no_match"
     INSUFFICIENT = "insufficient"
+
+
+class TrackMatchConfidence(IntEnum):
+    """Confidence level for a cross-provider track match."""
+
+    NO_MATCH = 0
+    LOOSE = 1
+    LIKELY = 2
+    EXACT = 3
 
 
 def compare_media_item(
@@ -449,6 +465,116 @@ def compare_track(
     # Note that as this stage, all other info already matches,
     # such as title, artist etc.
     return abs(base_item.duration - compare_item.duration) <= 2
+
+
+def compare_track_evidence(
+    base_item: Track,
+    compare_item: Track,
+    base_album: Album | ItemMapping | None = None,
+    compare_album_item: Album | ItemMapping | None = None,
+    *,
+    allow_item_id_match: bool = True,
+) -> TrackMatchConfidence:
+    """
+    Return the confidence that two provider tracks represent the same recording.
+
+    :param base_item: Reference track.
+    :param compare_item: Candidate track.
+    :param base_album: Optional full album for the reference track.
+    :param compare_album_item: Optional full album for the candidate track.
+    :param allow_item_id_match: Trust shared provider item identity as exact evidence.
+    """
+    if allow_item_id_match and compare_item_ids(base_item, compare_item):
+        return TrackMatchConfidence.EXACT
+
+    base_album = base_album or base_item.album
+    compare_album_item = compare_album_item or compare_item.album
+    mb_track_match = compare_external_ids(
+        base_item.external_ids, compare_item.external_ids, ExternalID.MB_TRACK
+    )
+    recording_id_match = False
+    for external_id_type in (ExternalID.MB_RECORDING, ExternalID.ACOUSTID):
+        external_id_match = compare_external_ids(
+            base_item.external_ids, compare_item.external_ids, external_id_type
+        )
+        if external_id_match is False:
+            return TrackMatchConfidence.NO_MATCH
+        recording_id_match |= external_id_match is True
+    if mb_track_match is True:
+        return TrackMatchConfidence.EXACT
+
+    base_version = _track_version(base_item)
+    compare_version_value = _track_version(compare_item)
+    if _track_versions_conflict(base_version, compare_version_value):
+        return TrackMatchConfidence.NO_MATCH
+    base_explicit = _track_explicit(base_item, base_album)
+    compare_explicit_value = _track_explicit(compare_item, compare_album_item)
+    if (
+        base_explicit is not None
+        and compare_explicit_value is not None
+        and base_explicit != compare_explicit_value
+    ):
+        return TrackMatchConfidence.NO_MATCH
+
+    title_matches = compare_track_title(base_item.name, compare_item.name)
+    artists_match = _track_artist_credits_match(base_item, compare_item)
+    versions_match = compare_version(base_version, compare_version_value)
+    same_album = (
+        isinstance(base_album, Album)
+        and isinstance(compare_album_item, Album)
+        and bool(compare_album(base_album, compare_album_item, strict=False))
+    )
+    if (
+        mb_track_match is not False
+        and same_album
+        and title_matches
+        and artists_match
+        and versions_match
+        and _same_album_position_matches(base_item, compare_item)
+    ):
+        return TrackMatchConfidence.EXACT
+
+    if recording_id_match:
+        return TrackMatchConfidence.LIKELY
+
+    base_isrcs = _track_isrcs(base_item)
+    compare_isrcs = _track_isrcs(compare_item)
+    if base_isrcs.intersection(compare_isrcs) and _track_durations_match(
+        base_item, compare_item, _ISRC_DURATION_TOLERANCE
+    ):
+        return TrackMatchConfidence.LIKELY
+
+    if _same_album_position_conflicts(
+        base_item,
+        compare_item,
+        base_album,
+        compare_album_item,
+    ):
+        return TrackMatchConfidence.NO_MATCH
+    if not title_matches or not artists_match:
+        return TrackMatchConfidence.NO_MATCH
+    if versions_match and _track_durations_match(
+        base_item, compare_item, _TRACK_DURATION_TOLERANCE
+    ):
+        return TrackMatchConfidence.LIKELY
+    if (
+        _is_missing_remaster_version(base_version, compare_version_value)
+        and _album_years_match(base_album, compare_album_item)
+        and _track_durations_match(base_item, compare_item, _TRACK_DURATION_TOLERANCE)
+    ):
+        return TrackMatchConfidence.LIKELY
+    if _track_durations_match(base_item, compare_item, _LOOSE_TRACK_DURATION_TOLERANCE):
+        return TrackMatchConfidence.LOOSE
+    return TrackMatchConfidence.NO_MATCH
+
+
+def compare_track_title(base_title: str, compare_title: str) -> bool:
+    """Return whether two track titles have the same identity."""
+    if compare_strings(base_title, compare_title, strict=True):
+        return True
+    base_search_title, _ = parse_title_and_version(base_title, strip_for_search=True)
+    compare_search_title, _ = parse_title_and_version(compare_title, strip_for_search=True)
+    return compare_strings(base_search_title, compare_search_title, strict=True)
 
 
 def compare_playlist(
@@ -950,6 +1076,143 @@ def _track_isrcs(track: Track) -> set[str]:
         for current_type, value in track.external_ids
         if current_type == ExternalID.ISRC and is_valid_isrc(value)
     }
+
+
+def _track_version(track: Track) -> str:
+    """Return version metadata combined with any version embedded in the title."""
+    _, version = parse_title_and_version(track.name, track.version)
+    return version
+
+
+def _track_artist_credits_match(base_track: Track, compare_track: Track) -> bool:
+    """Return whether credited artists agree or one provider omitted credits."""
+    if not compare_artists(base_track.artists, compare_track.artists, any_match=True):
+        return False
+    base_credits = _track_artist_credit_groups(base_track)
+    compare_credits = _track_artist_credit_groups(compare_track)
+    return _artist_credit_groups_cover(
+        base_credits,
+        compare_credits,
+    ) or _artist_credit_groups_cover(compare_credits, base_credits)
+
+
+def _track_artist_credit_groups(track: Track) -> set[frozenset[str]]:
+    """Return normalized structured and title-embedded artist credits."""
+    artist_credits: set[frozenset[str]] = set()
+    for artist in track.artists:
+        artist_credits.add(_artist_credit_group(artist.name))
+    for featured_artists in extract_title_artist_credits(track.name):
+        artist_credits.add(_artist_credit_group(featured_artists))
+    return artist_credits
+
+
+def _artist_credit_group(name: str) -> frozenset[str]:
+    """Return one artist credit as its grouped normalized components."""
+    return frozenset(
+        _artist_credit_key(artist_name)
+        for artist_name in _FEATURED_ARTIST_SPLITTER.split(name)
+        if artist_name
+    )
+
+
+def _artist_credit_groups_cover(
+    source_groups: set[frozenset[str]],
+    target_groups: set[frozenset[str]],
+) -> bool:
+    """Return whether target credits contain every complete source credit."""
+    target_singletons = {next(iter(group)) for group in target_groups if len(group) == 1}
+    return all(
+        group in target_groups or (len(group) > 1 and group.issubset(target_singletons))
+        for group in source_groups
+    )
+
+
+def _artist_credit_key(name: str) -> str:
+    """Return a stable key for an artist credit."""
+    return create_safe_string(name, True, True) or "".join(name.split()).casefold()
+
+
+def _track_versions_conflict(base_version: str, compare_version_value: str) -> bool:
+    """Return whether version metadata identifies different recordings."""
+    if compare_version(base_version, compare_version_value):
+        return False
+    base_tokens = set(_normalize_version_tokens(base_version))
+    compare_tokens = set(_normalize_version_tokens(compare_version_value))
+    return bool((base_tokens | compare_tokens) & _RECORDING_CONFLICT_VERSION_TOKENS)
+
+
+def _track_explicit(
+    track: Track,
+    album: Album | ItemMapping | None = None,
+) -> bool | None:
+    """Return explicitness from the track or its full album."""
+    if track.metadata.explicit is not None:
+        return track.metadata.explicit
+    album = album or track.album
+    if isinstance(album, Album):
+        return album.metadata.explicit
+    return None
+
+
+def _same_album_position_matches(base_track: Track, compare_track: Track) -> bool:
+    """Return whether track positions agree or duration can stand in for a missing position."""
+    if base_track.track_number and compare_track.track_number:
+        return (base_track.disc_number or 1, base_track.track_number) == (
+            compare_track.disc_number or 1,
+            compare_track.track_number,
+        )
+    return _track_durations_match(base_track, compare_track, _TRACK_DURATION_TOLERANCE)
+
+
+def _same_album_position_conflicts(
+    base_track: Track,
+    compare_track: Track,
+    base_album: Album | ItemMapping | None,
+    compare_album_item: Album | ItemMapping | None,
+) -> bool:
+    """Return whether tracks occupy different known positions on the same album."""
+    if not isinstance(base_album, Album) or not isinstance(compare_album_item, Album):
+        return False
+    if not compare_album(base_album, compare_album_item, strict=False):
+        return False
+    if not base_track.track_number or not compare_track.track_number:
+        return False
+    return (base_track.disc_number or 1, base_track.track_number) != (
+        compare_track.disc_number or 1,
+        compare_track.track_number,
+    )
+
+
+def _track_durations_match(base_track: Track, compare_track: Track, tolerance: int) -> bool:
+    """Return whether two known track durations are within tolerance."""
+    if not base_track.duration or not compare_track.duration:
+        return False
+    return _duration_close(base_track.duration, compare_track.duration, tolerance)
+
+
+def _is_missing_remaster_version(base_version: str, compare_version_value: str) -> bool:
+    """Return whether one provider omitted remaster-only version metadata."""
+    base_tokens = set(_normalize_version_tokens(base_version))
+    compare_tokens = set(_normalize_version_tokens(compare_version_value))
+    if bool(base_tokens) == bool(compare_tokens):
+        return False
+    version_tokens = base_tokens or compare_tokens
+    return "remaster" in version_tokens and all(
+        token == "remaster" or token.isdigit() for token in version_tokens
+    )
+
+
+def _album_years_match(
+    base_album: Album | ItemMapping | None,
+    compare_album_item: Album | ItemMapping | None,
+) -> bool:
+    """Return whether two full albums declare the same release year."""
+    return bool(
+        isinstance(base_album, Album)
+        and isinstance(compare_album_item, Album)
+        and base_album.year
+        and base_album.year == compare_album_item.year
+    )
 
 
 def _duration_close(base_duration: int, compare_duration: int, tolerance: int) -> bool:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -565,6 +565,10 @@ def compare_track_evidence(
         return TrackMatchConfidence.LIKELY
     if _track_durations_match(base_item, compare_item, _LOOSE_TRACK_DURATION_TOLERANCE):
         return TrackMatchConfidence.LOOSE
+    if not _track_durations_conflict(base_item, compare_item, _LOOSE_TRACK_DURATION_TOLERANCE):
+        # title and artist already matched above; a duration that is merely unknown on
+        # one side (e.g. an M3U entry with no #EXTINF length) isn't evidence against it
+        return TrackMatchConfidence.LOOSE
     return TrackMatchConfidence.NO_MATCH
 
 
@@ -1185,9 +1189,18 @@ def _same_album_position_conflicts(
 
 def _track_durations_match(base_track: Track, compare_track: Track, tolerance: int) -> bool:
     """Return whether two known track durations are within tolerance."""
-    if not base_track.duration or not compare_track.duration:
+    if base_track.duration <= 0 or compare_track.duration <= 0:
+        # 0 is the unset default and -1 is the M3U convention for "unknown duration"
         return False
     return _duration_close(base_track.duration, compare_track.duration, tolerance)
+
+
+def _track_durations_conflict(base_track: Track, compare_track: Track, tolerance: int) -> bool:
+    """Return whether both durations are known and fall outside tolerance."""
+    if base_track.duration <= 0 or compare_track.duration <= 0:
+        # a missing/unknown duration on either side is not evidence of a mismatch
+        return False
+    return not _duration_close(base_track.duration, compare_track.duration, tolerance)
 
 
 def _is_missing_remaster_version(base_version: str, compare_version_value: str) -> bool:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -70,6 +70,11 @@ _FEATURED_ARTIST_SPLITTER = re.compile(
     r"\s*(?:,|&|\+|\band\b|\bwith\b)\s*",
     re.IGNORECASE,
 )
+# a comma unambiguously joins a list of independent artist names, unlike an ampersand,
+# "and", or "with", which are just as likely to be part of an official act's own name
+# (e.g. "Earth, Wind & Fire", "Simon & Garfunkel") - used only as a conservative
+# fallback for a structured artist credit, never for a title-embedded feature credit
+_ARTIST_LIST_SPLITTER = re.compile(r"\s*,\s*")
 
 # retail suffixes a provider (notably Apple Music) appends to an EP/single title.
 # Entries must be a single ASCII alphanumeric word: album_retail_suffix_sql_match matches
@@ -467,6 +472,29 @@ def compare_track(
     return abs(base_item.duration - compare_item.duration) <= 2
 
 
+def _album_has_authoritative_release_evidence(
+    base_album: Album | ItemMapping | None, compare_album_item: Album | ItemMapping | None
+) -> bool:
+    """
+    Return whether two album references share decisive, release-level evidence.
+
+    Mirrors the external ids ``compare_album_evidence`` already treats as decisive on
+    their own (a shared item identity, or a MusicBrainz release id, Discogs, or
+    TheAudioDB match) - as opposed to a barcode/ASIN, which is shared across pressings
+    and only ever corroborates an otherwise ambiguous edition, never release identity
+    by itself.
+    """
+    if base_album is None or compare_album_item is None:
+        return False
+    if compare_item_ids(base_album, compare_album_item):
+        return True
+    return any(
+        compare_external_ids(base_album.external_ids, compare_album_item.external_ids, ext_id)
+        is True
+        for ext_id in (ExternalID.MB_ALBUM, ExternalID.DISCOGS, ExternalID.TADB)
+    )
+
+
 def compare_track_evidence(
     base_item: Track,
     compare_item: Track,
@@ -532,7 +560,15 @@ def compare_track_evidence(
         and versions_match
         and _same_album_position_matches(base_item, compare_item)
     ):
-        return TrackMatchConfidence.EXACT
+        # metadata agreement alone (title/artists/version/position on a nominally
+        # matching album) is provider drift risk, not proof of the same recording;
+        # only decisive release-level evidence earns EXACT here, otherwise this is
+        # still strong corroboration but only to LIKELY
+        return (
+            TrackMatchConfidence.EXACT
+            if _album_has_authoritative_release_evidence(base_album, compare_album_item)
+            else TrackMatchConfidence.LIKELY
+        )
 
     if recording_id_match:
         return TrackMatchConfidence.LIKELY
@@ -1098,11 +1134,11 @@ def _track_artist_credits_match(base_track: Track, compare_track: Track) -> bool
     # comparison is the one that must decide, so it must always run rather than
     # being preempted by a list-level comparison that splits composite credits
     # (e.g. "Artist A, Artist B" reconstructed as one M3U artist) differently
-    base_credits = _track_artist_credit_groups(base_track)
-    compare_credits = _track_artist_credit_groups(compare_track)
+    base_credits, base_list_groups = _track_artist_credit_groups(base_track)
+    compare_credits, compare_list_groups = _track_artist_credit_groups(compare_track)
     if not (
-        _artist_credit_groups_cover(base_credits, compare_credits)
-        or _artist_credit_groups_cover(compare_credits, base_credits)
+        _artist_credit_groups_cover(base_credits, compare_credits, base_list_groups)
+        or _artist_credit_groups_cover(compare_credits, base_credits, compare_list_groups)
     ):
         return False
     # a shared featured artist alone is not enough to accept the match: each side's
@@ -1113,14 +1149,26 @@ def _track_artist_credits_match(base_track: Track, compare_track: Track) -> bool
     )
 
 
-def _track_artist_credit_groups(track: Track) -> set[frozenset[str]]:
-    """Return normalized structured and title-embedded artist credits."""
+def _track_artist_credit_groups(
+    track: Track,
+) -> tuple[set[frozenset[str]], dict[frozenset[str], frozenset[str]]]:
+    """
+    Return normalized structured and title-embedded artist credits.
+
+    Also returns a per-structured-credit comma-only decomposition, keyed by its
+    normal (full-splitter) group, for ``_artist_credit_groups_cover``'s conservative
+    multi-artist fallback - a title-embedded feature credit needs no such entry, since
+    it only ever uses the full splitter it was already extracted with.
+    """
     artist_credits: set[frozenset[str]] = set()
+    list_groups: dict[frozenset[str], frozenset[str]] = {}
     for artist in track.artists:
-        artist_credits.add(_artist_credit_group(artist.name))
+        group = _artist_credit_group(artist.name)
+        artist_credits.add(group)
+        list_groups[group] = _artist_credit_list_group(artist.name)
     for featured_artists in extract_title_artist_credits(track.name):
         artist_credits.add(_artist_credit_group(featured_artists))
-    return artist_credits
+    return artist_credits, list_groups
 
 
 def _artist_credit_group(name: str) -> frozenset[str]:
@@ -1132,16 +1180,39 @@ def _artist_credit_group(name: str) -> frozenset[str]:
     )
 
 
+def _artist_credit_list_group(name: str) -> frozenset[str]:
+    """Return one structured artist credit split only on commas."""
+    return frozenset(
+        _artist_credit_key(artist_name)
+        for artist_name in _ARTIST_LIST_SPLITTER.split(name)
+        if artist_name
+    )
+
+
 def _artist_credit_groups_cover(
     source_groups: set[frozenset[str]],
     target_groups: set[frozenset[str]],
+    source_list_groups: dict[frozenset[str], frozenset[str]] | None = None,
 ) -> bool:
-    """Return whether target credits contain every complete source credit."""
+    """
+    Return whether target credits contain every complete source credit.
+
+    A multi-artist source credit with no matching combined group among the targets
+    can still be considered covered when every one of its components is separately
+    credited there - using ``source_list_groups``'s comma-only decomposition for that
+    fallback where available, instead of the same full splitter used for the direct
+    equality check just above, so that an official act's own name is never mistaken
+    for a list of unrelated artists that happen to share its individual words.
+    """
     target_singletons = {next(iter(group)) for group in target_groups if len(group) == 1}
-    return all(
-        group in target_groups or (len(group) > 1 and group.issubset(target_singletons))
-        for group in source_groups
-    )
+    for group in source_groups:
+        if group in target_groups:
+            continue
+        list_group = (source_list_groups or {}).get(group, group)
+        if len(list_group) > 1 and list_group.issubset(target_singletons):
+            continue
+        return False
+    return True
 
 
 def _artist_credited(name: str, credit_groups: set[frozenset[str]]) -> bool:
@@ -1153,7 +1224,10 @@ def _artist_credited(name: str, credit_groups: set[frozenset[str]]) -> bool:
     # components; it is still represented when the credits carry that same combined
     # group, or every one of its components separately
     own_group = _artist_credit_group(name)
-    return len(own_group) > 1 and _artist_credit_groups_cover({own_group}, credit_groups)
+    own_list_group = _artist_credit_list_group(name)
+    return len(own_group) > 1 and _artist_credit_groups_cover(
+        {own_group}, credit_groups, {own_group: own_list_group}
+    )
 
 
 def _artist_credit_key(name: str) -> str:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -1141,7 +1141,13 @@ def _artist_credit_groups_cover(
 def _artist_credited(name: str, credit_groups: set[frozenset[str]]) -> bool:
     """Return whether an artist name is represented, alone or within a group, among credits."""
     key = _artist_credit_key(name)
-    return any(key in group for group in credit_groups)
+    if any(key in group for group in credit_groups):
+        return True
+    # a composite band name (e.g. "Simon & Garfunkel") splits into several credited
+    # components; it is still represented when the credits carry that same combined
+    # group, or every one of its components separately
+    own_group = _artist_credit_group(name)
+    return len(own_group) > 1 and _artist_credit_groups_cover({own_group}, credit_groups)
 
 
 def _artist_credit_key(name: str) -> str:

--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -472,6 +472,43 @@ def compare_track(
     return abs(base_item.duration - compare_item.duration) <= 2
 
 
+def _same_instance_item_match(
+    base_item: MediaItem | ItemMapping, compare_item: MediaItem | ItemMapping
+) -> bool:
+    """
+    Return whether two items share the same provider instance and item id.
+
+    Unlike ``compare_item_ids``, this never widens the identity match across sibling
+    instances of the same domain. A shared item id there only proves catalog identity
+    for a genuinely portable (streaming) provider - for a non-streaming one (e.g.
+    filesystem), each instance mints its own local ids, so an id collision is
+    coincidence, not evidence. Confidence tiers built from this check have no way to
+    tell portable domains from non-portable ones here, so they only trust the
+    unambiguous case: the very same provider instance.
+    """
+    if not base_item.provider or not compare_item.provider:
+        return False
+    if not base_item.item_id or not compare_item.item_id:
+        return False
+    if base_item.provider == compare_item.provider and base_item.item_id == compare_item.item_id:
+        return True
+    base_mappings = getattr(base_item, "provider_mappings", None)
+    if base_mappings is not None:
+        for prov_l in base_mappings:
+            if prov_l.provider_instance == compare_item.provider and prov_l.item_id == (
+                compare_item.item_id
+            ):
+                return True
+    compare_mappings = getattr(compare_item, "provider_mappings", None)
+    if compare_mappings is not None:
+        for prov_r in compare_mappings:
+            if prov_r.provider_instance == base_item.provider and prov_r.item_id == (
+                base_item.item_id
+            ):
+                return True
+    return False
+
+
 def _album_has_authoritative_release_evidence(
     base_album: Album | ItemMapping | None, compare_album_item: Album | ItemMapping | None
 ) -> bool:
@@ -486,7 +523,7 @@ def _album_has_authoritative_release_evidence(
     """
     if base_album is None or compare_album_item is None:
         return False
-    if compare_item_ids(base_album, compare_album_item):
+    if _same_instance_item_match(base_album, compare_album_item):
         return True
     return any(
         compare_external_ids(base_album.external_ids, compare_album_item.external_ids, ext_id)
@@ -512,7 +549,7 @@ def compare_track_evidence(
     :param compare_album_item: Optional full album for the candidate track.
     :param allow_item_id_match: Trust shared provider item identity as exact evidence.
     """
-    if allow_item_id_match and compare_item_ids(base_item, compare_item):
+    if allow_item_id_match and _same_instance_item_match(base_item, compare_item):
         return TrackMatchConfidence.EXACT
 
     base_album = base_album or base_item.album

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -649,6 +649,11 @@ def _collect_external_ids(metadata: dict[str, str]) -> set[tuple[ExternalID, str
         external_ids.add((ExternalID.ISRC, isrc))
     if mbid := metadata.get("mbid"):
         external_ids.add((ExternalID.MB_RECORDING, mbid))
+    # the release-track id (as opposed to the recording id) pins a specific release,
+    # which is what lets import matching reach an EXACT confidence instead of merely
+    # the same underlying recording on a possibly different release
+    if mb_track := metadata.get("mb_track"):
+        external_ids.add((ExternalID.MB_TRACK, mb_track))
     return external_ids
 
 
@@ -815,6 +820,8 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
         metadata["isrc"] = isrc
     if mbid := full_item.get_external_id(ExternalID.MB_RECORDING):
         metadata["mbid"] = mbid
+    if mb_track := full_item.get_external_id(ExternalID.MB_TRACK):
+        metadata["mb_track"] = mb_track
 
     # collect one provider mapping per domain (highest quality)
     prov_infos: list[ProviderMappingInfo] = []

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -30,6 +30,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.helpers.aiohttp_client import encoded_request_url
+from music_assistant.helpers.external_ids import normalize_external_id
 from music_assistant.helpers.uri import BUILTIN_URL_SCHEMES
 from music_assistant.helpers.util import detect_charset, try_parse_int
 
@@ -900,15 +901,20 @@ def _unambiguous_external_id(full_item: MediaItem, external_id_type: ExternalID)
     Return an external ID value only when the item carries exactly one of that type.
 
     A library item merges external IDs from every matched provider, so more than
-    one distinct value for the same type means they disagree about which release
-    the item actually is (e.g. different MB_TRACK release-track pairings) - persisting
-    one arbitrarily would misrepresent it as reliable release evidence on export.
+    one distinct *canonical* value for the same type means they disagree about
+    which release the item actually is (e.g. different MB_TRACK release-track
+    pairings) - persisting one arbitrarily would misrepresent it as reliable
+    release evidence on export. Values are canonicalized before comparing so
+    equivalent identifiers in different provider formats (casing, separators,
+    braces) are not mistaken for a genuine conflict.
     """
-    values = {
-        value for current_type, value in full_item.external_ids if current_type == external_id_type
+    canonical_values = {
+        normalize_external_id(external_id_type, value)
+        for current_type, value in full_item.external_ids
+        if current_type == external_id_type
     }
-    if len(values) == 1:
-        return next(iter(values))
+    if len(canonical_values) == 1:
+        return next(iter(canonical_values))
     return None
 
 

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -585,6 +585,7 @@ def construct_media_item_from_playlist_item(
             duration,
             provider_mappings,
             external_ids,
+            mass,
         )
 
     for img in item.images:
@@ -667,6 +668,7 @@ def _construct_track(
     duration: int | None,
     provider_mappings: set[ProviderMapping],
     external_ids: set[tuple[ExternalID, str]],
+    mass: MusicAssistant,
 ) -> Track:
     """Construct a Track from playlist item data, including artists and album."""
     artists: UniqueList[Artist | ItemMapping] = UniqueList()
@@ -686,8 +688,19 @@ def _construct_track(
         # prefer the exact account this album was captured from over its bare domain -
         # a domain-only reference expands to every allowed sibling instance downstream
         # (see TracksController._get_full_track_album), which is only correct for
-        # legacy entries that never captured a specific instance in the first place
+        # legacy entries that never captured a specific instance in the first place -
+        # but only when that account actually exists on this server: a playlist
+        # imported from a different Music Assistant install carries instance ids that
+        # are randomly generated per install and will never resolve here, so fall back
+        # to the domain instead, letting that same downstream expansion try every
+        # allowed sibling instance of it rather than an instance id that can never match
         album_provider = item.album.provider_instance or item.album.provider_domain or item_provider
+        if (
+            item.album.provider_instance
+            and item.album.provider_domain
+            and not mass.get_provider(item.album.provider_instance, return_unavailable=True)
+        ):
+            album_provider = item.album.provider_domain
         album_item_id = item.album.item_id or item.album.name
         album_mapping = ItemMapping(
             item_id=album_item_id,

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -826,7 +826,13 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
     # collect one provider mapping per domain (highest quality)
     prov_infos: list[ProviderMappingInfo] = []
     seen_domains: set[str] = set()
-    sorted_mappings = sorted(full_item.provider_mappings, key=lambda x: x.quality, reverse=True)
+    # provider_mappings is a set, so its iteration order is not guaranteed stable across
+    # runs; tie-break equal-quality mappings by identity so the chosen primary URI is
+    # deterministic instead of process-dependent
+    sorted_mappings = sorted(
+        full_item.provider_mappings,
+        key=lambda x: (-x.quality, x.provider_domain, x.provider_instance, x.item_id),
+    )
     for prov_mapping in sorted_mappings:
         domain = prov_mapping.provider_domain
         if domain in seen_domains:

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -887,6 +887,14 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
 
     duration = getattr(full_item, "duration", None)
 
+    # provider_mappings is a set, so its iteration order is not guaranteed stable across
+    # runs; tie-break equal-quality mappings by identity so the chosen primary URI is
+    # deterministic instead of process-dependent. Available mappings are ranked before
+    # unavailable ones so an unplayable primary URI is never chosen while a playable
+    # sibling mapping exists (in the same or another domain).
+    sorted_mappings = sorted(full_item.provider_mappings, key=_provider_mapping_sort_key)
+    mapped_domains = {prov_mapping.provider_domain for prov_mapping in sorted_mappings}
+
     # build EXTMA metadata
     metadata: dict[str, str] = {
         "media_type": full_item.media_type.value,
@@ -902,18 +910,21 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
         metadata["isrc"] = isrc
     if mbid := _unambiguous_external_id(full_item, ExternalID.MB_RECORDING):
         metadata["mbid"] = mbid
-    if mb_track := _unambiguous_external_id(full_item, ExternalID.MB_TRACK):
+    # unlike a recording MBID (shared by every release of the same performance), a
+    # track MBID identifies one specific release's track listing entry - a library
+    # item spanning more than one domain merges external ids from whichever provider
+    # contributed them, with no record of which one, so a lone value could be an
+    # unverified claim from a mapping other than the chosen primary URI (below).
+    # Require corroboration from a second, independently-formatted value in that
+    # case; two providers agreeing is itself evidence the value is not isolated.
+    if mb_track := _unambiguous_external_id(
+        full_item, ExternalID.MB_TRACK, require_corroboration=len(mapped_domains) > 1
+    ):
         metadata["mb_track"] = mb_track
 
     # collect one provider mapping per domain (highest quality)
     prov_infos: list[ProviderMappingInfo] = []
     seen_domains: set[str] = set()
-    # provider_mappings is a set, so its iteration order is not guaranteed stable across
-    # runs; tie-break equal-quality mappings by identity so the chosen primary URI is
-    # deterministic instead of process-dependent. Available mappings are ranked before
-    # unavailable ones so an unplayable primary URI is never chosen while a playable
-    # sibling mapping exists (in the same or another domain).
-    sorted_mappings = sorted(full_item.provider_mappings, key=_provider_mapping_sort_key)
     for prov_mapping in sorted_mappings:
         domain = prov_mapping.provider_domain
         if domain in seen_domains:
@@ -970,7 +981,9 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
     )
 
 
-def _unambiguous_external_id(full_item: MediaItem, external_id_type: ExternalID) -> str | None:
+def _unambiguous_external_id(
+    full_item: MediaItem, external_id_type: ExternalID, *, require_corroboration: bool = False
+) -> str | None:
     """
     Return an external ID value only when the item carries exactly one of that type.
 
@@ -981,15 +994,23 @@ def _unambiguous_external_id(full_item: MediaItem, external_id_type: ExternalID)
     release evidence on export. Values are canonicalized before comparing so
     equivalent identifiers in different provider formats (casing, separators,
     braces) are not mistaken for a genuine conflict.
+
+    :param require_corroboration: There is no record of which provider mapping
+        contributed a given external ID, so a single raw value could be a lone
+        claim from a mapping other than the one exported as the primary URI.
+        When set, at least two distinct raw values (agreeing once normalized)
+        are required, since independent providers reporting the identical
+        value is itself evidence that it is not an isolated, unverified claim.
     """
-    canonical_values = {
-        normalize_external_id(external_id_type, value)
-        for current_type, value in full_item.external_ids
-        if current_type == external_id_type
+    raw_values = {
+        value for current_type, value in full_item.external_ids if current_type == external_id_type
     }
-    if len(canonical_values) == 1:
-        return next(iter(canonical_values))
-    return None
+    canonical_values = {normalize_external_id(external_id_type, value) for value in raw_values}
+    if len(canonical_values) != 1:
+        return None
+    if require_corroboration and len(raw_values) < 2:
+        return None
+    return next(iter(canonical_values))
 
 
 # --------------------------------------------------------------------------- #

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -893,7 +893,7 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
     # unavailable ones so an unplayable primary URI is never chosen while a playable
     # sibling mapping exists (in the same or another domain).
     sorted_mappings = sorted(full_item.provider_mappings, key=_provider_mapping_sort_key)
-    mapped_domains = {prov_mapping.provider_domain for prov_mapping in sorted_mappings}
+    mapped_instances = {prov_mapping.provider_instance for prov_mapping in sorted_mappings}
 
     # build EXTMA metadata
     metadata: dict[str, str] = {
@@ -912,15 +912,17 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
         metadata["mbid"] = mbid
     # unlike a recording MBID (shared by every release of the same performance), a
     # track MBID identifies one specific release's track listing entry - a library
-    # item spanning more than one domain merges external ids from whichever provider
-    # contributed them, with no record of which one, so there is no way to confirm
-    # a merged MB_TRACK actually belongs to the release the chosen primary URI (below)
-    # points at; only trust it when every mapping is the same domain's own catalog.
+    # item spanning more than one provider instance merges external ids from
+    # whichever mapping contributed them, with no record of which one, so there is
+    # no way to confirm a merged MB_TRACK actually belongs to the release the chosen
+    # primary URI (below) points at; only trust it when every mapping is the same
+    # single instance's own catalog - two instances of the same domain (e.g. two
+    # accounts on the same streaming service) can still disagree on release.
     # Even multiple raw values agreeing once normalized isn't reliable corroboration:
     # external_ids is a plain set, so identical reports from two providers collapse
     # into one value, while a single provider that just reformatted its own claim
     # over time can supply two distinct raw values - neither is distinguishable here.
-    if len(mapped_domains) <= 1 and (
+    if len(mapped_instances) <= 1 and (
         mb_track := _unambiguous_external_id(full_item, ExternalID.MB_TRACK)
     ):
         metadata["mb_track"] = mb_track

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -651,9 +651,7 @@ def _collect_external_ids(metadata: dict[str, str]) -> set[tuple[ExternalID, str
         external_ids.add((ExternalID.ISRC, isrc))
     if mbid := metadata.get("mbid"):
         external_ids.add((ExternalID.MB_RECORDING, mbid))
-    # the release-track id (as opposed to the recording id) pins a specific release,
-    # which is what lets import matching reach an EXACT confidence instead of merely
-    # the same underlying recording on a possibly different release
+    # MB_TRACK pins a specific release, unlike MB_RECORDING.
     if mb_track := metadata.get("mb_track"):
         external_ids.add((ExternalID.MB_TRACK, mb_track))
     return external_ids
@@ -685,15 +683,8 @@ def _construct_track(
         )
     album_mapping: ItemMapping | None = None
     if item.album:
-        # prefer the exact account this album was captured from over its bare domain -
-        # a domain-only reference expands to every allowed sibling instance downstream
-        # (see TracksController._get_full_track_album), which is only correct for
-        # legacy entries that never captured a specific instance in the first place -
-        # but only when that account actually exists on this server: a playlist
-        # imported from a different Music Assistant install carries instance ids that
-        # are randomly generated per install and will never resolve here, so fall back
-        # to the domain instead, letting that same downstream expansion try every
-        # allowed sibling instance of it rather than an instance id that can never match
+        # Prefer the captured instance when it exists locally; otherwise fall back to
+        # the domain so sibling instances can be tried later.
         album_provider = item.album.provider_instance or item.album.provider_domain or item_provider
         if (
             item.album.provider_instance
@@ -746,13 +737,7 @@ def _select_provider_mapping(
     """
     Pick the mapping to serialize for a related-item reference (album, artist, podcast).
 
-    A set's iteration order is not guaranteed stable, so picking an arbitrary mapping
-    would nondeterministically choose an unrelated sibling account across runs, or -
-    when several mappings happen to share ``preferred_instance`` - an arbitrary one of
-    those. Ranking ``preferred_instance`` as the first tie-break criterion, ahead of the
-    same deterministic ranking used to pick the track's own primary provider, keeps the
-    reference correlated with the account the rest of the entry was captured from while
-    remaining fully deterministic even among same-instance mappings.
+    Prefers ``preferred_instance`` when present and otherwise picks deterministically.
 
     :param provider_mappings: The related item's provider mappings, if any.
     :param preferred_instance: Provider instance to prefer among the mappings.
@@ -772,8 +757,7 @@ def collect_artist_infos(
     Extract artist info from a media item for M3U serialization.
 
     :param full_item: Any MediaItem (Track, Radio, PodcastEpisode, Audiobook, etc.).
-    :param preferred_instance: Provider instance to prefer among each artist's mappings,
-        typically the track's own primary instance.
+    :param preferred_instance: Provider instance to prefer among each artist's mappings.
     """
     artist_infos: list[ArtistInfo] = []
     if not hasattr(full_item, "artists") or not full_item.artists:
@@ -808,9 +792,7 @@ def collect_album_info(
     Extract album info from a media item for M3U serialization.
 
     :param full_item: Any MediaItem (Track, Radio, PodcastEpisode, Audiobook, etc.).
-    :param preferred_instance: Provider instance to prefer among the album's mappings,
-        typically the track's own primary instance, so the serialized album reference
-        stays consistent with the account the rest of the entry was captured from.
+    :param preferred_instance: Provider instance to prefer among the album's mappings.
     """
     if not hasattr(full_item, "album") or not full_item.album:
         return None
@@ -842,8 +824,7 @@ def collect_podcast_info(
     Extract podcast info from a media item for M3U serialization.
 
     :param full_item: Any MediaItem (Track, Radio, PodcastEpisode, Audiobook, etc.).
-    :param preferred_instance: Provider instance to prefer among the podcast's mappings,
-        typically the track's own primary instance.
+    :param preferred_instance: Provider instance to prefer among the podcast's mappings.
     """
     if not hasattr(full_item, "podcast") or not full_item.podcast:
         return None
@@ -871,9 +852,6 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
     """
     Convert a MediaItem to a PlaylistItem with full M3U metadata.
 
-    Pure conversion — takes an already-fetched MediaItem and produces a
-    PlaylistItem suitable for ``generate_m3u``.
-
     :param full_item: Any MediaItem (Track, Radio, PodcastEpisode, Audiobook, etc.).
     """
     # build M3U-compliant EXTINF title
@@ -887,11 +865,7 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
 
     duration = getattr(full_item, "duration", None)
 
-    # provider_mappings is a set, so its iteration order is not guaranteed stable across
-    # runs; tie-break equal-quality mappings by identity so the chosen primary URI is
-    # deterministic instead of process-dependent. Available mappings are ranked before
-    # unavailable ones so an unplayable primary URI is never chosen while a playable
-    # sibling mapping exists (in the same or another domain).
+    # Sort mappings deterministically and prefer available, higher-quality ones.
     sorted_mappings = sorted(full_item.provider_mappings, key=_provider_mapping_sort_key)
     mapped_instances = {prov_mapping.provider_instance for prov_mapping in sorted_mappings}
 
@@ -910,18 +884,8 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
         metadata["isrc"] = isrc
     if mbid := _unambiguous_external_id(full_item, ExternalID.MB_RECORDING):
         metadata["mbid"] = mbid
-    # unlike a recording MBID (shared by every release of the same performance), a
-    # track MBID identifies one specific release's track listing entry - a library
-    # item spanning more than one provider instance merges external ids from
-    # whichever mapping contributed them, with no record of which one, so there is
-    # no way to confirm a merged MB_TRACK actually belongs to the release the chosen
-    # primary URI (below) points at; only trust it when every mapping is the same
-    # single instance's own catalog - two instances of the same domain (e.g. two
-    # accounts on the same streaming service) can still disagree on release.
-    # Even multiple raw values agreeing once normalized isn't reliable corroboration:
-    # external_ids is a plain set, so identical reports from two providers collapse
-    # into one value, while a single provider that just reformatted its own claim
-    # over time can supply two distinct raw values - neither is distinguishable here.
+    # Only export MB_TRACK when every mapping comes from one instance; mixed-instance
+    # external IDs cannot prove the primary URI's exact release.
     if len(mapped_instances) <= 1 and (
         mb_track := _unambiguous_external_id(full_item, ExternalID.MB_TRACK)
     ):
@@ -990,13 +954,7 @@ def _unambiguous_external_id(full_item: MediaItem, external_id_type: ExternalID)
     """
     Return an external ID value only when the item carries exactly one of that type.
 
-    A library item merges external IDs from every matched provider, so more than
-    one distinct *canonical* value for the same type means they disagree about
-    which release the item actually is (e.g. different MB_TRACK release-track
-    pairings) - persisting one arbitrarily would misrepresent it as reliable
-    release evidence on export. Values are canonicalized before comparing so
-    equivalent identifiers in different provider formats (casing, separators,
-    braces) are not mistaken for a genuine conflict.
+    Mixed canonical values are treated as ambiguous and return ``None``.
     """
     canonical_values = {
         normalize_external_id(external_id_type, value)

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -727,18 +727,51 @@ def _provider_mapping_sort_key(mapping: ProviderMapping) -> tuple[bool, int, str
     )
 
 
-def collect_artist_infos(full_item: MediaItem) -> list[ArtistInfo]:
-    """Extract artist info from a media item for M3U serialization."""
+def _select_provider_mapping(
+    provider_mappings: set[ProviderMapping] | None, preferred_instance: str | None
+) -> ProviderMapping | None:
+    """
+    Pick the mapping to serialize for a related-item reference (album, artist, podcast).
+
+    A set's iteration order is not guaranteed stable, so picking an arbitrary mapping
+    would nondeterministically choose an unrelated sibling account across runs. Prefer
+    the mapping matching ``preferred_instance`` - typically the track's own primary
+    instance - so the reference stays correlated with the account the rest of the entry
+    was captured from; otherwise fall back to the same deterministic ranking used to
+    pick the track's own primary provider.
+
+    :param provider_mappings: The related item's provider mappings, if any.
+    :param preferred_instance: Provider instance to prefer among the mappings.
+    """
+    if not provider_mappings:
+        return None
+    return next(
+        (m for m in provider_mappings if m.provider_instance == preferred_instance),
+        None,
+    ) or min(provider_mappings, key=_provider_mapping_sort_key)
+
+
+def collect_artist_infos(
+    full_item: MediaItem, preferred_instance: str | None = None
+) -> list[ArtistInfo]:
+    """
+    Extract artist info from a media item for M3U serialization.
+
+    :param full_item: Any MediaItem (Track, Radio, PodcastEpisode, Audiobook, etc.).
+    :param preferred_instance: Provider instance to prefer among each artist's mappings,
+        typically the track's own primary instance.
+    """
     artist_infos: list[ArtistInfo] = []
     if not hasattr(full_item, "artists") or not full_item.artists:
         return artist_infos
     for artist in full_item.artists:
-        prov_mappings = getattr(artist, "provider_mappings", None)
-        if prov_mappings:
-            first_mapping = next(iter(prov_mappings))
-            a_domain = first_mapping.provider_domain
-            a_item_id = first_mapping.item_id
-            a_instance = first_mapping.provider_instance
+        mapping = _select_provider_mapping(
+            getattr(artist, "provider_mappings", None), preferred_instance
+        )
+        if mapping:
+            a_domain = mapping.provider_domain
+            a_item_id = mapping.item_id
+            a_instance = mapping.provider_instance
         else:
             a_domain = artist.provider
             a_item_id = artist.item_id
@@ -768,16 +801,10 @@ def collect_album_info(
     if not hasattr(full_item, "album") or not full_item.album:
         return None
     album = full_item.album
-    prov_mappings = getattr(album, "provider_mappings", None)
-    if prov_mappings:
-        # a set's iteration order is not guaranteed stable, so picking an arbitrary
-        # mapping here would nondeterministically pin an unrelated sibling account as
-        # authoritative album evidence; prefer the mapping matching the track's own
-        # instance, falling back to the same deterministic ranking used for tracks
-        mapping = next(
-            (m for m in prov_mappings if m.provider_instance == preferred_instance),
-            None,
-        ) or min(prov_mappings, key=_provider_mapping_sort_key)
+    mapping = _select_provider_mapping(
+        getattr(album, "provider_mappings", None), preferred_instance
+    )
+    if mapping:
         al_domain = mapping.provider_domain
         al_item_id = mapping.item_id
         al_instance = mapping.provider_instance
@@ -794,17 +821,26 @@ def collect_album_info(
     )
 
 
-def collect_podcast_info(full_item: MediaItem) -> PodcastInfo | None:
-    """Extract podcast info from a media item for M3U serialization."""
+def collect_podcast_info(
+    full_item: MediaItem, preferred_instance: str | None = None
+) -> PodcastInfo | None:
+    """
+    Extract podcast info from a media item for M3U serialization.
+
+    :param full_item: Any MediaItem (Track, Radio, PodcastEpisode, Audiobook, etc.).
+    :param preferred_instance: Provider instance to prefer among the podcast's mappings,
+        typically the track's own primary instance.
+    """
     if not hasattr(full_item, "podcast") or not full_item.podcast:
         return None
     podcast = full_item.podcast
-    prov_mappings = getattr(podcast, "provider_mappings", None)
-    if prov_mappings:
-        first_mapping = next(iter(prov_mappings))
-        p_domain = first_mapping.provider_domain
-        p_item_id = first_mapping.item_id
-        p_instance = first_mapping.provider_instance
+    mapping = _select_provider_mapping(
+        getattr(podcast, "provider_mappings", None), preferred_instance
+    )
+    if mapping:
+        p_domain = mapping.provider_domain
+        p_item_id = mapping.item_id
+        p_instance = mapping.provider_instance
     else:
         p_domain = podcast.provider
         p_item_id = podcast.item_id
@@ -885,14 +921,14 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
     if prov_infos:
         primary = prov_infos[0]
         primary_uri = create_uri(full_item.media_type, primary.domain, primary.item_id)
+        preferred_instance = primary.instance_id
     else:
         primary_uri = full_item.uri or ""
+        preferred_instance = None
 
-    artist_infos = collect_artist_infos(full_item)
-    album_info = collect_album_info(
-        full_item, preferred_instance=primary.instance_id if prov_infos else None
-    )
-    podcast_info = collect_podcast_info(full_item)
+    artist_infos = collect_artist_infos(full_item, preferred_instance=preferred_instance)
+    album_info = collect_album_info(full_item, preferred_instance=preferred_instance)
+    podcast_info = collect_podcast_info(full_item, preferred_instance=preferred_instance)
 
     # collect images
     images: list[ImageInfo] = []

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -816,11 +816,11 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
         metadata["narrators"] = "; ".join(full_item.narrators)
     if full_item.version:
         metadata["version"] = full_item.version
-    if isrc := full_item.get_external_id(ExternalID.ISRC):
+    if isrc := _unambiguous_external_id(full_item, ExternalID.ISRC):
         metadata["isrc"] = isrc
-    if mbid := full_item.get_external_id(ExternalID.MB_RECORDING):
+    if mbid := _unambiguous_external_id(full_item, ExternalID.MB_RECORDING):
         metadata["mbid"] = mbid
-    if mb_track := full_item.get_external_id(ExternalID.MB_TRACK):
+    if mb_track := _unambiguous_external_id(full_item, ExternalID.MB_TRACK):
         metadata["mb_track"] = mb_track
 
     # collect one provider mapping per domain (highest quality)
@@ -893,6 +893,23 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
         album=album_info,
         podcast=podcast_info,
     )
+
+
+def _unambiguous_external_id(full_item: MediaItem, external_id_type: ExternalID) -> str | None:
+    """
+    Return an external ID value only when the item carries exactly one of that type.
+
+    A library item merges external IDs from every matched provider, so more than
+    one distinct value for the same type means they disagree about which release
+    the item actually is (e.g. different MB_TRACK release-track pairings) - persisting
+    one arbitrarily would misrepresent it as reliable release evidence on export.
+    """
+    values = {
+        value for current_type, value in full_item.external_ids if current_type == external_id_type
+    }
+    if len(values) == 1:
+        return next(iter(values))
+    return None
 
 
 # --------------------------------------------------------------------------- #

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -716,6 +716,17 @@ def _construct_track(
 # --------------------------------------------------------------------------- #
 
 
+def _provider_mapping_sort_key(mapping: ProviderMapping) -> tuple[bool, int, str, str, str]:
+    """Sort key ranking available, higher-quality mappings first, tie-broken deterministically."""
+    return (
+        not mapping.available,
+        -mapping.quality,
+        mapping.provider_domain,
+        mapping.provider_instance,
+        mapping.item_id,
+    )
+
+
 def collect_artist_infos(full_item: MediaItem) -> list[ArtistInfo]:
     """Extract artist info from a media item for M3U serialization."""
     artist_infos: list[ArtistInfo] = []
@@ -743,17 +754,33 @@ def collect_artist_infos(full_item: MediaItem) -> list[ArtistInfo]:
     return artist_infos
 
 
-def collect_album_info(full_item: MediaItem) -> AlbumInfo | None:
-    """Extract album info from a media item for M3U serialization."""
+def collect_album_info(
+    full_item: MediaItem, preferred_instance: str | None = None
+) -> AlbumInfo | None:
+    """
+    Extract album info from a media item for M3U serialization.
+
+    :param full_item: Any MediaItem (Track, Radio, PodcastEpisode, Audiobook, etc.).
+    :param preferred_instance: Provider instance to prefer among the album's mappings,
+        typically the track's own primary instance, so the serialized album reference
+        stays consistent with the account the rest of the entry was captured from.
+    """
     if not hasattr(full_item, "album") or not full_item.album:
         return None
     album = full_item.album
     prov_mappings = getattr(album, "provider_mappings", None)
     if prov_mappings:
-        first_mapping = next(iter(prov_mappings))
-        al_domain = first_mapping.provider_domain
-        al_item_id = first_mapping.item_id
-        al_instance = first_mapping.provider_instance
+        # a set's iteration order is not guaranteed stable, so picking an arbitrary
+        # mapping here would nondeterministically pin an unrelated sibling account as
+        # authoritative album evidence; prefer the mapping matching the track's own
+        # instance, falling back to the same deterministic ranking used for tracks
+        mapping = next(
+            (m for m in prov_mappings if m.provider_instance == preferred_instance),
+            None,
+        ) or min(prov_mappings, key=_provider_mapping_sort_key)
+        al_domain = mapping.provider_domain
+        al_item_id = mapping.item_id
+        al_instance = mapping.provider_instance
     else:
         al_domain = album.provider
         al_item_id = album.item_id
@@ -836,16 +863,7 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
     # deterministic instead of process-dependent. Available mappings are ranked before
     # unavailable ones so an unplayable primary URI is never chosen while a playable
     # sibling mapping exists (in the same or another domain).
-    sorted_mappings = sorted(
-        full_item.provider_mappings,
-        key=lambda x: (
-            not x.available,
-            -x.quality,
-            x.provider_domain,
-            x.provider_instance,
-            x.item_id,
-        ),
-    )
+    sorted_mappings = sorted(full_item.provider_mappings, key=_provider_mapping_sort_key)
     for prov_mapping in sorted_mappings:
         domain = prov_mapping.provider_domain
         if domain in seen_domains:
@@ -871,7 +889,9 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
         primary_uri = full_item.uri or ""
 
     artist_infos = collect_artist_infos(full_item)
-    album_info = collect_album_info(full_item)
+    album_info = collect_album_info(
+        full_item, preferred_instance=primary.instance_id if prov_infos else None
+    )
     podcast_info = collect_podcast_info(full_item)
 
     # collect images

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -828,10 +828,18 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
     seen_domains: set[str] = set()
     # provider_mappings is a set, so its iteration order is not guaranteed stable across
     # runs; tie-break equal-quality mappings by identity so the chosen primary URI is
-    # deterministic instead of process-dependent
+    # deterministic instead of process-dependent. Available mappings are ranked before
+    # unavailable ones so an unplayable primary URI is never chosen while a playable
+    # sibling mapping exists (in the same or another domain).
     sorted_mappings = sorted(
         full_item.provider_mappings,
-        key=lambda x: (-x.quality, x.provider_domain, x.provider_instance, x.item_id),
+        key=lambda x: (
+            not x.available,
+            -x.quality,
+            x.provider_domain,
+            x.provider_instance,
+            x.item_id,
+        ),
     )
     for prov_mapping in sorted_mappings:
         domain = prov_mapping.provider_domain

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -913,12 +913,15 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
     # unlike a recording MBID (shared by every release of the same performance), a
     # track MBID identifies one specific release's track listing entry - a library
     # item spanning more than one domain merges external ids from whichever provider
-    # contributed them, with no record of which one, so a lone value could be an
-    # unverified claim from a mapping other than the chosen primary URI (below).
-    # Require corroboration from a second, independently-formatted value in that
-    # case; two providers agreeing is itself evidence the value is not isolated.
-    if mb_track := _unambiguous_external_id(
-        full_item, ExternalID.MB_TRACK, require_corroboration=len(mapped_domains) > 1
+    # contributed them, with no record of which one, so there is no way to confirm
+    # a merged MB_TRACK actually belongs to the release the chosen primary URI (below)
+    # points at; only trust it when every mapping is the same domain's own catalog.
+    # Even multiple raw values agreeing once normalized isn't reliable corroboration:
+    # external_ids is a plain set, so identical reports from two providers collapse
+    # into one value, while a single provider that just reformatted its own claim
+    # over time can supply two distinct raw values - neither is distinguishable here.
+    if len(mapped_domains) <= 1 and (
+        mb_track := _unambiguous_external_id(full_item, ExternalID.MB_TRACK)
     ):
         metadata["mb_track"] = mb_track
 
@@ -981,9 +984,7 @@ def media_item_to_playlist_item(full_item: MediaItem) -> PlaylistItem:
     )
 
 
-def _unambiguous_external_id(
-    full_item: MediaItem, external_id_type: ExternalID, *, require_corroboration: bool = False
-) -> str | None:
+def _unambiguous_external_id(full_item: MediaItem, external_id_type: ExternalID) -> str | None:
     """
     Return an external ID value only when the item carries exactly one of that type.
 
@@ -994,23 +995,15 @@ def _unambiguous_external_id(
     release evidence on export. Values are canonicalized before comparing so
     equivalent identifiers in different provider formats (casing, separators,
     braces) are not mistaken for a genuine conflict.
-
-    :param require_corroboration: There is no record of which provider mapping
-        contributed a given external ID, so a single raw value could be a lone
-        claim from a mapping other than the one exported as the primary URI.
-        When set, at least two distinct raw values (agreeing once normalized)
-        are required, since independent providers reporting the identical
-        value is itself evidence that it is not an isolated, unverified claim.
     """
-    raw_values = {
-        value for current_type, value in full_item.external_ids if current_type == external_id_type
+    canonical_values = {
+        normalize_external_id(external_id_type, value)
+        for current_type, value in full_item.external_ids
+        if current_type == external_id_type
     }
-    canonical_values = {normalize_external_id(external_id_type, value) for value in raw_values}
-    if len(canonical_values) != 1:
-        return None
-    if require_corroboration and len(raw_values) < 2:
-        return None
-    return next(iter(canonical_values))
+    if len(canonical_values) == 1:
+        return next(iter(canonical_values))
+    return None
 
 
 # --------------------------------------------------------------------------- #

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -734,21 +734,22 @@ def _select_provider_mapping(
     Pick the mapping to serialize for a related-item reference (album, artist, podcast).
 
     A set's iteration order is not guaranteed stable, so picking an arbitrary mapping
-    would nondeterministically choose an unrelated sibling account across runs. Prefer
-    the mapping matching ``preferred_instance`` - typically the track's own primary
-    instance - so the reference stays correlated with the account the rest of the entry
-    was captured from; otherwise fall back to the same deterministic ranking used to
-    pick the track's own primary provider.
+    would nondeterministically choose an unrelated sibling account across runs, or -
+    when several mappings happen to share ``preferred_instance`` - an arbitrary one of
+    those. Ranking ``preferred_instance`` as the first tie-break criterion, ahead of the
+    same deterministic ranking used to pick the track's own primary provider, keeps the
+    reference correlated with the account the rest of the entry was captured from while
+    remaining fully deterministic even among same-instance mappings.
 
     :param provider_mappings: The related item's provider mappings, if any.
     :param preferred_instance: Provider instance to prefer among the mappings.
     """
     if not provider_mappings:
         return None
-    return next(
-        (m for m in provider_mappings if m.provider_instance == preferred_instance),
-        None,
-    ) or min(provider_mappings, key=_provider_mapping_sort_key)
+    return min(
+        provider_mappings,
+        key=lambda m: (m.provider_instance != preferred_instance, *_provider_mapping_sort_key(m)),
+    )
 
 
 def collect_artist_infos(

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -683,7 +683,11 @@ def _construct_track(
         )
     album_mapping: ItemMapping | None = None
     if item.album:
-        album_provider = item.album.provider_domain or item_provider
+        # prefer the exact account this album was captured from over its bare domain -
+        # a domain-only reference expands to every allowed sibling instance downstream
+        # (see TracksController._get_full_track_album), which is only correct for
+        # legacy entries that never captured a specific instance in the first place
+        album_provider = item.album.provider_instance or item.album.provider_domain or item_provider
         album_item_id = item.album.item_id or item.album.name
         album_mapping = ItemMapping(
             item_id=album_item_id,

--- a/music_assistant/helpers/uri.py
+++ b/music_assistant/helpers/uri.py
@@ -45,7 +45,7 @@ async def parse_uri(uri: str, validate_id: bool = False) -> tuple[MediaType, str
             media_type = MediaType(media_type_str)
             item_id = uri.split("/")[4].split("?", maxsplit=1)[0]
             if not item_id:
-                # a truncated URL with a trailing slash (no id segment)
+                # truncated share URL with no id segment
                 raise KeyError
         elif uri.startswith("https://tidal.com/browse/"):
             # Tidal public share URL
@@ -55,7 +55,7 @@ async def parse_uri(uri: str, validate_id: bool = False) -> tuple[MediaType, str
             media_type = MediaType(media_type_str)
             item_id = uri.split("/")[5].split("?", maxsplit=1)[0]
             if not item_id:
-                # a truncated URL with a trailing slash (no id segment)
+                # truncated share URL with no id segment
                 raise KeyError
         elif uri.startswith("https://music.apple.com/"):
             # Apple Music share URL
@@ -142,8 +142,7 @@ async def parse_uri(uri: str, validate_id: bool = False) -> tuple[MediaType, str
         else:
             raise KeyError
     except (TypeError, AttributeError, ValueError, KeyError, IndexError) as err:
-        # IndexError covers a recognized share-URL prefix that is truncated
-        # (e.g. "https://open.spotify.com" with no path segments to split out)
+        # IndexError covers truncated share URLs with no path segments.
         msg = f"Not a valid Music Assistant uri: {uri}"
         raise InvalidProviderURI(msg) from err
     if validate_id and not valid_id(provider_instance_id_or_domain, item_id):

--- a/music_assistant/helpers/uri.py
+++ b/music_assistant/helpers/uri.py
@@ -135,7 +135,9 @@ async def parse_uri(uri: str, validate_id: bool = False) -> tuple[MediaType, str
             item_id = uri
         else:
             raise KeyError
-    except (TypeError, AttributeError, ValueError, KeyError) as err:
+    except (TypeError, AttributeError, ValueError, KeyError, IndexError) as err:
+        # IndexError covers a recognized share-URL prefix that is truncated
+        # (e.g. "https://open.spotify.com" with no path segments to split out)
         msg = f"Not a valid Music Assistant uri: {uri}"
         raise InvalidProviderURI(msg) from err
     if validate_id and not valid_id(provider_instance_id_or_domain, item_id):

--- a/music_assistant/helpers/uri.py
+++ b/music_assistant/helpers/uri.py
@@ -44,6 +44,9 @@ async def parse_uri(uri: str, validate_id: bool = False) -> tuple[MediaType, str
             media_type_str = uri.split("/")[3]
             media_type = MediaType(media_type_str)
             item_id = uri.split("/")[4].split("?", maxsplit=1)[0]
+            if not item_id:
+                # a truncated URL with a trailing slash (no id segment)
+                raise KeyError
         elif uri.startswith("https://tidal.com/browse/"):
             # Tidal public share URL
             # https://tidal.com/browse/track/123456
@@ -51,6 +54,9 @@ async def parse_uri(uri: str, validate_id: bool = False) -> tuple[MediaType, str
             media_type_str = uri.split("/")[4]
             media_type = MediaType(media_type_str)
             item_id = uri.split("/")[5].split("?", maxsplit=1)[0]
+            if not item_id:
+                # a truncated URL with a trailing slash (no id segment)
+                raise KeyError
         elif uri.startswith("https://music.apple.com/"):
             # Apple Music share URL
             # https://music.apple.com/{storefront}/{type}/{slug}/{id}

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -620,15 +620,6 @@ _DISPLAY_STRIP_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-# Featuring patterns for stripping from titles (not in parentheses).
-_FEATURING_PATTERNS = (
-    " featuring ",
-    " feat. ",
-    " feat ",
-    " ft. ",
-    " ft ",
-)
-
 
 def filename_from_string(string: str) -> str:
     """Create filename from unsafe string."""
@@ -751,13 +742,11 @@ def parse_title_and_version(
                 title = f"{title[: match.start()]}{title[match.end() :]}"
         title = _SEARCH_PAREN_PATTERN.sub("", title)
         title = _SEARCH_HYPHEN_PATTERN.sub("", title)
-        # Strip bare featuring credits (not in parentheses)
-        title_lower = title.lower()
-        for pattern in _FEATURING_PATTERNS:
-            if pattern in title_lower:
-                idx = title_lower.find(pattern)
-                title = title[:idx]
-                break
+        # Strip bare featuring credits (not in parentheses), reusing the same
+        # feat/ft pattern used for credit extraction so dot, colon, and space
+        # separator forms (e.g. "feat.", "feat:", "feat ") are all recognized
+        if bare_credit_match := _TITLE_FEATURED_CREDIT_PATTERN.search(title):
+            title = title[: bare_credit_match.start()]
         # Clean up dangling hyphens and extra spaces
         title = re.sub(r"\s*-\s*$", "", title)
         title = re.sub(r"\s+", " ", title).strip()

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -581,7 +581,10 @@ WITH_TITLE_WORDS = (
     "no",
 )
 _TITLE_FEATURED_CREDIT_PATTERN = re.compile(
-    r"(?:\(|\[)?\b(?:feat(?:uring)?|ft)(?:(?:\.|:)\s*|\s+)"
+    # a bare (unbracketed) credit marker must have preceding title text before it -
+    # otherwise a title that simply starts with "Featuring"/"Ft" (no credit actually
+    # being annotated) would be treated as an empty title plus a bogus artist credit
+    r"(?:[(\[]|(?<=\s))\b(?:feat(?:uring)?|ft)(?:(?:\.|:)\s*|\s+)"
     r"(.+?)(?=\s*(?:\(|\[|\)|\]| - |$))",
     re.IGNORECASE,
 )

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -571,14 +571,17 @@ IGNORE_TITLE_PARTS = (
     "with ",
     "explicit",
 )
-WITH_TITLE_WORDS = (
-    # words that, when following "with", indicate this is part of the song title
-    # not a featuring credit.
-    "someone",
-    "the",
+WITH_TITLE_PHRASES = (
+    # full "with"-credit phrases that are part of the song title itself, not an
+    # artist credit - e.g. Buzzcocks' "Ever Fallen in Love (With Someone You
+    # Shouldn't've)". Matched against the whole credit text rather than just its
+    # first word, so a genuine artist credit that happens to start with the same
+    # word (e.g. "The Weeknd", "No Doubt") is still recognized as a credit.
+    "someone you shouldn't've",
+    "the patent leather face",
+    "no big fat woman",
     "u",
     "you",
-    "no",
 )
 _TITLE_FEATURED_CREDIT_PATTERN = re.compile(
     # a bare (unbracketed) credit marker must have preceding title text before it -
@@ -713,8 +716,8 @@ def extract_title_artist_credits(title: str) -> tuple[str, ...]:
 
 def _is_with_artist_credit(value: str) -> bool:
     """Return whether a with-suffix identifies an artist rather than title words."""
-    first_word = value.split(maxsplit=1)[0].casefold().strip(".,:;!?") if value else ""
-    return bool(first_word) and first_word not in WITH_TITLE_WORDS
+    normalized = value.casefold().strip(".,:;!?") if value else ""
+    return bool(normalized) and normalized not in WITH_TITLE_PHRASES
 
 
 @functools.lru_cache(maxsize=2048)

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -572,14 +572,7 @@ IGNORE_TITLE_PARTS = (
     "explicit",
 )
 WITH_TITLE_WORDS = (
-    # words that, when following "with", indicate this is part of the song title
-    # not a featuring credit. Matching only the first word is a deliberately
-    # conservative trade-off: it means a genuine artist credit that happens to
-    # start with one of these words (e.g. "The Weeknd", "No Doubt") is kept as
-    # part of the title rather than extracted, but it reliably protects any
-    # title continuation starting with that word (not just a fixed list of
-    # known phrases) from being wrongly stripped as a bogus artist credit -
-    # a false-positive strip risks merging two different songs' titles.
+    # first words after "with" that should stay part of the title, not a credit
     "someone",
     "the",
     "u",
@@ -587,9 +580,7 @@ WITH_TITLE_WORDS = (
     "no",
 )
 _TITLE_FEATURED_CREDIT_PATTERN = re.compile(
-    # a bare (unbracketed) credit marker must have preceding title text before it -
-    # otherwise a title that simply starts with "Featuring"/"Ft" (no credit actually
-    # being annotated) would be treated as an empty title plus a bogus artist credit
+    # require preceding title text so titles starting with "Featuring"/"Ft" stay intact
     r"(?:[(\[]|(?<=\s))\b(?:feat(?:uring)?|ft)(?:(?:\.|:)\s*|\s+)"
     r"(.+?)(?=\s*(?:\(|\[|\)|\]| - |$))",
     re.IGNORECASE,
@@ -751,9 +742,7 @@ def parse_title_and_version(
                 title = f"{title[: match.start()]}{title[match.end() :]}"
         title = _SEARCH_PAREN_PATTERN.sub("", title)
         title = _SEARCH_HYPHEN_PATTERN.sub("", title)
-        # Strip bare featuring credits (not in parentheses), reusing the same
-        # feat/ft pattern used for credit extraction so dot, colon, and space
-        # separator forms (e.g. "feat.", "feat:", "feat ") are all recognized
+        # Strip bare featuring credits with the same pattern used for extraction.
         if bare_credit_match := _TITLE_FEATURED_CREDIT_PATTERN.search(title):
             title = title[: bare_credit_match.start()]
         # Clean up dangling hyphens and extra spaces

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -580,6 +580,23 @@ WITH_TITLE_WORDS = (
     "you",
     "no",
 )
+_TITLE_FEATURED_CREDIT_PATTERN = re.compile(
+    r"(?:\(|\[)?\b(?:feat(?:uring)?|ft)(?:(?:\.|:)\s*|\s+)"
+    r"(.+?)(?=\s*(?:\(|\[|\)|\]| - |$))",
+    re.IGNORECASE,
+)
+_TITLE_BRACKETED_WITH_CREDIT_PATTERN = re.compile(
+    r"(?:\(|\[)with\s+(?P<credit>.+?)(?:\)|\])",
+    re.IGNORECASE,
+)
+_TITLE_HYPHEN_WITH_CREDIT_PATTERN = re.compile(
+    r"\s+-\s+with\s+(?P<credit>.+?)(?=\s*(?:\(|\[| - |$))",
+    re.IGNORECASE,
+)
+_TITLE_WITH_CREDIT_PATTERNS = (
+    _TITLE_BRACKETED_WITH_CREDIT_PATTERN,
+    _TITLE_HYPHEN_WITH_CREDIT_PATTERN,
+)
 
 # Keywords for aggressive search cleaning (includes featuring).
 _VERSION_PATTERN = "|".join(re.escape(v) for v in VERSION_PARTS)
@@ -683,6 +700,30 @@ def normalize_unicode(value: str | None) -> str | None:
 
 
 @functools.lru_cache(maxsize=2048)
+def extract_title_artist_credits(title: str) -> tuple[str, ...]:
+    """Return artist credits embedded in a track title."""
+    matched_credits = [
+        *(
+            (match.start(), match.group(1).strip())
+            for match in _TITLE_FEATURED_CREDIT_PATTERN.finditer(title)
+        ),
+        *(
+            (match.start(), match.group("credit").strip())
+            for pattern in _TITLE_WITH_CREDIT_PATTERNS
+            for match in pattern.finditer(title)
+            if _is_with_artist_credit(match.group("credit"))
+        ),
+    ]
+    return tuple(credit for _, credit in sorted(matched_credits))
+
+
+def _is_with_artist_credit(value: str) -> bool:
+    """Return whether a with-suffix identifies an artist rather than title words."""
+    first_word = value.split(maxsplit=1)[0].casefold().strip(".,:;!?") if value else ""
+    return bool(first_word) and first_word not in WITH_TITLE_WORDS
+
+
+@functools.lru_cache(maxsize=2048)
 def parse_title_and_version(
     title: str,
     track_version: str | None = None,
@@ -702,6 +743,12 @@ def parse_title_and_version(
 
     # Strip featuring, bracketed version info, and hyphen suffixes (e.g. "- Remastered 2019")
     if strip_for_search:
+        with_credit_matches = [
+            match for pattern in _TITLE_WITH_CREDIT_PATTERNS for match in pattern.finditer(title)
+        ]
+        for match in sorted(with_credit_matches, key=lambda item: item.start(), reverse=True):
+            if _is_with_artist_credit(match.group("credit")):
+                title = f"{title[: match.start()]}{title[match.end() :]}"
         title = _SEARCH_PAREN_PATTERN.sub("", title)
         title = _SEARCH_HYPHEN_PATTERN.sub("", title)
         # Strip bare featuring credits (not in parentheses)
@@ -742,13 +789,7 @@ def parse_title_and_version(
                 if clean_part.startswith(ignore_str):
                     # Special handling for "with " - check if followed by title words
                     if ignore_str == "with ":
-                        # Extract the word after "with "
-                        after_with = (
-                            clean_part[len("with ") :].split()[0]
-                            if len(clean_part) > len("with ")
-                            else ""
-                        )
-                        if after_with in WITH_TITLE_WORDS:
+                        if not _is_with_artist_credit(clean_part[len("with ") :]):
                             # This is part of the title (e.g., "with you"), don't ignore
                             break
                     # Remove this part from the title

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -571,17 +571,20 @@ IGNORE_TITLE_PARTS = (
     "with ",
     "explicit",
 )
-WITH_TITLE_PHRASES = (
-    # full "with"-credit phrases that are part of the song title itself, not an
-    # artist credit - e.g. Buzzcocks' "Ever Fallen in Love (With Someone You
-    # Shouldn't've)". Matched against the whole credit text rather than just its
-    # first word, so a genuine artist credit that happens to start with the same
-    # word (e.g. "The Weeknd", "No Doubt") is still recognized as a credit.
-    "someone you shouldn't've",
-    "the patent leather face",
-    "no big fat woman",
+WITH_TITLE_WORDS = (
+    # words that, when following "with", indicate this is part of the song title
+    # not a featuring credit. Matching only the first word is a deliberately
+    # conservative trade-off: it means a genuine artist credit that happens to
+    # start with one of these words (e.g. "The Weeknd", "No Doubt") is kept as
+    # part of the title rather than extracted, but it reliably protects any
+    # title continuation starting with that word (not just a fixed list of
+    # known phrases) from being wrongly stripped as a bogus artist credit -
+    # a false-positive strip risks merging two different songs' titles.
+    "someone",
+    "the",
     "u",
     "you",
+    "no",
 )
 _TITLE_FEATURED_CREDIT_PATTERN = re.compile(
     # a bare (unbracketed) credit marker must have preceding title text before it -
@@ -716,8 +719,8 @@ def extract_title_artist_credits(title: str) -> tuple[str, ...]:
 
 def _is_with_artist_credit(value: str) -> bool:
     """Return whether a with-suffix identifies an artist rather than title words."""
-    normalized = value.casefold().strip(".,:;!?") if value else ""
-    return bool(normalized) and normalized not in WITH_TITLE_PHRASES
+    first_word = value.split(maxsplit=1)[0].casefold().strip(".,:;!?") if value else ""
+    return bool(first_word) and first_word not in WITH_TITLE_WORDS
 
 
 @functools.lru_cache(maxsize=2048)

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -589,16 +589,22 @@ class BuiltinProvider(MusicProvider):
 
         The playlist name is used as the filename (sanitized for filesystem safety).
         """
-        playlist_id = await self._reserve_playlist_file(name, [])
+        playlist_id, _generation = await self._reserve_playlist_file(name, [])
         return await self.get_playlist(playlist_id)
 
-    async def import_playlist(self, m3u_data: str) -> Playlist:
+    async def import_playlist(self, m3u_data: str) -> tuple[Playlist, int]:
         """
         Import a playlist from M3U8 format.
 
         Creates a new playlist and populates it with items from the M3U data.
         Items with valid MA URIs are added directly. Plain URLs or unresolvable
         URIs are stored as-is for later matching.
+
+        Also returns the created playlist's creation generation, so a caller that
+        schedules a deferred background match against it can snapshot exactly which
+        playlist instance that task is for, not merely its id - letting the match
+        detect a delete-and-recreate under the same id that happens before the
+        (possibly queued) task actually starts.
 
         :param m3u_data: The M3U8 playlist data as a string.
         """
@@ -614,14 +620,15 @@ class BuiltinProvider(MusicProvider):
         # reserving the id and writing its final content in the same locked step,
         # never exposes an intermediate empty playlist that a concurrent add/remove
         # on the same (predictable) id could race against
-        playlist_id = await self._reserve_playlist_file(
+        playlist_id, generation = await self._reserve_playlist_file(
             playlist_name, parsed_items, playlist_image_url
         )
-        return await self.get_playlist(playlist_id)
+        return await self.get_playlist(playlist_id), generation
 
     async def match_imported_playlist_tracks(
         self,
         prov_playlist_id: str,
+        expected_generation: int,
         match_policy: PlaylistMatchPolicy,
         allowed_provider_instances: tuple[tuple[str, str], ...],
         search_provider_instances: tuple[str, ...] | None = None,
@@ -637,6 +644,11 @@ class BuiltinProvider(MusicProvider):
         in-place so the playlist keeps its original order and duplicates.
 
         :param prov_playlist_id: The provider-side playlist ID of the playlist to match.
+        :param expected_generation: The creation generation of the playlist this task was
+            scheduled for, snapshotted at import time. This task itself may sit queued for
+            a while before it actually runs; if the playlist is deleted and an unrelated
+            one is created that reuses the same ID before that happens, its generation no
+            longer matches and this call is a no-op instead of matching that replacement.
         :param match_policy: Lowest track-match confidence accepted for a substitute.
         :param allowed_provider_instances: (instance_id, domain) pairs snapshotted from the
             user that requested the import, used to validate whether an entry's original
@@ -665,6 +677,13 @@ class BuiltinProvider(MusicProvider):
             # writing stale matches into an unrelated playlist that merely happens to
             # share its ID
             original_generation = await self._get_playlist_generation(prov_playlist_id)
+            if original_generation != expected_generation:
+                # this task itself was scheduled for a playlist that no longer exists
+                # under this ID - it was deleted and replaced before this (possibly
+                # queued) task could even start, so what is here now is an unrelated
+                # playlist that must not be matched under a policy that was never
+                # meant for it
+                return
 
         minimum_confidence = match_policy_minimum_confidence(match_policy)
         allowed_provider_instance_map = dict(allowed_provider_instances)
@@ -1731,7 +1750,7 @@ class BuiltinProvider(MusicProvider):
         name: str,
         entries: list[PlaylistItem],
         playlist_image_url: str | None = None,
-    ) -> str:
+    ) -> tuple[str, int]:
         """
         Reserve a unique playlist ID and write its initial M3U file with given content.
 
@@ -1742,6 +1761,10 @@ class BuiltinProvider(MusicProvider):
         starting from an empty file - also means the file never appears on disk in an
         intermediate state that a concurrent add/remove on the same (predictable) id
         could observe or silently overwrite.
+
+        Returns the reserved ID together with its creation generation, so a caller
+        that defers work against this exact playlist instance can detect a later
+        delete-and-recreate under the same ID.
 
         :param name: The playlist's display name, used to derive its sanitized id.
         :param entries: The initial playlist items to write.
@@ -1760,11 +1783,11 @@ class BuiltinProvider(MusicProvider):
             # recreation under the same sanitized ID must be distinguishable from an
             # in-place rewrite of the same playlist, even if the filesystem happens to
             # reuse the freed inode for the new file
-            self._playlist_generations[playlist_id] = (
+            generation = self._playlist_generations[playlist_id] = (
                 self._playlist_generations.get(playlist_id, 0) + 1
             )
             await self._write_m3u_file_locked(playlist_id, name, entries, playlist_image_url)
-        return playlist_id
+        return playlist_id, generation
 
     async def _write_m3u_file(
         self,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1262,7 +1262,9 @@ class BuiltinProvider(MusicProvider):
         ``rtsp://``/``rtmp://``) is never treated as confirmed gone. A HEAD
         404/410 is corroborated with a minimal ranged GET before being treated
         as terminal, since some servers reject HEAD requests they would still
-        serve on GET.
+        serve on GET. A server that explicitly refuses the HEAD method itself
+        (405/501) is also corroborated by that same GET, rather than being
+        treated as inconclusive forever.
         """
         if not url.startswith(("http://", "https://")):
             return False
@@ -1275,7 +1277,7 @@ class BuiltinProvider(MusicProvider):
                 timeout=ClientTimeout(total=10),
             ) as resp:
                 head_status = resp.status
-        if head_status not in (404, 410):
+        if head_status not in (404, 410, 405, 501):
             return False
         with suppress(ClientError, TimeoutError):
             async with self.mass.http_session.get(

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -640,10 +640,12 @@ class BuiltinProvider(MusicProvider):
         """
         Match imported playlist tracks against available providers.
 
-        Entries whose original provider is still available are left untouched. For the
-        remaining entries, other providers are searched for a substitute meeting
-        ``match_policy``'s minimum confidence; matched entries are replaced in-place so the
-        playlist keeps its original order and duplicates.
+        Entries whose original source is confirmed still playable - available and, once
+        probed, still resolvable, or merely unreachable right now - are left untouched.
+        For the remaining entries, whose original source is confirmed missing or
+        genuinely no longer available, other providers are searched for a substitute
+        meeting ``match_policy``'s minimum confidence; matched entries are replaced
+        in-place so the playlist keeps its original order and duplicates.
 
         :param prov_playlist_id: The provider-side playlist ID of the playlist to match.
         :param match_policy: Lowest track-match confidence accepted for a substitute.
@@ -1604,14 +1606,15 @@ class BuiltinProvider(MusicProvider):
     async def _read_m3u_file(self, playlist_id: str) -> str:
         """Read the raw M3U file content for a playlist."""
         playlist_file = os.path.join(self._playlists_dir, f"{playlist_id}.m3u")
-        if not await asyncio.to_thread(os.path.isfile, playlist_file):
-            return ""
-        async with (
-            self._playlist_lock,
-            aiofiles.open(playlist_file, encoding="utf-8") as _file,
-        ):
-            result: str = await _file.read()
-            return result
+        # the existence check and the open must happen while holding the same lock a
+        # concurrent delete uses, or a delete slipping in between the two could still
+        # remove the file after it was seen to exist but before it was opened
+        async with self._playlist_lock:
+            if not await asyncio.to_thread(os.path.isfile, playlist_file):
+                return ""
+            async with aiofiles.open(playlist_file, encoding="utf-8") as _file:
+                result: str = await _file.read()
+                return result
 
     async def _write_m3u_file(
         self,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -5,16 +5,17 @@ from __future__ import annotations
 import asyncio
 import os
 import re
-from collections.abc import AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator, Mapping, Sequence
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Final, cast
 from urllib.parse import urlparse
 
 import aiofiles
+from aiohttp import ClientError
 from music_assistant_models.auth import Scope
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.enums import (
     ContentType,
-    ExternalID,
     ImageType,
     MediaType,
     ProviderFeature,
@@ -25,6 +26,7 @@ from music_assistant_models.errors import (
     InvalidProviderURI,
     MediaNotFoundError,
     ProviderUnavailableError,
+    ResourceTemporarilyUnavailable,
 )
 from music_assistant_models.media_items import (
     Artist,
@@ -52,15 +54,20 @@ from music_assistant.constants import (
     PlaylistPlayableItem,
 )
 from music_assistant.controllers.cache import use_cache
+from music_assistant.controllers.music.media.playlists import (
+    PlaylistMatchPolicy,
+    match_policy_minimum_confidence,
+)
 from music_assistant.controllers.tasks.context import (
     get_current_task_id,
     report_current_task_failure,
+    set_current_task_report,
     update_current_task_progress_from_index,
     update_current_task_progress_text,
 )
-from music_assistant.helpers.compare import compare_strings
-from music_assistant.helpers.external_ids import normalize_external_id
+from music_assistant.helpers.compare import TrackMatchConfidence
 from music_assistant.helpers.playlists import (
+    ArtistInfo,
     ImageInfo,
     IsHLSPlaylist,
     PlaylistItem,
@@ -77,7 +84,6 @@ from music_assistant.helpers.playlists import (
 from music_assistant.helpers.security import is_safe_path
 from music_assistant.helpers.tags import AudioTags, async_parse_tags
 from music_assistant.helpers.track_filter import filter_tracks, get_track_filter
-from music_assistant.helpers.uri import parse_uri
 from music_assistant.models.music_provider import MusicProvider
 
 from .constants import (
@@ -115,6 +121,20 @@ if TYPE_CHECKING:
 CACHE_CATEGORY_MEDIA_INFO: Final[int] = 1
 CACHE_CATEGORY_PLAYLISTS: Final[int] = 2
 
+# maximum number of detail rows rendered per table in the import matching report
+_IMPORT_REPORT_DETAIL_LIMIT: Final[int] = 200
+# report count bucket for each accepted track-match confidence
+_CONFIDENCE_COUNT_KEY: Final[dict[TrackMatchConfidence, str]] = {
+    TrackMatchConfidence.EXACT: "exact",
+    TrackMatchConfidence.LIKELY: "same_recording",
+    TrackMatchConfidence.LOOSE: "best_effort",
+}
+_CONFIDENCE_TIER_LABELS: Final[dict[str, str]] = {
+    "exact": "Exact release",
+    "same_recording": "Same recording",
+    "best_effort": "Best effort",
+}
+
 SUPPORTED_FEATURES = {
     ProviderFeature.BROWSE,
     ProviderFeature.LIBRARY_TRACKS,
@@ -137,6 +157,19 @@ async def setup(
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
     return BuiltinProvider(mass, manifest, config, SUPPORTED_FEATURES)
+
+
+@dataclass(slots=True)
+class _ImportTrackMatchResult:
+    """Resolved outcome for one playlist entry during import matching."""
+
+    label: str
+    retained: bool = False
+    entry: PlaylistItem | None = None
+    confidence: TrackMatchConfidence = TrackMatchConfidence.NO_MATCH
+    ambiguous_providers: tuple[str, ...] = ()
+    failed_providers: tuple[str, ...] = ()
+    error: str | None = None
 
 
 class BuiltinProvider(MusicProvider):
@@ -592,66 +625,86 @@ class BuiltinProvider(MusicProvider):
     async def match_imported_playlist_tracks(
         self,
         prov_playlist_id: str,
-        match_providers: list[str] | None = None,
+        match_policy: PlaylistMatchPolicy,
+        allowed_provider_instances: tuple[str, ...],
     ) -> None:
         """
         Match imported playlist tracks against available providers.
 
-        Iterates through playlist items whose provider is unavailable,
-        searching other providers for matches using metadata stored in
-        the M3U file. Matched tracks are replaced in-place.
+        Entries whose original provider is still available are left untouched. For the
+        remaining entries, other providers are searched for a substitute meeting
+        ``match_policy``'s minimum confidence; matched entries are replaced in-place so the
+        playlist keeps its original order and duplicates.
 
-        :param prov_playlist_id: The provider-side playlist ID.
-        :param match_providers: Optional list of provider instance IDs or
-            domains to search. When None, all providers are searched.
+        :param prov_playlist_id: The provider-side playlist ID of the playlist to match.
+        :param match_policy: Lowest track-match confidence accepted for a substitute.
+        :param allowed_provider_instances: Provider instances to search, snapshotted from the
+            user that requested the import.
         """
         m3u_data = await self._read_m3u_file(prov_playlist_id)
         parsed_items = parse_m3u(m3u_data)
         if not parsed_items:
             return
+        playlist = await self.get_playlist(prov_playlist_id)
 
+        minimum_confidence = match_policy_minimum_confidence(match_policy)
+        allowed_provider_instance_set = set(allowed_provider_instances)
+        failed_provider_instances: set[str] = set()
         total = len(parsed_items)
-        matched_count = 0
-        unmatched_count = 0
+        counts = dict.fromkeys(
+            ("retained", "exact", "same_recording", "best_effort", "ambiguous", "unmatched"), 0
+        )
+        substitutions: list[tuple[str, str, str]] = []
+        unmatched_items: list[tuple[str, str]] = []
+        provider_issues: list[tuple[str, str]] = []
         changed = False
 
         for index, item in enumerate(parsed_items):
             update_current_task_progress_from_index(
                 index, total, f"Matching track {index + 1}/{total}"
             )
-            if not item.title:
+            result = await self._resolve_import_track(
+                item,
+                minimum_confidence,
+                allowed_provider_instance_set,
+                failed_provider_instances,
+            )
+            for provider_name in result.failed_providers:
+                issue = f"Matching failed on {provider_name}"
+                report_current_task_failure(f"{result.label}: {issue.lower()}")
+                provider_issues.append((result.label, issue))
+            for provider_name in result.ambiguous_providers:
+                issue = f"Ambiguous match on {provider_name}"
+                report_current_task_failure(f"{result.label}: {issue.lower()}")
+                provider_issues.append((result.label, issue))
+            if result.retained:
+                counts["retained"] += 1
                 continue
-            # check if the URI's provider is available
-            needs_matching = False
-            media_type = MediaType.TRACK
-            try:
-                media_type, prov_instance, _item_id = await parse_uri(item.path)
-                if media_type == MediaType.RADIO:
-                    continue
-                if not self.mass.get_provider(prov_instance):
-                    needs_matching = True
-            except Exception:
-                needs_matching = True
-
-            if not needs_matching:
+            if result.error:
+                report_current_task_failure(f"{result.label}: {result.error}")
+                provider_issues.append((result.label, result.error))
+                counts["unmatched"] += 1
+                unmatched_items.append((result.label, result.error))
                 continue
-
-            matched_uri = await self._match_track_by_metadata(item, match_providers=match_providers)
-            if matched_uri:
-                # enrich the entry with full metadata (#EXTPROV etc.) so it resolves to a
-                # playable item - just storing the URI leaves it without provider mappings
-                try:
-                    parsed_items[index] = await self._build_m3u_entry_from_uri(matched_uri)
-                except MediaNotFoundError, InvalidDataError, ProviderUnavailableError:
-                    item.path = matched_uri
-                changed = True
-                matched_count += 1
-            else:
-                report_current_task_failure(f"No match found for: {item.title}")
-                unmatched_count += 1
+            if result.entry is None:
+                if result.ambiguous_providers:
+                    counts["ambiguous"] += 1
+                    reason = "Ambiguous match"
+                else:
+                    counts["unmatched"] += 1
+                    reason = "No acceptable match"
+                    report_current_task_failure(f"{result.label}: {reason.lower()}")
+                unmatched_items.append((result.label, reason))
+                continue
+            parsed_items[index] = result.entry
+            changed = True
+            tier = _CONFIDENCE_COUNT_KEY[result.confidence]
+            counts[tier] += 1
+            substitutions.append(
+                (result.label, _entry_label(result.entry), _CONFIDENCE_TIER_LABELS[tier])
+            )
 
         if changed:
-            playlist = await self.get_playlist(prov_playlist_id)
             await self._write_m3u_file(
                 prov_playlist_id,
                 playlist.name,
@@ -659,11 +712,10 @@ class BuiltinProvider(MusicProvider):
                 self._get_playlist_image_url(playlist),
             )
 
-        self.logger.info(
-            "Import matching: %d matched, %d unmatched out of %d items",
-            matched_count,
-            unmatched_count,
-            total,
+        set_current_task_report(
+            _build_import_report(
+                playlist.name, total, counts, substitutions, unmatched_items, provider_issues
+            )
         )
         update_current_task_progress_from_index(total, total, "Matching complete")
 
@@ -816,196 +868,69 @@ class BuiltinProvider(MusicProvider):
         except OSError as err:
             self.logger.warning("Failed to update playlist metadata: %s", err)
 
-    async def _match_track_by_metadata(
+    async def _resolve_import_track(
         self,
         item: PlaylistItem,
-        match_providers: list[str] | None = None,
-    ) -> str | None:
-        """
-        Search providers for a track matching the given PlaylistItem metadata.
-
-        Uses ISRC/MusicBrainz ID for exact matching first, then falls back
-        to fuzzy title/artist/duration matching.
-
-        :param item: The PlaylistItem with metadata from the M3U file.
-        :param match_providers: Optional list of provider instance IDs or
-            domains to limit the search.
-        """
-        artist_name, track_name = parse_extinf_title(item.title)
-        if not track_name:
-            return None
-
-        search_query = f"{artist_name} - {track_name}" if artist_name else track_name
-
-        all_providers = self.mass.music.get_unique_providers()
-        if match_providers:
-            provider_domains: dict[str, str] = {}
-            for pid in all_providers:
-                prov = self.mass.get_provider(pid)
-                if prov:
-                    provider_domains[pid] = prov.domain
-            all_providers = [
-                pid
-                for pid in all_providers
-                if pid in match_providers or provider_domains.get(pid) in match_providers
-            ]
-
-        best_match: tuple[int, str] | None = None
-
-        for provider_id in all_providers:
-            try:
-                results = await self.mass.music.tracks.search(search_query, provider_id, limit=5)
-            except Exception:
-                self.logger.debug(
-                    "Search failed on provider %s for '%s'", provider_id, search_query
-                )
-                continue
-
-            for result in results:
-                if not result.uri:
-                    continue
-                score = self._score_track_match(result, item)
-                if score >= 10:
-                    self.logger.debug("Exact ID match for '%s' -> %s", search_query, result.uri)
-                    return result.uri
-                if score > 0 and (best_match is None or score > best_match[0]):
-                    best_match = (score, result.uri)
-
-        if best_match:
-            self.logger.debug(
-                "Matched '%s' -> %s (score=%d)",
-                search_query,
-                best_match[1],
-                best_match[0],
+        minimum_confidence: TrackMatchConfidence,
+        allowed_provider_instances: set[str],
+        failed_provider_instances: set[str],
+    ) -> _ImportTrackMatchResult:
+        """Resolve one imported playlist entry against the allowed providers."""
+        media_item = construct_media_item_from_playlist_item(item, self.mass)
+        if not isinstance(media_item, Track):
+            return _ImportTrackMatchResult(label=item.title or item.path, retained=True)
+        label = _entry_label(media_item)
+        if any(mapping.available for mapping in media_item.provider_mappings):
+            # the original provider is still available - nothing to substitute
+            return _ImportTrackMatchResult(label=label, retained=True)
+        if not media_item.artists:
+            # foreign M3U8 files only carry a combined "Artist - Title" EXTINF string;
+            # the shared matcher needs a structured artist to search and compare with
+            split_item = _split_artist_from_title(item)
+            if split_item is not item:
+                rebuilt = construct_media_item_from_playlist_item(split_item, self.mass)
+                if isinstance(rebuilt, Track):
+                    media_item = rebuilt
+                    label = _entry_label(media_item)
+        if not media_item.artists:
+            return _ImportTrackMatchResult(
+                label=label, error="No artist metadata available to search with"
             )
-            return best_match[1]
-
-        self.logger.info("No match found for '%s'", search_query)
-        return None
-
-    def _score_track_match(
-        self,
-        candidate: Track,
-        item: PlaylistItem,
-    ) -> int:
-        """
-        Score how well a candidate track matches the PlaylistItem metadata.
-
-        Returns 0 for no match, higher scores for better matches.
-        ISRC or MusicBrainz Recording ID match returns 10 (maximum).
-
-        :param candidate: The track from search results.
-        :param item: The PlaylistItem with metadata from the M3U file.
-        """
-        metadata = item.metadata or {}
-        artist_name, track_name = parse_extinf_title(item.title)
-        if not track_name:
-            return 0
-
-        isrc = metadata.get("isrc")
-        mbid = metadata.get("mbid")
-
-        # exact ID matches (cross-provider definitive match)
-        if isrc:
-            candidate_isrc = candidate.get_external_id(ExternalID.ISRC)
-            if candidate_isrc and normalize_external_id(
-                ExternalID.ISRC, candidate_isrc
-            ) == normalize_external_id(ExternalID.ISRC, isrc):
-                return 10
-        if mbid:
-            candidate_mbid = candidate.get_external_id(ExternalID.MB_RECORDING)
-            if candidate_mbid and normalize_external_id(
-                ExternalID.MB_RECORDING, candidate_mbid
-            ) == normalize_external_id(ExternalID.MB_RECORDING, mbid):
-                return 10
-
-        # media type gate
-        if metadata.get("media_type"):
-            candidate_type = getattr(candidate, "media_type", None)
-            if candidate_type and candidate_type.value != metadata["media_type"]:
-                return 0
-
-        return self._score_fuzzy_metadata(candidate, artist_name, track_name, metadata, item)
-
-    def _score_fuzzy_metadata(
-        self,
-        candidate: Track,
-        artist_name: str | None,
-        track_name: str,
-        metadata: dict[str, str],
-        item: PlaylistItem,
-    ) -> int:
-        """
-        Score fuzzy metadata fields (title, artist, album, duration, version).
-
-        :param candidate: The track from search results.
-        :param artist_name: Parsed artist name from EXTINF, or None.
-        :param track_name: Parsed track title from EXTINF.
-        :param metadata: The #EXTMA metadata dict.
-        :param item: The PlaylistItem (for duration from item.length).
-        """
-        if not compare_strings(candidate.name, track_name, strict=False):
-            return 0
-        score = 1
-
-        if artist_name:
-            candidate_artists = [a.name for a in candidate.artists] if candidate.artists else []
-            if not any(compare_strings(a, artist_name, strict=False) for a in candidate_artists):
-                return 0
-            score += 2
-
-        score += self._score_bonus_fields(candidate, metadata)
-        score += self._score_duration(candidate, item)
-        return score
-
-    @staticmethod
-    def _score_bonus_fields(candidate: Track, metadata: dict[str, str]) -> int:
-        """Score bonus metadata fields: podcast, authors, album, version."""
-        score = 0
-        if metadata.get("podcast"):
-            candidate_podcast = getattr(candidate, "podcast", None)
-            if candidate_podcast and hasattr(candidate_podcast, "name"):
-                if compare_strings(candidate_podcast.name, metadata["podcast"], strict=False):
-                    score += 2
-
-        if metadata.get("authors"):
-            candidate_authors = getattr(candidate, "authors", None)
-            if candidate_authors:
-                if compare_strings("; ".join(candidate_authors), metadata["authors"], strict=False):
-                    score += 2
-
-        if metadata.get("album"):
-            candidate_album = getattr(candidate, "album", None)
-            if candidate_album and hasattr(candidate_album, "name"):
-                if compare_strings(candidate_album.name, metadata["album"], strict=False):
-                    score += 1
-
-        if metadata.get("version"):
-            candidate_version = getattr(candidate, "version", None) or ""
-            if candidate_version and compare_strings(
-                candidate_version, metadata["version"], strict=False
-            ):
-                score += 1
-            elif candidate_version:
-                score -= 1
-
-        return score
-
-    @staticmethod
-    def _score_duration(candidate: Track, item: PlaylistItem) -> int:
-        """Score duration proximity between candidate and playlist item."""
         try:
-            duration = int(item.length) if item.length else None
-        except ValueError:
-            return 0
-        if duration is None or duration <= 0 or candidate.duration <= 0:
-            return 0
-        diff = abs(candidate.duration - duration)
-        if diff <= 2:
-            return 2
-        if diff <= 5:
-            return 1
-        return 0
+            enrichment = await self.mass.music.tracks.enrich_provider_mappings(
+                media_item,
+                minimum_confidence=minimum_confidence,
+                provider_instance_ids=allowed_provider_instances,
+                # imported metadata comes from outside Music Assistant and is unverified,
+                # so a provider mapping it already carries is not treated as authoritative
+                trust_track_mappings=False,
+                failed_provider_instances=failed_provider_instances,
+            )
+        except (
+            ResourceTemporarilyUnavailable,
+            ProviderUnavailableError,
+            ClientError,
+            OSError,
+            TimeoutError,
+            InvalidDataError,
+            MediaNotFoundError,
+        ) as err:
+            message = str(err).strip() or f"Matching failed ({type(err).__name__})"
+            return _ImportTrackMatchResult(label=label, error=message)
+        if not enrichment.track.provider_mappings:
+            return _ImportTrackMatchResult(
+                label=label,
+                ambiguous_providers=enrichment.ambiguous_providers,
+                failed_providers=enrichment.failed_providers,
+            )
+        best_confidence = max(match.confidence for match in enrichment.matches)
+        return _ImportTrackMatchResult(
+            label=label,
+            entry=media_item_to_playlist_item(enrichment.track),
+            confidence=best_confidence,
+            ambiguous_providers=enrichment.ambiguous_providers,
+            failed_providers=enrichment.failed_providers,
+        )
 
     def _get_stored_item(
         self, item: PlaylistItem, stored_by_media_type: Mapping[str, Mapping[str, StoredItem]]
@@ -1642,3 +1567,104 @@ def _has_music_tags(media_info: AudioTags) -> bool:
     return any(
         media_info.get(tag) for tag in ("artist", "artists", "albumartist", "albumartists", "album")
     )
+
+
+def _split_artist_from_title(item: PlaylistItem) -> PlaylistItem:
+    """
+    Return a copy of item with a structured artist parsed from its combined EXTINF title.
+
+    Playlists imported from outside Music Assistant only carry a combined "Artist - Title"
+    string; the shared track matcher needs a structured artist to search and compare
+    candidates against.
+
+    :param item: Parsed PlaylistItem to derive a structured artist for.
+    """
+    if item.artists or not item.title:
+        return item
+    artist_name, track_name = parse_extinf_title(item.title)
+    if not artist_name or not track_name:
+        return item
+    return replace(
+        item,
+        title=track_name,
+        artists=[
+            ArtistInfo(name=artist_name, provider_domain="", item_id="", provider_instance="")
+        ],
+    )
+
+
+def _entry_label(item: Track | PlaylistItem) -> str:
+    """Return a readable "artist - title" label for a report."""
+    if isinstance(item, Track):
+        return f"{item.artist_str} - {item.name}" if item.artist_str else item.name
+    artist_name, track_name = parse_extinf_title(item.title)
+    if artist_name and track_name:
+        return f"{artist_name} - {track_name}"
+    return track_name or item.title or item.path
+
+
+def _build_import_report(
+    playlist_name: str,
+    total: int,
+    counts: Mapping[str, int],
+    substitutions: Sequence[tuple[str, str, str]],
+    unmatched_items: Sequence[tuple[str, str]],
+    provider_issues: Sequence[tuple[str, str]],
+) -> str:
+    """Build the human-readable Markdown report for an import matching task."""
+    name = _escape_markdown(playlist_name)
+    matched = counts["exact"] + counts["same_recording"] + counts["best_effort"]
+    lines = [
+        "## Playlist import matching complete",
+        "",
+        f"Retained **{counts['retained']}** original entries and matched **{matched}** of the "
+        f"remaining **{total - counts['retained']}** items in **{name}**.",
+        "",
+        "| Result | Items |",
+        "| --- | ---: |",
+        f"| Retained | {counts['retained']} |",
+        f"| Exact release | {counts['exact']} |",
+        f"| Same recording | {counts['same_recording']} |",
+        f"| Best effort | {counts['best_effort']} |",
+        f"| Ambiguous | {counts['ambiguous']} |",
+        f"| Unmatched | {counts['unmatched']} |",
+    ]
+    _add_report_table(lines, "Substitutions", ("Original", "Substitute", "Match"), substitutions)
+    _add_report_table(lines, "Unmatched items", ("Item", "Reason"), unmatched_items)
+    _add_report_table(lines, "Provider lookup issues", ("Track", "Issue"), provider_issues)
+    return "\n".join(lines)
+
+
+def _add_report_table(
+    lines: list[str],
+    title: str,
+    headers: tuple[str, ...],
+    rows: Sequence[tuple[str, ...]],
+) -> None:
+    """Append a Markdown report table when it has rows."""
+    if not rows:
+        return
+    visible_rows = rows[:_IMPORT_REPORT_DETAIL_LIMIT]
+    lines.extend(
+        (
+            "",
+            f"### {title}",
+            "",
+            f"| {' | '.join(headers)} |",
+            f"| {' | '.join('---' for _ in headers)} |",
+        )
+    )
+    lines.extend(
+        f"| {' | '.join(_escape_markdown(value, table=True) for value in row)} |"
+        for row in visible_rows
+    )
+    if omitted_count := len(rows) - len(visible_rows):
+        lines.extend(("", f"_{omitted_count} additional rows omitted._"))
+
+
+def _escape_markdown(value: str, table: bool = False) -> str:
+    """Escape provider text before adding it to a Markdown report."""
+    value = value.replace("\\", "\\\\").replace("\n", " ")
+    for character in ("`", "*", "_", "[", "]", "<", ">"):
+        value = value.replace(character, f"\\{character}")
+    return value.replace("|", "\\|") if table else value

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -630,7 +630,7 @@ class BuiltinProvider(MusicProvider):
         self,
         prov_playlist_id: str,
         match_policy: PlaylistMatchPolicy,
-        allowed_provider_instances: tuple[str, ...],
+        allowed_provider_instances: tuple[tuple[str, str], ...],
         search_provider_instances: tuple[str, ...] | None = None,
     ) -> None:
         """
@@ -643,11 +643,13 @@ class BuiltinProvider(MusicProvider):
 
         :param prov_playlist_id: The provider-side playlist ID of the playlist to match.
         :param match_policy: Lowest track-match confidence accepted for a substitute.
-        :param allowed_provider_instances: Provider instances snapshotted from the user
-            that requested the import, used to validate whether an entry's original
+        :param allowed_provider_instances: (instance_id, domain) pairs snapshotted from the
+            user that requested the import, used to validate whether an entry's original
             source is still playable. Always the user's full accessible set, independent
             of any search narrowing, so a valid original outside that narrowing is never
-            treated as unavailable.
+            treated as unavailable. Carrying the domain alongside each instance allows a
+            domain-only reference to be expanded from this snapshot directly, without
+            depending on whether the provider is currently loaded.
         :param search_provider_instances: Provider instances to search for a substitute.
             Defaults to ``allowed_provider_instances`` when not narrowed by the caller.
         """
@@ -658,9 +660,9 @@ class BuiltinProvider(MusicProvider):
         playlist = await self.get_playlist(prov_playlist_id)
 
         minimum_confidence = match_policy_minimum_confidence(match_policy)
-        allowed_provider_instance_set = set(allowed_provider_instances)
+        allowed_provider_instance_map = dict(allowed_provider_instances)
         search_provider_instance_set = (
-            allowed_provider_instance_set
+            set(allowed_provider_instance_map)
             if search_provider_instances is None
             else set(search_provider_instances)
         )
@@ -703,7 +705,7 @@ class BuiltinProvider(MusicProvider):
                 result = await self._resolve_import_track(
                     item,
                     minimum_confidence,
-                    allowed_provider_instance_set,
+                    allowed_provider_instance_map,
                     search_provider_instance_set,
                     failed_provider_instances,
                 )
@@ -999,7 +1001,7 @@ class BuiltinProvider(MusicProvider):
         self,
         item: PlaylistItem,
         minimum_confidence: TrackMatchConfidence,
-        allowed_provider_instances: set[str],
+        allowed_provider_instances: Mapping[str, str],
         search_provider_instances: set[str],
         failed_provider_instances: set[str],
     ) -> _ImportTrackMatchResult:
@@ -1075,7 +1077,7 @@ class BuiltinProvider(MusicProvider):
         )
 
     async def _original_source_is_playable(
-        self, item: PlaylistItem, allowed_provider_instances: set[str]
+        self, item: PlaylistItem, allowed_provider_instances: Mapping[str, str]
     ) -> bool:
         """
         Check whether an imported entry's original source is still usable.
@@ -1151,7 +1153,7 @@ class BuiltinProvider(MusicProvider):
         return False
 
     def _allowed_instances_for(
-        self, provider_instance_or_domain: str, allowed_provider_instances: set[str]
+        self, provider_instance_or_domain: str, allowed_provider_instances: Mapping[str, str]
     ) -> list[str]:
         """
         Expand an entry's provider reference to allowed instance ids.
@@ -1159,18 +1161,17 @@ class BuiltinProvider(MusicProvider):
         An exact instance id is kept as-is, and only if it is in the caller's own
         snapshot; a bare domain is expanded to every one of the caller's allowed
         instances of that domain instead of the single, arbitrary instance the
-        shared library would otherwise resolve it to. The snapshot itself covers
-        every instance the caller has configured, whether or not it is currently
-        loaded, so this never depends on the provider's current load state.
+        shared library would otherwise resolve it to. The snapshot maps every
+        instance the caller has configured to its domain, whether or not the
+        instance is currently loaded, so this never depends on the provider's
+        current load state - including for the domain-only expansion.
         """
         if provider_instance_or_domain in allowed_provider_instances:
             return [provider_instance_or_domain]
         return [
-            provider.instance_id
-            for provider in self.mass.get_provider_instances(
-                provider_instance_or_domain, return_unavailable=True
-            )
-            if provider.instance_id in allowed_provider_instances
+            instance_id
+            for instance_id, domain in allowed_provider_instances.items()
+            if domain == provider_instance_or_domain
         ]
 
     def _get_stored_item(

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -665,6 +665,11 @@ class BuiltinProvider(MusicProvider):
         if not parsed_items:
             return
         playlist = await self.get_playlist(prov_playlist_id)
+        # this pass can run for a while; if the playlist is deleted and a new one is
+        # created that reuses the same sanitized ID before it finishes, this fingerprint
+        # lets the later write-back tell the two apart instead of writing stale matches
+        # into an unrelated playlist that merely happens to share its ID
+        original_generation = await self._get_playlist_generation(prov_playlist_id)
 
         minimum_confidence = match_policy_minimum_confidence(match_policy)
         allowed_provider_instance_map = dict(allowed_provider_instances)
@@ -735,7 +740,7 @@ class BuiltinProvider(MusicProvider):
 
         if pending_substitutions:
             not_applied = await self._apply_import_substitutions(
-                prov_playlist_id, pending_substitutions
+                prov_playlist_id, pending_substitutions, original_generation
             )
             # the report is built from tallies collected before this write - reconcile any
             # substitution the playlist no longer had an original for (a concurrent edit)
@@ -747,7 +752,7 @@ class BuiltinProvider(MusicProvider):
 
         if pending_metadata_updates:
             not_applied = await self._apply_import_substitutions(
-                prov_playlist_id, pending_metadata_updates
+                prov_playlist_id, pending_metadata_updates, original_generation
             )
             for _entry_index in not_applied:
                 counts["retained"] -= 1
@@ -914,6 +919,7 @@ class BuiltinProvider(MusicProvider):
         self,
         prov_playlist_id: str,
         pending_substitutions: list[tuple[PlaylistItem, PlaylistItem]],
+        expected_generation: tuple[int, int] | None,
     ) -> set[int]:
         """
         Write resolved substitutes into the playlist's current contents.
@@ -924,8 +930,13 @@ class BuiltinProvider(MusicProvider):
 
         :param prov_playlist_id: The provider-side playlist ID to update.
         :param pending_substitutions: (original, replacement) pairs found during matching.
+        :param expected_generation: The playlist's identity fingerprint captured when this
+            pass started, as returned by ``_get_playlist_generation``. If the file no longer
+            has this identity, the playlist behind this ID was deleted (and possibly replaced
+            by an unrelated new playlist reusing the same sanitized ID), so nothing is written.
         :return: Indices into `pending_substitutions` whose original entry was no longer in
-            the playlist (e.g. removed by a concurrent edit) and so were not applied.
+            the playlist (e.g. removed by a concurrent edit, or the playlist was replaced)
+            and so were not applied.
         """
         # index pending replacements by a stable key with per-key queues, so a playlist
         # with duplicate entries is still matched in original order without a per-item
@@ -935,6 +946,9 @@ class BuiltinProvider(MusicProvider):
             pending_by_key[repr(original)].append((index, replacement))
 
         async with self._get_playlist_lock(prov_playlist_id):
+            current_generation = await self._get_playlist_generation(prov_playlist_id)
+            if expected_generation is None or current_generation != expected_generation:
+                return set(range(len(pending_substitutions)))
             current_items = parse_m3u(await self._read_m3u_file(prov_playlist_id))
             updated_items: list[PlaylistItem] = []
             applied_indices: set[int] = set()
@@ -1680,6 +1694,24 @@ class BuiltinProvider(MusicProvider):
                 result: str = await _file.read()
                 return result
 
+    async def _get_playlist_generation(self, playlist_id: str) -> tuple[int, int] | None:
+        """
+        Return an (inode, device) identity fingerprint for a playlist's M3U file.
+
+        A rewrite of the same file (a rename, edit or matched substitution) keeps this
+        identity, while a delete followed by a new file recreated under the same
+        sanitized ID gets a new one - this is what lets a long-running background pass
+        tell the two apart. Returns None when the file does not currently exist.
+
+        :param playlist_id: The provider-side playlist ID to fingerprint.
+        """
+        playlist_file = os.path.join(self._playlists_dir, f"{playlist_id}.m3u")
+        try:
+            stat_result = await asyncio.to_thread(os.stat, playlist_file)
+        except FileNotFoundError:
+            return None
+        return (stat_result.st_ino, stat_result.st_dev)
+
     async def _write_m3u_file(
         self,
         playlist_id: str,
@@ -1904,87 +1936,94 @@ class BuiltinProvider(MusicProvider):
             if not filename.endswith(".m3u"):
                 continue
             playlist_id = filename[:-4]  # strip .m3u extension
-            m3u_data = await self._read_m3u_file(playlist_id)
-            playlist = await self.get_playlist(playlist_id)
-            self.logger.debug("Checking playlist '%s' for unresolved entries...", playlist.name)
-            update_current_task_progress_text(f"Checking playlist '{playlist.name}'")
-            all_items = parse_m3u(m3u_data)
-            has_changes = False
-            orphaned: set[int] = set()
-            for index, item in enumerate(all_items):
-                if _is_orphaned_entry_path(item.path):
-                    # leftover text from a value that once contained a line break: it is no
-                    # reference to anything and never will be, so drop it instead of failing
-                    # this (and every future) migration run on it
-                    self.logger.warning(
-                        "Dropping unresolvable entry %s from playlist '%s'",
-                        item.path,
-                        playlist.name,
-                    )
-                    orphaned.add(index)
-                    has_changes = True
-                    continue
-                force_migration = item.metadata and item.metadata.get("album") and not item.album
-                unresolved = bool(force_migration) or not (
-                    item.title and item.providers and item.metadata
-                )
-                if not unresolved and not self._stored_details_differ(item, stored_by_media_type):
-                    continue
-                self.logger.debug(
-                    "Found %s entry in playlist '%s': %s",
-                    "unresolved" if unresolved else "outdated",
-                    playlist_id,
-                    item.path,
-                )
-                try:
-                    enriched = await self._build_m3u_entry_from_uri(item.path)
-                    item.length = enriched.length
-                    item.title = enriched.title
-                    item.images = enriched.images
-                    item.providers = enriched.providers
-                    item.metadata = enriched.metadata
-                    item.album = enriched.album
-                    item.artists = enriched.artists
-                    item.podcast = enriched.podcast
-                except (
-                    MediaNotFoundError,
-                    InvalidDataError,
-                    InvalidProviderURI,
-                    ProviderUnavailableError,
-                ) as err:
-                    if unresolved:
+            async with self._get_playlist_lock(playlist_id):
+                m3u_data = await self._read_m3u_file(playlist_id)
+                playlist = await self.get_playlist(playlist_id)
+                self.logger.debug("Checking playlist '%s' for unresolved entries...", playlist.name)
+                update_current_task_progress_text(f"Checking playlist '{playlist.name}'")
+                all_items = parse_m3u(m3u_data)
+                has_changes = False
+                orphaned: set[int] = set()
+                for index, item in enumerate(all_items):
+                    if _is_orphaned_entry_path(item.path):
+                        # leftover text from a value that once contained a line break: it is no
+                        # reference to anything and never will be, so drop it instead of failing
+                        # this (and every future) migration run on it
                         self.logger.warning(
-                            "Could not enrich playlist entry %s during migration: %s",
+                            "Dropping unresolvable entry %s from playlist '%s'",
+                            item.path,
+                            playlist.name,
+                        )
+                        orphaned.add(index)
+                        has_changes = True
+                        continue
+                    force_migration = (
+                        item.metadata and item.metadata.get("album") and not item.album
+                    )
+                    unresolved = bool(force_migration) or not (
+                        item.title and item.providers and item.metadata
+                    )
+                    if not unresolved and not self._stored_details_differ(
+                        item, stored_by_media_type
+                    ):
+                        continue
+                    self.logger.debug(
+                        "Found %s entry in playlist '%s': %s",
+                        "unresolved" if unresolved else "outdated",
+                        playlist_id,
+                        item.path,
+                    )
+                    try:
+                        enriched = await self._build_m3u_entry_from_uri(item.path)
+                        item.length = enriched.length
+                        item.title = enriched.title
+                        item.images = enriched.images
+                        item.providers = enriched.providers
+                        item.metadata = enriched.metadata
+                        item.album = enriched.album
+                        item.artists = enriched.artists
+                        item.podcast = enriched.podcast
+                    except (
+                        MediaNotFoundError,
+                        InvalidDataError,
+                        InvalidProviderURI,
+                        ProviderUnavailableError,
+                    ) as err:
+                        if unresolved:
+                            self.logger.warning(
+                                "Could not enrich playlist entry %s during migration: %s",
+                                item.path,
+                                err,
+                            )
+                            report_current_task_failure(
+                                f"Could not enrich playlist entry: {item.path}"
+                            )
+                            errors += 1
+                            continue
+                        # an outdated entry is still playable, so failing to reach the stream is
+                        # no migration error; restore the stored details without any IO so a
+                        # permanently unreachable stream keeps its name and image
+                        self.logger.debug(
+                            "Could not refresh playlist entry %s, restoring stored details: %s",
                             item.path,
                             err,
                         )
-                        report_current_task_failure(f"Could not enrich playlist entry: {item.path}")
-                        errors += 1
-                        continue
-                    # an outdated entry is still playable, so failing to reach the stream is
-                    # no migration error; restore the stored details without any IO so a
-                    # permanently unreachable stream keeps its name and image
-                    self.logger.debug(
-                        "Could not refresh playlist entry %s, restoring stored details: %s",
-                        item.path,
-                        err,
-                    )
-                    self._restore_stored_details(item, stored_by_media_type)
-                else:
-                    # writing an entry the refresh did not bring back in step would leave
-                    # it outdated, and every later run would rewrite the file again
-                    if self._stored_details_differ(item, stored_by_media_type):
                         self._restore_stored_details(item, stored_by_media_type)
-                    self.logger.debug("Enriched playlist entry %s", item.path)
-                has_changes = True
-            if has_changes:
-                await self._write_m3u_file(
-                    playlist_id,
-                    playlist.name,
-                    [item for idx, item in enumerate(all_items) if idx not in orphaned],
-                    self._get_playlist_image_url(playlist),
-                )
-                self.logger.info("Updated playlist '%s' with enriched metadata", playlist.name)
+                    else:
+                        # writing an entry the refresh did not bring back in step would leave
+                        # it outdated, and every later run would rewrite the file again
+                        if self._stored_details_differ(item, stored_by_media_type):
+                            self._restore_stored_details(item, stored_by_media_type)
+                        self.logger.debug("Enriched playlist entry %s", item.path)
+                    has_changes = True
+                if has_changes:
+                    await self._write_m3u_file(
+                        playlist_id,
+                        playlist.name,
+                        [item for idx, item in enumerate(all_items) if idx not in orphaned],
+                        self._get_playlist_image_url(playlist),
+                    )
+                    self.logger.info("Updated playlist '%s' with enriched metadata", playlist.name)
             if errors > 25:
                 raise RuntimeError("Too many errors during playlist migration")
         self.logger.info("Playlist migration completed with %d errors", errors)

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1114,10 +1114,18 @@ class BuiltinProvider(MusicProvider):
         # accepted candidate's own metadata - using it (rather than the dead
         # source's copy) keeps release evidence such as MB_TRACK attributable to
         # the actual matched release, so a later export/re-import can't
-        # mistake a same-recording/best-effort substitution for an exact one
+        # mistake a same-recording/best-effort substitution for an exact one.
+        # A weaker, merely-compatible tier may still be present in the full match
+        # set, but media_item_to_playlist_item picks its primary playback URI by
+        # audio quality alone - mixing tiers into the persisted mappings could let
+        # a looser-tier provider become the actual substitute while the entry still
+        # carries the strongest tier's release evidence, so only the strongest
+        # tier's own mappings are kept.
         matched_track = replace(
             enrichment.matches[0].track,
-            provider_mappings={match.mapping for match in enrichment.matches},
+            provider_mappings={
+                match.mapping for match in enrichment.matches if match.confidence == best_confidence
+            },
         )
         return _ImportTrackMatchResult(
             label=label,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1754,13 +1754,18 @@ class BuiltinProvider(MusicProvider):
         """
         Reserve a unique playlist ID and write its initial M3U file with given content.
 
-        The uniqueness check, generation bump, and initial content write all happen
-        under the same lock: otherwise two concurrent creates for the same name could
-        both see the id as free, both claim it, and race each other's generation bump
-        and file write. Writing the given ``entries`` directly - rather than always
-        starting from an empty file - also means the file never appears on disk in an
-        intermediate state that a concurrent add/remove on the same (predictable) id
-        could observe or silently overwrite.
+        Every candidate ID is checked and, if free, claimed and written while holding
+        its own per-playlist edit lock (in the same outer-then-`_playlist_lock` order
+        `library_remove` uses) - not just `_playlist_lock` alone. Otherwise a
+        concurrent add/remove already mid-flight against that exact ID, having read
+        its old content before releasing its lock, could still overwrite this
+        reservation's freshly written file once it finally does release it: taking
+        the same per-ID lock here means such an edit is either fully finished (and
+        this reservation's existence check already sees its result) or fully blocked
+        until this reservation is done. Writing the given ``entries`` directly -
+        rather than always starting from an empty file - also means the file never
+        appears on disk in an intermediate state that a concurrent add/remove could
+        observe or silently overwrite.
 
         Returns the reserved ID together with its creation generation, so a caller
         that defers work against this exact playlist instance can detect a later
@@ -1771,23 +1776,27 @@ class BuiltinProvider(MusicProvider):
         :param playlist_image_url: Optional playlist image URL to embed in the header.
         """
         base_id = self._sanitize_playlist_id(name)
-        async with self._playlist_lock:
-            playlist_id = base_id
-            counter = 1
-            while await asyncio.to_thread(
-                os.path.isfile, os.path.join(self._playlists_dir, f"{playlist_id}.m3u")
-            ):
-                playlist_id = f"{base_id} ({counter})"
-                counter += 1
-            # bump this ID's generation before creating its file: a delete followed by a
-            # recreation under the same sanitized ID must be distinguishable from an
-            # in-place rewrite of the same playlist, even if the filesystem happens to
-            # reuse the freed inode for the new file
-            generation = self._playlist_generations[playlist_id] = (
-                self._playlist_generations.get(playlist_id, 0) + 1
-            )
-            await self._write_m3u_file_locked(playlist_id, name, entries, playlist_image_url)
-        return playlist_id, generation
+        playlist_id = base_id
+        counter = 1
+        while True:
+            async with self._get_playlist_lock(playlist_id), self._playlist_lock:
+                if not await asyncio.to_thread(
+                    os.path.isfile, os.path.join(self._playlists_dir, f"{playlist_id}.m3u")
+                ):
+                    # bump this ID's generation before creating its file: a delete
+                    # followed by a recreation under the same sanitized ID must be
+                    # distinguishable from an in-place rewrite of the same playlist,
+                    # even if the filesystem happens to reuse the freed inode for the
+                    # new file
+                    generation = self._playlist_generations[playlist_id] = (
+                        self._playlist_generations.get(playlist_id, 0) + 1
+                    )
+                    await self._write_m3u_file_locked(
+                        playlist_id, name, entries, playlist_image_url
+                    )
+                    return playlist_id, generation
+            playlist_id = f"{base_id} ({counter})"
+            counter += 1
 
     async def _write_m3u_file(
         self,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1080,10 +1080,11 @@ class BuiltinProvider(MusicProvider):
         """
         Check whether an imported entry's original source is still usable.
 
-        Resolves the exact provider instance and item id authoritatively (no stored
-        fallback) instead of trusting the ``available`` flag on a resolved track's
-        provider mappings, which only reflects whether the provider was loaded when
-        the M3U metadata was last written. Candidates are built directly from the
+        Resolves the exact provider instance and item id authoritatively - bypassing
+        cached details and without a stored fallback - instead of trusting the
+        ``available`` flag on a resolved track's provider mappings, which only
+        reflects whether the provider was loaded when the M3U metadata was last
+        written. Candidates are built directly from the
         entry's own ``#EXTPROV`` references (falling back to parsing the raw path for
         a plain M3U entry that carries a bare Music Assistant URI without one) instead
         of through the shared library's mapping resolution, which silently substitutes
@@ -1120,6 +1121,7 @@ class BuiltinProvider(MusicProvider):
                 await self.mass.music.tracks.get_provider_item(
                     provider_item_id,
                     provider.instance_id,
+                    force_refresh=True,
                     allow_fallback=False,
                     strict_provider_instance=True,
                 )

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1404,20 +1404,54 @@ class BuiltinProvider(MusicProvider):
         not registered on this server (e.g. a playlist imported from a different
         Music Assistant install, where instance ids are randomly generated per
         install) - every one of the caller's allowed instances of the entry's own
-        domain is tried instead: the single, arbitrary instance the shared library
-        would otherwise resolve a bare domain to, or silently giving up on a foreign
-        instance id that matches nothing here, would both be wrong. The snapshot
-        maps every instance the caller has configured to its domain, whether or not
-        the instance is currently loaded, so this never depends on the provider's
-        current load state - including for the domain-based expansion.
+        domain is tried instead, but only when that domain's item ids are actually
+        portable across instances (a shared streaming catalog): the single,
+        arbitrary instance the shared library would otherwise resolve a bare domain
+        to, or silently giving up on a foreign instance id that matches nothing
+        here, would both be wrong. For a non-streaming domain (e.g. filesystem),
+        each instance mints its own local ids, so a foreign or missing instance id
+        cannot be assumed valid on any of the caller's own same-domain instances -
+        expanding it could authoritatively confirm an unrelated file and wrongly
+        mark the true original as still playable. The snapshot maps every instance
+        the caller has configured to its domain, whether or not the instance is
+        currently loaded, so this never depends on the provider's current load
+        state - including for the domain-based expansion.
         """
         if instance_id and instance_id in allowed_provider_instances:
             return [instance_id]
+        if not self._domain_is_streaming(domain, allowed_provider_instances):
+            return []
         return [
             allowed_instance_id
             for allowed_instance_id, allowed_domain in allowed_provider_instances.items()
             if allowed_domain == domain
         ]
+
+    def _domain_is_streaming(
+        self, domain: str, allowed_provider_instances: Mapping[str, str]
+    ) -> bool:
+        """
+        Return whether providers of this domain share a single portable catalog.
+
+        Every instance of a domain shares the same provider class and therefore the
+        same ``is_streaming_provider`` trait, so any one allowed instance of it is
+        representative. Defaults to ``True`` when no instance of this domain can be
+        resolved at all, consistent with how an unresolvable provider is treated
+        everywhere else in this matching pass - a missing provider is never treated
+        as reason to force a substitution.
+
+        :param domain: The provider domain to check.
+        :param allowed_provider_instances: (instance_id, domain) pairs to search for a
+            representative instance of this domain.
+        """
+        for allowed_instance_id, allowed_domain in allowed_provider_instances.items():
+            if allowed_domain != domain:
+                continue
+            if provider := self.mass.get_provider(
+                allowed_instance_id, return_unavailable=True, provider_type=MusicProvider
+            ):
+                return provider.is_streaming_provider
+        return True
 
     def _get_stored_item(
         self, item: PlaylistItem, stored_by_media_type: Mapping[str, Mapping[str, StoredItem]]

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -176,10 +176,7 @@ class _ImportTrackMatchResult:
     ambiguous_providers: tuple[str, ...] = ()
     failed_providers: tuple[str, ...] = ()
     error: str | None = None
-    # only set when `error` came from a provider communication failure (a caught
-    # exception from enrich_provider_mappings) rather than a local data/validation
-    # issue (e.g. a foreign M3U entry with no structured artist to search with) - the
-    # report's provider issues section must not misattribute the latter to a provider
+    # True when the error came from provider communication, not local validation.
     error_is_provider_issue: bool = False
 
 
@@ -211,9 +208,7 @@ class BuiltinProvider(MusicProvider):
         if not await asyncio.to_thread(os.path.exists, self._playlists_dir):
             await asyncio.to_thread(os.mkdir, self._playlists_dir)
         await super().loaded_in_mass()
-        # run in the background to avoid blocking startup. besides migrating old-style
-        # playlists, this repairs entries whose manually set name or artwork no longer
-        # matches the builtin config, which is not a one-off.
+        # Run in the background: migrate legacy playlists and repair stored metadata drift.
         # TODO: drop the config->M3U migration after MA 2.9, keep the repair pass
         self.mass.tasks.register_scheduled_task(
             task_id="migrate_builtin_playlists",
@@ -421,10 +416,7 @@ class BuiltinProvider(MusicProvider):
         elif media_type == MediaType.PLAYLIST:
             # user-created playlist removal - delete the M3U file
             playlist_file = os.path.join(self._playlists_dir, f"{prov_item_id}.m3u")
-            # both the per-playlist edit lock and the global file-I/O lock used by
-            # _read_m3u_file/_write_m3u_file must be held, and the existence check
-            # itself must happen inside them - otherwise a concurrent read, write or
-            # second delete already in flight on this file could still race the unlink
+            # Hold both locks so the existence check and unlink cannot race other I/O.
             async with self._get_playlist_lock(prov_item_id), self._playlist_lock:
                 if await asyncio.to_thread(os.path.isfile, playlist_file):
                     await asyncio.to_thread(os.remove, playlist_file)
@@ -606,11 +598,8 @@ class BuiltinProvider(MusicProvider):
         Items with valid MA URIs are added directly. Plain URLs or unresolvable
         URIs are stored as-is for later matching.
 
-        Also returns the created playlist's creation generation, so a caller that
-        schedules a deferred background match against it can snapshot exactly which
-        playlist instance that task is for, not merely its id - letting the match
-        detect a delete-and-recreate under the same id that happens before the
-        (possibly queued) task actually starts.
+        Also returns the playlist generation so deferred work can detect a later
+        delete-and-recreate under the same ID.
 
         :param m3u_data: The M3U8 playlist data as a string.
         """
@@ -620,12 +609,7 @@ class BuiltinProvider(MusicProvider):
             raise InvalidDataError(msg)
         playlist_name = parse_m3u_playlist_name(m3u_data) or "Imported Playlist"
         playlist_image_url = parse_m3u_playlist_image(m3u_data)
-        # write the parsed items directly as the initial M3U file content, preserving
-        # all metadata from the source - this avoids re-resolving items that already
-        # have rich metadata (e.g. exported from another MA instance), and, by
-        # reserving the id and writing its final content in the same locked step,
-        # never exposes an intermediate empty playlist that a concurrent add/remove
-        # on the same (predictable) id could race against
+        # Reserve the ID and write the final contents in one step.
         playlist_id, generation = await self._reserve_playlist_file(
             playlist_name, parsed_items, playlist_image_url
         )
@@ -642,53 +626,27 @@ class BuiltinProvider(MusicProvider):
         """
         Match imported playlist tracks against available providers.
 
-        Entries whose original source is confirmed still playable - available and, once
-        probed, still resolvable, or merely unreachable right now - are left untouched.
-        For the remaining entries, whose original source is confirmed missing or
-        genuinely no longer available, other providers are searched for a substitute
-        meeting ``match_policy``'s minimum confidence; matched entries are replaced
-        in-place so the playlist keeps its original order and duplicates.
+        Playable originals are kept. Entries confirmed missing are replaced in place
+        with matches that meet ``match_policy``.
 
         :param prov_playlist_id: The provider-side playlist ID of the playlist to match.
-        :param expected_generation: The creation generation of the playlist this task was
-            scheduled for, snapshotted at import time. This task itself may sit queued for
-            a while before it actually runs; if the playlist is deleted and an unrelated
-            one is created that reuses the same ID before that happens, its generation no
-            longer matches and this call is a no-op instead of matching that replacement.
+        :param expected_generation: Creation generation captured at import time. If the
+            playlist was recreated under the same ID, this call is skipped.
         :param match_policy: Lowest track-match confidence accepted for a substitute.
-        :param allowed_provider_instances: (instance_id, domain) pairs snapshotted from the
-            user that requested the import, used to validate whether an entry's original
-            source is still playable. Always the user's full accessible set, independent
-            of any search narrowing, so a valid original outside that narrowing is never
-            treated as unavailable. Carrying the domain alongside each instance allows a
-            domain-only reference to be expanded from this snapshot directly, without
-            depending on whether the provider is currently loaded.
-        :param search_provider_instances: Provider instances to search for a substitute.
-            Defaults to ``allowed_provider_instances`` when not narrowed by the caller.
+        :param allowed_provider_instances: Snapshotted ``(instance_id, domain)`` pairs
+            used to validate the original source.
+        :param search_provider_instances: Optional subset to search for substitutes.
         """
-        # the initial content read and generation capture must happen atomically under
-        # the per-playlist lock: library_remove takes this same lock before unlinking
-        # the file, so holding it here prevents a delete-and-recreate from landing in
-        # between - which would otherwise pair this pass's old (pre-delete) content
-        # with the *new* playlist's generation, defeating the write-back check below
+        # Read the playlist and capture its generation under the per-playlist lock.
         async with self._get_playlist_lock(prov_playlist_id):
             m3u_data = await self._read_m3u_file(prov_playlist_id)
             parsed_items = parse_m3u(m3u_data)
             if not parsed_items:
                 return
             playlist = await self.get_playlist(prov_playlist_id)
-            # this pass can run for a while; if the playlist is deleted and a new one
-            # is created that reuses the same sanitized ID before it finishes, this
-            # generation lets the later write-back tell the two apart instead of
-            # writing stale matches into an unrelated playlist that merely happens to
-            # share its ID
+            # Distinguish a later delete-and-recreate under the same ID.
             original_generation = await self._get_playlist_generation(prov_playlist_id)
             if original_generation != expected_generation:
-                # this task itself was scheduled for a playlist that no longer exists
-                # under this ID - it was deleted and replaced before this (possibly
-                # queued) task could even start, so what is here now is an unrelated
-                # playlist that must not be matched under a policy that was never
-                # meant for it
                 return
 
         minimum_confidence = match_policy_minimum_confidence(match_policy)
@@ -699,9 +657,7 @@ class BuiltinProvider(MusicProvider):
             else set(search_provider_instances)
         )
         failed_provider_instances: set[str] = set()
-        # a transient (e.g. network) failure verifying an original source instance is
-        # remembered for the rest of this pass, so a large playlist repeating that same
-        # instance doesn't re-probe (and re-time-out on) it once per entry
+        # Cache transient source-verification failures for the rest of this pass.
         failed_source_instances: set[str] = set()
         total = len(parsed_items)
         counts = dict.fromkeys(
@@ -717,22 +673,15 @@ class BuiltinProvider(MusicProvider):
             0,
         )
         substitutions: list[tuple[str, str, str]] = []
-        # (original, replacement) pairs, applied against a freshly re-read playlist below so
-        # edits made elsewhere while this (possibly long-running) pass was searching aren't lost
+        # Apply substitutions against a fresh read so concurrent edits are preserved.
         pending_substitutions: list[tuple[PlaylistItem, PlaylistItem]] = []
-        # confidence-count key for each pending_substitutions entry, same index - lets the
-        # report be reconciled against what _apply_import_substitutions actually wrote
+        # Confidence bucket for each pending substitution.
         substitution_tiers: list[str] = []
-        # retained entries whose bare-URI original carried no #EXTPROV of its own - written
-        # back with the provider mapping confirmed playable during this pass, so they keep
-        # resolving on future loads too, without being reported as substitutions
+        # Retained entries that gained a confirmed provider mapping.
         pending_metadata_updates: list[tuple[PlaylistItem, PlaylistItem]] = []
         unmatched_items: list[tuple[str, str]] = []
         provider_issues: list[tuple[str, str]] = []
-        # results are cached by the entry's full content (not just its path) so a track
-        # that is byte-for-byte duplicated in the playlist is only probed and searched
-        # once, however many times it repeats - entries sharing a path but differing in
-        # any resolution input (title, artists, providers, ...) are resolved independently
+        # Cache results by full entry content so exact duplicates are resolved once.
         resolved_by_entry: dict[str, _ImportTrackMatchResult] = {}
 
         for index, item in enumerate(parsed_items):
@@ -767,9 +716,7 @@ class BuiltinProvider(MusicProvider):
             not_applied = await self._apply_import_substitutions(
                 prov_playlist_id, pending_substitutions, original_generation
             )
-            # the report is built from tallies collected before this write - reconcile any
-            # substitution the playlist no longer had an original for (a concurrent edit)
-            # so counts and detail rows only reflect what was actually applied
+            # Drop substitutions that no longer apply after concurrent edits.
             for entry_index in sorted(not_applied, reverse=True):
                 counts[substitution_tiers[entry_index]] -= 1
                 counts["concurrent_edit"] += 1
@@ -949,24 +896,15 @@ class BuiltinProvider(MusicProvider):
         """
         Write resolved substitutes into the playlist's current contents.
 
-        Matching can take a while, so entries are matched by value against a fresh read of
-        the playlist under its lock rather than overwriting the whole snapshot taken at the
-        start of the pass - this preserves edits made elsewhere while matching was running.
+        Matches originals against a fresh read so concurrent edits are preserved.
 
         :param prov_playlist_id: The provider-side playlist ID to update.
         :param pending_substitutions: (original, replacement) pairs found during matching.
-        :param expected_generation: The playlist's creation generation captured when this
-            pass started, as returned by ``_get_playlist_generation``. If the file's current
-            generation no longer matches, the playlist behind this ID was deleted (and
-            possibly replaced by an unrelated new playlist reusing the same sanitized ID),
-            so nothing is written.
-        :return: Indices into `pending_substitutions` whose original entry was no longer in
-            the playlist (e.g. removed by a concurrent edit, or the playlist was replaced)
-            and so were not applied.
+        :param expected_generation: Playlist generation captured at the start of the
+            pass. If it changed, nothing is written.
+        :return: Indices of substitutions whose original entry was no longer present.
         """
-        # index pending replacements by a stable key with per-key queues, so a playlist
-        # with duplicate entries is still matched in original order without a per-item
-        # linear scan of the (potentially large) remaining list
+        # Queue replacements by entry value so duplicates are applied in order.
         pending_by_key: dict[str, deque[tuple[int, PlaylistItem]]] = defaultdict(deque)
         for index, (original, replacement) in enumerate(pending_substitutions):
             pending_by_key[repr(original)].append((index, replacement))
@@ -1073,9 +1011,7 @@ class BuiltinProvider(MusicProvider):
         failed_source_instances: set[str],
     ) -> _ImportTrackMatchResult:
         """Resolve one imported playlist entry against the allowed providers."""
-        # a bare URI without #EXTMA metadata (e.g. a hand-written or foreign M3U entry)
-        # would otherwise default to Track; a radio:// path (or similar) must still be
-        # recognized as non-Track so it is retained rather than searched/substituted
+        # Bare MA URIs still need their real media type to avoid treating radios as tracks.
         default_media_type = MediaType.TRACK
         with suppress(InvalidProviderURI, InvalidProviderID):
             parsed_media_type, _, _ = await parse_uri(item.path)
@@ -1095,17 +1031,10 @@ class BuiltinProvider(MusicProvider):
             item, allowed_provider_instances, failed_source_instances
         )
         if is_playable:
-            # the original source still resolves, or its provider is merely down right
-            # now - either way there is nothing to substitute
             normalized_entry = None
             if confirmed_mapping is not None:
-                # a bare URI (no #EXTPROV metadata at all), a domain-only reference, or
-                # one pinning an instance id not registered on this server (e.g.
-                # imported from a different Music Assistant install) was just confirmed
-                # playable - persist the resolved mapping so this entry keeps resolving
-                # to the exact same instance on future loads too, instead of leaving one
-                # that can never attach an instance-pinned mapping, or that would repeat
-                # the same fallback, again
+                # Persist a confirmed mapping for bare, domain-only, or foreign-instance
+                # entries so later loads resolve the same instance directly.
                 normalized_entry = replace(
                     item,
                     providers=[
@@ -1122,8 +1051,7 @@ class BuiltinProvider(MusicProvider):
                 )
             return _ImportTrackMatchResult(label=label, retained=True, entry=normalized_entry)
         if not media_item.artists:
-            # foreign M3U8 files only carry a combined "Artist - Title" EXTINF string;
-            # the shared matcher needs a structured artist to search and compare with
+            # Foreign M3U entries may need the artist split from the EXTINF title first.
             split_item = _split_artist_from_title(item)
             if split_item is not item:
                 rebuilt = construct_media_item_from_playlist_item(split_item, self.mass)
@@ -1139,24 +1067,14 @@ class BuiltinProvider(MusicProvider):
                 media_item,
                 minimum_confidence=minimum_confidence,
                 provider_instance_ids=search_provider_instances,
-                # imported metadata comes from outside Music Assistant and is unverified,
-                # so a provider mapping it already carries is not treated as authoritative
+                # Imported playlist metadata is untrusted.
                 trust_track_mappings=False,
                 failed_provider_instances=failed_provider_instances,
-                # the liveness check above already force-refreshed these exact
-                # (instance, item id) pairs and proved them dead - hydrating them again
-                # here would double every stale entry's provider API traffic for nothing
+                # Skip source mappings already force-refreshed and confirmed dead.
                 known_dead_mappings=confirmed_dead_mappings,
-                # release-evidence hydration (e.g. the source's own album) must reach the
-                # user's full allowed snapshot, not just the narrowed search targets, or a
-                # match_providers filter would starve EXACT matching of evidence that is
-                # still on one of the user's own, merely un-searched, accounts
+                # Keep album-evidence hydration scoped to the full allowed set.
                 evidence_provider_instances=set(allowed_provider_instances),
-                # search_provider_instances is the initiating user's own deliberate
-                # selection of fallback targets - a non-streaming provider (e.g.
-                # filesystem) chosen there must actually be searched, not silently
-                # skipped for lacking a mapping no freshly imported track could ever
-                # already carry
+                # Explicit non-streaming fallback targets must still be searched.
                 search_non_streaming_without_mapping=True,
             )
         except (
@@ -1171,10 +1089,7 @@ class BuiltinProvider(MusicProvider):
             message = str(err).strip() or f"Matching failed ({type(err).__name__})"
             return _ImportTrackMatchResult(label=label, error=message, error_is_provider_issue=True)
         if not enrichment.matches:
-            # nothing was actually matched - the track's provider_mappings may still carry
-            # an untrusted, unverified original mapping (trust_track_mappings=False keeps
-            # it around unless a same-domain match displaces it), so branch on the matches
-            # that were actually found rather than on the mapping set itself
+            # Branch on accepted matches, not the raw mapping set.
             return _ImportTrackMatchResult(
                 label=label,
                 ambiguous_providers=enrichment.ambiguous_providers,
@@ -1184,12 +1099,7 @@ class BuiltinProvider(MusicProvider):
         tier_matches = [
             match for match in enrichment.matches if match.confidence == best_confidence
         ]
-        # media_item_to_playlist_item picks its primary playback URI by the same
-        # availability/quality/identity ordering used here, so the primary match must
-        # be selected the same way - otherwise the entry's release evidence (from
-        # whichever match's track happened to be first) could describe a different
-        # release than the mapping the serializer actually ends up exporting as the
-        # playable URI.
+        # Match serializer ordering so exported metadata describes the chosen primary URI.
         primary_match = min(
             tier_matches,
             key=lambda match: (
@@ -1200,11 +1110,7 @@ class BuiltinProvider(MusicProvider):
                 match.mapping.item_id,
             ),
         )
-        # a same-tier sibling from another provider is only safe to keep alongside
-        # the primary match's own release evidence (e.g. MB_TRACK) when it is
-        # confirmed to be that exact same release - a merely LIKELY-compatible
-        # sibling may share the recording but not the release, and combining its
-        # mapping under the primary's metadata would misattribute it as exact
+        # Keep sibling mappings only when they resolve to the same exact release.
         matched_track = replace(
             primary_match.track,
             provider_mappings={
@@ -1232,54 +1138,24 @@ class BuiltinProvider(MusicProvider):
         """
         Check whether an imported entry's original source is still usable.
 
-        Resolves the exact provider instance and item id authoritatively - bypassing
-        cached details and without a stored fallback - instead of trusting the
-        ``available`` flag on a resolved track's provider mappings, which only
-        reflects whether the provider was loaded when the M3U metadata was last
-        written. Candidates are built directly from the entry's own ``#EXTPROV``
-        references (falling back to parsing the raw path for a plain M3U entry that
-        carries a bare Music Assistant URI without one) instead of through the shared
-        library's mapping resolution, which silently substitutes an arbitrary
-        same-domain instance for a domain-only reference. A domain-only or foreign
-        reference can expand to several of the caller's own same-domain instances;
-        one of those being down or otherwise unverifiable right now does not rule
-        out another already-healthy sibling actually confirming the item, so every
-        candidate is tried before falling back to a verdict. Only once every
-        candidate is exhausted does an unresolved one count: a provider that is
-        merely down right now, or is configured but not currently loaded (e.g. it
-        failed setup), counts as still usable, so a transient outage does not
-        trigger a permanent substitution. Candidates are only ever expanded within
-        the initiating user's own provider instances, so a domain-only reference can
-        never reach an inaccessible account.
+        Performs authoritative provider lookups on the entry's own references.
+        Domain-only or foreign-instance references expand only within the caller's
+        allowed instances, and unverifiable providers stay inconclusive rather than
+        being treated as missing.
 
-        Returns the confirmed provider mapping alongside the playable verdict whenever
-        the entry needs it written back to keep resolving on its own next time: a bare
-        Music Assistant provider URI with no ``#EXTPROV`` metadata at all, a
-        domain-only ``#EXTPROV`` reference, or one that pins an instance id not
-        registered on this server (e.g. imported from a different Music Assistant
-        install, where instance ids are randomly generated per install) - each
-        normalized to whichever allowed instance actually confirmed it. A raw builtin
-        stream URL already reconstructs its own mapping from the path alone and needs
-        nothing written back, and an ``#EXTPROV`` reference that already names an
-        exact allowed instance already resolves correctly on its own. Also returns
-        every ``(instance_id, item_id)`` pair that was just authoritatively confirmed
-        dead here, so a subsequent matching pass does not force-refresh the exact same
-        candidate a second time.
+        Returns the normalized mapping to persist for bare, domain-only, or
+        foreign-instance entries, plus any exact ``(instance_id, item_id)`` pairs
+        confirmed dead during this pass.
 
-        :param failed_source_instances: Instances that already failed verification
-            with a transient error earlier this pass, mutated in place - skipped
-            here without probing (and potentially timing out on) them again.
+        :param failed_source_instances: Instances that already failed transiently in
+            this pass and should be skipped here too.
         """
         candidates: list[tuple[str, str, bool]] = []
         seen: set[tuple[str, str]] = set()
         confirmed_dead: set[tuple[str, str]] = set()
         for prov_info in item.providers:
-            # a domain-only reference (no pinned instance id), or a pinned instance id
-            # that is not registered on this server at all (e.g. a playlist imported
-            # from a different Music Assistant install, where instance ids are
-            # randomly generated per install), is not yet tied to one of the caller's
-            # own accounts; once resolved, normalize it to whichever allowed instance
-            # actually confirmed it, so a later load doesn't need this same fallback again
+            # Normalize domain-only or foreign-instance references to the confirming
+            # allowed instance.
             needs_provider_metadata = (
                 not prov_info.instance_id or prov_info.instance_id not in allowed_provider_instances
             )
@@ -1291,45 +1167,28 @@ class BuiltinProvider(MusicProvider):
                     seen.add(key)
                     candidates.append((instance_id, prov_info.item_id, needs_provider_metadata))
         if not item.providers:
-            # only a plain M3U entry with a bare Music Assistant URI and no #EXTPROV
-            # metadata at all needs this path parsed - an entry that does carry
-            # #EXTPROV references is fully handled by the loop above, including its
-            # own domain-based fallback for an unregistered pinned instance
+            # Bare MA URIs without #EXTPROV need path parsing to build candidates.
             with suppress(InvalidProviderURI, InvalidProviderID, IndexError, ValueError):
                 _, provider_instance_or_domain, raw_item_id = await parse_uri(item.path)
-                # a resolved external provider reference - a bare MA URI or a public
-                # share link such as https://open.spotify.com/track/... - has no other
-                # way to attach a provider mapping and must be persisted; a raw builtin
-                # stream URL already reconstructs "builtin" from the path alone on
-                # every future load and needs nothing written back
+                # Raw builtin stream URLs already reconstruct their mapping from the path.
                 needs_provider_metadata = provider_instance_or_domain != "builtin"
-                # a bare URI carries no separate domain field to fall back on, so an
-                # instance id that isn't allowed here (unlike a genuine domain, e.g.
-                # from a public share link) simply yields no candidates below
+                # Bare URIs have no separate domain fallback for disallowed instances.
                 for instance_id in self._allowed_instances_for(
                     provider_instance_or_domain,
                     provider_instance_or_domain,
                     allowed_provider_instances,
                 ):
                     candidates.append((instance_id, raw_item_id, needs_provider_metadata))
-        # tracks whether any candidate could not be authoritatively checked at all
-        # (down/unloaded provider, already-known or fresh transient error) - only
-        # once every candidate is exhausted does this decide the final verdict,
-        # so one unreachable sibling instance never rules out trying another
+        # Track whether any candidate stayed inconclusive.
         any_unverifiable = False
         for provider_instance, provider_item_id, needs_provider_metadata in candidates:
             if provider_instance in failed_source_instances:
-                # a transient error already confirmed this instance unreachable
-                # earlier this pass - skip re-probing (and potentially timing out
-                # on) it again, but still give any other candidate a chance
+                # Skip instances that already failed transiently in this pass.
                 any_unverifiable = True
                 continue
             provider = self.mass.get_provider(provider_instance, return_unavailable=True)
             if provider is None or not provider.available:
-                # every candidate here already passed the allowed-instances snapshot, so
-                # a missing/unavailable provider is a configured source that is merely
-                # down or failed setup right now, not one the user removed - try any
-                # other candidate before treating this alone as inconclusive
+                # Unloaded or unavailable allowed providers are inconclusive, not dead.
                 any_unverifiable = True
                 continue
             try:
@@ -1341,19 +1200,14 @@ class BuiltinProvider(MusicProvider):
                     strict_provider_instance=True,
                 )
             except MediaNotFoundError, InvalidProviderID:
-                # a catalog id genuinely no longer exists on the provider, or is
-                # malformed for it (e.g. an id that no longer matches the provider's
-                # expected format) - either way it will never resolve on retry
+                # Missing or malformed ids are permanently dead for this provider.
                 confirmed_dead.add((provider.instance_id, provider_item_id))
                 continue
             except InvalidDataError:
                 if provider_item_id.startswith(
                     BUILTIN_URL_SCHEMES
                 ) and await self._stream_url_confirmed_gone(provider_item_id):
-                    # a confirmed terminal HTTP status (404/410) proves this stream
-                    # is actually gone - anything else this error can mean (a DNS
-                    # hiccup, a timeout, a 5xx response, or - for a catalog id - a
-                    # provider's own API/HTTP fault) does not prove deletion
+                    # Only a terminal HTTP failure proves a builtin stream URL is gone.
                     confirmed_dead.add((provider.instance_id, provider_item_id))
                     continue
                 any_unverifiable = True
@@ -1365,20 +1219,15 @@ class BuiltinProvider(MusicProvider):
                 OSError,
                 TimeoutError,
             ):
-                # could not verify right now (network blip) - remember this instance
-                # for the rest of the pass so a large playlist doesn't retry (and
-                # re-time-out on) it once per entry, but still try any other
-                # candidate before treating this alone as inconclusive
+                # Cache transient verification failures and keep trying siblings.
                 failed_source_instances.add(provider.instance_id)
                 any_unverifiable = True
                 continue
             else:
                 if not needs_provider_metadata:
                     return True, None, frozenset(confirmed_dead)
-                # a bare URI without #EXTPROV, or a domain-only reference not yet
-                # pinned to one instance, would otherwise stay unresolvable or keep
-                # guessing the wrong account on every future load - persist what was
-                # just confirmed so the entry keeps resolving after this pass
+                # Persist the confirmed mapping for bare, domain-only, or foreign
+                # instance references.
                 own_mapping = next(
                     (
                         pm
@@ -1387,9 +1236,7 @@ class BuiltinProvider(MusicProvider):
                     ),
                     None,
                 )
-                # audio format details are only known when the hydrated item actually
-                # carried its own mapping - otherwise leave them unset rather than
-                # writing a guessed/default format into the persisted metadata
+                # Only persist audio format fields when the provider supplied them.
                 audio_format = own_mapping.audio_format if own_mapping else None
                 return (
                     True,
@@ -1405,8 +1252,7 @@ class BuiltinProvider(MusicProvider):
                     frozenset(confirmed_dead),
                 )
         if any_unverifiable:
-            # at least one candidate couldn't be authoritatively checked, so the
-            # entry cannot be proven dead - never substitute on an unproven verdict
+            # Any inconclusive candidate keeps the entry playable.
             return True, None, frozenset(confirmed_dead)
         return False, None, frozenset(confirmed_dead)
 
@@ -1414,15 +1260,8 @@ class BuiltinProvider(MusicProvider):
         """
         Return whether a stream URL is confirmed to no longer exist.
 
-        ffprobe reports a transient failure (a DNS hiccup, a timeout, a 5xx
-        response) with the same error as a genuinely deleted stream, so only a
-        terminal HTTP status confirms deletion. A scheme this cannot check (e.g.
-        ``rtsp://``/``rtmp://``) is never treated as confirmed gone. A HEAD
-        404/410 is corroborated with a minimal ranged GET before being treated
-        as terminal, since some servers reject HEAD requests they would still
-        serve on GET. A server that explicitly refuses the HEAD method itself
-        (405/501) is also corroborated by that same GET, rather than being
-        treated as inconclusive forever.
+        Only terminal 404/410 responses count; HEAD results are confirmed with a
+        ranged GET.
         """
         if not url.startswith(("http://", "https://")):
             return False
@@ -1453,23 +1292,8 @@ class BuiltinProvider(MusicProvider):
         """
         Expand an entry's provider reference to allowed instance ids.
 
-        An exact instance id is kept as-is when it is in the caller's own snapshot.
-        Otherwise - whether the entry never pinned one at all, or it pins one that is
-        not registered on this server (e.g. a playlist imported from a different
-        Music Assistant install, where instance ids are randomly generated per
-        install) - every one of the caller's allowed instances of the entry's own
-        domain is tried instead, but only when that domain's item ids are actually
-        portable across instances (a shared streaming catalog): the single,
-        arbitrary instance the shared library would otherwise resolve a bare domain
-        to, or silently giving up on a foreign instance id that matches nothing
-        here, would both be wrong. For a non-streaming domain (e.g. filesystem),
-        each instance mints its own local ids, so a foreign or missing instance id
-        cannot be assumed valid on any of the caller's own same-domain instances -
-        expanding it could authoritatively confirm an unrelated file and wrongly
-        mark the true original as still playable. The snapshot maps every instance
-        the caller has configured to its domain, whether or not the instance is
-        currently loaded, so this never depends on the provider's current load
-        state - including for the domain-based expansion.
+        Keeps exact allowed instances. Domain-only or foreign-instance references
+        expand only across allowed streaming instances of the same domain.
         """
         if instance_id and instance_id in allowed_provider_instances:
             return [instance_id]
@@ -1487,16 +1311,10 @@ class BuiltinProvider(MusicProvider):
         """
         Return whether providers of this domain share a single portable catalog.
 
-        Every instance of a domain shares the same provider class and therefore the
-        same ``is_streaming_provider`` trait, so any one allowed instance of it is
-        representative. Defaults to ``True`` when no instance of this domain can be
-        resolved at all, consistent with how an unresolvable provider is treated
-        everywhere else in this matching pass - a missing provider is never treated
-        as reason to force a substitution.
+        Defaults to ``True`` when no allowed instance of the domain can be resolved.
 
         :param domain: The provider domain to check.
-        :param allowed_provider_instances: (instance_id, domain) pairs to search for a
-            representative instance of this domain.
+        :param allowed_provider_instances: ``(instance_id, domain)`` pairs to search.
         """
         for allowed_instance_id, allowed_domain in allowed_provider_instances.items():
             if allowed_domain != domain:
@@ -1806,9 +1624,7 @@ class BuiltinProvider(MusicProvider):
     async def _read_m3u_file(self, playlist_id: str) -> str:
         """Read the raw M3U file content for a playlist."""
         playlist_file = os.path.join(self._playlists_dir, f"{playlist_id}.m3u")
-        # the existence check and the open must happen while holding the same lock a
-        # concurrent delete uses, or a delete slipping in between the two could still
-        # remove the file after it was seen to exist but before it was opened
+        # Hold the same lock delete uses for the existence check and open.
         async with self._playlist_lock:
             if not await asyncio.to_thread(os.path.isfile, playlist_file):
                 return ""
@@ -1820,11 +1636,8 @@ class BuiltinProvider(MusicProvider):
         """
         Return the current creation generation for a playlist's M3U file.
 
-        Bumped by create_playlist every time a new file is created under this sanitized
-        ID, so a delete followed by a recreation under the same ID - even one that, by
-        pure filesystem-level chance, reuses the just-freed inode - is still
-        distinguishable from an in-place rewrite of the same playlist (a rename, edit,
-        or matched substitution). Returns None when the file does not currently exist.
+        Bumped whenever a new file is created under this sanitized ID. Returns
+        ``None`` when the file does not currently exist.
 
         :param playlist_id: The provider-side playlist ID to fingerprint.
         """
@@ -1842,22 +1655,8 @@ class BuiltinProvider(MusicProvider):
         """
         Reserve a unique playlist ID and write its initial M3U file with given content.
 
-        Every candidate ID is checked and, if free, claimed and written while holding
-        its own per-playlist edit lock (in the same outer-then-`_playlist_lock` order
-        `library_remove` uses) - not just `_playlist_lock` alone. Otherwise a
-        concurrent add/remove already mid-flight against that exact ID, having read
-        its old content before releasing its lock, could still overwrite this
-        reservation's freshly written file once it finally does release it: taking
-        the same per-ID lock here means such an edit is either fully finished (and
-        this reservation's existence check already sees its result) or fully blocked
-        until this reservation is done. Writing the given ``entries`` directly -
-        rather than always starting from an empty file - also means the file never
-        appears on disk in an intermediate state that a concurrent add/remove could
-        observe or silently overwrite.
-
-        Returns the reserved ID together with its creation generation, so a caller
-        that defers work against this exact playlist instance can detect a later
-        delete-and-recreate under the same ID.
+        Claims and writes each candidate ID while holding that playlist's edit lock,
+        so concurrent edits cannot overwrite a newly created file.
 
         :param name: The playlist's display name, used to derive its sanitized id.
         :param entries: The initial playlist items to write.
@@ -1871,11 +1670,7 @@ class BuiltinProvider(MusicProvider):
                 if not await asyncio.to_thread(
                     os.path.isfile, os.path.join(self._playlists_dir, f"{playlist_id}.m3u")
                 ):
-                    # bump this ID's generation before creating its file: a delete
-                    # followed by a recreation under the same sanitized ID must be
-                    # distinguishable from an in-place rewrite of the same playlist,
-                    # even if the filesystem happens to reuse the freed inode for the
-                    # new file
+                    # Bump the generation before creating a new file under this ID.
                     generation = self._playlist_generations[playlist_id] = (
                         self._playlist_generations.get(playlist_id, 0) + 1
                     )

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1084,11 +1084,13 @@ class BuiltinProvider(MusicProvider):
             # now - either way there is nothing to substitute
             normalized_entry = None
             if confirmed_mapping is not None:
-                # a bare URI (no #EXTPROV metadata at all) or a domain-only reference
-                # was just confirmed playable - persist the resolved mapping so this
-                # entry keeps resolving to the exact same instance on future loads too,
-                # instead of leaving one that can never attach an instance-pinned
-                # mapping, or that would re-guess the first registered account, again
+                # a bare URI (no #EXTPROV metadata at all), a domain-only reference, or
+                # one pinning an instance id not registered on this server (e.g.
+                # imported from a different Music Assistant install) was just confirmed
+                # playable - persist the resolved mapping so this entry keeps resolving
+                # to the exact same instance on future loads too, instead of leaving one
+                # that can never attach an instance-pinned mapping, or that would repeat
+                # the same fallback, again
                 normalized_entry = replace(
                     item,
                     providers=[
@@ -1096,7 +1098,7 @@ class BuiltinProvider(MusicProvider):
                         if (
                             pm.domain == confirmed_mapping.domain
                             and pm.item_id == confirmed_mapping.item_id
-                            and not pm.instance_id
+                            and pm.instance_id != confirmed_mapping.instance_id
                         )
                         else pm
                         for pm in item.providers
@@ -1223,26 +1225,33 @@ class BuiltinProvider(MusicProvider):
 
         Returns the confirmed provider mapping alongside the playable verdict whenever
         the entry needs it written back to keep resolving on its own next time: a bare
-        Music Assistant provider URI with no ``#EXTPROV`` metadata at all, or a
-        domain-only ``#EXTPROV`` reference that was just confirmed on one specific
-        allowed instance. A raw builtin stream URL already reconstructs its own mapping
-        from the path alone and needs nothing written back, and an ``#EXTPROV``
-        reference that already names an exact instance already resolves correctly on
-        its own. Also returns every ``(instance_id, item_id)`` pair that was just
-        authoritatively confirmed dead here, so a subsequent matching pass does not
-        force-refresh the exact same candidate a second time.
+        Music Assistant provider URI with no ``#EXTPROV`` metadata at all, a
+        domain-only ``#EXTPROV`` reference, or one that pins an instance id not
+        registered on this server (e.g. imported from a different Music Assistant
+        install, where instance ids are randomly generated per install) - each
+        normalized to whichever allowed instance actually confirmed it. A raw builtin
+        stream URL already reconstructs its own mapping from the path alone and needs
+        nothing written back, and an ``#EXTPROV`` reference that already names an
+        exact allowed instance already resolves correctly on its own. Also returns
+        every ``(instance_id, item_id)`` pair that was just authoritatively confirmed
+        dead here, so a subsequent matching pass does not force-refresh the exact same
+        candidate a second time.
         """
         candidates: list[tuple[str, str, bool]] = []
         seen: set[tuple[str, str]] = set()
         confirmed_dead: set[tuple[str, str]] = set()
         for prov_info in item.providers:
-            # a domain-only reference (no pinned instance id) is not yet tied to one
-            # specific account; once resolved, normalize it to whichever allowed
-            # instance actually confirmed it, so a later load doesn't fall back to
-            # guessing the first registered account of that domain again
-            needs_provider_metadata = not prov_info.instance_id
+            # a domain-only reference (no pinned instance id), or a pinned instance id
+            # that is not registered on this server at all (e.g. a playlist imported
+            # from a different Music Assistant install, where instance ids are
+            # randomly generated per install), is not yet tied to one of the caller's
+            # own accounts; once resolved, normalize it to whichever allowed instance
+            # actually confirmed it, so a later load doesn't need this same fallback again
+            needs_provider_metadata = (
+                not prov_info.instance_id or prov_info.instance_id not in allowed_provider_instances
+            )
             for instance_id in self._allowed_instances_for(
-                prov_info.instance_id or prov_info.domain, allowed_provider_instances
+                prov_info.instance_id, prov_info.domain, allowed_provider_instances
             ):
                 key = (instance_id, prov_info.item_id)
                 if key not in seen:
@@ -1251,9 +1260,8 @@ class BuiltinProvider(MusicProvider):
         if not item.providers:
             # only a plain M3U entry with a bare Music Assistant URI and no #EXTPROV
             # metadata at all needs this path parsed - an entry that does carry
-            # #EXTPROV references but none of them fall within the allowed snapshot
-            # must not fall back to guessing an allowed sibling instance of the same
-            # domain, since that sibling is not actually the entry's original source
+            # #EXTPROV references is fully handled by the loop above, including its
+            # own domain-based fallback for an unregistered pinned instance
             with suppress(InvalidProviderURI, InvalidProviderID, IndexError, ValueError):
                 _, provider_instance_or_domain, raw_item_id = await parse_uri(item.path)
                 # a resolved external provider reference - a bare MA URI or a public
@@ -1262,8 +1270,13 @@ class BuiltinProvider(MusicProvider):
                 # stream URL already reconstructs "builtin" from the path alone on
                 # every future load and needs nothing written back
                 needs_provider_metadata = provider_instance_or_domain != "builtin"
+                # a bare URI carries no separate domain field to fall back on, so an
+                # instance id that isn't allowed here (unlike a genuine domain, e.g.
+                # from a public share link) simply yields no candidates below
                 for instance_id in self._allowed_instances_for(
-                    provider_instance_or_domain, allowed_provider_instances
+                    provider_instance_or_domain,
+                    provider_instance_or_domain,
+                    allowed_provider_instances,
                 ):
                     candidates.append((instance_id, raw_item_id, needs_provider_metadata))
         for provider_instance, provider_item_id, needs_provider_metadata in candidates:
@@ -1379,25 +1392,29 @@ class BuiltinProvider(MusicProvider):
         return False
 
     def _allowed_instances_for(
-        self, provider_instance_or_domain: str, allowed_provider_instances: Mapping[str, str]
+        self, instance_id: str, domain: str, allowed_provider_instances: Mapping[str, str]
     ) -> list[str]:
         """
         Expand an entry's provider reference to allowed instance ids.
 
-        An exact instance id is kept as-is, and only if it is in the caller's own
-        snapshot; a bare domain is expanded to every one of the caller's allowed
-        instances of that domain instead of the single, arbitrary instance the
-        shared library would otherwise resolve it to. The snapshot maps every
-        instance the caller has configured to its domain, whether or not the
-        instance is currently loaded, so this never depends on the provider's
-        current load state - including for the domain-only expansion.
+        An exact instance id is kept as-is when it is in the caller's own snapshot.
+        Otherwise - whether the entry never pinned one at all, or it pins one that is
+        not registered on this server (e.g. a playlist imported from a different
+        Music Assistant install, where instance ids are randomly generated per
+        install) - every one of the caller's allowed instances of the entry's own
+        domain is tried instead: the single, arbitrary instance the shared library
+        would otherwise resolve a bare domain to, or silently giving up on a foreign
+        instance id that matches nothing here, would both be wrong. The snapshot
+        maps every instance the caller has configured to its domain, whether or not
+        the instance is currently loaded, so this never depends on the provider's
+        current load state - including for the domain-based expansion.
         """
-        if provider_instance_or_domain in allowed_provider_instances:
-            return [provider_instance_or_domain]
+        if instance_id and instance_id in allowed_provider_instances:
+            return [instance_id]
         return [
-            instance_id
-            for instance_id, domain in allowed_provider_instances.items()
-            if domain == provider_instance_or_domain
+            allowed_instance_id
+            for allowed_instance_id, allowed_domain in allowed_provider_instances.items()
+            if allowed_domain == domain
         ]
 
     def _get_stored_item(

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -589,22 +589,28 @@ class BuiltinProvider(MusicProvider):
 
         The playlist name is used as the filename (sanitized for filesystem safety).
         """
-        playlist_id = self._sanitize_playlist_id(name)
-        # ensure uniqueness
-        counter = 1
-        base_id = playlist_id
-        while await asyncio.to_thread(
-            os.path.isfile, os.path.join(self._playlists_dir, f"{playlist_id}.m3u")
-        ):
-            playlist_id = f"{base_id} ({counter})"
-            counter += 1
-        # bump this ID's generation before creating its file: a delete followed by a
-        # recreation under the same sanitized ID must be distinguishable from an
-        # in-place rewrite of the same playlist, even if the filesystem happens to
-        # reuse the freed inode for the new file
-        self._playlist_generations[playlist_id] = self._playlist_generations.get(playlist_id, 0) + 1
-        # create empty M3U file with header
-        await self._write_m3u_file(playlist_id, name, [])
+        base_id = self._sanitize_playlist_id(name)
+        # the uniqueness check, generation bump and initial file creation must all
+        # happen under the same lock: otherwise two concurrent creates for the same
+        # name can both see the id as free, both claim it, and race each other's
+        # generation bump and file write.
+        async with self._playlist_lock:
+            playlist_id = base_id
+            counter = 1
+            while await asyncio.to_thread(
+                os.path.isfile, os.path.join(self._playlists_dir, f"{playlist_id}.m3u")
+            ):
+                playlist_id = f"{base_id} ({counter})"
+                counter += 1
+            # bump this ID's generation before creating its file: a delete followed by a
+            # recreation under the same sanitized ID must be distinguishable from an
+            # in-place rewrite of the same playlist, even if the filesystem happens to
+            # reuse the freed inode for the new file
+            self._playlist_generations[playlist_id] = (
+                self._playlist_generations.get(playlist_id, 0) + 1
+            )
+            # create empty M3U file with header
+            await self._write_m3u_file_locked(playlist_id, name, [])
         return await self.get_playlist(playlist_id)
 
     async def import_playlist(self, m3u_data: str) -> Playlist:
@@ -1751,12 +1757,29 @@ class BuiltinProvider(MusicProvider):
         playlist_image_url: str | None = None,
     ) -> None:
         """Write an M3U playlist file to disk."""
+        async with self._playlist_lock:
+            await self._write_m3u_file_locked(
+                playlist_id, playlist_name, entries, playlist_image_url
+            )
+
+    async def _write_m3u_file_locked(
+        self,
+        playlist_id: str,
+        playlist_name: str,
+        entries: list[PlaylistItem],
+        playlist_image_url: str | None = None,
+    ) -> None:
+        """
+        Write an M3U playlist file to disk, assuming the caller already holds `_playlist_lock`.
+
+        :param playlist_id: The provider-side playlist ID to write.
+        :param playlist_name: The playlist's display name to embed in the M3U header.
+        :param entries: The playlist items to write.
+        :param playlist_image_url: Optional playlist image URL to embed in the M3U header.
+        """
         m3u_content = generate_m3u(playlist_name, entries, playlist_image_url)
         playlist_file = os.path.join(self._playlists_dir, f"{playlist_id}.m3u")
-        async with (
-            self._playlist_lock,
-            aiofiles.open(playlist_file, "w", encoding="utf-8") as _file,
-        ):
+        async with aiofiles.open(playlist_file, "w", encoding="utf-8") as _file:
             await _file.write(m3u_content)
 
     def _get_playlist_lock(self, playlist_id: str) -> asyncio.Lock:

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -20,6 +20,7 @@ from music_assistant_models.enums import (
     ContentType,
     ImageType,
     MediaType,
+    PlaylistMatchPolicy,
     ProviderFeature,
     StreamType,
 )
@@ -58,7 +59,6 @@ from music_assistant.constants import (
 )
 from music_assistant.controllers.cache import use_cache
 from music_assistant.controllers.music.media.playlists import (
-    PlaylistMatchPolicy,
     match_policy_minimum_confidence,
 )
 from music_assistant.controllers.tasks.context import (

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -667,16 +667,23 @@ class BuiltinProvider(MusicProvider):
         :param search_provider_instances: Provider instances to search for a substitute.
             Defaults to ``allowed_provider_instances`` when not narrowed by the caller.
         """
-        m3u_data = await self._read_m3u_file(prov_playlist_id)
-        parsed_items = parse_m3u(m3u_data)
-        if not parsed_items:
-            return
-        playlist = await self.get_playlist(prov_playlist_id)
-        # this pass can run for a while; if the playlist is deleted and a new one is
-        # created that reuses the same sanitized ID before it finishes, this generation
-        # lets the later write-back tell the two apart instead of writing stale matches
-        # into an unrelated playlist that merely happens to share its ID
-        original_generation = await self._get_playlist_generation(prov_playlist_id)
+        # the initial content read and generation capture must happen atomically under
+        # the per-playlist lock: library_remove takes this same lock before unlinking
+        # the file, so holding it here prevents a delete-and-recreate from landing in
+        # between - which would otherwise pair this pass's old (pre-delete) content
+        # with the *new* playlist's generation, defeating the write-back check below
+        async with self._get_playlist_lock(prov_playlist_id):
+            m3u_data = await self._read_m3u_file(prov_playlist_id)
+            parsed_items = parse_m3u(m3u_data)
+            if not parsed_items:
+                return
+            playlist = await self.get_playlist(prov_playlist_id)
+            # this pass can run for a while; if the playlist is deleted and a new one
+            # is created that reuses the same sanitized ID before it finishes, this
+            # generation lets the later write-back tell the two apart instead of
+            # writing stale matches into an unrelated playlist that merely happens to
+            # share its ID
+            original_generation = await self._get_playlist_generation(prov_playlist_id)
 
         minimum_confidence = match_policy_minimum_confidence(match_policy)
         allowed_provider_instance_map = dict(allowed_provider_instances)

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1006,7 +1006,17 @@ class BuiltinProvider(MusicProvider):
         failed_provider_instances: set[str],
     ) -> _ImportTrackMatchResult:
         """Resolve one imported playlist entry against the allowed providers."""
-        media_item = construct_media_item_from_playlist_item(item, self.mass)
+        # a bare URI without #EXTMA metadata (e.g. a hand-written or foreign M3U entry)
+        # would otherwise default to Track; a radio:// path (or similar) must still be
+        # recognized as non-Track so it is retained rather than searched/substituted
+        default_media_type = MediaType.TRACK
+        with suppress(InvalidProviderURI, InvalidProviderID):
+            parsed_media_type, _, _ = await parse_uri(item.path)
+            if parsed_media_type != MediaType.UNKNOWN:
+                default_media_type = parsed_media_type
+        media_item = construct_media_item_from_playlist_item(
+            item, self.mass, default_media_type=default_media_type
+        )
         if not isinstance(media_item, Track):
             return _ImportTrackMatchResult(label=item.title or item.path, retained=True)
         label = _entry_label(media_item)

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1084,13 +1084,14 @@ class BuiltinProvider(MusicProvider):
         cached details and without a stored fallback - instead of trusting the
         ``available`` flag on a resolved track's provider mappings, which only
         reflects whether the provider was loaded when the M3U metadata was last
-        written. Candidates are built directly from the
-        entry's own ``#EXTPROV`` references (falling back to parsing the raw path for
-        a plain M3U entry that carries a bare Music Assistant URI without one) instead
-        of through the shared library's mapping resolution, which silently substitutes
-        an arbitrary same-domain instance for a domain-only reference. A provider that
-        is merely down right now counts as still usable, so a transient outage does not
-        trigger a permanent substitution. Candidates are only ever expanded within the
+        written. Candidates are built directly from the entry's own ``#EXTPROV``
+        references (falling back to parsing the raw path for a plain M3U entry that
+        carries a bare Music Assistant URI without one) instead of through the shared
+        library's mapping resolution, which silently substitutes an arbitrary
+        same-domain instance for a domain-only reference. A provider that is merely
+        down right now, or is configured but not currently loaded (e.g. it failed
+        setup), counts as still usable, so a transient outage does not trigger a
+        permanent substitution. Candidates are only ever expanded within the
         initiating user's own provider instances, so a domain-only reference can never
         reach an inaccessible account.
         """
@@ -1113,9 +1114,11 @@ class BuiltinProvider(MusicProvider):
                     candidates.append((instance_id, raw_item_id))
         for provider_instance, provider_item_id in candidates:
             provider = self.mass.get_provider(provider_instance, return_unavailable=True)
-            if provider is None:
-                continue
-            if not provider.available:
+            if provider is None or not provider.available:
+                # every candidate here already passed the allowed-instances snapshot, so
+                # a missing/unavailable provider is a configured source that is merely
+                # down or failed setup right now, not one the user removed - a transient
+                # outage must not trigger a permanent substitution
                 return True
             try:
                 await self.mass.music.tracks.get_provider_item(
@@ -1151,14 +1154,12 @@ class BuiltinProvider(MusicProvider):
         An exact instance id is kept as-is, and only if it is in the caller's own
         snapshot; a bare domain is expanded to every one of the caller's allowed
         instances of that domain instead of the single, arbitrary instance the
-        shared library would otherwise resolve it to.
+        shared library would otherwise resolve it to. The snapshot itself covers
+        every instance the caller has configured, whether or not it is currently
+        loaded, so this never depends on the provider's current load state.
         """
-        if any(
-            provider.instance_id == provider_instance_or_domain for provider in self.mass.providers
-        ):
-            if provider_instance_or_domain in allowed_provider_instances:
-                return [provider_instance_or_domain]
-            return []
+        if provider_instance_or_domain in allowed_provider_instances:
+            return [provider_instance_or_domain]
         return [
             provider.instance_id
             for provider in self.mass.get_provider_instances(

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1255,14 +1255,29 @@ class BuiltinProvider(MusicProvider):
         ffprobe reports a transient failure (a DNS hiccup, a timeout, a 5xx
         response) with the same error as a genuinely deleted stream, so only a
         terminal HTTP status confirms deletion. A scheme this cannot check (e.g.
-        ``rtsp://``/``rtmp://``) is never treated as confirmed gone.
+        ``rtsp://``/``rtmp://``) is never treated as confirmed gone. A HEAD
+        404/410 is corroborated with a minimal ranged GET before being treated
+        as terminal, since some servers reject HEAD requests they would still
+        serve on GET.
         """
         if not url.startswith(("http://", "https://")):
             return False
+        encoded_url = encoded_request_url(url)
+        head_status: int | None = None
         with suppress(ClientError, TimeoutError):
             async with self.mass.http_session.head(
-                encoded_request_url(url),
+                encoded_url,
                 allow_redirects=True,
+                timeout=ClientTimeout(total=10),
+            ) as resp:
+                head_status = resp.status
+        if head_status not in (404, 410):
+            return False
+        with suppress(ClientError, TimeoutError):
+            async with self.mass.http_session.get(
+                encoded_url,
+                allow_redirects=True,
+                headers={"Range": "bytes=0-0"},
                 timeout=ClientTimeout(total=10),
             ) as resp:
                 return resp.status in (404, 410)

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -412,7 +412,7 @@ class BuiltinProvider(MusicProvider):
             # user-created playlist removal - delete the M3U file
             playlist_file = os.path.join(self._playlists_dir, f"{prov_item_id}.m3u")
             if await asyncio.to_thread(os.path.isfile, playlist_file):
-                async with self._playlist_lock:
+                async with self._get_playlist_lock(prov_item_id):
                     await asyncio.to_thread(os.remove, playlist_file)
             return True
         else:
@@ -858,14 +858,15 @@ class BuiltinProvider(MusicProvider):
         if playlist_id in BUILTIN_PLAYLISTS:
             # builtin playlists are not editable
             return
-        m3u_data = await self._read_m3u_file(playlist_id)
-        if not m3u_data:
-            return
-        existing_items = parse_m3u(m3u_data)
-        try:
-            await self._write_m3u_file(playlist_id, new_name, list(existing_items), image_url)
-        except OSError as err:
-            self.logger.warning("Failed to update playlist metadata: %s", err)
+        async with self._get_playlist_lock(playlist_id):
+            m3u_data = await self._read_m3u_file(playlist_id)
+            if not m3u_data:
+                return
+            existing_items = parse_m3u(m3u_data)
+            try:
+                await self._write_m3u_file(playlist_id, new_name, list(existing_items), image_url)
+            except OSError as err:
+                self.logger.warning("Failed to update playlist metadata: %s", err)
 
     async def _apply_import_substitutions(
         self,
@@ -919,7 +920,7 @@ class BuiltinProvider(MusicProvider):
         if not isinstance(media_item, Track):
             return _ImportTrackMatchResult(label=item.title or item.path, retained=True)
         label = _entry_label(media_item)
-        if await self._original_source_is_playable(item, media_item):
+        if await self._original_source_is_playable(item, media_item, allowed_provider_instances):
             # the original source still resolves, or its provider is merely down right
             # now - either way there is nothing to substitute
             return _ImportTrackMatchResult(label=label, retained=True)
@@ -957,22 +958,37 @@ class BuiltinProvider(MusicProvider):
         ) as err:
             message = str(err).strip() or f"Matching failed ({type(err).__name__})"
             return _ImportTrackMatchResult(label=label, error=message)
-        if not enrichment.track.provider_mappings:
+        if not enrichment.matches:
+            # nothing was actually matched - the track's provider_mappings may still carry
+            # an untrusted, unverified original mapping (trust_track_mappings=False keeps
+            # it around unless a same-domain match displaces it), so branch on the matches
+            # that were actually found rather than on the mapping set itself
             return _ImportTrackMatchResult(
                 label=label,
                 ambiguous_providers=enrichment.ambiguous_providers,
                 failed_providers=enrichment.failed_providers,
             )
         best_confidence = max(match.confidence for match in enrichment.matches)
+        matched_domains = {match.mapping.provider_domain for match in enrichment.matches}
+        matched_track = replace(
+            enrichment.track,
+            provider_mappings={
+                mapping
+                for mapping in enrichment.track.provider_mappings
+                if mapping.provider_domain in matched_domains
+            },
+        )
         return _ImportTrackMatchResult(
             label=label,
-            entry=media_item_to_playlist_item(enrichment.track),
+            entry=media_item_to_playlist_item(matched_track),
             confidence=best_confidence,
             ambiguous_providers=enrichment.ambiguous_providers,
             failed_providers=enrichment.failed_providers,
         )
 
-    async def _original_source_is_playable(self, item: PlaylistItem, track: Track) -> bool:
+    async def _original_source_is_playable(
+        self, item: PlaylistItem, track: Track, allowed_provider_instances: set[str]
+    ) -> bool:
         """
         Check whether an imported entry's original source is still usable.
 
@@ -982,7 +998,9 @@ class BuiltinProvider(MusicProvider):
         metadata was last written. Falls back to parsing the raw path itself for plain
         M3U entries that carry a bare Music Assistant URI without ``#EXTPROV`` metadata.
         A provider that is merely down right now counts as still usable, so a transient
-        outage does not trigger a permanent substitution.
+        outage does not trigger a permanent substitution. Candidates are only resolved
+        within the initiating user's own provider instances, so a domain or an
+        unavailable instance can never be probed against an inaccessible account.
         """
         candidates = [
             (mapping.provider_instance or mapping.provider_domain, mapping.item_id)
@@ -994,7 +1012,7 @@ class BuiltinProvider(MusicProvider):
                 candidates.append((provider_instance_or_domain, raw_item_id))
         for provider_instance_or_domain, provider_item_id in candidates:
             provider = self.mass.get_provider(provider_instance_or_domain, return_unavailable=True)
-            if provider is None:
+            if provider is None or provider.instance_id not in allowed_provider_instances:
                 continue
             if not provider.available:
                 return True

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -663,49 +663,31 @@ class BuiltinProvider(MusicProvider):
         pending_substitutions: list[tuple[PlaylistItem, PlaylistItem]] = []
         unmatched_items: list[tuple[str, str]] = []
         provider_issues: list[tuple[str, str]] = []
+        # results are cached by the entry's original path so a track that is duplicated
+        # in the playlist is only probed and searched once, however many times it repeats
+        resolved_by_path: dict[str, _ImportTrackMatchResult] = {}
 
         for index, item in enumerate(parsed_items):
             update_current_task_progress_from_index(
                 index, total, f"Matching track {index + 1}/{total}"
             )
-            result = await self._resolve_import_track(
+            result = resolved_by_path.get(item.path)
+            if result is None:
+                result = await self._resolve_import_track(
+                    item,
+                    minimum_confidence,
+                    allowed_provider_instance_set,
+                    failed_provider_instances,
+                )
+                resolved_by_path[item.path] = result
+            self._tally_import_track_result(
                 item,
-                minimum_confidence,
-                allowed_provider_instance_set,
-                failed_provider_instances,
-            )
-            for provider_name in result.failed_providers:
-                issue = f"Matching failed on {provider_name}"
-                report_current_task_failure(f"{result.label}: {issue.lower()}")
-                provider_issues.append((result.label, issue))
-            for provider_name in result.ambiguous_providers:
-                issue = f"Ambiguous match on {provider_name}"
-                report_current_task_failure(f"{result.label}: {issue.lower()}")
-                provider_issues.append((result.label, issue))
-            if result.retained:
-                counts["retained"] += 1
-                continue
-            if result.error:
-                report_current_task_failure(f"{result.label}: {result.error}")
-                provider_issues.append((result.label, result.error))
-                counts["unmatched"] += 1
-                unmatched_items.append((result.label, result.error))
-                continue
-            if result.entry is None:
-                if result.ambiguous_providers:
-                    counts["ambiguous"] += 1
-                    reason = "Ambiguous match"
-                else:
-                    counts["unmatched"] += 1
-                    reason = "No acceptable match"
-                    report_current_task_failure(f"{result.label}: {reason.lower()}")
-                unmatched_items.append((result.label, reason))
-                continue
-            pending_substitutions.append((item, result.entry))
-            tier = _CONFIDENCE_COUNT_KEY[result.confidence]
-            counts[tier] += 1
-            substitutions.append(
-                (result.label, _entry_label(result.entry), _CONFIDENCE_TIER_LABELS[tier])
+                result,
+                counts,
+                substitutions,
+                unmatched_items,
+                provider_issues,
+                pending_substitutions,
             )
 
         if pending_substitutions:
@@ -908,6 +890,61 @@ class BuiltinProvider(MusicProvider):
                 self._get_playlist_image_url(playlist),
             )
 
+    def _tally_import_track_result(
+        self,
+        item: PlaylistItem,
+        result: _ImportTrackMatchResult,
+        counts: dict[str, int],
+        substitutions: list[tuple[str, str, str]],
+        unmatched_items: list[tuple[str, str]],
+        provider_issues: list[tuple[str, str]],
+        pending_substitutions: list[tuple[PlaylistItem, PlaylistItem]],
+    ) -> None:
+        """
+        Record a resolved track match result into the running import report state.
+
+        :param item: The playlist entry this result applies to.
+        :param result: The resolution outcome, possibly reused from an earlier duplicate.
+        :param counts: Per-outcome totals, updated in place.
+        :param substitutions: Accepted substitution rows, appended in place.
+        :param unmatched_items: Ambiguous/unmatched rows, appended in place.
+        :param provider_issues: Provider-level issue rows, appended in place.
+        :param pending_substitutions: Accepted (original, replacement) pairs, appended in place.
+        """
+        for provider_name in result.failed_providers:
+            issue = f"Matching failed on {provider_name}"
+            report_current_task_failure(f"{result.label}: {issue.lower()}")
+            provider_issues.append((result.label, issue))
+        for provider_name in result.ambiguous_providers:
+            issue = f"Ambiguous match on {provider_name}"
+            report_current_task_failure(f"{result.label}: {issue.lower()}")
+            provider_issues.append((result.label, issue))
+        if result.retained:
+            counts["retained"] += 1
+            return
+        if result.error:
+            report_current_task_failure(f"{result.label}: {result.error}")
+            provider_issues.append((result.label, result.error))
+            counts["unmatched"] += 1
+            unmatched_items.append((result.label, result.error))
+            return
+        if result.entry is None:
+            if result.ambiguous_providers:
+                counts["ambiguous"] += 1
+                reason = "Ambiguous match"
+            else:
+                counts["unmatched"] += 1
+                reason = "No acceptable match"
+                report_current_task_failure(f"{result.label}: {reason.lower()}")
+            unmatched_items.append((result.label, reason))
+            return
+        pending_substitutions.append((item, result.entry))
+        tier = _CONFIDENCE_COUNT_KEY[result.confidence]
+        counts[tier] += 1
+        substitutions.append(
+            (result.label, _entry_label(result.entry), _CONFIDENCE_TIER_LABELS[tier])
+        )
+
     async def _resolve_import_track(
         self,
         item: PlaylistItem,
@@ -920,7 +957,7 @@ class BuiltinProvider(MusicProvider):
         if not isinstance(media_item, Track):
             return _ImportTrackMatchResult(label=item.title or item.path, retained=True)
         label = _entry_label(media_item)
-        if await self._original_source_is_playable(item, media_item, allowed_provider_instances):
+        if await self._original_source_is_playable(item, allowed_provider_instances):
             # the original source still resolves, or its provider is merely down right
             # now - either way there is nothing to substitute
             return _ImportTrackMatchResult(label=label, retained=True)
@@ -987,32 +1024,44 @@ class BuiltinProvider(MusicProvider):
         )
 
     async def _original_source_is_playable(
-        self, item: PlaylistItem, track: Track, allowed_provider_instances: set[str]
+        self, item: PlaylistItem, allowed_provider_instances: set[str]
     ) -> bool:
         """
         Check whether an imported entry's original source is still usable.
 
         Resolves the exact provider instance and item id authoritatively (no stored
-        fallback) instead of trusting the ``available`` flag on the track's provider
-        mappings, which only reflects whether the provider was loaded when the M3U
-        metadata was last written. Falls back to parsing the raw path itself for plain
-        M3U entries that carry a bare Music Assistant URI without ``#EXTPROV`` metadata.
-        A provider that is merely down right now counts as still usable, so a transient
-        outage does not trigger a permanent substitution. Candidates are only resolved
-        within the initiating user's own provider instances, so a domain or an
-        unavailable instance can never be probed against an inaccessible account.
+        fallback) instead of trusting the ``available`` flag on a resolved track's
+        provider mappings, which only reflects whether the provider was loaded when
+        the M3U metadata was last written. Candidates are built directly from the
+        entry's own ``#EXTPROV`` references (falling back to parsing the raw path for
+        a plain M3U entry that carries a bare Music Assistant URI without one) instead
+        of through the shared library's mapping resolution, which silently substitutes
+        an arbitrary same-domain instance for a domain-only reference. A provider that
+        is merely down right now counts as still usable, so a transient outage does not
+        trigger a permanent substitution. Candidates are only ever expanded within the
+        initiating user's own provider instances, so a domain-only reference can never
+        reach an inaccessible account.
         """
-        candidates = [
-            (mapping.provider_instance or mapping.provider_domain, mapping.item_id)
-            for mapping in track.provider_mappings
-        ]
+        candidates: list[tuple[str, str]] = []
+        seen: set[tuple[str, str]] = set()
+        for prov_info in item.providers:
+            for instance_id in self._allowed_instances_for(
+                prov_info.instance_id or prov_info.domain, allowed_provider_instances
+            ):
+                key = (instance_id, prov_info.item_id)
+                if key not in seen:
+                    seen.add(key)
+                    candidates.append(key)
         if not candidates:
             with suppress(InvalidProviderURI, InvalidProviderID, IndexError, ValueError):
                 _, provider_instance_or_domain, raw_item_id = await parse_uri(item.path)
-                candidates.append((provider_instance_or_domain, raw_item_id))
-        for provider_instance_or_domain, provider_item_id in candidates:
-            provider = self.mass.get_provider(provider_instance_or_domain, return_unavailable=True)
-            if provider is None or provider.instance_id not in allowed_provider_instances:
+                for instance_id in self._allowed_instances_for(
+                    provider_instance_or_domain, allowed_provider_instances
+                ):
+                    candidates.append((instance_id, raw_item_id))
+        for provider_instance, provider_item_id in candidates:
+            provider = self.mass.get_provider(provider_instance, return_unavailable=True)
+            if provider is None:
                 continue
             if not provider.available:
                 return True
@@ -1039,6 +1088,31 @@ class BuiltinProvider(MusicProvider):
             else:
                 return True
         return False
+
+    def _allowed_instances_for(
+        self, provider_instance_or_domain: str, allowed_provider_instances: set[str]
+    ) -> list[str]:
+        """
+        Expand an entry's provider reference to allowed instance ids.
+
+        An exact instance id is kept as-is, and only if it is in the caller's own
+        snapshot; a bare domain is expanded to every one of the caller's allowed
+        instances of that domain instead of the single, arbitrary instance the
+        shared library would otherwise resolve it to.
+        """
+        if any(
+            provider.instance_id == provider_instance_or_domain for provider in self.mass.providers
+        ):
+            if provider_instance_or_domain in allowed_provider_instances:
+                return [provider_instance_or_domain]
+            return []
+        return [
+            provider.instance_id
+            for provider in self.mass.get_provider_instances(
+                provider_instance_or_domain, return_unavailable=True
+            )
+            if provider.instance_id in allowed_provider_instances
+        ]
 
     def _get_stored_item(
         self, item: PlaylistItem, stored_by_media_type: Mapping[str, Mapping[str, StoredItem]]

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1036,6 +1036,11 @@ class BuiltinProvider(MusicProvider):
                 # so a provider mapping it already carries is not treated as authoritative
                 trust_track_mappings=False,
                 failed_provider_instances=failed_provider_instances,
+                # release-evidence hydration (e.g. the source's own album) must reach the
+                # user's full allowed snapshot, not just the narrowed search targets, or a
+                # match_providers filter would starve EXACT matching of evidence that is
+                # still on one of the user's own, merely un-searched, accounts
+                evidence_provider_instances=set(allowed_provider_instances),
             )
         except (
             ResourceTemporarilyUnavailable,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -183,6 +183,7 @@ class BuiltinProvider(MusicProvider):
     _playlists_dir: str
     _playlist_lock: asyncio.Lock
     _playlist_locks: dict[str, asyncio.Lock]
+    _playlist_generations: dict[str, int]
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to setup this provider."""
@@ -199,6 +200,7 @@ class BuiltinProvider(MusicProvider):
         """Call after the provider has been loaded."""
         self._playlist_lock = asyncio.Lock()
         self._playlist_locks = {}
+        self._playlist_generations = {}
         self._playlists_dir = os.path.join(self.mass.storage_path, "playlists")
         if not await asyncio.to_thread(os.path.exists, self._playlists_dir):
             await asyncio.to_thread(os.mkdir, self._playlists_dir)
@@ -596,6 +598,11 @@ class BuiltinProvider(MusicProvider):
         ):
             playlist_id = f"{base_id} ({counter})"
             counter += 1
+        # bump this ID's generation before creating its file: a delete followed by a
+        # recreation under the same sanitized ID must be distinguishable from an
+        # in-place rewrite of the same playlist, even if the filesystem happens to
+        # reuse the freed inode for the new file
+        self._playlist_generations[playlist_id] = self._playlist_generations.get(playlist_id, 0) + 1
         # create empty M3U file with header
         await self._write_m3u_file(playlist_id, name, [])
         return await self.get_playlist(playlist_id)
@@ -666,7 +673,7 @@ class BuiltinProvider(MusicProvider):
             return
         playlist = await self.get_playlist(prov_playlist_id)
         # this pass can run for a while; if the playlist is deleted and a new one is
-        # created that reuses the same sanitized ID before it finishes, this fingerprint
+        # created that reuses the same sanitized ID before it finishes, this generation
         # lets the later write-back tell the two apart instead of writing stale matches
         # into an unrelated playlist that merely happens to share its ID
         original_generation = await self._get_playlist_generation(prov_playlist_id)
@@ -919,7 +926,7 @@ class BuiltinProvider(MusicProvider):
         self,
         prov_playlist_id: str,
         pending_substitutions: list[tuple[PlaylistItem, PlaylistItem]],
-        expected_generation: tuple[int, int] | None,
+        expected_generation: int | None,
     ) -> set[int]:
         """
         Write resolved substitutes into the playlist's current contents.
@@ -930,10 +937,11 @@ class BuiltinProvider(MusicProvider):
 
         :param prov_playlist_id: The provider-side playlist ID to update.
         :param pending_substitutions: (original, replacement) pairs found during matching.
-        :param expected_generation: The playlist's identity fingerprint captured when this
-            pass started, as returned by ``_get_playlist_generation``. If the file no longer
-            has this identity, the playlist behind this ID was deleted (and possibly replaced
-            by an unrelated new playlist reusing the same sanitized ID), so nothing is written.
+        :param expected_generation: The playlist's creation generation captured when this
+            pass started, as returned by ``_get_playlist_generation``. If the file's current
+            generation no longer matches, the playlist behind this ID was deleted (and
+            possibly replaced by an unrelated new playlist reusing the same sanitized ID),
+            so nothing is written.
         :return: Indices into `pending_substitutions` whose original entry was no longer in
             the playlist (e.g. removed by a concurrent edit, or the playlist was replaced)
             and so were not applied.
@@ -1694,23 +1702,22 @@ class BuiltinProvider(MusicProvider):
                 result: str = await _file.read()
                 return result
 
-    async def _get_playlist_generation(self, playlist_id: str) -> tuple[int, int] | None:
+    async def _get_playlist_generation(self, playlist_id: str) -> int | None:
         """
-        Return an (inode, device) identity fingerprint for a playlist's M3U file.
+        Return the current creation generation for a playlist's M3U file.
 
-        A rewrite of the same file (a rename, edit or matched substitution) keeps this
-        identity, while a delete followed by a new file recreated under the same
-        sanitized ID gets a new one - this is what lets a long-running background pass
-        tell the two apart. Returns None when the file does not currently exist.
+        Bumped by create_playlist every time a new file is created under this sanitized
+        ID, so a delete followed by a recreation under the same ID - even one that, by
+        pure filesystem-level chance, reuses the just-freed inode - is still
+        distinguishable from an in-place rewrite of the same playlist (a rename, edit,
+        or matched substitution). Returns None when the file does not currently exist.
 
         :param playlist_id: The provider-side playlist ID to fingerprint.
         """
         playlist_file = os.path.join(self._playlists_dir, f"{playlist_id}.m3u")
-        try:
-            stat_result = await asyncio.to_thread(os.stat, playlist_file)
-        except FileNotFoundError:
+        if not await asyncio.to_thread(os.path.isfile, playlist_file):
             return None
-        return (stat_result.st_ino, stat_result.st_dev)
+        return self._playlist_generations.get(playlist_id, 0)
 
     async def _write_m3u_file(
         self,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -175,6 +175,11 @@ class _ImportTrackMatchResult:
     ambiguous_providers: tuple[str, ...] = ()
     failed_providers: tuple[str, ...] = ()
     error: str | None = None
+    # only set when `error` came from a provider communication failure (a caught
+    # exception from enrich_provider_mappings) rather than a local data/validation
+    # issue (e.g. a foreign M3U entry with no structured artist to search with) - the
+    # report's provider issues section must not misattribute the latter to a provider
+    error_is_provider_issue: bool = False
 
 
 class BuiltinProvider(MusicProvider):
@@ -1034,7 +1039,8 @@ class BuiltinProvider(MusicProvider):
             return
         if result.error:
             report_current_task_failure(f"{result.label}: {result.error}")
-            provider_issues.append((result.label, result.error))
+            if result.error_is_provider_issue:
+                provider_issues.append((result.label, result.error))
             counts["unmatched"] += 1
             unmatched_items.append((result.label, result.error))
             return
@@ -1162,7 +1168,7 @@ class BuiltinProvider(MusicProvider):
             MediaNotFoundError,
         ) as err:
             message = str(err).strip() or f"Matching failed ({type(err).__name__})"
-            return _ImportTrackMatchResult(label=label, error=message)
+            return _ImportTrackMatchResult(label=label, error=message, error_is_provider_issue=True)
         if not enrichment.matches:
             # nothing was actually matched - the track's provider_mappings may still carry
             # an untrusted, unverified original mapping (trust_track_mappings=False keeps

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -413,11 +413,12 @@ class BuiltinProvider(MusicProvider):
         elif media_type == MediaType.PLAYLIST:
             # user-created playlist removal - delete the M3U file
             playlist_file = os.path.join(self._playlists_dir, f"{prov_item_id}.m3u")
-            if await asyncio.to_thread(os.path.isfile, playlist_file):
-                # both the per-playlist edit lock and the global file-I/O lock used by
-                # _read_m3u_file/_write_m3u_file must be held, or a concurrent read or
-                # write already in flight on this file could still race the unlink
-                async with self._get_playlist_lock(prov_item_id), self._playlist_lock:
+            # both the per-playlist edit lock and the global file-I/O lock used by
+            # _read_m3u_file/_write_m3u_file must be held, and the existence check
+            # itself must happen inside them - otherwise a concurrent read, write or
+            # second delete already in flight on this file could still race the unlink
+            async with self._get_playlist_lock(prov_item_id), self._playlist_lock:
+                if await asyncio.to_thread(os.path.isfile, playlist_file):
                     await asyncio.to_thread(os.remove, playlist_file)
             return True
         else:

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -655,12 +655,24 @@ class BuiltinProvider(MusicProvider):
         failed_provider_instances: set[str] = set()
         total = len(parsed_items)
         counts = dict.fromkeys(
-            ("retained", "exact", "same_recording", "best_effort", "ambiguous", "unmatched"), 0
+            (
+                "retained",
+                "exact",
+                "same_recording",
+                "best_effort",
+                "ambiguous",
+                "unmatched",
+                "concurrent_edit",
+            ),
+            0,
         )
         substitutions: list[tuple[str, str, str]] = []
         # (original, replacement) pairs, applied against a freshly re-read playlist below so
         # edits made elsewhere while this (possibly long-running) pass was searching aren't lost
         pending_substitutions: list[tuple[PlaylistItem, PlaylistItem]] = []
+        # confidence-count key for each pending_substitutions entry, same index - lets the
+        # report be reconciled against what _apply_import_substitutions actually wrote
+        substitution_tiers: list[str] = []
         unmatched_items: list[tuple[str, str]] = []
         provider_issues: list[tuple[str, str]] = []
         # results are cached by the entry's full content (not just its path) so a track
@@ -691,10 +703,20 @@ class BuiltinProvider(MusicProvider):
                 unmatched_items,
                 provider_issues,
                 pending_substitutions,
+                substitution_tiers,
             )
 
         if pending_substitutions:
-            await self._apply_import_substitutions(prov_playlist_id, pending_substitutions)
+            not_applied = await self._apply_import_substitutions(
+                prov_playlist_id, pending_substitutions
+            )
+            # the report is built from tallies collected before this write - reconcile any
+            # substitution the playlist no longer had an original for (a concurrent edit)
+            # so counts and detail rows only reflect what was actually applied
+            for entry_index in sorted(not_applied, reverse=True):
+                counts[substitution_tiers[entry_index]] -= 1
+                counts["concurrent_edit"] += 1
+                del substitutions[entry_index]
 
         set_current_task_report(
             _build_import_report(
@@ -857,7 +879,7 @@ class BuiltinProvider(MusicProvider):
         self,
         prov_playlist_id: str,
         pending_substitutions: list[tuple[PlaylistItem, PlaylistItem]],
-    ) -> None:
+    ) -> set[int]:
         """
         Write resolved substitutes into the playlist's current contents.
 
@@ -867,31 +889,39 @@ class BuiltinProvider(MusicProvider):
 
         :param prov_playlist_id: The provider-side playlist ID to update.
         :param pending_substitutions: (original, replacement) pairs found during matching.
+        :return: Indices into `pending_substitutions` whose original entry was no longer in
+            the playlist (e.g. removed by a concurrent edit) and so were not applied.
         """
         async with self._get_playlist_lock(prov_playlist_id):
             current_items = parse_m3u(await self._read_m3u_file(prov_playlist_id))
-            remaining = list(pending_substitutions)
+            remaining = list(enumerate(pending_substitutions))
             updated_items: list[PlaylistItem] = []
             changed = False
             for current_item in current_items:
                 match_index = next(
-                    (i for i, (original, _) in enumerate(remaining) if original == current_item),
+                    (
+                        i
+                        for i, (_, (original, _)) in enumerate(remaining)
+                        if original == current_item
+                    ),
                     None,
                 )
                 if match_index is None:
                     updated_items.append(current_item)
                     continue
-                updated_items.append(remaining.pop(match_index)[1])
+                _, (_, replacement) = remaining.pop(match_index)
+                updated_items.append(replacement)
                 changed = True
-            if not changed:
-                return
-            playlist = await self.get_playlist(prov_playlist_id)
-            await self._write_m3u_file(
-                prov_playlist_id,
-                playlist.name,
-                updated_items,
-                self._get_playlist_image_url(playlist),
-            )
+            not_applied = {original_index for original_index, _ in remaining}
+            if changed:
+                playlist = await self.get_playlist(prov_playlist_id)
+                await self._write_m3u_file(
+                    prov_playlist_id,
+                    playlist.name,
+                    updated_items,
+                    self._get_playlist_image_url(playlist),
+                )
+            return not_applied
 
     def _tally_import_track_result(
         self,
@@ -902,6 +932,7 @@ class BuiltinProvider(MusicProvider):
         unmatched_items: list[tuple[str, str]],
         provider_issues: list[tuple[str, str]],
         pending_substitutions: list[tuple[PlaylistItem, PlaylistItem]],
+        substitution_tiers: list[str],
     ) -> None:
         """
         Record a resolved track match result into the running import report state.
@@ -913,6 +944,7 @@ class BuiltinProvider(MusicProvider):
         :param unmatched_items: Ambiguous/unmatched rows, appended in place.
         :param provider_issues: Provider-level issue rows, appended in place.
         :param pending_substitutions: Accepted (original, replacement) pairs, appended in place.
+        :param substitution_tiers: Counts key for each pending_substitutions entry, same index.
         """
         for provider_name in result.failed_providers:
             issue = f"Matching failed on {provider_name}"
@@ -947,6 +979,7 @@ class BuiltinProvider(MusicProvider):
         substitutions.append(
             (result.label, _entry_label(result.entry), _CONFIDENCE_TIER_LABELS[tier])
         )
+        substitution_tiers.append(tier)
 
     async def _resolve_import_track(
         self,
@@ -1814,6 +1847,10 @@ def _build_import_report(
         f"| Ambiguous | {counts['ambiguous']} |",
         f"| Unmatched | {counts['unmatched']} |",
     ]
+    if counts["concurrent_edit"]:
+        lines.append(
+            f"| Skipped (playlist changed during matching) | {counts['concurrent_edit']} |"
+        )
     _add_report_table(lines, "Substitutions", ("Original", "Substitute", "Match"), substitutions)
     _add_report_table(lines, "Unmatched items", ("Item", "Reason"), unmatched_items)
     _add_report_table(lines, "Provider lookup issues", ("Track", "Issue"), provider_issues)

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1198,14 +1198,13 @@ class BuiltinProvider(MusicProvider):
             except InvalidDataError:
                 if provider_item_id.startswith(
                     BUILTIN_URL_SCHEMES
-                ) and not await self._stream_url_confirmed_gone(provider_item_id):
-                    # ffprobe wraps a transient failure (DNS, timeout, 5xx) in the
-                    # same error as a genuinely dead stream - only a confirmed
-                    # terminal HTTP status proves this one is actually gone
-                    return True, None
-                # confirmed unusable, e.g. an unreadable stream with no way to
-                # verify its status, or one that is verified terminally gone
-                continue
+                ) and await self._stream_url_confirmed_gone(provider_item_id):
+                    # a confirmed terminal HTTP status (404/410) proves this stream
+                    # is actually gone - anything else this error can mean (a DNS
+                    # hiccup, a timeout, a 5xx response, or - for a catalog id - a
+                    # provider's own API/HTTP fault) does not prove deletion
+                    continue
+                return True, None
             except (
                 ResourceTemporarilyUnavailable,
                 ProviderUnavailableError,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1053,11 +1053,25 @@ class BuiltinProvider(MusicProvider):
             # now - either way there is nothing to substitute
             normalized_entry = None
             if confirmed_mapping is not None:
-                # a bare URI without #EXTPROV metadata was just confirmed playable -
-                # persist the resolved mapping so this entry keeps resolving to it on
-                # future loads too, instead of leaving one that can never attach a
-                # provider mapping of its own again
-                normalized_entry = replace(item, providers=[confirmed_mapping])
+                # a bare URI (no #EXTPROV metadata at all) or a domain-only reference
+                # was just confirmed playable - persist the resolved mapping so this
+                # entry keeps resolving to the exact same instance on future loads too,
+                # instead of leaving one that can never attach an instance-pinned
+                # mapping, or that would re-guess the first registered account, again
+                normalized_entry = replace(
+                    item,
+                    providers=[
+                        confirmed_mapping
+                        if (
+                            pm.domain == confirmed_mapping.domain
+                            and pm.item_id == confirmed_mapping.item_id
+                            and not pm.instance_id
+                        )
+                        else pm
+                        for pm in item.providers
+                    ]
+                    or [confirmed_mapping],
+                )
             return _ImportTrackMatchResult(label=label, retained=True, entry=normalized_entry)
         if not media_item.artists:
             # foreign M3U8 files only carry a combined "Artist - Title" EXTINF string;
@@ -1156,24 +1170,30 @@ class BuiltinProvider(MusicProvider):
         initiating user's own provider instances, so a domain-only reference can never
         reach an inaccessible account.
 
-        Returns the confirmed provider mapping alongside the playable verdict when the
-        entry carried no ``#EXTPROV`` metadata of its own and is a bare Music Assistant
-        provider URI, so the caller can persist it - a raw stream URL already
-        reconstructs its own builtin mapping from the path alone and needs nothing
-        written back, and an entry that already carries ``#EXTPROV`` metadata already
-        resolves correctly on its own.
+        Returns the confirmed provider mapping alongside the playable verdict whenever
+        the entry needs it written back to keep resolving on its own next time: a bare
+        Music Assistant provider URI with no ``#EXTPROV`` metadata at all, or a
+        domain-only ``#EXTPROV`` reference that was just confirmed on one specific
+        allowed instance. A raw builtin stream URL already reconstructs its own mapping
+        from the path alone and needs nothing written back, and an ``#EXTPROV``
+        reference that already names an exact instance already resolves correctly on
+        its own.
         """
-        candidates: list[tuple[str, str]] = []
+        candidates: list[tuple[str, str, bool]] = []
         seen: set[tuple[str, str]] = set()
         for prov_info in item.providers:
+            # a domain-only reference (no pinned instance id) is not yet tied to one
+            # specific account; once resolved, normalize it to whichever allowed
+            # instance actually confirmed it, so a later load doesn't fall back to
+            # guessing the first registered account of that domain again
+            needs_provider_metadata = not prov_info.instance_id
             for instance_id in self._allowed_instances_for(
                 prov_info.instance_id or prov_info.domain, allowed_provider_instances
             ):
                 key = (instance_id, prov_info.item_id)
                 if key not in seen:
                     seen.add(key)
-                    candidates.append(key)
-        needs_provider_metadata = False
+                    candidates.append((instance_id, prov_info.item_id, needs_provider_metadata))
         if not item.providers:
             # only a plain M3U entry with a bare Music Assistant URI and no #EXTPROV
             # metadata at all needs this path parsed - an entry that does carry
@@ -1191,8 +1211,8 @@ class BuiltinProvider(MusicProvider):
                 for instance_id in self._allowed_instances_for(
                     provider_instance_or_domain, allowed_provider_instances
                 ):
-                    candidates.append((instance_id, raw_item_id))
-        for provider_instance, provider_item_id in candidates:
+                    candidates.append((instance_id, raw_item_id, needs_provider_metadata))
+        for provider_instance, provider_item_id, needs_provider_metadata in candidates:
             provider = self.mass.get_provider(provider_instance, return_unavailable=True)
             if provider is None or not provider.available:
                 # every candidate here already passed the allowed-instances snapshot, so
@@ -1234,9 +1254,10 @@ class BuiltinProvider(MusicProvider):
             else:
                 if not needs_provider_metadata:
                     return True, None
-                # a bare URI without #EXTPROV would otherwise stay unresolvable to a
-                # provider mapping on every future load - persist what was just
-                # confirmed so the entry keeps resolving after this pass
+                # a bare URI without #EXTPROV, or a domain-only reference not yet
+                # pinned to one instance, would otherwise stay unresolvable or keep
+                # guessing the wrong account on every future load - persist what was
+                # just confirmed so the entry keeps resolving after this pass
                 own_mapping = next(
                     (
                         pm

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Final, cast
 from urllib.parse import urlparse
 
 import aiofiles
-from aiohttp import ClientError
+from aiohttp import ClientError, ClientTimeout
 from music_assistant_models.auth import Scope
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.enums import (
@@ -68,6 +68,7 @@ from music_assistant.controllers.tasks.context import (
     update_current_task_progress_from_index,
     update_current_task_progress_text,
 )
+from music_assistant.helpers.aiohttp_client import encoded_request_url
 from music_assistant.helpers.compare import TrackMatchConfidence
 from music_assistant.helpers.playlists import (
     ArtistInfo,
@@ -413,7 +414,10 @@ class BuiltinProvider(MusicProvider):
             # user-created playlist removal - delete the M3U file
             playlist_file = os.path.join(self._playlists_dir, f"{prov_item_id}.m3u")
             if await asyncio.to_thread(os.path.isfile, playlist_file):
-                async with self._get_playlist_lock(prov_item_id):
+                # both the per-playlist edit lock and the global file-I/O lock used by
+                # _read_m3u_file/_write_m3u_file must be held, or a concurrent read or
+                # write already in flight on this file could still race the unlink
+                async with self._get_playlist_lock(prov_item_id), self._playlist_lock:
                     await asyncio.to_thread(os.remove, playlist_file)
             return True
         else:
@@ -1188,8 +1192,19 @@ class BuiltinProvider(MusicProvider):
                     allow_fallback=False,
                     strict_provider_instance=True,
                 )
-            except MediaNotFoundError, InvalidDataError:
-                # confirmed unusable, e.g. a deleted catalog id or an unreadable stream
+            except MediaNotFoundError:
+                # a catalog id genuinely no longer exists on the provider
+                continue
+            except InvalidDataError:
+                if provider_item_id.startswith(
+                    BUILTIN_URL_SCHEMES
+                ) and not await self._stream_url_confirmed_gone(provider_item_id):
+                    # ffprobe wraps a transient failure (DNS, timeout, 5xx) in the
+                    # same error as a genuinely dead stream - only a confirmed
+                    # terminal HTTP status proves this one is actually gone
+                    return True, None
+                # confirmed unusable, e.g. an unreadable stream with no way to
+                # verify its status, or one that is verified terminally gone
                 continue
             except (
                 ResourceTemporarilyUnavailable,
@@ -1229,6 +1244,26 @@ class BuiltinProvider(MusicProvider):
                     bit_rate=(audio_format.bit_rate or 0) if audio_format else 0,
                 )
         return False, None
+
+    async def _stream_url_confirmed_gone(self, url: str) -> bool:
+        """
+        Return whether a stream URL is confirmed to no longer exist.
+
+        ffprobe reports a transient failure (a DNS hiccup, a timeout, a 5xx
+        response) with the same error as a genuinely deleted stream, so only a
+        terminal HTTP status confirms deletion. A scheme this cannot check (e.g.
+        ``rtsp://``/``rtmp://``) is never treated as confirmed gone.
+        """
+        if not url.startswith(("http://", "https://")):
+            return False
+        with suppress(ClientError, TimeoutError):
+            async with self.mass.http_session.head(
+                encoded_request_url(url),
+                allow_redirects=True,
+                timeout=ClientTimeout(total=10),
+            ) as resp:
+                return resp.status in (404, 410)
+        return False
 
     def _allowed_instances_for(
         self, provider_instance_or_domain: str, allowed_provider_instances: Mapping[str, str]

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -58,9 +58,6 @@ from music_assistant.constants import (
     PlaylistPlayableItem,
 )
 from music_assistant.controllers.cache import use_cache
-from music_assistant.controllers.music.media.playlists import (
-    match_policy_minimum_confidence,
-)
 from music_assistant.controllers.tasks.context import (
     get_current_task_id,
     report_current_task_failure,
@@ -69,7 +66,11 @@ from music_assistant.controllers.tasks.context import (
     update_current_task_progress_text,
 )
 from music_assistant.helpers.aiohttp_client import encoded_request_url
-from music_assistant.helpers.compare import TrackMatchConfidence, compare_track_evidence
+from music_assistant.helpers.compare import (
+    TrackMatchConfidence,
+    compare_track_evidence,
+    match_policy_minimum_confidence,
+)
 from music_assistant.helpers.playlists import (
     ArtistInfo,
     ImageInfo,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1233,12 +1233,17 @@ class BuiltinProvider(MusicProvider):
         references (falling back to parsing the raw path for a plain M3U entry that
         carries a bare Music Assistant URI without one) instead of through the shared
         library's mapping resolution, which silently substitutes an arbitrary
-        same-domain instance for a domain-only reference. A provider that is merely
-        down right now, or is configured but not currently loaded (e.g. it failed
-        setup), counts as still usable, so a transient outage does not trigger a
-        permanent substitution. Candidates are only ever expanded within the
-        initiating user's own provider instances, so a domain-only reference can never
-        reach an inaccessible account.
+        same-domain instance for a domain-only reference. A domain-only or foreign
+        reference can expand to several of the caller's own same-domain instances;
+        one of those being down or otherwise unverifiable right now does not rule
+        out another already-healthy sibling actually confirming the item, so every
+        candidate is tried before falling back to a verdict. Only once every
+        candidate is exhausted does an unresolved one count: a provider that is
+        merely down right now, or is configured but not currently loaded (e.g. it
+        failed setup), counts as still usable, so a transient outage does not
+        trigger a permanent substitution. Candidates are only ever expanded within
+        the initiating user's own provider instances, so a domain-only reference can
+        never reach an inaccessible account.
 
         Returns the confirmed provider mapping alongside the playable verdict whenever
         the entry needs it written back to keep resolving on its own next time: a bare
@@ -1300,19 +1305,26 @@ class BuiltinProvider(MusicProvider):
                     allowed_provider_instances,
                 ):
                     candidates.append((instance_id, raw_item_id, needs_provider_metadata))
+        # tracks whether any candidate could not be authoritatively checked at all
+        # (down/unloaded provider, already-known or fresh transient error) - only
+        # once every candidate is exhausted does this decide the final verdict,
+        # so one unreachable sibling instance never rules out trying another
+        any_unverifiable = False
         for provider_instance, provider_item_id, needs_provider_metadata in candidates:
             if provider_instance in failed_source_instances:
                 # a transient error already confirmed this instance unreachable
-                # earlier this pass - assume it is still fine (the same verdict a
-                # fresh probe would give) rather than time out on it again
-                return True, None, frozenset(confirmed_dead)
+                # earlier this pass - skip re-probing (and potentially timing out
+                # on) it again, but still give any other candidate a chance
+                any_unverifiable = True
+                continue
             provider = self.mass.get_provider(provider_instance, return_unavailable=True)
             if provider is None or not provider.available:
                 # every candidate here already passed the allowed-instances snapshot, so
                 # a missing/unavailable provider is a configured source that is merely
-                # down or failed setup right now, not one the user removed - a transient
-                # outage must not trigger a permanent substitution
-                return True, None, frozenset(confirmed_dead)
+                # down or failed setup right now, not one the user removed - try any
+                # other candidate before treating this alone as inconclusive
+                any_unverifiable = True
+                continue
             try:
                 hydrated = await self.mass.music.tracks.get_provider_item(
                     provider_item_id,
@@ -1337,7 +1349,8 @@ class BuiltinProvider(MusicProvider):
                     # provider's own API/HTTP fault) does not prove deletion
                     confirmed_dead.add((provider.instance_id, provider_item_id))
                     continue
-                return True, None, frozenset(confirmed_dead)
+                any_unverifiable = True
+                continue
             except (
                 ResourceTemporarilyUnavailable,
                 ProviderUnavailableError,
@@ -1345,12 +1358,13 @@ class BuiltinProvider(MusicProvider):
                 OSError,
                 TimeoutError,
             ):
-                # could not verify right now (network blip) - assume it is still fine
-                # rather than substitute it, and remember this instance for the rest
-                # of the pass so a large playlist doesn't retry (and re-time-out on)
-                # it once per entry
+                # could not verify right now (network blip) - remember this instance
+                # for the rest of the pass so a large playlist doesn't retry (and
+                # re-time-out on) it once per entry, but still try any other
+                # candidate before treating this alone as inconclusive
                 failed_source_instances.add(provider.instance_id)
-                return True, None, frozenset(confirmed_dead)
+                any_unverifiable = True
+                continue
             else:
                 if not needs_provider_metadata:
                     return True, None, frozenset(confirmed_dead)
@@ -1383,6 +1397,10 @@ class BuiltinProvider(MusicProvider):
                     ),
                     frozenset(confirmed_dead),
                 )
+        if any_unverifiable:
+            # at least one candidate couldn't be authoritatively checked, so the
+            # entry cannot be proven dead - never substitute on an unproven verdict
+            return True, None, frozenset(confirmed_dead)
         return False, None, frozenset(confirmed_dead)
 
     async def _stream_url_confirmed_gone(self, url: str) -> bool:

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1109,14 +1109,15 @@ class BuiltinProvider(MusicProvider):
                 failed_providers=enrichment.failed_providers,
             )
         best_confidence = max(match.confidence for match in enrichment.matches)
-        matched_domains = {match.mapping.provider_domain for match in enrichment.matches}
+        # enrichment.matches is ordered strongest-tier-first (see
+        # _resolve_confident_matches), so the first entry carries the strongest
+        # accepted candidate's own metadata - using it (rather than the dead
+        # source's copy) keeps release evidence such as MB_TRACK attributable to
+        # the actual matched release, so a later export/re-import can't
+        # mistake a same-recording/best-effort substitution for an exact one
         matched_track = replace(
-            enrichment.track,
-            provider_mappings={
-                mapping
-                for mapping in enrichment.track.provider_mappings
-                if mapping.provider_domain in matched_domains
-            },
+            enrichment.matches[0].track,
+            provider_mappings={match.mapping for match in enrichment.matches},
         )
         return _ImportTrackMatchResult(
             label=label,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+from collections import defaultdict, deque
 from collections.abc import AsyncGenerator, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, replace
@@ -892,27 +893,28 @@ class BuiltinProvider(MusicProvider):
         :return: Indices into `pending_substitutions` whose original entry was no longer in
             the playlist (e.g. removed by a concurrent edit) and so were not applied.
         """
+        # index pending replacements by a stable key with per-key queues, so a playlist
+        # with duplicate entries is still matched in original order without a per-item
+        # linear scan of the (potentially large) remaining list
+        pending_by_key: dict[str, deque[tuple[int, PlaylistItem]]] = defaultdict(deque)
+        for index, (original, replacement) in enumerate(pending_substitutions):
+            pending_by_key[repr(original)].append((index, replacement))
+
         async with self._get_playlist_lock(prov_playlist_id):
             current_items = parse_m3u(await self._read_m3u_file(prov_playlist_id))
-            remaining = list(enumerate(pending_substitutions))
             updated_items: list[PlaylistItem] = []
+            applied_indices: set[int] = set()
             changed = False
             for current_item in current_items:
-                match_index = next(
-                    (
-                        i
-                        for i, (_, (original, _)) in enumerate(remaining)
-                        if original == current_item
-                    ),
-                    None,
-                )
-                if match_index is None:
+                queue = pending_by_key.get(repr(current_item))
+                if not queue:
                     updated_items.append(current_item)
                     continue
-                _, (_, replacement) = remaining.pop(match_index)
+                index, replacement = queue.popleft()
                 updated_items.append(replacement)
+                applied_indices.add(index)
                 changed = True
-            not_applied = {original_index for original_index, _ in remaining}
+            not_applied = set(range(len(pending_substitutions))) - applied_indices
             if changed:
                 playlist = await self.get_playlist(prov_playlist_id)
                 await self._write_m3u_file(
@@ -1515,10 +1517,12 @@ class BuiltinProvider(MusicProvider):
     ) -> list[PlaylistPlayableItem]:
         """Get user-created playlist tracks with caching and parallel resolution."""
         playlist_file = os.path.join(self._playlists_dir, f"{prov_playlist_id}.m3u")
-        # use file mtime as cache checksum so edits invalidate the cache
+        # use file mtime as cache checksum so edits invalidate the cache; nanosecond
+        # resolution avoids two writes within the same second (e.g. import immediately
+        # followed by a background match) sharing a checksum and hiding the second write
         try:
             stat = await asyncio.to_thread(os.stat, playlist_file)
-            cache_checksum = str(int(stat.st_mtime))
+            cache_checksum = str(stat.st_mtime_ns)
         except OSError:
             cache_checksum = "0"
 

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -693,6 +693,10 @@ class BuiltinProvider(MusicProvider):
             else set(search_provider_instances)
         )
         failed_provider_instances: set[str] = set()
+        # a transient (e.g. network) failure verifying an original source instance is
+        # remembered for the rest of this pass, so a large playlist repeating that same
+        # instance doesn't re-probe (and re-time-out on) it once per entry
+        failed_source_instances: set[str] = set()
         total = len(parsed_items)
         counts = dict.fromkeys(
             (
@@ -738,6 +742,7 @@ class BuiltinProvider(MusicProvider):
                     allowed_provider_instance_map,
                     search_provider_instance_set,
                     failed_provider_instances,
+                    failed_source_instances,
                 )
                 resolved_by_entry[entry_key] = result
             self._tally_import_track_result(
@@ -1058,6 +1063,7 @@ class BuiltinProvider(MusicProvider):
         allowed_provider_instances: Mapping[str, str],
         search_provider_instances: set[str],
         failed_provider_instances: set[str],
+        failed_source_instances: set[str],
     ) -> _ImportTrackMatchResult:
         """Resolve one imported playlist entry against the allowed providers."""
         # a bare URI without #EXTMA metadata (e.g. a hand-written or foreign M3U entry)
@@ -1078,7 +1084,9 @@ class BuiltinProvider(MusicProvider):
             is_playable,
             confirmed_mapping,
             confirmed_dead_mappings,
-        ) = await self._original_source_is_playable(item, allowed_provider_instances)
+        ) = await self._original_source_is_playable(
+            item, allowed_provider_instances, failed_source_instances
+        )
         if is_playable:
             # the original source still resolves, or its provider is merely down right
             # now - either way there is nothing to substitute
@@ -1209,7 +1217,10 @@ class BuiltinProvider(MusicProvider):
         )
 
     async def _original_source_is_playable(
-        self, item: PlaylistItem, allowed_provider_instances: Mapping[str, str]
+        self,
+        item: PlaylistItem,
+        allowed_provider_instances: Mapping[str, str],
+        failed_source_instances: set[str],
     ) -> tuple[bool, ProviderMappingInfo | None, frozenset[tuple[str, str]]]:
         """
         Check whether an imported entry's original source is still usable.
@@ -1242,6 +1253,10 @@ class BuiltinProvider(MusicProvider):
         every ``(instance_id, item_id)`` pair that was just authoritatively confirmed
         dead here, so a subsequent matching pass does not force-refresh the exact same
         candidate a second time.
+
+        :param failed_source_instances: Instances that already failed verification
+            with a transient error earlier this pass, mutated in place - skipped
+            here without probing (and potentially timing out on) them again.
         """
         candidates: list[tuple[str, str, bool]] = []
         seen: set[tuple[str, str]] = set()
@@ -1286,6 +1301,11 @@ class BuiltinProvider(MusicProvider):
                 ):
                     candidates.append((instance_id, raw_item_id, needs_provider_metadata))
         for provider_instance, provider_item_id, needs_provider_metadata in candidates:
+            if provider_instance in failed_source_instances:
+                # a transient error already confirmed this instance unreachable
+                # earlier this pass - assume it is still fine (the same verdict a
+                # fresh probe would give) rather than time out on it again
+                return True, None, frozenset(confirmed_dead)
             provider = self.mass.get_provider(provider_instance, return_unavailable=True)
             if provider is None or not provider.available:
                 # every candidate here already passed the allowed-instances snapshot, so
@@ -1326,7 +1346,10 @@ class BuiltinProvider(MusicProvider):
                 TimeoutError,
             ):
                 # could not verify right now (network blip) - assume it is still fine
-                # rather than substitute it
+                # rather than substitute it, and remember this instance for the rest
+                # of the pass so a large playlist doesn't retry (and re-time-out on)
+                # it once per entry
+                failed_source_instances.add(provider.instance_id)
                 return True, None, frozenset(confirmed_dead)
             else:
                 if not needs_provider_metadata:

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -631,6 +631,7 @@ class BuiltinProvider(MusicProvider):
         prov_playlist_id: str,
         match_policy: PlaylistMatchPolicy,
         allowed_provider_instances: tuple[str, ...],
+        search_provider_instances: tuple[str, ...] | None = None,
     ) -> None:
         """
         Match imported playlist tracks against available providers.
@@ -642,8 +643,13 @@ class BuiltinProvider(MusicProvider):
 
         :param prov_playlist_id: The provider-side playlist ID of the playlist to match.
         :param match_policy: Lowest track-match confidence accepted for a substitute.
-        :param allowed_provider_instances: Provider instances to search, snapshotted from the
-            user that requested the import.
+        :param allowed_provider_instances: Provider instances snapshotted from the user
+            that requested the import, used to validate whether an entry's original
+            source is still playable. Always the user's full accessible set, independent
+            of any search narrowing, so a valid original outside that narrowing is never
+            treated as unavailable.
+        :param search_provider_instances: Provider instances to search for a substitute.
+            Defaults to ``allowed_provider_instances`` when not narrowed by the caller.
         """
         m3u_data = await self._read_m3u_file(prov_playlist_id)
         parsed_items = parse_m3u(m3u_data)
@@ -653,6 +659,11 @@ class BuiltinProvider(MusicProvider):
 
         minimum_confidence = match_policy_minimum_confidence(match_policy)
         allowed_provider_instance_set = set(allowed_provider_instances)
+        search_provider_instance_set = (
+            allowed_provider_instance_set
+            if search_provider_instances is None
+            else set(search_provider_instances)
+        )
         failed_provider_instances: set[str] = set()
         total = len(parsed_items)
         counts = dict.fromkeys(
@@ -693,6 +704,7 @@ class BuiltinProvider(MusicProvider):
                     item,
                     minimum_confidence,
                     allowed_provider_instance_set,
+                    search_provider_instance_set,
                     failed_provider_instances,
                 )
                 resolved_by_entry[entry_key] = result
@@ -988,6 +1000,7 @@ class BuiltinProvider(MusicProvider):
         item: PlaylistItem,
         minimum_confidence: TrackMatchConfidence,
         allowed_provider_instances: set[str],
+        search_provider_instances: set[str],
         failed_provider_instances: set[str],
     ) -> _ImportTrackMatchResult:
         """Resolve one imported playlist entry against the allowed providers."""
@@ -1016,7 +1029,7 @@ class BuiltinProvider(MusicProvider):
             enrichment = await self.mass.music.tracks.enrich_provider_mappings(
                 media_item,
                 minimum_confidence=minimum_confidence,
-                provider_instance_ids=allowed_provider_instances,
+                provider_instance_ids=search_provider_instances,
                 # imported metadata comes from outside Music Assistant and is unverified,
                 # so a provider mapping it already carries is not treated as authoritative
                 trust_track_mappings=False,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -663,15 +663,18 @@ class BuiltinProvider(MusicProvider):
         pending_substitutions: list[tuple[PlaylistItem, PlaylistItem]] = []
         unmatched_items: list[tuple[str, str]] = []
         provider_issues: list[tuple[str, str]] = []
-        # results are cached by the entry's original path so a track that is duplicated
-        # in the playlist is only probed and searched once, however many times it repeats
-        resolved_by_path: dict[str, _ImportTrackMatchResult] = {}
+        # results are cached by the entry's full content (not just its path) so a track
+        # that is byte-for-byte duplicated in the playlist is only probed and searched
+        # once, however many times it repeats - entries sharing a path but differing in
+        # any resolution input (title, artists, providers, ...) are resolved independently
+        resolved_by_entry: dict[str, _ImportTrackMatchResult] = {}
 
         for index, item in enumerate(parsed_items):
             update_current_task_progress_from_index(
                 index, total, f"Matching track {index + 1}/{total}"
             )
-            result = resolved_by_path.get(item.path)
+            entry_key = repr(item)
+            result = resolved_by_entry.get(entry_key)
             if result is None:
                 result = await self._resolve_import_track(
                     item,
@@ -679,7 +682,7 @@ class BuiltinProvider(MusicProvider):
                     allowed_provider_instance_set,
                     failed_provider_instances,
                 )
-                resolved_by_path[item.path] = result
+                resolved_by_entry[entry_key] = result
             self._tally_import_track_result(
                 item,
                 result,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -69,7 +69,7 @@ from music_assistant.controllers.tasks.context import (
     update_current_task_progress_text,
 )
 from music_assistant.helpers.aiohttp_client import encoded_request_url
-from music_assistant.helpers.compare import TrackMatchConfidence
+from music_assistant.helpers.compare import TrackMatchConfidence, compare_track_evidence
 from music_assistant.helpers.playlists import (
     ArtistInfo,
     ImageInfo,
@@ -1123,22 +1123,38 @@ class BuiltinProvider(MusicProvider):
                 failed_providers=enrichment.failed_providers,
             )
         best_confidence = max(match.confidence for match in enrichment.matches)
-        # enrichment.matches is ordered strongest-tier-first (see
-        # _resolve_confident_matches), so the first entry carries the strongest
-        # accepted candidate's own metadata - using it (rather than the dead
-        # source's copy) keeps release evidence such as MB_TRACK attributable to
-        # the actual matched release, so a later export/re-import can't
-        # mistake a same-recording/best-effort substitution for an exact one.
-        # A weaker, merely-compatible tier may still be present in the full match
-        # set, but media_item_to_playlist_item picks its primary playback URI by
-        # audio quality alone - mixing tiers into the persisted mappings could let
-        # a looser-tier provider become the actual substitute while the entry still
-        # carries the strongest tier's release evidence, so only the strongest
-        # tier's own mappings are kept.
+        tier_matches = [
+            match for match in enrichment.matches if match.confidence == best_confidence
+        ]
+        # media_item_to_playlist_item picks its primary playback URI by the same
+        # availability/quality/identity ordering used here, so the primary match must
+        # be selected the same way - otherwise the entry's release evidence (from
+        # whichever match's track happened to be first) could describe a different
+        # release than the mapping the serializer actually ends up exporting as the
+        # playable URI.
+        primary_match = min(
+            tier_matches,
+            key=lambda match: (
+                not match.mapping.available,
+                -match.mapping.quality,
+                match.mapping.provider_domain,
+                match.mapping.provider_instance,
+                match.mapping.item_id,
+            ),
+        )
+        # a same-tier sibling from another provider is only safe to keep alongside
+        # the primary match's own release evidence (e.g. MB_TRACK) when it is
+        # confirmed to be that exact same release - a merely LIKELY-compatible
+        # sibling may share the recording but not the release, and combining its
+        # mapping under the primary's metadata would misattribute it as exact
         matched_track = replace(
-            enrichment.matches[0].track,
+            primary_match.track,
             provider_mappings={
-                match.mapping for match in enrichment.matches if match.confidence == best_confidence
+                match.mapping
+                for match in tier_matches
+                if match is primary_match
+                or compare_track_evidence(primary_match.track, match.track)
+                == TrackMatchConfidence.EXACT
             },
         )
         return _ImportTrackMatchResult(

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1045,9 +1045,11 @@ class BuiltinProvider(MusicProvider):
         if not isinstance(media_item, Track):
             return _ImportTrackMatchResult(label=item.title or item.path, retained=True)
         label = _entry_label(media_item)
-        is_playable, confirmed_mapping = await self._original_source_is_playable(
-            item, allowed_provider_instances
-        )
+        (
+            is_playable,
+            confirmed_mapping,
+            confirmed_dead_mappings,
+        ) = await self._original_source_is_playable(item, allowed_provider_instances)
         if is_playable:
             # the original source still resolves, or its provider is merely down right
             # now - either way there is nothing to substitute
@@ -1095,6 +1097,10 @@ class BuiltinProvider(MusicProvider):
                 # so a provider mapping it already carries is not treated as authoritative
                 trust_track_mappings=False,
                 failed_provider_instances=failed_provider_instances,
+                # the liveness check above already force-refreshed these exact
+                # (instance, item id) pairs and proved them dead - hydrating them again
+                # here would double every stale entry's provider API traffic for nothing
+                known_dead_mappings=confirmed_dead_mappings,
                 # release-evidence hydration (e.g. the source's own album) must reach the
                 # user's full allowed snapshot, not just the narrowed search targets, or a
                 # match_providers filter would starve EXACT matching of evidence that is
@@ -1167,7 +1173,7 @@ class BuiltinProvider(MusicProvider):
 
     async def _original_source_is_playable(
         self, item: PlaylistItem, allowed_provider_instances: Mapping[str, str]
-    ) -> tuple[bool, ProviderMappingInfo | None]:
+    ) -> tuple[bool, ProviderMappingInfo | None, frozenset[tuple[str, str]]]:
         """
         Check whether an imported entry's original source is still usable.
 
@@ -1193,10 +1199,13 @@ class BuiltinProvider(MusicProvider):
         allowed instance. A raw builtin stream URL already reconstructs its own mapping
         from the path alone and needs nothing written back, and an ``#EXTPROV``
         reference that already names an exact instance already resolves correctly on
-        its own.
+        its own. Also returns every ``(instance_id, item_id)`` pair that was just
+        authoritatively confirmed dead here, so a subsequent matching pass does not
+        force-refresh the exact same candidate a second time.
         """
         candidates: list[tuple[str, str, bool]] = []
         seen: set[tuple[str, str]] = set()
+        confirmed_dead: set[tuple[str, str]] = set()
         for prov_info in item.providers:
             # a domain-only reference (no pinned instance id) is not yet tied to one
             # specific account; once resolved, normalize it to whichever allowed
@@ -1235,7 +1244,7 @@ class BuiltinProvider(MusicProvider):
                 # a missing/unavailable provider is a configured source that is merely
                 # down or failed setup right now, not one the user removed - a transient
                 # outage must not trigger a permanent substitution
-                return True, None
+                return True, None, frozenset(confirmed_dead)
             try:
                 hydrated = await self.mass.music.tracks.get_provider_item(
                     provider_item_id,
@@ -1246,6 +1255,7 @@ class BuiltinProvider(MusicProvider):
                 )
             except MediaNotFoundError:
                 # a catalog id genuinely no longer exists on the provider
+                confirmed_dead.add((provider.instance_id, provider_item_id))
                 continue
             except InvalidDataError:
                 if provider_item_id.startswith(
@@ -1255,8 +1265,9 @@ class BuiltinProvider(MusicProvider):
                     # is actually gone - anything else this error can mean (a DNS
                     # hiccup, a timeout, a 5xx response, or - for a catalog id - a
                     # provider's own API/HTTP fault) does not prove deletion
+                    confirmed_dead.add((provider.instance_id, provider_item_id))
                     continue
-                return True, None
+                return True, None, frozenset(confirmed_dead)
             except (
                 ResourceTemporarilyUnavailable,
                 ProviderUnavailableError,
@@ -1266,10 +1277,10 @@ class BuiltinProvider(MusicProvider):
             ):
                 # could not verify right now (network blip) - assume it is still fine
                 # rather than substitute it
-                return True, None
+                return True, None, frozenset(confirmed_dead)
             else:
                 if not needs_provider_metadata:
-                    return True, None
+                    return True, None, frozenset(confirmed_dead)
                 # a bare URI without #EXTPROV, or a domain-only reference not yet
                 # pinned to one instance, would otherwise stay unresolvable or keep
                 # guessing the wrong account on every future load - persist what was
@@ -1286,16 +1297,20 @@ class BuiltinProvider(MusicProvider):
                 # carried its own mapping - otherwise leave them unset rather than
                 # writing a guessed/default format into the persisted metadata
                 audio_format = own_mapping.audio_format if own_mapping else None
-                return True, ProviderMappingInfo(
-                    domain=provider.domain,
-                    item_id=provider_item_id,
-                    instance_id=provider.instance_id,
-                    content_type=audio_format.content_type.value if audio_format else "",
-                    sample_rate=audio_format.sample_rate if audio_format else 0,
-                    bit_depth=audio_format.bit_depth if audio_format else 0,
-                    bit_rate=(audio_format.bit_rate or 0) if audio_format else 0,
+                return (
+                    True,
+                    ProviderMappingInfo(
+                        domain=provider.domain,
+                        item_id=provider_item_id,
+                        instance_id=provider.instance_id,
+                        content_type=audio_format.content_type.value if audio_format else "",
+                        sample_rate=audio_format.sample_rate if audio_format else 0,
+                        bit_depth=audio_format.bit_depth if audio_format else 0,
+                        bit_rate=(audio_format.bit_rate or 0) if audio_format else 0,
+                    ),
+                    frozenset(confirmed_dead),
                 )
-        return False, None
+        return False, None, frozenset(confirmed_dead)
 
     async def _stream_url_confirmed_gone(self, url: str) -> bool:
         """

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1105,7 +1105,12 @@ class BuiltinProvider(MusicProvider):
                 if key not in seen:
                     seen.add(key)
                     candidates.append(key)
-        if not candidates:
+        if not item.providers:
+            # only a plain M3U entry with a bare Music Assistant URI and no #EXTPROV
+            # metadata at all needs this path parsed - an entry that does carry
+            # #EXTPROV references but none of them fall within the allowed snapshot
+            # must not fall back to guessing an allowed sibling instance of the same
+            # domain, since that sibling is not actually the entry's original source
             with suppress(InvalidProviderURI, InvalidProviderID, IndexError, ValueError):
                 _, provider_instance_or_domain, raw_item_id = await parse_uri(item.path)
                 for instance_id in self._allowed_instances_for(

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1137,6 +1137,12 @@ class BuiltinProvider(MusicProvider):
                 # match_providers filter would starve EXACT matching of evidence that is
                 # still on one of the user's own, merely un-searched, accounts
                 evidence_provider_instances=set(allowed_provider_instances),
+                # search_provider_instances is the initiating user's own deliberate
+                # selection of fallback targets - a non-streaming provider (e.g.
+                # filesystem) chosen there must actually be searched, not silently
+                # skipped for lacking a mapping no freshly imported track could ever
+                # already carry
+                search_non_streaming_without_mapping=True,
             )
         except (
             ResourceTemporarilyUnavailable,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 import re
 from collections.abc import AsyncGenerator, Mapping, Sequence
+from contextlib import suppress
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Final, cast
 from urllib.parse import urlparse
@@ -23,6 +24,7 @@ from music_assistant_models.enums import (
 )
 from music_assistant_models.errors import (
     InvalidDataError,
+    InvalidProviderID,
     InvalidProviderURI,
     MediaNotFoundError,
     ProviderUnavailableError,
@@ -84,6 +86,7 @@ from music_assistant.helpers.playlists import (
 from music_assistant.helpers.security import is_safe_path
 from music_assistant.helpers.tags import AudioTags, async_parse_tags
 from music_assistant.helpers.track_filter import filter_tracks, get_track_filter
+from music_assistant.helpers.uri import parse_uri
 from music_assistant.models.music_provider import MusicProvider
 
 from .constants import (
@@ -916,8 +919,9 @@ class BuiltinProvider(MusicProvider):
         if not isinstance(media_item, Track):
             return _ImportTrackMatchResult(label=item.title or item.path, retained=True)
         label = _entry_label(media_item)
-        if any(mapping.available for mapping in media_item.provider_mappings):
-            # the original provider is still available - nothing to substitute
+        if await self._original_source_is_playable(item, media_item):
+            # the original source still resolves, or its provider is merely down right
+            # now - either way there is nothing to substitute
             return _ImportTrackMatchResult(label=label, retained=True)
         if not media_item.artists:
             # foreign M3U8 files only carry a combined "Artist - Title" EXTINF string;
@@ -967,6 +971,56 @@ class BuiltinProvider(MusicProvider):
             ambiguous_providers=enrichment.ambiguous_providers,
             failed_providers=enrichment.failed_providers,
         )
+
+    async def _original_source_is_playable(self, item: PlaylistItem, track: Track) -> bool:
+        """
+        Check whether an imported entry's original source is still usable.
+
+        Resolves the exact provider instance and item id authoritatively (no stored
+        fallback) instead of trusting the ``available`` flag on the track's provider
+        mappings, which only reflects whether the provider was loaded when the M3U
+        metadata was last written. Falls back to parsing the raw path itself for plain
+        M3U entries that carry a bare Music Assistant URI without ``#EXTPROV`` metadata.
+        A provider that is merely down right now counts as still usable, so a transient
+        outage does not trigger a permanent substitution.
+        """
+        candidates = [
+            (mapping.provider_instance or mapping.provider_domain, mapping.item_id)
+            for mapping in track.provider_mappings
+        ]
+        if not candidates:
+            with suppress(InvalidProviderURI, InvalidProviderID, IndexError, ValueError):
+                _, provider_instance_or_domain, raw_item_id = await parse_uri(item.path)
+                candidates.append((provider_instance_or_domain, raw_item_id))
+        for provider_instance_or_domain, provider_item_id in candidates:
+            provider = self.mass.get_provider(provider_instance_or_domain, return_unavailable=True)
+            if provider is None:
+                continue
+            if not provider.available:
+                return True
+            try:
+                await self.mass.music.tracks.get_provider_item(
+                    provider_item_id,
+                    provider.instance_id,
+                    allow_fallback=False,
+                    strict_provider_instance=True,
+                )
+            except MediaNotFoundError, InvalidDataError:
+                # confirmed unusable, e.g. a deleted catalog id or an unreadable stream
+                continue
+            except (
+                ResourceTemporarilyUnavailable,
+                ProviderUnavailableError,
+                ClientError,
+                OSError,
+                TimeoutError,
+            ):
+                # could not verify right now (network blip) - assume it is still fine
+                # rather than substitute it
+                return True
+            else:
+                return True
+        return False
 
     def _get_stored_item(
         self, item: PlaylistItem, stored_by_media_type: Mapping[str, Mapping[str, StoredItem]]

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1161,9 +1161,7 @@ class BuiltinProvider(MusicProvider):
                 if key not in seen:
                     seen.add(key)
                     candidates.append(key)
-        needs_provider_metadata = not item.providers and not item.path.startswith(
-            BUILTIN_URL_SCHEMES
-        )
+        needs_provider_metadata = False
         if not item.providers:
             # only a plain M3U entry with a bare Music Assistant URI and no #EXTPROV
             # metadata at all needs this path parsed - an entry that does carry
@@ -1172,6 +1170,12 @@ class BuiltinProvider(MusicProvider):
             # domain, since that sibling is not actually the entry's original source
             with suppress(InvalidProviderURI, InvalidProviderID, IndexError, ValueError):
                 _, provider_instance_or_domain, raw_item_id = await parse_uri(item.path)
+                # a resolved external provider reference - a bare MA URI or a public
+                # share link such as https://open.spotify.com/track/... - has no other
+                # way to attach a provider mapping and must be persisted; a raw builtin
+                # stream URL already reconstructs "builtin" from the path alone on
+                # every future load and needs nothing written back
+                needs_provider_metadata = provider_instance_or_domain != "builtin"
                 for instance_id in self._allowed_instances_for(
                     provider_instance_or_domain, allowed_provider_instances
                 ):

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -655,9 +655,11 @@ class BuiltinProvider(MusicProvider):
             ("retained", "exact", "same_recording", "best_effort", "ambiguous", "unmatched"), 0
         )
         substitutions: list[tuple[str, str, str]] = []
+        # (original, replacement) pairs, applied against a freshly re-read playlist below so
+        # edits made elsewhere while this (possibly long-running) pass was searching aren't lost
+        pending_substitutions: list[tuple[PlaylistItem, PlaylistItem]] = []
         unmatched_items: list[tuple[str, str]] = []
         provider_issues: list[tuple[str, str]] = []
-        changed = False
 
         for index, item in enumerate(parsed_items):
             update_current_task_progress_from_index(
@@ -696,21 +698,15 @@ class BuiltinProvider(MusicProvider):
                     report_current_task_failure(f"{result.label}: {reason.lower()}")
                 unmatched_items.append((result.label, reason))
                 continue
-            parsed_items[index] = result.entry
-            changed = True
+            pending_substitutions.append((item, result.entry))
             tier = _CONFIDENCE_COUNT_KEY[result.confidence]
             counts[tier] += 1
             substitutions.append(
                 (result.label, _entry_label(result.entry), _CONFIDENCE_TIER_LABELS[tier])
             )
 
-        if changed:
-            await self._write_m3u_file(
-                prov_playlist_id,
-                playlist.name,
-                parsed_items,
-                self._get_playlist_image_url(playlist),
-            )
+        if pending_substitutions:
+            await self._apply_import_substitutions(prov_playlist_id, pending_substitutions)
 
         set_current_task_report(
             _build_import_report(
@@ -867,6 +863,46 @@ class BuiltinProvider(MusicProvider):
             await self._write_m3u_file(playlist_id, new_name, list(existing_items), image_url)
         except OSError as err:
             self.logger.warning("Failed to update playlist metadata: %s", err)
+
+    async def _apply_import_substitutions(
+        self,
+        prov_playlist_id: str,
+        pending_substitutions: list[tuple[PlaylistItem, PlaylistItem]],
+    ) -> None:
+        """
+        Write resolved substitutes into the playlist's current contents.
+
+        Matching can take a while, so entries are matched by value against a fresh read of
+        the playlist under its lock rather than overwriting the whole snapshot taken at the
+        start of the pass - this preserves edits made elsewhere while matching was running.
+
+        :param prov_playlist_id: The provider-side playlist ID to update.
+        :param pending_substitutions: (original, replacement) pairs found during matching.
+        """
+        async with self._get_playlist_lock(prov_playlist_id):
+            current_items = parse_m3u(await self._read_m3u_file(prov_playlist_id))
+            remaining = list(pending_substitutions)
+            updated_items: list[PlaylistItem] = []
+            changed = False
+            for current_item in current_items:
+                match_index = next(
+                    (i for i, (original, _) in enumerate(remaining) if original == current_item),
+                    None,
+                )
+                if match_index is None:
+                    updated_items.append(current_item)
+                    continue
+                updated_items.append(remaining.pop(match_index)[1])
+                changed = True
+            if not changed:
+                return
+            playlist = await self.get_playlist(prov_playlist_id)
+            await self._write_m3u_file(
+                prov_playlist_id,
+                playlist.name,
+                updated_items,
+                self._get_playlist_image_url(playlist),
+            )
 
     async def _resolve_import_track(
         self,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -589,28 +589,7 @@ class BuiltinProvider(MusicProvider):
 
         The playlist name is used as the filename (sanitized for filesystem safety).
         """
-        base_id = self._sanitize_playlist_id(name)
-        # the uniqueness check, generation bump and initial file creation must all
-        # happen under the same lock: otherwise two concurrent creates for the same
-        # name can both see the id as free, both claim it, and race each other's
-        # generation bump and file write.
-        async with self._playlist_lock:
-            playlist_id = base_id
-            counter = 1
-            while await asyncio.to_thread(
-                os.path.isfile, os.path.join(self._playlists_dir, f"{playlist_id}.m3u")
-            ):
-                playlist_id = f"{base_id} ({counter})"
-                counter += 1
-            # bump this ID's generation before creating its file: a delete followed by a
-            # recreation under the same sanitized ID must be distinguishable from an
-            # in-place rewrite of the same playlist, even if the filesystem happens to
-            # reuse the freed inode for the new file
-            self._playlist_generations[playlist_id] = (
-                self._playlist_generations.get(playlist_id, 0) + 1
-            )
-            # create empty M3U file with header
-            await self._write_m3u_file_locked(playlist_id, name, [])
+        playlist_id = await self._reserve_playlist_file(name, [])
         return await self.get_playlist(playlist_id)
 
     async def import_playlist(self, m3u_data: str) -> Playlist:
@@ -628,21 +607,17 @@ class BuiltinProvider(MusicProvider):
             msg = "No items found in M3U data"
             raise InvalidDataError(msg)
         playlist_name = parse_m3u_playlist_name(m3u_data) or "Imported Playlist"
-        playlist = await self.create_playlist(
-            playlist_name,
-            media_types={MediaType.TRACK, MediaType.RADIO},
-        )
         playlist_image_url = parse_m3u_playlist_image(m3u_data)
-        # Write the parsed items directly as the M3U file, preserving all
-        # metadata from the source. This avoids re-resolving items that
-        # already have rich metadata (e.g. exported from another MA instance).
-        await self._write_m3u_file(
-            playlist.item_id,
-            playlist_name,
-            parsed_items,
-            playlist_image_url,
+        # write the parsed items directly as the initial M3U file content, preserving
+        # all metadata from the source - this avoids re-resolving items that already
+        # have rich metadata (e.g. exported from another MA instance), and, by
+        # reserving the id and writing its final content in the same locked step,
+        # never exposes an intermediate empty playlist that a concurrent add/remove
+        # on the same (predictable) id could race against
+        playlist_id = await self._reserve_playlist_file(
+            playlist_name, parsed_items, playlist_image_url
         )
-        return await self.get_playlist(playlist.item_id)
+        return await self.get_playlist(playlist_id)
 
     async def match_imported_playlist_tracks(
         self,
@@ -1301,8 +1276,10 @@ class BuiltinProvider(MusicProvider):
                     allow_fallback=False,
                     strict_provider_instance=True,
                 )
-            except MediaNotFoundError:
-                # a catalog id genuinely no longer exists on the provider
+            except MediaNotFoundError, InvalidProviderID:
+                # a catalog id genuinely no longer exists on the provider, or is
+                # malformed for it (e.g. an id that no longer matches the provider's
+                # expected format) - either way it will never resolve on retry
                 confirmed_dead.add((provider.instance_id, provider_item_id))
                 continue
             except InvalidDataError:
@@ -1748,6 +1725,46 @@ class BuiltinProvider(MusicProvider):
         if not await asyncio.to_thread(os.path.isfile, playlist_file):
             return None
         return self._playlist_generations.get(playlist_id, 0)
+
+    async def _reserve_playlist_file(
+        self,
+        name: str,
+        entries: list[PlaylistItem],
+        playlist_image_url: str | None = None,
+    ) -> str:
+        """
+        Reserve a unique playlist ID and write its initial M3U file with given content.
+
+        The uniqueness check, generation bump, and initial content write all happen
+        under the same lock: otherwise two concurrent creates for the same name could
+        both see the id as free, both claim it, and race each other's generation bump
+        and file write. Writing the given ``entries`` directly - rather than always
+        starting from an empty file - also means the file never appears on disk in an
+        intermediate state that a concurrent add/remove on the same (predictable) id
+        could observe or silently overwrite.
+
+        :param name: The playlist's display name, used to derive its sanitized id.
+        :param entries: The initial playlist items to write.
+        :param playlist_image_url: Optional playlist image URL to embed in the header.
+        """
+        base_id = self._sanitize_playlist_id(name)
+        async with self._playlist_lock:
+            playlist_id = base_id
+            counter = 1
+            while await asyncio.to_thread(
+                os.path.isfile, os.path.join(self._playlists_dir, f"{playlist_id}.m3u")
+            ):
+                playlist_id = f"{base_id} ({counter})"
+                counter += 1
+            # bump this ID's generation before creating its file: a delete followed by a
+            # recreation under the same sanitized ID must be distinguishable from an
+            # in-place rewrite of the same playlist, even if the filesystem happens to
+            # reuse the freed inode for the new file
+            self._playlist_generations[playlist_id] = (
+                self._playlist_generations.get(playlist_id, 0) + 1
+            )
+            await self._write_m3u_file_locked(playlist_id, name, entries, playlist_image_url)
+        return playlist_id
 
     async def _write_m3u_file(
         self,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -87,7 +87,7 @@ from music_assistant.helpers.playlists import (
 from music_assistant.helpers.security import is_safe_path
 from music_assistant.helpers.tags import AudioTags, async_parse_tags
 from music_assistant.helpers.track_filter import filter_tracks, get_track_filter
-from music_assistant.helpers.uri import parse_uri
+from music_assistant.helpers.uri import BUILTIN_URL_SCHEMES, parse_uri
 from music_assistant.models.music_provider import MusicProvider
 
 from .constants import (
@@ -687,6 +687,10 @@ class BuiltinProvider(MusicProvider):
         # confidence-count key for each pending_substitutions entry, same index - lets the
         # report be reconciled against what _apply_import_substitutions actually wrote
         substitution_tiers: list[str] = []
+        # retained entries whose bare-URI original carried no #EXTPROV of its own - written
+        # back with the provider mapping confirmed playable during this pass, so they keep
+        # resolving on future loads too, without being reported as substitutions
+        pending_metadata_updates: list[tuple[PlaylistItem, PlaylistItem]] = []
         unmatched_items: list[tuple[str, str]] = []
         provider_issues: list[tuple[str, str]] = []
         # results are cached by the entry's full content (not just its path) so a track
@@ -719,6 +723,7 @@ class BuiltinProvider(MusicProvider):
                 provider_issues,
                 pending_substitutions,
                 substitution_tiers,
+                pending_metadata_updates,
             )
 
         if pending_substitutions:
@@ -732,6 +737,14 @@ class BuiltinProvider(MusicProvider):
                 counts[substitution_tiers[entry_index]] -= 1
                 counts["concurrent_edit"] += 1
                 del substitutions[entry_index]
+
+        if pending_metadata_updates:
+            not_applied = await self._apply_import_substitutions(
+                prov_playlist_id, pending_metadata_updates
+            )
+            for _entry_index in not_applied:
+                counts["retained"] -= 1
+                counts["concurrent_edit"] += 1
 
         set_current_task_report(
             _build_import_report(
@@ -949,6 +962,7 @@ class BuiltinProvider(MusicProvider):
         provider_issues: list[tuple[str, str]],
         pending_substitutions: list[tuple[PlaylistItem, PlaylistItem]],
         substitution_tiers: list[str],
+        pending_metadata_updates: list[tuple[PlaylistItem, PlaylistItem]],
     ) -> None:
         """
         Record a resolved track match result into the running import report state.
@@ -961,6 +975,8 @@ class BuiltinProvider(MusicProvider):
         :param provider_issues: Provider-level issue rows, appended in place.
         :param pending_substitutions: Accepted (original, replacement) pairs, appended in place.
         :param substitution_tiers: Counts key for each pending_substitutions entry, same index.
+        :param pending_metadata_updates: Retained (original, normalized) pairs whose bare-URI
+            entry gained a confirmed provider mapping, appended in place.
         """
         for provider_name in result.failed_providers:
             issue = f"Matching failed on {provider_name}"
@@ -972,6 +988,8 @@ class BuiltinProvider(MusicProvider):
             provider_issues.append((result.label, issue))
         if result.retained:
             counts["retained"] += 1
+            if result.entry is not None:
+                pending_metadata_updates.append((item, result.entry))
             return
         if result.error:
             report_current_task_failure(f"{result.label}: {result.error}")
@@ -1020,10 +1038,20 @@ class BuiltinProvider(MusicProvider):
         if not isinstance(media_item, Track):
             return _ImportTrackMatchResult(label=item.title or item.path, retained=True)
         label = _entry_label(media_item)
-        if await self._original_source_is_playable(item, allowed_provider_instances):
+        is_playable, confirmed_mapping = await self._original_source_is_playable(
+            item, allowed_provider_instances
+        )
+        if is_playable:
             # the original source still resolves, or its provider is merely down right
             # now - either way there is nothing to substitute
-            return _ImportTrackMatchResult(label=label, retained=True)
+            normalized_entry = None
+            if confirmed_mapping is not None:
+                # a bare URI without #EXTPROV metadata was just confirmed playable -
+                # persist the resolved mapping so this entry keeps resolving to it on
+                # future loads too, instead of leaving one that can never attach a
+                # provider mapping of its own again
+                normalized_entry = replace(item, providers=[confirmed_mapping])
+            return _ImportTrackMatchResult(label=label, retained=True, entry=normalized_entry)
         if not media_item.artists:
             # foreign M3U8 files only carry a combined "Artist - Title" EXTINF string;
             # the shared matcher needs a structured artist to search and compare with
@@ -1093,7 +1121,7 @@ class BuiltinProvider(MusicProvider):
 
     async def _original_source_is_playable(
         self, item: PlaylistItem, allowed_provider_instances: Mapping[str, str]
-    ) -> bool:
+    ) -> tuple[bool, ProviderMappingInfo | None]:
         """
         Check whether an imported entry's original source is still usable.
 
@@ -1111,6 +1139,13 @@ class BuiltinProvider(MusicProvider):
         permanent substitution. Candidates are only ever expanded within the
         initiating user's own provider instances, so a domain-only reference can never
         reach an inaccessible account.
+
+        Returns the confirmed provider mapping alongside the playable verdict when the
+        entry carried no ``#EXTPROV`` metadata of its own and is a bare Music Assistant
+        provider URI, so the caller can persist it - a raw stream URL already
+        reconstructs its own builtin mapping from the path alone and needs nothing
+        written back, and an entry that already carries ``#EXTPROV`` metadata already
+        resolves correctly on its own.
         """
         candidates: list[tuple[str, str]] = []
         seen: set[tuple[str, str]] = set()
@@ -1122,6 +1157,9 @@ class BuiltinProvider(MusicProvider):
                 if key not in seen:
                     seen.add(key)
                     candidates.append(key)
+        needs_provider_metadata = not item.providers and not item.path.startswith(
+            BUILTIN_URL_SCHEMES
+        )
         if not item.providers:
             # only a plain M3U entry with a bare Music Assistant URI and no #EXTPROV
             # metadata at all needs this path parsed - an entry that does carry
@@ -1141,9 +1179,9 @@ class BuiltinProvider(MusicProvider):
                 # a missing/unavailable provider is a configured source that is merely
                 # down or failed setup right now, not one the user removed - a transient
                 # outage must not trigger a permanent substitution
-                return True
+                return True, None
             try:
-                await self.mass.music.tracks.get_provider_item(
+                hydrated = await self.mass.music.tracks.get_provider_item(
                     provider_item_id,
                     provider.instance_id,
                     force_refresh=True,
@@ -1162,10 +1200,35 @@ class BuiltinProvider(MusicProvider):
             ):
                 # could not verify right now (network blip) - assume it is still fine
                 # rather than substitute it
-                return True
+                return True, None
             else:
-                return True
-        return False
+                if not needs_provider_metadata:
+                    return True, None
+                # a bare URI without #EXTPROV would otherwise stay unresolvable to a
+                # provider mapping on every future load - persist what was just
+                # confirmed so the entry keeps resolving after this pass
+                own_mapping = next(
+                    (
+                        pm
+                        for pm in hydrated.provider_mappings
+                        if pm.provider_instance == provider.instance_id
+                    ),
+                    None,
+                )
+                # audio format details are only known when the hydrated item actually
+                # carried its own mapping - otherwise leave them unset rather than
+                # writing a guessed/default format into the persisted metadata
+                audio_format = own_mapping.audio_format if own_mapping else None
+                return True, ProviderMappingInfo(
+                    domain=provider.domain,
+                    item_id=provider_item_id,
+                    instance_id=provider.instance_id,
+                    content_type=audio_format.content_type.value if audio_format else "",
+                    sample_rate=audio_format.sample_rate if audio_format else 0,
+                    bit_depth=audio_format.bit_depth if audio_format else 0,
+                    bit_rate=(audio_format.bit_rate or 0) if audio_format else 0,
+                )
+        return False, None
 
     def _allowed_instances_for(
         self, provider_instance_or_domain: str, allowed_provider_instances: Mapping[str, str]

--- a/tests/controllers/music/helpers.py
+++ b/tests/controllers/music/helpers.py
@@ -73,6 +73,7 @@ def create_album(
     name: str = "Test Album",
     artist_name: str | None = "Test Artist",
     artist_item_id: str | None = None,
+    external_ids: set[tuple[ExternalID, str]] | None = None,
 ) -> Album:
     """
     Create an Album as it would be received from a music provider.
@@ -83,6 +84,7 @@ def create_album(
     :param artist_name: The album artist name, or None for an album without artists.
     :param artist_item_id: The item id of the album artist on the provider,
         defaults to one derived from the album item id.
+    :param external_ids: External ids (e.g. a MusicBrainz release id) to attach.
     """
     provider_domain = provider_instance.split("_", maxsplit=1)[0]
     artists: UniqueList[Artist | ItemMapping] = UniqueList()
@@ -116,4 +118,5 @@ def create_album(
             )
         },
         artists=artists,
+        external_ids=external_ids or set(),
     )

--- a/tests/controllers/music/test_playlist_import.py
+++ b/tests/controllers/music/test_playlist_import.py
@@ -40,6 +40,15 @@ def _make_provider_mock(instance_id: str, domain: str) -> MagicMock:
     return provider
 
 
+def _make_provider_config_mock(instance_id: str, domain: str, enabled: bool = True) -> MagicMock:
+    """Build a mock ProviderConfig exposing instance_id, domain, and enabled."""
+    config = MagicMock()
+    config.instance_id = instance_id
+    config.domain = domain
+    config.enabled = enabled
+    return config
+
+
 async def test_import_without_match_policy_skips_background_task() -> None:
     """No background task is scheduled when match_policy is omitted."""
     ctrl = _make_controller()
@@ -69,6 +78,12 @@ async def test_import_with_match_policy_snapshots_allowed_providers() -> None:
         _make_provider_mock("spotify--1", "spotify"),
         _make_provider_mock("qobuz--1", "qobuz"),
     ]
+    ctrl_any.mass.config.get_provider_configs = AsyncMock(
+        return_value=[
+            _make_provider_config_mock("spotify--1", "spotify"),
+            _make_provider_config_mock("qobuz--1", "qobuz"),
+        ]
+    )
 
     with (
         patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
@@ -105,6 +120,9 @@ async def test_import_with_library_matching_true_defaults_to_best_effort() -> No
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
     ctrl_any.mass.music.providers = [_make_provider_mock("qobuz--1", "qobuz")]
+    ctrl_any.mass.config.get_provider_configs = AsyncMock(
+        return_value=[_make_provider_config_mock("qobuz--1", "qobuz")]
+    )
 
     with (
         patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
@@ -134,6 +152,9 @@ async def test_import_with_explicit_match_policy_overrides_library_matching() ->
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
     ctrl_any.mass.music.providers = [_make_provider_mock("qobuz--1", "qobuz")]
+    ctrl_any.mass.config.get_provider_configs = AsyncMock(
+        return_value=[_make_provider_config_mock("qobuz--1", "qobuz")]
+    )
 
     with (
         patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
@@ -163,6 +184,12 @@ async def test_import_with_match_providers_narrows_search_only() -> None:
         _make_provider_mock("spotify--1", "spotify"),
         _make_provider_mock("qobuz--1", "qobuz"),
     ]
+    ctrl_any.mass.config.get_provider_configs = AsyncMock(
+        return_value=[
+            _make_provider_config_mock("spotify--1", "spotify"),
+            _make_provider_config_mock("qobuz--1", "qobuz"),
+        ]
+    )
 
     with (
         patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
@@ -187,4 +214,126 @@ async def test_import_with_match_providers_narrows_search_only() -> None:
         PlaylistMatchPolicy.BEST_EFFORT,
         ("qobuz--1", "spotify--1"),
         ("qobuz--1",),
+    )
+
+
+async def test_import_source_validation_includes_configured_but_unloaded_provider() -> None:
+    """A configured provider that failed to load still counts for source validation."""
+    ctrl = _make_controller()
+    ctrl_any = cast("Any", ctrl)
+    builtin_prov = MagicMock()
+    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.match_imported_playlist_tracks = AsyncMock()
+    ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
+    ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
+    # spotify--1 failed setup (or is temporarily down) and is therefore not loaded,
+    # but it is still configured and enabled
+    ctrl_any.mass.music.providers = [_make_provider_mock("qobuz--1", "qobuz")]
+    ctrl_any.mass.config.get_provider_configs = AsyncMock(
+        return_value=[
+            _make_provider_config_mock("spotify--1", "spotify"),
+            _make_provider_config_mock("qobuz--1", "qobuz"),
+        ]
+    )
+
+    with (
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+        patch(
+            "music_assistant.controllers.music.media.playlists.get_current_user",
+            return_value=None,
+        ),
+    ):
+        await ctrl.import_playlist("#EXTM3U\n", match_policy=PlaylistMatchPolicy.BEST_EFFORT)
+
+    call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
+    await call_kwargs["handler"]()
+    # the unloaded spotify--1 is still part of the source-validation snapshot (so its
+    # tracks are not mistaken for removed), but it is excluded from the search targets
+    # since nothing can be searched on a provider that isn't loaded
+    builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
+        "playlist_1",
+        PlaylistMatchPolicy.BEST_EFFORT,
+        ("qobuz--1", "spotify--1"),
+        ("qobuz--1",),
+    )
+
+
+async def test_import_source_validation_excludes_disabled_provider() -> None:
+    """A disabled provider config is not treated as one of the user's own sources."""
+    ctrl = _make_controller()
+    ctrl_any = cast("Any", ctrl)
+    builtin_prov = MagicMock()
+    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.match_imported_playlist_tracks = AsyncMock()
+    ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
+    ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
+    ctrl_any.mass.music.providers = [_make_provider_mock("qobuz--1", "qobuz")]
+    ctrl_any.mass.config.get_provider_configs = AsyncMock(
+        return_value=[
+            _make_provider_config_mock("spotify--1", "spotify", enabled=False),
+            _make_provider_config_mock("qobuz--1", "qobuz"),
+        ]
+    )
+
+    with (
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+        patch(
+            "music_assistant.controllers.music.media.playlists.get_current_user",
+            return_value=None,
+        ),
+    ):
+        await ctrl.import_playlist("#EXTM3U\n", match_policy=PlaylistMatchPolicy.BEST_EFFORT)
+
+    call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
+    await call_kwargs["handler"]()
+    builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
+        "playlist_1",
+        PlaylistMatchPolicy.BEST_EFFORT,
+        ("qobuz--1",),
+        ("qobuz--1",),
+    )
+
+
+async def test_import_source_validation_respects_user_provider_filter() -> None:
+    """A provider outside the requesting user's own filter is never part of the snapshot."""
+    ctrl = _make_controller()
+    ctrl_any = cast("Any", ctrl)
+    builtin_prov = MagicMock()
+    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.match_imported_playlist_tracks = AsyncMock()
+    ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
+    ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
+    ctrl_any.mass.music.providers = [
+        _make_provider_mock("spotify--1", "spotify"),
+        _make_provider_mock("qobuz--1", "qobuz"),
+    ]
+    ctrl_any.mass.config.get_provider_configs = AsyncMock(
+        return_value=[
+            _make_provider_config_mock("spotify--1", "spotify"),
+            _make_provider_config_mock("qobuz--1", "qobuz"),
+        ]
+    )
+    user = MagicMock()
+    user.provider_filter = {"qobuz--1"}
+
+    with (
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+        patch(
+            "music_assistant.controllers.music.media.playlists.get_current_user",
+            return_value=user,
+        ),
+    ):
+        await ctrl.import_playlist("#EXTM3U\n", match_policy=PlaylistMatchPolicy.BEST_EFFORT)
+
+    call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
+    await call_kwargs["handler"]()
+    # allowed_provider_instances (source validation) is built from provider configs and
+    # explicitly narrowed by the user's own filter; search_provider_instances is read
+    # straight from mass.music.providers, which already applies that same filter in
+    # production - this double just returns both instances unfiltered
+    builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
+        "playlist_1",
+        PlaylistMatchPolicy.BEST_EFFORT,
+        ("qobuz--1",),
+        ("qobuz--1", "spotify--1"),
     )

--- a/tests/controllers/music/test_playlist_import.py
+++ b/tests/controllers/music/test_playlist_import.py
@@ -105,7 +105,7 @@ async def test_import_with_match_policy_snapshots_allowed_providers() -> None:
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         PlaylistMatchPolicy.SAME_RECORDING,
-        ("qobuz--1", "spotify--1"),
+        (("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
         ("qobuz--1", "spotify--1"),
     )
 
@@ -138,7 +138,7 @@ async def test_import_with_library_matching_true_defaults_to_best_effort() -> No
     assert call_kwargs["metadata"]["match_policy"] == "best_effort"
     await call_kwargs["handler"]()
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
-        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",), ("qobuz--1",)
+        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, (("qobuz--1", "qobuz"),), ("qobuz--1",)
     )
 
 
@@ -212,7 +212,7 @@ async def test_import_with_match_providers_narrows_search_only() -> None:
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         PlaylistMatchPolicy.BEST_EFFORT,
-        ("qobuz--1", "spotify--1"),
+        (("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
         ("qobuz--1",),
     )
 
@@ -253,7 +253,7 @@ async def test_import_source_validation_includes_configured_but_unloaded_provide
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         PlaylistMatchPolicy.BEST_EFFORT,
-        ("qobuz--1", "spotify--1"),
+        (("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
         ("qobuz--1",),
     )
 
@@ -289,7 +289,7 @@ async def test_import_source_validation_excludes_disabled_provider() -> None:
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         PlaylistMatchPolicy.BEST_EFFORT,
-        ("qobuz--1",),
+        (("qobuz--1", "qobuz"),),
         ("qobuz--1",),
     )
 
@@ -334,6 +334,6 @@ async def test_import_source_validation_respects_user_provider_filter() -> None:
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         PlaylistMatchPolicy.BEST_EFFORT,
-        ("qobuz--1",),
+        (("qobuz--1", "qobuz"),),
         ("qobuz--1", "spotify--1"),
     )

--- a/tests/controllers/music/test_playlist_import.py
+++ b/tests/controllers/music/test_playlist_import.py
@@ -1,0 +1,130 @@
+"""Tests for PlaylistController.import_playlist's matching hand-off."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from music_assistant_models.media_items import Playlist, ProviderMapping
+
+from music_assistant.controllers.music.media.playlists import (
+    PlaylistController,
+    PlaylistMatchPolicy,
+)
+
+
+def _make_controller() -> PlaylistController:
+    """Create a minimal PlaylistController with a mocked mass, bypassing __init__."""
+    ctrl = object.__new__(PlaylistController)
+    ctrl.mass = MagicMock()
+    return ctrl
+
+
+def _make_playlist(item_id: str = "playlist_1") -> Playlist:
+    """Build a minimal builtin Playlist."""
+    return Playlist(
+        item_id=item_id,
+        provider="builtin",
+        name="Imported Playlist",
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain="builtin", provider_instance="builtin")
+        },
+    )
+
+
+def _make_provider_mock(instance_id: str, domain: str) -> MagicMock:
+    """Build a mock provider exposing instance_id and domain."""
+    provider = MagicMock()
+    provider.instance_id = instance_id
+    provider.domain = domain
+    return provider
+
+
+async def test_import_without_match_policy_skips_background_task() -> None:
+    """No background task is scheduled when match_policy is omitted."""
+    ctrl = _make_controller()
+    ctrl_any = cast("Any", ctrl)
+    builtin_prov = MagicMock()
+    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
+    ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
+
+    with patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock):
+        result = await ctrl.import_playlist("#EXTM3U\n")
+
+    assert result.item_id == "playlist_1"
+    ctrl_any.mass.tasks.run_background_task.assert_not_called()
+
+
+async def test_import_with_match_policy_snapshots_allowed_providers() -> None:
+    """The background task receives a frozen snapshot of the user's allowed providers."""
+    ctrl = _make_controller()
+    ctrl_any = cast("Any", ctrl)
+    builtin_prov = MagicMock()
+    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.match_imported_playlist_tracks = AsyncMock()
+    ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
+    ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
+    ctrl_any.mass.music.providers = [
+        _make_provider_mock("spotify--1", "spotify"),
+        _make_provider_mock("qobuz--1", "qobuz"),
+    ]
+
+    with (
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+        patch(
+            "music_assistant.controllers.music.media.playlists.get_current_user",
+            return_value=None,
+        ),
+    ):
+        await ctrl.import_playlist("#EXTM3U\n", match_policy=PlaylistMatchPolicy.SAME_RECORDING)
+
+    ctrl_any.mass.tasks.run_background_task.assert_called_once()
+    call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
+    assert call_kwargs["metadata"]["match_policy"] == "same_recording"
+
+    # invoking the deferred handler must call the builtin provider with the snapshot,
+    # independent of mass.music.providers at call time (simulating a later, unrelated user)
+    ctrl_any.mass.music.providers = []
+    await call_kwargs["handler"]()
+    builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
+        "playlist_1",
+        PlaylistMatchPolicy.SAME_RECORDING,
+        ("qobuz--1", "spotify--1"),
+    )
+
+
+async def test_import_with_match_providers_filter_restricts_snapshot() -> None:
+    """match_providers narrows the snapshot to the requested instances/domains."""
+    ctrl = _make_controller()
+    ctrl_any = cast("Any", ctrl)
+    builtin_prov = MagicMock()
+    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.match_imported_playlist_tracks = AsyncMock()
+    ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
+    ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
+    ctrl_any.mass.music.providers = [
+        _make_provider_mock("spotify--1", "spotify"),
+        _make_provider_mock("qobuz--1", "qobuz"),
+    ]
+
+    with (
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+        patch(
+            "music_assistant.controllers.music.media.playlists.get_current_user",
+            return_value=None,
+        ),
+    ):
+        await ctrl.import_playlist(
+            "#EXTM3U\n",
+            match_policy=PlaylistMatchPolicy.BEST_EFFORT,
+            match_providers=["qobuz"],
+        )
+
+    call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
+    await call_kwargs["handler"]()
+    builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
+        "playlist_1",
+        PlaylistMatchPolicy.BEST_EFFORT,
+        ("qobuz--1",),
+    )

--- a/tests/controllers/music/test_playlist_import.py
+++ b/tests/controllers/music/test_playlist_import.py
@@ -118,13 +118,7 @@ async def test_import_with_match_policy_snapshots_allowed_providers() -> None:
 
 
 async def test_import_schedules_match_with_import_generation() -> None:
-    """
-    The scheduled task is given the exact generation import_playlist returned.
-
-    A distinct, non-default value (not the ``1`` used by every other test here)
-    proves this is threaded through from the actual return value rather than a
-    coincidental default matching what the background task expects.
-    """
+    """The scheduled task uses the exact generation returned by import_playlist."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
@@ -388,12 +382,7 @@ async def test_import_source_validation_excludes_disabled_provider() -> None:
 
 
 async def test_import_source_validation_respects_user_provider_filter() -> None:
-    """
-    A provider outside the requesting user's own filter is never part of the snapshot.
-
-    Both source validation and search targets are affected identically - the builtin
-    provider itself always is.
-    """
+    """The provider snapshot respects the requesting user's filter."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
@@ -421,10 +410,7 @@ async def test_import_source_validation_respects_user_provider_filter() -> None:
 
     call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
     await call_kwargs["handler"]()
-    # both source validation and the search target set are derived from the same
-    # configured-and-enabled snapshot, explicitly narrowed by the user's own filter,
-    # except the builtin provider - which is not an opt-in/opt-out streaming choice
-    # and always stays authoritatively probable, but is never itself a search target
+    # The user filter narrows both snapshots, except for builtin validation.
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         1,
@@ -435,13 +421,7 @@ async def test_import_source_validation_respects_user_provider_filter() -> None:
 
 
 async def test_import_source_validation_always_includes_builtin() -> None:
-    """
-    The builtin provider is always part of the snapshot.
-
-    Even when a restricted user's filter excludes it and it is absent from the configured
-    provider list entirely - it hosts the playlist itself rather than being an
-    opt-in/opt-out streaming source.
-    """
+    """Builtin is always kept in the validation snapshot."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()

--- a/tests/controllers/music/test_playlist_import.py
+++ b/tests/controllers/music/test_playlist_import.py
@@ -147,6 +147,9 @@ async def test_import_with_explicit_match_policy_overrides_library_matching() ->
 
     call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
     assert call_kwargs["metadata"]["match_policy"] == "exact"
+
+
+async def test_import_with_match_providers_narrows_snapshot() -> None:
     """match_providers narrows the snapshot to the requested instances/domains."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)

--- a/tests/controllers/music/test_playlist_import.py
+++ b/tests/controllers/music/test_playlist_import.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from music_assistant_models.enums import PlaylistMatchPolicy
 from music_assistant_models.media_items import Playlist, ProviderMapping
 
-from music_assistant.controllers.music.media.playlists import (
-    PlaylistController,
-    PlaylistMatchPolicy,
-)
+from music_assistant.controllers.music.media.playlists import PlaylistController
 
 
 def _make_controller() -> PlaylistController:

--- a/tests/controllers/music/test_playlist_import.py
+++ b/tests/controllers/music/test_playlist_import.py
@@ -94,7 +94,59 @@ async def test_import_with_match_policy_snapshots_allowed_providers() -> None:
     )
 
 
-async def test_import_with_match_providers_filter_restricts_snapshot() -> None:
+async def test_import_with_library_matching_true_defaults_to_best_effort() -> None:
+    """The deprecated library_matching=True still schedules matching, at BEST_EFFORT."""
+    ctrl = _make_controller()
+    ctrl_any = cast("Any", ctrl)
+    builtin_prov = MagicMock()
+    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.match_imported_playlist_tracks = AsyncMock()
+    ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
+    ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
+    ctrl_any.mass.music.providers = [_make_provider_mock("qobuz--1", "qobuz")]
+
+    with (
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+        patch(
+            "music_assistant.controllers.music.media.playlists.get_current_user",
+            return_value=None,
+        ),
+    ):
+        await ctrl.import_playlist("#EXTM3U\n", library_matching=True)
+
+    ctrl_any.mass.tasks.run_background_task.assert_called_once()
+    call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
+    assert call_kwargs["metadata"]["match_policy"] == "best_effort"
+    await call_kwargs["handler"]()
+    builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
+        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+    )
+
+
+async def test_import_with_explicit_match_policy_overrides_library_matching() -> None:
+    """An explicit match_policy takes precedence over the deprecated library_matching flag."""
+    ctrl = _make_controller()
+    ctrl_any = cast("Any", ctrl)
+    builtin_prov = MagicMock()
+    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.match_imported_playlist_tracks = AsyncMock()
+    ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
+    ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
+    ctrl_any.mass.music.providers = [_make_provider_mock("qobuz--1", "qobuz")]
+
+    with (
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+        patch(
+            "music_assistant.controllers.music.media.playlists.get_current_user",
+            return_value=None,
+        ),
+    ):
+        await ctrl.import_playlist(
+            "#EXTM3U\n", library_matching=True, match_policy=PlaylistMatchPolicy.EXACT
+        )
+
+    call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
+    assert call_kwargs["metadata"]["match_policy"] == "exact"
     """match_providers narrows the snapshot to the requested instances/domains."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)

--- a/tests/controllers/music/test_playlist_import.py
+++ b/tests/controllers/music/test_playlist_import.py
@@ -40,6 +40,14 @@ def _make_provider_mock(instance_id: str, domain: str) -> MagicMock:
     return provider
 
 
+def _make_builtin_provider_mock() -> MagicMock:
+    """Build a mock builtin provider exposing its fixed instance_id and domain."""
+    provider = MagicMock()
+    provider.instance_id = "builtin"
+    provider.domain = "builtin"
+    return provider
+
+
 def _make_provider_config_mock(instance_id: str, domain: str, enabled: bool = True) -> MagicMock:
     """Build a mock ProviderConfig exposing instance_id, domain, and enabled."""
     config = MagicMock()
@@ -53,7 +61,7 @@ async def test_import_without_match_policy_skips_background_task() -> None:
     """No background task is scheduled when match_policy is omitted."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
-    builtin_prov = MagicMock()
+    builtin_prov = _make_builtin_provider_mock()
     builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
@@ -69,7 +77,7 @@ async def test_import_with_match_policy_snapshots_allowed_providers() -> None:
     """The background task receives a frozen snapshot of the user's allowed providers."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
-    builtin_prov = MagicMock()
+    builtin_prov = _make_builtin_provider_mock()
     builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
@@ -105,7 +113,7 @@ async def test_import_with_match_policy_snapshots_allowed_providers() -> None:
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         PlaylistMatchPolicy.SAME_RECORDING,
-        (("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
+        (("builtin", "builtin"), ("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
         ("qobuz--1", "spotify--1"),
     )
 
@@ -114,7 +122,7 @@ async def test_import_with_library_matching_true_defaults_to_best_effort() -> No
     """The deprecated library_matching=True still schedules matching, at BEST_EFFORT."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
-    builtin_prov = MagicMock()
+    builtin_prov = _make_builtin_provider_mock()
     builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
@@ -138,7 +146,10 @@ async def test_import_with_library_matching_true_defaults_to_best_effort() -> No
     assert call_kwargs["metadata"]["match_policy"] == "best_effort"
     await call_kwargs["handler"]()
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
-        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, (("qobuz--1", "qobuz"),), ("qobuz--1",)
+        "playlist_1",
+        PlaylistMatchPolicy.BEST_EFFORT,
+        (("builtin", "builtin"), ("qobuz--1", "qobuz")),
+        ("qobuz--1",),
     )
 
 
@@ -146,7 +157,7 @@ async def test_import_with_explicit_match_policy_overrides_library_matching() ->
     """An explicit match_policy takes precedence over the deprecated library_matching flag."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
-    builtin_prov = MagicMock()
+    builtin_prov = _make_builtin_provider_mock()
     builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
@@ -175,7 +186,7 @@ async def test_import_with_match_providers_narrows_search_only() -> None:
     """match_providers narrows only the search targets, not the source-validation snapshot."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
-    builtin_prov = MagicMock()
+    builtin_prov = _make_builtin_provider_mock()
     builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
@@ -212,7 +223,7 @@ async def test_import_with_match_providers_narrows_search_only() -> None:
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         PlaylistMatchPolicy.BEST_EFFORT,
-        (("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
+        (("builtin", "builtin"), ("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
         ("qobuz--1",),
     )
 
@@ -221,7 +232,7 @@ async def test_import_with_empty_match_providers_narrows_search_to_nothing() -> 
     """An explicit empty match_providers list deselects every provider, not every provider."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
-    builtin_prov = MagicMock()
+    builtin_prov = _make_builtin_provider_mock()
     builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
@@ -257,7 +268,7 @@ async def test_import_with_empty_match_providers_narrows_search_to_nothing() -> 
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         PlaylistMatchPolicy.BEST_EFFORT,
-        (("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
+        (("builtin", "builtin"), ("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
         (),
     )
 
@@ -266,7 +277,7 @@ async def test_import_source_validation_includes_configured_but_unloaded_provide
     """A configured provider that failed to load still counts for source validation."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
-    builtin_prov = MagicMock()
+    builtin_prov = _make_builtin_provider_mock()
     builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
@@ -298,7 +309,7 @@ async def test_import_source_validation_includes_configured_but_unloaded_provide
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         PlaylistMatchPolicy.BEST_EFFORT,
-        (("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
+        (("builtin", "builtin"), ("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
         ("qobuz--1",),
     )
 
@@ -307,7 +318,7 @@ async def test_import_source_validation_excludes_disabled_provider() -> None:
     """A disabled provider config is not treated as one of the user's own sources."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
-    builtin_prov = MagicMock()
+    builtin_prov = _make_builtin_provider_mock()
     builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
@@ -334,16 +345,20 @@ async def test_import_source_validation_excludes_disabled_provider() -> None:
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         PlaylistMatchPolicy.BEST_EFFORT,
-        (("qobuz--1", "qobuz"),),
+        (("builtin", "builtin"), ("qobuz--1", "qobuz")),
         ("qobuz--1",),
     )
 
 
 async def test_import_source_validation_respects_user_provider_filter() -> None:
-    """A provider outside the requesting user's own filter is never part of the snapshot."""
+    """
+    A provider outside the requesting user's own filter is never part of the snapshot.
+
+    The builtin provider itself always is.
+    """
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
-    builtin_prov = MagicMock()
+    builtin_prov = _make_builtin_provider_mock()
     builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
@@ -373,12 +388,57 @@ async def test_import_source_validation_respects_user_provider_filter() -> None:
     call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
     await call_kwargs["handler"]()
     # allowed_provider_instances (source validation) is built from provider configs and
-    # explicitly narrowed by the user's own filter; search_provider_instances is read
-    # straight from mass.music.providers, which already applies that same filter in
-    # production - this double just returns both instances unfiltered
+    # explicitly narrowed by the user's own filter, except the builtin provider - which
+    # is not an opt-in/opt-out streaming choice and always stays authoritatively probable;
+    # search_provider_instances is read straight from mass.music.providers, which already
+    # applies that same filter in production - this double just returns both instances
+    # unfiltered
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         PlaylistMatchPolicy.BEST_EFFORT,
-        (("qobuz--1", "qobuz"),),
+        (("builtin", "builtin"), ("qobuz--1", "qobuz")),
         ("qobuz--1", "spotify--1"),
+    )
+
+
+async def test_import_source_validation_always_includes_builtin() -> None:
+    """
+    The builtin provider is always part of the snapshot.
+
+    Even when a restricted user's filter excludes it and it is absent from the configured
+    provider list entirely - it hosts the playlist itself rather than being an
+    opt-in/opt-out streaming source.
+    """
+    ctrl = _make_controller()
+    ctrl_any = cast("Any", ctrl)
+    builtin_prov = _make_builtin_provider_mock()
+    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.match_imported_playlist_tracks = AsyncMock()
+    ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
+    ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
+    ctrl_any.mass.music.providers = [_make_provider_mock("qobuz--1", "qobuz")]
+    # builtin is a virtual provider that never appears in the user-configurable provider
+    # list, and the restrictive filter below doesn't mention it either
+    ctrl_any.mass.config.get_provider_configs = AsyncMock(
+        return_value=[_make_provider_config_mock("qobuz--1", "qobuz")]
+    )
+    user = MagicMock()
+    user.provider_filter = {"qobuz--1"}
+
+    with (
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+        patch(
+            "music_assistant.controllers.music.media.playlists.get_current_user",
+            return_value=user,
+        ),
+    ):
+        await ctrl.import_playlist("#EXTM3U\n", match_policy=PlaylistMatchPolicy.BEST_EFFORT)
+
+    call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
+    await call_kwargs["handler"]()
+    builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
+        "playlist_1",
+        PlaylistMatchPolicy.BEST_EFFORT,
+        (("builtin", "builtin"), ("qobuz--1", "qobuz")),
+        ("qobuz--1",),
     )

--- a/tests/controllers/music/test_playlist_import.py
+++ b/tests/controllers/music/test_playlist_import.py
@@ -60,7 +60,7 @@ async def test_import_without_match_policy_skips_background_task() -> None:
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
-    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.import_playlist = AsyncMock(return_value=(_make_playlist(), 1))
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
 
@@ -76,7 +76,7 @@ async def test_import_with_match_policy_snapshots_allowed_providers() -> None:
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
-    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.import_playlist = AsyncMock(return_value=(_make_playlist(), 1))
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
@@ -110,10 +110,44 @@ async def test_import_with_match_policy_snapshots_allowed_providers() -> None:
     await call_kwargs["handler"]()
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
+        1,
         PlaylistMatchPolicy.SAME_RECORDING,
         (("builtin", "builtin"), ("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
         ("qobuz--1", "spotify--1"),
     )
+
+
+async def test_import_schedules_match_with_import_generation() -> None:
+    """
+    The scheduled task is given the exact generation import_playlist returned.
+
+    A distinct, non-default value (not the ``1`` used by every other test here)
+    proves this is threaded through from the actual return value rather than a
+    coincidental default matching what the background task expects.
+    """
+    ctrl = _make_controller()
+    ctrl_any = cast("Any", ctrl)
+    builtin_prov = _make_builtin_provider_mock()
+    builtin_prov.import_playlist = AsyncMock(return_value=(_make_playlist(), 7))
+    builtin_prov.match_imported_playlist_tracks = AsyncMock()
+    ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
+    ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
+    ctrl_any.mass.music.providers = []
+    ctrl_any.mass.config.get_provider_configs = AsyncMock(return_value=[])
+
+    with (
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+        patch(
+            "music_assistant.controllers.music.media.playlists.get_current_user",
+            return_value=None,
+        ),
+    ):
+        await ctrl.import_playlist("#EXTM3U\n", match_policy=PlaylistMatchPolicy.BEST_EFFORT)
+
+    call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
+    await call_kwargs["handler"]()
+    args = builtin_prov.match_imported_playlist_tracks.await_args.args
+    assert args[1] == 7
 
 
 async def test_import_with_library_matching_true_defaults_to_best_effort() -> None:
@@ -121,7 +155,7 @@ async def test_import_with_library_matching_true_defaults_to_best_effort() -> No
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
-    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.import_playlist = AsyncMock(return_value=(_make_playlist(), 1))
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
@@ -145,6 +179,7 @@ async def test_import_with_library_matching_true_defaults_to_best_effort() -> No
     await call_kwargs["handler"]()
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
+        1,
         PlaylistMatchPolicy.BEST_EFFORT,
         (("builtin", "builtin"), ("qobuz--1", "qobuz")),
         ("qobuz--1",),
@@ -156,7 +191,7 @@ async def test_import_with_explicit_match_policy_overrides_library_matching() ->
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
-    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.import_playlist = AsyncMock(return_value=(_make_playlist(), 1))
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
@@ -185,7 +220,7 @@ async def test_import_with_match_providers_narrows_search_only() -> None:
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
-    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.import_playlist = AsyncMock(return_value=(_make_playlist(), 1))
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
@@ -220,6 +255,7 @@ async def test_import_with_match_providers_narrows_search_only() -> None:
     # search target set is narrowed to the requested provider
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
+        1,
         PlaylistMatchPolicy.BEST_EFFORT,
         (("builtin", "builtin"), ("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
         ("qobuz--1",),
@@ -231,7 +267,7 @@ async def test_import_with_empty_match_providers_narrows_search_to_nothing() -> 
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
-    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.import_playlist = AsyncMock(return_value=(_make_playlist(), 1))
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
@@ -265,6 +301,7 @@ async def test_import_with_empty_match_providers_narrows_search_to_nothing() -> 
     # while source validation still keeps the user's full snapshot
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
+        1,
         PlaylistMatchPolicy.BEST_EFFORT,
         (("builtin", "builtin"), ("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
         (),
@@ -276,7 +313,7 @@ async def test_import_source_validation_includes_configured_but_unloaded_provide
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
-    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.import_playlist = AsyncMock(return_value=(_make_playlist(), 1))
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
@@ -306,6 +343,7 @@ async def test_import_source_validation_includes_configured_but_unloaded_provide
     # since nothing can be searched on a provider that isn't loaded
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
+        1,
         PlaylistMatchPolicy.BEST_EFFORT,
         (("builtin", "builtin"), ("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
         ("qobuz--1",),
@@ -317,7 +355,7 @@ async def test_import_source_validation_excludes_disabled_provider() -> None:
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
-    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.import_playlist = AsyncMock(return_value=(_make_playlist(), 1))
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
@@ -342,6 +380,7 @@ async def test_import_source_validation_excludes_disabled_provider() -> None:
     await call_kwargs["handler"]()
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
+        1,
         PlaylistMatchPolicy.BEST_EFFORT,
         (("builtin", "builtin"), ("qobuz--1", "qobuz")),
         ("qobuz--1",),
@@ -357,7 +396,7 @@ async def test_import_source_validation_respects_user_provider_filter() -> None:
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
-    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.import_playlist = AsyncMock(return_value=(_make_playlist(), 1))
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
@@ -393,6 +432,7 @@ async def test_import_source_validation_respects_user_provider_filter() -> None:
     # unfiltered
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
+        1,
         PlaylistMatchPolicy.BEST_EFFORT,
         (("builtin", "builtin"), ("qobuz--1", "qobuz")),
         ("qobuz--1", "spotify--1"),
@@ -410,7 +450,7 @@ async def test_import_source_validation_always_includes_builtin() -> None:
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
-    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.import_playlist = AsyncMock(return_value=(_make_playlist(), 1))
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
@@ -436,6 +476,7 @@ async def test_import_source_validation_always_includes_builtin() -> None:
     await call_kwargs["handler"]()
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
+        1,
         PlaylistMatchPolicy.BEST_EFFORT,
         (("builtin", "builtin"), ("qobuz--1", "qobuz")),
         ("qobuz--1",),

--- a/tests/controllers/music/test_playlist_import.py
+++ b/tests/controllers/music/test_playlist_import.py
@@ -91,6 +91,7 @@ async def test_import_with_match_policy_snapshots_allowed_providers() -> None:
         "playlist_1",
         PlaylistMatchPolicy.SAME_RECORDING,
         ("qobuz--1", "spotify--1"),
+        ("qobuz--1", "spotify--1"),
     )
 
 
@@ -119,7 +120,7 @@ async def test_import_with_library_matching_true_defaults_to_best_effort() -> No
     assert call_kwargs["metadata"]["match_policy"] == "best_effort"
     await call_kwargs["handler"]()
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
-        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",), ("qobuz--1",)
     )
 
 
@@ -149,8 +150,8 @@ async def test_import_with_explicit_match_policy_overrides_library_matching() ->
     assert call_kwargs["metadata"]["match_policy"] == "exact"
 
 
-async def test_import_with_match_providers_narrows_snapshot() -> None:
-    """match_providers narrows the snapshot to the requested instances/domains."""
+async def test_import_with_match_providers_narrows_search_only() -> None:
+    """match_providers narrows only the search targets, not the source-validation snapshot."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = MagicMock()
@@ -178,8 +179,12 @@ async def test_import_with_match_providers_narrows_snapshot() -> None:
 
     call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
     await call_kwargs["handler"]()
+    # source validation keeps the user's full snapshot (a playable spotify original must
+    # not look unavailable just because match_providers narrows the search), while the
+    # search target set is narrowed to the requested provider
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         PlaylistMatchPolicy.BEST_EFFORT,
+        ("qobuz--1", "spotify--1"),
         ("qobuz--1",),
     )

--- a/tests/controllers/music/test_playlist_import.py
+++ b/tests/controllers/music/test_playlist_import.py
@@ -309,7 +309,7 @@ async def test_import_with_empty_match_providers_narrows_search_to_nothing() -> 
 
 
 async def test_import_source_validation_includes_configured_but_unloaded_provider() -> None:
-    """A configured provider that failed to load still counts for source validation."""
+    """A configured provider that failed to load still counts for search and validation."""
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
     builtin_prov = _make_builtin_provider_mock()
@@ -338,15 +338,15 @@ async def test_import_source_validation_includes_configured_but_unloaded_provide
 
     call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
     await call_kwargs["handler"]()
-    # the unloaded spotify--1 is still part of the source-validation snapshot (so its
-    # tracks are not mistaken for removed), but it is excluded from the search targets
-    # since nothing can be searched on a provider that isn't loaded
+    # the unloaded spotify--1 is part of both the source-validation snapshot and the
+    # search targets - the deferred task resolves it to a provider object again once
+    # it actually runs, by which point it may well have finished loading
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         1,
         PlaylistMatchPolicy.BEST_EFFORT,
         (("builtin", "builtin"), ("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
-        ("qobuz--1",),
+        ("qobuz--1", "spotify--1"),
     )
 
 
@@ -391,7 +391,8 @@ async def test_import_source_validation_respects_user_provider_filter() -> None:
     """
     A provider outside the requesting user's own filter is never part of the snapshot.
 
-    The builtin provider itself always is.
+    Both source validation and search targets are affected identically - the builtin
+    provider itself always is.
     """
     ctrl = _make_controller()
     ctrl_any = cast("Any", ctrl)
@@ -400,10 +401,6 @@ async def test_import_source_validation_respects_user_provider_filter() -> None:
     builtin_prov.match_imported_playlist_tracks = AsyncMock()
     ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
     ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
-    ctrl_any.mass.music.providers = [
-        _make_provider_mock("spotify--1", "spotify"),
-        _make_provider_mock("qobuz--1", "qobuz"),
-    ]
     ctrl_any.mass.config.get_provider_configs = AsyncMock(
         return_value=[
             _make_provider_config_mock("spotify--1", "spotify"),
@@ -424,18 +421,16 @@ async def test_import_source_validation_respects_user_provider_filter() -> None:
 
     call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
     await call_kwargs["handler"]()
-    # allowed_provider_instances (source validation) is built from provider configs and
-    # explicitly narrowed by the user's own filter, except the builtin provider - which
-    # is not an opt-in/opt-out streaming choice and always stays authoritatively probable;
-    # search_provider_instances is read straight from mass.music.providers, which already
-    # applies that same filter in production - this double just returns both instances
-    # unfiltered
+    # both source validation and the search target set are derived from the same
+    # configured-and-enabled snapshot, explicitly narrowed by the user's own filter,
+    # except the builtin provider - which is not an opt-in/opt-out streaming choice
+    # and always stays authoritatively probable, but is never itself a search target
     builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
         "playlist_1",
         1,
         PlaylistMatchPolicy.BEST_EFFORT,
         (("builtin", "builtin"), ("qobuz--1", "qobuz")),
-        ("qobuz--1", "spotify--1"),
+        ("qobuz--1",),
     )
 
 

--- a/tests/controllers/music/test_playlist_import.py
+++ b/tests/controllers/music/test_playlist_import.py
@@ -217,6 +217,51 @@ async def test_import_with_match_providers_narrows_search_only() -> None:
     )
 
 
+async def test_import_with_empty_match_providers_narrows_search_to_nothing() -> None:
+    """An explicit empty match_providers list deselects every provider, not every provider."""
+    ctrl = _make_controller()
+    ctrl_any = cast("Any", ctrl)
+    builtin_prov = MagicMock()
+    builtin_prov.import_playlist = AsyncMock(return_value=_make_playlist())
+    builtin_prov.match_imported_playlist_tracks = AsyncMock()
+    ctrl_any.mass.get_provider = MagicMock(return_value=builtin_prov)
+    ctrl_any.add_item_to_library = AsyncMock(return_value=_make_playlist())
+    ctrl_any.mass.music.providers = [
+        _make_provider_mock("spotify--1", "spotify"),
+        _make_provider_mock("qobuz--1", "qobuz"),
+    ]
+    ctrl_any.mass.config.get_provider_configs = AsyncMock(
+        return_value=[
+            _make_provider_config_mock("spotify--1", "spotify"),
+            _make_provider_config_mock("qobuz--1", "qobuz"),
+        ]
+    )
+
+    with (
+        patch("music_assistant.controllers.music.media.playlists.MusicProvider", MagicMock),
+        patch(
+            "music_assistant.controllers.music.media.playlists.get_current_user",
+            return_value=None,
+        ),
+    ):
+        await ctrl.import_playlist(
+            "#EXTM3U\n",
+            match_policy=PlaylistMatchPolicy.BEST_EFFORT,
+            match_providers=[],
+        )
+
+    call_kwargs = ctrl_any.mass.tasks.run_background_task.call_args.kwargs
+    await call_kwargs["handler"]()
+    # an explicit [] means "nothing selected", so the search target set must be empty,
+    # while source validation still keeps the user's full snapshot
+    builtin_prov.match_imported_playlist_tracks.assert_awaited_once_with(
+        "playlist_1",
+        PlaylistMatchPolicy.BEST_EFFORT,
+        (("qobuz--1", "qobuz"), ("spotify--1", "spotify")),
+        (),
+    )
+
+
 async def test_import_source_validation_includes_configured_but_unloaded_provider() -> None:
     """A configured provider that failed to load still counts for source validation."""
     ctrl = _make_controller()

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.enums import MediaType, ProviderFeature, ProviderType
 from music_assistant_models.errors import (
     MusicAssistantError,
     ResourceTemporarilyUnavailable,
@@ -213,6 +213,57 @@ async def test_search_provider_does_not_substitute_unavailable_scoped_instance()
     controller.mass.get_provider.assert_called_once_with(
         "qobuz_1",
         return_unavailable=True,
+    )
+
+
+async def test_search_provider_scoped_domain_all_unavailable_raises() -> None:
+    """A domain lookup within scope raises rather than looking like an empty result."""
+    unavailable_a = _make_search_provider("qobuz_1", domain="qobuz")
+    unavailable_a.available = False
+    unavailable_b = _make_search_provider("qobuz_2", domain="qobuz")
+    unavailable_b.available = False
+    controller = _make_controller([unavailable_a, unavailable_b])
+    controller.mass.get_provider = Mock(  # type: ignore[method-assign]
+        side_effect=lambda instance_id, **_kwargs: next(
+            (p for p in (unavailable_a, unavailable_b) if p.instance_id == instance_id), None
+        )
+    )
+    controller._search_provider = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(ResourceTemporarilyUnavailable, match="qobuz"):
+        await controller.search_provider(
+            "My Song",
+            "qobuz",
+            [MediaType.TRACK],
+            allowed_provider_instances={"qobuz_1", "qobuz_2"},
+        )
+
+    controller._search_provider.assert_not_awaited()
+
+
+async def test_search_provider_unscoped_domain_skips_unavailable_sibling() -> None:
+    """An unscoped domain lookup does not let an unavailable instance mask a sibling."""
+    unavailable_first = _make_search_provider("qobuz_1", domain="qobuz")
+    unavailable_first.available = False
+    available_second = _make_search_provider("qobuz_2", domain="qobuz")
+    for provider in (unavailable_first, available_second):
+        provider.type = ProviderType.MUSIC
+    controller = _make_controller([unavailable_first, available_second])
+    controller._apply_user_provider_filter = Mock(  # type: ignore[method-assign]
+        return_value=[unavailable_first, available_second]
+    )
+    expected = SearchResults(tracks=[_make_track("track1", "qobuz_2", "My Song")])
+    controller._search_provider = AsyncMock(return_value=expected)  # type: ignore[method-assign]
+
+    result = await controller.search_provider("My Song", "qobuz", [MediaType.TRACK])
+
+    assert result == expected
+    controller._search_provider.assert_awaited_once_with(
+        "My Song",
+        "qobuz_2",
+        [MediaType.TRACK],
+        limit=10,
+        strict_provider_instance=True,
     )
 
 

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -8,8 +8,12 @@ import time
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from music_assistant_models.enums import MediaType, ProviderFeature
-from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.errors import (
+    MusicAssistantError,
+    ResourceTemporarilyUnavailable,
+)
 from music_assistant_models.media_items import (
     Artist,
     Genre,
@@ -27,8 +31,6 @@ from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    import pytest
 
 
 def _make_track(item_id: str, provider: str, name: str) -> Track:
@@ -69,6 +71,7 @@ def _make_search_provider(instance_id: str, domain: str | None = None) -> Mock:
     prov.instance_id = instance_id
     prov.domain = domain or instance_id
     prov.name = instance_id
+    prov.available = True
     prov.supported_features = {ProviderFeature.SEARCH}
     prov.is_streaming_provider = True
     prov.search = AsyncMock(return_value=SearchResults())
@@ -131,6 +134,124 @@ async def _wait_for(condition: Callable[[], bool], timeout: float = 1.0) -> None
     async with asyncio.timeout(timeout):
         while not condition():
             await asyncio.sleep(0.01)
+
+
+async def test_search_provider_uses_centralized_provider_search() -> None:
+    """A single-provider lookup uses the cached and timeout-bounded search path."""
+    provider = _make_search_provider("prov_a")
+    controller = _make_controller([provider])
+    expected = SearchResults(tracks=[_make_track("track1", "prov_a", "My Song")])
+    controller._apply_user_provider_filter = Mock(return_value=[])  # type: ignore[method-assign]
+    controller._search_provider = AsyncMock(return_value=expected)  # type: ignore[method-assign]
+
+    result = await controller.search_provider(
+        "My Song",
+        provider.instance_id,
+        [MediaType.TRACK],
+        limit=5,
+        allowed_provider_instances={"prov_a"},
+    )
+
+    assert result == expected
+    controller._search_provider.assert_awaited_once_with(
+        "My Song",
+        provider.instance_id,
+        [MediaType.TRACK],
+        limit=5,
+        strict_provider_instance=True,
+    )
+
+
+async def test_search_provider_resolves_domain_within_explicit_scope() -> None:
+    """A domain lookup selects an allowed instance rather than a filtered global instance."""
+    filtered_provider = _make_search_provider("qobuz_1", domain="qobuz")
+    allowed_provider = _make_search_provider("qobuz_2", domain="qobuz")
+    controller = _make_controller([filtered_provider, allowed_provider])
+    expected = SearchResults(tracks=[_make_track("track1", "qobuz_2", "My Song")])
+    controller._search_provider = AsyncMock(return_value=expected)  # type: ignore[method-assign]
+
+    result = await controller.search_provider(
+        "My Song",
+        "qobuz",
+        [MediaType.TRACK],
+        limit=5,
+        allowed_provider_instances={"qobuz_2"},
+    )
+
+    assert result == expected
+    controller._search_provider.assert_awaited_once_with(
+        "My Song",
+        "qobuz_2",
+        [MediaType.TRACK],
+        limit=5,
+        strict_provider_instance=True,
+    )
+
+
+async def test_search_provider_does_not_substitute_unavailable_scoped_instance() -> None:
+    """An unavailable scoped account can not fall back to another account."""
+    unavailable_provider = _make_search_provider("qobuz_1", domain="qobuz")
+    unavailable_provider.available = False
+    outside_scope_provider = _make_search_provider("qobuz_2", domain="qobuz")
+    controller = _make_controller([unavailable_provider, outside_scope_provider])
+    controller.mass.get_provider = Mock(  # type: ignore[method-assign]
+        side_effect=lambda _instance_id, return_unavailable=False: (
+            unavailable_provider if return_unavailable else outside_scope_provider
+        )
+    )
+    controller._search_provider = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(ResourceTemporarilyUnavailable, match="qobuz_1"):
+        await controller.search_provider(
+            "My Song",
+            "qobuz_1",
+            [MediaType.TRACK],
+            allowed_provider_instances={"qobuz_1"},
+        )
+
+    controller._search_provider.assert_not_awaited()
+    controller.mass.get_provider.assert_called_once_with(
+        "qobuz_1",
+        return_unavailable=True,
+    )
+
+
+async def test_internal_search_rejects_strict_instance_fallback() -> None:
+    """The cached provider search keeps an exact captured account."""
+    unavailable_provider = _make_search_provider("qobuz_1", domain="qobuz")
+    unavailable_provider.available = False
+    outside_scope_provider = _make_search_provider("qobuz_2", domain="qobuz")
+    controller = _make_controller([unavailable_provider, outside_scope_provider])
+    controller.mass.get_provider = Mock(  # type: ignore[method-assign]
+        side_effect=lambda _instance_id, return_unavailable=False, **_kwargs: (
+            unavailable_provider if return_unavailable else outside_scope_provider
+        )
+    )
+
+    result = await controller._search_provider(
+        "My Song",
+        "qobuz_1",
+        [MediaType.TRACK],
+        strict_provider_instance=True,
+    )
+
+    assert result is None
+    outside_scope_provider.search.assert_not_awaited()
+
+
+async def test_search_provider_reports_timeout_as_failure() -> None:
+    """A provider timeout remains distinguishable from a genuine empty result."""
+    provider = _make_search_provider("prov_a")
+    controller = _make_controller([provider])
+    controller._search_provider = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    with pytest.raises(ResourceTemporarilyUnavailable, match="prov_a"):
+        await controller.search_provider(
+            "My Song",
+            provider.instance_id,
+            [MediaType.TRACK],
+            allowed_provider_instances={provider.instance_id},
+        )
 
 
 async def test_search_provider_returns_none_on_provider_error() -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -363,14 +363,42 @@ async def test_full_track_album_falls_back_after_transient_failure(
         media_type=MediaType.ALBUM,
     )
 
-    with patch.object(
-        music.albums,
-        "get",
-        AsyncMock(side_effect=error),
+    with (
+        patch.object(music.albums, "get_library_item_by_prov_id", AsyncMock(return_value=None)),
+        patch.object(
+            music.albums,
+            "get_provider_item",
+            AsyncMock(side_effect=error),
+        ),
     ):
         result = await music.tracks._get_full_track_album(track)
 
     assert result is track.album
+
+
+async def test_full_track_album_prefers_library_item_over_provider_fetch(
+    music: MusicController,
+) -> None:
+    """A library copy of the album is preferred over a fresh provider fetch."""
+    track = create_track("spotify_1", "track")
+    track.album = ItemMapping(
+        item_id="album",
+        provider="qobuz_1",
+        name="Album",
+        media_type=MediaType.ALBUM,
+    )
+    library_album = create_album("library", "album_db_id", name="Album")
+
+    with (
+        patch.object(
+            music.albums, "get_library_item_by_prov_id", AsyncMock(return_value=library_album)
+        ),
+        patch.object(music.albums, "get_provider_item", AsyncMock()) as get_provider_item,
+    ):
+        result = await music.tracks._get_full_track_album(track)
+
+    assert result is library_album
+    get_provider_item.assert_not_called()
 
 
 async def test_full_track_album_domain_only_tries_every_allowed_instance(
@@ -401,13 +429,18 @@ async def test_full_track_album_domain_only_tries_every_allowed_instance(
         # the runtime registry resolves the bare "qobuz" domain to whichever instance
         # happens to be registered first ("qobuz_1"), regardless of allow-listing
         patch.object(music.mass, "get_provider", side_effect=get_provider),
-        patch.object(music.albums, "get", AsyncMock(return_value=album)) as albums_get,
+        patch.object(music.albums, "get_library_item_by_prov_id", AsyncMock(return_value=None)),
+        patch.object(
+            music.albums, "get_provider_item", AsyncMock(return_value=album)
+        ) as albums_get,
     ):
         result = await music.tracks._get_full_track_album(
             track, allowed_provider_instances={"qobuz_2"}
         )
 
-    albums_get.assert_awaited_once_with("album", "qobuz_2", allow_update_metadata=False)
+    albums_get.assert_awaited_once_with(
+        "album", "qobuz_2", allow_fallback=False, strict_provider_instance=True
+    )
     assert result is album
 
 
@@ -448,7 +481,10 @@ async def test_full_track_album_domain_only_falls_back_after_instance_failure(
 
     with (
         patch.object(music.mass, "get_provider", side_effect=get_provider),
-        patch.object(music.albums, "get", AsyncMock(side_effect=albums_get_side_effect)) as get_,
+        patch.object(music.albums, "get_library_item_by_prov_id", AsyncMock(return_value=None)),
+        patch.object(
+            music.albums, "get_provider_item", AsyncMock(side_effect=albums_get_side_effect)
+        ) as get_,
     ):
         result = await music.tracks._get_full_track_album(
             track, allowed_provider_instances={"qobuz_1", "qobuz_2"}
@@ -456,8 +492,8 @@ async def test_full_track_album_domain_only_falls_back_after_instance_failure(
 
     assert result is album
     assert get_.await_args_list == [
-        call("album", "qobuz_1", allow_update_metadata=False),
-        call("album", "qobuz_2", allow_update_metadata=False),
+        call("album", "qobuz_1", allow_fallback=False, strict_provider_instance=True),
+        call("album", "qobuz_2", allow_fallback=False, strict_provider_instance=True),
     ]
 
 

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -1163,7 +1163,7 @@ def test_tied_loose_matches_require_pairwise_compatibility() -> None:
         for track in tracks
     ]
 
-    assert TracksController._matches_are_compatible(matches) is False
+    assert TracksController._matches_are_compatible(matches, TrackMatchConfidence.LOOSE) is False
 
 
 async def test_enrich_provider_mappings_uses_library_without_mutating_it(
@@ -1521,11 +1521,16 @@ async def test_enrich_provider_mappings_prefers_higher_quality_among_compatible_
 ) -> None:
     """Compatible top-tier matches on sibling accounts are resolved by mapping quality."""
     source = create_track("spotify_1", "source")
-    # same ISRC on both, so the two candidates are compatible (same recording), not ambiguous
+    # a shared MB_TRACK id makes the two candidates EXACT-compatible with each other -
+    # required for an EXACT tie-break now that same tier requires same-release evidence,
+    # not just an agreeing ISRC, between the tied candidates themselves
+    mb_track = (ExternalID.MB_TRACK, "12345678-1234-1234-1234-123456789abc")
     lossy_track = create_track("qobuz_1", "lossy-track")
+    lossy_track.external_ids.add(mb_track)
     lossy_mapping = next(iter(lossy_track.provider_mappings))
     lossy_mapping.audio_format = AudioFormat(content_type=ContentType.MP3)
     lossless_track = create_track("qobuz_2", "lossless-track")
+    lossless_track.external_ids.add(mb_track)
     lossless_mapping = next(iter(lossless_track.provider_mappings))
     lossless_mapping.audio_format = AudioFormat(content_type=ContentType.FLAC)
     first_provider = MagicMock(spec=MusicProvider)
@@ -1652,6 +1657,83 @@ async def test_enrich_provider_mappings_treats_tied_conflicting_matches_as_ambig
 
     # neither can be trusted over the other at the same confidence - a tie-break
     # would otherwise pick one arbitrarily based on which provider was visited first
+    assert result.matches == ()
+    assert set(result.ambiguous_providers) == {"Qobuz", "Deezer"}
+    assert qobuz_mapping not in result.track.provider_mappings
+    assert deezer_mapping not in result.track.provider_mappings
+
+
+async def test_enrich_provider_mappings_treats_conflicting_exact_release_evidence_as_ambiguous(
+    music: MusicController,
+) -> None:
+    """Two independently EXACT candidates with conflicting MB_TRACK IDs are ambiguous."""
+    source = create_track("spotify_1", "source")
+    # same ISRC/duration ties the two candidates at LIKELY release evidence, but each
+    # references a different MusicBrainz release track - they cannot both be the
+    # authoritative EXACT release, even though each independently matched as EXACT
+    qobuz_track = create_track("qobuz_1", "qobuz-track")
+    qobuz_track.external_ids.add((ExternalID.MB_TRACK, "11111111-1111-1111-1111-111111111111"))
+    qobuz_mapping = next(iter(qobuz_track.provider_mappings))
+    deezer_track = create_track("deezer_1", "deezer-track")
+    deezer_track.external_ids.add((ExternalID.MB_TRACK, "22222222-2222-2222-2222-222222222222"))
+    deezer_mapping = next(iter(deezer_track.provider_mappings))
+    qobuz_provider = MagicMock(spec=MusicProvider)
+    qobuz_provider.name = "Qobuz"
+    qobuz_provider.instance_id = "qobuz_1"
+    qobuz_provider.domain = "qobuz"
+    qobuz_provider.available = True
+    qobuz_provider.is_streaming_provider = True
+    deezer_provider = MagicMock(spec=MusicProvider)
+    deezer_provider.name = "Deezer"
+    deezer_provider.instance_id = "deezer_1"
+    deezer_provider.domain = "deezer"
+    deezer_provider.available = True
+    deezer_provider.is_streaming_provider = True
+    qobuz_match = TrackProviderMatch(
+        track=qobuz_track, mapping=qobuz_mapping, confidence=TrackMatchConfidence.EXACT
+    )
+    deezer_match = TrackProviderMatch(
+        track=deezer_track, mapping=deezer_mapping, confidence=TrackMatchConfidence.EXACT
+    )
+    results = {
+        "qobuz_1": TrackProviderMatchResult(match=qobuz_match),
+        "deezer_1": TrackProviderMatchResult(match=deezer_match),
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(
+                side_effect=lambda _track, provider, **_kwargs: results[provider.instance_id]
+            ),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "qobuz_1": qobuz_provider,
+                "deezer_1": deezer_provider,
+            }[provider_instance_id],
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1", "deezer_1"},
+        )
+
+    # a shared ISRC/duration only ties them at LIKELY once their conflicting release
+    # evidence is considered - neither can be trusted as the selected EXACT release
     assert result.matches == ()
     assert set(result.ambiguous_providers) == {"Qobuz", "Deezer"}
     assert qobuz_mapping not in result.track.provider_mappings

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -1472,6 +1472,72 @@ async def test_enrich_provider_mappings_skips_album_lookup_for_existing_domains(
     find_provider_match.assert_not_awaited()
 
 
+async def test_enrich_provider_mappings_skips_unmapped_non_streaming_provider_by_default(
+    music: MusicController,
+) -> None:
+    """A non-streaming provider without an existing mapping is skipped by default."""
+    source = create_track("spotify_1", "source")
+    provider = MagicMock(spec=MusicProvider)
+    provider.instance_id = "filesystem_1"
+    provider.domain = "filesystem"
+    provider.available = True
+    provider.is_streaming_provider = False
+    find_provider_match = AsyncMock()
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "find_provider_match", find_provider_match),
+        patch.object(music.mass, "get_provider", return_value=provider),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"filesystem_1"},
+        )
+
+    assert result.matches == ()
+    find_provider_match.assert_not_awaited()
+
+
+async def test_enrich_provider_mappings_searches_non_streaming_provider_when_opted_in(
+    music: MusicController,
+) -> None:
+    """An explicitly selected non-streaming provider is searched when opted in."""
+    source = create_track("spotify_1", "source")
+    provider = MagicMock(spec=MusicProvider)
+    provider.instance_id = "filesystem_1"
+    provider.domain = "filesystem"
+    provider.available = True
+    provider.is_streaming_provider = False
+    filesystem_track = create_track("filesystem_1", "filesystem-track")
+    filesystem_mapping = next(iter(filesystem_track.provider_mappings))
+    filesystem_match = TrackProviderMatch(
+        track=filesystem_track,
+        mapping=filesystem_mapping,
+        confidence=TrackMatchConfidence.LIKELY,
+    )
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(return_value=TrackProviderMatchResult(match=filesystem_match)),
+        ),
+        patch.object(music.mass, "get_provider", return_value=provider),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"filesystem_1"},
+            # the caller (e.g. import matching) explicitly selected this instance as a
+            # match target, so it must be searched even without a pre-existing mapping
+            search_non_streaming_without_mapping=True,
+        )
+
+    assert result.matches == (filesystem_match,)
+
+
 async def test_enrich_provider_mappings_hydrates_evidence_from_wider_allowed_scope(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -2,7 +2,7 @@
 
 from collections.abc import AsyncGenerator
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
 from music_assistant_models.enums import ContentType, ExternalID, MediaType, ProviderFeature
@@ -13,6 +13,7 @@ from music_assistant_models.errors import (
     ResourceTemporarilyUnavailable,
 )
 from music_assistant_models.media_items import (
+    Album,
     Artist,
     AudioFormat,
     ItemMapping,
@@ -408,6 +409,56 @@ async def test_full_track_album_domain_only_tries_every_allowed_instance(
 
     albums_get.assert_awaited_once_with("album", "qobuz_2", allow_update_metadata=False)
     assert result is album
+
+
+async def test_full_track_album_domain_only_falls_back_after_instance_failure(
+    music: MusicController,
+) -> None:
+    """A failing candidate instance does not block a sibling instance from supplying the album."""
+    track = create_track("spotify_1", "track")
+    track.album = ItemMapping(
+        item_id="album",
+        provider="qobuz",
+        name="Album",
+        media_type=MediaType.ALBUM,
+    )
+    qobuz_1 = MagicMock(spec=MusicProvider)
+    qobuz_1.instance_id = "qobuz_1"
+    qobuz_1.domain = "qobuz"
+    qobuz_2 = MagicMock(spec=MusicProvider)
+    qobuz_2.instance_id = "qobuz_2"
+    qobuz_2.domain = "qobuz"
+    qobuz_3 = MagicMock(spec=MusicProvider)
+    qobuz_3.instance_id = "qobuz_3"
+    qobuz_3.domain = "qobuz"
+    # the bare "qobuz" domain resolves to an instance the user is not allowed to
+    # use, forcing expansion across the allowed instances of that same domain
+    providers = {"qobuz": qobuz_3, "qobuz_1": qobuz_1, "qobuz_2": qobuz_2, "qobuz_3": qobuz_3}
+    album = create_album("qobuz_2", "album", name="Album")
+
+    def get_provider(provider_instance_or_domain: str, **_kwargs: Any) -> MusicProvider | None:
+        return providers.get(provider_instance_or_domain)
+
+    async def albums_get_side_effect(_item_id: str, instance_id: str, **_kwargs: Any) -> Album:
+        if instance_id == "qobuz_1":
+            # this account no longer has the album - a sibling instance must still
+            # be tried instead of falling back to the unhydrated mapping right away
+            raise MediaNotFoundError("gone")
+        return album
+
+    with (
+        patch.object(music.mass, "get_provider", side_effect=get_provider),
+        patch.object(music.albums, "get", AsyncMock(side_effect=albums_get_side_effect)) as get_,
+    ):
+        result = await music.tracks._get_full_track_album(
+            track, allowed_provider_instances={"qobuz_1", "qobuz_2"}
+        )
+
+    assert result is album
+    assert get_.await_args_list == [
+        call("album", "qobuz_1", allow_update_metadata=False),
+        call("album", "qobuz_2", allow_update_metadata=False),
+    ]
 
 
 async def test_find_provider_match_classifies_library_mapping_against_source(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -1029,6 +1029,78 @@ async def test_enrich_provider_mappings_tries_next_instance_after_miss(
     assert result.matches == (match,)
 
 
+async def test_enrich_provider_mappings_prefers_stronger_match_within_same_domain(
+    music: MusicController,
+) -> None:
+    """A weaker match on one account does not stop a stronger one on a sibling account."""
+    source = create_track("spotify_1", "source")
+    loose_track = create_track("qobuz_1", "loose-track")
+    loose_mapping = next(iter(loose_track.provider_mappings))
+    exact_track = create_track("qobuz_2", "exact-track")
+    exact_mapping = next(iter(exact_track.provider_mappings))
+    first_provider = MagicMock(spec=MusicProvider)
+    first_provider.name = "Qobuz first"
+    first_provider.instance_id = "qobuz_1"
+    first_provider.domain = "qobuz"
+    first_provider.available = True
+    first_provider.is_streaming_provider = True
+    second_provider = MagicMock(spec=MusicProvider)
+    second_provider.name = "Qobuz second"
+    second_provider.instance_id = "qobuz_2"
+    second_provider.domain = "qobuz"
+    second_provider.available = True
+    second_provider.is_streaming_provider = True
+    loose_match = TrackProviderMatch(
+        track=loose_track, mapping=loose_mapping, confidence=TrackMatchConfidence.LOOSE
+    )
+    exact_match = TrackProviderMatch(
+        track=exact_track, mapping=exact_mapping, confidence=TrackMatchConfidence.EXACT
+    )
+    results = {
+        "qobuz_1": TrackProviderMatchResult(match=loose_match),
+        "qobuz_2": TrackProviderMatchResult(match=exact_match),
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(
+                side_effect=lambda _track, provider, **_kwargs: results[provider.instance_id]
+            ),
+        ) as find_match,
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "qobuz_1": first_provider,
+                "qobuz_2": second_provider,
+            }[provider_instance_id],
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1", "qobuz_2"},
+        )
+
+    # both accounts must be evaluated - an early LOOSE hit on the first must not
+    # prevent the stronger EXACT hit on the second from being found and preferred
+    assert find_match.await_count == 2
+    assert result.matches == (exact_match,)
+    assert exact_mapping in result.track.provider_mappings
+    assert loose_mapping not in result.track.provider_mappings
+
+
 async def test_enrich_provider_mappings_treats_tied_conflicting_matches_as_ambiguous(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 import pytest
 from music_assistant_models.enums import ExternalID, MediaType, ProviderFeature
 from music_assistant_models.errors import (
+    InvalidDataError,
     MediaNotFoundError,
     ProviderUnavailableError,
     ResourceTemporarilyUnavailable,
@@ -631,6 +632,81 @@ async def test_find_provider_match_keeps_fallback_after_later_hydration_failure(
     assert result.match is not None
     assert result.match.track.item_id == candidate.item_id
     assert get_provider_item.await_count == 2
+
+
+async def test_find_provider_match_skips_invalid_data_search_candidate(
+    music: MusicController,
+) -> None:
+    """An unusable hydrated search result is skipped, not fatal to the whole search."""
+    base = create_track("spotify_1", "base")
+    unusable_candidate = create_track("qobuz_1", "unreadable")
+    good_candidate = create_track("qobuz_1", "candidate")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    async def get_provider_item(item_id: str, *_args: object, **_kwargs: object) -> Track:
+        if item_id == "unreadable":
+            raise InvalidDataError("Corrupt provider response")
+        return good_candidate
+
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[unusable_candidate, good_candidate])),
+        ),
+        patch.object(music.tracks, "get_provider_item", AsyncMock(side_effect=get_provider_item)),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+    ):
+        result = await music.tracks.find_provider_match(
+            base,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+        )
+
+    assert result.match is not None
+    assert result.match.track.item_id == good_candidate.item_id
+
+
+async def test_find_provider_match_falls_through_search_after_invalid_mapped_candidate(
+    music: MusicController,
+) -> None:
+    """A stale/unreadable mapped candidate falls through to search, instead of aborting."""
+    source = create_track("qobuz_1", "source")
+    search_candidate = create_track("qobuz_1", "found")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    async def get_provider_item(item_id: str, *_args: object, **_kwargs: object) -> Track:
+        if item_id == "source":
+            # resolving the trusted mapping directly - simulate a stale, unreadable
+            # catalog entry rather than a confirmed removal
+            raise InvalidDataError("Unreadable catalog entry")
+        return search_candidate
+
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[search_candidate])),
+        ),
+        patch.object(music.tracks, "get_provider_item", AsyncMock(side_effect=get_provider_item)),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+    ):
+        result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+            trust_base_mapping=False,
+        )
+
+    assert result.match is not None
 
 
 async def test_find_provider_match_reports_ambiguous_loose_candidates(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -1703,6 +1703,33 @@ async def test_enrich_provider_mappings_reports_unavailable_allowed_provider(
     assert failed_provider_instances == {"qobuz_1"}
 
 
+async def test_enrich_provider_mappings_reports_fully_unloaded_allowed_provider(
+    music: MusicController,
+) -> None:
+    """An allowed instance that has fully unloaded is reported, not silently skipped."""
+    source = create_track("spotify_1", "source")
+    failed_provider_instances: set[str] = set()
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "find_provider_match", AsyncMock()) as find_match,
+        # no provider object left at all for this instance - fully unregistered
+        patch.object(music.mass, "get_provider", return_value=None),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+            failed_provider_instances=failed_provider_instances,
+        )
+
+    # never queried - the caller should still learn this instance couldn't be tried,
+    # using its instance id as display name since no provider object remains
+    find_match.assert_not_awaited()
+    assert result.failed_providers == ("qobuz_1",)
+    assert failed_provider_instances == {"qobuz_1"}
+
+
 async def test_overwrite_update_keeps_artists_when_none_are_given(
     mass: MusicAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -348,6 +348,30 @@ async def test_find_provider_match_force_refreshes_untrusted_mapped_candidate(
     assert trusted_call.kwargs["force_refresh"] is False
 
 
+async def test_find_provider_match_skips_known_dead_mapping_hydration(
+    music: MusicController,
+) -> None:
+    """A mapped candidate a caller already confirmed dead is not hydrated again here."""
+    source = create_track("qobuz_1", "source")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    # no SEARCH feature - isolates this test to the mapped-candidate hydration path
+    provider.supported_features = set()
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with patch.object(music.tracks, "get_provider_item", AsyncMock()) as get_provider_item:
+        result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            trust_base_mapping=False,
+            known_dead_mappings=frozenset({("qobuz_1", "source")}),
+        )
+
+    get_provider_item.assert_not_awaited()
+    assert result.match is None
+
+
 async def test_match_confidence_hydrates_album_after_initial_no_match(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -2,15 +2,35 @@
 
 from collections.abc import AsyncGenerator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
-from music_assistant_models.media_items import Artist, ProviderMapping, UniqueList
+from music_assistant_models.enums import ExternalID, MediaType, ProviderFeature
+from music_assistant_models.errors import (
+    MediaNotFoundError,
+    ProviderUnavailableError,
+    ResourceTemporarilyUnavailable,
+)
+from music_assistant_models.media_items import (
+    Artist,
+    ItemMapping,
+    ProviderMapping,
+    SearchResults,
+    Track,
+    UniqueList,
+)
 
 from music_assistant.controllers.music import MusicController
+from music_assistant.controllers.music.media.tracks import (
+    TrackProviderMatch,
+    TrackProviderMatchResult,
+    TracksController,
+)
+from music_assistant.helpers.compare import TrackMatchConfidence
 from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
 
-from .helpers import create_track
+from .helpers import create_album, create_track
 
 
 @pytest.fixture
@@ -159,6 +179,926 @@ async def test_match_provider_uses_full_track_mapping(music: MusicController) ->
         mappings = await music.tracks.match_provider(base_track, provider, ref_albums=[])
 
     assert mappings == list(full_track.provider_mappings)
+
+
+async def test_get_provider_item_can_disable_library_fallback(
+    music: MusicController,
+) -> None:
+    """Authoritative hydration surfaces a missing provider ID instead of stored details."""
+    provider = MagicMock(spec=MusicProvider)
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.get_track = AsyncMock(side_effect=MediaNotFoundError("gone"))
+    library_fallback = create_track("qobuz_1", "stale")
+
+    with (
+        patch.object(music.mass, "get_provider", return_value=provider),
+        patch.object(
+            music.tracks,
+            "get_library_item_by_prov_id",
+            AsyncMock(return_value=library_fallback),
+        ),
+    ):
+        with pytest.raises(MediaNotFoundError, match="not found"):
+            await music.tracks.get_provider_item(
+                "stale",
+                provider.instance_id,
+                allow_fallback=False,
+            )
+        result = await music.tracks.get_provider_item(
+            "stale",
+            provider.instance_id,
+        )
+
+    assert result is library_fallback
+
+
+async def test_get_provider_item_strict_instance_rejects_fallback(
+    music: MusicController,
+) -> None:
+    """Authoritative hydration can not switch to another provider account."""
+    unavailable_provider = MagicMock(spec=MusicProvider)
+    unavailable_provider.instance_id = "qobuz_1"
+    unavailable_provider.available = False
+    outside_scope_provider = MagicMock(spec=MusicProvider)
+    outside_scope_provider.instance_id = "qobuz_2"
+    outside_scope_provider.available = True
+    outside_scope_provider.get_track = AsyncMock()
+
+    with (
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda _provider_instance_id, return_unavailable=False: (
+                unavailable_provider if return_unavailable else outside_scope_provider
+            ),
+        ),
+        pytest.raises(ProviderUnavailableError, match="qobuz_1"),
+    ):
+        await music.tracks.get_provider_item(
+            "track",
+            "qobuz_1",
+            allow_fallback=False,
+            strict_provider_instance=True,
+        )
+
+    outside_scope_provider.get_track.assert_not_awaited()
+
+
+async def test_find_provider_match_reuses_domain_mapping_for_target_instance(
+    music: MusicController,
+) -> None:
+    """A catalog mapping is reused across instances without searching."""
+    track = create_track("qobuz_1", "track")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_2"
+    provider.domain = "qobuz"
+
+    with patch.object(music, "search_provider", AsyncMock()) as search:
+        result = await music.tracks.find_provider_match(track, provider)
+
+    assert result.match is not None
+    assert result.match.mapping.item_id == "track"
+    assert result.match.mapping.provider_instance == "qobuz_2"
+    assert result.match.confidence == TrackMatchConfidence.EXACT
+    search.assert_not_awaited()
+
+
+async def test_find_provider_match_revalidates_untrusted_source_mapping(
+    music: MusicController,
+) -> None:
+    """A mapping restored from a Music Assistant playlist is reclassified from metadata."""
+    source = create_track("qobuz_1", "source")
+    candidate = create_track("qobuz_1", "source")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = set()
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(return_value=candidate),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        exact_result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.EXACT,
+            trust_base_mapping=False,
+        )
+        likely_result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+            trust_base_mapping=False,
+        )
+
+    assert exact_result.match is None
+    assert likely_result.match is not None
+    assert likely_result.match.confidence == TrackMatchConfidence.LIKELY
+
+
+async def test_match_confidence_hydrates_album_after_initial_no_match(
+    music: MusicController,
+) -> None:
+    """Full release evidence can resolve a duration-based first-pass rejection."""
+    base = create_track("spotify_1", "base", duration=200)
+    candidate = create_track("qobuz_1", "candidate", duration=210)
+    base.disc_number = candidate.disc_number = 1
+    base.track_number = candidate.track_number = 1
+    base_album = create_album("spotify_1", "base-album", name="Album")
+    candidate_album = create_album("qobuz_1", "candidate-album", name="Album")
+    base.album = ItemMapping(
+        item_id=base_album.item_id,
+        provider=base_album.provider,
+        name=base_album.name,
+        media_type=MediaType.ALBUM,
+    )
+    candidate.album = ItemMapping(
+        item_id=candidate_album.item_id,
+        provider=candidate_album.provider,
+        name=candidate_album.name,
+        media_type=MediaType.ALBUM,
+    )
+
+    with patch.object(
+        music.tracks,
+        "_get_full_track_album",
+        AsyncMock(side_effect=(base_album, candidate_album)),
+    ):
+        confidence, _ = await music.tracks._get_match_confidence(
+            base,
+            candidate,
+            None,
+        )
+
+    assert confidence == TrackMatchConfidence.EXACT
+
+
+@pytest.mark.parametrize(
+    "error",
+    [TimeoutError(), ResourceTemporarilyUnavailable("Provider temporarily unavailable")],
+)
+async def test_full_track_album_falls_back_after_transient_failure(
+    music: MusicController,
+    error: Exception,
+) -> None:
+    """Optional album evidence falls back to the mapping after a transient provider failure."""
+    track = create_track("spotify_1", "track")
+    track.album = ItemMapping(
+        item_id="album",
+        provider="spotify_1",
+        name="Album",
+        media_type=MediaType.ALBUM,
+    )
+
+    with patch.object(
+        music.albums,
+        "get",
+        AsyncMock(side_effect=error),
+    ):
+        result = await music.tracks._get_full_track_album(track)
+
+    assert result is track.album
+
+
+async def test_find_provider_match_classifies_library_mapping_against_source(
+    music: MusicController,
+) -> None:
+    """A library mapping is a candidate, not proof of an exact source release."""
+    source = create_track("spotify_1", "source")
+    library_track = create_track("spotify_1", "library")
+    target = create_track("qobuz_1", "target")
+    library_track.provider_mappings.add(next(iter(target.provider_mappings)))
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = set()
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(return_value=target),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        exact_result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.EXACT,
+            mapping_source=library_track,
+            allowed_provider_instances={"qobuz_1"},
+        )
+        likely_result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+            mapping_source=library_track,
+            allowed_provider_instances={"qobuz_1"},
+        )
+
+    assert exact_result.match is None
+    assert likely_result.match is not None
+    assert likely_result.match.confidence == TrackMatchConfidence.LIKELY
+
+
+async def test_library_mapping_does_not_preempt_exact_provider_search(
+    music: MusicController,
+) -> None:
+    """An alternate library mapping remains a fallback while exact search continues."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    source = create_track("spotify_1", "source")
+    source.external_ids.add(mb_track)
+    source.artists.append(
+        ItemMapping(
+            item_id="other-artist",
+            provider="spotify_1",
+            name="Other Artist",
+            media_type=MediaType.ARTIST,
+        )
+    )
+    library_track = create_track("spotify_1", "library")
+    mapped_candidate = create_track("qobuz_1", "mapped")
+    exact_candidate = create_track("qobuz_1", "exact")
+    exact_candidate.external_ids.add(mb_track)
+    library_track.provider_mappings.add(next(iter(mapped_candidate.provider_mappings)))
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+    candidates = {
+        "mapped": mapped_candidate,
+        "exact": exact_candidate,
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(side_effect=lambda item_id, *_args, **_kwargs: candidates[item_id]),
+        ),
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(
+                side_effect=(
+                    SearchResults(tracks=[exact_candidate]),
+                    ResourceTemporarilyUnavailable("Later search timed out"),
+                )
+            ),
+        ) as search_provider,
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+            mapping_source=library_track,
+            allowed_provider_instances={"qobuz_1"},
+        )
+
+    assert result.match is not None
+    assert result.match.track.item_id == "exact"
+    assert result.match.confidence == TrackMatchConfidence.EXACT
+    assert search_provider.await_count == 1
+
+
+async def test_find_provider_match_prefers_exact_candidate(
+    music: MusicController,
+) -> None:
+    """An exact candidate outranks a loose result returned earlier."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    base = create_track("spotify_1", "base", isrc="USRC17607839")
+    base.external_ids.add(mb_track)
+    loose = create_track("qobuz_1", "loose", isrc="OTHER")
+    loose.version = "Deluxe"
+    stale = create_track("qobuz_1", "stale", isrc="STALE")
+    exact = create_track("qobuz_1", "exact", isrc="USRC17607839")
+    exact.provider = "qobuz"
+    exact.external_ids.add(mb_track)
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    async def get_provider_item(item_id: str, *_args: object, **_kwargs: object) -> Track:
+        if item_id == "stale":
+            raise MediaNotFoundError("Stale search result")
+        return {"loose": loose, "exact": exact}[item_id]
+
+    get_provider_item_mock = AsyncMock(side_effect=get_provider_item)
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[stale, loose, exact])),
+        ),
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            get_provider_item_mock,
+        ),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+    ):
+        result = await music.tracks.find_provider_match(
+            base,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LOOSE,
+        )
+
+    assert result.match is not None
+    assert result.match.track.item_id == "exact"
+    assert result.match.confidence == TrackMatchConfidence.EXACT
+    assert all(
+        call.args[1] == provider.instance_id and call.kwargs["strict_provider_instance"] is True
+        for call in get_provider_item_mock.await_args_list
+    )
+
+
+async def test_find_provider_match_keeps_fallback_after_later_timeout(
+    music: MusicController,
+) -> None:
+    """A later artist-query timeout does not discard an acceptable candidate."""
+    base = create_track("spotify_1", "base")
+    base.artists.append(
+        ItemMapping(
+            item_id="other-artist",
+            provider="spotify_1",
+            name="Other Artist",
+            media_type=MediaType.ARTIST,
+        )
+    )
+    candidate = create_track("qobuz_1", "candidate")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(
+                side_effect=(
+                    SearchResults(tracks=[candidate]),
+                    ResourceTemporarilyUnavailable("Later search timed out"),
+                )
+            ),
+        ) as search_provider,
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(return_value=candidate),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        result = await music.tracks.find_provider_match(
+            base,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+        )
+
+    assert result.match is not None
+    assert result.match.confidence == TrackMatchConfidence.LIKELY
+    assert search_provider.await_count == 2
+
+
+async def test_find_provider_match_keeps_fallback_after_later_hydration_failure(
+    music: MusicController,
+) -> None:
+    """A later hydration failure does not discard an acceptable candidate."""
+    base = create_track("spotify_1", "base")
+    candidate = create_track("qobuz_1", "candidate")
+    failing_candidate = create_track("qobuz_1", "failing")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+    get_provider_item = AsyncMock(
+        side_effect=(
+            candidate,
+            ResourceTemporarilyUnavailable("Hydration failed"),
+        )
+    )
+
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[candidate, failing_candidate])),
+        ),
+        patch.object(music.tracks, "get_provider_item", get_provider_item),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+    ):
+        result = await music.tracks.find_provider_match(
+            base,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+        )
+
+    assert result.match is not None
+    assert result.match.track.item_id == candidate.item_id
+    assert get_provider_item.await_count == 2
+
+
+async def test_find_provider_match_reports_ambiguous_loose_candidates(
+    music: MusicController,
+) -> None:
+    """Different tied best-effort versions are ambiguous rather than arbitrary."""
+    base = create_track("spotify_1", "base", isrc="BASE")
+    deluxe = create_track("qobuz_1", "deluxe", isrc="DELUXE")
+    deluxe.version = "Deluxe"
+    remaster = create_track("qobuz_1", "remaster", isrc="REMASTER")
+    remaster.version = "2022 Remaster"
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[deluxe, remaster])),
+        ),
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(
+                side_effect=lambda item_id, *_args, **_kwargs: {
+                    "deluxe": deluxe,
+                    "remaster": remaster,
+                }[item_id]
+            ),
+        ),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+    ):
+        result = await music.tracks.find_provider_match(
+            base,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LOOSE,
+        )
+
+    assert result.match is None
+    assert result.ambiguous is True
+
+
+def test_tied_loose_matches_require_pairwise_compatibility() -> None:
+    """A middle-duration candidate can not make incompatible outer candidates look equivalent."""
+    tracks = [
+        create_track("qobuz_1", "middle", duration=103, isrc="MIDDLE"),
+        create_track("qobuz_1", "short", duration=100, isrc="SHORT"),
+        create_track("qobuz_1", "long", duration=106, isrc="LONG"),
+    ]
+    matches = [
+        TrackProviderMatch(
+            track=track,
+            mapping=next(iter(track.provider_mappings)),
+            confidence=TrackMatchConfidence.LOOSE,
+        )
+        for track in tracks
+    ]
+
+    assert TracksController._matches_are_compatible(matches) is False
+
+
+async def test_enrich_provider_mappings_uses_library_without_mutating_it(
+    music: MusicController,
+) -> None:
+    """Library mappings seed playlist enrichment without being updated."""
+    source = create_track("spotify_1", "source")
+    library_track = create_track("spotify_1", "library")
+    library_track.provider = "library"
+    library_track.item_id = "42"
+    qobuz_track = create_track("qobuz_1", "qobuz-track")
+    qobuz_mapping = next(iter(qobuz_track.provider_mappings))
+    library_track.provider_mappings.add(qobuz_mapping)
+    stale_tidal_mapping = ProviderMapping(
+        item_id="old-tidal-track",
+        provider_domain="tidal",
+        provider_instance="tidal_1",
+        available=False,
+    )
+    library_track.provider_mappings.add(stale_tidal_mapping)
+    original_mappings = set(library_track.provider_mappings)
+    tidal_track = create_track("tidal_1", "tidal-track")
+    tidal_mapping = next(iter(tidal_track.provider_mappings))
+    tidal_provider = MagicMock()
+    tidal_provider.name = "Tidal"
+    tidal_provider.instance_id = "tidal_1"
+    tidal_provider.domain = "tidal"
+    tidal_provider.is_streaming_provider = True
+    qobuz_provider = MagicMock()
+    qobuz_provider.name = "Qobuz"
+    qobuz_provider.instance_id = "qobuz_1"
+    qobuz_provider.domain = "qobuz"
+    qobuz_provider.is_streaming_provider = True
+    qobuz_match = TrackProviderMatch(
+        track=qobuz_track,
+        mapping=qobuz_mapping,
+        confidence=TrackMatchConfidence.LIKELY,
+    )
+    tidal_match = TrackProviderMatch(
+        track=tidal_track,
+        mapping=tidal_mapping,
+        confidence=TrackMatchConfidence.LIKELY,
+    )
+    matches = {
+        "qobuz": TrackProviderMatchResult(match=qobuz_match),
+        "tidal": TrackProviderMatchResult(match=tidal_match),
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=library_track),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ) as get_full_track_album,
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(side_effect=lambda _track, provider, **_kwargs: matches[provider.domain]),
+        ),
+        patch.object(
+            MusicController,
+            "providers",
+            new_callable=PropertyMock,
+            return_value=[qobuz_provider, tidal_provider],
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(source)
+
+    assert result.used_library_item is True
+    assert result.track is not library_track
+    assert result.track.provider_mappings == {
+        *source.provider_mappings,
+        qobuz_mapping,
+        tidal_mapping,
+    }
+    assert library_track.provider_mappings == original_mappings
+    assert result.matches == (qobuz_match, tidal_match)
+    get_full_track_album.assert_awaited_once_with(source)
+
+
+async def test_enrich_provider_mappings_skips_album_lookup_for_existing_domains(
+    music: MusicController,
+) -> None:
+    """Trusted source mappings avoid unnecessary album and provider lookups."""
+    source = create_track("spotify_1", "source")
+    provider = MagicMock(spec=MusicProvider)
+    provider.instance_id = "spotify_1"
+    provider.domain = "spotify"
+    provider.available = True
+    provider.is_streaming_provider = True
+    get_full_track_album = AsyncMock()
+    find_provider_match = AsyncMock()
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "_get_full_track_album", get_full_track_album),
+        patch.object(music.tracks, "find_provider_match", find_provider_match),
+        patch.object(music.mass, "get_provider", return_value=provider),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"spotify_1"},
+        )
+
+    assert result.track.provider_mappings == source.provider_mappings
+    get_full_track_album.assert_not_awaited()
+    find_provider_match.assert_not_awaited()
+
+
+async def test_enrich_provider_mappings_does_not_substitute_unavailable_instance(
+    music: MusicController,
+) -> None:
+    """A captured provider instance can not fall back to another account."""
+    source = create_track("spotify_1", "source")
+    unavailable_provider = MagicMock(spec=MusicProvider)
+    unavailable_provider.instance_id = "qobuz_1"
+    unavailable_provider.domain = "qobuz"
+    unavailable_provider.available = False
+    outside_scope_provider = MagicMock(spec=MusicProvider)
+    outside_scope_provider.instance_id = "qobuz_2"
+    outside_scope_provider.domain = "qobuz"
+    outside_scope_provider.available = True
+    find_provider_match = AsyncMock()
+
+    def get_provider(
+        _provider_instance_id: str,
+        return_unavailable: bool = False,
+    ) -> MusicProvider:
+        return unavailable_provider if return_unavailable else outside_scope_provider
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "find_provider_match", find_provider_match),
+        patch.object(music.mass, "get_provider", side_effect=get_provider),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+        )
+
+    assert result.track.provider_mappings == set()
+    find_provider_match.assert_not_awaited()
+
+
+async def test_enrich_provider_mappings_tries_next_instance_after_miss(
+    music: MusicController,
+) -> None:
+    """A miss on one account does not suppress another account of the same service."""
+    source = create_track("spotify_1", "source")
+    qobuz_track = create_track("qobuz_2", "qobuz-track")
+    qobuz_mapping = next(iter(qobuz_track.provider_mappings))
+    first_provider = MagicMock(spec=MusicProvider)
+    first_provider.name = "Qobuz first"
+    first_provider.instance_id = "qobuz_1"
+    first_provider.domain = "qobuz"
+    first_provider.available = True
+    first_provider.is_streaming_provider = True
+    second_provider = MagicMock(spec=MusicProvider)
+    second_provider.name = "Qobuz second"
+    second_provider.instance_id = "qobuz_2"
+    second_provider.domain = "qobuz"
+    second_provider.available = True
+    second_provider.is_streaming_provider = True
+    match = TrackProviderMatch(
+        track=qobuz_track,
+        mapping=qobuz_mapping,
+        confidence=TrackMatchConfidence.LIKELY,
+    )
+    results = {
+        "qobuz_1": TrackProviderMatchResult(),
+        "qobuz_2": TrackProviderMatchResult(match=match),
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(
+                side_effect=lambda _track, provider, **_kwargs: results[provider.instance_id]
+            ),
+        ) as find_match,
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "qobuz_1": first_provider,
+                "qobuz_2": second_provider,
+            }[provider_instance_id],
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1", "qobuz_2"},
+        )
+
+    assert find_match.await_count == 2
+    assert qobuz_mapping in result.track.provider_mappings
+    assert result.matches == (match,)
+
+
+async def test_enrich_provider_mappings_filters_inaccessible_source_mappings(
+    music: MusicController,
+) -> None:
+    """Builtin source entries retain only provider mappings allowed for the initiating user."""
+    source = create_track("spotify_1", "source")
+    allowed_track = create_track("spotify_2", "source")
+    allowed_mapping = next(iter(allowed_track.provider_mappings))
+    allowed_provider = MagicMock(spec=MusicProvider)
+    allowed_provider.name = "Spotify allowed"
+    allowed_provider.instance_id = "spotify_2"
+    allowed_provider.domain = "spotify"
+    allowed_provider.available = True
+    allowed_provider.is_streaming_provider = True
+    match = TrackProviderMatch(
+        track=allowed_track,
+        mapping=allowed_mapping,
+        confidence=TrackMatchConfidence.EXACT,
+    )
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(return_value=TrackProviderMatchResult(match=match)),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            return_value=allowed_provider,
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"spotify_2"},
+        )
+
+    assert result.track.provider_mappings == {allowed_mapping}
+    assert all(
+        mapping.provider_instance != "spotify_1" for mapping in result.track.provider_mappings
+    )
+
+
+async def test_enrich_provider_mappings_preserves_allowed_untrusted_fallback(
+    music: MusicController,
+) -> None:
+    """A Music Assistant copy keeps an allowed source mapping when revalidation finds no match."""
+    source = create_track("qobuz_1", "source")
+    source_mapping = next(iter(source.provider_mappings))
+    provider = MagicMock(spec=MusicProvider)
+    provider.name = "Qobuz"
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.available = True
+    provider.is_streaming_provider = True
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(return_value=TrackProviderMatchResult()),
+        ) as find_match,
+        patch.object(
+            music.mass,
+            "get_provider",
+            return_value=provider,
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+            trust_track_mappings=False,
+        )
+
+    assert result.track.provider_mappings == {source_mapping}
+    assert find_match.await_args is not None
+    assert find_match.await_args.kwargs["trust_base_mapping"] is False
+
+
+async def test_enrich_provider_mappings_drops_unavailable_source_mappings(
+    music: MusicController,
+) -> None:
+    """Unavailable source mappings are not copied into a migrated playlist."""
+    source = create_track("qobuz_1", "source")
+    source.provider_mappings = {
+        ProviderMapping(
+            item_id="unavailable",
+            provider_domain="qobuz",
+            provider_instance="qobuz_1",
+            available=False,
+        )
+    }
+    provider = MagicMock(spec=MusicProvider)
+    provider.name = "Qobuz"
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.available = True
+    provider.is_streaming_provider = True
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(return_value=TrackProviderMatchResult()),
+        ),
+        patch.object(music.mass, "get_provider", return_value=provider),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+            trust_track_mappings=False,
+        )
+
+    assert result.track.provider_mappings == set()
+
+
+async def test_enrich_provider_mappings_stops_after_provider_failure(
+    music: MusicController,
+) -> None:
+    """A timed-out provider is not queried again for every remaining migration track."""
+    source = create_track("spotify_1", "source")
+    provider = MagicMock(spec=MusicProvider)
+    provider.name = "Qobuz"
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.available = True
+    provider.is_streaming_provider = True
+    failed_provider_instances: set[str] = set()
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(side_effect=ResourceTemporarilyUnavailable("Search timed out")),
+        ) as find_match,
+        patch.object(
+            music.mass,
+            "get_provider",
+            return_value=provider,
+        ),
+    ):
+        first_result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+            failed_provider_instances=failed_provider_instances,
+        )
+        second_result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+            failed_provider_instances=failed_provider_instances,
+        )
+
+    assert failed_provider_instances == {"qobuz_1"}
+    assert find_match.await_count == 1
+    assert first_result.failed_providers == ("Qobuz",)
+    assert second_result.failed_providers == ()
 
 
 async def test_overwrite_update_keeps_artists_when_none_are_given(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -687,6 +687,54 @@ async def test_full_track_album_domain_only_falls_back_after_instance_failure(
     ]
 
 
+async def test_full_track_album_domain_reference_does_not_expand_for_non_streaming_provider(
+    music: MusicController,
+) -> None:
+    """A non-streaming domain's ids are instance-local, so siblings must not be tried."""
+    track = create_track("spotify_1", "track")
+    track.album = ItemMapping(
+        # a domain, not an instance id - filesystem item ids are only meaningful
+        # within the instance that minted them, so a same-domain sibling with a
+        # coincidentally-matching id must never be trusted as the same album
+        item_id="album",
+        provider="filesystem",
+        name="Album",
+        media_type=MediaType.ALBUM,
+    )
+    filesystem_1 = MagicMock(spec=MusicProvider)
+    filesystem_1.instance_id = "filesystem_1"
+    filesystem_1.domain = "filesystem"
+    filesystem_1.is_streaming_provider = False
+    filesystem_2 = MagicMock(spec=MusicProvider)
+    filesystem_2.instance_id = "filesystem_2"
+    filesystem_2.domain = "filesystem"
+    filesystem_2.is_streaming_provider = False
+    providers = {
+        "filesystem": filesystem_1,
+        "filesystem_1": filesystem_1,
+        "filesystem_2": filesystem_2,
+    }
+    # a different, unrelated album that happens to share the same instance-local id
+    colliding_album = create_album("filesystem_2", "album", name="Unrelated Album")
+
+    def get_provider(provider_instance_or_domain: str, **_kwargs: Any) -> MusicProvider | None:
+        return providers.get(provider_instance_or_domain)
+
+    with (
+        patch.object(music.mass, "get_provider", side_effect=get_provider),
+        patch.object(music.albums, "get_library_item_by_prov_id", AsyncMock(return_value=None)),
+        patch.object(
+            music.albums, "get_provider_item", AsyncMock(return_value=colliding_album)
+        ) as get_,
+    ):
+        result = await music.tracks._get_full_track_album(
+            track, allowed_provider_instances={"filesystem_2"}
+        )
+
+    get_.assert_not_called()
+    assert result is track.album
+
+
 async def test_find_provider_match_classifies_library_mapping_against_source(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -372,6 +372,44 @@ async def test_full_track_album_falls_back_after_transient_failure(
     assert result is track.album
 
 
+async def test_full_track_album_domain_only_tries_every_allowed_instance(
+    music: MusicController,
+) -> None:
+    """A bare domain album reference tries every allowed instance of that domain."""
+    track = create_track("spotify_1", "track")
+    track.album = ItemMapping(
+        # a domain, not an instance id, as reconstructed from imported #EXTALBUM metadata
+        item_id="album",
+        provider="qobuz",
+        name="Album",
+        media_type=MediaType.ALBUM,
+    )
+    qobuz_1 = MagicMock(spec=MusicProvider)
+    qobuz_1.instance_id = "qobuz_1"
+    qobuz_1.domain = "qobuz"
+    qobuz_2 = MagicMock(spec=MusicProvider)
+    qobuz_2.instance_id = "qobuz_2"
+    qobuz_2.domain = "qobuz"
+    providers = {"qobuz": qobuz_1, "qobuz_1": qobuz_1, "qobuz_2": qobuz_2}
+    album = create_album("qobuz_2", "album", name="Album")
+
+    def get_provider(provider_instance_or_domain: str, **_kwargs: Any) -> MusicProvider | None:
+        return providers.get(provider_instance_or_domain)
+
+    with (
+        # the runtime registry resolves the bare "qobuz" domain to whichever instance
+        # happens to be registered first ("qobuz_1"), regardless of allow-listing
+        patch.object(music.mass, "get_provider", side_effect=get_provider),
+        patch.object(music.albums, "get", AsyncMock(return_value=album)) as albums_get,
+    ):
+        result = await music.tracks._get_full_track_album(
+            track, allowed_provider_instances={"qobuz_2"}
+        )
+
+    albums_get.assert_awaited_once_with("album", "qobuz_2", allow_update_metadata=False)
+    assert result is album
+
+
 async def test_find_provider_match_classifies_library_mapping_against_source(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -444,6 +444,60 @@ async def test_full_track_album_domain_only_tries_every_allowed_instance(
     assert result is album
 
 
+async def test_full_track_album_domain_reference_expands_past_incidentally_allowed_instance(
+    music: MusicController,
+) -> None:
+    """A domain reference keeps expanding even when it happens to resolve to an allowed instance."""
+    track = create_track("spotify_1", "track")
+    track.album = ItemMapping(
+        # a domain, not an instance id - the registry happens to resolve it to an
+        # instance that is itself allowed, which must not stop expansion to siblings
+        item_id="album",
+        provider="qobuz",
+        name="Album",
+        media_type=MediaType.ALBUM,
+    )
+    qobuz_1 = MagicMock(spec=MusicProvider)
+    qobuz_1.instance_id = "qobuz_1"
+    qobuz_1.domain = "qobuz"
+    qobuz_2 = MagicMock(spec=MusicProvider)
+    qobuz_2.instance_id = "qobuz_2"
+    qobuz_2.domain = "qobuz"
+    providers = {"qobuz": qobuz_1, "qobuz_1": qobuz_1, "qobuz_2": qobuz_2}
+    album = create_album("qobuz_2", "album", name="Album")
+
+    def get_provider(provider_instance_or_domain: str, **_kwargs: Any) -> MusicProvider | None:
+        return providers.get(provider_instance_or_domain)
+
+    async def get_provider_item_side_effect(
+        _item_id: str, instance_id: str, **_kwargs: Any
+    ) -> Album:
+        if instance_id == "qobuz_1":
+            # this account no longer has the album - qobuz_2 must still be tried
+            # even though qobuz_1 was itself an allowed instance
+            raise MediaNotFoundError("gone")
+        return album
+
+    with (
+        patch.object(music.mass, "get_provider", side_effect=get_provider),
+        patch.object(music.albums, "get_library_item_by_prov_id", AsyncMock(return_value=None)),
+        patch.object(
+            music.albums,
+            "get_provider_item",
+            AsyncMock(side_effect=get_provider_item_side_effect),
+        ) as get_,
+    ):
+        result = await music.tracks._get_full_track_album(
+            track, allowed_provider_instances={"qobuz_1", "qobuz_2"}
+        )
+
+    assert result is album
+    assert get_.await_args_list == [
+        call("album", "qobuz_1", allow_fallback=False, strict_provider_instance=True),
+        call("album", "qobuz_2", allow_fallback=False, strict_provider_instance=True),
+    ]
+
+
 async def test_full_track_album_domain_only_falls_back_after_instance_failure(
     music: MusicController,
 ) -> None:
@@ -1564,6 +1618,97 @@ async def test_enrich_provider_mappings_prefers_higher_confidence_over_visitatio
     assert "Aaa" in result.ambiguous_providers
     assert loose_mapping not in result.track.provider_mappings
     assert exact_mapping in result.track.provider_mappings
+
+
+async def test_enrich_provider_mappings_stops_at_ambiguous_top_tier(
+    music: MusicController,
+) -> None:
+    """A conflicting top tier blocks a weaker, otherwise-clean, tier from being accepted."""
+    source = create_track("spotify_1", "source")
+    # qobuz and deezer tie at the strongest tier (EXACT) but disagree with each other
+    qobuz_track = create_track("qobuz_1", "qobuz-track", isrc="QOBUZ")
+    qobuz_track.metadata.explicit = True
+    qobuz_mapping = next(iter(qobuz_track.provider_mappings))
+    deezer_track = create_track("deezer_1", "deezer-track", isrc="DEEZER")
+    deezer_track.metadata.explicit = False
+    deezer_mapping = next(iter(deezer_track.provider_mappings))
+    # aaa is a single, internally-consistent match, but only at a weaker tier (LIKELY)
+    aaa_track = create_track("aaa_1", "aaa-track", isrc="AAA")
+    aaa_mapping = next(iter(aaa_track.provider_mappings))
+    qobuz_provider = MagicMock(spec=MusicProvider)
+    qobuz_provider.name = "Qobuz"
+    qobuz_provider.instance_id = "qobuz_1"
+    qobuz_provider.domain = "qobuz"
+    qobuz_provider.available = True
+    qobuz_provider.is_streaming_provider = True
+    deezer_provider = MagicMock(spec=MusicProvider)
+    deezer_provider.name = "Deezer"
+    deezer_provider.instance_id = "deezer_1"
+    deezer_provider.domain = "deezer"
+    deezer_provider.available = True
+    deezer_provider.is_streaming_provider = True
+    aaa_provider = MagicMock(spec=MusicProvider)
+    aaa_provider.name = "Aaa"
+    aaa_provider.instance_id = "aaa_1"
+    aaa_provider.domain = "aaa"
+    aaa_provider.available = True
+    aaa_provider.is_streaming_provider = True
+    qobuz_match = TrackProviderMatch(
+        track=qobuz_track, mapping=qobuz_mapping, confidence=TrackMatchConfidence.EXACT
+    )
+    deezer_match = TrackProviderMatch(
+        track=deezer_track, mapping=deezer_mapping, confidence=TrackMatchConfidence.EXACT
+    )
+    aaa_match = TrackProviderMatch(
+        track=aaa_track, mapping=aaa_mapping, confidence=TrackMatchConfidence.LIKELY
+    )
+    results = {
+        "qobuz_1": TrackProviderMatchResult(match=qobuz_match),
+        "deezer_1": TrackProviderMatchResult(match=deezer_match),
+        "aaa_1": TrackProviderMatchResult(match=aaa_match),
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(
+                side_effect=lambda _track, provider, **_kwargs: results[provider.instance_id]
+            ),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "qobuz_1": qobuz_provider,
+                "deezer_1": deezer_provider,
+                "aaa_1": aaa_provider,
+            }[provider_instance_id],
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1", "deezer_1", "aaa_1"},
+        )
+
+    # the conflicting EXACT tier can't be resolved, and a weaker LIKELY match doesn't
+    # settle which EXACT candidate was right - it must not be substituted in instead
+    assert result.matches == ()
+    assert set(result.ambiguous_providers) == {"Qobuz", "Deezer"}
+    assert "Aaa" not in result.ambiguous_providers
+    assert qobuz_mapping not in result.track.provider_mappings
+    assert deezer_mapping not in result.track.provider_mappings
+    assert aaa_mapping not in result.track.provider_mappings
 
 
 async def test_enrich_provider_mappings_filters_inaccessible_source_mappings(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -972,10 +972,17 @@ async def test_find_provider_match_keeps_fallback_after_later_timeout(
     assert search_provider.await_count == 2
 
 
-async def test_find_provider_match_keeps_fallback_after_later_hydration_failure(
+async def test_find_provider_match_raises_on_later_hydration_failure(
     music: MusicController,
 ) -> None:
-    """A later hydration failure does not discard an acceptable candidate."""
+    """
+    A hydration failure mid-loop must propagate rather than silently truncate.
+
+    Unlike a search-request failure (which only loses queries not yet attempted),
+    a failed hydration still leaves unseen candidates - possibly stronger or
+    ambiguity-triggering ones - among the already-fetched search results, so an
+    already-accepted candidate must not be returned as if evaluation completed.
+    """
     base = create_track("spotify_1", "base")
     candidate = create_track("qobuz_1", "candidate")
     failing_candidate = create_track("qobuz_1", "failing")
@@ -999,15 +1006,14 @@ async def test_find_provider_match_keeps_fallback_after_later_hydration_failure(
         ),
         patch.object(music.tracks, "get_provider_item", get_provider_item),
         patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+        pytest.raises(ResourceTemporarilyUnavailable),
     ):
-        result = await music.tracks.find_provider_match(
+        await music.tracks.find_provider_match(
             base,
             provider,
             minimum_confidence=TrackMatchConfidence.LIKELY,
         )
 
-    assert result.match is not None
-    assert result.match.track.item_id == candidate.item_id
     assert get_provider_item.await_count == 2
 
 

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -987,6 +987,71 @@ async def test_enrich_provider_mappings_skips_album_lookup_for_existing_domains(
     find_provider_match.assert_not_awaited()
 
 
+async def test_enrich_provider_mappings_hydrates_evidence_from_wider_allowed_scope(
+    music: MusicController,
+) -> None:
+    """Narrowing the search targets must not also narrow album-evidence hydration."""
+    source = create_track("spotify_1", "source")
+    qobuz_provider = MagicMock(spec=MusicProvider)
+    qobuz_provider.name = "Qobuz"
+    qobuz_provider.instance_id = "qobuz_1"
+    qobuz_provider.domain = "qobuz"
+    qobuz_provider.available = True
+    qobuz_provider.is_streaming_provider = True
+    get_full_track_album = AsyncMock(return_value=None)
+    find_provider_match = AsyncMock(return_value=TrackProviderMatchResult())
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "_get_full_track_album", get_full_track_album),
+        patch.object(music.tracks, "find_provider_match", find_provider_match),
+        patch.object(music.mass, "get_provider", return_value=qobuz_provider),
+    ):
+        await music.tracks.enrich_provider_mappings(
+            source,
+            # the search is narrowed to qobuz only, but the source's own album may still
+            # live on spotify, which remains part of the caller's wider allowed snapshot
+            provider_instance_ids={"qobuz_1"},
+            evidence_provider_instances={"qobuz_1", "spotify_1"},
+        )
+
+    get_full_track_album.assert_awaited_once_with(
+        source, allowed_provider_instances={"qobuz_1", "spotify_1"}
+    )
+    assert find_provider_match.call_args.kwargs["allowed_provider_instances"] == {
+        "qobuz_1",
+        "spotify_1",
+    }
+
+
+async def test_enrich_provider_mappings_defaults_evidence_scope_to_search_scope(
+    music: MusicController,
+) -> None:
+    """Without an explicit evidence scope, hydration still respects the search scope."""
+    source = create_track("spotify_1", "source")
+    qobuz_provider = MagicMock(spec=MusicProvider)
+    qobuz_provider.name = "Qobuz"
+    qobuz_provider.instance_id = "qobuz_1"
+    qobuz_provider.domain = "qobuz"
+    qobuz_provider.available = True
+    qobuz_provider.is_streaming_provider = True
+    get_full_track_album = AsyncMock(return_value=None)
+    find_provider_match = AsyncMock(return_value=TrackProviderMatchResult())
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "_get_full_track_album", get_full_track_album),
+        patch.object(music.tracks, "find_provider_match", find_provider_match),
+        patch.object(music.mass, "get_provider", return_value=qobuz_provider),
+    ):
+        await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+        )
+
+    get_full_track_album.assert_awaited_once_with(source, allowed_provider_instances={"qobuz_1"})
+
+
 async def test_enrich_provider_mappings_does_not_substitute_unavailable_instance(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -1,7 +1,7 @@
 """Tests for the tracks controller."""
 
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -1728,6 +1728,42 @@ async def test_enrich_provider_mappings_reports_fully_unloaded_allowed_provider(
     find_match.assert_not_awaited()
     assert result.failed_providers == ("qobuz_1",)
     assert failed_provider_instances == {"qobuz_1"}
+
+
+def test_get_provider_mapping_breaks_quality_ties_deterministically() -> None:
+    """Equal-quality domain mappings resolve to the same one regardless of set order."""
+    provider = MagicMock(spec=MusicProvider)
+    provider.instance_id = "qobuz_3"
+    provider.domain = "qobuz"
+    # both mappings share the same quality and neither is unique, so only the
+    # identity tie-breaker (domain, instance, item id) can decide between them
+    mapping_a = ProviderMapping(
+        item_id="track_a",
+        provider_domain="qobuz",
+        provider_instance="qobuz_1",
+        audio_format=AudioFormat(),
+    )
+    mapping_b = ProviderMapping(
+        item_id="track_b",
+        provider_domain="qobuz",
+        provider_instance="qobuz_2",
+        audio_format=AudioFormat(),
+    )
+    # a real set's iteration order is stable within one process regardless of
+    # insertion order, so a plain list is used here to control the input order
+    # directly and prove the tie-break, not just the incidental set layout
+    track_forward = create_track("spotify_1", "source")
+    track_forward.provider_mappings = cast("set[ProviderMapping]", [mapping_a, mapping_b])
+    track_reversed = create_track("spotify_1", "source")
+    track_reversed.provider_mappings = cast("set[ProviderMapping]", [mapping_b, mapping_a])
+
+    resolved_forward = TracksController._get_provider_mapping(track_forward, provider)
+    resolved_reversed = TracksController._get_provider_mapping(track_reversed, provider)
+
+    assert resolved_forward is not None
+    assert resolved_forward.item_id == "track_a"
+    assert resolved_reversed is not None
+    assert resolved_reversed.item_id == "track_a"
 
 
 async def test_overwrite_update_keeps_artists_when_none_are_given(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -5,7 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
-from music_assistant_models.enums import ExternalID, MediaType, ProviderFeature
+from music_assistant_models.enums import ContentType, ExternalID, MediaType, ProviderFeature
 from music_assistant_models.errors import (
     InvalidDataError,
     MediaNotFoundError,
@@ -14,6 +14,7 @@ from music_assistant_models.errors import (
 )
 from music_assistant_models.media_items import (
     Artist,
+    AudioFormat,
     ItemMapping,
     ProviderMapping,
     SearchResults,
@@ -1157,6 +1158,72 @@ async def test_enrich_provider_mappings_prefers_stronger_match_within_same_domai
     assert result.matches == (exact_match,)
     assert exact_mapping in result.track.provider_mappings
     assert loose_mapping not in result.track.provider_mappings
+
+
+async def test_enrich_provider_mappings_prefers_higher_quality_among_compatible_ties(
+    music: MusicController,
+) -> None:
+    """Compatible top-tier matches on sibling accounts are resolved by mapping quality."""
+    source = create_track("spotify_1", "source")
+    # same ISRC on both, so the two candidates are compatible (same recording), not ambiguous
+    lossy_track = create_track("qobuz_1", "lossy-track")
+    lossy_mapping = next(iter(lossy_track.provider_mappings))
+    lossy_mapping.audio_format = AudioFormat(content_type=ContentType.MP3)
+    lossless_track = create_track("qobuz_2", "lossless-track")
+    lossless_mapping = next(iter(lossless_track.provider_mappings))
+    lossless_mapping.audio_format = AudioFormat(content_type=ContentType.FLAC)
+    first_provider = MagicMock(spec=MusicProvider)
+    first_provider.name = "Qobuz first"
+    first_provider.instance_id = "qobuz_1"
+    first_provider.domain = "qobuz"
+    first_provider.available = True
+    first_provider.is_streaming_provider = True
+    second_provider = MagicMock(spec=MusicProvider)
+    second_provider.name = "Qobuz second"
+    second_provider.instance_id = "qobuz_2"
+    second_provider.domain = "qobuz"
+    second_provider.available = True
+    second_provider.is_streaming_provider = True
+    # qobuz_1 sorts first and would win under a naive "first in iteration order" pick,
+    # even though qobuz_2's mapping is the higher-quality one
+    lossy_match = TrackProviderMatch(
+        track=lossy_track, mapping=lossy_mapping, confidence=TrackMatchConfidence.EXACT
+    )
+    lossless_match = TrackProviderMatch(
+        track=lossless_track, mapping=lossless_mapping, confidence=TrackMatchConfidence.EXACT
+    )
+    results = {
+        "qobuz_1": TrackProviderMatchResult(match=lossy_match),
+        "qobuz_2": TrackProviderMatchResult(match=lossless_match),
+    }
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(
+                side_effect=lambda _track, provider, **_kwargs: results[provider.instance_id]
+            ),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "qobuz_1": first_provider,
+                "qobuz_2": second_provider,
+            }[provider_instance_id],
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1", "qobuz_2"},
+        )
+
+    assert result.matches == (lossless_match,)
+    assert lossless_mapping in result.track.provider_mappings
+    assert lossy_mapping not in result.track.provider_mappings
 
 
 async def test_enrich_provider_mappings_treats_tied_conflicting_matches_as_ambiguous(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -676,6 +676,51 @@ async def test_find_provider_match_reports_ambiguous_loose_candidates(
     assert result.ambiguous is True
 
 
+async def test_tied_likely_matches_from_missing_evidence_are_ambiguous(
+    music: MusicController,
+) -> None:
+    """Tied LIKELY matches that disagree (e.g. explicit vs. clean) are ambiguous, not arbitrary."""
+    # the base track carries no explicitness metadata, so neither candidate is rejected
+    # against it individually - only comparing the candidates to each other exposes the conflict
+    base = create_track("spotify_1", "base", isrc="BASE")
+    explicit_version = create_track("qobuz_1", "explicit", isrc="EXPLICIT")
+    explicit_version.metadata.explicit = True
+    clean_version = create_track("qobuz_1", "clean", isrc="CLEAN")
+    clean_version.metadata.explicit = False
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[explicit_version, clean_version])),
+        ),
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(
+                side_effect=lambda item_id, *_args, **_kwargs: {
+                    "explicit": explicit_version,
+                    "clean": clean_version,
+                }[item_id]
+            ),
+        ),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+    ):
+        result = await music.tracks.find_provider_match(
+            base,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+        )
+
+    assert result.match is None
+    assert result.ambiguous is True
+
+
 def test_tied_loose_matches_require_pairwise_compatibility() -> None:
     """A middle-duration candidate can not make incompatible outer candidates look equivalent."""
     tracks = [
@@ -906,6 +951,80 @@ async def test_enrich_provider_mappings_tries_next_instance_after_miss(
     assert find_match.await_count == 2
     assert qobuz_mapping in result.track.provider_mappings
     assert result.matches == (match,)
+
+
+async def test_enrich_provider_mappings_rejects_incompatible_cross_provider_match(
+    music: MusicController,
+) -> None:
+    """A second provider's match that disagrees with an accepted one is ambiguous, not merged."""
+    source = create_track("spotify_1", "source")
+    # missing explicitness evidence on the source lets each candidate independently tie
+    # with it, but the two candidates plainly disagree with each other (explicit vs. clean)
+    qobuz_track = create_track("qobuz_1", "qobuz-track", isrc="QOBUZ")
+    qobuz_track.metadata.explicit = True
+    qobuz_mapping = next(iter(qobuz_track.provider_mappings))
+    deezer_track = create_track("deezer_1", "deezer-track", isrc="DEEZER")
+    deezer_track.metadata.explicit = False
+    deezer_mapping = next(iter(deezer_track.provider_mappings))
+    qobuz_provider = MagicMock(spec=MusicProvider)
+    qobuz_provider.name = "Qobuz"
+    qobuz_provider.instance_id = "qobuz_1"
+    qobuz_provider.domain = "qobuz"
+    qobuz_provider.available = True
+    qobuz_provider.is_streaming_provider = True
+    deezer_provider = MagicMock(spec=MusicProvider)
+    deezer_provider.name = "Deezer"
+    deezer_provider.instance_id = "deezer_1"
+    deezer_provider.domain = "deezer"
+    deezer_provider.available = True
+    deezer_provider.is_streaming_provider = True
+    qobuz_match = TrackProviderMatch(
+        track=qobuz_track, mapping=qobuz_mapping, confidence=TrackMatchConfidence.LIKELY
+    )
+    deezer_match = TrackProviderMatch(
+        track=deezer_track, mapping=deezer_mapping, confidence=TrackMatchConfidence.LIKELY
+    )
+    results = {
+        "qobuz_1": TrackProviderMatchResult(match=qobuz_match),
+        "deezer_1": TrackProviderMatchResult(match=deezer_match),
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(
+                side_effect=lambda _track, provider, **_kwargs: results[provider.instance_id]
+            ),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "qobuz_1": qobuz_provider,
+                "deezer_1": deezer_provider,
+            }[provider_instance_id],
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1", "deezer_1"},
+        )
+
+    assert result.matches == (deezer_match,)
+    assert "Qobuz" in result.ambiguous_providers
+    assert qobuz_mapping not in result.track.provider_mappings
+    assert deezer_mapping in result.track.provider_mappings
 
 
 async def test_enrich_provider_mappings_filters_inaccessible_source_mappings(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -404,13 +404,82 @@ async def test_match_confidence_hydrates_album_after_initial_no_match(
         "_get_full_track_album",
         AsyncMock(side_effect=(base_album, candidate_album)),
     ):
-        confidence, _ = await music.tracks._get_match_confidence(
+        confidence, _, _ = await music.tracks._get_match_confidence(
             base,
             candidate,
             None,
         )
 
     assert confidence == TrackMatchConfidence.EXACT
+
+
+async def test_matches_compatible_reuses_hydrated_album_evidence(
+    music: MusicController,
+) -> None:
+    """
+    Two independently EXACT candidates are compatible via reused album evidence.
+
+    Neither is treated as ambiguous against the other for lacking that same
+    evidence in their raw (unhydrated) track.album references.
+    """
+    base = create_track("spotify_1", "base", duration=200)
+    qobuz_candidate = create_track("qobuz_1", "candidate-q", duration=210)
+    deezer_candidate = create_track("deezer_1", "candidate-d", duration=210)
+    base.disc_number = qobuz_candidate.disc_number = deezer_candidate.disc_number = 1
+    base.track_number = qobuz_candidate.track_number = deezer_candidate.track_number = 1
+    mb_album_id = {(ExternalID.MB_ALBUM, "11111111-1111-1111-1111-111111111111")}
+    base_album = create_album("spotify_1", "base-album", name="Album", external_ids=mb_album_id)
+    qobuz_album = create_album("qobuz_1", "qobuz-album", name="Album", external_ids=mb_album_id)
+    deezer_album = create_album("deezer_1", "deezer-album", name="Album", external_ids=mb_album_id)
+    for track, album in (
+        (base, base_album),
+        (qobuz_candidate, qobuz_album),
+        (deezer_candidate, deezer_album),
+    ):
+        track.album = ItemMapping(
+            item_id=album.item_id,
+            provider=album.provider,
+            name=album.name,
+            media_type=MediaType.ALBUM,
+        )
+
+    with patch.object(
+        music.tracks,
+        "_get_full_track_album",
+        AsyncMock(side_effect=(base_album, qobuz_album, deezer_album)),
+    ):
+        (
+            qobuz_confidence,
+            resolved_base_album,
+            qobuz_match_album,
+        ) = await music.tracks._get_match_confidence(base, qobuz_candidate, None)
+        deezer_confidence, _, deezer_match_album = await music.tracks._get_match_confidence(
+            base, deezer_candidate, resolved_base_album
+        )
+
+    assert qobuz_confidence == TrackMatchConfidence.EXACT
+    assert deezer_confidence == TrackMatchConfidence.EXACT
+
+    qobuz_match = TrackProviderMatch(
+        track=qobuz_candidate,
+        mapping=next(iter(qobuz_candidate.provider_mappings)),
+        confidence=qobuz_confidence,
+        album=qobuz_match_album,
+    )
+    deezer_match = TrackProviderMatch(
+        track=deezer_candidate,
+        mapping=next(iter(deezer_candidate.provider_mappings)),
+        confidence=deezer_confidence,
+        album=deezer_match_album,
+    )
+
+    # both candidates are the authoritative release on the base track, so they
+    # must also compare as compatible with each other - without the hydrated
+    # album evidence, the tracks' raw (unhydrated) `.album` references alone
+    # cannot prove this and would be falsely reported ambiguous
+    assert music.tracks._matches_are_compatible(
+        [qobuz_match, deezer_match], TrackMatchConfidence.EXACT
+    )
 
 
 @pytest.mark.parametrize(
@@ -994,6 +1063,7 @@ async def test_find_provider_match_checks_every_artist_credit_query(
                 side_effect=lambda _base, _candidate, base_album, **_kw: (
                     TrackMatchConfidence.EXACT,
                     base_album,
+                    None,
                 )
             ),
         ),
@@ -1199,6 +1269,7 @@ async def test_search_result_with_asymmetric_composite_credit_is_hydrated(
                 side_effect=lambda _base, _candidate, base_album, **_kw: (
                     TrackMatchConfidence.EXACT,
                     base_album,
+                    None,
                 )
             ),
         ),

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -416,12 +416,7 @@ async def test_match_confidence_hydrates_album_after_initial_no_match(
 async def test_matches_compatible_reuses_hydrated_album_evidence(
     music: MusicController,
 ) -> None:
-    """
-    Two independently EXACT candidates are compatible via reused album evidence.
-
-    Neither is treated as ambiguous against the other for lacking that same
-    evidence in their raw (unhydrated) track.album references.
-    """
+    """Hydrated album evidence is reused when comparing EXACT candidates."""
     base = create_track("spotify_1", "base", duration=200)
     qobuz_candidate = create_track("qobuz_1", "candidate-q", duration=210)
     deezer_candidate = create_track("deezer_1", "candidate-d", duration=210)
@@ -473,10 +468,7 @@ async def test_matches_compatible_reuses_hydrated_album_evidence(
         album=deezer_match_album,
     )
 
-    # both candidates are the authoritative release on the base track, so they
-    # must also compare as compatible with each other - without the hydrated
-    # album evidence, the tracks' raw (unhydrated) `.album` references alone
-    # cannot prove this and would be falsely reported ambiguous
+    # Reused album evidence keeps the two EXACT candidates compatible.
     assert music.tracks._matches_are_compatible(
         [qobuz_match, deezer_match], TrackMatchConfidence.EXACT
     )
@@ -586,8 +578,7 @@ async def test_full_track_album_domain_reference_expands_past_incidentally_allow
     """A domain reference keeps expanding even when it happens to resolve to an allowed instance."""
     track = create_track("spotify_1", "track")
     track.album = ItemMapping(
-        # a domain, not an instance id - the registry happens to resolve it to an
-        # instance that is itself allowed, which must not stop expansion to siblings
+        # This is a domain reference, so sibling expansion must still happen.
         item_id="album",
         provider="qobuz",
         name="Album",
@@ -609,8 +600,7 @@ async def test_full_track_album_domain_reference_expands_past_incidentally_allow
         _item_id: str, instance_id: str, **_kwargs: Any
     ) -> Album:
         if instance_id == "qobuz_1":
-            # this account no longer has the album - qobuz_2 must still be tried
-            # even though qobuz_1 was itself an allowed instance
+            # A miss on qobuz_1 must not stop qobuz_2 from being tried.
             raise MediaNotFoundError("gone")
         return album
 
@@ -654,8 +644,7 @@ async def test_full_track_album_domain_only_falls_back_after_instance_failure(
     qobuz_3 = MagicMock(spec=MusicProvider)
     qobuz_3.instance_id = "qobuz_3"
     qobuz_3.domain = "qobuz"
-    # the bare "qobuz" domain resolves to an instance the user is not allowed to
-    # use, forcing expansion across the allowed instances of that same domain
+    # The bare domain resolves to a disallowed instance, so allowed siblings must be tried.
     providers = {"qobuz": qobuz_3, "qobuz_1": qobuz_1, "qobuz_2": qobuz_2, "qobuz_3": qobuz_3}
     album = create_album("qobuz_2", "album", name="Album")
 
@@ -664,8 +653,7 @@ async def test_full_track_album_domain_only_falls_back_after_instance_failure(
 
     async def albums_get_side_effect(_item_id: str, instance_id: str, **_kwargs: Any) -> Album:
         if instance_id == "qobuz_1":
-            # this account no longer has the album - a sibling instance must still
-            # be tried instead of falling back to the unhydrated mapping right away
+            # A miss on qobuz_1 must still allow a sibling lookup.
             raise MediaNotFoundError("gone")
         return album
 
@@ -693,9 +681,7 @@ async def test_full_track_album_domain_reference_does_not_expand_for_non_streami
     """A non-streaming domain's ids are instance-local, so siblings must not be tried."""
     track = create_track("spotify_1", "track")
     track.album = ItemMapping(
-        # a domain, not an instance id - filesystem item ids are only meaningful
-        # within the instance that minted them, so a same-domain sibling with a
-        # coincidentally-matching id must never be trusted as the same album
+        # Filesystem item IDs are instance-local, so siblings must not be tried.
         item_id="album",
         provider="filesystem",
         name="Album",
@@ -899,8 +885,7 @@ async def test_library_mapping_does_not_preempt_exact_provider_search(
     assert result.match is not None
     assert result.match.track.item_id == "exact"
     assert result.match.confidence == TrackMatchConfidence.EXACT
-    # the second artist-credit query still runs and fails transiently, but the
-    # already-found exact candidate is kept rather than raising
+    # A later query failure must not discard the earlier EXACT match.
     assert search_provider.await_count == 2
 
 
@@ -1080,9 +1065,7 @@ async def test_find_provider_match_skips_known_dead_search_result(
     )
     base = create_track("spotify_1", "base", isrc="USRC17607839")
     base.external_ids.add(mb_track)
-    # this search result carries the exact (instance, item id) a caller already
-    # authoritatively confirmed dead moments ago - a stale cached hit must not
-    # resurrect it as a confident substitute
+    # A caller-confirmed dead mapping must not be revived by a stale search hit.
     dead = create_track("qobuz_1", "dead", isrc="USRC17607839")
     dead.external_ids.add(mb_track)
     provider = MagicMock()
@@ -1154,8 +1137,7 @@ async def test_find_provider_match_checks_every_artist_credit_query(
                 }[item_id]
             ),
         ),
-        # both candidates independently tie the base track at EXACT confidence, so a
-        # single artist-credit query must not decide the outcome on its own
+        # One artist-credit query alone must not decide between tied EXACT candidates.
         patch.object(
             music.tracks,
             "_get_match_confidence",
@@ -1240,14 +1222,7 @@ async def test_find_provider_match_keeps_fallback_after_later_timeout(
 async def test_find_provider_match_raises_on_later_hydration_failure(
     music: MusicController,
 ) -> None:
-    """
-    A hydration failure mid-loop must propagate rather than silently truncate.
-
-    Unlike a search-request failure (which only loses queries not yet attempted),
-    a failed hydration still leaves unseen candidates - possibly stronger or
-    ambiguity-triggering ones - among the already-fetched search results, so an
-    already-accepted candidate must not be returned as if evaluation completed.
-    """
+    """Mid-loop hydration failures propagate instead of truncating candidate evaluation."""
     base = create_track("spotify_1", "base")
     candidate = create_track("qobuz_1", "candidate")
     failing_candidate = create_track("qobuz_1", "failing")
@@ -2376,9 +2351,7 @@ async def test_enrich_provider_mappings_accepts_stronger_match_despite_weaker_ti
 ) -> None:
     """A confident, strictly stronger match is accepted despite a weaker unresolved tie."""
     source = create_track("spotify_1", "source")
-    # qobuz's own candidates only tied ambiguously at LOOSE, which is weaker evidence
-    # than deezer's confident EXACT match - the stronger, uncontested match should
-    # still be trusted since it isn't the tier that was actually left unresolved
+    # A weaker unresolved tier must not block a stronger uncontested match.
     deezer_track = create_track("deezer_1", "deezer-track")
     deezer_mapping = next(iter(deezer_track.provider_mappings))
     qobuz_provider = MagicMock(spec=MusicProvider)
@@ -2445,8 +2418,7 @@ async def test_enrich_provider_mappings_prefers_higher_confidence_over_visitatio
 ) -> None:
     """A later provider's stronger match wins over an earlier, weaker, conflicting one."""
     source = create_track("spotify_1", "source")
-    # "aaa" is visited first (alphabetically) but only ties at LOOSE, while the
-    # conflicting "zzz" match is visited later yet is a much stronger EXACT hit
+    # Visitation order must not outrank match confidence.
     loose_track = create_track("aaa_1", "loose-track", isrc="LOOSE")
     loose_track.metadata.explicit = True
     loose_mapping = next(iter(loose_track.provider_mappings))
@@ -2519,14 +2491,14 @@ async def test_enrich_provider_mappings_stops_at_ambiguous_top_tier(
 ) -> None:
     """A conflicting top tier blocks a weaker, otherwise-clean, tier from being accepted."""
     source = create_track("spotify_1", "source")
-    # qobuz and deezer tie at the strongest tier (EXACT) but disagree with each other
+    # Qobuz and Deezer disagree at the strongest tier.
     qobuz_track = create_track("qobuz_1", "qobuz-track", isrc="QOBUZ")
     qobuz_track.metadata.explicit = True
     qobuz_mapping = next(iter(qobuz_track.provider_mappings))
     deezer_track = create_track("deezer_1", "deezer-track", isrc="DEEZER")
     deezer_track.metadata.explicit = False
     deezer_mapping = next(iter(deezer_track.provider_mappings))
-    # aaa is a single, internally-consistent match, but only at a weaker tier (LIKELY)
+    # Aaa is clean, but only at a weaker tier.
     aaa_track = create_track("aaa_1", "aaa-track", isrc="AAA")
     aaa_mapping = next(iter(aaa_track.provider_mappings))
     qobuz_provider = MagicMock(spec=MusicProvider)
@@ -2595,8 +2567,7 @@ async def test_enrich_provider_mappings_stops_at_ambiguous_top_tier(
             provider_instance_ids={"qobuz_1", "deezer_1", "aaa_1"},
         )
 
-    # the conflicting EXACT tier can't be resolved, and a weaker LIKELY match doesn't
-    # settle which EXACT candidate was right - it must not be substituted in instead
+    # A weaker LIKELY match cannot break an unresolved EXACT tie.
     assert result.matches == ()
     assert set(result.ambiguous_providers) == {"Qobuz", "Deezer"}
     assert "Aaa" not in result.ambiguous_providers
@@ -2895,13 +2866,7 @@ def test_get_provider_mapping_breaks_quality_ties_deterministically() -> None:
 
 
 def test_get_provider_mapping_non_streaming_default_is_unique() -> None:
-    """
-    A mapping with unset ``is_unique`` from a non-streaming provider is not expanded.
-
-    ``is_unique=None`` means "use the provider's default", and non-streaming
-    providers (filesystem, plex) default to instance-unique - the same effective
-    uniqueness rule ``MusicProvider._check_provider_mappings`` already applies.
-    """
+    """Unset ``is_unique`` stays instance-unique for non-streaming providers."""
     provider = MagicMock(spec=MusicProvider)
     provider.instance_id = "filesystem_2"
     provider.domain = "filesystem"
@@ -2919,8 +2884,7 @@ def test_get_provider_mapping_non_streaming_default_is_unique() -> None:
 
     resolved = TracksController._get_provider_mapping(track, provider)
 
-    # this instance's own filesystem library has no mapping for this track - a
-    # sibling instance's mapping must not be reused as if it were portable
+    # A sibling filesystem mapping must not be reused as portable.
     assert resolved is None
 
 

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -486,6 +486,64 @@ async def test_library_mapping_does_not_preempt_exact_provider_search(
     assert search_provider.await_count == 1
 
 
+async def test_exact_mapped_candidate_still_checked_against_search_results(
+    music: MusicController,
+) -> None:
+    """An already-exact mapped candidate does not skip the search-based comparison."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    source = create_track("spotify_1", "source")
+    source.external_ids.add(mb_track)
+    library_track = create_track("spotify_1", "library")
+    mapped_candidate = create_track("qobuz_1", "mapped")
+    mapped_candidate.external_ids.add(mb_track)
+    library_track.provider_mappings.add(next(iter(mapped_candidate.provider_mappings)))
+    likely_candidate = create_track("qobuz_1", "likely", isrc="OTHER")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+    candidates = {
+        "mapped": mapped_candidate,
+        "likely": likely_candidate,
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(side_effect=lambda item_id, *_args, **_kwargs: candidates[item_id]),
+        ),
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[likely_candidate])),
+        ) as search_provider,
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+            mapping_source=library_track,
+            allowed_provider_instances={"qobuz_1"},
+        )
+
+    # the mapped candidate is already exact (shared mb_track), but search must still run
+    # so a conflicting or better candidate isn't silently missed
+    assert search_provider.await_count == 1
+    assert result.match is not None
+    assert result.match.track.item_id == "mapped"
+    assert result.match.confidence == TrackMatchConfidence.EXACT
+
+
 async def test_find_provider_match_prefers_exact_candidate(
     music: MusicController,
 ) -> None:
@@ -1442,6 +1500,37 @@ async def test_enrich_provider_mappings_stops_after_provider_failure(
     assert find_match.await_count == 1
     assert first_result.failed_providers == ("Qobuz",)
     assert second_result.failed_providers == ()
+
+
+async def test_enrich_provider_mappings_reports_unavailable_allowed_provider(
+    music: MusicController,
+) -> None:
+    """An allowed instance that is currently unreachable is reported, not silently skipped."""
+    source = create_track("spotify_1", "source")
+    provider = MagicMock(spec=MusicProvider)
+    provider.name = "Qobuz"
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.available = False
+    provider.is_streaming_provider = True
+    failed_provider_instances: set[str] = set()
+
+    with (
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "find_provider_match", AsyncMock()) as find_match,
+        patch.object(music.mass, "get_provider", return_value=provider),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1"},
+            failed_provider_instances=failed_provider_instances,
+        )
+
+    # never queried - the caller should still learn this instance couldn't be tried
+    find_match.assert_not_awaited()
+    assert result.failed_providers == ("Qobuz",)
+    assert failed_provider_instances == {"qobuz_1"}
 
 
 async def test_overwrite_update_keeps_artists_when_none_are_given(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -1740,6 +1740,145 @@ async def test_enrich_provider_mappings_treats_conflicting_exact_release_evidenc
     assert deezer_mapping not in result.track.provider_mappings
 
 
+async def test_enrich_provider_mappings_rejects_weaker_match_when_stronger_tier_is_ambiguous(
+    music: MusicController,
+) -> None:
+    """A provider's own unresolved tie at a higher tier blocks a weaker confident match."""
+    source = create_track("spotify_1", "source")
+    # qobuz's own candidates tied ambiguously at EXACT and were discarded entirely, so
+    # deezer's confident but merely LIKELY match must not be quietly accepted in its
+    # place - that would substitute weaker, uncontested-looking evidence for a
+    # disagreement that was never actually resolved
+    deezer_track = create_track("deezer_1", "deezer-track")
+    deezer_mapping = next(iter(deezer_track.provider_mappings))
+    qobuz_provider = MagicMock(spec=MusicProvider)
+    qobuz_provider.name = "Qobuz"
+    qobuz_provider.instance_id = "qobuz_1"
+    qobuz_provider.domain = "qobuz"
+    qobuz_provider.available = True
+    qobuz_provider.is_streaming_provider = True
+    deezer_provider = MagicMock(spec=MusicProvider)
+    deezer_provider.name = "Deezer"
+    deezer_provider.instance_id = "deezer_1"
+    deezer_provider.domain = "deezer"
+    deezer_provider.available = True
+    deezer_provider.is_streaming_provider = True
+    deezer_match = TrackProviderMatch(
+        track=deezer_track, mapping=deezer_mapping, confidence=TrackMatchConfidence.LIKELY
+    )
+    results = {
+        "qobuz_1": TrackProviderMatchResult(
+            ambiguous=True, ambiguous_confidence=TrackMatchConfidence.EXACT
+        ),
+        "deezer_1": TrackProviderMatchResult(match=deezer_match),
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(
+                side_effect=lambda _track, provider, **_kwargs: results[provider.instance_id]
+            ),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "qobuz_1": qobuz_provider,
+                "deezer_1": deezer_provider,
+            }[provider_instance_id],
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1", "deezer_1"},
+        )
+
+    assert result.matches == ()
+    assert set(result.ambiguous_providers) == {"Qobuz", "Deezer"}
+    assert deezer_mapping not in result.track.provider_mappings
+
+
+async def test_enrich_provider_mappings_accepts_stronger_match_despite_weaker_tier_ambiguity(
+    music: MusicController,
+) -> None:
+    """A confident, strictly stronger match is accepted despite a weaker unresolved tie."""
+    source = create_track("spotify_1", "source")
+    # qobuz's own candidates only tied ambiguously at LOOSE, which is weaker evidence
+    # than deezer's confident EXACT match - the stronger, uncontested match should
+    # still be trusted since it isn't the tier that was actually left unresolved
+    deezer_track = create_track("deezer_1", "deezer-track")
+    deezer_mapping = next(iter(deezer_track.provider_mappings))
+    qobuz_provider = MagicMock(spec=MusicProvider)
+    qobuz_provider.name = "Qobuz"
+    qobuz_provider.instance_id = "qobuz_1"
+    qobuz_provider.domain = "qobuz"
+    qobuz_provider.available = True
+    qobuz_provider.is_streaming_provider = True
+    deezer_provider = MagicMock(spec=MusicProvider)
+    deezer_provider.name = "Deezer"
+    deezer_provider.instance_id = "deezer_1"
+    deezer_provider.domain = "deezer"
+    deezer_provider.available = True
+    deezer_provider.is_streaming_provider = True
+    deezer_match = TrackProviderMatch(
+        track=deezer_track, mapping=deezer_mapping, confidence=TrackMatchConfidence.EXACT
+    )
+    results = {
+        "qobuz_1": TrackProviderMatchResult(
+            ambiguous=True, ambiguous_confidence=TrackMatchConfidence.LOOSE
+        ),
+        "deezer_1": TrackProviderMatchResult(match=deezer_match),
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(
+                side_effect=lambda _track, provider, **_kwargs: results[provider.instance_id]
+            ),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "qobuz_1": qobuz_provider,
+                "deezer_1": deezer_provider,
+            }[provider_instance_id],
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_1", "deezer_1"},
+        )
+
+    assert result.matches == (deezer_match,)
+    assert result.ambiguous_providers == ("Qobuz",)
+    assert deezer_mapping in result.track.provider_mappings
+
+
 async def test_enrich_provider_mappings_prefers_higher_confidence_over_visitation_order(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -735,6 +735,58 @@ async def test_full_track_album_domain_reference_does_not_expand_for_non_streami
     assert result is track.album
 
 
+async def test_full_track_album_domain_only_falls_back_after_invalid_provider_id(
+    music: MusicController,
+) -> None:
+    """A malformed candidate id does not abort the search for a sibling instance."""
+    track = create_track("spotify_1", "track")
+    track.album = ItemMapping(
+        item_id="album",
+        provider="qobuz",
+        name="Album",
+        media_type=MediaType.ALBUM,
+    )
+    qobuz_1 = MagicMock(spec=MusicProvider)
+    qobuz_1.instance_id = "qobuz_1"
+    qobuz_1.domain = "qobuz"
+    qobuz_2 = MagicMock(spec=MusicProvider)
+    qobuz_2.instance_id = "qobuz_2"
+    qobuz_2.domain = "qobuz"
+    providers = {"qobuz": qobuz_1, "qobuz_1": qobuz_1, "qobuz_2": qobuz_2}
+    album = create_album("qobuz_2", "album", name="Album")
+
+    def get_provider(provider_instance_or_domain: str, **_kwargs: Any) -> MusicProvider | None:
+        return providers.get(provider_instance_or_domain)
+
+    async def get_provider_item_side_effect(
+        _item_id: str, instance_id: str, **_kwargs: Any
+    ) -> Album:
+        if instance_id == "qobuz_1":
+            # this id was reconstructed from imported M3U metadata and is malformed
+            # on this instance - qobuz_2 must still be tried, not abort the search
+            raise InvalidProviderID("Malformed id")
+        return album
+
+    with (
+        patch.object(music.mass, "get_provider", side_effect=get_provider),
+        patch.object(music.albums, "get_library_item_by_prov_id", AsyncMock(return_value=None)),
+        patch.object(
+            music.albums,
+            "get_provider_item",
+            AsyncMock(side_effect=get_provider_item_side_effect),
+        ) as get_,
+    ):
+        result = await music.tracks._get_full_track_album(
+            track, allowed_provider_instances={"qobuz_1", "qobuz_2"}
+        )
+
+    assert result is album
+    assert get_.await_args_list == [
+        call("album", "qobuz_1", allow_fallback=False, strict_provider_instance=True),
+        call("album", "qobuz_2", allow_fallback=False, strict_provider_instance=True),
+    ]
+
+
 async def test_find_provider_match_classifies_library_mapping_against_source(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -1834,6 +1834,94 @@ async def test_enrich_provider_mappings_treats_conflicting_exact_release_evidenc
     assert deezer_mapping not in result.track.provider_mappings
 
 
+async def test_enrich_provider_mappings_same_domain_tie_blocks_weaker_cross_domain_match(
+    music: MusicController,
+) -> None:
+    """An unresolved same-domain tie at EXACT blocks a weaker match from another domain."""
+    source = create_track("spotify_1", "source")
+    # two personal accounts on the same domain each independently match as EXACT but
+    # reference a different MusicBrainz release track, so _select_best_match_per_domain
+    # discards both as an unresolved same-domain tie - deezer's confident but merely
+    # LIKELY match must not be quietly accepted in their place afterwards
+    qobuz_a_track = create_track("qobuz_a", "qobuz-a-track")
+    qobuz_a_track.external_ids.add((ExternalID.MB_TRACK, "11111111-1111-1111-1111-111111111111"))
+    qobuz_a_mapping = next(iter(qobuz_a_track.provider_mappings))
+    qobuz_b_track = create_track("qobuz_b", "qobuz-b-track")
+    qobuz_b_track.external_ids.add((ExternalID.MB_TRACK, "22222222-2222-2222-2222-222222222222"))
+    qobuz_b_mapping = next(iter(qobuz_b_track.provider_mappings))
+    deezer_track = create_track("deezer_1", "deezer-track")
+    deezer_mapping = next(iter(deezer_track.provider_mappings))
+    qobuz_a_provider = MagicMock(spec=MusicProvider)
+    qobuz_a_provider.name = "Qobuz A"
+    qobuz_a_provider.instance_id = "qobuz_a"
+    qobuz_a_provider.domain = "qobuz"
+    qobuz_a_provider.available = True
+    qobuz_a_provider.is_streaming_provider = True
+    qobuz_b_provider = MagicMock(spec=MusicProvider)
+    qobuz_b_provider.name = "Qobuz B"
+    qobuz_b_provider.instance_id = "qobuz_b"
+    qobuz_b_provider.domain = "qobuz"
+    qobuz_b_provider.available = True
+    qobuz_b_provider.is_streaming_provider = True
+    deezer_provider = MagicMock(spec=MusicProvider)
+    deezer_provider.name = "Deezer"
+    deezer_provider.instance_id = "deezer_1"
+    deezer_provider.domain = "deezer"
+    deezer_provider.available = True
+    deezer_provider.is_streaming_provider = True
+    qobuz_a_match = TrackProviderMatch(
+        track=qobuz_a_track, mapping=qobuz_a_mapping, confidence=TrackMatchConfidence.EXACT
+    )
+    qobuz_b_match = TrackProviderMatch(
+        track=qobuz_b_track, mapping=qobuz_b_mapping, confidence=TrackMatchConfidence.EXACT
+    )
+    deezer_match = TrackProviderMatch(
+        track=deezer_track, mapping=deezer_mapping, confidence=TrackMatchConfidence.LIKELY
+    )
+    results = {
+        "qobuz_a": TrackProviderMatchResult(match=qobuz_a_match),
+        "qobuz_b": TrackProviderMatchResult(match=qobuz_b_match),
+        "deezer_1": TrackProviderMatchResult(match=deezer_match),
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(
+                side_effect=lambda _track, provider, **_kwargs: results[provider.instance_id]
+            ),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "qobuz_a": qobuz_a_provider,
+                "qobuz_b": qobuz_b_provider,
+                "deezer_1": deezer_provider,
+            }[provider_instance_id],
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"qobuz_a", "qobuz_b", "deezer_1"},
+        )
+
+    assert result.matches == ()
+    assert "Deezer" in result.ambiguous_providers
+    assert deezer_mapping not in result.track.provider_mappings
+
+
 async def test_enrich_provider_mappings_rejects_weaker_match_when_stronger_tier_is_ambiguous(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -8,6 +8,7 @@ import pytest
 from music_assistant_models.enums import ContentType, ExternalID, MediaType, ProviderFeature
 from music_assistant_models.errors import (
     InvalidDataError,
+    InvalidProviderID,
     MediaNotFoundError,
     ProviderUnavailableError,
     ResourceTemporarilyUnavailable,
@@ -848,6 +849,58 @@ async def test_find_provider_match_prefers_exact_candidate(
     )
 
 
+async def test_find_provider_match_skips_search_result_with_malformed_id(
+    music: MusicController,
+) -> None:
+    """A search result with a malformed id is skipped, other candidates still resolve."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    base = create_track("spotify_1", "base", isrc="USRC17607839")
+    base.external_ids.add(mb_track)
+    malformed = create_track("qobuz_1", "malformed", isrc="MALFORMED")
+    exact = create_track("qobuz_1", "exact", isrc="USRC17607839")
+    exact.provider = "qobuz"
+    exact.external_ids.add(mb_track)
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    async def get_provider_item(item_id: str, *_args: object, **_kwargs: object) -> Track:
+        if item_id == "malformed":
+            # this candidate's own id no longer matches the provider's expected
+            # format (e.g. a provider like Yoto that validates id shape)
+            raise InvalidProviderID("Malformed id")
+        return exact
+
+    get_provider_item_mock = AsyncMock(side_effect=get_provider_item)
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[malformed, exact])),
+        ),
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            get_provider_item_mock,
+        ),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+    ):
+        result = await music.tracks.find_provider_match(
+            base,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LOOSE,
+        )
+
+    assert result.match is not None
+    assert result.match.track.item_id == "exact"
+    assert result.match.confidence == TrackMatchConfidence.EXACT
+
+
 async def test_find_provider_match_checks_every_artist_credit_query(
     music: MusicController,
 ) -> None:
@@ -1141,6 +1194,44 @@ async def test_find_provider_match_falls_through_search_after_invalid_mapped_can
             # resolving the trusted mapping directly - simulate a stale, unreadable
             # catalog entry rather than a confirmed removal
             raise InvalidDataError("Unreadable catalog entry")
+        return search_candidate
+
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[search_candidate])),
+        ),
+        patch.object(music.tracks, "get_provider_item", AsyncMock(side_effect=get_provider_item)),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+    ):
+        result = await music.tracks.find_provider_match(
+            source,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LIKELY,
+            trust_base_mapping=False,
+        )
+
+    assert result.match is not None
+
+
+async def test_find_provider_match_falls_through_search_after_malformed_mapped_candidate_id(
+    music: MusicController,
+) -> None:
+    """A malformed mapped candidate id falls through to search, instead of aborting."""
+    source = create_track("qobuz_1", "source")
+    search_candidate = create_track("qobuz_1", "found")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    async def get_provider_item(item_id: str, *_args: object, **_kwargs: object) -> Track:
+        if item_id == "source":
+            # the persisted mapping's own id no longer matches this provider's
+            # expected format (e.g. a provider like Yoto that validates id shape)
+            raise InvalidProviderID("Malformed id")
         return search_candidate
 
     with (
@@ -2522,6 +2613,36 @@ def test_get_provider_mapping_breaks_quality_ties_deterministically() -> None:
     assert resolved_forward.item_id == "track_a"
     assert resolved_reversed is not None
     assert resolved_reversed.item_id == "track_a"
+
+
+def test_get_provider_mapping_non_streaming_default_is_unique() -> None:
+    """
+    A mapping with unset ``is_unique`` from a non-streaming provider is not expanded.
+
+    ``is_unique=None`` means "use the provider's default", and non-streaming
+    providers (filesystem, plex) default to instance-unique - the same effective
+    uniqueness rule ``MusicProvider._check_provider_mappings`` already applies.
+    """
+    provider = MagicMock(spec=MusicProvider)
+    provider.instance_id = "filesystem_2"
+    provider.domain = "filesystem"
+    provider.is_streaming_provider = False
+    # is_unique left at its default (None) - as if the provider never set it,
+    # the same as most real non-streaming provider mappings in practice
+    mapping = ProviderMapping(
+        item_id="track_a",
+        provider_domain="filesystem",
+        provider_instance="filesystem_1",
+        audio_format=AudioFormat(),
+    )
+    track = create_track("spotify_1", "source")
+    track.provider_mappings = cast("set[ProviderMapping]", [mapping])
+
+    resolved = TracksController._get_provider_mapping(track, provider)
+
+    # this instance's own filesystem library has no mapping for this track - a
+    # sibling instance's mapping must not be reused as if it were portable
+    assert resolved is None
 
 
 async def test_overwrite_update_keeps_artists_when_none_are_given(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -663,7 +663,9 @@ async def test_library_mapping_does_not_preempt_exact_provider_search(
     assert result.match is not None
     assert result.match.track.item_id == "exact"
     assert result.match.confidence == TrackMatchConfidence.EXACT
-    assert search_provider.await_count == 1
+    # the second artist-credit query still runs and fails transiently, but the
+    # already-found exact candidate is kept rather than raising
+    assert search_provider.await_count == 2
 
 
 async def test_exact_mapped_candidate_still_checked_against_search_results(
@@ -778,6 +780,77 @@ async def test_find_provider_match_prefers_exact_candidate(
         call.args[1] == provider.instance_id and call.kwargs["strict_provider_instance"] is True
         for call in get_provider_item_mock.await_args_list
     )
+
+
+async def test_find_provider_match_checks_every_artist_credit_query(
+    music: MusicController,
+) -> None:
+    """An exact hit on the first artist-credit query must not skip later credited artists."""
+    base = create_track("spotify_1", "base")
+    base.artists.append(
+        ItemMapping(
+            item_id="other-artist",
+            provider="spotify_1",
+            name="Other Artist",
+            media_type=MediaType.ARTIST,
+        )
+    )
+    first_candidate = create_track("qobuz_1", "first")
+    second_candidate = create_track("qobuz_1", "second")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(
+                side_effect=(
+                    SearchResults(tracks=[first_candidate]),
+                    SearchResults(tracks=[second_candidate]),
+                )
+            ),
+        ) as search_provider,
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(
+                side_effect=lambda item_id, *_args, **_kwargs: {
+                    "first": first_candidate,
+                    "second": second_candidate,
+                }[item_id]
+            ),
+        ),
+        # both candidates independently tie the base track at EXACT confidence, so a
+        # single artist-credit query must not decide the outcome on its own
+        patch.object(
+            music.tracks,
+            "_get_match_confidence",
+            AsyncMock(
+                side_effect=lambda _base, _candidate, base_album, **_kw: (
+                    TrackMatchConfidence.EXACT,
+                    base_album,
+                )
+            ),
+        ),
+    ):
+        candidates = await music.tracks._search_provider_track_matches(
+            base,
+            provider,
+            TrackMatchConfidence.LOOSE,
+            None,
+            None,
+            True,
+            None,
+        )
+
+    # the second artist's query must still run, and its candidate must still be
+    # collected, even though the first query already produced an exact match
+    assert search_provider.await_count == 2
+    assert {match.track.item_id for _, match in candidates} == {"first", "second"}
 
 
 async def test_find_provider_match_keeps_fallback_after_later_timeout(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -309,6 +309,45 @@ async def test_find_provider_match_revalidates_untrusted_source_mapping(
     assert likely_result.match.confidence == TrackMatchConfidence.LIKELY
 
 
+async def test_find_provider_match_force_refreshes_untrusted_mapped_candidate(
+    music: MusicController,
+) -> None:
+    """An untrusted mapping is revalidated without trusting a stale cached candidate."""
+    source = create_track("qobuz_1", "source")
+    candidate = create_track("qobuz_1", "source")
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = set()
+    provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_provider_item",
+            AsyncMock(return_value=candidate),
+        ) as get_provider_item,
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await music.tracks.find_provider_match(source, provider, trust_base_mapping=False)
+        untrusted_call = get_provider_item.await_args
+        get_provider_item.reset_mock()
+
+        await music.tracks.find_provider_match(
+            source, provider, mapping_source=candidate, trust_base_mapping=True
+        )
+        trusted_call = get_provider_item.await_args
+
+    assert untrusted_call is not None
+    assert trusted_call is not None
+    assert untrusted_call.kwargs["force_refresh"] is True
+    assert trusted_call.kwargs["force_refresh"] is False
+
+
 async def test_match_confidence_hydrates_album_after_initial_no_match(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -901,6 +901,48 @@ async def test_find_provider_match_skips_search_result_with_malformed_id(
     assert result.match.confidence == TrackMatchConfidence.EXACT
 
 
+async def test_find_provider_match_skips_known_dead_search_result(
+    music: MusicController,
+) -> None:
+    """A search result matching a known-dead pair is never hydrated as a substitute."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    base = create_track("spotify_1", "base", isrc="USRC17607839")
+    base.external_ids.add(mb_track)
+    # this search result carries the exact (instance, item id) a caller already
+    # authoritatively confirmed dead moments ago - a stale cached hit must not
+    # resurrect it as a confident substitute
+    dead = create_track("qobuz_1", "dead", isrc="USRC17607839")
+    dead.external_ids.add(mb_track)
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    get_provider_item_mock = AsyncMock()
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[dead])),
+        ),
+        patch.object(music.tracks, "get_provider_item", get_provider_item_mock),
+        patch.object(music.tracks, "_get_full_track_album", AsyncMock(return_value=None)),
+    ):
+        result = await music.tracks.find_provider_match(
+            base,
+            provider,
+            minimum_confidence=TrackMatchConfidence.LOOSE,
+            known_dead_mappings=frozenset({("qobuz_1", "dead")}),
+        )
+
+    get_provider_item_mock.assert_not_awaited()
+    assert result.match is None
+
+
 async def test_find_provider_match_checks_every_artist_credit_query(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -1021,6 +1021,76 @@ async def test_find_provider_match_skips_invalid_data_search_candidate(
     assert result.match.track.item_id == good_candidate.item_id
 
 
+async def test_search_result_with_asymmetric_composite_credit_is_hydrated(
+    music: MusicController,
+) -> None:
+    """A search result whose artist credit is split differently is not pre-filtered out."""
+    base = create_track("spotify_1", "base")
+    # the base track carries one composite artist entry, as a third-party M3U would
+    base.artists = UniqueList(
+        [
+            Artist(
+                item_id="composite-artist",
+                provider="spotify_1",
+                name="Artist A, Artist B",
+                provider_mappings=set(),
+            )
+        ]
+    )
+    # the provider represents the same credit as two separate artists - a plain
+    # artist-list comparison never pairwise-matches this against the composite entry
+    search_result = create_track("qobuz_1", "candidate")
+    search_result.artists = UniqueList(
+        [
+            Artist(
+                item_id="artist-a", provider="qobuz_1", name="Artist A", provider_mappings=set()
+            ),
+            Artist(
+                item_id="artist-b", provider="qobuz_1", name="Artist B", provider_mappings=set()
+            ),
+        ]
+    )
+    provider = MagicMock()
+    provider.instance_id = "qobuz_1"
+    provider.domain = "qobuz"
+    provider.supported_features = {ProviderFeature.SEARCH}
+    provider.supported_media_types = {MediaType.TRACK}
+
+    get_provider_item = AsyncMock(return_value=search_result)
+    with (
+        patch.object(
+            music,
+            "search_provider",
+            AsyncMock(return_value=SearchResults(tracks=[search_result])),
+        ),
+        patch.object(music.tracks, "get_provider_item", get_provider_item),
+        patch.object(
+            music.tracks,
+            "_get_match_confidence",
+            AsyncMock(
+                side_effect=lambda _base, _candidate, base_album, **_kw: (
+                    TrackMatchConfidence.EXACT,
+                    base_album,
+                )
+            ),
+        ),
+    ):
+        candidates = await music.tracks._search_provider_track_matches(
+            base,
+            provider,
+            TrackMatchConfidence.LOOSE,
+            None,
+            None,
+            True,
+            None,
+        )
+
+    # the candidate must reach hydration (and the full evidence comparator) instead
+    # of being discarded by a plain artist-list pre-filter
+    get_provider_item.assert_awaited_once()
+    assert {match.track.item_id for _, match in candidates} == {"candidate"}
+
+
 async def test_find_provider_match_falls_through_search_after_invalid_mapped_candidate(
     music: MusicController,
 ) -> None:

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -380,8 +380,11 @@ async def test_match_confidence_hydrates_album_after_initial_no_match(
     candidate = create_track("qobuz_1", "candidate", duration=210)
     base.disc_number = candidate.disc_number = 1
     base.track_number = candidate.track_number = 1
-    base_album = create_album("spotify_1", "base-album", name="Album")
-    candidate_album = create_album("qobuz_1", "candidate-album", name="Album")
+    mb_album_id = {(ExternalID.MB_ALBUM, "11111111-1111-1111-1111-111111111111")}
+    base_album = create_album("spotify_1", "base-album", name="Album", external_ids=mb_album_id)
+    candidate_album = create_album(
+        "qobuz_1", "candidate-album", name="Album", external_ids=mb_album_id
+    )
     base.album = ItemMapping(
         item_id=base_album.item_id,
         provider=base_album.provider,

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -820,7 +820,7 @@ async def test_enrich_provider_mappings_uses_library_without_mutating_it(
     }
     assert library_track.provider_mappings == original_mappings
     assert result.matches == (qobuz_match, tidal_match)
-    get_full_track_album.assert_awaited_once_with(source)
+    get_full_track_album.assert_awaited_once_with(source, allowed_provider_instances=None)
 
 
 async def test_enrich_provider_mappings_skips_album_lookup_for_existing_domains(
@@ -953,10 +953,10 @@ async def test_enrich_provider_mappings_tries_next_instance_after_miss(
     assert result.matches == (match,)
 
 
-async def test_enrich_provider_mappings_rejects_incompatible_cross_provider_match(
+async def test_enrich_provider_mappings_treats_tied_conflicting_matches_as_ambiguous(
     music: MusicController,
 ) -> None:
-    """A second provider's match that disagrees with an accepted one is ambiguous, not merged."""
+    """Two same-confidence providers that disagree with each other are both ambiguous."""
     source = create_track("spotify_1", "source")
     # missing explicitness evidence on the source lets each candidate independently tie
     # with it, but the two candidates plainly disagree with each other (explicit vs. clean)
@@ -1021,10 +1021,12 @@ async def test_enrich_provider_mappings_rejects_incompatible_cross_provider_matc
             provider_instance_ids={"qobuz_1", "deezer_1"},
         )
 
-    assert result.matches == (deezer_match,)
-    assert "Qobuz" in result.ambiguous_providers
+    # neither can be trusted over the other at the same confidence - a tie-break
+    # would otherwise pick one arbitrarily based on which provider was visited first
+    assert result.matches == ()
+    assert set(result.ambiguous_providers) == {"Qobuz", "Deezer"}
     assert qobuz_mapping not in result.track.provider_mappings
-    assert deezer_mapping in result.track.provider_mappings
+    assert deezer_mapping not in result.track.provider_mappings
 
 
 async def test_enrich_provider_mappings_prefers_higher_confidence_over_visitation_order(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -1974,7 +1974,9 @@ async def test_enrich_provider_mappings_stops_after_provider_failure(
     assert failed_provider_instances == {"qobuz_1"}
     assert find_match.await_count == 1
     assert first_result.failed_providers == ("Qobuz",)
-    assert second_result.failed_providers == ()
+    # the second call skips querying (already confirmed failed) but must still report
+    # the instance as failed, or this entry would be misattributed as "no match found"
+    assert second_result.failed_providers == ("qobuz_1",)
 
 
 async def test_enrich_provider_mappings_reports_unavailable_allowed_provider(

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -1027,6 +1027,80 @@ async def test_enrich_provider_mappings_rejects_incompatible_cross_provider_matc
     assert deezer_mapping in result.track.provider_mappings
 
 
+async def test_enrich_provider_mappings_prefers_higher_confidence_over_visitation_order(
+    music: MusicController,
+) -> None:
+    """A later provider's stronger match wins over an earlier, weaker, conflicting one."""
+    source = create_track("spotify_1", "source")
+    # "aaa" is visited first (alphabetically) but only ties at LOOSE, while the
+    # conflicting "zzz" match is visited later yet is a much stronger EXACT hit
+    loose_track = create_track("aaa_1", "loose-track", isrc="LOOSE")
+    loose_track.metadata.explicit = True
+    loose_mapping = next(iter(loose_track.provider_mappings))
+    exact_track = create_track("zzz_1", "exact-track", isrc="EXACT")
+    exact_track.metadata.explicit = False
+    exact_mapping = next(iter(exact_track.provider_mappings))
+    loose_provider = MagicMock(spec=MusicProvider)
+    loose_provider.name = "Aaa"
+    loose_provider.instance_id = "aaa_1"
+    loose_provider.domain = "aaa"
+    loose_provider.available = True
+    loose_provider.is_streaming_provider = True
+    exact_provider = MagicMock(spec=MusicProvider)
+    exact_provider.name = "Zzz"
+    exact_provider.instance_id = "zzz_1"
+    exact_provider.domain = "zzz"
+    exact_provider.available = True
+    exact_provider.is_streaming_provider = True
+    loose_match = TrackProviderMatch(
+        track=loose_track, mapping=loose_mapping, confidence=TrackMatchConfidence.LOOSE
+    )
+    exact_match = TrackProviderMatch(
+        track=exact_track, mapping=exact_mapping, confidence=TrackMatchConfidence.EXACT
+    )
+    results = {
+        "aaa_1": TrackProviderMatchResult(match=loose_match),
+        "zzz_1": TrackProviderMatchResult(match=exact_match),
+    }
+
+    with (
+        patch.object(
+            music.tracks,
+            "get_library_match",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "_get_full_track_album",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            music.tracks,
+            "find_provider_match",
+            AsyncMock(
+                side_effect=lambda _track, provider, **_kwargs: results[provider.instance_id]
+            ),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "aaa_1": loose_provider,
+                "zzz_1": exact_provider,
+            }[provider_instance_id],
+        ),
+    ):
+        result = await music.tracks.enrich_provider_mappings(
+            source,
+            provider_instance_ids={"aaa_1", "zzz_1"},
+        )
+
+    assert result.matches == (exact_match,)
+    assert "Aaa" in result.ambiguous_providers
+    assert loose_mapping not in result.track.provider_mappings
+    assert exact_mapping in result.track.provider_mappings
+
+
 async def test_enrich_provider_mappings_filters_inaccessible_source_mappings(
     music: MusicController,
 ) -> None:

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -4,7 +4,7 @@ import sqlite3
 
 import pytest
 from music_assistant_models import media_items
-from music_assistant_models.enums import ExternalID
+from music_assistant_models.enums import ExternalID, MediaType
 
 from music_assistant.helpers import compare
 
@@ -69,6 +69,54 @@ def _track(
         provider_mappings={
             media_items.ProviderMapping(
                 item_id=item_id, provider_domain="test", provider_instance="test1"
+            )
+        },
+    )
+
+
+def _provider_track(
+    item_id: str,
+    provider: str,
+    *,
+    name: str = "Track",
+    version: str = "",
+    duration: int = 200,
+    album_name: str = "Album",
+    artist_names: tuple[str, ...] = ("Artist A",),
+    external_ids: set[tuple[ExternalID, str]] | None = None,
+) -> media_items.Track:
+    """Build a provider track for confidence comparisons."""
+    album = _album(
+        item_id=f"album-{item_id}",
+        provider=provider,
+        name=album_name,
+    )
+    return media_items.Track(
+        item_id=item_id,
+        provider=provider,
+        name=name,
+        version=version,
+        duration=duration,
+        disc_number=1,
+        track_number=1,
+        artists=media_items.UniqueList(
+            [
+                media_items.ItemMapping(
+                    item_id=f"artist-{index}",
+                    provider=provider,
+                    name=artist_name,
+                    media_type=MediaType.ARTIST,
+                )
+                for index, artist_name in enumerate(artist_names)
+            ]
+        ),
+        album=album,
+        external_ids=external_ids or set(),
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id=item_id,
+                provider_domain=provider,
+                provider_instance=provider,
             )
         },
     )
@@ -1212,6 +1260,427 @@ def test_compare_track_missing_disc_number_assumes_disc_one() -> None:
     disc_two = _albumtrack("3", "test2", disc_number=2)
     disc_two.duration = 320
     assert compare.compare_track(untagged, disc_two) is False
+
+
+def test_compare_track_evidence_ranks_release_and_recording_matches() -> None:
+    """Exact-release evidence outranks the same recording on another album."""
+    base = _provider_track("base", "provider_a")
+    exact = _provider_track("exact", "provider_b")
+    alternate_release = _provider_track(
+        "alternate",
+        "provider_b",
+        album_name="Compilation",
+    )
+
+    assert compare.compare_track_evidence(base, exact) == compare.TrackMatchConfidence.EXACT
+    assert (
+        compare.compare_track_evidence(base, alternate_release)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+
+
+def test_compare_track_evidence_conflicting_release_track_ids_are_not_exact() -> None:
+    """Different MusicBrainz release-track IDs can still identify the same recording."""
+    base = _provider_track(
+        "base",
+        "provider_a",
+        external_ids={
+            (
+                ExternalID.MB_TRACK,
+                "11111111-1111-1111-1111-111111111111",
+            )
+        },
+    )
+    candidate = _provider_track(
+        "candidate",
+        "provider_b",
+        external_ids={
+            (
+                ExternalID.MB_TRACK,
+                "22222222-2222-2222-2222-222222222222",
+            )
+        },
+    )
+
+    assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.LIKELY
+
+
+def test_compare_track_evidence_authoritative_id_overrides_position_drift() -> None:
+    """Provider track-number drift does not override an authoritative release-track ID."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "11111111-1111-1111-1111-111111111111",
+    )
+    base = _provider_track("base", "provider_a", external_ids={mb_track})
+    candidate = _provider_track(
+        "candidate",
+        "provider_b",
+        external_ids={mb_track},
+    )
+    candidate.track_number = 2
+
+    assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.EXACT
+
+    base.external_ids.clear()
+    candidate.external_ids.clear()
+    assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.NO_MATCH
+
+
+def test_compare_track_evidence_simplified_albums_do_not_prove_exact_release() -> None:
+    """Album mappings without artist and year evidence only support a recording match."""
+    base = _provider_track("base", "provider_a")
+    candidate = _provider_track("candidate", "provider_b")
+    base.album = media_items.ItemMapping(
+        item_id="album-a",
+        provider="provider_a",
+        name="Album",
+        media_type=MediaType.ALBUM,
+    )
+    candidate.album = media_items.ItemMapping(
+        item_id="album-b",
+        provider="provider_b",
+        name="Album",
+        media_type=MediaType.ALBUM,
+    )
+
+    assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.LIKELY
+
+
+def test_compare_track_evidence_accepts_missing_remaster_by_album_year() -> None:
+    """Matching album years resolve version metadata omitted by one provider."""
+    base = _provider_track("base", "provider_a")
+    remaster = _provider_track(
+        "remaster",
+        "provider_b",
+        version="2022 Remaster",
+    )
+    assert isinstance(base.album, media_items.Album)
+    base.album.year = 2022
+    assert isinstance(remaster.album, media_items.Album)
+    remaster.album.year = 2022
+
+    assert compare.compare_track_evidence(base, remaster) == compare.TrackMatchConfidence.LIKELY
+
+    remaster.album.year = 2021
+    assert compare.compare_track_evidence(base, remaster) == compare.TrackMatchConfidence.LOOSE
+
+
+def test_compare_track_evidence_rejects_recording_version_conflicts() -> None:
+    """A recording-changing version never matches the original recording."""
+    recording_id = (
+        ExternalID.MB_RECORDING,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    base = _provider_track("base", "provider_a", external_ids={recording_id})
+    remix = _provider_track(
+        "remix",
+        "provider_b",
+        version="Club Remix",
+        external_ids={recording_id},
+    )
+
+    assert compare.compare_track_evidence(base, remix) == compare.TrackMatchConfidence.NO_MATCH
+
+
+def test_compare_track_evidence_release_track_id_overrides_version_drift() -> None:
+    """A shared release-track ID overrides conflicting provider version metadata."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    base = _provider_track("base", "provider_a", external_ids={mb_track})
+    mislabeled = _provider_track(
+        "candidate",
+        "provider_b",
+        version="Club Remix",
+        external_ids={mb_track},
+    )
+
+    assert compare.compare_track_evidence(base, mislabeled) == compare.TrackMatchConfidence.EXACT
+
+
+def test_compare_track_evidence_handles_featured_artist_title_drift() -> None:
+    """Featured credits may move between the title and structured artist list."""
+    title_credit = _provider_track(
+        "base",
+        "provider_a",
+        name="Track (feat. Guest)",
+    )
+    structured_credit = _provider_track(
+        "candidate",
+        "provider_b",
+        album_name="Compilation",
+        artist_names=("Artist A", "Guest"),
+    )
+
+    assert (
+        compare.compare_track_evidence(title_credit, structured_credit)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+
+
+def test_compare_track_evidence_handles_with_artist_title_drift() -> None:
+    """A with-credit may move between the title and structured artist list."""
+    title_credit = _provider_track(
+        "base",
+        "provider_a",
+        name="Track (with Guest)",
+    )
+    structured_credit = _provider_track(
+        "candidate",
+        "provider_b",
+        album_name="Compilation",
+        artist_names=("Artist A", "Guest"),
+    )
+
+    assert (
+        compare.compare_track_evidence(title_credit, structured_credit)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+
+
+def test_compare_track_evidence_stops_feature_credit_before_version() -> None:
+    """Version brackets after a bare featured credit are not part of the artist name."""
+    title_credit = _provider_track(
+        "base",
+        "provider_a",
+        name="Track feat. Guest (Radio Edit)",
+        album_name="Original",
+    )
+    structured_credit = _provider_track(
+        "candidate",
+        "provider_b",
+        version="Radio Edit",
+        album_name="Compilation",
+        artist_names=("Artist A", "Guest"),
+    )
+
+    assert (
+        compare.compare_track_evidence(title_credit, structured_credit)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+
+
+def test_compare_track_evidence_allows_omitted_featured_artist() -> None:
+    """A provider may omit a featured credit carried by the other provider."""
+    credited = _provider_track(
+        "base",
+        "provider_a",
+        name="Track (feat. Guest)",
+        album_name="Original",
+    )
+    omitted = _provider_track(
+        "candidate",
+        "provider_b",
+        album_name="Compilation",
+    )
+
+    assert compare.compare_track_evidence(credited, omitted) == compare.TrackMatchConfidence.LIKELY
+
+
+def test_compare_track_evidence_rejects_conflicting_featured_artists() -> None:
+    """Different explicit featured credits identify different collaborations."""
+    alice = _provider_track(
+        "alice",
+        "provider_a",
+        name="Track (feat. Alice)",
+        album_name="Original",
+    )
+    bob = _provider_track(
+        "bob",
+        "provider_b",
+        name="Track (feat. Bob)",
+        album_name="Compilation",
+    )
+
+    assert compare.compare_track_evidence(alice, bob) == compare.TrackMatchConfidence.NO_MATCH
+
+
+def test_compare_track_evidence_rejects_conflicting_colon_featured_artists() -> None:
+    """Colon-form featured credits remain part of track identity."""
+    alice = _provider_track(
+        "alice",
+        "provider_a",
+        name="Track (feat:Alice)",
+        album_name="Original",
+    )
+    bob = _provider_track(
+        "bob",
+        "provider_b",
+        name="Track (feat:Bob)",
+        album_name="Compilation",
+    )
+
+    assert compare.compare_track_evidence(alice, bob) == compare.TrackMatchConfidence.NO_MATCH
+
+
+def test_compare_track_evidence_keeps_composite_artist_identity() -> None:
+    """A partial overlap does not match a complete composite artist credit."""
+    partial_credit = _provider_track(
+        "partial",
+        "provider_a",
+        name="Track (feat. Tyler)",
+        album_name="Original",
+    )
+    composite_credit = _provider_track(
+        "composite",
+        "provider_b",
+        album_name="Compilation",
+        artist_names=("Artist A", "Tyler, The Creator"),
+    )
+
+    assert (
+        compare.compare_track_evidence(partial_credit, composite_credit)
+        == compare.TrackMatchConfidence.NO_MATCH
+    )
+
+
+def test_compare_track_evidence_keeps_complete_featured_artist_name() -> None:
+    """A separator inside one featured artist name is not treated as conflicting credits."""
+    title_credit = _provider_track(
+        "base",
+        "provider_a",
+        name="Track (feat. Simon and Garfunkel)",
+        album_name="Original",
+    )
+    structured_credit = _provider_track(
+        "candidate",
+        "provider_b",
+        album_name="Compilation",
+        artist_names=("Artist A", "Simon & Garfunkel"),
+    )
+
+    assert (
+        compare.compare_track_evidence(title_credit, structured_credit)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+
+
+def test_compare_track_evidence_ranks_recording_identifiers() -> None:
+    """Release-track IDs are exact while recording IDs identify alternate releases."""
+    mb_track = (
+        ExternalID.MB_TRACK,
+        "12345678-1234-1234-1234-123456789abc",
+    )
+    mb_recording = (
+        ExternalID.MB_RECORDING,
+        "abcdefab-abcd-abcd-abcd-abcdefabcdef",
+    )
+    base = _provider_track(
+        "base",
+        "provider_a",
+        album_name="Original",
+        external_ids={mb_track, mb_recording},
+    )
+    exact = _provider_track(
+        "exact",
+        "provider_b",
+        album_name="Reissue",
+        external_ids={mb_track, mb_recording},
+    )
+    recording = _provider_track(
+        "recording",
+        "provider_b",
+        album_name="Compilation",
+        external_ids={
+            (
+                ExternalID.MB_TRACK,
+                "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb",
+            ),
+            mb_recording,
+        },
+    )
+    conflicting_recording = _provider_track(
+        "conflict",
+        "provider_b",
+        external_ids={
+            mb_track,
+            (
+                ExternalID.MB_RECORDING,
+                "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            ),
+        },
+    )
+
+    assert compare.compare_track_evidence(base, exact) == compare.TrackMatchConfidence.EXACT
+    assert compare.compare_track_evidence(base, recording) == compare.TrackMatchConfidence.LIKELY
+    assert (
+        compare.compare_track_evidence(base, conflicting_recording)
+        == compare.TrackMatchConfidence.NO_MATCH
+    )
+
+
+def test_compare_track_evidence_uses_isrc_duration_tolerance() -> None:
+    """A valid shared ISRC tolerates provider duration drift up to eight seconds."""
+    isrc = (ExternalID.ISRC, "USRC17607839")
+    base = _provider_track("base", "provider_a", duration=200, external_ids={isrc})
+    within_tolerance = _provider_track(
+        "within",
+        "provider_b",
+        duration=208,
+        album_name="Compilation",
+        external_ids={isrc},
+    )
+    outside_tolerance = _provider_track(
+        "outside",
+        "provider_b",
+        duration=209,
+        album_name="Compilation",
+        external_ids={isrc},
+    )
+
+    assert (
+        compare.compare_track_evidence(base, within_tolerance)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+    assert (
+        compare.compare_track_evidence(base, outside_tolerance)
+        == compare.TrackMatchConfidence.NO_MATCH
+    )
+
+
+def test_compare_track_evidence_rejects_explicitness_conflicts() -> None:
+    """Explicit and clean recordings are not interchangeable migration matches."""
+    explicit = _provider_track("explicit", "provider_a")
+    clean = _provider_track("clean", "provider_b")
+    explicit.metadata.explicit = True
+    clean.metadata.explicit = False
+
+    assert compare.compare_track_evidence(explicit, clean) == compare.TrackMatchConfidence.NO_MATCH
+
+
+def test_compare_track_evidence_uses_hydrated_album_explicitness() -> None:
+    """Hydrated album metadata prevents clean and explicit substitutions."""
+    base = _provider_track("base", "provider_a")
+    candidate = _provider_track("candidate", "provider_b")
+    assert isinstance(base.album, media_items.Album)
+    assert isinstance(candidate.album, media_items.Album)
+    base_album = base.album
+    candidate_album = candidate.album
+    base_album.metadata.explicit = True
+    candidate_album.metadata.explicit = False
+    base.album = media_items.ItemMapping(
+        item_id=base_album.item_id,
+        provider=base_album.provider,
+        name=base_album.name,
+        media_type=MediaType.ALBUM,
+    )
+    candidate.album = media_items.ItemMapping(
+        item_id=candidate_album.item_id,
+        provider=candidate_album.provider,
+        name=candidate_album.name,
+        media_type=MediaType.ALBUM,
+    )
+
+    assert (
+        compare.compare_track_evidence(
+            base,
+            candidate,
+            base_album=base_album,
+            compare_album_item=candidate_album,
+        )
+        == compare.TrackMatchConfidence.NO_MATCH
+    )
 
 
 def test_compare_strings_accent_drift_matches() -> None:

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1616,6 +1616,29 @@ def test_compare_track_evidence_matches_composite_primary_artist() -> None:
     assert compare.compare_track_evidence(base, candidate) != compare.TrackMatchConfidence.NO_MATCH
 
 
+def test_compare_track_evidence_matches_asymmetric_composite_credit() -> None:
+    """A single composite credit reconstructed from an M3U still matches two split artists."""
+    # a third-party M3U exporter can collapse a multi-artist credit into one combined
+    # name; the provider candidate credits the same two artists as separate entries
+    m3u_credit = _provider_track(
+        "m3u",
+        "provider_a",
+        album_name="Original",
+        artist_names=("Artist A, Artist B",),
+    )
+    provider_credit = _provider_track(
+        "provider",
+        "provider_b",
+        album_name="Compilation",
+        artist_names=("Artist A", "Artist B"),
+    )
+
+    assert (
+        compare.compare_track_evidence(m3u_credit, provider_credit)
+        != compare.TrackMatchConfidence.NO_MATCH
+    )
+
+
 def test_compare_track_evidence_ranks_recording_identifiers() -> None:
     """Release-track IDs are exact while recording IDs identify alternate releases."""
     mb_track = (

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -84,12 +84,14 @@ def _provider_track(
     album_name: str = "Album",
     artist_names: tuple[str, ...] = ("Artist A",),
     external_ids: set[tuple[ExternalID, str]] | None = None,
+    album_external_ids: set[tuple[ExternalID, str]] | None = None,
 ) -> media_items.Track:
     """Build a provider track for confidence comparisons."""
     album = _album(
         item_id=f"album-{item_id}",
         provider=provider,
         name=album_name,
+        external_ids=album_external_ids,
     )
     return media_items.Track(
         item_id=item_id,
@@ -1264,8 +1266,9 @@ def test_compare_track_missing_disc_number_assumes_disc_one() -> None:
 
 def test_compare_track_evidence_ranks_release_and_recording_matches() -> None:
     """Exact-release evidence outranks the same recording on another album."""
-    base = _provider_track("base", "provider_a")
-    exact = _provider_track("exact", "provider_b")
+    mb_album_id = {(ExternalID.MB_ALBUM, "11111111-1111-1111-1111-111111111111")}
+    base = _provider_track("base", "provider_a", album_external_ids=mb_album_id)
+    exact = _provider_track("exact", "provider_b", album_external_ids=mb_album_id)
     alternate_release = _provider_track(
         "alternate",
         "provider_b",
@@ -1277,6 +1280,19 @@ def test_compare_track_evidence_ranks_release_and_recording_matches() -> None:
         compare.compare_track_evidence(base, alternate_release)
         == compare.TrackMatchConfidence.LIKELY
     )
+
+
+def test_compare_track_evidence_full_metadata_agreement_without_release_evidence_is_likely() -> (
+    None
+):
+    """Title/artist/version/position agreement alone, with no release-level id, caps at LIKELY."""
+    base = _provider_track("base", "provider_a")
+    candidate = _provider_track("candidate", "provider_b")
+
+    # same nominal album name, same title/artist/version/position - but neither side
+    # carries any release-level identifier (MusicBrainz release, Discogs, TheAudioDB,
+    # or a shared item identity), so this is provider metadata drift risk, not proof
+    assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.LIKELY
 
 
 def test_compare_track_evidence_conflicting_release_track_ids_are_not_exact() -> None:
@@ -1636,6 +1652,30 @@ def test_compare_track_evidence_matches_asymmetric_composite_credit() -> None:
     assert (
         compare.compare_track_evidence(m3u_credit, provider_credit)
         != compare.TrackMatchConfidence.NO_MATCH
+    )
+
+
+def test_compare_track_evidence_rejects_unrelated_separate_artists_matching_band_name() -> None:
+    """A structured act name is not shredded into unrelated solo artists sharing its words."""
+    # "Earth, Wind & Fire" is one official act's own name, not a list of three artists -
+    # a track crediting three separate solo artists literally named Earth/Wind/Fire is
+    # an unrelated recording that must not be treated as the same one
+    band_credit = _provider_track(
+        "band",
+        "provider_a",
+        album_name="Original",
+        artist_names=("Earth, Wind & Fire",),
+    )
+    solo_artists_credit = _provider_track(
+        "solo",
+        "provider_b",
+        album_name="Compilation",
+        artist_names=("Earth", "Wind", "Fire"),
+    )
+
+    assert (
+        compare.compare_track_evidence(band_credit, solo_artists_credit)
+        == compare.TrackMatchConfidence.NO_MATCH
     )
 
 

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1639,6 +1639,25 @@ def test_compare_track_evidence_uses_isrc_duration_tolerance() -> None:
     )
 
 
+def test_compare_track_evidence_treats_unknown_duration_as_loose_not_reject() -> None:
+    """A title/artist match isn't rejected just because one side's duration is unknown."""
+    base = _provider_track("base", "provider_a", duration=200)
+    # 0 is the unset default; -1 is the M3U convention for an unadvertised duration
+    missing_duration = _provider_track(
+        "missing", "provider_b", duration=0, album_name="Compilation"
+    )
+    unknown_duration = _provider_track(
+        "unknown", "provider_b", duration=-1, album_name="Compilation"
+    )
+
+    assert (
+        compare.compare_track_evidence(base, missing_duration) == compare.TrackMatchConfidence.LOOSE
+    )
+    assert (
+        compare.compare_track_evidence(base, unknown_duration) == compare.TrackMatchConfidence.LOOSE
+    )
+
+
 def test_compare_track_evidence_rejects_explicitness_conflicts() -> None:
     """Explicit and clean recordings are not interchangeable migration matches."""
     explicit = _provider_track("explicit", "provider_a")

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1461,6 +1461,27 @@ def test_compare_track_evidence_stops_feature_credit_before_version() -> None:
     )
 
 
+def test_compare_track_evidence_strips_bare_colon_feature_credit() -> None:
+    """A bare colon-form featured credit is stripped like the dot/space forms during search."""
+    title_credit = _provider_track(
+        "base",
+        "provider_a",
+        name="Track feat:Guest",
+        album_name="Original",
+    )
+    structured_credit = _provider_track(
+        "candidate",
+        "provider_b",
+        album_name="Compilation",
+        artist_names=("Artist A", "Guest"),
+    )
+
+    assert (
+        compare.compare_track_evidence(title_credit, structured_credit)
+        == compare.TrackMatchConfidence.LIKELY
+    )
+
+
 def test_compare_track_evidence_allows_omitted_featured_artist() -> None:
     """A provider may omit a featured credit carried by the other provider."""
     credited = _provider_track(

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1577,6 +1577,24 @@ def test_compare_track_evidence_keeps_complete_featured_artist_name() -> None:
     )
 
 
+def test_compare_track_evidence_matches_composite_primary_artist() -> None:
+    """A composite band name credited as the sole primary artist still matches itself."""
+    base = _provider_track(
+        "base",
+        "provider_a",
+        album_name="Original",
+        artist_names=("Simon & Garfunkel",),
+    )
+    candidate = _provider_track(
+        "candidate",
+        "provider_b",
+        album_name="Compilation",
+        artist_names=("Simon & Garfunkel",),
+    )
+
+    assert compare.compare_track_evidence(base, candidate) != compare.TrackMatchConfidence.NO_MATCH
+
+
 def test_compare_track_evidence_ranks_recording_identifiers() -> None:
     """Release-track IDs are exact while recording IDs identify alternate releases."""
     mb_track = (

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1402,6 +1402,84 @@ def test_compare_track_evidence_cross_instance_item_id_collision_is_not_exact() 
     assert compare.compare_track_evidence(base, same_instance) == compare.TrackMatchConfidence.EXACT
 
 
+def test_compare_track_evidence_cross_instance_album_id_collision_is_not_same_album() -> None:
+    """A coincidental album item id shared across non-streaming instances is not proof."""
+
+    def _colliding_album(provider_instance: str, name: str) -> media_items.Album:
+        return media_items.Album(
+            item_id="Various/Comp/album.dir",
+            provider=provider_instance,
+            name=name,
+            artists=media_items.UniqueList(
+                [
+                    media_items.Artist(
+                        item_id="artist",
+                        provider=provider_instance,
+                        name="Various Artists",
+                        provider_mappings={
+                            media_items.ProviderMapping(
+                                item_id="artist",
+                                provider_domain="filesystem",
+                                provider_instance=provider_instance,
+                            )
+                        },
+                    )
+                ]
+            ),
+            provider_mappings={
+                media_items.ProviderMapping(
+                    item_id="Various/Comp/album.dir",
+                    provider_domain="filesystem",
+                    provider_instance=provider_instance,
+                )
+            },
+        )
+
+    def _album_track(
+        provider_instance: str, album: media_items.Album, track_number: int
+    ) -> media_items.Track:
+        return media_items.Track(
+            item_id=f"{provider_instance}-track",
+            provider=provider_instance,
+            name="Some Song Title",
+            duration=200,
+            disc_number=1,
+            track_number=track_number,
+            artists=media_items.UniqueList(
+                [
+                    media_items.ItemMapping(
+                        item_id="artist-a",
+                        provider=provider_instance,
+                        name="Some Artist",
+                        media_type=MediaType.ARTIST,
+                    )
+                ]
+            ),
+            album=album,
+            provider_mappings={
+                media_items.ProviderMapping(
+                    item_id=f"{provider_instance}-track",
+                    provider_domain="filesystem",
+                    provider_instance=provider_instance,
+                )
+            },
+        )
+
+    # two unrelated filesystem albums that happen to share the same relative-path
+    # item id on their own (different) instances - each instance mints its own
+    # local ids, so this must not be trusted as evidence they are the same album
+    album_a = _colliding_album("filesystem_1", "Compilation Volume 1")
+    album_b = _colliding_album("filesystem_2", "A Totally Different Compilation")
+    assert compare._same_album(album_a, album_b) is False
+
+    # without the fix, the false "same album" match forces a position-conflict
+    # NO_MATCH despite matching title/artist/duration; it should instead reach a
+    # LIKELY (metadata-corroborated) confidence
+    base = _album_track("filesystem_1", album_a, 3)
+    candidate = _album_track("filesystem_2", album_b, 9)
+    assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.LIKELY
+
+
 def test_compare_track_evidence_authoritative_id_overrides_position_drift() -> None:
     """Provider track-number drift does not override an authoritative release-track ID."""
     mb_track = (

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -821,13 +821,7 @@ def test_compare_album_evidence_blank_vs_remaster_resolves_with_fingerprint() ->
 def test_compare_album_evidence_blank_vs_recording_conflict_is_no_match(
     conflict_version: str,
 ) -> None:
-    """
-    A blank version next to a recording-changing qualifier is a proven conflict.
-
-    Unlike a blank version next to plain packaging wording (remaster, deluxe, ...), a
-    missing version tag can never explain away a recording-altering qualifier on the
-    other side, so this must not be left for a tracklist to resolve.
-    """
+    """A blank version never cancels a recording-changing qualifier."""
     base_item = _album(version="")
     compare_item = _album(item_id="2", provider="test2", version=conflict_version)
 
@@ -1289,9 +1283,7 @@ def test_compare_track_evidence_full_metadata_agreement_without_release_evidence
     base = _provider_track("base", "provider_a")
     candidate = _provider_track("candidate", "provider_b")
 
-    # same nominal album name, same title/artist/version/position - but neither side
-    # carries any release-level identifier (MusicBrainz release, Discogs, TheAudioDB,
-    # or a shared item identity), so this is provider metadata drift risk, not proof
+    # Matching metadata alone is not release-level proof.
     assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.LIKELY
 
 
@@ -1349,9 +1341,7 @@ def test_compare_track_evidence_cross_instance_item_id_collision_is_not_exact() 
             )
         },
     )
-    # a second, unrelated filesystem instance happens to mint the same relative
-    # path/item id for an entirely different recording - non-streaming providers
-    # do not share a portable catalog, so this must not be trusted as identity
+    # Non-streaming sibling instances do not share item IDs.
     unrelated = media_items.Track(
         item_id="Artist/Album/01.flac",
         provider="filesystem_2",
@@ -1465,16 +1455,12 @@ def test_compare_track_evidence_cross_instance_album_id_collision_is_not_same_al
             },
         )
 
-    # two unrelated filesystem albums that happen to share the same relative-path
-    # item id on their own (different) instances - each instance mints its own
-    # local ids, so this must not be trusted as evidence they are the same album
+    # Non-streaming sibling instances do not share album IDs either.
     album_a = _colliding_album("filesystem_1", "Compilation Volume 1")
     album_b = _colliding_album("filesystem_2", "A Totally Different Compilation")
     assert compare._same_album(album_a, album_b) is False
 
-    # without the fix, the false "same album" match forces a position-conflict
-    # NO_MATCH despite matching title/artist/duration; it should instead reach a
-    # LIKELY (metadata-corroborated) confidence
+    # The false album match must not force a NO_MATCH here.
     base = _album_track("filesystem_1", album_a, 3)
     candidate = _album_track("filesystem_2", album_b, 9)
     assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.LIKELY

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1321,6 +1321,87 @@ def test_compare_track_evidence_conflicting_release_track_ids_are_not_exact() ->
     assert compare.compare_track_evidence(base, candidate) == compare.TrackMatchConfidence.LIKELY
 
 
+def test_compare_track_evidence_cross_instance_item_id_collision_is_not_exact() -> None:
+    """A coincidental item id shared by two different provider instances is not proof."""
+    base = media_items.Track(
+        item_id="Artist/Album/01.flac",
+        provider="filesystem_1",
+        name="Track One",
+        version="",
+        duration=200,
+        disc_number=1,
+        track_number=1,
+        artists=media_items.UniqueList(
+            [
+                media_items.ItemMapping(
+                    item_id="artist-a",
+                    provider="filesystem_1",
+                    name="Artist A",
+                    media_type=MediaType.ARTIST,
+                )
+            ]
+        ),
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id="Artist/Album/01.flac",
+                provider_domain="filesystem",
+                provider_instance="filesystem_1",
+            )
+        },
+    )
+    # a second, unrelated filesystem instance happens to mint the same relative
+    # path/item id for an entirely different recording - non-streaming providers
+    # do not share a portable catalog, so this must not be trusted as identity
+    unrelated = media_items.Track(
+        item_id="Artist/Album/01.flac",
+        provider="filesystem_2",
+        name="Completely Different Song",
+        version="",
+        duration=321,
+        disc_number=1,
+        track_number=7,
+        artists=media_items.UniqueList(
+            [
+                media_items.ItemMapping(
+                    item_id="artist-b",
+                    provider="filesystem_2",
+                    name="Someone Else",
+                    media_type=MediaType.ARTIST,
+                )
+            ]
+        ),
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id="Artist/Album/01.flac",
+                provider_domain="filesystem",
+                provider_instance="filesystem_2",
+            )
+        },
+    )
+
+    assert compare.compare_track_evidence(base, unrelated) == compare.TrackMatchConfidence.NO_MATCH
+
+    # the same instance sharing the same item id is unambiguous identity and stays EXACT
+    same_instance = media_items.Track(
+        item_id="Artist/Album/01.flac",
+        provider="filesystem_1",
+        name="Completely Different Song",
+        version="",
+        duration=321,
+        disc_number=1,
+        track_number=7,
+        artists=base.artists,
+        provider_mappings={
+            media_items.ProviderMapping(
+                item_id="Artist/Album/01.flac",
+                provider_domain="filesystem",
+                provider_instance="filesystem_1",
+            )
+        },
+    )
+    assert compare.compare_track_evidence(base, same_instance) == compare.TrackMatchConfidence.EXACT
+
+
 def test_compare_track_evidence_authoritative_id_overrides_position_drift() -> None:
     """Provider track-number drift does not override an authoritative release-track ID."""
     mb_track = (

--- a/tests/helpers/test_compare.py
+++ b/tests/helpers/test_compare.py
@@ -1535,6 +1535,27 @@ def test_compare_track_evidence_keeps_composite_artist_identity() -> None:
     )
 
 
+def test_compare_track_evidence_rejects_candidate_missing_primary_artist() -> None:
+    """A candidate crediting only the source's featured guest is not the same track."""
+    original = _provider_track(
+        "original",
+        "provider_a",
+        artist_names=("Alice", "Bob"),
+        album_name="Original",
+    )
+    guest_only = _provider_track(
+        "guest_only",
+        "provider_b",
+        artist_names=("Bob",),
+        album_name="Bob Solo Album",
+    )
+
+    assert (
+        compare.compare_track_evidence(original, guest_only)
+        == compare.TrackMatchConfidence.NO_MATCH
+    )
+
+
 def test_compare_track_evidence_keeps_complete_featured_artist_name() -> None:
     """A separator inside one featured artist name is not treated as conflicting credits."""
     title_credit = _provider_track(

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -275,6 +275,9 @@ async def test_uri_parsing() -> None:
     # test invalid uri
     with pytest.raises(MusicAssistantError):
         await uri.parse_uri("invalid://blah")
+    # test truncated public share url (no path segments to parse out)
+    with pytest.raises(MusicAssistantError):
+        await uri.parse_uri("https://open.spotify.com")
 
 
 async def test_apple_music_uri_parsing() -> None:

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -210,6 +210,30 @@ def test_with_handling_in_titles() -> None:
     assert version == "Remix"
 
 
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        ("Great Song (with John Smith)", ("John Smith",)),
+        ("Great Song [with Jane Doe]", ("Jane Doe",)),
+        ("Great Song - with John Smith (Duet)", ("John Smith",)),
+        ("Rockin' Around (With You)", ()),
+        ("The Catastrophe (Good Luck with That Man)", ()),
+        ("Great Song (feat:Alice)", ("Alice",)),
+    ],
+)
+def test_extract_title_artist_credits(title: str, expected: tuple[str, ...]) -> None:
+    """Embedded artist credits use the same title-word exceptions as title parsing."""
+    assert util.extract_title_artist_credits(title) == expected
+
+
+def test_with_artist_credit_preserves_trailing_title_content() -> None:
+    """Search normalization removes the credit without consuming later title content."""
+    assert util.parse_title_and_version(
+        "Great Song - with John Smith (Duet)",
+        strip_for_search=True,
+    ) == ("Great Song (Duet)", "")
+
+
 async def test_uri_parsing() -> None:
     """Test parsing of URI."""
     # test regular uri

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -183,8 +183,7 @@ def test_with_handling_in_titles() -> None:
     title, version = util.parse_title_and_version(test_str)
     assert title == "Ain't Gonna Bump No More (With No Big Fat Woman)"
     assert version == ""
-    # 'with that' - not a title-phrase exception, but not stripped because the
-    # bracket content doesn't start with "with "
+    # 'with that' - not in WITH_TITLE_WORDS but not stripped because it doesn't start with "with "
     test_str = "The Catastrophe (Good Luck with That Man)"
     title, version = util.parse_title_and_version(test_str)
     assert title == "The Catastrophe (Good Luck with That Man)"
@@ -219,10 +218,10 @@ def test_with_handling_in_titles() -> None:
         ("Great Song - with John Smith (Duet)", ("John Smith",)),
         ("Rockin' Around (With You)", ()),
         ("The Catastrophe (Good Luck with That Man)", ()),
-        # real artist credits starting with the same word as a title-phrase
-        # exception must still be recognized as credits, not title continuations
-        ("Great Song (with The Weeknd)", ("The Weeknd",)),
-        ("Great Song (with No Doubt)", ("No Doubt",)),
+        # an arbitrary title continuation starting with a title word, not just
+        # one of the specific known song titles, must still be protected -
+        # matching the whole credit against a fixed phrase list would strip it
+        ("Example Song (With You Tonight)", ()),
         ("Great Song (feat:Alice)", ("Alice",)),
         # a bare credit marker with no title text before it is part of the title
         # itself, not an actual credit annotation

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -234,6 +234,14 @@ def test_with_artist_credit_preserves_trailing_title_content() -> None:
     ) == ("Great Song (Duet)", "")
 
 
+def test_bare_colon_feature_credit_stripped_for_search() -> None:
+    """A bare, unbracketed colon-form featured credit is stripped like the other forms."""
+    assert util.parse_title_and_version(
+        "Great Song feat:Alice",
+        strip_for_search=True,
+    ) == ("Great Song", "")
+
+
 async def test_uri_parsing() -> None:
     """Test parsing of URI."""
     # test regular uri

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -218,13 +218,10 @@ def test_with_handling_in_titles() -> None:
         ("Great Song - with John Smith (Duet)", ("John Smith",)),
         ("Rockin' Around (With You)", ()),
         ("The Catastrophe (Good Luck with That Man)", ()),
-        # an arbitrary title continuation starting with a title word, not just
-        # one of the specific known song titles, must still be protected -
-        # matching the whole credit against a fixed phrase list would strip it
+        # Title-word exceptions must protect arbitrary continuations too.
         ("Example Song (With You Tonight)", ()),
         ("Great Song (feat:Alice)", ("Alice",)),
-        # a bare credit marker with no title text before it is part of the title
-        # itself, not an actual credit annotation
+        # Bare leading markers are part of the title, not a credit.
         ("Featuring Alice", ()),
         ("Featuring Bob", ()),
         ("Ft Bob", ()),
@@ -257,7 +254,7 @@ def test_bare_credit_marker_without_leading_title_is_not_stripped() -> None:
         "Featuring Alice",
         strip_for_search=True,
     ) == ("Featuring Alice", "")
-    # two different such titles must not normalize to the same (empty) search title
+    # Distinct leading-marker titles must stay distinct after normalization.
     assert util.parse_title_and_version(
         "Featuring Bob",
         strip_for_search=True,
@@ -305,13 +302,10 @@ async def test_uri_parsing() -> None:
     # test invalid uri
     with pytest.raises(MusicAssistantError):
         await uri.parse_uri("invalid://blah")
-    # test truncated public share url (no path segments to parse out)
     with pytest.raises(MusicAssistantError):
         await uri.parse_uri("https://open.spotify.com")
-    # test truncated public share url with a trailing slash (empty id segment)
     with pytest.raises(MusicAssistantError):
         await uri.parse_uri("https://open.spotify.com/track/")
-    # test truncated Tidal browse url with a trailing slash (empty id segment)
     with pytest.raises(MusicAssistantError):
         await uri.parse_uri("https://tidal.com/browse/track/")
 

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -304,6 +304,12 @@ async def test_uri_parsing() -> None:
     # test truncated public share url (no path segments to parse out)
     with pytest.raises(MusicAssistantError):
         await uri.parse_uri("https://open.spotify.com")
+    # test truncated public share url with a trailing slash (empty id segment)
+    with pytest.raises(MusicAssistantError):
+        await uri.parse_uri("https://open.spotify.com/track/")
+    # test truncated Tidal browse url with a trailing slash (empty id segment)
+    with pytest.raises(MusicAssistantError):
+        await uri.parse_uri("https://tidal.com/browse/track/")
 
 
 async def test_apple_music_uri_parsing() -> None:

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -219,6 +219,11 @@ def test_with_handling_in_titles() -> None:
         ("Rockin' Around (With You)", ()),
         ("The Catastrophe (Good Luck with That Man)", ()),
         ("Great Song (feat:Alice)", ("Alice",)),
+        # a bare credit marker with no title text before it is part of the title
+        # itself, not an actual credit annotation
+        ("Featuring Alice", ()),
+        ("Featuring Bob", ()),
+        ("Ft Bob", ()),
     ],
 )
 def test_extract_title_artist_credits(title: str, expected: tuple[str, ...]) -> None:
@@ -240,6 +245,19 @@ def test_bare_colon_feature_credit_stripped_for_search() -> None:
         "Great Song feat:Alice",
         strip_for_search=True,
     ) == ("Great Song", "")
+
+
+def test_bare_credit_marker_without_leading_title_is_not_stripped() -> None:
+    """A title that starts with a bare credit marker keeps its full text, not an empty title."""
+    assert util.parse_title_and_version(
+        "Featuring Alice",
+        strip_for_search=True,
+    ) == ("Featuring Alice", "")
+    # two different such titles must not normalize to the same (empty) search title
+    assert util.parse_title_and_version(
+        "Featuring Bob",
+        strip_for_search=True,
+    ) == ("Featuring Bob", "")
 
 
 async def test_uri_parsing() -> None:

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -183,7 +183,8 @@ def test_with_handling_in_titles() -> None:
     title, version = util.parse_title_and_version(test_str)
     assert title == "Ain't Gonna Bump No More (With No Big Fat Woman)"
     assert version == ""
-    # 'with that' - not in WITH_TITLE_WORDS but not stripped because it doesn't start with "with "
+    # 'with that' - not a title-phrase exception, but not stripped because the
+    # bracket content doesn't start with "with "
     test_str = "The Catastrophe (Good Luck with That Man)"
     title, version = util.parse_title_and_version(test_str)
     assert title == "The Catastrophe (Good Luck with That Man)"
@@ -218,6 +219,10 @@ def test_with_handling_in_titles() -> None:
         ("Great Song - with John Smith (Duet)", ("John Smith",)),
         ("Rockin' Around (With You)", ()),
         ("The Catastrophe (Good Luck with That Man)", ()),
+        # real artist credits starting with the same word as a title-phrase
+        # exception must still be recognized as credits, not title continuations
+        ("Great Song (with The Weeknd)", ("The Weeknd",)),
+        ("Great Song (with No Doubt)", ("No Doubt",)),
         ("Great Song (feat:Alice)", ("Alice",)),
         # a bare credit marker with no title text before it is part of the title
         # itself, not an actual credit annotation

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -727,14 +727,7 @@ def test_media_item_to_playlist_item_track_round_trip_preserves_mb_track() -> No
 
 
 def test_media_item_to_playlist_item_track_round_trip_preserves_album_instance() -> None:
-    """
-    A track's album keeps its exact originating instance, not just its bare domain.
-
-    Reconstructing with only the domain would let matching expand across every allowed
-    sibling instance of that domain instead of the one #EXTALBUM actually captured,
-    letting an unrelated sibling account's same-domain album ID supply release evidence
-    for exact-tier matching.
-    """
+    """A round-tripped album keeps its captured provider instance."""
 
     class DummyProvider:
         def __init__(self, domain: str, instance_id: str) -> None:
@@ -781,22 +774,12 @@ def test_media_item_to_playlist_item_track_round_trip_preserves_album_instance()
 
     assert isinstance(reconstructed, Track)
     assert reconstructed.album is not None
-    # the album was captured on spotify--2, a *different* instance than the track's own
-    # spotify--1 - the reconstructed reference must pin to that exact instance
+    # The album stays pinned to the captured sibling instance.
     assert reconstructed.album.provider == "spotify--2"
 
 
 def test_media_item_to_playlist_item_track_round_trip_falls_back_to_album_domain() -> None:
-    """
-    An album pinned to an instance id unknown on this server falls back to its domain.
-
-    A playlist exported from a different Music Assistant install carries instance ids
-    that are randomly generated per install and will never resolve here; reconstructing
-    with that foreign instance id verbatim would leave the album permanently
-    unhydratable. Falling back to the domain lets downstream hydration
-    (``TracksController._get_full_track_album``) try every allowed sibling instance of
-    it instead.
-    """
+    """An unknown album instance falls back to its domain on round-trip."""
 
     class DummyProvider:
         def __init__(self, domain: str, instance_id: str) -> None:
@@ -804,9 +787,7 @@ def test_media_item_to_playlist_item_track_round_trip_falls_back_to_album_domain
             self.instance_id = instance_id
 
     mass = MagicMock()
-    # spotify--2 (the account this album was originally captured on, on a *different*
-    # Music Assistant install) does not exist on this server at all - only an unrelated
-    # sibling of the same domain does
+    # The captured instance does not exist here; only a same-domain sibling does.
     spotify_9 = DummyProvider("spotify", "spotify--9")
     mass.get_provider.side_effect = lambda ref, **_kwargs: {"spotify--9": spotify_9}.get(ref)
     album = Album(
@@ -841,19 +822,12 @@ def test_media_item_to_playlist_item_track_round_trip_falls_back_to_album_domain
 
     assert isinstance(reconstructed, Track)
     assert reconstructed.album is not None
-    # falls back to the bare domain instead of the foreign, unresolvable instance id
+    # The unresolvable foreign instance falls back to the bare domain.
     assert reconstructed.album.provider == "spotify"
 
 
 def test_media_item_to_playlist_item_album_prefers_track_instance_when_multiple() -> None:
-    """
-    An album with mappings on multiple sibling instances pins to the track's own account.
-
-    Picking an arbitrary album mapping (set iteration order is not guaranteed stable)
-    would let an unrelated sibling account's same-domain album ID nondeterministically
-    become the serialized - and later pinned - album reference; the mapping matching the
-    track's own instance is unambiguous and must win instead.
-    """
+    """Album mapping selection prefers the track's own provider instance."""
     album = Album(
         item_id="alb1",
         provider="spotify--2",
@@ -894,14 +868,7 @@ def test_media_item_to_playlist_item_album_prefers_track_instance_when_multiple(
 
 
 def test_media_item_to_playlist_item_album_deterministic_among_same_instance_mappings() -> None:
-    """
-    Two mappings sharing the track's own instance still resolve to the same one.
-
-    An album can hold more than one mapping for the same account (for example an
-    alternate catalog ID for the same release) - matching by instance alone is not
-    enough to guarantee a single candidate, so the deterministic ranking must still
-    apply among those matches instead of leaving the choice to set iteration order.
-    """
+    """Same-instance album mappings still resolve deterministically."""
     album = Album(
         item_id="alb1",
         provider="spotify--1",
@@ -947,14 +914,7 @@ def test_media_item_to_playlist_item_album_deterministic_among_same_instance_map
 def test_media_item_to_playlist_item_album_mapping_selection_is_deterministic_without_match() -> (
     None
 ):
-    """
-    Without a mapping matching the track's own instance, the choice is still deterministic.
-
-    Falling back to a set's iteration order would let hash-order variance pick a
-    different sibling account across runs; the same ranking used for the track's own
-    primary provider (available, higher quality, then domain/instance/item_id) applies
-    here too, instead of whichever mapping the set happens to iterate first.
-    """
+    """Album mapping selection stays deterministic without an instance match."""
     album = Album(
         item_id="alb1",
         provider="tidal--1",
@@ -988,12 +948,7 @@ def test_media_item_to_playlist_item_album_mapping_selection_is_deterministic_wi
 
 
 def test_media_item_to_playlist_item_album_prefers_available_mapping() -> None:
-    """
-    An available mapping wins over an unavailable one, regardless of iteration order.
-
-    Without a match to the track's own instance, the fallback ranking must still put an
-    available sibling ahead of an unavailable one.
-    """
+    """Available album mappings outrank unavailable ones."""
     album = Album(
         item_id="alb1",
         provider="tidal--2",
@@ -1037,13 +992,7 @@ def test_media_item_to_playlist_item_album_prefers_available_mapping() -> None:
 
 
 def test_media_item_to_playlist_item_track_round_trip_preserves_exact_capable_album() -> None:
-    """
-    An album with several sibling mappings round-trips to the account holding exact evidence.
-
-    Exporting must pick the mapping matching the track's own account (rather than an
-    arbitrary sibling) so the reconstructed reference resolves to the same account that
-    supplied the track, keeping strict Exact-tier evidence available after a round trip.
-    """
+    """Round-tripping keeps the album mapping that preserves exact evidence."""
     mass = MagicMock()
 
     class DummyProvider:
@@ -1088,8 +1037,7 @@ def test_media_item_to_playlist_item_track_round_trip_preserves_exact_capable_al
 
     assert isinstance(reconstructed, Track)
     assert reconstructed.album is not None
-    # the track's own account (tidal--1) holds the album's exact-evidence mapping (alb1a) -
-    # the round trip must resolve to that specific instance, not an arbitrary sibling
+    # The round trip must keep the album mapping from the track's own account.
     assert reconstructed.album.provider == "tidal--1"
     assert reconstructed.album.item_id == "alb1a"
 
@@ -1107,9 +1055,7 @@ def test_media_item_to_playlist_item_omits_conflicting_merged_external_ids() -> 
             ),
             ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz_1"),
         },
-        # a library track merges external IDs from every matched provider - two
-        # providers disagreeing on MB_TRACK means they identify different releases,
-        # so neither value is reliable release evidence for the exported entry
+        # Conflicting MB_TRACK values from different providers are not reliable.
         external_ids={
             (ExternalID.ISRC, "USRC17607839"),
             (ExternalID.MB_TRACK, "spotify-release-track-mbid"),
@@ -1138,12 +1084,7 @@ def test_media_item_to_playlist_item_merges_equivalent_external_ids() -> None:
             ),
             ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz_1"),
         },
-        # both providers actually agree on the same MusicBrainz recording ID, just
-        # formatted differently (braces + uppercase vs bare lowercase) - this must
-        # still be recognized as the single, unambiguous identifier. Unlike a
-        # release-specific MB_TRACK, a recording MBID is safely shared across every
-        # release of the same performance, so it isn't subject to the same
-        # multi-domain provenance restriction.
+        # Equivalent MB_RECORDING values with different formatting still agree.
         external_ids={
             (ExternalID.MB_RECORDING, "a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
             (ExternalID.MB_RECORDING, "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"),
@@ -1169,9 +1110,7 @@ def test_media_item_to_playlist_item_omits_multi_domain_mb_track() -> None:
             ),
             ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz_1"),
         },
-        # external_ids merges whichever provider mapping happened to contribute a
-        # value, with no record of which one - even a single, unambiguous value
-        # cannot be tied to whichever mapping ends up chosen as the primary URI
+        # A merged MB_TRACK cannot be tied back to the chosen primary URI.
         external_ids={
             (ExternalID.MB_TRACK, "release-track-mbid"),
         },
@@ -1191,8 +1130,7 @@ def test_media_item_to_playlist_item_omits_multi_instance_same_domain_mb_track()
         name="Everything In Its Right Place",
         duration=240,
         provider_mappings={
-            # two separate accounts of the same streaming service - a single
-            # merged domain must not be mistaken for a single trusted catalog
+            # Same-domain sibling accounts are still separate sources.
             ProviderMapping(item_id="abc123", provider_domain="qobuz", provider_instance="qobuz_1"),
             ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz_2"),
         },
@@ -1208,14 +1146,7 @@ def test_media_item_to_playlist_item_omits_multi_instance_same_domain_mb_track()
 
 
 def test_import_match_policy_reachability_new_vs_legacy_m3u() -> None:
-    """
-    EXACT is only reachable when the parsed M3U carries release-track evidence.
-
-    A new-format export with MB_TRACK reconstructs a track that reaches EXACT confidence
-    against a candidate sharing that release-track id, while a legacy M3U that only ever
-    carried an ISRC caps out at LIKELY (the SAME_RECORDING policy tier), even against a
-    candidate that would otherwise be a plausible substitute.
-    """
+    """Only M3U entries with MB_TRACK can reach EXACT match confidence."""
 
     class DummyProvider:
         def __init__(self, domain: str, instance_id: str) -> None:
@@ -1863,11 +1794,7 @@ async def test_fetch_playlist_client_error() -> None:
 
 @pytest.mark.asyncio
 async def test_fetch_playlist_error_status() -> None:
-    """
-    An error response is rejected instead of parsed.
-
-    Without the status check every markup line of the error page becomes an entry.
-    """
+    """An error response is rejected instead of being parsed as a playlist."""
     error_page = (
         b"<html>\n<head><title>404 Not Found</title></head>\n"
         b"<body>\n<center><h1>404 Not Found</h1></center>\n</body>\n</html>\n"
@@ -1931,8 +1858,7 @@ async def test_fetch_playlist_hls_master_playlist_always_raises() -> None:
 @pytest.mark.asyncio
 async def test_fetch_playlist_pls_by_extension(monkeypatch: pytest.MonkeyPatch) -> None:
     """A .pls url picks the PLS parser on the extension alone."""
-    # every real PLS body carries the marker too, so only a marker-free body can
-    # show which of the two conditions selected the parser
+    # Use marker-free content so the extension alone selects the parser.
     parsed = [PlaylistItem(path="http://stream.example.com/aac")]
     parse_pls_mock = MagicMock(return_value=parsed)
     monkeypatch.setattr(playlists, "parse_pls", parse_pls_mock)
@@ -1980,12 +1906,7 @@ async def test_fetch_playlist_empty() -> None:
 
 @pytest.mark.asyncio
 async def test_fetch_playlist_unknown_charset_falls_back_to_detection() -> None:
-    """
-    A charset the remote server made up must not break the fetch.
-
-    Stations do send names Python has no codec for, which decode() answers with a
-    LookupError that no caller on this path catches.
-    """
+    """An unknown declared charset falls back to content detection."""
     mass = _mass_serving(M3U_PLAYLIST.encode(), charset="utf8mb4")
 
     result = await fetch_playlist(mass, "http://example.com/station.m3u")

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -725,6 +725,37 @@ def test_media_item_to_playlist_item_track_round_trip_preserves_mb_track() -> No
     assert reconstructed.get_external_id(ExternalID.ISRC) == "USRC17607839"
 
 
+def test_media_item_to_playlist_item_omits_conflicting_merged_external_ids() -> None:
+    """Conflicting merged external IDs from different providers are not exported arbitrarily."""
+    track = Track(
+        item_id="abc123",
+        provider="library",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            ProviderMapping(
+                item_id="abc123", provider_domain="spotify", provider_instance="spotify_1"
+            ),
+            ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz_1"),
+        },
+        # a library track merges external IDs from every matched provider - two
+        # providers disagreeing on MB_TRACK means they identify different releases,
+        # so neither value is reliable release evidence for the exported entry
+        external_ids={
+            (ExternalID.ISRC, "USRC17607839"),
+            (ExternalID.MB_TRACK, "spotify-release-track-mbid"),
+            (ExternalID.MB_TRACK, "qobuz-release-track-mbid"),
+        },
+    )
+
+    playlist_item = media_item_to_playlist_item(track)
+
+    assert playlist_item.metadata is not None
+    assert "mb_track" not in playlist_item.metadata
+    # unambiguous external IDs are unaffected
+    assert playlist_item.metadata["isrc"] == "USRC17607839"
+
+
 def test_import_match_policy_reachability_new_vs_legacy_m3u() -> None:
     """
     EXACT is only reachable when the parsed M3U carries release-track evidence.

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -9,6 +9,7 @@ from aiohttp import client_exceptions
 from music_assistant_models.enums import ContentType, ExternalID, ImageType, MediaType
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import (
+    Album,
     AudioFormat,
     ItemMapping,
     MediaItemImage,
@@ -723,6 +724,66 @@ def test_media_item_to_playlist_item_track_round_trip_preserves_mb_track() -> No
     assert reconstructed.get_external_id(ExternalID.MB_TRACK) == "release-track-mbid"
     assert reconstructed.get_external_id(ExternalID.MB_RECORDING) == "recording-mbid"
     assert reconstructed.get_external_id(ExternalID.ISRC) == "USRC17607839"
+
+
+def test_media_item_to_playlist_item_track_round_trip_preserves_album_instance() -> None:
+    """
+    A track's album keeps its exact originating instance, not just its bare domain.
+
+    Reconstructing with only the domain would let matching expand across every allowed
+    sibling instance of that domain instead of the one #EXTALBUM actually captured,
+    letting an unrelated sibling account's same-domain album ID supply release evidence
+    for exact-tier matching.
+    """
+
+    class DummyProvider:
+        def __init__(self, domain: str, instance_id: str) -> None:
+            self.domain = domain
+            self.instance_id = instance_id
+
+    mass = MagicMock()
+    spotify_1 = DummyProvider("spotify", "spotify--1")
+    spotify_2 = DummyProvider("spotify", "spotify--2")
+    mass.get_provider.side_effect = lambda ref: {
+        "spotify": spotify_1,
+        "spotify--1": spotify_1,
+        "spotify--2": spotify_2,
+    }.get(ref)
+    album = Album(
+        item_id="alb1",
+        provider="spotify--2",
+        name="Kid A",
+        provider_mappings={
+            ProviderMapping(
+                item_id="alb1", provider_domain="spotify", provider_instance="spotify--2"
+            )
+        },
+    )
+    track = Track(
+        item_id="abc123",
+        provider="spotify--1",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            ProviderMapping(
+                item_id="abc123",
+                provider_domain="spotify",
+                provider_instance="spotify--1",
+                audio_format=AudioFormat(content_type=ContentType.FLAC),
+            ),
+        },
+        album=album,
+    )
+
+    playlist_item = media_item_to_playlist_item(track)
+    parsed = parse_m3u(generate_m3u("Kid A", [playlist_item]))
+    reconstructed = construct_media_item_from_playlist_item(parsed[0], mass)
+
+    assert isinstance(reconstructed, Track)
+    assert reconstructed.album is not None
+    # the album was captured on spotify--2, a *different* instance than the track's own
+    # spotify--1 - the reconstructed reference must pin to that exact instance
+    assert reconstructed.album.provider == "spotify--2"
 
 
 def test_media_item_to_playlist_item_omits_conflicting_merged_external_ids() -> None:

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -1138,23 +1138,26 @@ def test_media_item_to_playlist_item_merges_equivalent_external_ids() -> None:
             ),
             ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz_1"),
         },
-        # both providers actually agree on the same MusicBrainz track ID, just
+        # both providers actually agree on the same MusicBrainz recording ID, just
         # formatted differently (braces + uppercase vs bare lowercase) - this must
-        # still be recognized as the single, unambiguous release-track identifier
+        # still be recognized as the single, unambiguous identifier. Unlike a
+        # release-specific MB_TRACK, a recording MBID is safely shared across every
+        # release of the same performance, so it isn't subject to the same
+        # multi-domain provenance restriction.
         external_ids={
-            (ExternalID.MB_TRACK, "a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
-            (ExternalID.MB_TRACK, "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"),
+            (ExternalID.MB_RECORDING, "a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+            (ExternalID.MB_RECORDING, "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"),
         },
     )
 
     playlist_item = media_item_to_playlist_item(track)
 
     assert playlist_item.metadata is not None
-    assert playlist_item.metadata["mb_track"] == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    assert playlist_item.metadata["mbid"] == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
 
-def test_media_item_to_playlist_item_omits_uncorroborated_multi_domain_mb_track() -> None:
-    """A lone MB_TRACK claim on a multi-domain item is not exported as release evidence."""
+def test_media_item_to_playlist_item_omits_multi_domain_mb_track() -> None:
+    """A multi-domain item's merged MB_TRACK is never exported as release evidence."""
     track = Track(
         item_id="abc123",
         provider="library",
@@ -1166,9 +1169,9 @@ def test_media_item_to_playlist_item_omits_uncorroborated_multi_domain_mb_track(
             ),
             ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz_1"),
         },
-        # only one provider mapping actually contributed this value - there is no
-        # record of which one, so it cannot be trusted to describe whichever
-        # mapping ends up chosen as the exported entry's primary URI
+        # external_ids merges whichever provider mapping happened to contribute a
+        # value, with no record of which one - even a single, unambiguous value
+        # cannot be tied to whichever mapping ends up chosen as the primary URI
         external_ids={
             (ExternalID.MB_TRACK, "release-track-mbid"),
         },

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -756,6 +756,34 @@ def test_media_item_to_playlist_item_omits_conflicting_merged_external_ids() -> 
     assert playlist_item.metadata["isrc"] == "USRC17607839"
 
 
+def test_media_item_to_playlist_item_merges_equivalent_external_ids() -> None:
+    """Providers formatting the same MBID differently is not treated as a conflict."""
+    track = Track(
+        item_id="abc123",
+        provider="library",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            ProviderMapping(
+                item_id="abc123", provider_domain="spotify", provider_instance="spotify_1"
+            ),
+            ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz_1"),
+        },
+        # both providers actually agree on the same MusicBrainz track ID, just
+        # formatted differently (braces + uppercase vs bare lowercase) - this must
+        # still be recognized as the single, unambiguous release-track identifier
+        external_ids={
+            (ExternalID.MB_TRACK, "a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+            (ExternalID.MB_TRACK, "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"),
+        },
+    )
+
+    playlist_item = media_item_to_playlist_item(track)
+
+    assert playlist_item.metadata is not None
+    assert playlist_item.metadata["mb_track"] == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+
 def test_import_match_policy_reachability_new_vs_legacy_m3u() -> None:
     """
     EXACT is only reachable when the parsed M3U carries release-track evidence.

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -22,6 +22,7 @@ from music_assistant_models.media_items import (
 
 from music_assistant.controllers.music.media.playlists import PlaylistController
 from music_assistant.helpers import playlists
+from music_assistant.helpers.compare import TrackMatchConfidence, compare_track_evidence
 from music_assistant.helpers.playlists import (
     AlbumInfo,
     ArtistInfo,
@@ -678,6 +679,124 @@ def test_media_item_to_playlist_item_sound_effect_round_trip() -> None:
     assert reconstructed.metadata.images[0].path == "https://example.com/chime.jpg"
 
 
+def test_media_item_to_playlist_item_track_round_trip_preserves_mb_track() -> None:
+    """A track's release-track (MB_TRACK) evidence survives export, generate and re-parse."""
+
+    class DummyProvider:
+        def __init__(self, domain: str, instance_id: str) -> None:
+            self.domain = domain
+            self.instance_id = instance_id
+
+    mass = MagicMock()
+    spotify_provider = DummyProvider("spotify", "spotify_1")
+    mass.get_provider.side_effect = lambda ref: {
+        "spotify": spotify_provider,
+        "spotify_1": spotify_provider,
+    }.get(ref)
+    track = Track(
+        item_id="abc123",
+        provider="spotify",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            ProviderMapping(
+                item_id="abc123",
+                provider_domain="spotify",
+                provider_instance="spotify_1",
+                audio_format=AudioFormat(content_type=ContentType.FLAC),
+            ),
+        },
+        external_ids={
+            (ExternalID.ISRC, "USRC17607839"),
+            (ExternalID.MB_RECORDING, "recording-mbid"),
+            (ExternalID.MB_TRACK, "release-track-mbid"),
+        },
+    )
+
+    playlist_item = media_item_to_playlist_item(track)
+    parsed = parse_m3u(generate_m3u("Kid A", [playlist_item]))
+    reconstructed = construct_media_item_from_playlist_item(parsed[0], mass)
+
+    assert playlist_item.metadata is not None
+    assert playlist_item.metadata["mb_track"] == "release-track-mbid"
+    assert isinstance(reconstructed, Track)
+    assert reconstructed.get_external_id(ExternalID.MB_TRACK) == "release-track-mbid"
+    assert reconstructed.get_external_id(ExternalID.MB_RECORDING) == "recording-mbid"
+    assert reconstructed.get_external_id(ExternalID.ISRC) == "USRC17607839"
+
+
+def test_import_match_policy_reachability_new_vs_legacy_m3u() -> None:
+    """
+    EXACT is only reachable when the parsed M3U carries release-track evidence.
+
+    A new-format export with MB_TRACK reconstructs a track that reaches EXACT confidence
+    against a candidate sharing that release-track id, while a legacy M3U that only ever
+    carried an ISRC caps out at LIKELY (the SAME_RECORDING policy tier), even against a
+    candidate that would otherwise be a plausible substitute.
+    """
+
+    class DummyProvider:
+        def __init__(self, domain: str, instance_id: str) -> None:
+            self.domain = domain
+            self.instance_id = instance_id
+
+    mass = MagicMock()
+    spotify_provider = DummyProvider("spotify", "spotify_1")
+    mass.get_provider.side_effect = lambda ref: {
+        "spotify": spotify_provider,
+        "spotify_1": spotify_provider,
+    }.get(ref)
+
+    new_m3u_item = PlaylistItem(
+        path="spotify://track/abc123",
+        title="Everything In Its Right Place",
+        length="240",
+        metadata={
+            "media_type": "track",
+            "name": "Everything In Its Right Place",
+            "isrc": "USRC17607839",
+            "mb_track": "release-track-mbid",
+        },
+    )
+    legacy_m3u_item = PlaylistItem(
+        path="spotify://track/abc123",
+        title="Everything In Its Right Place",
+        length="240",
+        metadata={
+            "media_type": "track",
+            "name": "Everything In Its Right Place",
+            "isrc": "USRC17607839",
+        },
+    )
+    candidate = Track(
+        item_id="def456",
+        provider="qobuz",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            ProviderMapping(item_id="def456", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+        external_ids={
+            (ExternalID.ISRC, "USRC17607839"),
+            (ExternalID.MB_TRACK, "release-track-mbid"),
+        },
+    )
+
+    new_track = construct_media_item_from_playlist_item(new_m3u_item, mass)
+    legacy_track = construct_media_item_from_playlist_item(legacy_m3u_item, mass)
+    assert isinstance(new_track, Track)
+    assert isinstance(legacy_track, Track)
+
+    assert (
+        compare_track_evidence(new_track, candidate, allow_item_id_match=False)
+        is TrackMatchConfidence.EXACT
+    )
+    assert (
+        compare_track_evidence(legacy_track, candidate, allow_item_id_match=False)
+        is TrackMatchConfidence.LIKELY
+    )
+
+
 # --------------------------------------------------------------------------- #
 #  media_item_to_playlist_item tests                                           #
 # --------------------------------------------------------------------------- #
@@ -732,6 +851,7 @@ def test_media_item_to_playlist_item_track() -> None:
     assert result.metadata["name"] == "Everything In Its Right Place"
     assert result.metadata["isrc"] == "USRC17607839"
     assert result.metadata["version"] == "Deluxe"
+    assert "mb_track" not in result.metadata
     assert len(result.providers) == 1
     assert result.providers[0].domain == "spotify"
     assert result.providers[0].item_id == "abc123"

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -1153,6 +1153,33 @@ def test_media_item_to_playlist_item_merges_equivalent_external_ids() -> None:
     assert playlist_item.metadata["mb_track"] == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
 
+def test_media_item_to_playlist_item_omits_uncorroborated_multi_domain_mb_track() -> None:
+    """A lone MB_TRACK claim on a multi-domain item is not exported as release evidence."""
+    track = Track(
+        item_id="abc123",
+        provider="library",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            ProviderMapping(
+                item_id="abc123", provider_domain="spotify", provider_instance="spotify_1"
+            ),
+            ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz_1"),
+        },
+        # only one provider mapping actually contributed this value - there is no
+        # record of which one, so it cannot be trusted to describe whichever
+        # mapping ends up chosen as the exported entry's primary URI
+        external_ids={
+            (ExternalID.MB_TRACK, "release-track-mbid"),
+        },
+    )
+
+    playlist_item = media_item_to_playlist_item(track)
+
+    assert playlist_item.metadata is not None
+    assert "mb_track" not in playlist_item.metadata
+
+
 def test_import_match_policy_reachability_new_vs_legacy_m3u() -> None:
     """
     EXACT is only reachable when the parsed M3U carries release-track evidence.

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -956,6 +956,41 @@ def test_media_item_to_playlist_item_multiple_providers() -> None:
     assert result.path == "tidal://track/t2"
 
 
+def test_media_item_to_playlist_item_prefers_available_provider_as_primary() -> None:
+    """A higher-quality but unavailable mapping must not be chosen as the primary URI."""
+    track = Track(
+        item_id="t1",
+        provider="spotify",
+        name="Track With An Unavailable Best Match",
+        duration=200,
+        provider_mappings={
+            ProviderMapping(
+                item_id="unavailable-best",
+                provider_domain="tidal",
+                provider_instance="tidal_1",
+                available=False,
+                audio_format=AudioFormat(
+                    content_type=ContentType.FLAC, sample_rate=96000, bit_depth=24, bit_rate=0
+                ),
+            ),
+            ProviderMapping(
+                item_id="s1",
+                provider_domain="spotify",
+                provider_instance="spotify_1",
+                audio_format=AudioFormat(
+                    content_type=ContentType.OGG, sample_rate=44100, bit_depth=0, bit_rate=320
+                ),
+            ),
+        },
+    )
+
+    result = media_item_to_playlist_item(track)
+
+    # the tidal mapping has the higher quality, but it is unavailable - the primary
+    # URI must fall back to the playable spotify mapping instead
+    assert result.path == "spotify://track/s1"
+
+
 def test_media_item_to_playlist_item_ties_are_broken_deterministically() -> None:
     """Equal-quality provider mappings resolve to the same primary URI every time."""
     tied_format = AudioFormat(

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -877,6 +877,113 @@ def test_media_item_to_playlist_item_album_mapping_selection_is_deterministic_wi
     assert playlist_item.album.item_id == "alb1a"
 
 
+def test_media_item_to_playlist_item_album_prefers_available_mapping() -> None:
+    """
+    An available mapping wins over an unavailable one, regardless of iteration order.
+
+    Without a match to the track's own instance, the fallback ranking must still put an
+    available sibling ahead of an unavailable one.
+    """
+    album = Album(
+        item_id="alb1",
+        provider="tidal--2",
+        name="Kid A",
+        provider_mappings={
+            ProviderMapping(
+                item_id="alb1a",
+                provider_domain="tidal",
+                provider_instance="tidal--1",
+                available=False,
+            ),
+            ProviderMapping(
+                item_id="alb1b",
+                provider_domain="tidal",
+                provider_instance="tidal--2",
+                available=True,
+            ),
+        },
+    )
+    track = Track(
+        item_id="abc123",
+        provider="spotify--1",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            ProviderMapping(
+                item_id="abc123",
+                provider_domain="spotify",
+                provider_instance="spotify--1",
+                audio_format=AudioFormat(content_type=ContentType.FLAC),
+            ),
+        },
+        album=album,
+    )
+
+    playlist_item = media_item_to_playlist_item(track)
+
+    assert playlist_item.album is not None
+    assert playlist_item.album.provider_instance == "tidal--2"
+    assert playlist_item.album.item_id == "alb1b"
+
+
+def test_media_item_to_playlist_item_track_round_trip_preserves_exact_capable_album() -> None:
+    """
+    An album with several sibling mappings round-trips to the account holding exact evidence.
+
+    Exporting must pick the mapping matching the track's own account (rather than an
+    arbitrary sibling) so the reconstructed reference resolves to the same account that
+    supplied the track, keeping strict Exact-tier evidence available after a round trip.
+    """
+    mass = MagicMock()
+
+    class DummyProvider:
+        def __init__(self, domain: str, instance_id: str) -> None:
+            self.domain = domain
+            self.instance_id = instance_id
+
+    tidal_1 = DummyProvider("tidal", "tidal--1")
+    mass.get_provider.side_effect = lambda ref: {
+        "tidal": tidal_1,
+        "tidal--1": tidal_1,
+    }.get(ref)
+    album = Album(
+        item_id="alb1",
+        provider="tidal--1",
+        name="Kid A",
+        provider_mappings={
+            ProviderMapping(item_id="alb1a", provider_domain="tidal", provider_instance="tidal--1"),
+            ProviderMapping(item_id="alb1b", provider_domain="tidal", provider_instance="tidal--2"),
+            ProviderMapping(item_id="alb1c", provider_domain="tidal", provider_instance="tidal--3"),
+        },
+    )
+    track = Track(
+        item_id="abc123",
+        provider="tidal--1",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            ProviderMapping(
+                item_id="abc123",
+                provider_domain="tidal",
+                provider_instance="tidal--1",
+                audio_format=AudioFormat(content_type=ContentType.FLAC),
+            ),
+        },
+        album=album,
+    )
+
+    playlist_item = media_item_to_playlist_item(track)
+    parsed = parse_m3u(generate_m3u("Kid A", [playlist_item]))
+    reconstructed = construct_media_item_from_playlist_item(parsed[0], mass)
+
+    assert isinstance(reconstructed, Track)
+    assert reconstructed.album is not None
+    # the track's own account (tidal--1) holds the album's exact-evidence mapping (alb1a) -
+    # the round trip must resolve to that specific instance, not an arbitrary sibling
+    assert reconstructed.album.provider == "tidal--1"
+    assert reconstructed.album.item_id == "alb1a"
+
+
 def test_media_item_to_playlist_item_omits_conflicting_merged_external_ids() -> None:
     """Conflicting merged external IDs from different providers are not exported arbitrarily."""
     track = Track(

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -744,7 +744,7 @@ def test_media_item_to_playlist_item_track_round_trip_preserves_album_instance()
     mass = MagicMock()
     spotify_1 = DummyProvider("spotify", "spotify--1")
     spotify_2 = DummyProvider("spotify", "spotify--2")
-    mass.get_provider.side_effect = lambda ref: {
+    mass.get_provider.side_effect = lambda ref, **_kwargs: {
         "spotify": spotify_1,
         "spotify--1": spotify_1,
         "spotify--2": spotify_2,
@@ -784,6 +784,65 @@ def test_media_item_to_playlist_item_track_round_trip_preserves_album_instance()
     # the album was captured on spotify--2, a *different* instance than the track's own
     # spotify--1 - the reconstructed reference must pin to that exact instance
     assert reconstructed.album.provider == "spotify--2"
+
+
+def test_media_item_to_playlist_item_track_round_trip_falls_back_to_album_domain() -> None:
+    """
+    An album pinned to an instance id unknown on this server falls back to its domain.
+
+    A playlist exported from a different Music Assistant install carries instance ids
+    that are randomly generated per install and will never resolve here; reconstructing
+    with that foreign instance id verbatim would leave the album permanently
+    unhydratable. Falling back to the domain lets downstream hydration
+    (``TracksController._get_full_track_album``) try every allowed sibling instance of
+    it instead.
+    """
+
+    class DummyProvider:
+        def __init__(self, domain: str, instance_id: str) -> None:
+            self.domain = domain
+            self.instance_id = instance_id
+
+    mass = MagicMock()
+    # spotify--2 (the account this album was originally captured on, on a *different*
+    # Music Assistant install) does not exist on this server at all - only an unrelated
+    # sibling of the same domain does
+    spotify_9 = DummyProvider("spotify", "spotify--9")
+    mass.get_provider.side_effect = lambda ref, **_kwargs: {"spotify--9": spotify_9}.get(ref)
+    album = Album(
+        item_id="alb1",
+        provider="spotify--2",
+        name="Kid A",
+        provider_mappings={
+            ProviderMapping(
+                item_id="alb1", provider_domain="spotify", provider_instance="spotify--2"
+            )
+        },
+    )
+    track = Track(
+        item_id="abc123",
+        provider="spotify--2",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            ProviderMapping(
+                item_id="abc123",
+                provider_domain="spotify",
+                provider_instance="spotify--2",
+                audio_format=AudioFormat(content_type=ContentType.FLAC),
+            ),
+        },
+        album=album,
+    )
+
+    playlist_item = media_item_to_playlist_item(track)
+    parsed = parse_m3u(generate_m3u("Kid A", [playlist_item]))
+    reconstructed = construct_media_item_from_playlist_item(parsed[0], mass)
+
+    assert isinstance(reconstructed, Track)
+    assert reconstructed.album is not None
+    # falls back to the bare domain instead of the foreign, unresolvable instance id
+    assert reconstructed.album.provider == "spotify"
 
 
 def test_media_item_to_playlist_item_album_prefers_track_instance_when_multiple() -> None:
@@ -993,7 +1052,7 @@ def test_media_item_to_playlist_item_track_round_trip_preserves_exact_capable_al
             self.instance_id = instance_id
 
     tidal_1 = DummyProvider("tidal", "tidal--1")
-    mass.get_provider.side_effect = lambda ref: {
+    mass.get_provider.side_effect = lambda ref, **_kwargs: {
         "tidal": tidal_1,
         "tidal--1": tidal_1,
     }.get(ref)

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -834,6 +834,57 @@ def test_media_item_to_playlist_item_album_prefers_track_instance_when_multiple(
     assert playlist_item.album.item_id == "alb1b"
 
 
+def test_media_item_to_playlist_item_album_deterministic_among_same_instance_mappings() -> None:
+    """
+    Two mappings sharing the track's own instance still resolve to the same one.
+
+    An album can hold more than one mapping for the same account (for example an
+    alternate catalog ID for the same release) - matching by instance alone is not
+    enough to guarantee a single candidate, so the deterministic ranking must still
+    apply among those matches instead of leaving the choice to set iteration order.
+    """
+    album = Album(
+        item_id="alb1",
+        provider="spotify--1",
+        name="Kid A",
+        provider_mappings={
+            ProviderMapping(
+                item_id="alb1-alt",
+                provider_domain="spotify",
+                provider_instance="spotify--1",
+                available=False,
+            ),
+            ProviderMapping(
+                item_id="alb1-main",
+                provider_domain="spotify",
+                provider_instance="spotify--1",
+                available=True,
+            ),
+        },
+    )
+    track = Track(
+        item_id="abc123",
+        provider="spotify--1",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            ProviderMapping(
+                item_id="abc123",
+                provider_domain="spotify",
+                provider_instance="spotify--1",
+                audio_format=AudioFormat(content_type=ContentType.FLAC),
+            ),
+        },
+        album=album,
+    )
+
+    playlist_item = media_item_to_playlist_item(track)
+
+    assert playlist_item.album is not None
+    assert playlist_item.album.provider_instance == "spotify--1"
+    assert playlist_item.album.item_id == "alb1-main"
+
+
 def test_media_item_to_playlist_item_album_mapping_selection_is_deterministic_without_match() -> (
     None
 ):

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -786,6 +786,97 @@ def test_media_item_to_playlist_item_track_round_trip_preserves_album_instance()
     assert reconstructed.album.provider == "spotify--2"
 
 
+def test_media_item_to_playlist_item_album_prefers_track_instance_when_multiple() -> None:
+    """
+    An album with mappings on multiple sibling instances pins to the track's own account.
+
+    Picking an arbitrary album mapping (set iteration order is not guaranteed stable)
+    would let an unrelated sibling account's same-domain album ID nondeterministically
+    become the serialized - and later pinned - album reference; the mapping matching the
+    track's own instance is unambiguous and must win instead.
+    """
+    album = Album(
+        item_id="alb1",
+        provider="spotify--2",
+        name="Kid A",
+        provider_mappings={
+            ProviderMapping(
+                item_id="alb1a", provider_domain="spotify", provider_instance="spotify--2"
+            ),
+            ProviderMapping(
+                item_id="alb1b", provider_domain="spotify", provider_instance="spotify--1"
+            ),
+            ProviderMapping(
+                item_id="alb1c", provider_domain="spotify", provider_instance="spotify--3"
+            ),
+        },
+    )
+    track = Track(
+        item_id="abc123",
+        provider="spotify--1",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            ProviderMapping(
+                item_id="abc123",
+                provider_domain="spotify",
+                provider_instance="spotify--1",
+                audio_format=AudioFormat(content_type=ContentType.FLAC),
+            ),
+        },
+        album=album,
+    )
+
+    playlist_item = media_item_to_playlist_item(track)
+
+    assert playlist_item.album is not None
+    assert playlist_item.album.provider_instance == "spotify--1"
+    assert playlist_item.album.item_id == "alb1b"
+
+
+def test_media_item_to_playlist_item_album_mapping_selection_is_deterministic_without_match() -> (
+    None
+):
+    """
+    Without a mapping matching the track's own instance, the choice is still deterministic.
+
+    Falling back to a set's iteration order would let hash-order variance pick a
+    different sibling account across runs; the same ranking used for the track's own
+    primary provider (available, higher quality, then domain/instance/item_id) applies
+    here too, instead of whichever mapping the set happens to iterate first.
+    """
+    album = Album(
+        item_id="alb1",
+        provider="tidal--1",
+        name="Kid A",
+        provider_mappings={
+            ProviderMapping(item_id="alb1z", provider_domain="tidal", provider_instance="tidal--2"),
+            ProviderMapping(item_id="alb1a", provider_domain="tidal", provider_instance="tidal--1"),
+        },
+    )
+    track = Track(
+        item_id="abc123",
+        provider="spotify--1",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            ProviderMapping(
+                item_id="abc123",
+                provider_domain="spotify",
+                provider_instance="spotify--1",
+                audio_format=AudioFormat(content_type=ContentType.FLAC),
+            ),
+        },
+        album=album,
+    )
+
+    playlist_item = media_item_to_playlist_item(track)
+
+    assert playlist_item.album is not None
+    assert playlist_item.album.provider_instance == "tidal--1"
+    assert playlist_item.album.item_id == "alb1a"
+
+
 def test_media_item_to_playlist_item_omits_conflicting_merged_external_ids() -> None:
     """Conflicting merged external IDs from different providers are not exported arbitrarily."""
     track = Track(

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -1183,6 +1183,30 @@ def test_media_item_to_playlist_item_omits_multi_domain_mb_track() -> None:
     assert "mb_track" not in playlist_item.metadata
 
 
+def test_media_item_to_playlist_item_omits_multi_instance_same_domain_mb_track() -> None:
+    """Two instances of the same domain can still disagree on release, so MB_TRACK is omitted."""
+    track = Track(
+        item_id="abc123",
+        provider="library",
+        name="Everything In Its Right Place",
+        duration=240,
+        provider_mappings={
+            # two separate accounts of the same streaming service - a single
+            # merged domain must not be mistaken for a single trusted catalog
+            ProviderMapping(item_id="abc123", provider_domain="qobuz", provider_instance="qobuz_1"),
+            ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz_2"),
+        },
+        external_ids={
+            (ExternalID.MB_TRACK, "release-track-mbid"),
+        },
+    )
+
+    playlist_item = media_item_to_playlist_item(track)
+
+    assert playlist_item.metadata is not None
+    assert "mb_track" not in playlist_item.metadata
+
+
 def test_import_match_policy_reachability_new_vs_legacy_m3u() -> None:
     """
     EXACT is only reachable when the parsed M3U carries release-track evidence.

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -956,6 +956,45 @@ def test_media_item_to_playlist_item_multiple_providers() -> None:
     assert result.path == "tidal://track/t2"
 
 
+def test_media_item_to_playlist_item_ties_are_broken_deterministically() -> None:
+    """Equal-quality provider mappings resolve to the same primary URI every time."""
+    tied_format = AudioFormat(
+        content_type=ContentType.FLAC, sample_rate=44100, bit_depth=16, bit_rate=1000
+    )
+    track = Track(
+        item_id="t1",
+        provider="zulu",
+        name="Tied Quality Track",
+        duration=200,
+        provider_mappings={
+            ProviderMapping(
+                item_id="z1",
+                provider_domain="zulu",
+                provider_instance="zulu_1",
+                audio_format=tied_format,
+            ),
+            ProviderMapping(
+                item_id="a1",
+                provider_domain="alpha",
+                provider_instance="alpha_1",
+                audio_format=tied_format,
+            ),
+            ProviderMapping(
+                item_id="m1",
+                provider_domain="mid",
+                provider_instance="mid_1",
+                audio_format=tied_format,
+            ),
+        },
+    )
+
+    result = media_item_to_playlist_item(track)
+
+    # provider_mappings is a set: without a tie-break, equal-quality mappings would
+    # resolve to whichever the set happens to iterate first
+    assert result.path == "alpha://track/a1"
+
+
 def test_radio_entries_round_trip() -> None:
     """Test that radio entries survive generation and parsing unchanged."""
     items = [

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -1919,6 +1919,102 @@ async def test_playlist_deleted_and_recreated_during_matching_is_not_overwritten
     assert "Substitutions" not in report_markdown
 
 
+async def test_match_discards_substitution_when_recreated_between_read_and_capture() -> None:
+    """
+    A recreate landing between the M3U read and generation capture is still caught.
+
+    The initial read and the generation capture happen under the same per-playlist lock
+    that ``library_remove`` takes before unlinking a playlist's file, so a concurrent
+    recreate can only complete *after* that pair has been captured together - closing the
+    narrower race where old content could otherwise be paired with a fresh generation and
+    incorrectly accepted by the write-back check.
+    """
+    prov = _make_provider()
+    prov_playlist_id = "playlist_1"
+    to_match = _make_playlist_item(
+        path="spotify:track:original",
+        title="Artist - Song",
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    m3u_data = generate_m3u("Imported", [to_match])
+    prov_any = _prepare(prov, m3u_data, playlist_name="Imported")
+
+    generation = 1
+    content_read = asyncio.Event()
+    recreated = asyncio.Event()
+    generation_calls = 0
+
+    async def read_m3u(_playlist_id: str) -> str:
+        content_read.set()
+        # yield control so the concurrent recreate below gets a chance to attempt the
+        # per-playlist lock before this pass's own generation capture happens
+        await asyncio.sleep(0)
+        return m3u_data
+
+    async def get_generation(_playlist_id: str) -> int:
+        nonlocal generation_calls
+        generation_calls += 1
+        if generation_calls == 2:
+            # this is the write-back's final check - wait for the concurrent recreate
+            # to actually finish so this reads its bumped value deterministically,
+            # rather than depending on incidental task-scheduling order
+            await recreated.wait()
+        return generation
+
+    async def race_recreate() -> None:
+        nonlocal generation
+        await content_read.wait()
+        # mirrors library_remove, which takes this same per-playlist lock before
+        # unlinking the file - it can only proceed once the read+capture pair below
+        # releases the lock
+        async with prov._get_playlist_lock(prov_playlist_id):
+            generation += 1
+        recreated.set()
+
+    prov_any._read_m3u_file = AsyncMock(side_effect=read_m3u)
+    prov_any._get_playlist_generation = AsyncMock(side_effect=get_generation)
+
+    matched_track = _make_track(
+        "Song",
+        artists=["Artist"],
+        provider_mappings={
+            ProviderMapping(item_id="xyz", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    race_task = asyncio.ensure_future(race_recreate())
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            prov_playlist_id, PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
+        )
+    await race_task
+
+    # the recreate genuinely raced in and completed - this isn't passing by mere
+    # absence of contention
+    assert recreated.is_set()
+    assert generation == 2
+    # the substitution was matched against the pre-recreate content, so it must be
+    # discarded rather than written into the recreated playlist
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Skipped (playlist changed during matching) | 1 |" in report_markdown
+    assert "Substitutions" not in report_markdown
+
+
 async def test_create_playlist_generation_survives_inode_reuse(tmp_path: Path) -> None:
     """
     A recreate under the same ID gets a new generation, even with the same inode.

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -8,7 +8,12 @@ from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.enums import ExternalID, ImageType, MediaType, PlaylistMatchPolicy
-from music_assistant_models.errors import InvalidDataError, InvalidProviderID, MediaNotFoundError
+from music_assistant_models.errors import (
+    InvalidDataError,
+    InvalidProviderID,
+    MediaNotFoundError,
+    ResourceTemporarilyUnavailable,
+)
 from music_assistant_models.media_items import (
     AudioFormat,
     ItemMapping,
@@ -452,6 +457,47 @@ async def test_transient_stream_failure_retains_original_without_confirmation() 
     prov_any._write_m3u_file.assert_not_awaited()
     report_markdown = set_report.call_args.args[0]
     assert "| Retained | 1 |" in report_markdown
+
+
+async def test_transient_source_failure_is_not_reprobed_per_entry() -> None:
+    """A transient source-provider error is remembered, not retried once per entry."""
+    get_provider_item = AsyncMock(side_effect=ResourceTemporarilyUnavailable("Timed out"))
+    prov = _make_provider(
+        loaded_provider_domains={"builtin"},
+        provider_entries=[("spotify", "spotify_1", True)],
+        get_provider_item=get_provider_item,
+    )
+    items = [
+        _make_playlist_item(
+            path="spotify://track/track_one",
+            title="Artist - Song One",
+            providers=[
+                ProviderMappingInfo(domain="spotify", item_id="track_one", instance_id="spotify_1")
+            ],
+        ),
+        _make_playlist_item(
+            path="spotify://track/track_two",
+            title="Artist - Song Two",
+            providers=[
+                ProviderMappingInfo(domain="spotify", item_id="track_two", instance_id="spotify_1")
+            ],
+        ),
+    ]
+    prov_any = _prepare(prov, generate_m3u("Imported", items))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report"):
+        await prov.match_imported_playlist_tracks(
+            "playlist_1",
+            1,
+            PlaylistMatchPolicy.BEST_EFFORT,
+            _allowed(prov, "builtin", "spotify_1"),
+        )
+
+    # the second entry's identical failing instance is skipped outright, sparing it
+    # a second timeout rather than probing (and failing) it again
+    assert get_provider_item.await_count == 1
+    prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
+    prov_any._write_m3u_file.assert_not_awaited()
 
 
 async def test_confirmed_dead_stream_url_falls_through_to_matching() -> None:

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -1010,3 +1010,53 @@ async def test_concurrent_edit_during_matching_is_preserved() -> None:
     assert len(written_items) == 2
     assert written_items[0].providers[0].domain == "qobuz"
     assert written_items[1].path == "https://example.com/new.mp3"
+
+
+async def test_concurrent_deletion_during_matching_is_reflected_in_report() -> None:
+    """A track removed from the playlist while matching runs is reported, not double-counted."""
+    prov = _make_provider()
+    to_match = _make_playlist_item(
+        path="spotify:track:original",
+        title="Artist - Song",
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    initial_m3u = generate_m3u("Imported", [to_match])
+    prov_any = _prepare(prov, initial_m3u)
+    # the user removed the only entry while the (possibly long-running) matching pass was
+    # still running: the second read - taken under the lock, right before the write - no
+    # longer has it, so the resolved substitute must not be written or reported as applied
+    edited_m3u = generate_m3u("Imported", [])
+    prov_any._read_m3u_file = AsyncMock(side_effect=[initial_m3u, edited_m3u])
+
+    matched_track = _make_track(
+        "Song",
+        artists=["Artist"],
+        provider_mappings={
+            ProviderMapping(item_id="xyz", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.EXACT, ("qobuz--1",)
+        )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Exact release | 0 |" in report_markdown
+    assert "| Skipped (playlist changed during matching) | 1 |" in report_markdown
+    assert "Substitutions" not in report_markdown

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from music_assistant_models.enums import ExternalID, ImageType, MediaType
 from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import (
+    AudioFormat,
     ItemMapping,
     MediaItemImage,
     MediaItemMetadata,
@@ -684,6 +685,100 @@ async def test_persisted_mappings_exclude_weaker_compatible_tier() -> None:
     ]
     report_markdown = set_report.call_args.args[0]
     assert "| Exact release | 1 |" in report_markdown
+
+
+async def test_same_tier_mappings_only_combine_with_the_primary_release() -> None:
+    """Two same-tier matches for different releases don't get merged as one exact release."""
+    prov = _make_provider(
+        loaded_provider_domains={"spotify--1"},
+        get_provider_item=AsyncMock(side_effect=MediaNotFoundError("gone")),
+    )
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        title="Artist - Song",
+        providers=[
+            ProviderMappingInfo(
+                domain="spotify", instance_id="spotify--1", item_id="abc123", content_type=""
+            )
+        ],
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    # a low-quality mapping that happens to be first in the (unordered) matches tuple
+    low_quality_mapping = ProviderMapping(
+        item_id="low456",
+        provider_domain="tidal",
+        provider_instance="tidal--1",
+        audio_format=AudioFormat(sample_rate=44100, bit_depth=16),
+    )
+    low_quality_track = _make_track(
+        "Song", artists=["Artist"], provider_mappings={low_quality_mapping}
+    )
+    # distinct provider identity from the other candidate track, so the two aren't
+    # trivially recognised as the same item by shared-identity comparison
+    low_quality_track.item_id = "low456"
+    low_quality_track.provider = "tidal--1"
+    low_quality_track.external_ids = {(ExternalID.MB_TRACK, "low-quality-release-mbid")}
+    # a higher-quality mapping for a genuinely different release, at the same
+    # (merely recording-level compatible) LIKELY confidence tier
+    high_quality_mapping = ProviderMapping(
+        item_id="high789",
+        provider_domain="qobuz",
+        provider_instance="qobuz--1",
+        audio_format=AudioFormat(sample_rate=192000, bit_depth=24),
+    )
+    high_quality_track = _make_track(
+        "Song", artists=["Artist"], provider_mappings={high_quality_mapping}
+    )
+    high_quality_track.item_id = "high789"
+    high_quality_track.provider = "qobuz--1"
+    high_quality_track.external_ids = {(ExternalID.MB_TRACK, "high-quality-release-mbid")}
+    enrichment = TrackProviderEnrichment(
+        track=low_quality_track,
+        matches=(
+            TrackProviderMatch(
+                track=low_quality_track,
+                mapping=low_quality_mapping,
+                confidence=TrackMatchConfidence.LIKELY,
+            ),
+            TrackProviderMatch(
+                track=high_quality_track,
+                mapping=high_quality_mapping,
+                confidence=TrackMatchConfidence.LIKELY,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1",
+            PlaylistMatchPolicy.SAME_RECORDING,
+            _allowed(prov, "spotify--1", "qobuz--1", "tidal--1"),
+        )
+
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    # media_item_to_playlist_item picks its primary playback URI by mapping quality,
+    # so the higher-quality qobuz mapping is what will actually be exported - the
+    # entry's release evidence must describe that same release, not the low-quality
+    # tidal candidate's unrelated one, and the tidal mapping must not be kept either
+    assert written_items[0].providers == [
+        ProviderMappingInfo(
+            domain="qobuz",
+            item_id="high789",
+            instance_id="qobuz--1",
+            content_type="?",
+            sample_rate=192000,
+            bit_depth=24,
+        )
+    ]
+    assert written_items[0].metadata is not None
+    assert written_items[0].metadata.get("mb_track") == "high-quality-release-mbid"
+    report_markdown = set_report.call_args.args[0]
+    assert "| Same recording | 1 |" in report_markdown
 
 
 async def test_dead_url_is_matched_instead_of_retained() -> None:

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -1447,6 +1447,76 @@ async def test_concurrent_deletes_of_the_same_playlist_do_not_race() -> None:
     remove_mock.assert_called_once()
 
 
+async def test_concurrent_create_playlist_with_same_name_does_not_race() -> None:
+    """Two concurrent creates for the same name must not collide on the same file/generation."""
+    prov = _make_provider()
+    prov_any = cast("Any", prov)
+    prov_any._playlists_dir = "stubbed-playlists-dir"
+    prov_any._playlist_generations = {}
+    # get_playlist's own read-back path isn't what this test is exercising
+    prov_any.get_playlist = AsyncMock(side_effect=lambda pid: MagicMock(item_id=pid))
+    files: dict[str, str] = {}
+
+    def fake_isfile(path: str) -> bool:
+        return path in files
+
+    class _FakeM3uFile:
+        """Stand-in for aiofiles' write-mode open() that records into the fake filesystem."""
+
+        def __init__(self, path: str) -> None:
+            self._path = path
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def write(self, content: str) -> None:
+            # simulate the write actually landing on "disk" only once the writer
+            # is done, the same way a real file create becomes visible to a
+            # concurrent isfile() check only after the write completes
+            files[self._path] = content
+
+        async def read(self) -> str:
+            return files.get(self._path, "")
+
+    def fake_open(path: str, _mode: str = "r", **_kwargs: object) -> _FakeM3uFile:
+        return _FakeM3uFile(path)
+
+    async def fake_to_thread(func: Any, *args: object) -> object:
+        # mimic a real thread pool: the check runs immediately (possibly before the
+        # other concurrent caller has written anything), and only the *return* of
+        # that already-computed result is delayed, so two callers can genuinely
+        # race the same stale "file does not exist" answer
+        result = func(*args)
+        await asyncio.sleep(0.01)
+        return result
+
+    with (
+        patch("music_assistant.providers.builtin.os.path.isfile", side_effect=fake_isfile),
+        patch("music_assistant.providers.builtin.aiofiles.open", side_effect=fake_open),
+        patch("music_assistant.providers.builtin.asyncio.to_thread", side_effect=fake_to_thread),
+    ):
+        # both calls race the uniqueness check/generation bump/initial write for the
+        # exact same sanitized name; without serializing the whole sequence under a
+        # single lock, both could see the id as free and collide on it
+        playlist_a, playlist_b = await asyncio.gather(
+            prov.create_playlist("My Playlist", media_types={MediaType.PLAYLIST}),
+            prov.create_playlist("My Playlist", media_types={MediaType.PLAYLIST}),
+        )
+
+    # each concurrent create must land on its own distinct id
+    assert playlist_a.item_id != playlist_b.item_id
+    assert {playlist_a.item_id, playlist_b.item_id} == {"My Playlist", "My Playlist (1)"}
+    # both files must actually exist on the fake filesystem, i.e. neither create
+    # silently overwrote the other's file
+    assert len(files) == 2
+    # each id's generation was bumped exactly once, not raced into a shared value
+    assert prov_any._playlist_generations["My Playlist"] == 1
+    assert prov_any._playlist_generations["My Playlist (1)"] == 1
+
+
 async def test_read_m3u_file_existence_check_is_atomic_with_delete() -> None:
     """A read's existence check and file open cannot be split by a concurrent delete."""
     prov = _make_provider()

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -500,6 +500,52 @@ async def test_transient_source_failure_is_not_reprobed_per_entry() -> None:
     prov_any._write_m3u_file.assert_not_awaited()
 
 
+async def test_domain_only_reference_tries_next_sibling_when_one_is_unavailable() -> None:
+    """One unreachable sibling account must not stop a healthy sibling from being tried."""
+    hydrated = _make_track(
+        "Song",
+        provider_mappings={
+            ProviderMapping(
+                item_id="track_one", provider_domain="spotify", provider_instance="spotify_2"
+            )
+        },
+    )
+    prov = _make_provider(
+        loaded_provider_domains={"builtin"},
+        # spotify_1 is configured but currently down; spotify_2 is a healthy
+        # sibling account of the very same domain and should still get a chance
+        provider_entries=[("spotify", "spotify_1", False), ("spotify", "spotify_2", True)],
+        get_provider_item=AsyncMock(return_value=hydrated),
+    )
+    # a domain-only reference (no pinned instance id) is what triggers the
+    # same-domain sibling widening in the first place
+    item = _make_playlist_item(
+        path="spotify://track/track_one",
+        title="Artist - Song",
+        providers=[ProviderMappingInfo(domain="spotify", item_id="track_one")],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report"):
+        await prov.match_imported_playlist_tracks(
+            "playlist_1",
+            1,
+            PlaylistMatchPolicy.BEST_EFFORT,
+            _allowed(prov, "builtin", "spotify_1", "spotify_2"),
+        )
+
+    # the healthy sibling confirmed the item is still there, so it must be
+    # retained and normalized to that instance - never substituted just because
+    # a different sibling account happened to be down
+    prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
+    prov_any._write_m3u_file.assert_awaited_once()
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    written_mapping = written_items[0].providers[0]
+    assert written_mapping.domain == "spotify"
+    assert written_mapping.item_id == "track_one"
+    assert written_mapping.instance_id == "spotify_2"
+
+
 async def test_confirmed_dead_stream_url_falls_through_to_matching() -> None:
     """A HEAD and corroborating GET both reporting terminal status prove the stream is gone."""
     prov = _make_provider(

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -402,6 +402,39 @@ async def test_head_404_alone_does_not_confirm_a_stream_is_gone() -> None:
     assert "| Retained | 1 |" in report_markdown
 
 
+async def test_head_method_not_allowed_still_confirms_via_get() -> None:
+    """A server that rejects HEAD outright must still have a dead GET confirm it."""
+    prov = _make_provider(
+        loaded_provider_domains={"builtin"},
+        get_provider_item=AsyncMock(side_effect=InvalidDataError("ffprobe failed")),
+    )
+    item = PlaylistItem(
+        path="https://example.com/stream.mp3", title="Artist - Live Stream", length=None
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    # 405 means the server doesn't support HEAD at all, not that the stream is alive -
+    # the ranged GET must still be attempted to determine that
+    prov_any.mass.http_session.head = MagicMock(return_value=_FakeHttpResponse(405))
+    prov_any.mass.http_session.get = MagicMock(return_value=_FakeHttpResponse(404))
+    enrichment = TrackProviderEnrichment(
+        track=cast("Any", MagicMock()),
+        matches=(),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
+        )
+
+    prov_any.mass.music.tracks.enrich_provider_mappings.assert_awaited_once()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" not in report_markdown
+
+
 async def test_catalog_item_api_error_retains_original_without_confirmation() -> None:
     """A provider API error must not be treated as proof a catalog id was deleted."""
     prov = _make_provider(

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -1,14 +1,12 @@
-"""Tests for playlist import track matching and scoring logic."""
+"""Tests for playlist import track matching against the shared resolver."""
 
 from __future__ import annotations
 
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from music_assistant_models.enums import ExternalID, ImageType, MediaType
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.enums import ImageType, MediaType
 from music_assistant_models.media_items import (
-    Artist,
     ItemMapping,
     MediaItemImage,
     MediaItemMetadata,
@@ -18,7 +16,14 @@ from music_assistant_models.media_items import (
     UniqueList,
 )
 
+from music_assistant.controllers.music.media.playlists import PlaylistMatchPolicy
+from music_assistant.controllers.music.media.tracks import (
+    TrackProviderEnrichment,
+    TrackProviderMatch,
+)
+from music_assistant.helpers.compare import TrackMatchConfidence
 from music_assistant.helpers.playlists import (
+    ArtistInfo,
     PlaylistItem,
     ProviderMappingInfo,
     generate_m3u,
@@ -26,9 +31,13 @@ from music_assistant.helpers.playlists import (
 from music_assistant.providers.builtin import BuiltinProvider
 
 
-def _make_provider() -> BuiltinProvider:
-    """Create a minimal BuiltinProvider with mocked mass."""
+def _make_provider(loaded_provider_domains: set[str] | None = None) -> BuiltinProvider:
+    """Create a minimal BuiltinProvider with a mocked mass."""
     mass = MagicMock()
+    loaded = loaded_provider_domains or set()
+    mass.get_provider = MagicMock(
+        side_effect=lambda pid, **_kwargs: MagicMock(domain=pid) if pid in loaded else None
+    )
     prov = object.__new__(BuiltinProvider)
     prov.mass = mass
     prov.logger = MagicMock()
@@ -38,63 +47,39 @@ def _make_provider() -> BuiltinProvider:
 def _make_track(
     name: str,
     artists: list[str] | None = None,
-    duration: int = 0,
-    album_name: str | None = None,
-    version: str = "",
-    isrc: str | None = None,
-    mbid: str | None = None,
-    media_type: MediaType = MediaType.TRACK,
+    provider_mappings: set[ProviderMapping] | None = None,
 ) -> Track:
-    """Build a Track for matching tests."""
-    artist_list: UniqueList[Artist | ItemMapping] = UniqueList()
+    """Build a Track for enrichment stubbing."""
+    artist_list: UniqueList[Any] = UniqueList()
     for a in artists or []:
         artist_list.append(
             ItemMapping(item_id=a, provider="test", name=a, media_type=MediaType.ARTIST)
         )
-    external_ids: set[tuple[ExternalID, str]] = set()
-    if isrc:
-        external_ids.add((ExternalID.ISRC, isrc))
-    if mbid:
-        external_ids.add((ExternalID.MB_RECORDING, mbid))
-    album_mapping = None
-    if album_name:
-        album_mapping = ItemMapping(
-            item_id=album_name, provider="test", name=album_name, media_type=MediaType.ALBUM
-        )
-    track = Track(
-        item_id="test123",
-        provider="test",
+    return Track(
+        item_id="matched123",
+        provider="opensubsonic--abc123",
         name=name,
-        version=version,
-        duration=duration,
         artists=artist_list,
-        album=album_mapping,
-        external_ids=external_ids,
-        provider_mappings={
-            ProviderMapping(
-                item_id="test123",
-                provider_domain="test",
-                provider_instance="test",
-            )
-        },
+        provider_mappings=provider_mappings or set(),
     )
-    track.media_type = media_type
-    return track
 
 
 def _make_playlist_item(
-    title: str | None = None,
-    length: str | None = None,
+    path: str = "spotify:track:original",
+    title: str | None = "Artist - Song",
+    length: str | None = "294",
     metadata: dict[str, str] | None = None,
     providers: list[ProviderMappingInfo] | None = None,
+    artists: list[ArtistInfo] | None = None,
 ) -> PlaylistItem:
-    """Build a PlaylistItem for matching tests."""
+    """Build a PlaylistItem representing one parsed M3U entry."""
     return PlaylistItem(
-        path="spotify://track/original",
+        path=path,
         title=title,
         length=length,
         metadata=metadata,
         providers=providers or [],
+        artists=artists or [],
     )
 
 
@@ -119,165 +104,19 @@ def _make_playlist(name: str, image_url: str | None = None) -> Playlist:
         metadata=metadata,
         provider_mappings={
             ProviderMapping(
-                item_id="playlist_1",
-                provider_domain="builtin",
-                provider_instance="builtin",
+                item_id="playlist_1", provider_domain="builtin", provider_instance="builtin"
             )
         },
     )
 
 
-# --------------------------------------------------------------------------- #
-#  _score_track_match                                                          #
-# --------------------------------------------------------------------------- #
-
-
-class TestScoreTrackMatch:
-    """Tests for the _score_track_match scoring method."""
-
-    def setup_method(self) -> None:
-        """Set up test fixtures."""
-        self.prov = _make_provider()
-
-    def test_isrc_match_returns_max_score(self) -> None:
-        """ISRC match should return 10 (maximum score)."""
-        candidate = _make_track("Song", artists=["Artist"], isrc="USRC17607839")
-        item = _make_playlist_item(
-            title="Artist - Song",
-            metadata={"isrc": "USRC17607839"},
-        )
-        assert self.prov._score_track_match(candidate, item) == 10
-
-    def test_isrc_match_case_insensitive(self) -> None:
-        """ISRC matching should be case-insensitive."""
-        candidate = _make_track("Song", artists=["Artist"], isrc="usrc17607839")
-        item = _make_playlist_item(
-            title="Artist - Song",
-            metadata={"isrc": "USRC17607839"},
-        )
-        assert self.prov._score_track_match(candidate, item) == 10
-
-    def test_mbid_match_returns_max_score(self) -> None:
-        """MusicBrainz recording ID match should return 10."""
-        candidate = _make_track(
-            "Song", artists=["Artist"], mbid="a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-        )
-        item = _make_playlist_item(
-            title="Artist - Song",
-            metadata={"mbid": "A1B2C3D4-E5F6-7890-ABCD-EF1234567890"},
-        )
-        assert self.prov._score_track_match(candidate, item) == 10
-
-    def test_title_match_only(self) -> None:
-        """Title-only match (no artist) should score 1."""
-        candidate = _make_track("Song Title")
-        item = _make_playlist_item(title="Song Title")
-        assert self.prov._score_track_match(candidate, item) == 1
-
-    def test_title_mismatch_returns_zero(self) -> None:
-        """Non-matching title should return 0."""
-        candidate = _make_track("Completely Different")
-        item = _make_playlist_item(title="Song Title")
-        assert self.prov._score_track_match(candidate, item) == 0
-
-    def test_title_and_artist_match(self) -> None:
-        """Title + artist match should score 3 (1 title + 2 artist)."""
-        candidate = _make_track("Song", artists=["Radiohead"])
-        item = _make_playlist_item(title="Radiohead - Song")
-        assert self.prov._score_track_match(candidate, item) == 3
-
-    def test_artist_mismatch_returns_zero(self) -> None:
-        """When artist is provided but doesn't match, return 0."""
-        candidate = _make_track("Song", artists=["Coldplay"])
-        item = _make_playlist_item(title="Radiohead - Song")
-        assert self.prov._score_track_match(candidate, item) == 0
-
-    def test_album_bonus(self) -> None:
-        """Matching album adds 1 to the score."""
-        candidate = _make_track("Song", artists=["Artist"], album_name="OK Computer")
-        item = _make_playlist_item(
-            title="Artist - Song",
-            metadata={"album": "OK Computer"},
-        )
-        # 1 (title) + 2 (artist) + 1 (album) = 4
-        assert self.prov._score_track_match(candidate, item) == 4
-
-    def test_duration_near_exact_bonus(self) -> None:
-        """Duration within 2 seconds adds 2 to the score."""
-        candidate = _make_track("Song", artists=["Artist"], duration=241)
-        item = _make_playlist_item(title="Artist - Song", length="240")
-        # 1 (title) + 2 (artist) + 2 (duration) = 5
-        assert self.prov._score_track_match(candidate, item) == 5
-
-    def test_duration_close_bonus(self) -> None:
-        """Duration within 5 seconds adds 1 to the score."""
-        candidate = _make_track("Song", artists=["Artist"], duration=245)
-        item = _make_playlist_item(title="Artist - Song", length="240")
-        # 1 (title) + 2 (artist) + 1 (duration close) = 4
-        assert self.prov._score_track_match(candidate, item) == 4
-
-    def test_duration_too_far_no_bonus(self) -> None:
-        """Duration beyond 5 seconds gets no bonus."""
-        candidate = _make_track("Song", artists=["Artist"], duration=260)
-        item = _make_playlist_item(title="Artist - Song", length="240")
-        # 1 (title) + 2 (artist) = 3
-        assert self.prov._score_track_match(candidate, item) == 3
-
-    def test_version_match_bonus(self) -> None:
-        """Matching version adds 1."""
-        candidate = _make_track("Song", artists=["Artist"], version="Remastered")
-        item = _make_playlist_item(
-            title="Artist - Song",
-            metadata={"version": "Remastered"},
-        )
-        # 1 (title) + 2 (artist) + 1 (version) = 4
-        assert self.prov._score_track_match(candidate, item) == 4
-
-    def test_version_mismatch_penalty(self) -> None:
-        """Mismatched version subtracts 1."""
-        candidate = _make_track("Song", artists=["Artist"], version="Live")
-        item = _make_playlist_item(
-            title="Artist - Song",
-            metadata={"version": "Remastered"},
-        )
-        # 1 (title) + 2 (artist) - 1 (version mismatch) = 2
-        assert self.prov._score_track_match(candidate, item) == 2
-
-    def test_media_type_gate(self) -> None:
-        """Mismatched media type should return 0."""
-        candidate = _make_track("Song", artists=["Artist"])
-        item = _make_playlist_item(
-            title="Artist - Song",
-            metadata={"media_type": "podcast_episode"},
-        )
-        assert self.prov._score_track_match(candidate, item) == 0
-
-    def test_none_title_returns_zero(self) -> None:
-        """PlaylistItem with no title should score 0."""
-        candidate = _make_track("Song")
-        item = _make_playlist_item(title=None)
-        assert self.prov._score_track_match(candidate, item) == 0
-
-    def test_full_metadata_high_score(self) -> None:
-        """Track with all metadata matching should get a high score."""
-        candidate = _make_track(
-            "Everything In Its Right Place",
-            artists=["Radiohead"],
-            duration=240,
-            album_name="Kid A",
-            version="Remastered",
-        )
-        item = _make_playlist_item(
-            title="Radiohead - Everything In Its Right Place",
-            length="240",
-            metadata={
-                "media_type": "track",
-                "album": "Kid A",
-                "version": "Remastered",
-            },
-        )
-        # 1 (title) + 2 (artist) + 1 (album) + 1 (version) + 2 (duration exact) = 7
-        assert self.prov._score_track_match(candidate, item) == 7
+def _prepare(prov: BuiltinProvider, m3u_data: str, playlist_name: str = "Imported") -> Any:
+    """Wire up the read/write/get_playlist mocks shared by every test."""
+    prov_any = cast("Any", prov)
+    prov_any._read_m3u_file = AsyncMock(return_value=m3u_data)
+    prov_any.get_playlist = AsyncMock(return_value=_make_playlist(playlist_name))
+    prov_any._write_m3u_file = AsyncMock()
+    return prov_any
 
 
 async def test_import_playlist_preserves_playlist_image() -> None:
@@ -305,66 +144,6 @@ async def test_import_playlist_preserves_playlist_image() -> None:
     assert args[3] == "https://img.example.com/cover.jpg"
     assert result.image is not None
     assert result.image.path == "https://img.example.com/cover.jpg"
-
-
-async def test_match_imported_tracks_enriches_matched_entries() -> None:
-    """Test that a matched entry is enriched with provider metadata, not just its URI."""
-    prov = _make_provider()
-    prov_any = cast("Any", prov)
-    prov_any._read_m3u_file = AsyncMock(
-        return_value=(
-            "#EXTM3U\n"
-            "#PLAYLIST:Imported\n"
-            "#EXTMA:media_type=track||name=Song||mbid=a1b2c3d4-e5f6-7890-abcd-ef1234567890\n"
-            "#EXTINF:294,Artist - Song\n"
-            "track-1\n"
-        )
-    )
-    matched_uri = "opensubsonic--abc123://track/xyz789"
-    enriched_entry = PlaylistItem(
-        path=matched_uri,
-        title="Artist - Song",
-        length="294",
-        metadata={"media_type": "track", "name": "Song"},
-        providers=[
-            ProviderMappingInfo(
-                domain="opensubsonic", item_id="xyz789", instance_id="opensubsonic--abc123"
-            )
-        ],
-    )
-    prov_any._match_track_by_metadata = AsyncMock(return_value=matched_uri)
-    prov_any._build_m3u_entry_from_uri = AsyncMock(return_value=enriched_entry)
-    prov_any.get_playlist = AsyncMock(return_value=_make_playlist("Imported"))
-    prov_any._write_m3u_file = AsyncMock()
-
-    await prov.match_imported_playlist_tracks("playlist_1")
-
-    prov_any._build_m3u_entry_from_uri.assert_awaited_once_with(matched_uri)
-    assert prov_any._write_m3u_file.await_args is not None
-    written_items = prov_any._write_m3u_file.await_args.args[2]
-    assert written_items == [enriched_entry]
-    assert written_items[0].providers
-
-
-async def test_match_imported_tracks_falls_back_to_uri_when_enrich_fails() -> None:
-    """Test that the matched URI is still stored when enrichment fails."""
-    prov = _make_provider()
-    prov_any = cast("Any", prov)
-    prov_any._read_m3u_file = AsyncMock(
-        return_value="#EXTM3U\n#PLAYLIST:Imported\n#EXTINF:294,Artist - Song\ntrack-1\n"
-    )
-    matched_uri = "opensubsonic--abc123://track/xyz789"
-    prov_any._match_track_by_metadata = AsyncMock(return_value=matched_uri)
-    prov_any._build_m3u_entry_from_uri = AsyncMock(side_effect=MediaNotFoundError("gone"))
-    prov_any.get_playlist = AsyncMock(return_value=_make_playlist("Imported"))
-    prov_any._write_m3u_file = AsyncMock()
-
-    await prov.match_imported_playlist_tracks("playlist_1")
-
-    assert prov_any._write_m3u_file.await_args is not None
-    written_items = prov_any._write_m3u_file.await_args.args[2]
-    assert written_items[0].path == matched_uri
-    assert not written_items[0].providers
 
 
 async def test_remove_playlist_tracks_preserves_playlist_image() -> None:
@@ -395,3 +174,262 @@ async def test_remove_playlist_tracks_preserves_playlist_image() -> None:
     assert args[1] == "My Playlist"
     assert len(args[2]) == 1
     assert args[3] == "https://img.example.com/cover.jpg"
+
+
+async def test_available_original_is_retained_without_search() -> None:
+    """An entry whose original provider is still loaded is left untouched."""
+    prov = _make_provider(loaded_provider_domains={"builtin"})
+    m3u_data = generate_m3u(
+        "Imported",
+        [PlaylistItem(path="https://example.com/stream.mp3", title="Live Stream", length=None)],
+    )
+    prov_any = _prepare(prov, m3u_data)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+        )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
+
+
+async def test_matched_entry_is_enriched_and_reported_as_exact() -> None:
+    """A structured-artist entry matched at EXACT confidence is substituted and reported."""
+    prov = _make_provider()
+    item = _make_playlist_item(
+        path="spotify:track:original",
+        title="Artist - Song",
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    m3u_data = generate_m3u("Imported", [item])
+    prov_any = _prepare(prov, m3u_data)
+
+    matched_track = _make_track(
+        "Song",
+        artists=["Artist"],
+        provider_mappings={
+            ProviderMapping(
+                item_id="xyz789",
+                provider_domain="opensubsonic",
+                provider_instance="opensubsonic--abc123",
+            )
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("opensubsonic--abc123",)
+        )
+
+    prov_any._write_m3u_file.assert_awaited_once()
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert len(written_items) == 1
+    assert written_items[0].providers
+    assert written_items[0].providers[0].domain == "opensubsonic"
+    report_markdown = set_report.call_args.args[0]
+    assert "| Exact release | 1 |" in report_markdown
+    assert "Substitutions" in report_markdown
+
+
+async def test_ambiguous_match_is_reported_and_not_substituted() -> None:
+    """An ambiguous provider match leaves the entry unmatched and notes the ambiguity."""
+    prov = _make_provider()
+    item = _make_playlist_item(
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")]
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    enrichment = TrackProviderEnrichment(
+        track=_make_track("Song", artists=["Artist"]),
+        matches=(),
+        ambiguous_providers=("Qobuz",),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+        )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Ambiguous | 1 |" in report_markdown
+    assert "| Unmatched | 0 |" in report_markdown
+    assert "Ambiguous match on Qobuz" in report_markdown
+
+
+async def test_no_acceptable_match_is_reported_as_unmatched() -> None:
+    """A search that yields nothing above the policy threshold is reported as unmatched."""
+    prov = _make_provider()
+    item = _make_playlist_item(
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")]
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    enrichment = TrackProviderEnrichment(
+        track=_make_track("Song", artists=["Artist"]),
+        matches=(),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.EXACT, ("qobuz--1",)
+        )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Unmatched | 1 |" in report_markdown
+    assert "No acceptable match" in report_markdown
+
+
+async def test_provider_error_is_reported_as_unmatched_with_issue() -> None:
+    """A transient provider failure during matching is surfaced as a provider issue."""
+    prov = _make_provider()
+    item = _make_playlist_item(
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")]
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(
+        side_effect=TimeoutError("provider timed out")
+    )
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+        )
+
+    report_markdown = set_report.call_args.args[0]
+    assert "| Unmatched | 1 |" in report_markdown
+    assert "Provider lookup issues" in report_markdown
+    assert "provider timed out" in report_markdown
+
+
+async def test_extinf_title_without_structured_artist_is_split_for_matching() -> None:
+    """A foreign M3U8 entry with only a combined EXTINF title still gets matched."""
+    prov = _make_provider()
+    # no #EXTARTIST tag: only a combined "Artist - Title" EXTINF string is available
+    item = _make_playlist_item(
+        path="/music/song.mp3", title="Radiohead - Everything In Its Right Place"
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    matched_track = _make_track(
+        "Everything In Its Right Place",
+        artists=["Radiohead"],
+        provider_mappings={
+            ProviderMapping(item_id="xyz", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.LIKELY,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    enrich_mock = AsyncMock(return_value=enrichment)
+    prov_any.mass.music.tracks.enrich_provider_mappings = enrich_mock
+
+    await prov.match_imported_playlist_tracks(
+        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+    )
+
+    enrich_mock.assert_awaited_once()
+    assert enrich_mock.await_args is not None
+    resolved_track = enrich_mock.await_args.args[0]
+    assert resolved_track.artists
+    assert resolved_track.artists[0].name == "Radiohead"
+    assert resolved_track.name == "Everything In Its Right Place"
+    prov_any._write_m3u_file.assert_awaited_once()
+
+
+async def test_missing_artist_metadata_is_unmatched_without_search() -> None:
+    """An entry with no title at all cannot be searched and is reported as unmatched."""
+    prov = _make_provider()
+    item = _make_playlist_item(path="/music/track01.flac", title=None, length=None)
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    enrich_mock = AsyncMock()
+    prov_any.mass.music.tracks.enrich_provider_mappings = enrich_mock
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+        )
+
+    enrich_mock.assert_not_awaited()
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Unmatched | 1 |" in report_markdown
+    assert "No artist metadata" in report_markdown
+
+
+async def test_order_and_duplicates_preserved_across_mixed_results() -> None:
+    """Retained, matched and unmatched entries keep their original position and duplicates."""
+    prov = _make_provider(loaded_provider_domains={"builtin"})
+    retained = PlaylistItem(path="https://example.com/a.mp3", title="Retained", length=None)
+    to_match = _make_playlist_item(
+        path="spotify:track:dup",
+        title="Artist - Song",
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    unmatched = _make_playlist_item(path="/music/none.flac", title=None, length=None)
+    items = [retained, to_match, to_match, unmatched]
+    prov_any = _prepare(prov, generate_m3u("Imported", items))
+
+    matched_track = _make_track(
+        "Song",
+        artists=["Artist"],
+        provider_mappings={
+            ProviderMapping(item_id="xyz", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.LOOSE,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    await prov.match_imported_playlist_tracks(
+        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+    )
+
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert len(written_items) == 4
+    assert written_items[0].path == "https://example.com/a.mp3"
+    assert written_items[1].providers[0].domain == "qobuz"
+    assert written_items[2].providers[0].domain == "qobuz"
+    assert written_items[3].path == "/music/none.flac"

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -617,6 +617,61 @@ async def test_available_provider_with_dead_item_id_is_matched() -> None:
     assert "| Exact release | 1 |" in report_markdown
 
 
+async def test_confirmed_dead_original_is_not_hydrated_again_during_matching() -> None:
+    """The just-confirmed-dead original mapping is passed on, not force-refreshed twice."""
+    prov = _make_provider(
+        loaded_provider_domains={"spotify--1"},
+        get_provider_item=AsyncMock(side_effect=MediaNotFoundError("gone")),
+    )
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        title="Artist - Song",
+        providers=[
+            ProviderMappingInfo(
+                domain="spotify", instance_id="spotify--1", item_id="abc123", content_type=""
+            )
+        ],
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    matched_track = _make_track(
+        "Song",
+        artists=["Artist"],
+        provider_mappings={
+            ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    enrich_provider_mappings = AsyncMock(return_value=enrichment)
+    prov_any.mass.music.tracks.enrich_provider_mappings = enrich_provider_mappings
+
+    with patch("music_assistant.providers.builtin.set_current_task_report"):
+        await prov.match_imported_playlist_tracks(
+            "playlist_1",
+            PlaylistMatchPolicy.SAME_RECORDING,
+            _allowed(prov, "spotify--1", "qobuz--1"),
+        )
+
+    # the liveness check above already force-refreshed and confirmed this exact
+    # (instance, item id) pair dead, so it must be handed on rather than probed twice
+    assert enrich_provider_mappings.await_args is not None
+    assert enrich_provider_mappings.await_args.kwargs["known_dead_mappings"] == frozenset(
+        {("spotify--1", "abc123")}
+    )
+
+
 async def test_persisted_mappings_exclude_weaker_compatible_tier() -> None:
     """A weaker, merely-compatible tier does not end up as the persisted substitute."""
     prov = _make_provider(

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -834,7 +834,15 @@ async def test_domain_only_reference_tries_every_allowed_instance() -> None:
             _allowed(prov, "spotify--1", "spotify--2"),
         )
 
-    prov_any._write_m3u_file.assert_not_awaited()
+    # the domain-only reference is normalized to the instance that actually confirmed
+    # it, so a later load resolves straight to spotify--2 instead of guessing the
+    # first registered account (spotify--1, which just proved this id gone) again
+    prov_any._write_m3u_file.assert_awaited_once()
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert len(written_items) == 1
+    assert written_items[0].providers == [
+        ProviderMappingInfo(domain="spotify", instance_id="spotify--2", item_id="abc123")
+    ]
     assert prov_any.mass.music.tracks.get_provider_item.await_count == 2
     report_markdown = set_report.call_args.args[0]
     assert "| Retained | 1 |" in report_markdown

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from music_assistant_models.enums import ExternalID, ImageType, MediaType
+from music_assistant_models.enums import ExternalID, ImageType, MediaType, PlaylistMatchPolicy
 from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import (
     AudioFormat,
@@ -19,7 +19,6 @@ from music_assistant_models.media_items import (
     UniqueList,
 )
 
-from music_assistant.controllers.music.media.playlists import PlaylistMatchPolicy
 from music_assistant.controllers.music.media.tracks import (
     TrackProviderEnrichment,
     TrackProviderMatch,

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -41,6 +41,7 @@ def _make_provider(loaded_provider_domains: set[str] | None = None) -> BuiltinPr
     prov = object.__new__(BuiltinProvider)
     prov.mass = mass
     prov.logger = MagicMock()
+    prov._playlist_locks = {}
     return prov
 
 
@@ -433,3 +434,52 @@ async def test_order_and_duplicates_preserved_across_mixed_results() -> None:
     assert written_items[1].providers[0].domain == "qobuz"
     assert written_items[2].providers[0].domain == "qobuz"
     assert written_items[3].path == "/music/none.flac"
+
+
+async def test_concurrent_edit_during_matching_is_preserved() -> None:
+    """A track added to the playlist while matching runs is not discarded by the write-back."""
+    prov = _make_provider()
+    to_match = _make_playlist_item(
+        path="spotify:track:original",
+        title="Artist - Song",
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    initial_m3u = generate_m3u("Imported", [to_match])
+    prov_any = _prepare(prov, initial_m3u)
+    # simulate a track added by the user while the (possibly long-running) matching pass
+    # above was still running: the second read - taken under the lock, right before the
+    # write - reflects that concurrent edit
+    concurrently_added = PlaylistItem(path="https://example.com/new.mp3", title="New", length=None)
+    edited_m3u = generate_m3u("Imported", [to_match, concurrently_added])
+    prov_any._read_m3u_file = AsyncMock(side_effect=[initial_m3u, edited_m3u])
+
+    matched_track = _make_track(
+        "Song",
+        artists=["Artist"],
+        provider_mappings={
+            ProviderMapping(item_id="xyz", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    await prov.match_imported_playlist_tracks(
+        "playlist_1", PlaylistMatchPolicy.EXACT, ("qobuz--1",)
+    )
+
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert len(written_items) == 2
+    assert written_items[0].providers[0].domain == "qobuz"
+    assert written_items[1].path == "https://example.com/new.mp3"

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -1092,6 +1092,41 @@ async def test_delete_playlist_waits_for_global_file_lock() -> None:
                 delete_task.cancel()
 
 
+async def test_concurrent_deletes_of_the_same_playlist_do_not_race() -> None:
+    """Two concurrent deletes of the same playlist must not both attempt os.remove."""
+    prov = _make_provider()
+    prov_any = cast("Any", prov)
+    prov_any._playlists_dir = "stubbed-playlists-dir"
+    file_state = {"exists": True}
+
+    def fake_isfile(_path: str) -> bool:
+        return file_state["exists"]
+
+    def fake_remove(path: str) -> None:
+        if not file_state["exists"]:
+            # a real os.remove on an already-deleted file raises this
+            raise FileNotFoundError(path)
+        file_state["exists"] = False
+
+    with (
+        patch("music_assistant.providers.builtin.os.path.isfile", side_effect=fake_isfile),
+        patch(
+            "music_assistant.providers.builtin.os.remove", side_effect=fake_remove
+        ) as remove_mock,
+    ):
+        # the existence check must be re-evaluated under the lock for each caller,
+        # rather than both callers trusting a stale check made before either
+        # acquired it
+        result_a, result_b = await asyncio.gather(
+            prov.library_remove("playlist_1", MediaType.PLAYLIST),
+            prov.library_remove("playlist_1", MediaType.PLAYLIST),
+        )
+
+    assert result_a is True
+    assert result_b is True
+    remove_mock.assert_called_once()
+
+
 async def test_read_m3u_file_existence_check_is_atomic_with_delete() -> None:
     """A read's existence check and file open cannot be split by a concurrent delete."""
     prov = _make_provider()

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -195,7 +195,7 @@ async def test_import_playlist_preserves_playlist_image() -> None:
     """Test that importing an M3U keeps the playlist-level image."""
     prov = _make_provider()
     prov_any = cast("Any", prov)
-    prov_any._reserve_playlist_file = AsyncMock(return_value="playlist_1")
+    prov_any._reserve_playlist_file = AsyncMock(return_value=("playlist_1", 1))
     prov_any.get_playlist = AsyncMock(
         return_value=_make_playlist("Imported Playlist", "https://img.example.com/cover.jpg")
     )
@@ -206,13 +206,14 @@ async def test_import_playlist_preserves_playlist_image() -> None:
         "https://img.example.com/cover.jpg",
     )
 
-    result = await prov.import_playlist(m3u_data)
+    result, generation = await prov.import_playlist(m3u_data)
 
     assert prov_any._reserve_playlist_file.await_args is not None
     args = prov_any._reserve_playlist_file.await_args.args
     assert args[0] == "Imported Playlist"
     assert args[1][0].path == "spotify://track/abc123"
     assert args[2] == "https://img.example.com/cover.jpg"
+    assert generation == 1
     assert result.image is not None
     assert result.image.path == "https://img.example.com/cover.jpg"
 
@@ -317,7 +318,7 @@ async def test_available_original_is_retained_without_search() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -334,7 +335,7 @@ async def test_bare_uri_without_extprov_is_recognized_as_available() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify", "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify", "qobuz--1")
         )
 
     # written back once so the entry keeps resolving to a provider mapping on future
@@ -359,7 +360,7 @@ async def test_share_url_without_extprov_is_persisted_as_provider_mapping() -> N
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify", "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify", "qobuz--1")
         )
 
     # written back so the entry resolves through Spotify on future loads too, instead
@@ -388,7 +389,7 @@ async def test_transient_stream_failure_retains_original_without_confirmation() 
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
         )
 
     prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
@@ -420,7 +421,7 @@ async def test_confirmed_dead_stream_url_falls_through_to_matching() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
         )
 
     prov_any.mass.music.tracks.enrich_provider_mappings.assert_awaited_once()
@@ -442,7 +443,7 @@ async def test_head_404_alone_does_not_confirm_a_stream_is_gone() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
         )
 
     prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
@@ -476,7 +477,7 @@ async def test_head_method_not_allowed_still_confirms_via_get() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
         )
 
     prov_any.mass.music.tracks.enrich_provider_mappings.assert_awaited_once()
@@ -502,7 +503,7 @@ async def test_catalog_item_api_error_retains_original_without_confirmation() ->
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
         )
 
     prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
@@ -524,7 +525,7 @@ async def test_bare_radio_uri_without_extma_is_not_matched_as_track() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "radiobrowser")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "radiobrowser")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -543,6 +544,7 @@ async def test_search_narrowing_does_not_affect_source_validation() -> None:
         # spotify is allowed (source validation), but the search is narrowed to qobuz only
         await prov.match_imported_playlist_tracks(
             "playlist_1",
+            1,
             PlaylistMatchPolicy.BEST_EFFORT,
             _allowed(prov, "spotify", "qobuz--1"),
             ("qobuz--1",),
@@ -575,7 +577,10 @@ async def test_configured_but_unavailable_provider_is_retained() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--1", "qobuz--1")
+            "playlist_1",
+            1,
+            PlaylistMatchPolicy.BEST_EFFORT,
+            _allowed(prov, "spotify--1", "qobuz--1"),
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -601,7 +606,10 @@ async def test_configured_but_unloaded_provider_is_retained() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--1", "qobuz--1")
+            "playlist_1",
+            1,
+            PlaylistMatchPolicy.BEST_EFFORT,
+            _allowed(prov, "spotify--1", "qobuz--1"),
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -652,6 +660,7 @@ async def test_available_provider_with_dead_item_id_is_matched() -> None:
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
             "playlist_1",
+            1,
             PlaylistMatchPolicy.SAME_RECORDING,
             _allowed(prov, "spotify--1", "qobuz--1"),
         )
@@ -709,6 +718,7 @@ async def test_available_provider_with_invalid_provider_id_is_matched() -> None:
         # rest of the playlist's entries
         await prov.match_imported_playlist_tracks(
             "playlist_1",
+            1,
             PlaylistMatchPolicy.SAME_RECORDING,
             _allowed(prov, "spotify--1", "qobuz--1"),
         )
@@ -763,6 +773,7 @@ async def test_confirmed_dead_original_is_not_hydrated_again_during_matching() -
     with patch("music_assistant.providers.builtin.set_current_task_report"):
         await prov.match_imported_playlist_tracks(
             "playlist_1",
+            1,
             PlaylistMatchPolicy.SAME_RECORDING,
             _allowed(prov, "spotify--1", "qobuz--1"),
         )
@@ -822,6 +833,7 @@ async def test_persisted_mappings_exclude_weaker_compatible_tier() -> None:
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
             "playlist_1",
+            1,
             PlaylistMatchPolicy.SAME_RECORDING,
             _allowed(prov, "spotify--1", "qobuz--1", "tidal--1"),
         )
@@ -914,6 +926,7 @@ async def test_same_tier_mappings_only_combine_with_the_primary_release() -> Non
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
             "playlist_1",
+            1,
             PlaylistMatchPolicy.SAME_RECORDING,
             _allowed(prov, "spotify--1", "qobuz--1", "tidal--1"),
         )
@@ -975,7 +988,7 @@ async def test_dead_url_is_matched_instead_of_retained() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_awaited_once()
@@ -1023,7 +1036,7 @@ async def test_original_source_outside_allowed_instances_is_not_trusted() -> Non
     # it must never be trusted (or even probed) just because some account can resolve it
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_awaited_once()
@@ -1050,7 +1063,7 @@ async def test_original_source_probe_bypasses_cached_provider_details() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report"):
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--1")
         )
 
     # cached (possibly stale) details are never good enough for this check - a
@@ -1083,6 +1096,7 @@ async def test_domain_only_reference_tries_every_allowed_instance() -> None:
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
             "playlist_1",
+            1,
             PlaylistMatchPolicy.BEST_EFFORT,
             _allowed(prov, "spotify--1", "spotify--2"),
         )
@@ -1130,7 +1144,7 @@ async def test_exact_instance_reference_never_widens_to_sibling_instance() -> No
     prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
 
     await prov.match_imported_playlist_tracks(
-        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--1", "spotify--2")
+        "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--1", "spotify--2")
     )
 
     prov_any.mass.music.tracks.get_provider_item.assert_awaited_once()
@@ -1158,7 +1172,7 @@ async def test_extprov_naming_unregistered_instance_falls_back_to_allowed_siblin
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--2")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--2")
         )
 
     # the unregistered pinned instance is normalized to the allowed sibling that
@@ -1199,6 +1213,7 @@ async def test_domain_only_reference_to_unloaded_instance_is_retained() -> None:
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
             "playlist_1",
+            1,
             PlaylistMatchPolicy.BEST_EFFORT,
             (("spotify--1", "spotify"), ("qobuz--1", "qobuz")),
         )
@@ -1250,6 +1265,7 @@ async def test_duplicate_original_entries_are_resolved_only_once() -> None:
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
             "playlist_1",
+            1,
             PlaylistMatchPolicy.SAME_RECORDING,
             _allowed(prov, "qobuz--1", "spotify--1"),
         )
@@ -1327,7 +1343,7 @@ async def test_duplicate_path_with_different_metadata_is_resolved_independently(
     prov_any.mass.music.tracks.enrich_provider_mappings = enrich_mock
 
     await prov.match_imported_playlist_tracks(
-        "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
+        "playlist_1", 1, PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
     )
 
     # a metadata-poor or different first duplicate must not suppress resolution of the
@@ -1359,7 +1375,7 @@ async def test_unmatched_stale_mapping_does_not_crash_or_get_reused() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -1400,7 +1416,7 @@ async def test_matched_entry_excludes_unmatched_stale_mapping() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
         )
 
     written_items = prov_any._write_m3u_file.await_args.args[2]
@@ -1448,7 +1464,7 @@ async def test_matched_entry_uses_matched_candidate_metadata_not_source() -> Non
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
         )
 
     written_items = prov_any._write_m3u_file.await_args.args[2]
@@ -1748,7 +1764,10 @@ async def test_matched_entry_is_enriched_and_reported_as_exact() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "opensubsonic--abc123")
+            "playlist_1",
+            1,
+            PlaylistMatchPolicy.SAME_RECORDING,
+            _allowed(prov, "opensubsonic--abc123"),
         )
 
     prov_any._write_m3u_file.assert_awaited_once()
@@ -1779,7 +1798,7 @@ async def test_ambiguous_match_is_reported_and_not_substituted() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -1807,7 +1826,7 @@ async def test_no_acceptable_match_is_reported_as_unmatched() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -1829,7 +1848,7 @@ async def test_provider_error_is_reported_as_unmatched_with_issue() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
         )
 
     report_markdown = set_report.call_args.args[0]
@@ -1870,7 +1889,7 @@ async def test_extinf_title_without_structured_artist_is_split_for_matching() ->
     prov_any.mass.music.tracks.enrich_provider_mappings = enrich_mock
 
     await prov.match_imported_playlist_tracks(
-        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
+        "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
     )
 
     enrich_mock.assert_awaited_once()
@@ -1892,7 +1911,7 @@ async def test_missing_artist_metadata_is_unmatched_without_search() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
         )
 
     enrich_mock.assert_not_awaited()
@@ -1938,7 +1957,7 @@ async def test_order_and_duplicates_preserved_across_mixed_results() -> None:
     prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
 
     await prov.match_imported_playlist_tracks(
-        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
+        "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
     )
 
     written_items = prov_any._write_m3u_file.await_args.args[2]
@@ -1989,7 +2008,7 @@ async def test_concurrent_edit_during_matching_is_preserved() -> None:
     prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
 
     await prov.match_imported_playlist_tracks(
-        "playlist_1", PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
+        "playlist_1", 1, PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
     )
 
     written_items = prov_any._write_m3u_file.await_args.args[2]
@@ -2038,7 +2057,7 @@ async def test_concurrent_deletion_during_matching_is_reflected_in_report() -> N
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -2046,6 +2065,37 @@ async def test_concurrent_deletion_during_matching_is_reflected_in_report() -> N
     assert "| Exact release | 0 |" in report_markdown
     assert "| Skipped (playlist changed during matching) | 1 |" in report_markdown
     assert "Substitutions" not in report_markdown
+
+
+async def test_match_aborts_when_scheduled_generation_already_stale() -> None:
+    """
+    A task whose target was deleted and recreated before it even started is a no-op.
+
+    Unlike the mid-pass recreate races below, here the recreate is already complete
+    by the time this call starts - simulating a task that sat queued behind the
+    tasks controller's concurrency limit long enough for that to happen. The very
+    first generation read must already disagree with what the task was scheduled
+    for, so no substitute is even searched.
+    """
+    prov = _make_provider()
+    to_match = _make_playlist_item(
+        path="spotify:track:original",
+        title="Artist - Song",
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    m3u_data = generate_m3u("Imported", [to_match])
+    prov_any = _prepare(prov, m3u_data)
+    # the playlist under this id is already on generation 2 by the time this call
+    # starts - the task was scheduled for generation 1 and sat queued too long
+    prov_any._get_playlist_generation = AsyncMock(return_value=2)
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock()
+
+    await prov.match_imported_playlist_tracks(
+        "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
+    )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_awaited()
 
 
 async def test_playlist_deleted_and_recreated_during_matching_is_not_overwritten() -> None:
@@ -2088,7 +2138,7 @@ async def test_playlist_deleted_and_recreated_during_matching_is_not_overwritten
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
+            "playlist_1", 1, PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -2177,7 +2227,7 @@ async def test_match_discards_substitution_when_recreated_between_read_and_captu
     race_task = asyncio.ensure_future(race_recreate())
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            prov_playlist_id, PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
+            prov_playlist_id, 1, PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
         )
     await race_task
 

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+import asyncio
+from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.enums import ImageType, MediaType
@@ -91,6 +92,7 @@ def _make_provider(
     prov.mass = mass
     prov.logger = MagicMock()
     prov._playlist_locks = {}
+    prov._playlist_lock = asyncio.Lock()
     return prov
 
 
@@ -242,6 +244,19 @@ async def test_remove_playlist_tracks_preserves_playlist_image() -> None:
     assert args[3] == "https://img.example.com/cover.jpg"
 
 
+class _FakeHeadResponse:
+    """Stand-in for an aiohttp HEAD response carrying a fixed status code."""
+
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+
 async def test_available_original_is_retained_without_search() -> None:
     """An entry whose original provider is still loaded is left untouched."""
     prov = _make_provider(loaded_provider_domains={"builtin"})
@@ -284,6 +299,59 @@ async def test_bare_uri_without_extprov_is_recognized_as_available() -> None:
     ]
     report_markdown = set_report.call_args.args[0]
     assert "| Retained | 1 |" in report_markdown
+
+
+async def test_transient_stream_failure_retains_original_without_confirmation() -> None:
+    """A network blip during the ffprobe check must not substitute a live stream."""
+    prov = _make_provider(
+        loaded_provider_domains={"builtin"},
+        get_provider_item=AsyncMock(side_effect=InvalidDataError("ffprobe failed")),
+    )
+    item = PlaylistItem(path="https://example.com/stream.mp3", title="Live Stream", length=None)
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    # a 500 response does not prove the stream is gone - ffprobe wraps both a
+    # transient server error and a genuinely dead stream in the same error
+    prov_any.mass.http_session.head = MagicMock(return_value=_FakeHeadResponse(500))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
+        )
+
+    prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
+
+
+async def test_confirmed_dead_stream_url_falls_through_to_matching() -> None:
+    """A confirmed terminal HTTP status proves the stream is actually gone."""
+    prov = _make_provider(
+        loaded_provider_domains={"builtin"},
+        get_provider_item=AsyncMock(side_effect=InvalidDataError("ffprobe failed")),
+    )
+    item = PlaylistItem(
+        path="https://example.com/stream.mp3", title="Artist - Live Stream", length=None
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    prov_any.mass.http_session.head = MagicMock(return_value=_FakeHeadResponse(404))
+    enrichment = TrackProviderEnrichment(
+        track=cast("Any", MagicMock()),
+        matches=(),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
+        )
+
+    prov_any.mass.music.tracks.enrich_provider_mappings.assert_awaited_once()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" not in report_markdown
 
 
 async def test_bare_radio_uri_without_extma_is_not_matched_as_track() -> None:
@@ -915,6 +983,33 @@ async def test_delete_playlist_uses_per_playlist_lock() -> None:
         await prov.library_remove("playlist_1", MediaType.PLAYLIST)
 
     assert "playlist_1" in prov_any._playlist_locks
+
+
+async def test_delete_playlist_waits_for_global_file_lock() -> None:
+    """Deleting a playlist file cannot race an in-flight _read_m3u_file/_write_m3u_file call."""
+    prov = _make_provider()
+    prov_any = cast("Any", prov)
+    prov_any._playlists_dir = "stubbed-playlists-dir"
+
+    with (
+        patch("music_assistant.providers.builtin.os.path.isfile", return_value=True),
+        patch("music_assistant.providers.builtin.os.remove") as remove_mock,
+    ):
+        # hold the same global file-I/O lock that _read_m3u_file/_write_m3u_file
+        # acquire around their actual file access, as if a read or write were
+        # already in flight
+        await prov_any._playlist_lock.acquire()
+        delete_task = asyncio.ensure_future(prov.library_remove("playlist_1", MediaType.PLAYLIST))
+        try:
+            await asyncio.sleep(0.1)
+            # the removal must not proceed while the global lock is held elsewhere
+            remove_mock.assert_not_called()
+            prov_any._playlist_lock.release()
+            await asyncio.wait_for(delete_task, timeout=2)
+            remove_mock.assert_called_once()
+        finally:
+            if not delete_task.done():
+                delete_task.cancel()
 
 
 async def test_matched_entry_is_enriched_and_reported_as_exact() -> None:

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from music_assistant_models.enums import ImageType, MediaType
+from music_assistant_models.enums import ExternalID, ImageType, MediaType
 from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import (
     ItemMapping,
@@ -1036,6 +1036,54 @@ async def test_matched_entry_excludes_unmatched_stale_mapping() -> None:
     assert domains == {"qobuz"}
     report_markdown = set_report.call_args.args[0]
     assert "| Exact release | 1 |" in report_markdown
+
+
+async def test_matched_entry_uses_matched_candidate_metadata_not_source() -> None:
+    """The substituted entry reflects the matched candidate, not the dead source's metadata."""
+    prov = _make_provider()
+    item = _make_playlist_item(
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")]
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    # the dead source track carries release evidence (MB_TRACK) for a release that is
+    # no longer reachable - it must not leak into the substituted entry, or a later
+    # export/re-import could mistake this same-recording match for an exact one
+    stale_source_track = _make_track("Song", artists=["Artist"])
+    stale_source_track.external_ids = {(ExternalID.MB_TRACK, "stale-dead-release-mbid")}
+    matched_mapping = ProviderMapping(
+        item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz--1"
+    )
+    # the actual matched candidate, freshly fetched from qobuz, has its own (different)
+    # release evidence that genuinely belongs to it
+    matched_candidate_track = _make_track(
+        "Song", artists=["Artist"], provider_mappings={matched_mapping}
+    )
+    matched_candidate_track.external_ids = {(ExternalID.MB_TRACK, "fresh-matched-release-mbid")}
+    enrichment = TrackProviderEnrichment(
+        track=stale_source_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_candidate_track,
+                mapping=matched_mapping,
+                confidence=TrackMatchConfidence.LIKELY,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
+        )
+
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert written_items[0].metadata is not None
+    assert written_items[0].metadata.get("mb_track") == "fresh-matched-release-mbid"
+    report_markdown = set_report.call_args.args[0]
+    assert "| Same recording | 1 |" in report_markdown
 
 
 async def test_update_playlist_metadata_uses_per_playlist_lock() -> None:

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -548,6 +548,82 @@ async def test_duplicate_original_entries_are_resolved_only_once() -> None:
     assert "| Exact release | 3 |" in report_markdown
 
 
+async def test_duplicate_path_with_different_metadata_is_resolved_independently() -> None:
+    """Entries sharing a path but differing in title/artists are not conflated by the cache."""
+    prov = _make_provider(
+        loaded_provider_domains={"builtin"},
+        get_provider_item=AsyncMock(side_effect=InvalidDataError("404")),
+    )
+    first = _make_playlist_item(
+        path="https://example.com/shared.mp3",
+        title="Artist One - Song One",
+        artists=[
+            ArtistInfo(name="Artist One", provider_domain="", item_id="", provider_instance="")
+        ],
+    )
+    second = _make_playlist_item(
+        path="https://example.com/shared.mp3",
+        title="Artist Two - Song Two",
+        artists=[
+            ArtistInfo(name="Artist Two", provider_domain="", item_id="", provider_instance="")
+        ],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [first, second]))
+    track_one = _make_track(
+        "Song One",
+        artists=["Artist One"],
+        provider_mappings={
+            ProviderMapping(item_id="one", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    track_two = _make_track(
+        "Song Two",
+        artists=["Artist Two"],
+        provider_mappings={
+            ProviderMapping(item_id="two", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment_one = TrackProviderEnrichment(
+        track=track_one,
+        matches=(
+            TrackProviderMatch(
+                track=track_one,
+                mapping=next(iter(track_one.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    enrichment_two = TrackProviderEnrichment(
+        track=track_two,
+        matches=(
+            TrackProviderMatch(
+                track=track_two,
+                mapping=next(iter(track_two.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    enrich_mock = AsyncMock(side_effect=[enrichment_one, enrichment_two])
+    prov_any.mass.music.tracks.enrich_provider_mappings = enrich_mock
+
+    await prov.match_imported_playlist_tracks(
+        "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("qobuz--1",)
+    )
+
+    # a metadata-poor or different first duplicate must not suppress resolution of the
+    # second entry - each is matched against its own title/artist evidence
+    assert enrich_mock.await_count == 2
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert written_items[0].providers[0].item_id == "one"
+    assert written_items[1].providers[0].item_id == "two"
+
+
 async def test_unmatched_stale_mapping_does_not_crash_or_get_reused() -> None:
     """A preserved but unverified mapping with no actual match is unmatched, not a crash."""
     prov = _make_provider()

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -1038,11 +1038,13 @@ async def test_exact_instance_reference_never_widens_to_sibling_instance() -> No
     assert called_instance == "spotify--1"
 
 
-async def test_extprov_naming_disallowed_instance_does_not_fall_back_to_path() -> None:
-    """An #EXTPROV entry outside the allowed snapshot must not resolve via a sibling instance."""
+async def test_extprov_naming_unregistered_instance_falls_back_to_allowed_sibling_domain() -> None:
+    """A pinned instance absent locally is retried on allowed siblings of its own domain."""
+    # spotify--1 does not exist in this server's registry at all - as if the M3U was
+    # exported from a different Music Assistant install, where instance ids are
+    # randomly generated per install - but the allowed snapshot's own spotify--2
+    # sibling of the same domain does have the item
     prov = _make_provider(
-        # spotify--2 is an allowed, loaded sibling that does have the item - but the
-        # entry's own #EXTPROV names spotify--1, which is not in the allowed snapshot
         provider_entries=[("spotify", "spotify--2", True)],
         get_provider_item=AsyncMock(return_value=MagicMock()),
     )
@@ -1051,26 +1053,32 @@ async def test_extprov_naming_disallowed_instance_does_not_fall_back_to_path() -
         providers=[
             ProviderMappingInfo(domain="spotify", instance_id="spotify--1", item_id="abc123"),
         ],
-        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
     )
     prov_any = _prepare(prov, generate_m3u("Imported", [item]))
-    enrichment = TrackProviderEnrichment(
-        track=_make_track("Song", artists=["Artist"]),
-        matches=(),
-        ambiguous_providers=(),
-        failed_providers=(),
-        used_library_item=False,
-    )
-    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
 
-    await prov.match_imported_playlist_tracks(
-        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--2")
-    )
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--2")
+        )
 
-    # the entry's own #EXTPROV data already names a provider reference, so a bare-path
-    # guess must never be tried against an unrelated allowed sibling instance
-    prov_any.mass.music.tracks.get_provider_item.assert_not_awaited()
-    prov_any.mass.music.tracks.enrich_provider_mappings.assert_awaited_once()
+    # the unregistered pinned instance is normalized to the allowed sibling that
+    # actually confirmed it, so a later load resolves straight to spotify--2 instead
+    # of repeating this same fallback every pass
+    prov_any._write_m3u_file.assert_awaited_once()
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert len(written_items) == 1
+    assert written_items[0].providers == [
+        ProviderMappingInfo(domain="spotify", instance_id="spotify--2", item_id="abc123")
+    ]
+    prov_any.mass.music.tracks.get_provider_item.assert_awaited_once_with(
+        "abc123",
+        "spotify--2",
+        force_refresh=True,
+        allow_fallback=False,
+        strict_provider_instance=True,
+    )
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
 
 
 async def test_domain_only_reference_to_unloaded_instance_is_retained() -> None:

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -278,6 +278,28 @@ async def test_bare_uri_without_extprov_is_recognized_as_available() -> None:
     assert "| Retained | 1 |" in report_markdown
 
 
+async def test_bare_radio_uri_without_extma_is_not_matched_as_track() -> None:
+    """A bare radio:// entry with no #EXTMA metadata must not be searched as a Track."""
+    prov = _make_provider(
+        loaded_provider_domains={"radiobrowser"},
+        get_provider_item=AsyncMock(side_effect=MediaNotFoundError("gone")),
+    )
+    item = PlaylistItem(path="radiobrowser://radio/xyz123", title="Live Station", length=None)
+    assert item.metadata is None
+    assert not item.providers
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "radiobrowser")
+        )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
+
+
 async def test_search_narrowing_does_not_affect_source_validation() -> None:
     """Narrowing the search targets must not make a playable original look unavailable."""
     prov = _make_provider(loaded_provider_domains={"spotify", "qobuz"})

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -301,7 +301,29 @@ async def test_bare_uri_without_extprov_is_recognized_as_available() -> None:
     assert "| Retained | 1 |" in report_markdown
 
 
-async def test_transient_stream_failure_retains_original_without_confirmation() -> None:
+async def test_share_url_without_extprov_is_persisted_as_provider_mapping() -> None:
+    """A public share URL is resolved and persisted, not treated as a raw builtin stream."""
+    prov = _make_provider(loaded_provider_domains={"spotify"})
+    item = PlaylistItem(path="https://open.spotify.com/track/abc123", title="Test", length="120")
+    assert not item.providers
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify", "qobuz--1")
+        )
+
+    # written back so the entry resolves through Spotify on future loads too, instead
+    # of reconstructing as an unplayable raw builtin web URL
+    prov_any._write_m3u_file.assert_awaited_once()
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert len(written_items) == 1
+    assert written_items[0].providers == [
+        ProviderMappingInfo(domain="spotify", item_id="abc123", instance_id="spotify")
+    ]
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
+
     """A network blip during the ffprobe check must not substitute a live stream."""
     prov = _make_provider(
         loaded_provider_domains={"builtin"},

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -450,6 +450,33 @@ async def test_original_source_outside_allowed_instances_is_not_trusted() -> Non
     assert "| Exact release | 1 |" in report_markdown
 
 
+async def test_original_source_probe_bypasses_cached_provider_details() -> None:
+    """The authoritative liveness probe must not trust a stale cached hit."""
+    prov = _make_provider(
+        loaded_provider_domains={"spotify--1"},
+        get_provider_item=AsyncMock(return_value=MagicMock()),
+    )
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        providers=[
+            ProviderMappingInfo(domain="spotify", instance_id="spotify--1", item_id="abc123"),
+        ],
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report"):
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify--1",)
+        )
+
+    # cached (possibly stale) details are never good enough for this check - a
+    # provider hit that only comes from cache would hide a deletion that happened
+    # after the cache entry was written
+    prov_any.mass.music.tracks.get_provider_item.assert_awaited_once()
+    assert prov_any.mass.music.tracks.get_provider_item.await_args.kwargs["force_refresh"] is True
+
+
 async def test_domain_only_reference_tries_every_allowed_instance() -> None:
     """A domain-only #EXTPROV entry is probed on every allowed instance of that domain."""
     prov = _make_provider(

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -262,7 +262,7 @@ async def test_available_original_is_retained_without_search() -> None:
 
 
 async def test_bare_uri_without_extprov_is_recognized_as_available() -> None:
-    """A plain M3U entry with a bare MA URI, but no #EXTPROV metadata, is still retained."""
+    """A plain M3U entry with a bare MA URI, but no #EXTPROV metadata, is retained."""
     prov = _make_provider(loaded_provider_domains={"spotify"})
     item = PlaylistItem(path="spotify://track/abc123", title="Test", length="120")
     assert not item.providers
@@ -273,7 +273,15 @@ async def test_bare_uri_without_extprov_is_recognized_as_available() -> None:
             "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify", "qobuz--1")
         )
 
-    prov_any._write_m3u_file.assert_not_awaited()
+    # written back once so the entry keeps resolving to a provider mapping on future
+    # loads too, since a bare URI with no #EXTPROV can otherwise never attach one -
+    # it is still counted and reported as retained though, not as a substitution
+    prov_any._write_m3u_file.assert_awaited_once()
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert len(written_items) == 1
+    assert written_items[0].providers == [
+        ProviderMappingInfo(domain="spotify", item_id="abc123", instance_id="spotify")
+    ]
     report_markdown = set_report.call_args.args[0]
     assert "| Retained | 1 |" in report_markdown
 
@@ -316,7 +324,13 @@ async def test_search_narrowing_does_not_affect_source_validation() -> None:
         )
 
     prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
-    prov_any._write_m3u_file.assert_not_awaited()
+    # written back once so the entry keeps resolving to a provider mapping on future
+    # loads too, but the search narrowing itself must not have been touched
+    prov_any._write_m3u_file.assert_awaited_once()
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert written_items[0].providers == [
+        ProviderMappingInfo(domain="spotify", item_id="abc123", instance_id="spotify")
+    ]
     report_markdown = set_report.call_args.args[0]
     assert "| Retained | 1 |" in report_markdown
 

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -1251,6 +1251,49 @@ async def test_extprov_naming_unregistered_instance_falls_back_to_allowed_siblin
     assert "| Retained | 1 |" in report_markdown
 
 
+async def test_non_streaming_domain_does_not_expand_foreign_instance_to_sibling() -> None:
+    """A non-streaming domain's foreign instance id is never probed against a sibling."""
+    # filesystem--1 does not exist in this server's registry at all - as if the M3U
+    # was exported from a different Music Assistant install - but unlike a streaming
+    # catalog, filesystem--1's own item ids are local to that install and are not
+    # guaranteed to mean anything on the allowed filesystem--2 sibling; probing that
+    # sibling could authoritatively confirm a wholly unrelated file
+    prov = _make_provider(
+        provider_entries=[("filesystem", "filesystem--2", True)],
+        get_provider_item=AsyncMock(return_value=MagicMock()),
+    )
+    for provider in cast("list[MagicMock]", prov.mass.providers):
+        if provider.domain == "filesystem":
+            provider.is_streaming_provider = False
+    item = _make_playlist_item(
+        path="music_assistant://track/filesystem--1/track_a",
+        providers=[
+            ProviderMappingInfo(domain="filesystem", instance_id="filesystem--1", item_id="a"),
+        ],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    enrichment = TrackProviderEnrichment(
+        track=_make_track("Song", artists=["Artist"]),
+        matches=(),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "filesystem--2")
+        )
+
+    # the sibling instance is never probed - its own local id namespace cannot
+    # authoritatively confirm a foreign install's id, so the entry falls through to
+    # ordinary matching instead of being wrongly retained as still playable
+    prov_any.mass.music.tracks.get_provider_item.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Unmatched | 1 |" in report_markdown
+
+
 async def test_domain_only_reference_to_unloaded_instance_is_retained() -> None:
     """A domain-only reference expands from the configured snapshot, not the live registry."""
     # spotify--1 is deliberately absent from the registry (failed setup), but it is

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -8,7 +8,7 @@ from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.enums import ExternalID, ImageType, MediaType, PlaylistMatchPolicy
-from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
+from music_assistant_models.errors import InvalidDataError, InvalidProviderID, MediaNotFoundError
 from music_assistant_models.media_items import (
     AudioFormat,
     ItemMapping,
@@ -195,11 +195,10 @@ async def test_import_playlist_preserves_playlist_image() -> None:
     """Test that importing an M3U keeps the playlist-level image."""
     prov = _make_provider()
     prov_any = cast("Any", prov)
-    prov_any.create_playlist = AsyncMock(return_value=_make_playlist("Imported Playlist"))
+    prov_any._reserve_playlist_file = AsyncMock(return_value="playlist_1")
     prov_any.get_playlist = AsyncMock(
         return_value=_make_playlist("Imported Playlist", "https://img.example.com/cover.jpg")
     )
-    prov_any._write_m3u_file = AsyncMock()
 
     m3u_data = generate_m3u(
         "Imported Playlist",
@@ -209,13 +208,59 @@ async def test_import_playlist_preserves_playlist_image() -> None:
 
     result = await prov.import_playlist(m3u_data)
 
-    assert prov_any._write_m3u_file.await_args is not None
-    args = prov_any._write_m3u_file.await_args.args
-    assert args[0] == "playlist_1"
-    assert args[1] == "Imported Playlist"
-    assert args[3] == "https://img.example.com/cover.jpg"
+    assert prov_any._reserve_playlist_file.await_args is not None
+    args = prov_any._reserve_playlist_file.await_args.args
+    assert args[0] == "Imported Playlist"
+    assert args[1][0].path == "spotify://track/abc123"
+    assert args[2] == "https://img.example.com/cover.jpg"
     assert result.image is not None
     assert result.image.path == "https://img.example.com/cover.jpg"
+
+
+async def test_import_playlist_never_exposes_empty_intermediate_file() -> None:
+    """
+    An imported playlist's file must appear on disk already fully populated.
+
+    A concurrent add/remove on the same (predictable) id must never be able to
+    observe or race an intermediate empty file between creation and population.
+    """
+    prov = _make_provider()
+    prov_any = cast("Any", prov)
+    prov_any._playlists_dir = "stubbed-playlists-dir"
+    prov_any._playlist_generations = {}
+    prov_any.get_playlist = AsyncMock(side_effect=lambda pid: _make_playlist(pid))
+    writes: list[str] = []
+
+    class _FakeM3uFile:
+        """Stand-in for aiofiles' write-mode open() that records every write's content."""
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def write(self, content: str) -> None:
+            writes.append(content)
+
+    def fake_open(_path: str, _mode: str = "r", **_kwargs: object) -> _FakeM3uFile:
+        return _FakeM3uFile()
+
+    with (
+        patch("music_assistant.providers.builtin.os.path.isfile", return_value=False),
+        patch("music_assistant.providers.builtin.aiofiles.open", side_effect=fake_open),
+    ):
+        m3u_data = generate_m3u(
+            "Imported Playlist",
+            [PlaylistItem(path="spotify://track/abc123", title="Test", length="120")],
+        )
+        await prov.import_playlist(m3u_data)
+
+    # the file must be written exactly once, and that single write must already
+    # contain the imported track - never an empty file followed by a second,
+    # separately-locked write that a concurrent add/remove could race against
+    assert len(writes) == 1
+    assert "abc123" in writes[0]
 
 
 async def test_remove_playlist_tracks_preserves_playlist_image() -> None:
@@ -613,6 +658,61 @@ async def test_available_provider_with_dead_item_id_is_matched() -> None:
 
     # the configured source must actually be probed authoritatively - it must not be
     # skipped as if it were simply out of scope
+    prov_any.mass.music.tracks.get_provider_item.assert_awaited_once()
+    prov_any._write_m3u_file.assert_awaited_once()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 0 |" in report_markdown
+    assert "| Exact release | 1 |" in report_markdown
+
+
+async def test_available_provider_with_invalid_provider_id_is_matched() -> None:
+    """A malformed stored item id is treated as terminally dead, not as an aborting error."""
+    prov = _make_provider(
+        loaded_provider_domains={"spotify--1"},
+        get_provider_item=AsyncMock(side_effect=InvalidProviderID("malformed id")),
+    )
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        title="Artist - Song",
+        providers=[
+            ProviderMappingInfo(
+                domain="spotify", instance_id="spotify--1", item_id="abc123", content_type=""
+            )
+        ],
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    matched_track = _make_track(
+        "Song",
+        artists=["Artist"],
+        provider_mappings={
+            ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        # a malformed id must not raise out of the pass and abort matching for the
+        # rest of the playlist's entries
+        await prov.match_imported_playlist_tracks(
+            "playlist_1",
+            PlaylistMatchPolicy.SAME_RECORDING,
+            _allowed(prov, "spotify--1", "qobuz--1"),
+        )
+
     prov_any.mass.music.tracks.get_provider_item.assert_awaited_once()
     prov_any._write_m3u_file.assert_awaited_once()
     report_markdown = set_report.call_args.args[0]

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -616,6 +616,76 @@ async def test_available_provider_with_dead_item_id_is_matched() -> None:
     assert "| Exact release | 1 |" in report_markdown
 
 
+async def test_persisted_mappings_exclude_weaker_compatible_tier() -> None:
+    """A weaker, merely-compatible tier does not end up as the persisted substitute."""
+    prov = _make_provider(
+        loaded_provider_domains={"spotify--1"},
+        get_provider_item=AsyncMock(side_effect=MediaNotFoundError("gone")),
+    )
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        title="Artist - Song",
+        providers=[
+            ProviderMappingInfo(
+                domain="spotify", instance_id="spotify--1", item_id="abc123", content_type=""
+            )
+        ],
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    exact_mapping = ProviderMapping(
+        item_id="exact123", provider_domain="qobuz", provider_instance="qobuz--1"
+    )
+    likely_mapping = ProviderMapping(
+        item_id="likely456", provider_domain="tidal", provider_instance="tidal--1"
+    )
+    exact_track = _make_track("Song", artists=["Artist"], provider_mappings={exact_mapping})
+    likely_track = _make_track("Song", artists=["Artist"], provider_mappings={likely_mapping})
+    enrichment = TrackProviderEnrichment(
+        track=exact_track,
+        # ordered strongest-tier-first, as _resolve_confident_matches guarantees
+        matches=(
+            TrackProviderMatch(
+                track=exact_track, mapping=exact_mapping, confidence=TrackMatchConfidence.EXACT
+            ),
+            TrackProviderMatch(
+                track=likely_track,
+                mapping=likely_mapping,
+                confidence=TrackMatchConfidence.LIKELY,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1",
+            PlaylistMatchPolicy.SAME_RECORDING,
+            _allowed(prov, "spotify--1", "qobuz--1", "tidal--1"),
+        )
+
+    prov_any._write_m3u_file.assert_awaited_once()
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    # the weaker LIKELY tier's own mapping must not become the persisted (and
+    # therefore potentially chosen-as-primary-URI) substitute, even though it was
+    # compatible enough to be accepted alongside the stronger EXACT tier
+    assert written_items[0].providers == [
+        ProviderMappingInfo(
+            domain="qobuz",
+            item_id="exact123",
+            instance_id="qobuz--1",
+            content_type="?",
+            sample_rate=44100,
+            bit_depth=16,
+        )
+    ]
+    report_markdown = set_report.call_args.args[0]
+    assert "| Exact release | 1 |" in report_markdown
+
+
 async def test_dead_url_is_matched_instead_of_retained() -> None:
     """A plain stream URL that no longer resolves is substituted, not silently kept."""
     prov = _make_provider(

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -354,6 +354,33 @@ async def test_confirmed_dead_stream_url_falls_through_to_matching() -> None:
     assert "| Retained | 1 |" not in report_markdown
 
 
+async def test_catalog_item_api_error_retains_original_without_confirmation() -> None:
+    """A provider API error must not be treated as proof a catalog id was deleted."""
+    prov = _make_provider(
+        loaded_provider_domains={"qobuz--1"},
+        get_provider_item=AsyncMock(side_effect=InvalidDataError("Error 500 while handling")),
+    )
+    item = _make_playlist_item(
+        path="qobuz://track/12345",
+        providers=[
+            ProviderMappingInfo(
+                domain="qobuz", instance_id="qobuz--1", item_id="12345", content_type=""
+            )
+        ],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
+        )
+
+    prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
+
+
 async def test_bare_radio_uri_without_extma_is_not_matched_as_track() -> None:
     """A bare radio:// entry with no #EXTMA metadata must not be searched as a Track."""
     prov = _make_provider(

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -36,6 +36,7 @@ def _make_provider(
     loaded_provider_domains: set[str] | None = None,
     unavailable_provider_domains: set[str] | None = None,
     get_provider_item: AsyncMock | None = None,
+    provider_entries: list[tuple[str, str, bool]] | None = None,
 ) -> BuiltinProvider:
     """
     Create a minimal BuiltinProvider with a mocked mass.
@@ -48,21 +49,43 @@ def _make_provider(
     :param get_provider_item: Optional stub for the authoritative
         ``mass.music.tracks.get_provider_item`` lookup; defaults to one that always
         succeeds, as if the original track still resolves.
+    :param provider_entries: Optional explicit (domain, instance_id, available) entries, for
+        scenarios with several distinct instances of the same domain.
     """
     mass = MagicMock()
     loaded = loaded_provider_domains or set()
     unavailable = unavailable_provider_domains or set()
+    # a single shared registry so mass.get_provider, mass.providers and
+    # mass.get_provider_instances all agree on what is actually loaded
+    registry = (
+        [MagicMock(domain=pid, instance_id=pid, available=True) for pid in loaded]
+        + [MagicMock(domain=pid, instance_id=pid, available=False) for pid in unavailable]
+        + [
+            MagicMock(domain=domain, instance_id=instance_id, available=available)
+            for domain, instance_id, available in (provider_entries or [])
+        ]
+    )
 
     def _get_provider(
         pid: str, return_unavailable: bool = False, **_kwargs: Any
     ) -> MagicMock | None:
-        if pid in loaded:
-            return MagicMock(domain=pid, instance_id=pid, available=True)
-        if return_unavailable and pid in unavailable:
-            return MagicMock(domain=pid, instance_id=pid, available=False)
+        for provider in registry:
+            if provider.instance_id == pid and (return_unavailable or provider.available):
+                return provider
         return None
 
+    def _get_provider_instances(
+        domain: str, return_unavailable: bool = False, **_kwargs: Any
+    ) -> list[MagicMock]:
+        return [
+            provider
+            for provider in registry
+            if provider.domain == domain and (return_unavailable or provider.available)
+        ]
+
+    mass.providers = registry
     mass.get_provider = MagicMock(side_effect=_get_provider)
+    mass.get_provider_instances = MagicMock(side_effect=_get_provider_instances)
     mass.music.tracks.get_provider_item = get_provider_item or AsyncMock(return_value=MagicMock())
     prov = object.__new__(BuiltinProvider)
     prov.mass = mass
@@ -404,6 +427,125 @@ async def test_original_source_outside_allowed_instances_is_not_trusted() -> Non
     report_markdown = set_report.call_args.args[0]
     assert "| Retained | 0 |" in report_markdown
     assert "| Exact release | 1 |" in report_markdown
+
+
+async def test_domain_only_reference_tries_every_allowed_instance() -> None:
+    """A domain-only #EXTPROV entry is probed on every allowed instance of that domain."""
+    prov = _make_provider(
+        provider_entries=[
+            ("spotify", "spotify--1", True),
+            ("spotify", "spotify--2", True),
+        ],
+        # the first instance probed does not have the item, the second one does
+        get_provider_item=AsyncMock(
+            side_effect=[MediaNotFoundError("gone"), MagicMock()],
+        ),
+    )
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        providers=[
+            ProviderMappingInfo(domain="spotify", instance_id="", item_id="abc123"),
+        ],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify--1", "spotify--2")
+        )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    assert prov_any.mass.music.tracks.get_provider_item.await_count == 2
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
+
+
+async def test_exact_instance_reference_never_widens_to_sibling_instance() -> None:
+    """An exact #EXTPROV instance reference is never retried against a sibling instance."""
+    prov = _make_provider(
+        provider_entries=[
+            ("spotify", "spotify--1", True),
+            ("spotify", "spotify--2", True),
+        ],
+        # spotify--2 (a different account) does have the item, but must never be tried:
+        # the entry names spotify--1 exactly, so only that instance may be probed
+        get_provider_item=AsyncMock(side_effect=MediaNotFoundError("gone")),
+    )
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        providers=[
+            ProviderMappingInfo(domain="spotify", instance_id="spotify--1", item_id="abc123"),
+        ],
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    enrichment = TrackProviderEnrichment(
+        track=_make_track("Song", artists=["Artist"]),
+        matches=(),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    await prov.match_imported_playlist_tracks(
+        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify--1", "spotify--2")
+    )
+
+    prov_any.mass.music.tracks.get_provider_item.assert_awaited_once()
+    called_instance = prov_any.mass.music.tracks.get_provider_item.await_args.args[1]
+    assert called_instance == "spotify--1"
+
+
+async def test_duplicate_original_entries_are_resolved_only_once() -> None:
+    """A track that repeats in the playlist is probed and searched only once."""
+    prov = _make_provider(
+        loaded_provider_domains={"spotify--1"},
+        get_provider_item=AsyncMock(side_effect=MediaNotFoundError("gone")),
+    )
+    to_match = _make_playlist_item(
+        path="spotify:track:dup",
+        title="Artist - Song",
+        providers=[
+            ProviderMappingInfo(domain="spotify", instance_id="spotify--1", item_id="abc123"),
+        ],
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [to_match, to_match, to_match]))
+    matched_track = _make_track(
+        "Song",
+        artists=["Artist"],
+        provider_mappings={
+            ProviderMapping(item_id="xyz", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    enrich_mock = AsyncMock(return_value=enrichment)
+    prov_any.mass.music.tracks.enrich_provider_mappings = enrich_mock
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("qobuz--1", "spotify--1")
+        )
+
+    enrich_mock.assert_awaited_once()
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    assert len(written_items) == 3
+    assert all(entry.providers[0].domain == "qobuz" for entry in written_items)
+    report_markdown = set_report.call_args.args[0]
+    assert "| Exact release | 3 |" in report_markdown
 
 
 async def test_unmatched_stale_mapping_does_not_crash_or_get_reused() -> None:

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.enums import ImageType, MediaType
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import (
     ItemMapping,
     MediaItemImage,
@@ -31,13 +32,38 @@ from music_assistant.helpers.playlists import (
 from music_assistant.providers.builtin import BuiltinProvider
 
 
-def _make_provider(loaded_provider_domains: set[str] | None = None) -> BuiltinProvider:
-    """Create a minimal BuiltinProvider with a mocked mass."""
+def _make_provider(
+    loaded_provider_domains: set[str] | None = None,
+    unavailable_provider_domains: set[str] | None = None,
+    get_provider_item: AsyncMock | None = None,
+) -> BuiltinProvider:
+    """
+    Create a minimal BuiltinProvider with a mocked mass.
+
+    :param loaded_provider_domains: Domains/instances that resolve to a loaded, available
+        provider.
+    :param unavailable_provider_domains: Domains/instances that resolve to a provider that
+        is configured but currently unavailable (only returned when ``return_unavailable``
+        is passed).
+    :param get_provider_item: Optional stub for the authoritative
+        ``mass.music.tracks.get_provider_item`` lookup; defaults to one that always
+        succeeds, as if the original track still resolves.
+    """
     mass = MagicMock()
     loaded = loaded_provider_domains or set()
-    mass.get_provider = MagicMock(
-        side_effect=lambda pid, **_kwargs: MagicMock(domain=pid) if pid in loaded else None
-    )
+    unavailable = unavailable_provider_domains or set()
+
+    def _get_provider(
+        pid: str, return_unavailable: bool = False, **_kwargs: Any
+    ) -> MagicMock | None:
+        if pid in loaded:
+            return MagicMock(domain=pid, instance_id=pid, available=True)
+        if return_unavailable and pid in unavailable:
+            return MagicMock(domain=pid, instance_id=pid, available=False)
+        return None
+
+    mass.get_provider = MagicMock(side_effect=_get_provider)
+    mass.music.tracks.get_provider_item = get_provider_item or AsyncMock(return_value=MagicMock())
     prov = object.__new__(BuiltinProvider)
     prov.mass = mass
     prov.logger = MagicMock()
@@ -194,6 +220,141 @@ async def test_available_original_is_retained_without_search() -> None:
     prov_any._write_m3u_file.assert_not_awaited()
     report_markdown = set_report.call_args.args[0]
     assert "| Retained | 1 |" in report_markdown
+
+
+async def test_bare_uri_without_extprov_is_recognized_as_available() -> None:
+    """A plain M3U entry with a bare MA URI, but no #EXTPROV metadata, is still retained."""
+    prov = _make_provider(loaded_provider_domains={"spotify"})
+    item = PlaylistItem(path="spotify://track/abc123", title="Test", length="120")
+    assert not item.providers
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+        )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
+
+
+async def test_configured_but_unavailable_provider_is_retained() -> None:
+    """A provider that is configured but currently down is not treated as gone."""
+    prov = _make_provider(unavailable_provider_domains={"spotify--1"})
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        providers=[
+            ProviderMappingInfo(
+                domain="spotify", instance_id="spotify--1", item_id="abc123", content_type=""
+            )
+        ],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+        )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
+
+
+async def test_available_provider_with_dead_item_id_is_matched() -> None:
+    """A loaded provider whose item id no longer resolves is substituted, not retained."""
+    prov = _make_provider(
+        loaded_provider_domains={"spotify--1"},
+        get_provider_item=AsyncMock(side_effect=MediaNotFoundError("gone")),
+    )
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        title="Artist - Song",
+        providers=[
+            ProviderMappingInfo(
+                domain="spotify", instance_id="spotify--1", item_id="abc123", content_type=""
+            )
+        ],
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    matched_track = _make_track(
+        "Song",
+        artists=["Artist"],
+        provider_mappings={
+            ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("qobuz--1",)
+        )
+
+    prov_any._write_m3u_file.assert_awaited_once()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 0 |" in report_markdown
+    assert "| Exact release | 1 |" in report_markdown
+
+
+async def test_dead_url_is_matched_instead_of_retained() -> None:
+    """A plain stream URL that no longer resolves is substituted, not silently kept."""
+    prov = _make_provider(
+        loaded_provider_domains={"builtin"},
+        get_provider_item=AsyncMock(side_effect=InvalidDataError("404")),
+    )
+    item = _make_playlist_item(
+        path="https://example.com/dead.mp3",
+        title="Artist - Song",
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    matched_track = _make_track(
+        "Song",
+        artists=["Artist"],
+        provider_mappings={
+            ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("qobuz--1",)
+        )
+
+    prov_any._write_m3u_file.assert_awaited_once()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 0 |" in report_markdown
+    assert "| Exact release | 1 |" in report_markdown
 
 
 async def test_matched_entry_is_enriched_and_reported_as_exact() -> None:

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -2110,6 +2110,8 @@ async def test_missing_artist_metadata_is_unmatched_without_search() -> None:
     report_markdown = set_report.call_args.args[0]
     assert "| Unmatched | 1 |" in report_markdown
     assert "No artist metadata" in report_markdown
+    # a local data-quality issue is not a provider lookup failure
+    assert "Provider lookup issues" not in report_markdown
 
 
 async def test_order_and_duplicates_preserved_across_mixed_results() -> None:

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -184,9 +185,9 @@ def _prepare(prov: BuiltinProvider, m3u_data: str, playlist_name: str = "Importe
     prov_any._read_m3u_file = AsyncMock(return_value=m3u_data)
     prov_any.get_playlist = AsyncMock(return_value=_make_playlist(playlist_name))
     prov_any._write_m3u_file = AsyncMock()
-    # a stable dummy fingerprint: the playlist is the same file throughout the pass
+    # a stable dummy generation: the playlist is the same file throughout the pass
     # unless a test overrides this to simulate a delete-and-recreate race
-    prov_any._get_playlist_generation = AsyncMock(return_value=(1, 1))
+    prov_any._get_playlist_generation = AsyncMock(return_value=1)
     return prov_any
 
 
@@ -1881,9 +1882,9 @@ async def test_playlist_deleted_and_recreated_during_matching_is_not_overwritten
     prov_any = _prepare(prov, m3u_data)
     # the original playlist was deleted and a new, unrelated playlist was created that
     # reused the same sanitized ID while this (possibly long-running) pass was still
-    # searching - even though its content happens to look identical, its file identity
-    # (captured once at the start of the pass) is now different
-    prov_any._get_playlist_generation = AsyncMock(side_effect=[(1, 1), (2, 2)])
+    # searching - even though its content happens to look identical, its creation
+    # generation (captured once at the start of the pass) is now different
+    prov_any._get_playlist_generation = AsyncMock(side_effect=[1, 2])
 
     matched_track = _make_track(
         "Song",
@@ -1916,3 +1917,36 @@ async def test_playlist_deleted_and_recreated_during_matching_is_not_overwritten
     report_markdown = set_report.call_args.args[0]
     assert "| Skipped (playlist changed during matching) | 1 |" in report_markdown
     assert "Substitutions" not in report_markdown
+
+
+async def test_create_playlist_generation_survives_inode_reuse(tmp_path: Path) -> None:
+    """
+    A recreate under the same ID gets a new generation, even with the same inode.
+
+    The generation counter is an in-memory value bumped by ``create_playlist``, not a
+    filesystem fingerprint, so it stays reliable even when a delete followed by a
+    same-path create happens to have the filesystem reuse the just-freed inode number -
+    a scenario this test does not need to force, since the implementation never reads
+    inode/device information in the first place.
+    """
+    prov = _make_provider()
+    prov_any = cast("Any", prov)
+    prov_any._playlists_dir = str(tmp_path)
+    prov_any._playlist_generations = {}
+    prov_any.get_playlist = AsyncMock(return_value=_make_playlist("Test"))
+
+    await prov.create_playlist("Test", {MediaType.TRACK})
+    playlist_id = prov._sanitize_playlist_id("Test")
+    playlist_file = tmp_path / f"{playlist_id}.m3u"
+    first_generation = await prov._get_playlist_generation(playlist_id)
+    assert first_generation == 1
+
+    playlist_file.unlink()
+    assert await prov._get_playlist_generation(playlist_id) is None
+    await prov.create_playlist("Test", {MediaType.TRACK})
+
+    second_generation = await prov._get_playlist_generation(playlist_id)
+    assert second_generation == 2
+    assert second_generation != first_generation
+
+    assert second_generation != first_generation

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -185,6 +185,9 @@ def _prepare(prov: BuiltinProvider, m3u_data: str, playlist_name: str = "Importe
     prov_any._read_m3u_file = AsyncMock(return_value=m3u_data)
     prov_any.get_playlist = AsyncMock(return_value=_make_playlist(playlist_name))
     prov_any._write_m3u_file = AsyncMock()
+    # a stable dummy fingerprint: the playlist is the same file throughout the pass
+    # unless a test overrides this to simulate a delete-and-recreate race
+    prov_any._get_playlist_generation = AsyncMock(return_value=(1, 1))
     return prov_any
 
 
@@ -1485,6 +1488,49 @@ async def test_read_m3u_file_existence_check_is_atomic_with_delete() -> None:
     assert result == ""
 
 
+async def test_startup_migration_waits_for_per_playlist_lock() -> None:
+    """The startup repair pass shares the per-playlist lock with delete/edit/import matching."""
+    prov = _make_provider()
+    prov_any = cast("Any", prov)
+    prov_any._playlists_dir = "stubbed-playlists-dir"
+    prov_any.manifest = MagicMock(domain="builtin")
+    prov_any.mass.config.get = MagicMock(side_effect=lambda _key, default=None: default)
+    prov_any._read_m3u_file = AsyncMock(
+        return_value=generate_m3u(
+            "Imported",
+            [
+                PlaylistItem(
+                    path="builtin://track/1",
+                    title="Already Resolved",
+                    providers=[ProviderMappingInfo(domain="builtin", item_id="1")],
+                    metadata={"media_type": "track"},
+                )
+            ],
+        )
+    )
+    prov_any.get_playlist = AsyncMock(return_value=_make_playlist("Imported"))
+    prov_any._write_m3u_file = AsyncMock()
+
+    with patch(
+        "music_assistant.providers.builtin.os.listdir",
+        return_value=["playlist_1.m3u"],
+    ):
+        # hold the same per-playlist lock a concurrent delete/edit/import-matching write
+        # would hold, as if one of those was already in flight for this playlist
+        async with prov._get_playlist_lock("playlist_1"):
+            migration_task = asyncio.ensure_future(prov._migrate_playlists())
+            try:
+                await asyncio.sleep(0.1)
+                # the migration pass must not read/repair this playlist while it is locked
+                assert not migration_task.done()
+                prov_any._read_m3u_file.assert_not_awaited()
+            finally:
+                pass
+        await asyncio.wait_for(migration_task, timeout=2)
+
+    prov_any._read_m3u_file.assert_awaited_once_with("playlist_1")
+
+
 async def test_matched_entry_is_enriched_and_reported_as_exact() -> None:
     """A structured-artist entry matched at EXACT confidence is substituted and reported."""
     prov = _make_provider()
@@ -1820,5 +1866,54 @@ async def test_concurrent_deletion_during_matching_is_reflected_in_report() -> N
     prov_any._write_m3u_file.assert_not_awaited()
     report_markdown = set_report.call_args.args[0]
     assert "| Exact release | 0 |" in report_markdown
+    assert "| Skipped (playlist changed during matching) | 1 |" in report_markdown
+    assert "Substitutions" not in report_markdown
+
+
+async def test_playlist_deleted_and_recreated_during_matching_is_not_overwritten() -> None:
+    """A stale pass must not write into an unrelated new playlist that reused the same ID."""
+    prov = _make_provider()
+    to_match = _make_playlist_item(
+        path="spotify:track:original",
+        title="Artist - Song",
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    m3u_data = generate_m3u("Imported", [to_match])
+    prov_any = _prepare(prov, m3u_data)
+    # the original playlist was deleted and a new, unrelated playlist was created that
+    # reused the same sanitized ID while this (possibly long-running) pass was still
+    # searching - even though its content happens to look identical, its file identity
+    # (captured once at the start of the pass) is now different
+    prov_any._get_playlist_generation = AsyncMock(side_effect=[(1, 1), (2, 2)])
+
+    matched_track = _make_track(
+        "Song",
+        artists=["Artist"],
+        provider_mappings={
+            ProviderMapping(item_id="xyz", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
+        )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
     assert "| Skipped (playlist changed during matching) | 1 |" in report_markdown
     assert "Substitutions" not in report_markdown

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -1092,6 +1092,55 @@ async def test_delete_playlist_waits_for_global_file_lock() -> None:
                 delete_task.cancel()
 
 
+async def test_read_m3u_file_existence_check_is_atomic_with_delete() -> None:
+    """A read's existence check and file open cannot be split by a concurrent delete."""
+    prov = _make_provider()
+    prov_any = cast("Any", prov)
+    prov_any._playlists_dir = "stubbed-playlists-dir"
+    file_exists = True
+
+    def fake_isfile(_path: str) -> bool:
+        return file_exists
+
+    class _FakeM3uFile:
+        """Stand-in for aiofiles' open() that only succeeds while the file still exists."""
+
+        async def __aenter__(self) -> Self:
+            if not file_exists:
+                raise FileNotFoundError(self)
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def read(self) -> str:
+            return "#EXTM3U"
+
+    with (
+        patch("music_assistant.providers.builtin.os.path.isfile", side_effect=fake_isfile),
+        patch("music_assistant.providers.builtin.aiofiles.open", return_value=_FakeM3uFile()),
+    ):
+        # hold the global file-I/O lock as if a concurrent operation is already in flight,
+        # so the read's existence check cannot yet run ahead of a delete that is about to
+        # remove the file
+        await prov_any._playlist_lock.acquire()
+        read_task = asyncio.ensure_future(prov._read_m3u_file("playlist_1"))
+        try:
+            await asyncio.sleep(0.1)
+            assert not read_task.done()
+            # the file is removed while the read is still waiting for the lock
+            file_exists = False
+            prov_any._playlist_lock.release()
+            result = await asyncio.wait_for(read_task, timeout=2)
+        finally:
+            if not read_task.done():
+                read_task.cancel()
+
+    # the existence check must be re-evaluated under the lock rather than trusting a
+    # stale result from before the file was removed
+    assert result == ""
+
+
 async def test_matched_entry_is_enriched_and_reported_as_exact() -> None:
     """A structured-artist entry matched at EXACT confidence is substituted and reported."""
     prov = _make_provider()

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -214,7 +214,7 @@ async def test_available_original_is_retained_without_search() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("builtin", "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -231,7 +231,7 @@ async def test_bare_uri_without_extprov_is_recognized_as_available() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify", "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -254,7 +254,7 @@ async def test_configured_but_unavailable_provider_is_retained() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify--1", "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -355,6 +355,154 @@ async def test_dead_url_is_matched_instead_of_retained() -> None:
     report_markdown = set_report.call_args.args[0]
     assert "| Retained | 0 |" in report_markdown
     assert "| Exact release | 1 |" in report_markdown
+
+
+async def test_original_source_outside_allowed_instances_is_not_trusted() -> None:
+    """A source provider outside the initiating user's snapshot is never treated as playable."""
+    prov = _make_provider(loaded_provider_domains={"spotify--1"})
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        providers=[
+            ProviderMappingInfo(
+                domain="spotify", instance_id="spotify--1", item_id="abc123", content_type=""
+            )
+        ],
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    matched_track = _make_track(
+        "Song",
+        artists=["Artist"],
+        provider_mappings={
+            ProviderMapping(item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz--1")
+        },
+    )
+    enrichment = TrackProviderEnrichment(
+        track=matched_track,
+        matches=(
+            TrackProviderMatch(
+                track=matched_track,
+                mapping=next(iter(matched_track.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    # spotify--1 is loaded and available, but is not part of this user's allowed snapshot -
+    # it must never be trusted (or even probed) just because some account can resolve it
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("qobuz--1",)
+        )
+
+    prov_any._write_m3u_file.assert_awaited_once()
+    prov_any.mass.music.tracks.get_provider_item.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 0 |" in report_markdown
+    assert "| Exact release | 1 |" in report_markdown
+
+
+async def test_unmatched_stale_mapping_does_not_crash_or_get_reused() -> None:
+    """A preserved but unverified mapping with no actual match is unmatched, not a crash."""
+    prov = _make_provider()
+    item = _make_playlist_item(
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")]
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    stale_mapping = ProviderMapping(
+        item_id="original", provider_domain="spotify", provider_instance="spotify--1"
+    )
+    enrichment = TrackProviderEnrichment(
+        track=_make_track("Song", artists=["Artist"], provider_mappings={stale_mapping}),
+        matches=(),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+        )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Unmatched | 1 |" in report_markdown
+
+
+async def test_matched_entry_excludes_unmatched_stale_mapping() -> None:
+    """The substituted entry only carries mappings produced by an actual match."""
+    prov = _make_provider()
+    item = _make_playlist_item(
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")]
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    stale_mapping = ProviderMapping(
+        item_id="original", provider_domain="spotify", provider_instance="spotify--1"
+    )
+    matched_mapping = ProviderMapping(
+        item_id="xyz789", provider_domain="qobuz", provider_instance="qobuz--1"
+    )
+    enriched_track = _make_track(
+        "Song", artists=["Artist"], provider_mappings={stale_mapping, matched_mapping}
+    )
+    enrichment = TrackProviderEnrichment(
+        track=enriched_track,
+        matches=(
+            TrackProviderMatch(
+                track=enriched_track,
+                mapping=matched_mapping,
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("qobuz--1",)
+        )
+
+    written_items = prov_any._write_m3u_file.await_args.args[2]
+    domains = {p.domain for p in written_items[0].providers}
+    assert domains == {"qobuz"}
+    report_markdown = set_report.call_args.args[0]
+    assert "| Exact release | 1 |" in report_markdown
+
+
+async def test_update_playlist_metadata_uses_per_playlist_lock() -> None:
+    """Metadata edits share the same per-playlist lock as substitutions and track edits."""
+    prov = _make_provider()
+    prov_any = _prepare(
+        prov, generate_m3u("Imported", [PlaylistItem(path="a", title="A", length=None)])
+    )
+
+    await prov._update_playlist_metadata("playlist_1", "New Name", None)
+
+    assert "playlist_1" in prov_any._playlist_locks
+
+
+async def test_delete_playlist_uses_per_playlist_lock() -> None:
+    """Deleting a user playlist shares the same per-playlist lock as other mutations."""
+    prov = _make_provider()
+    prov_any = cast("Any", prov)
+    prov_any._playlists_dir = "stubbed-playlists-dir"
+
+    with (
+        patch("music_assistant.providers.builtin.os.path.isfile", return_value=True),
+        patch("music_assistant.providers.builtin.os.remove"),
+    ):
+        await prov.library_remove("playlist_1", MediaType.PLAYLIST)
+
+    assert "playlist_1" in prov_any._playlist_locks
 
 
 async def test_matched_entry_is_enriched_and_reported_as_exact() -> None:

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -262,6 +262,27 @@ async def test_bare_uri_without_extprov_is_recognized_as_available() -> None:
     assert "| Retained | 1 |" in report_markdown
 
 
+async def test_search_narrowing_does_not_affect_source_validation() -> None:
+    """Narrowing the search targets must not make a playable original look unavailable."""
+    prov = _make_provider(loaded_provider_domains={"spotify", "qobuz"})
+    item = PlaylistItem(path="spotify://track/abc123", title="Test", length="120")
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        # spotify is allowed (source validation), but the search is narrowed to qobuz only
+        await prov.match_imported_playlist_tracks(
+            "playlist_1",
+            PlaylistMatchPolicy.BEST_EFFORT,
+            ("spotify", "qobuz--1"),
+            ("qobuz--1",),
+        )
+
+    prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
+
+
 async def test_configured_but_unavailable_provider_is_retained() -> None:
     """A provider that is configured but currently down is not treated as gone."""
     prov = _make_provider(unavailable_provider_domains={"spotify--1"})

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -244,8 +244,8 @@ async def test_remove_playlist_tracks_preserves_playlist_image() -> None:
     assert args[3] == "https://img.example.com/cover.jpg"
 
 
-class _FakeHeadResponse:
-    """Stand-in for an aiohttp HEAD response carrying a fixed status code."""
+class _FakeHttpResponse:
+    """Stand-in for an aiohttp HEAD/GET response carrying a fixed status code."""
 
     def __init__(self, status: int) -> None:
         self.status = status
@@ -324,6 +324,8 @@ async def test_share_url_without_extprov_is_persisted_as_provider_mapping() -> N
     report_markdown = set_report.call_args.args[0]
     assert "| Retained | 1 |" in report_markdown
 
+
+async def test_transient_stream_failure_retains_original_without_confirmation() -> None:
     """A network blip during the ffprobe check must not substitute a live stream."""
     prov = _make_provider(
         loaded_provider_domains={"builtin"},
@@ -333,7 +335,7 @@ async def test_share_url_without_extprov_is_persisted_as_provider_mapping() -> N
     prov_any = _prepare(prov, generate_m3u("Imported", [item]))
     # a 500 response does not prove the stream is gone - ffprobe wraps both a
     # transient server error and a genuinely dead stream in the same error
-    prov_any.mass.http_session.head = MagicMock(return_value=_FakeHeadResponse(500))
+    prov_any.mass.http_session.head = MagicMock(return_value=_FakeHttpResponse(500))
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
@@ -347,7 +349,7 @@ async def test_share_url_without_extprov_is_persisted_as_provider_mapping() -> N
 
 
 async def test_confirmed_dead_stream_url_falls_through_to_matching() -> None:
-    """A confirmed terminal HTTP status proves the stream is actually gone."""
+    """A HEAD and corroborating GET both reporting terminal status prove the stream is gone."""
     prov = _make_provider(
         loaded_provider_domains={"builtin"},
         get_provider_item=AsyncMock(side_effect=InvalidDataError("ffprobe failed")),
@@ -356,7 +358,8 @@ async def test_confirmed_dead_stream_url_falls_through_to_matching() -> None:
         path="https://example.com/stream.mp3", title="Artist - Live Stream", length=None
     )
     prov_any = _prepare(prov, generate_m3u("Imported", [item]))
-    prov_any.mass.http_session.head = MagicMock(return_value=_FakeHeadResponse(404))
+    prov_any.mass.http_session.head = MagicMock(return_value=_FakeHttpResponse(404))
+    prov_any.mass.http_session.get = MagicMock(return_value=_FakeHttpResponse(404))
     enrichment = TrackProviderEnrichment(
         track=cast("Any", MagicMock()),
         matches=(),
@@ -374,6 +377,29 @@ async def test_confirmed_dead_stream_url_falls_through_to_matching() -> None:
     prov_any.mass.music.tracks.enrich_provider_mappings.assert_awaited_once()
     report_markdown = set_report.call_args.args[0]
     assert "| Retained | 1 |" not in report_markdown
+
+
+async def test_head_404_alone_does_not_confirm_a_stream_is_gone() -> None:
+    """A server that rejects HEAD but still serves GET must not have its stream substituted."""
+    prov = _make_provider(
+        loaded_provider_domains={"builtin"},
+        get_provider_item=AsyncMock(side_effect=InvalidDataError("ffprobe failed")),
+    )
+    item = PlaylistItem(path="https://example.com/stream.mp3", title="Live Stream", length=None)
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    # some servers reply 404 to HEAD for endpoints they do serve correctly on GET
+    prov_any.mass.http_session.head = MagicMock(return_value=_FakeHttpResponse(404))
+    prov_any.mass.http_session.get = MagicMock(return_value=_FakeHttpResponse(200))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
+        )
+
+    prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
+    prov_any._write_m3u_file.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
 
 
 async def test_catalog_item_api_error_retains_original_without_confirmation() -> None:
@@ -543,9 +569,14 @@ async def test_available_provider_with_dead_item_id_is_matched() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
+            "playlist_1",
+            PlaylistMatchPolicy.SAME_RECORDING,
+            _allowed(prov, "spotify--1", "qobuz--1"),
         )
 
+    # the configured source must actually be probed authoritatively - it must not be
+    # skipped as if it were simply out of scope
+    prov_any.mass.music.tracks.get_provider_item.assert_awaited_once()
     prov_any._write_m3u_file.assert_awaited_once()
     report_markdown = set_report.call_args.args[0]
     assert "| Retained | 0 |" in report_markdown

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -264,6 +264,62 @@ async def test_import_playlist_never_exposes_empty_intermediate_file() -> None:
     assert "abc123" in writes[0]
 
 
+async def test_reserve_playlist_file_waits_for_in_flight_edit_on_same_id() -> None:
+    """
+    A create/import reusing an id must wait for an in-flight edit already holding it.
+
+    Without also taking that same per-playlist edit lock, a create/import could run
+    to completion entirely while a slow add is still resolving new tracks - so once
+    that add finally writes back the entries it built before the create/import ever
+    happened, it would clobber the freshly (re)created file.
+    """
+    prov = _make_provider()
+    prov_any = cast("Any", prov)
+    prov_any._playlists_dir = "stubbed-playlists-dir"
+    prov_any._playlist_generations = {}
+    prov_any._read_m3u_file = AsyncMock(return_value="")
+    prov_any.get_playlist = AsyncMock(side_effect=lambda pid: _make_playlist(pid))
+    prov_any._write_m3u_file = AsyncMock()
+    prov_any._write_m3u_file_locked = AsyncMock()
+    order: list[str] = []
+
+    add_resolving = asyncio.Event()
+    release_add = asyncio.Event()
+
+    async def slow_build_entry(uri: str) -> PlaylistItem:
+        add_resolving.set()
+        await release_add.wait()
+        return PlaylistItem(path=uri, title="New")
+
+    prov_any._build_m3u_entry_from_uri = AsyncMock(side_effect=slow_build_entry)
+
+    async def run_add() -> None:
+        await prov.add_playlist_tracks("foo", ["spotify://track/new"])
+        order.append("add")
+
+    async def run_reserve() -> None:
+        await add_resolving.wait()
+        with patch("music_assistant.providers.builtin.os.path.isfile", return_value=False):
+            await prov._reserve_playlist_file("foo", [])
+        order.append("reserve")
+
+    add_task = asyncio.ensure_future(run_add())
+    reserve_task = asyncio.ensure_future(run_reserve())
+    await add_resolving.wait()
+    # give reserve every chance to run ahead if it were not actually blocked
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert prov_any._write_m3u_file_locked.await_count == 0
+
+    release_add.set()
+    await add_task
+    await reserve_task
+
+    # the in-flight add must fully finish (and release the lock) before the
+    # create/import reusing its id is allowed to proceed
+    assert order == ["add", "reserve"]
+
+
 async def test_remove_playlist_tracks_preserves_playlist_image() -> None:
     """Test that rewriting a playlist after track removal keeps the playlist image."""
     prov = _make_provider()

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -572,6 +572,41 @@ async def test_exact_instance_reference_never_widens_to_sibling_instance() -> No
     assert called_instance == "spotify--1"
 
 
+async def test_extprov_naming_disallowed_instance_does_not_fall_back_to_path() -> None:
+    """An #EXTPROV entry outside the allowed snapshot must not resolve via a sibling instance."""
+    prov = _make_provider(
+        # spotify--2 is an allowed, loaded sibling that does have the item - but the
+        # entry's own #EXTPROV names spotify--1, which is not in the allowed snapshot
+        provider_entries=[("spotify", "spotify--2", True)],
+        get_provider_item=AsyncMock(return_value=MagicMock()),
+    )
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        providers=[
+            ProviderMappingInfo(domain="spotify", instance_id="spotify--1", item_id="abc123"),
+        ],
+        artists=[ArtistInfo(name="Artist", provider_domain="", item_id="", provider_instance="")],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+    enrichment = TrackProviderEnrichment(
+        track=_make_track("Song", artists=["Artist"]),
+        matches=(),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+    prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
+
+    await prov.match_imported_playlist_tracks(
+        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify--2",)
+    )
+
+    # the entry's own #EXTPROV data already names a provider reference, so a bare-path
+    # guess must never be tried against an unrelated allowed sibling instance
+    prov_any.mass.music.tracks.get_provider_item.assert_not_awaited()
+    prov_any.mass.music.tracks.enrich_provider_mappings.assert_awaited_once()
+
+
 async def test_duplicate_original_entries_are_resolved_only_once() -> None:
     """A track that repeats in the playlist is probed and searched only once."""
     prov = _make_provider(

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -94,6 +94,22 @@ def _make_provider(
     return prov
 
 
+def _allowed(prov: BuiltinProvider, *instance_ids: str) -> tuple[tuple[str, str], ...]:
+    """
+    Build an allowed-instances snapshot for the given instance ids.
+
+    The domain for each id is taken from the provider's mocked registry when it is
+    present there (loaded or unavailable); an id deliberately absent from the registry,
+    simulating one that is configured but did not load at all, keeps its own string as
+    a stand-in domain, which is fine since none of those tests exercise domain-only
+    expansion.
+    """
+    domains = {provider.instance_id: provider.domain for provider in prov.mass.providers}
+    return tuple(
+        (instance_id, domains.get(instance_id, instance_id)) for instance_id in instance_ids
+    )
+
+
 def _make_track(
     name: str,
     artists: list[str] | None = None,
@@ -237,7 +253,7 @@ async def test_available_original_is_retained_without_search() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("builtin", "qobuz--1")
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "builtin", "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -254,7 +270,7 @@ async def test_bare_uri_without_extprov_is_recognized_as_available() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify", "qobuz--1")
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify", "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -273,7 +289,7 @@ async def test_search_narrowing_does_not_affect_source_validation() -> None:
         await prov.match_imported_playlist_tracks(
             "playlist_1",
             PlaylistMatchPolicy.BEST_EFFORT,
-            ("spotify", "qobuz--1"),
+            _allowed(prov, "spotify", "qobuz--1"),
             ("qobuz--1",),
         )
 
@@ -298,7 +314,7 @@ async def test_configured_but_unavailable_provider_is_retained() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify--1", "qobuz--1")
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--1", "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -324,7 +340,7 @@ async def test_configured_but_unloaded_provider_is_retained() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify--1", "qobuz--1")
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--1", "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -374,7 +390,7 @@ async def test_available_provider_with_dead_item_id_is_matched() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_awaited_once()
@@ -419,7 +435,7 @@ async def test_dead_url_is_matched_instead_of_retained() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_awaited_once()
@@ -467,7 +483,7 @@ async def test_original_source_outside_allowed_instances_is_not_trusted() -> Non
     # it must never be trusted (or even probed) just because some account can resolve it
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_awaited_once()
@@ -494,7 +510,7 @@ async def test_original_source_probe_bypasses_cached_provider_details() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report"):
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify--1",)
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--1")
         )
 
     # cached (possibly stale) details are never good enough for this check - a
@@ -526,7 +542,9 @@ async def test_domain_only_reference_tries_every_allowed_instance() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify--1", "spotify--2")
+            "playlist_1",
+            PlaylistMatchPolicy.BEST_EFFORT,
+            _allowed(prov, "spotify--1", "spotify--2"),
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -564,7 +582,7 @@ async def test_exact_instance_reference_never_widens_to_sibling_instance() -> No
     prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
 
     await prov.match_imported_playlist_tracks(
-        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify--1", "spotify--2")
+        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--1", "spotify--2")
     )
 
     prov_any.mass.music.tracks.get_provider_item.assert_awaited_once()
@@ -598,13 +616,41 @@ async def test_extprov_naming_disallowed_instance_does_not_fall_back_to_path() -
     prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
 
     await prov.match_imported_playlist_tracks(
-        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify--2",)
+        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify--2")
     )
 
     # the entry's own #EXTPROV data already names a provider reference, so a bare-path
     # guess must never be tried against an unrelated allowed sibling instance
     prov_any.mass.music.tracks.get_provider_item.assert_not_awaited()
     prov_any.mass.music.tracks.enrich_provider_mappings.assert_awaited_once()
+
+
+async def test_domain_only_reference_to_unloaded_instance_is_retained() -> None:
+    """A domain-only reference expands from the configured snapshot, not the live registry."""
+    # spotify--1 is deliberately absent from the registry (failed setup), but it is
+    # still part of the allowed snapshot together with its configured domain - a
+    # domain-only reference must be able to find it there, not just among instances
+    # mass.get_provider_instances happens to know about right now
+    prov = _make_provider(loaded_provider_domains={"qobuz--1"})
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        providers=[
+            ProviderMappingInfo(domain="spotify", instance_id="", item_id="abc123"),
+        ],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1",
+            PlaylistMatchPolicy.BEST_EFFORT,
+            (("spotify--1", "spotify"), ("qobuz--1", "qobuz")),
+        )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    prov_any.mass.music.tracks.get_provider_item.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
 
 
 async def test_duplicate_original_entries_are_resolved_only_once() -> None:
@@ -647,7 +693,9 @@ async def test_duplicate_original_entries_are_resolved_only_once() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("qobuz--1", "spotify--1")
+            "playlist_1",
+            PlaylistMatchPolicy.SAME_RECORDING,
+            _allowed(prov, "qobuz--1", "spotify--1"),
         )
 
     enrich_mock.assert_awaited_once()
@@ -723,7 +771,7 @@ async def test_duplicate_path_with_different_metadata_is_resolved_independently(
     prov_any.mass.music.tracks.enrich_provider_mappings = enrich_mock
 
     await prov.match_imported_playlist_tracks(
-        "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("qobuz--1",)
+        "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
     )
 
     # a metadata-poor or different first duplicate must not suppress resolution of the
@@ -755,7 +803,7 @@ async def test_unmatched_stale_mapping_does_not_crash_or_get_reused() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -796,7 +844,7 @@ async def test_matched_entry_excludes_unmatched_stale_mapping() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "qobuz--1")
         )
 
     written_items = prov_any._write_m3u_file.await_args.args[2]
@@ -872,7 +920,7 @@ async def test_matched_entry_is_enriched_and_reported_as_exact() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, ("opensubsonic--abc123",)
+            "playlist_1", PlaylistMatchPolicy.SAME_RECORDING, _allowed(prov, "opensubsonic--abc123")
         )
 
     prov_any._write_m3u_file.assert_awaited_once()
@@ -903,7 +951,7 @@ async def test_ambiguous_match_is_reported_and_not_substituted() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -931,7 +979,7 @@ async def test_no_acceptable_match_is_reported_as_unmatched() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.EXACT, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()
@@ -953,7 +1001,7 @@ async def test_provider_error_is_reported_as_unmatched_with_issue() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
         )
 
     report_markdown = set_report.call_args.args[0]
@@ -994,7 +1042,7 @@ async def test_extinf_title_without_structured_artist_is_split_for_matching() ->
     prov_any.mass.music.tracks.enrich_provider_mappings = enrich_mock
 
     await prov.match_imported_playlist_tracks(
-        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
     )
 
     enrich_mock.assert_awaited_once()
@@ -1016,7 +1064,7 @@ async def test_missing_artist_metadata_is_unmatched_without_search() -> None:
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
         )
 
     enrich_mock.assert_not_awaited()
@@ -1062,7 +1110,7 @@ async def test_order_and_duplicates_preserved_across_mixed_results() -> None:
     prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
 
     await prov.match_imported_playlist_tracks(
-        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("qobuz--1",)
+        "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "qobuz--1")
     )
 
     written_items = prov_any._write_m3u_file.await_args.args[2]
@@ -1113,7 +1161,7 @@ async def test_concurrent_edit_during_matching_is_preserved() -> None:
     prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock(return_value=enrichment)
 
     await prov.match_imported_playlist_tracks(
-        "playlist_1", PlaylistMatchPolicy.EXACT, ("qobuz--1",)
+        "playlist_1", PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
     )
 
     written_items = prov_any._write_m3u_file.await_args.args[2]
@@ -1162,7 +1210,7 @@ async def test_concurrent_deletion_during_matching_is_reflected_in_report() -> N
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
         await prov.match_imported_playlist_tracks(
-            "playlist_1", PlaylistMatchPolicy.EXACT, ("qobuz--1",)
+            "playlist_1", PlaylistMatchPolicy.EXACT, _allowed(prov, "qobuz--1")
         )
 
     prov_any._write_m3u_file.assert_not_awaited()

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -48,22 +48,16 @@ def _make_provider(
     """
     Create a minimal BuiltinProvider with a mocked mass.
 
-    :param loaded_provider_domains: Domains/instances that resolve to a loaded, available
-        provider.
-    :param unavailable_provider_domains: Domains/instances that resolve to a provider that
-        is configured but currently unavailable (only returned when ``return_unavailable``
-        is passed).
-    :param get_provider_item: Optional stub for the authoritative
-        ``mass.music.tracks.get_provider_item`` lookup; defaults to one that always
-        succeeds, as if the original track still resolves.
-    :param provider_entries: Optional explicit (domain, instance_id, available) entries, for
-        scenarios with several distinct instances of the same domain.
+    :param loaded_provider_domains: Domains or instances that resolve to an available provider.
+    :param unavailable_provider_domains: Domains or instances that resolve only when
+        ``return_unavailable`` is requested.
+    :param get_provider_item: Optional stub for ``mass.music.tracks.get_provider_item``.
+    :param provider_entries: Optional explicit ``(domain, instance_id, available)`` entries.
     """
     mass = MagicMock()
     loaded = loaded_provider_domains or set()
     unavailable = unavailable_provider_domains or set()
-    # a single shared registry so mass.get_provider, mass.providers and
-    # mass.get_provider_instances all agree on what is actually loaded
+    # Keep every mocked provider lookup backed by the same registry.
     registry = (
         [MagicMock(domain=pid, instance_id=pid, available=True) for pid in loaded]
         + [MagicMock(domain=pid, instance_id=pid, available=False) for pid in unavailable]
@@ -106,11 +100,7 @@ def _allowed(prov: BuiltinProvider, *instance_ids: str) -> tuple[tuple[str, str]
     """
     Build an allowed-instances snapshot for the given instance ids.
 
-    The domain for each id is taken from the provider's mocked registry when it is
-    present there (loaded or unavailable); an id deliberately absent from the registry,
-    simulating one that is configured but did not load at all, keeps its own string as
-    a stand-in domain, which is fine since none of those tests exercise domain-only
-    expansion.
+    Missing registry entries keep their own ID as a stand-in domain.
     """
     domains = {provider.instance_id: provider.domain for provider in prov.mass.providers}
     return tuple(
@@ -190,8 +180,7 @@ def _prepare(prov: BuiltinProvider, m3u_data: str, playlist_name: str = "Importe
     prov_any._read_m3u_file = AsyncMock(return_value=m3u_data)
     prov_any.get_playlist = AsyncMock(return_value=_make_playlist(playlist_name))
     prov_any._write_m3u_file = AsyncMock()
-    # a stable dummy generation: the playlist is the same file throughout the pass
-    # unless a test overrides this to simulate a delete-and-recreate race
+    # Stable default generation unless a test simulates a recreate race.
     prov_any._get_playlist_generation = AsyncMock(return_value=1)
     return prov_any
 
@@ -224,12 +213,7 @@ async def test_import_playlist_preserves_playlist_image() -> None:
 
 
 async def test_import_playlist_never_exposes_empty_intermediate_file() -> None:
-    """
-    An imported playlist's file must appear on disk already fully populated.
-
-    A concurrent add/remove on the same (predictable) id must never be able to
-    observe or race an intermediate empty file between creation and population.
-    """
+    """Imported playlists are written once, never via an empty intermediate file."""
     prov = _make_provider()
     prov_any = cast("Any", prov)
     prov_any._playlists_dir = "stubbed-playlists-dir"
@@ -262,22 +246,13 @@ async def test_import_playlist_never_exposes_empty_intermediate_file() -> None:
         )
         await prov.import_playlist(m3u_data)
 
-    # the file must be written exactly once, and that single write must already
-    # contain the imported track - never an empty file followed by a second,
-    # separately-locked write that a concurrent add/remove could race against
+    # The single write must already contain the imported track.
     assert len(writes) == 1
     assert "abc123" in writes[0]
 
 
 async def test_reserve_playlist_file_waits_for_in_flight_edit_on_same_id() -> None:
-    """
-    A create/import reusing an id must wait for an in-flight edit already holding it.
-
-    Without also taking that same per-playlist edit lock, a create/import could run
-    to completion entirely while a slow add is still resolving new tracks - so once
-    that add finally writes back the entries it built before the create/import ever
-    happened, it would clobber the freshly (re)created file.
-    """
+    """A create or import waits for an in-flight edit on the same playlist ID."""
     prov = _make_provider()
     prov_any = cast("Any", prov)
     prov_any._playlists_dir = "stubbed-playlists-dir"
@@ -311,7 +286,7 @@ async def test_reserve_playlist_file_waits_for_in_flight_edit_on_same_id() -> No
     add_task = asyncio.ensure_future(run_add())
     reserve_task = asyncio.ensure_future(run_reserve())
     await add_resolving.wait()
-    # give reserve every chance to run ahead if it were not actually blocked
+    # Give reserve every chance to run ahead if it is not blocked.
     for _ in range(5):
         await asyncio.sleep(0)
     assert prov_any._write_m3u_file_locked.await_count == 0
@@ -320,8 +295,7 @@ async def test_reserve_playlist_file_waits_for_in_flight_edit_on_same_id() -> No
     await add_task
     await reserve_task
 
-    # the in-flight add must fully finish (and release the lock) before the
-    # create/import reusing its id is allowed to proceed
+    # The in-flight add must release the lock before reserve can proceed.
     assert order == ["add", "reserve"]
 
 
@@ -399,9 +373,7 @@ async def test_bare_uri_without_extprov_is_recognized_as_available() -> None:
             "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify", "qobuz--1")
         )
 
-    # written back once so the entry keeps resolving to a provider mapping on future
-    # loads too, since a bare URI with no #EXTPROV can otherwise never attach one -
-    # it is still counted and reported as retained though, not as a substitution
+    # Persist the confirmed mapping, but still count the entry as retained.
     prov_any._write_m3u_file.assert_awaited_once()
     written_items = prov_any._write_m3u_file.await_args.args[2]
     assert len(written_items) == 1
@@ -424,8 +396,7 @@ async def test_share_url_without_extprov_is_persisted_as_provider_mapping() -> N
             "playlist_1", 1, PlaylistMatchPolicy.BEST_EFFORT, _allowed(prov, "spotify", "qobuz--1")
         )
 
-    # written back so the entry resolves through Spotify on future loads too, instead
-    # of reconstructing as an unplayable raw builtin web URL
+    # Persist the resolved provider mapping for future loads.
     prov_any._write_m3u_file.assert_awaited_once()
     written_items = prov_any._write_m3u_file.await_args.args[2]
     assert len(written_items) == 1
@@ -444,8 +415,7 @@ async def test_transient_stream_failure_retains_original_without_confirmation() 
     )
     item = PlaylistItem(path="https://example.com/stream.mp3", title="Live Stream", length=None)
     prov_any = _prepare(prov, generate_m3u("Imported", [item]))
-    # a 500 response does not prove the stream is gone - ffprobe wraps both a
-    # transient server error and a genuinely dead stream in the same error
+    # A 500 does not prove the stream is gone.
     prov_any.mass.http_session.head = MagicMock(return_value=_FakeHttpResponse(500))
 
     with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
@@ -493,8 +463,7 @@ async def test_transient_source_failure_is_not_reprobed_per_entry() -> None:
             _allowed(prov, "builtin", "spotify_1"),
         )
 
-    # the second entry's identical failing instance is skipped outright, sparing it
-    # a second timeout rather than probing (and failing) it again
+    # The second entry skips the same transiently failing instance.
     assert get_provider_item.await_count == 1
     prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
     prov_any._write_m3u_file.assert_not_awaited()
@@ -512,13 +481,11 @@ async def test_domain_only_reference_tries_next_sibling_when_one_is_unavailable(
     )
     prov = _make_provider(
         loaded_provider_domains={"builtin"},
-        # spotify_1 is configured but currently down; spotify_2 is a healthy
-        # sibling account of the very same domain and should still get a chance
+        # spotify_2 should still be tried even if spotify_1 is down.
         provider_entries=[("spotify", "spotify_1", False), ("spotify", "spotify_2", True)],
         get_provider_item=AsyncMock(return_value=hydrated),
     )
-    # a domain-only reference (no pinned instance id) is what triggers the
-    # same-domain sibling widening in the first place
+    # A domain-only reference triggers same-domain sibling widening.
     item = _make_playlist_item(
         path="spotify://track/track_one",
         title="Artist - Song",
@@ -534,9 +501,7 @@ async def test_domain_only_reference_tries_next_sibling_when_one_is_unavailable(
             _allowed(prov, "builtin", "spotify_1", "spotify_2"),
         )
 
-    # the healthy sibling confirmed the item is still there, so it must be
-    # retained and normalized to that instance - never substituted just because
-    # a different sibling account happened to be down
+    # The healthy sibling keeps the entry retained and normalized to that instance.
     prov_any.mass.music.tracks.enrich_provider_mappings.assert_not_called()
     prov_any._write_m3u_file.assert_awaited_once()
     written_items = prov_any._write_m3u_file.await_args.args[2]
@@ -2261,15 +2226,7 @@ async def test_concurrent_deletion_during_matching_is_reflected_in_report() -> N
 
 
 async def test_match_aborts_when_scheduled_generation_already_stale() -> None:
-    """
-    A task whose target was deleted and recreated before it even started is a no-op.
-
-    Unlike the mid-pass recreate races below, here the recreate is already complete
-    by the time this call starts - simulating a task that sat queued behind the
-    tasks controller's concurrency limit long enough for that to happen. The very
-    first generation read must already disagree with what the task was scheduled
-    for, so no substitute is even searched.
-    """
+    """A task is skipped if its target playlist was recreated before it started."""
     prov = _make_provider()
     to_match = _make_playlist_item(
         path="spotify:track:original",
@@ -2278,8 +2235,7 @@ async def test_match_aborts_when_scheduled_generation_already_stale() -> None:
     )
     m3u_data = generate_m3u("Imported", [to_match])
     prov_any = _prepare(prov, m3u_data)
-    # the playlist under this id is already on generation 2 by the time this call
-    # starts - the task was scheduled for generation 1 and sat queued too long
+    # The task was queued for generation 1, but the playlist is already on 2.
     prov_any._get_playlist_generation = AsyncMock(return_value=2)
     prov_any.mass.music.tracks.enrich_provider_mappings = AsyncMock()
 
@@ -2301,10 +2257,7 @@ async def test_playlist_deleted_and_recreated_during_matching_is_not_overwritten
     )
     m3u_data = generate_m3u("Imported", [to_match])
     prov_any = _prepare(prov, m3u_data)
-    # the original playlist was deleted and a new, unrelated playlist was created that
-    # reused the same sanitized ID while this (possibly long-running) pass was still
-    # searching - even though its content happens to look identical, its creation
-    # generation (captured once at the start of the pass) is now different
+    # The reused ID now points to a different playlist generation.
     prov_any._get_playlist_generation = AsyncMock(side_effect=[1, 2])
 
     matched_track = _make_track(
@@ -2341,15 +2294,7 @@ async def test_playlist_deleted_and_recreated_during_matching_is_not_overwritten
 
 
 async def test_match_discards_substitution_when_recreated_between_read_and_capture() -> None:
-    """
-    A recreate landing between the M3U read and generation capture is still caught.
-
-    The initial read and the generation capture happen under the same per-playlist lock
-    that ``library_remove`` takes before unlinking a playlist's file, so a concurrent
-    recreate can only complete *after* that pair has been captured together - closing the
-    narrower race where old content could otherwise be paired with a fresh generation and
-    incorrectly accepted by the write-back check.
-    """
+    """A recreate between read and write-back generation checks is still caught."""
     prov = _make_provider()
     prov_playlist_id = "playlist_1"
     to_match = _make_playlist_item(
@@ -2367,8 +2312,7 @@ async def test_match_discards_substitution_when_recreated_between_read_and_captu
 
     async def read_m3u(_playlist_id: str) -> str:
         content_read.set()
-        # yield control so the concurrent recreate below gets a chance to attempt the
-        # per-playlist lock before this pass's own generation capture happens
+        # Let the concurrent recreate queue for the same playlist lock.
         await asyncio.sleep(0)
         return m3u_data
 
@@ -2376,18 +2320,14 @@ async def test_match_discards_substitution_when_recreated_between_read_and_captu
         nonlocal generation_calls
         generation_calls += 1
         if generation_calls == 2:
-            # this is the write-back's final check - wait for the concurrent recreate
-            # to actually finish so this reads its bumped value deterministically,
-            # rather than depending on incidental task-scheduling order
+            # Wait for the recreate so the final generation check is deterministic.
             await recreated.wait()
         return generation
 
     async def race_recreate() -> None:
         nonlocal generation
         await content_read.wait()
-        # mirrors library_remove, which takes this same per-playlist lock before
-        # unlinking the file - it can only proceed once the read+capture pair below
-        # releases the lock
+        # The recreate must wait for the read-and-capture lock to be released.
         async with prov._get_playlist_lock(prov_playlist_id):
             generation += 1
         recreated.set()
@@ -2424,12 +2364,10 @@ async def test_match_discards_substitution_when_recreated_between_read_and_captu
         )
     await race_task
 
-    # the recreate genuinely raced in and completed - this isn't passing by mere
-    # absence of contention
+    # The recreate actually completed during the test.
     assert recreated.is_set()
     assert generation == 2
-    # the substitution was matched against the pre-recreate content, so it must be
-    # discarded rather than written into the recreated playlist
+    # The stale substitution must not be written into the recreated playlist.
     prov_any._write_m3u_file.assert_not_awaited()
     report_markdown = set_report.call_args.args[0]
     assert "| Skipped (playlist changed during matching) | 1 |" in report_markdown
@@ -2437,15 +2375,7 @@ async def test_match_discards_substitution_when_recreated_between_read_and_captu
 
 
 async def test_create_playlist_generation_survives_inode_reuse(tmp_path: Path) -> None:
-    """
-    A recreate under the same ID gets a new generation, even with the same inode.
-
-    The generation counter is an in-memory value bumped by ``create_playlist``, not a
-    filesystem fingerprint, so it stays reliable even when a delete followed by a
-    same-path create happens to have the filesystem reuse the just-freed inode number -
-    a scenario this test does not need to force, since the implementation never reads
-    inode/device information in the first place.
-    """
+    """Recreating a playlist still bumps its generation, regardless of inode reuse."""
     prov = _make_provider()
     prov_any = cast("Any", prov)
     prov_any._playlists_dir = str(tmp_path)

--- a/tests/providers/builtin/test_import_matching.py
+++ b/tests/providers/builtin/test_import_matching.py
@@ -306,6 +306,33 @@ async def test_configured_but_unavailable_provider_is_retained() -> None:
     assert "| Retained | 1 |" in report_markdown
 
 
+async def test_configured_but_unloaded_provider_is_retained() -> None:
+    """A provider that failed setup entirely (not just down) is still not treated as gone."""
+    # spotify--1 is deliberately absent from the registry: this simulates a provider
+    # that is configured and allowed for this user, but did not load at all right now
+    # (e.g. it failed setup), as opposed to one that loaded but is currently unavailable
+    prov = _make_provider(loaded_provider_domains={"qobuz--1"})
+    item = _make_playlist_item(
+        path="spotify://track/abc123",
+        providers=[
+            ProviderMappingInfo(
+                domain="spotify", instance_id="spotify--1", item_id="abc123", content_type=""
+            )
+        ],
+    )
+    prov_any = _prepare(prov, generate_m3u("Imported", [item]))
+
+    with patch("music_assistant.providers.builtin.set_current_task_report") as set_report:
+        await prov.match_imported_playlist_tracks(
+            "playlist_1", PlaylistMatchPolicy.BEST_EFFORT, ("spotify--1", "qobuz--1")
+        )
+
+    prov_any._write_m3u_file.assert_not_awaited()
+    prov_any.mass.music.tracks.get_provider_item.assert_not_awaited()
+    report_markdown = set_report.call_args.args[0]
+    assert "| Retained | 1 |" in report_markdown
+
+
 async def test_available_provider_with_dead_item_id_is_matched() -> None:
     """A loaded provider whose item id no longer resolves is substituted, not retained."""
     prov = _make_provider(


### PR DESCRIPTION
## What does this implement/fix?

When you import a playlist and some of its tracks are no longer available because their source provider isn't configured anymore, Music Assistant now looks them up on your other connected providers instead of leaving them broken.

- Import accepts an optional `match_policy` (`exact`, `same_recording`, or `best_effort`) to control how loose a substitute is allowed to be.
- With matching enabled, each original track is verified against its own configured provider; only a confirmed-dead entry (a deleted catalog ID or a dead URL) is replaced. A provider that's merely down right now is left untouched, and matching never runs against providers outside the importing user's own account access.
- The playlist is created immediately on import; matching happens in the background afterwards and updates it in place, keeping the original order and duplicates.
- You get a Markdown report after the pass summarising what was retained, matched, or left unmatched.
- Shares the underlying track-matching logic (evidence comparison, cached provider search, ambiguity handling) so it can be reused by future playlist features.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository.