### PR TITLE
Notice when Spotify playback loses its pairing

### DIFF
--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -185,6 +185,10 @@ _REPEAT_OFF: Final[str] = "off"
 # exiting with a plain code 1 - its message is the only way to tell that case
 # apart from any other startup failure.
 _DATA_DIR_BUSY_MARKER: Final[str] = "another session is running"
+# A daemon that cannot log in advertises itself for pairing instead of failing,
+# and then sits there until the startup budget runs out. The engine reports no
+# other way that a stored session is gone.
+_UNPAIRED_MARKER: Final[str] = "waiting for login"
 # how long the log reader is given to catch up on a daemon's parting words
 _LOG_DRAIN_TIMEOUT_S: Final[float] = 2.0
 # How many pauses from the Spotify app are put back before the session gives up.
@@ -743,6 +747,8 @@ class _SoloistSession:
         self._teardown_done = False
         # None until the engine reports its login state for the first time
         self._logged_in: bool | None = None
+        # set once the daemon is known to have no stored session to log in with
+        self._unpaired = False
         # set once this daemon is the active Connect device; losing that again is
         # the user moving playback elsewhere from their Spotify app
         self._was_active = False
@@ -1280,7 +1286,7 @@ class _SoloistSession:
         # a pairing that never logged in is checked first: it also fails the
         # session, and its recovery (back through the setup flow) beats failing
         # every track with a generic error
-        if self._logged_in is False:
+        if self._unpaired or self._logged_in is False:
             # the stored session no longer logs in: route the user through the
             # setup flow instead of failing every item (mirrors librespot's
             # INVALID_CREDENTIALS handling)
@@ -1335,6 +1341,8 @@ class _SoloistSession:
             text = line.replace(api_key, "<redacted>") if api_key else line
             if _DATA_DIR_BUSY_MARKER in text:
                 self._data_dir_busy = True
+            if _UNPAIRED_MARKER in text and not self._unpaired:
+                await self._check_pairing_lost()
             self.logger.debug("[soloist] %s", text)
 
     async def _read_capture(self) -> None:
@@ -1736,6 +1744,20 @@ class _SoloistSession:
             return
         self.mass.player_queues.prepare_next_audio_buffer(queue_id)
 
+    async def _check_pairing_lost(self) -> None:
+        """
+        Fail the session when the engine has no stored session left to log in with.
+
+        The engine advertises itself for pairing while it is still restoring a
+        session too, so its report is confirmed against the stored session:
+        acting on it alone would fail every playback on a pairing that is only
+        moments away from logging in.
+        """
+        if await asyncio.to_thread(self.backend._has_stored_session):
+            return
+        self._unpaired = True
+        self._fail("the stored session is gone")
+
     def _observe_auth_state(self, *, logged_in: bool) -> None:
         """
         Follow the engine's login state.
@@ -1744,9 +1766,8 @@ class _SoloistSession:
         its session, so its first snapshot reports logged_in=False even for a
         perfectly good pairing. That is a startup race, not a lost pairing, and
         failing on it would break every playback. Only losing a login that was
-        already established is fatal; a pairing that never logs in surfaces when
-        the item fails to start, where _raise_startup_error routes the user back
-        through the setup flow.
+        already established is fatal; a pairing that is gone altogether is caught
+        by :meth:`_check_pairing_lost`.
 
         :param logged_in: Whether the engine reports an active login.
         """

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -1198,10 +1198,15 @@ class _SoloistSession:
         # then restores its session and logs in. A command sent before that last
         # step is dropped and its acknowledgement never arrives, so wait for the
         # login the engine announces rather than for the socket alone.
+        # A failure reported while the endpoint is still awaited - the engine
+        # having no session to log in with - is watched for throughout: waiting
+        # the endpoint out would outlast the queue's own patience for the audio,
+        # and the item would fail with a timeout instead of its real cause.
         try:
             async with asyncio.timeout(_STARTUP_TIMEOUT_S):
-                await client_ready.wait()
-                while not self._error and not (client.connected and self._logged_in):
+                while not self._error and not (
+                    client_ready.is_set() and client.connected and self._logged_in
+                ):
                     await asyncio.sleep(_CONNECT_POLL_S)
         except TimeoutError:
             self._raise_startup_error("did not connect and log in", spotify_uri)

--- a/music_assistant/providers/spotify/helpers.py
+++ b/music_assistant/providers/spotify/helpers.py
@@ -19,10 +19,6 @@ from music_assistant_models.errors import LoginFailed
 from music_assistant.helpers.json import json_loads
 from music_assistant.helpers.process import AsyncProcess, check_output
 from music_assistant.providers.spotify_connect.soloist import SoloistBinaryManager
-from music_assistant.providers.spotify_connect.soloist.runtime import (
-    WS_ADDR_FILE,
-    WS_PORT_FILE,
-)
 
 from .constants import (
     CHECK_AUTH_TIMEOUT,
@@ -217,21 +213,12 @@ def soloist_session_account(data_dir: Path) -> str | None:
     """
     Return the Spotify username a stored soloist session belongs to (blocking).
 
-    The engine keeps its per-account state under ``settings/Users/<username>-user``,
-    which is where the paired identity is written down. Answers None when it
-    cannot be told apart: no session yet, or state for more than one account.
+    Answers None when it cannot be told apart: no session yet, or state for more
+    than one account.
 
     :param data_dir: The soloist data directory to inspect.
     """
-    users_dir = data_dir / "settings" / "Users"
-    try:
-        accounts = [
-            entry.name.removesuffix(SOLOIST_USER_DIR_SUFFIX)
-            for entry in users_dir.iterdir()
-            if entry.is_dir() and entry.name.endswith(SOLOIST_USER_DIR_SUFFIX)
-        ]
-    except OSError:
-        return None
+    accounts = _soloist_session_accounts(data_dir)
     return accounts[0] if len(accounts) == 1 else None
 
 
@@ -239,14 +226,9 @@ def soloist_session_present(data_dir: Path) -> bool:
     """
     Return whether a soloist data dir holds a stored (paired) session (blocking).
 
-    The session storage format is opaque; any persisted file besides the WebSocket
-    endpoint files counts as a stored session.
-
     :param data_dir: The soloist data directory to inspect.
     """
-    if not data_dir.is_dir():
-        return False
-    return any(entry.name not in (WS_ADDR_FILE, WS_PORT_FILE) for entry in data_dir.iterdir())
+    return bool(_soloist_session_accounts(data_dir))
 
 
 async def await_loopback_authorization(port: int, path: str) -> dict[str, str]:
@@ -371,3 +353,20 @@ def _read_credentials_file(credentials_file: str) -> str:
         msg = "Incomplete librespot credential file"
         raise ValueError(msg)
     return contents
+
+
+def _soloist_session_accounts(data_dir: Path) -> list[str]:
+    """Return the Spotify accounts a soloist data dir holds paired state for (blocking)."""
+    # The per-account state under settings/Users/<username>-user is the only thing
+    # a pairing leaves behind: the prefs stores rewritten before every spawn, the
+    # pid and lock files and the WebSocket endpoint all outlive one, so a data
+    # directory that ever ran a daemon never looks empty again.
+    users_dir = data_dir / "settings" / "Users"
+    try:
+        return [
+            entry.name.removesuffix(SOLOIST_USER_DIR_SUFFIX)
+            for entry in users_dir.iterdir()
+            if entry.is_dir() and entry.name.endswith(SOLOIST_USER_DIR_SUFFIX)
+        ]
+    except OSError:
+        return []

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -554,6 +554,24 @@ async def test_a_lost_pairing_is_caught_the_moment_the_daemon_reports_it(
     unload_with_error.assert_called_once()
 
 
+async def test_a_lost_pairing_fails_the_item_without_waiting_for_the_endpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The item fails on the lost pairing, not on the endpoint that is no longer coming."""
+    session = _make_session(tmp_path)
+    session._logged_in = None
+    monkeypatch.setattr(session.backend.provider, "unload_with_error", MagicMock())
+    await session._log_output(
+        _stdout_of('waiting for login - connect to "X" from your Spotify app')
+    )
+    # the endpoint never appears, so the wait for it must not swallow the failure:
+    # sitting it out would outlast the queue's own patience for the audio
+    with pytest.raises(LoginFailed) as err:
+        async with asyncio.timeout(5):
+            await session._play(TRACK_A, 0, asyncio.Event())
+    assert err.value.translation_key == "soloist_pairing_required"
+
+
 async def test_a_daemon_still_restoring_its_session_is_left_alone(tmp_path: Path) -> None:
     """The engine advertises for pairing while restoring too; the stored session decides."""
     session = _make_session(tmp_path)

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -524,19 +524,46 @@ async def test_a_busy_data_directory_is_reported_as_such(tmp_path: Path) -> None
 async def test_the_busy_marker_is_picked_up_from_the_daemon_output(tmp_path: Path) -> None:
     """The marker is read off the daemon's stdout, with the API key still redacted."""
     session = _make_session(tmp_path)
-    proc = MagicMock()
-    lines = [
-        'Error: another session is running for data directory "/data/x/soloist-data".',
-        "Stop the running session before starting soloist again.",
-    ]
-
-    async def _iter_stdout() -> AsyncGenerator[str]:
-        for line in lines:
-            yield line
-
-    proc.iter_stdout = _iter_stdout
-    await session._log_output(proc)
+    await session._log_output(
+        _stdout_of(
+            'Error: another session is running for data directory "/data/x/soloist-data".',
+            "Stop the running session before starting soloist again.",
+        )
+    )
     assert session._data_dir_busy is True
+
+
+async def test_a_lost_pairing_is_caught_the_moment_the_daemon_reports_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A daemon advertising for pairing fails the session at once, not on a timeout."""
+    session = _make_session(tmp_path)
+    session._logged_in = None
+    unload_with_error = MagicMock()
+    monkeypatch.setattr(session.backend.provider, "unload_with_error", unload_with_error)
+    await session._log_output(
+        _stdout_of('waiting for login - connect to "X" from your Spotify app')
+    )
+    assert session._unpaired is True
+    # the buffer gives up on the audio long before the startup budget runs out, so
+    # the session has to fail while an item is still waiting on it
+    assert session._error is not None
+    with pytest.raises(LoginFailed) as err:
+        session._raise_startup_error("did not connect and log in", TRACK_A)
+    assert err.value.translation_key == "soloist_pairing_required"
+    unload_with_error.assert_called_once()
+
+
+async def test_a_daemon_still_restoring_its_session_is_left_alone(tmp_path: Path) -> None:
+    """The engine advertises for pairing while restoring too; the stored session decides."""
+    session = _make_session(tmp_path)
+    data_dir = session.backend._data_dir
+    (data_dir / "settings" / "Users" / "spotify-user-user").mkdir(parents=True)
+    await session._log_output(
+        _stdout_of('waiting for login - connect to "X" from your Spotify app')
+    )
+    assert session._unpaired is False
+    assert session._error is None
 
 
 async def test_a_pairing_that_never_logs_in_routes_through_setup(
@@ -1718,14 +1745,19 @@ async def test_streaming_without_setup_is_refused(tmp_path: Path) -> None:
 
 
 def test_session_present_detection(tmp_path: Path) -> None:
-    """Only a dir holding something besides the WS endpoint files counts as paired."""
+    """Only the engine's per-account state counts as paired."""
     data_dir = tmp_path / "soloist-data"
     assert soloist_session_present(data_dir) is False
     data_dir.mkdir()
     (data_dir / WS_ADDR_FILE).write_text("127.0.0.1", encoding="utf-8")
     (data_dir / WS_PORT_FILE).write_text("1234", encoding="utf-8")
     assert soloist_session_present(data_dir) is False
-    (data_dir / "session.bin").write_bytes(b"x")
+    # everything a spawn leaves behind outlives the pairing it ran on
+    (data_dir / "settings").mkdir()
+    (data_dir / "settings" / "prefs").write_text("audio.normalize_v2=false\n", encoding="utf-8")
+    (data_dir / "soloist.pid").write_text("42", encoding="utf-8")
+    assert soloist_session_present(data_dir) is False
+    (data_dir / "settings" / "Users" / "spotify-user-user").mkdir(parents=True)
     assert soloist_session_present(data_dir) is True
 
 
@@ -1873,6 +1905,18 @@ def _capture_holding(
         session._reader = None
         os.close(read_fd)
         os.close(write_fd)
+
+
+def _stdout_of(*lines: str) -> MagicMock:
+    """Return a process mock whose stdout yields the given daemon log lines."""
+
+    async def _iter_stdout() -> AsyncGenerator[str]:
+        for line in lines:
+            yield line
+
+    proc = MagicMock()
+    proc.iter_stdout = _iter_stdout
+    return proc
 
 
 def _make_provider(tmp_path: Path, setup_data: dict[str, Any] | None = None) -> SpotifyProvider:

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -1770,10 +1770,16 @@ def test_session_present_detection(tmp_path: Path) -> None:
     (data_dir / WS_ADDR_FILE).write_text("127.0.0.1", encoding="utf-8")
     (data_dir / WS_PORT_FILE).write_text("1234", encoding="utf-8")
     assert soloist_session_present(data_dir) is False
-    # everything a spawn leaves behind outlives the pairing it ran on
+    # everything a spawn leaves behind outlives the pairing it ran on: the engine
+    # keeps its identity, lock, cache and crash handler in the data dir even
+    # though it is given a cache dir of its own, and Music Assistant writes the
+    # prefs there before every spawn
     (data_dir / "settings").mkdir()
     (data_dir / "settings" / "prefs").write_text("audio.normalize_v2=false\n", encoding="utf-8")
-    (data_dir / "soloist.pid").write_text("42", encoding="utf-8")
+    (data_dir / ".device_id").write_text("6b6c2a07", encoding="utf-8")
+    (data_dir / ".lock").write_bytes(b"")
+    (data_dir / "cache" / "Users" / "spotify-user-user").mkdir(parents=True)
+    (data_dir / "crashpad").mkdir()
     assert soloist_session_present(data_dir) is False
     (data_dir / "settings" / "Users" / "spotify-user-user").mkdir(parents=True)
     assert soloist_session_present(data_dir) is True

--- a/tests/providers/spotify/test_soloist_setup_flow.py
+++ b/tests/providers/spotify/test_soloist_setup_flow.py
@@ -35,6 +35,7 @@ from music_assistant.providers.spotify.constants import (
 from music_assistant.providers.spotify.helpers import (
     pair_soloist_session,
     soloist_session_account,
+    soloist_session_present,
 )
 from music_assistant.providers.spotify_connect.soloist import UnsupportedPlatformError
 
@@ -192,8 +193,7 @@ async def test_reconfigure_keeps_the_existing_paired_session(
     monkeypatch.setattr(setup_flow, "verify_platform_supported", MagicMock())
     paired_dirs = _record_pairing(monkeypatch)
     canonical = tmp_path / "spotify" / "spotify--test" / SOLOIST_DATA_DIR_NAME
-    canonical.mkdir(parents=True)
-    (canonical / "session.bin").write_bytes(b"session")
+    (canonical / "settings" / "Users" / "spotify-user-user").mkdir(parents=True)
     session = _make_session(
         tmp_path,
         [
@@ -404,7 +404,7 @@ async def test_pairing_captures_its_output_and_redacts_the_api_key(
     _install_fake_soloist(
         monkeypatch,
         0,
-        on_wait=lambda: (tmp_path / "data" / "session.bin").write_bytes(b"x"),
+        on_wait=lambda: _store_session(tmp_path / "data"),
         spawns=spawns,
         output_lines=(f"starting with --api-key {api_key}",),
     )
@@ -442,11 +442,14 @@ async def test_pairing_success_stores_a_session(
 ) -> None:
     """A pairing run that stores a session completes without error."""
     data_dir = tmp_path / "pairdir"
-    _install_fake_soloist(
-        monkeypatch, returncode=0, on_wait=lambda: (data_dir / "session.bin").write_bytes(b"x")
-    )
+    _install_fake_soloist(monkeypatch, returncode=0, on_wait=lambda: _store_session(data_dir))
     await pair_soloist_session(MagicMock(), "k" * 20, data_dir)
-    assert (data_dir / "session.bin").is_file()
+    assert soloist_session_present(data_dir)
+
+
+def _store_session(data_dir: Path, account: str = "spotify-user") -> None:
+    """Write a paired session the way the engine records it."""
+    (data_dir / "settings" / "Users" / f"{account}-user").mkdir(parents=True, exist_ok=True)
 
 
 async def _run_awaitable(awaitable: Any, **_kwargs: Any) -> Any:

--- a/tests/providers/spotify/test_soloist_setup_flow.py
+++ b/tests/providers/spotify/test_soloist_setup_flow.py
@@ -35,7 +35,6 @@ from music_assistant.providers.spotify.constants import (
 from music_assistant.providers.spotify.helpers import (
     pair_soloist_session,
     soloist_session_account,
-    soloist_session_present,
 )
 from music_assistant.providers.spotify_connect.soloist import UnsupportedPlatformError
 
@@ -444,7 +443,23 @@ async def test_pairing_success_stores_a_session(
     data_dir = tmp_path / "pairdir"
     _install_fake_soloist(monkeypatch, returncode=0, on_wait=lambda: _store_session(data_dir))
     await pair_soloist_session(MagicMock(), "k" * 20, data_dir)
-    assert soloist_session_present(data_dir)
+    assert (data_dir / "settings" / "Users" / "spotify-user-user").is_dir()
+
+
+async def test_a_pairing_that_stored_no_account_is_not_mistaken_for_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run leaving only what every spawn leaves behind never paired: it must not be adopted."""
+    data_dir = tmp_path / "pairdir"
+
+    def _leave_spawn_debris() -> None:
+        (data_dir / "settings").mkdir(parents=True)
+        (data_dir / "settings" / "prefs").write_text("audio.normalize_v2=false\n", encoding="utf-8")
+        (data_dir / "soloist.pid").write_text("42", encoding="utf-8")
+
+    _install_fake_soloist(monkeypatch, returncode=0, on_wait=_leave_spawn_debris)
+    with pytest.raises(LoginFailed, match="did not store"):
+        await pair_soloist_session(MagicMock(), "k" * 20, data_dir)
 
 
 def _store_session(data_dir: Path, account: str = "spotify-user") -> None:


### PR DESCRIPTION
# What does this implement/fix?

When the Spotify account paired for playback was no longer stored, Music Assistant did not notice: the provider stayed loaded and every track failed with a generic "timeout waiting for audio data" instead of asking to redo the setup.

Two reasons, both fixed here:

- A data directory was considered "paired" when it held *any* file. Music Assistant writes the engine's audio settings into that directory before every playback start, so once a session had run there it never looked empty again — even with the pairing gone. It now keys on the engine's per-account state, which is what a pairing actually leaves behind.
- The recovery that sends the user back to setup only ran after the backend's 30 second startup budget, but the audio buffer gives up on the audio well before that and cancels the attempt — so it never ran. The lost pairing is now caught the moment the engine reports it, and no longer waits on a WebSocket endpoint that is not coming either.

This also stops a pairing run that stored nothing from overwriting a working pairing, which used the same weak check.

Not covered: a pairing that is still stored but that Spotify no longer accepts (a revoked device, a password change). The engine gives no distinguishable report for that yet, so it still fails per track.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
