### PR TITLE
Add playlist migration between providers

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 66
+API_SCHEMA_VERSION: Final[int] = 67
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
+from bisect import bisect_right
 from collections.abc import AsyncGenerator, Sequence
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, cast
+from dataclasses import dataclass
+from itertools import batched
+from typing import TYPE_CHECKING, Any, Final, cast
 
+from aiohttp import ClientError
 from music_assistant_models.auth import Scope
 from music_assistant_models.enums import (
     MediaType,
@@ -18,20 +23,26 @@ from music_assistant_models.errors import (
     InvalidProviderURI,
     MediaNotFoundError,
     ProviderUnavailableError,
+    ResourceTemporarilyUnavailable,
 )
 from music_assistant_models.helpers import create_safe_string
-from music_assistant_models.media_items import Playlist, PlaylistSummary
+from music_assistant_models.media_items import Playlist, PlaylistSummary, ProviderMapping, Track
 
 from music_assistant.constants import DB_TABLE_PLAYLISTS, PLAYLIST_MEDIA_TYPES, PlaylistPlayableItem
 from music_assistant.controllers.tasks.context import (
+    get_current_task,
+    report_current_task_failure,
+    set_current_task_report,
     update_current_task_progress,
     update_current_task_progress_text,
 )
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
+from music_assistant.helpers.compare import TrackMatchConfidence, match_policy_minimum_confidence
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.helpers.playlists import (
     PlaylistItem,
+    escape_markdown,
     generate_m3u,
     media_item_to_playlist_item,
 )
@@ -39,11 +50,17 @@ from music_assistant.helpers.security import is_safe_name
 from music_assistant.helpers.uri import create_uri, parse_uri
 from music_assistant.helpers.util import guard_single_request
 from music_assistant.models.music_provider import MusicProvider
+from music_assistant.models.plugin import PluginProvider
 
 from .audiobooks import AudiobooksController
 from .base import MediaControllerBase
 from .radio import RadioController
-from .tracks import TracksController
+from .tracks import TrackProviderMatch, TracksController
+
+_PROVIDER_PLAYLIST_ADD_BATCH_SIZE: Final[int] = 100
+_MIGRATION_REPORT_DETAIL_LIMIT: Final[int] = 200
+_MIGRATION_RESOLVE_BATCH_SIZE: Final[int] = 5
+_MIGRATION_VERIFY_RETRY_DELAYS: Final[tuple[int, ...]] = (1, 2, 4)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -67,6 +84,21 @@ def _update_stage_progress(
         return
     progress = start + int((current * (end - start)) / total)
     update_current_task_progress(min(progress, end), text)
+
+
+@dataclass(frozen=True, slots=True)
+class _PlaylistMigrationTrackResult:
+    """Resolved destination details for one source track."""
+
+    track: Track | None = None
+    mapping: ProviderMapping | None = None
+    confidence: TrackMatchConfidence = TrackMatchConfidence.NO_MATCH
+    provider_matches: tuple[TrackProviderMatch, ...] = ()
+    ambiguous_providers: tuple[str, ...] = ()
+    failed_providers: tuple[str, ...] = ()
+    used_library_item: bool = False
+    ambiguous: bool = False
+    error: str | None = None
 
 
 class PlaylistController(MediaControllerBase[Playlist]):
@@ -110,6 +142,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
             self.import_playlist,
             required_scope=Scope.LIBRARY_WRITE,
         )
+        self.mass.register_api_command(
+            "music/playlists/migrate_playlist",
+            self.migrate_playlist,
+            required_scope=Scope.LIBRARY_WRITE,
+        )
 
     @property
     def summary_query(self) -> tuple[str, dict[str, Any]]:
@@ -134,8 +171,17 @@ class PlaylistController(MediaControllerBase[Playlist]):
         provider_instance_id_or_domain: str,
         force_refresh: bool = False,
         allow_dynamic_tracks: bool = False,
+        strict_provider_instance: bool = False,
     ) -> AsyncGenerator[PlaylistPlayableItem]:
-        """Return playlist tracks for the given provider playlist id."""
+        """
+        Return playlist items for a provider playlist.
+
+        :param item_id: Provider playlist ID.
+        :param provider_instance_id_or_domain: Provider instance ID or domain.
+        :param force_refresh: Bypass cached playlist contents.
+        :param allow_dynamic_tracks: Request a fresh sample from dynamic playlists.
+        :param strict_provider_instance: Do not fall back to another provider instance.
+        """
         if provider_instance_id_or_domain == "library":
             library_item = await self.get_library_item(item_id)
             provider_instance_id_or_domain, item_id = self._select_provider_id(library_item)
@@ -155,6 +201,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 provider_instance_id_or_domain,
                 page=page,
                 force_refresh=force_refresh,
+                strict_provider_instance=strict_provider_instance,
             )
             if not tracks:
                 break
@@ -167,12 +214,26 @@ class PlaylistController(MediaControllerBase[Playlist]):
         name: str,
         media_types: list[MediaType] | None = None,
         provider_instance_or_domain: str | None = None,
+        strict_provider_instance: bool = False,
     ) -> Playlist:
-        """Create new playlist."""
+        """
+        Create a playlist on an available provider.
+
+        :param name: Playlist name.
+        :param media_types: Media types the playlist must support.
+        :param provider_instance_or_domain: Destination provider instance ID or domain.
+        :param strict_provider_instance: Do not fall back to another provider instance.
+        """
         # if provider is omitted, just pick builtin provider
         if provider_instance_or_domain:
-            provider = self.mass.get_provider(provider_instance_or_domain)
-            if provider is None:
+            provider = self.mass.get_provider(
+                provider_instance_or_domain,
+                return_unavailable=strict_provider_instance,
+            )
+            if provider is None or (
+                strict_provider_instance
+                and (provider.instance_id != provider_instance_or_domain or not provider.available)
+            ):
                 raise ProviderUnavailableError
         else:
             provider = self.mass.get_provider("builtin")
@@ -413,6 +474,714 @@ class PlaylistController(MediaControllerBase[Playlist]):
             )
         return db_playlist
 
+    async def migrate_playlist(
+        self,
+        db_playlist_id: str | int,
+        destination_provider: str = "builtin",
+        name: str | None = None,
+        match_policy: PlaylistMatchPolicy = PlaylistMatchPolicy.SAME_RECORDING,
+    ) -> BackgroundTask:
+        """
+        Queue copying a playlist to another provider or Music Assistant.
+
+        :param db_playlist_id: Library database ID of the source playlist.
+        :param destination_provider: Destination provider instance ID or domain.
+        :param name: Optional destination playlist name.
+        :param match_policy: Lowest track-match confidence that may be accepted.
+        :return: Managed background task performing the migration.
+        """
+        source_playlist = await self.get_library_item(int(db_playlist_id))
+        if source_playlist.is_dynamic:
+            raise InvalidDataError("Dynamic playlists can not be migrated")
+        # exclude unavailable providers: mass.music.providers only applies user filtering,
+        # so an unavailable instance would otherwise be selected and fail once the task runs
+        available_providers = [item for item in self.mass.music.providers if item.available]
+        provider = next(
+            (item for item in available_providers if item.instance_id == destination_provider),
+            None,
+        ) or next(
+            (item for item in available_providers if item.domain == destination_provider),
+            None,
+        )
+        if provider is None and destination_provider == "builtin":
+            provider = self.mass.get_provider(
+                "builtin",
+                provider_type=MusicProvider,
+            )
+        if not provider or not isinstance(provider, MusicProvider):
+            raise ProviderUnavailableError(f"Provider {destination_provider} is not available")
+        if provider.domain != "builtin" and not provider.is_streaming_provider:
+            raise InvalidDataError(
+                "Playlists can only be migrated to Music Assistant or a streaming provider"
+            )
+        if not (
+            {
+                ProviderFeature.PLAYLIST_CREATE,
+                ProviderFeature.PLAYLIST_CREATE_TRACKS,
+            }
+            & provider.supported_features
+        ):
+            raise InvalidDataError(
+                f"Provider {provider.name} does not support creating track playlists"
+            )
+        if ProviderFeature.PLAYLIST_TRACKS_EDIT not in provider.supported_features:
+            raise InvalidDataError(f"Provider {provider.name} does not support editing playlists")
+        if MediaType.TRACK not in provider.supported_media_types:
+            raise InvalidDataError(f"Provider {provider.name} does not support track playlists")
+        destination_name = name or source_playlist.name
+        if not is_safe_name(destination_name):
+            raise InvalidDataError(f"{destination_name} is not a valid Playlist name")
+
+        user = get_current_user()
+        source_provider, source_item_id = self._select_provider_id(source_playlist)
+        allowed_provider_instances = {item.instance_id for item in available_providers}
+        source_provider_obj = self.mass.get_provider(
+            source_provider,
+            return_unavailable=True,
+        )
+        if (
+            not isinstance(source_provider_obj, MusicProvider | PluginProvider)
+            or source_provider_obj.instance_id != source_provider
+            or not source_provider_obj.available
+        ):
+            raise ProviderUnavailableError(f"Provider {source_provider} is not available")
+        if isinstance(source_provider_obj, MusicProvider):
+            if (
+                source_provider not in allowed_provider_instances
+                and source_provider_obj.domain != "builtin"
+            ):
+                raise ProviderUnavailableError(f"Provider {source_provider} is not available")
+            allowed_provider_instances.add(source_provider)
+        allowed_provider_instances.add(provider.instance_id)
+        return self.mass.tasks.run_background_task(
+            name=f"Migrate playlist {source_playlist.name}",
+            handler=lambda: self._handle_migrate_playlist(
+                source_playlist.item_id,
+                source_item_id,
+                source_provider,
+                provider.instance_id,
+                destination_name,
+                match_policy,
+                tuple(sorted(allowed_provider_instances)),
+            ),
+            user_id=user.user_id if user else None,
+            metadata={
+                "task_domain": "playlist_migration",
+                "source_playlist_id": source_playlist.item_id,
+                "source_playlist_name": source_playlist.name,
+                "destination_provider": provider.instance_id,
+                "destination_provider_name": provider.name,
+                "match_policy": match_policy.value,
+            },
+            allow_cancel=True,
+            priority=True,
+        )
+
+    async def _handle_migrate_playlist(
+        self,
+        source_playlist_id: str,
+        source_playlist_item_id: str,
+        source_provider: str,
+        destination_provider: str,
+        destination_name: str,
+        match_policy: PlaylistMatchPolicy,
+        allowed_provider_instances: tuple[str, ...],
+    ) -> None:
+        """Resolve and copy a playlist inside a managed task."""
+        source_playlist = await self.get_library_item(source_playlist_id)
+        if source_playlist.is_dynamic:
+            raise InvalidDataError("Dynamic playlists can not be migrated")
+        provider = self.mass.get_provider(
+            destination_provider,
+            return_unavailable=True,
+        )
+        if (
+            not isinstance(provider, MusicProvider)
+            or provider.instance_id != destination_provider
+            or not provider.available
+        ):
+            raise ProviderUnavailableError(f"Provider {destination_provider} is not available")
+        source_provider_obj = self.mass.get_provider(
+            source_provider,
+            return_unavailable=True,
+        )
+        if (
+            not isinstance(source_provider_obj, MusicProvider | PluginProvider)
+            or source_provider_obj.instance_id != source_provider
+            or not source_provider_obj.available
+        ):
+            raise ProviderUnavailableError(f"Provider {source_provider} is not available")
+        trust_source_mappings = (
+            isinstance(source_provider_obj, MusicProvider)
+            and source_provider_obj.domain != "builtin"
+        )
+        update_current_task_progress(0, "Loading source playlist")
+        source_tracks: list[Track] = []
+        unsupported_items: list[tuple[str, str]] = []
+        async for item in self.tracks(
+            source_playlist_item_id,
+            source_provider,
+            force_refresh=True,
+            strict_provider_instance=True,
+        ):
+            if isinstance(item, Track):
+                source_tracks.append(item)
+                continue
+            reason = (
+                f"{item.media_type.value.replace('_', ' ').capitalize()} entries are not supported"
+            )
+            report_current_task_failure(f"{item.name}: {reason.lower()}")
+            unsupported_items.append((item.name, reason))
+        if not source_tracks:
+            raise InvalidDataError("The source playlist has no tracks to migrate")
+
+        minimum_confidence = match_policy_minimum_confidence(match_policy)
+        unique_tracks = {self._migration_track_key(track): track for track in source_tracks}
+        allowed_provider_instance_set = set(allowed_provider_instances)
+        failed_provider_instances: set[str] = set()
+        completed = 0
+
+        async def resolve_track(
+            key: str, track: Track
+        ) -> tuple[str, _PlaylistMigrationTrackResult]:
+            nonlocal completed
+            result = await self._resolve_migration_track(
+                track,
+                provider,
+                minimum_confidence,
+                allowed_provider_instance_set,
+                trust_source_mappings,
+                failed_provider_instances,
+            )
+            completed += 1
+            _update_stage_progress(
+                completed,
+                len(unique_tracks),
+                5,
+                80,
+                f"Matching track {completed}/{len(unique_tracks)}",
+            )
+            return key, result
+
+        resolved_items: list[tuple[str, _PlaylistMigrationTrackResult]] = []
+        for track_batch in batched(
+            unique_tracks.items(),
+            _MIGRATION_RESOLVE_BATCH_SIZE,
+            strict=False,
+        ):
+            resolved_items.extend(
+                await asyncio.gather(*(resolve_track(key, track) for key, track in track_batch))
+            )
+        resolved_tracks = dict(resolved_items)
+        target_ids: list[str] = []
+        target_results: list[tuple[Track, _PlaylistMigrationTrackResult]] = []
+        builtin_entries: list[PlaylistItem] = []
+        counts = {
+            "total": len(source_tracks) + len(unsupported_items),
+            "exact": 0,
+            "same_recording": 0,
+            "best_effort": 0,
+            "skipped": len(unsupported_items),
+            "ambiguous": 0,
+            "library_matches": 0,
+            "provider_matches": 0,
+        }
+        substitutions_by_track: dict[str, tuple[str, str, str]] = {}
+        skipped_items = unsupported_items.copy()
+        provider_issues: list[tuple[str, str]] = []
+        for key, result in resolved_tracks.items():
+            track = unique_tracks[key]
+            track_label = self._migration_track_label(track)
+            if result.used_library_item:
+                counts["library_matches"] += 1
+            counts["provider_matches"] += len(result.provider_matches)
+            if result.error:
+                report_current_task_failure(f"{track_label}: {result.error}")
+                if provider.domain == "builtin":
+                    provider_issues.append((track_label, result.error))
+            for provider_name in result.failed_providers:
+                issue = f"Matching failed on {provider_name}"
+                report_current_task_failure(f"{track_label}: {issue.lower()}")
+                provider_issues.append((track_label, issue))
+            for provider_name in result.ambiguous_providers:
+                issue = f"Ambiguous match on {provider_name}"
+                report_current_task_failure(f"{track_label}: {issue.lower()}")
+                provider_issues.append((track_label, issue))
+            if provider.domain == "builtin" and result.track:
+                continue
+            if result.mapping:
+                if result.track and result.confidence != TrackMatchConfidence.EXACT:
+                    substitutions_by_track[key] = (
+                        track_label,
+                        self._migration_track_label(result.track),
+                        "Same recording"
+                        if result.confidence == TrackMatchConfidence.LIKELY
+                        else "Best effort",
+                    )
+                continue
+            if result.error:
+                skipped_items.append((track_label, result.error))
+                continue
+            reason = (
+                "multiple equally likely matches" if result.ambiguous else "no acceptable match"
+            )
+            report_current_task_failure(f"{track_label}: {reason}")
+            skipped_items.append((track_label, reason.capitalize()))
+
+        seen_target_ids: set[str] = set()
+        for track in source_tracks:
+            result = resolved_tracks[self._migration_track_key(track)]
+            if provider.domain == "builtin" and result.track:
+                builtin_entries.append(media_item_to_playlist_item(result.track))
+                continue
+            if not result.mapping:
+                counts["skipped"] += 1
+                if result.ambiguous:
+                    counts["ambiguous"] += 1
+                continue
+            if (
+                not provider.playlist_duplicates_supported
+                and result.mapping.item_id in seen_target_ids
+            ):
+                reason = f"{provider.name} does not support duplicate playlist entries"
+                counts["skipped"] += 1
+                report_current_task_failure(
+                    f"{self._migration_track_label(track)}: {reason.lower()}"
+                )
+                skipped_items.append((self._migration_track_label(track), reason))
+                continue
+            seen_target_ids.add(result.mapping.item_id)
+            target_ids.append(result.mapping.item_id)
+            target_results.append((track, result))
+            self._adjust_migration_match_count(
+                counts,
+                result.confidence,
+                1,
+            )
+
+        prepared_count = (
+            len(builtin_entries) if provider.domain == "builtin" else len(target_results)
+        )
+        set_current_task_report(
+            self._build_migration_report(
+                source_playlist.name,
+                destination_name,
+                provider.name,
+                prepared_count,
+                counts,
+                list(substitutions_by_track.values()),
+                skipped_items,
+                provider_issues,
+                completed=False,
+                builtin_destination=provider.domain == "builtin",
+            )
+        )
+        if not prepared_count:
+            raise InvalidDataError("No tracks could be migrated")
+        update_current_task_progress(85, "Creating destination playlist")
+        if provider.domain == "builtin":
+            destination_playlist = await self._create_builtin_migration_playlist(
+                destination_name,
+                builtin_entries,
+                source_playlist.image.path if source_playlist.image else None,
+            )
+            migrated_count = prepared_count
+        else:
+            destination_playlist = await self.create_playlist(
+                destination_name,
+                media_types=[MediaType.TRACK],
+                provider_instance_or_domain=provider.instance_id,
+                strict_provider_instance=True,
+            )
+            playlist_provider, playlist_item_id = self._select_provider_id(destination_playlist)
+            if playlist_provider != provider.instance_id:
+                raise ProviderUnavailableError(
+                    f"Created playlist is not available on provider {provider.name}"
+                )
+            update_current_task_progress(
+                90,
+                f"Adding {len(target_ids)} tracks to destination playlist",
+            )
+            await self._add_provider_playlist_tracks(
+                provider,
+                playlist_item_id,
+                target_ids,
+            )
+            update_current_task_progress(95, "Verifying destination playlist")
+            try:
+                confirmed_indexes, destination_mismatch = await self._verify_migration_results(
+                    playlist_item_id,
+                    provider.instance_id,
+                    target_results,
+                )
+            except (
+                ResourceTemporarilyUnavailable,
+                ProviderUnavailableError,
+                MediaNotFoundError,
+                ClientError,
+                OSError,
+                TimeoutError,
+            ) as err:
+                migrated_count = len(target_results)
+                issue = (
+                    "Could not verify destination playlist: "
+                    f"{self._migration_error_message(err, 'Verification failed')}"
+                )
+                self.logger.warning(
+                    "Could not verify migrated playlist %s on provider %s: %s",
+                    destination_playlist.name,
+                    provider.name,
+                    err,
+                )
+                report_current_task_failure(issue)
+                provider_issues.append(("Destination playlist", issue))
+            else:
+                missing_results = [
+                    target_result
+                    for index, target_result in enumerate(target_results)
+                    if index not in confirmed_indexes
+                ]
+                migrated_count = len(confirmed_indexes)
+                for track, result in missing_results:
+                    reason = f"{provider.name} did not add this track in the expected order"
+                    counts["skipped"] += 1
+                    self._adjust_migration_match_count(
+                        counts,
+                        result.confidence,
+                        -1,
+                    )
+                    report_current_task_failure(
+                        f"{self._migration_track_label(track)}: {reason.lower()}"
+                    )
+                    skipped_items.append((self._migration_track_label(track), reason))
+                if destination_mismatch:
+                    issue = "Destination playlist contains unexpected or reordered tracks"
+                    report_current_task_failure(issue)
+                    provider_issues.append(("Destination playlist", issue))
+                confirmed_track_keys = {
+                    self._migration_track_key(target_results[index][0])
+                    for index in confirmed_indexes
+                }
+                substitutions_by_track = {
+                    key: substitution
+                    for key, substitution in substitutions_by_track.items()
+                    if key in confirmed_track_keys
+                }
+            destination_playlist.metadata.last_refresh = None
+            await self.update_item_in_library(
+                destination_playlist.item_id,
+                destination_playlist,
+            )
+
+        if current_task := get_current_task():
+            current_task.metadata.update(
+                {
+                    "playlist_id": destination_playlist.item_id,
+                    "playlist_name": destination_playlist.name,
+                    "migrated_count": migrated_count,
+                    **counts,
+                }
+            )
+        set_current_task_report(
+            self._build_migration_report(
+                source_playlist.name,
+                destination_playlist.name,
+                provider.name,
+                migrated_count,
+                counts,
+                list(substitutions_by_track.values()),
+                skipped_items,
+                provider_issues,
+                completed=True,
+                builtin_destination=provider.domain == "builtin",
+            )
+        )
+        if not migrated_count:
+            raise InvalidDataError("The destination provider did not add any tracks")
+        update_current_task_progress(
+            100,
+            f"Migrated {migrated_count} of {counts['total']} playlist items",
+        )
+
+    async def _resolve_migration_track(
+        self,
+        track: Track,
+        provider: MusicProvider,
+        minimum_confidence: TrackMatchConfidence,
+        allowed_provider_instances: set[str],
+        trust_source_mappings: bool,
+        failed_provider_instances: set[str],
+    ) -> _PlaylistMigrationTrackResult:
+        """Resolve one source track for a migration destination."""
+        if provider.domain != "builtin" and provider.instance_id in failed_provider_instances:
+            return _PlaylistMigrationTrackResult(
+                error=f"Matching unavailable on {provider.name} after an earlier failure"
+            )
+        try:
+            if provider.domain == "builtin":
+                enrichment = await self.mass.music.tracks.enrich_provider_mappings(
+                    track,
+                    minimum_confidence=minimum_confidence,
+                    provider_instance_ids=allowed_provider_instances,
+                    trust_track_mappings=trust_source_mappings,
+                    failed_provider_instances=failed_provider_instances,
+                )
+                return _PlaylistMigrationTrackResult(
+                    track=enrichment.track if enrichment.track.provider_mappings else None,
+                    provider_matches=enrichment.matches,
+                    ambiguous_providers=enrichment.ambiguous_providers,
+                    failed_providers=enrichment.failed_providers,
+                    used_library_item=enrichment.used_library_item,
+                )
+            library_track = await self.mass.music.tracks.get_library_match(track)
+            result = await self.mass.music.tracks.find_provider_match(
+                track,
+                provider,
+                minimum_confidence=minimum_confidence,
+                mapping_source=library_track,
+                allowed_provider_instances=allowed_provider_instances,
+                trust_base_mapping=trust_source_mappings,
+            )
+            if not result.match:
+                return _PlaylistMigrationTrackResult(
+                    used_library_item=library_track is not None,
+                    ambiguous=result.ambiguous,
+                )
+            return _PlaylistMigrationTrackResult(
+                track=result.match.track,
+                mapping=result.match.mapping,
+                confidence=result.match.confidence,
+                used_library_item=library_track is not None,
+            )
+        except (
+            ResourceTemporarilyUnavailable,
+            ProviderUnavailableError,
+            ClientError,
+            OSError,
+            TimeoutError,
+        ) as err:
+            failed_provider_instances.add(provider.instance_id)
+            return _PlaylistMigrationTrackResult(
+                error=self._migration_error_message(
+                    err,
+                    f"Matching failed on {provider.name}",
+                )
+            )
+        except (InvalidDataError, MediaNotFoundError) as err:
+            return _PlaylistMigrationTrackResult(
+                error=self._migration_error_message(
+                    err,
+                    f"Matching failed on {provider.name}",
+                ),
+            )
+
+    async def _create_builtin_migration_playlist(
+        self,
+        name: str,
+        entries: list[PlaylistItem],
+        image_url: str | None,
+    ) -> Playlist:
+        """Create a Music Assistant playlist from resolved entries."""
+        provider = self.mass.get_provider("builtin")
+        if not provider or not isinstance(provider, MusicProvider):
+            raise ProviderUnavailableError("Builtin provider is not available")
+        builtin_provider = cast("BuiltinProvider", provider)
+        # migration writes the playlist directly, with no deferred matching step, so
+        # the generation returned alongside it (used to detect a later delete-and-recreate)
+        # is not needed here
+        playlist, _generation = await builtin_provider.import_playlist(
+            generate_m3u(name, entries, image_url)
+        )
+        for mapping in playlist.provider_mappings:
+            mapping.in_library = True
+        return await self.add_item_to_library(playlist, False)
+
+    async def _verify_migration_results(
+        self,
+        playlist_item_id: str,
+        provider_instance_id: str,
+        target_results: Sequence[tuple[Track, _PlaylistMigrationTrackResult]],
+    ) -> tuple[set[int], bool]:
+        """Verify which requested tracks appear in the destination playlist."""
+        confirmed_indexes: set[int] = set()
+        destination_mismatch = False
+        for retry_delay in (0, *_MIGRATION_VERIFY_RETRY_DELAYS):
+            if retry_delay:
+                await asyncio.sleep(retry_delay)
+            actual_target_ids = [
+                item.item_id
+                async for item in self.tracks(
+                    playlist_item_id,
+                    provider_instance_id,
+                    force_refresh=True,
+                    strict_provider_instance=True,
+                )
+            ]
+            confirmed_indexes, destination_mismatch = self._reconcile_migration_results(
+                actual_target_ids,
+                target_results,
+            )
+            if len(confirmed_indexes) == len(target_results) and not destination_mismatch:
+                break
+        return confirmed_indexes, destination_mismatch
+
+    @staticmethod
+    def _reconcile_migration_results(
+        actual_target_ids: list[str],
+        target_results: Sequence[tuple[Track, _PlaylistMigrationTrackResult]],
+    ) -> tuple[set[int], bool]:
+        """Return confirmed result indexes and whether destination content is unexpected."""
+        expected_positions: dict[str, list[int]] = {}
+        for index, (_track, result) in enumerate(target_results):
+            assert result.mapping is not None
+            expected_positions.setdefault(result.mapping.item_id, []).append(index)
+
+        confirmed_indexes: set[int] = set()
+        last_confirmed_index = -1
+        destination_mismatch = False
+        for actual_target_id in actual_target_ids:
+            positions = expected_positions.get(actual_target_id)
+            if not positions:
+                destination_mismatch = True
+                continue
+            position_index = bisect_right(positions, last_confirmed_index)
+            if position_index == len(positions):
+                destination_mismatch = True
+                continue
+            last_confirmed_index = positions[position_index]
+            confirmed_indexes.add(last_confirmed_index)
+        return confirmed_indexes, destination_mismatch
+
+    @staticmethod
+    def _adjust_migration_match_count(
+        counts: dict[str, int],
+        confidence: TrackMatchConfidence,
+        amount: int,
+    ) -> None:
+        """Adjust the aggregate count for a migration match confidence."""
+        count_key = {
+            TrackMatchConfidence.EXACT: "exact",
+            TrackMatchConfidence.LIKELY: "same_recording",
+            TrackMatchConfidence.LOOSE: "best_effort",
+        }[confidence]
+        counts[count_key] += amount
+
+    @staticmethod
+    def _migration_track_key(track: Track) -> str:
+        """Return a stable key for reusing duplicate track resolutions."""
+        return track.uri or f"{track.provider}://track/{track.item_id}"
+
+    @classmethod
+    def _build_migration_report(
+        cls,
+        source_name: str,
+        destination_name: str,
+        destination_provider: str,
+        migrated_count: int,
+        counts: Mapping[str, int],
+        substitutions: list[tuple[str, str, str]],
+        skipped_items: list[tuple[str, str]],
+        provider_issues: list[tuple[str, str]],
+        *,
+        completed: bool,
+        builtin_destination: bool,
+    ) -> str:
+        """Build the human-readable Markdown report for a migration task."""
+        source = escape_markdown(source_name)
+        destination = escape_markdown(destination_name)
+        provider = escape_markdown(destination_provider)
+        action = "Migrated" if completed else "Prepared"
+        lines = [
+            f"## Playlist migration {'complete' if completed else 'analysis'}",
+            "",
+            f"{action} **{migrated_count}** of **{counts['total']}** playlist items "
+            f"from **{source}** for **{destination}** on **{provider}**.",
+            "",
+            "| Result | Items |",
+            "| --- | ---: |",
+        ]
+        if builtin_destination:
+            lines.extend(
+                (
+                    f"| Included | {migrated_count} |",
+                    f"| Existing library matches used | {counts['library_matches']} |",
+                    f"| Additional provider mappings found | {counts['provider_matches']} |",
+                    f"| Skipped | {counts['skipped']} |",
+                )
+            )
+        else:
+            lines.extend(
+                (
+                    f"| Exact release | {counts['exact']} |",
+                    f"| Same recording | {counts['same_recording']} |",
+                    f"| Best effort | {counts['best_effort']} |",
+                    f"| Skipped | {counts['skipped']} |",
+                    f"| Ambiguous | {counts['ambiguous']} |",
+                )
+            )
+        cls._add_report_table(
+            lines,
+            "Substitutions",
+            ("Source", "Destination", "Match"),
+            substitutions,
+        )
+        cls._add_report_table(
+            lines,
+            "Skipped items",
+            ("Item", "Reason"),
+            skipped_items,
+        )
+        cls._add_report_table(
+            lines,
+            "Provider lookup issues",
+            ("Track", "Issue"),
+            provider_issues,
+        )
+        return "\n".join(lines)
+
+    @classmethod
+    def _add_report_table(
+        cls,
+        lines: list[str],
+        title: str,
+        headers: tuple[str, ...],
+        rows: Sequence[tuple[str, ...]],
+    ) -> None:
+        """Append a Markdown report table when it has rows."""
+        if not rows:
+            return
+        visible_rows = rows[:_MIGRATION_REPORT_DETAIL_LIMIT]
+        lines.extend(
+            (
+                "",
+                f"### {title}",
+                "",
+                f"| {' | '.join(headers)} |",
+                f"| {' | '.join('---' for _ in headers)} |",
+            )
+        )
+        lines.extend(
+            f"| {' | '.join(escape_markdown(value, table=True) for value in row)} |"
+            for row in visible_rows
+        )
+        if omitted_count := len(rows) - len(visible_rows):
+            lines.extend(
+                (
+                    "",
+                    f"_{omitted_count} additional rows omitted._",
+                )
+            )
+
+    @staticmethod
+    def _migration_track_label(track: Track) -> str:
+        """Return a readable artist and title label."""
+        return f"{track.artist_str} - {track.name}" if track.artist_str else track.name
+
+    @staticmethod
+    def _migration_error_message(error: BaseException, fallback: str) -> str:
+        """Return a non-empty error message for a migration report."""
+        return str(error).strip() or f"{fallback} ({type(error).__name__})"
+
     def _verify_update_allowed(self, current_item: Playlist, update: Playlist) -> None:
         """
         Verify that the update is allowed from a security perspective.
@@ -536,12 +1305,24 @@ class PlaylistController(MediaControllerBase[Playlist]):
         provider_instance_id_or_domain: str,
         page: int = 0,
         force_refresh: bool = False,
+        strict_provider_instance: bool = False,
     ) -> Sequence[PlaylistPlayableItem]:
         """Return playlist tracks for the given provider playlist id."""
         assert provider_instance_id_or_domain != "library"
-        if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
+        provider = self.mass.get_provider(
+            provider_instance_id_or_domain,
+            return_unavailable=strict_provider_instance,
+        )
+        if strict_provider_instance and (
+            provider is None
+            or provider.instance_id != provider_instance_id_or_domain
+            or not provider.available
+        ):
+            raise ProviderUnavailableError(
+                f"Provider {provider_instance_id_or_domain} is not available"
+            )
+        if not isinstance(provider, MusicProvider | PluginProvider):
             return []
-        provider = cast("MusicProvider", provider)
         async with self.mass.cache.handle_refresh(force_refresh):
             return await provider.get_playlist_tracks(item_id, page=page)
 
@@ -815,6 +1596,23 @@ class PlaylistController(MediaControllerBase[Playlist]):
         # in the next scheduled run of the playlist metadata task
         playlist.metadata.last_refresh = None
         await self.update_item_in_library(db_playlist_id, playlist)
+
+    @staticmethod
+    async def _add_provider_playlist_tracks(
+        provider: MusicProvider,
+        playlist_item_id: str,
+        track_ids: list[str],
+    ) -> None:
+        """Add tracks in ordered batches accepted by provider APIs."""
+        for track_id_batch in batched(
+            track_ids,
+            _PROVIDER_PLAYLIST_ADD_BATCH_SIZE,
+            strict=False,
+        ):
+            await provider.add_playlist_tracks(
+                playlist_item_id,
+                list(track_id_batch),
+            )
 
     def _parse_summary_row(self, db_row: Mapping[str, Any]) -> PlaylistSummary:
         """Parse a raw summary db row into a PlaylistSummary object."""

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -392,6 +392,19 @@ def sanitize_m3u_value(value: str) -> str:
     return value.translate(_LINE_BREAK_TABLE)
 
 
+def escape_markdown(value: str, table: bool = False) -> str:
+    """
+    Escape provider text before adding it to a Markdown import/migration report.
+
+    :param value: Raw provider text (name, title or error message) to escape.
+    :param table: Whether the value is placed inside a Markdown table cell.
+    """
+    value = value.replace("\r\n", "\n").translate(_LINE_BREAK_TABLE).replace("\\", "\\\\")
+    for character in ("`", "*", "_", "[", "]", "<", ">"):
+        value = value.replace(character, f"\\{character}")
+    return value.replace("|", "\\|") if table else value
+
+
 def generate_m3u(
     playlist_name: str,
     items: Sequence[PlaylistItem],

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -163,6 +163,10 @@ class MusicProvider(Provider):
     Music Provider implementations should inherit from this base model.
     """
 
+    # whether a playlist on this provider accepts the same track more than once;
+    # providers that dedupe entries server-side must override this to False
+    playlist_duplicates_supported = True
+
     def __init__(
         self,
         mass: MusicAssistant,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -78,6 +78,7 @@ from music_assistant.helpers.playlists import (
     PlaylistItem,
     ProviderMappingInfo,
     construct_media_item_from_playlist_item,
+    escape_markdown,
     fetch_playlist,
     generate_m3u,
     media_item_to_playlist_item,
@@ -2079,7 +2080,7 @@ def _build_import_report(
     provider_issues: Sequence[tuple[str, str]],
 ) -> str:
     """Build the human-readable Markdown report for an import matching task."""
-    name = _escape_markdown(playlist_name)
+    name = escape_markdown(playlist_name)
     matched = counts["exact"] + counts["same_recording"] + counts["best_effort"]
     lines = [
         "## Playlist import matching complete",
@@ -2126,16 +2127,8 @@ def _add_report_table(
         )
     )
     lines.extend(
-        f"| {' | '.join(_escape_markdown(value, table=True) for value in row)} |"
+        f"| {' | '.join(escape_markdown(value, table=True) for value in row)} |"
         for row in visible_rows
     )
     if omitted_count := len(rows) - len(visible_rows):
         lines.extend(("", f"_{omitted_count} additional rows omitted._"))
-
-
-def _escape_markdown(value: str, table: bool = False) -> str:
-    """Escape provider text before adding it to a Markdown report."""
-    value = value.replace("\\", "\\\\").replace("\n", " ")
-    for character in ("`", "*", "_", "[", "]", "<", ">"):
-        value = value.replace(character, f"\\{character}")
-    return value.replace("|", "\\|") if table else value

--- a/music_assistant/providers/nicovideo/provider.py
+++ b/music_assistant/providers/nicovideo/provider.py
@@ -54,6 +54,9 @@ class NicovideoMusicProvider(
 ):
     """Coordinator combining all nicovideo provider mixins."""
 
+    # Nicovideo playlists silently ignore a second add of the same video
+    playlist_duplicates_supported = False
+
     @override
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return Config entries to configure this provider."""

--- a/music_assistant/providers/tidal/provider.py
+++ b/music_assistant/providers/tidal/provider.py
@@ -82,6 +82,9 @@ SUPPORTED_FEATURES = {
 class TidalProvider(RecommendationPayloadMixin, MusicProvider):
     """Implementation of a Tidal MusicProvider."""
 
+    # Tidal playlists reject adding a track that is already in the playlist
+    playlist_duplicates_supported = False
+
     def __init__(self, mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig):
         """Initialize Tidal provider."""
         super().__init__(mass, manifest, config, SUPPORTED_FEATURES)

--- a/music_assistant/providers/yousee/provider.py
+++ b/music_assistant/providers/yousee/provider.py
@@ -59,6 +59,9 @@ if TYPE_CHECKING:
 class YouSeeMusikProvider(RecommendationPayloadMixin, MusicProvider):
     """Provider implementation for YouSee Musik."""
 
+    # YouSee playlists reject adding a track that is already in the playlist
+    playlist_duplicates_supported = False
+
     # the personalized sections barely change intraday; keep the pre-refactor 24h interval
     recommendation_payload_ttl = 3600 * 24
 

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -295,7 +295,13 @@ async def add_remove_playlist_tracks(
     def _add_playlist_tracks() -> str | dict[str, Any]:
         ytm = ytmusicapi.YTMusic(auth=headers, user=user)
         if add:
-            return ytm.add_playlist_items(playlistId=prov_playlist_id, videoIds=prov_track_ids)
+            # duplicates=True: YT Music silently drops repeated video IDs otherwise,
+            # which would desync migrated/added playlists from their source order
+            return ytm.add_playlist_items(
+                playlistId=prov_playlist_id,
+                videoIds=prov_track_ids,
+                duplicates=True,
+            )
         return ytm.remove_playlist_items(playlistId=prov_playlist_id, videos=prov_track_ids)
 
     return await _run_ytmusic(_add_playlist_tracks)

--- a/tests/controllers/music/test_playlist_migration.py
+++ b/tests/controllers/music/test_playlist_migration.py
@@ -1,0 +1,1086 @@
+"""Tests for playlist migration."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from copy import deepcopy
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
+
+import pytest
+from music_assistant_models.enums import MediaType, PlaylistMatchPolicy, ProviderFeature
+from music_assistant_models.errors import (
+    InvalidDataError,
+    ProviderUnavailableError,
+)
+from music_assistant_models.media_items import Playlist, ProviderMapping, Radio, Track
+
+from music_assistant.controllers.music import MusicController
+from music_assistant.controllers.music.media.playlists import (
+    PlaylistController,
+    _PlaylistMigrationTrackResult,
+)
+from music_assistant.controllers.music.media.tracks import (
+    TrackProviderEnrichment,
+    TrackProviderMatch,
+    TrackProviderMatchResult,
+)
+from music_assistant.helpers.compare import TrackMatchConfidence
+from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
+from music_assistant.models.plugin import PluginProvider
+
+from .helpers import create_track
+
+
+@pytest.fixture
+async def music(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicController]:
+    """Return a music controller attached to the minimal mass instance."""
+    controller = MusicController(mass_minimal)
+    mass_minimal.music = controller
+    yield controller
+    if controller._database:
+        await controller._database.close()
+
+
+def _playlist(
+    item_id: str,
+    name: str,
+    provider_instance: str,
+    provider_item_id: str,
+) -> Playlist:
+    """Build a provider-backed playlist."""
+    return Playlist(
+        item_id=item_id,
+        provider="library",
+        name=name,
+        provider_mappings={
+            ProviderMapping(
+                item_id=provider_item_id,
+                provider_domain=provider_instance.split("_", maxsplit=1)[0],
+                provider_instance=provider_instance,
+            )
+        },
+        owner="Test",
+        is_editable=True,
+    )
+
+
+def test_migration_report_renders_substitutions_and_skips() -> None:
+    """Migration reports summarize counts and item-level decisions as Markdown."""
+    report = PlaylistController._build_migration_report(
+        "Source",
+        "Migrated",
+        "Tidal",
+        2,
+        {
+            "total": 3,
+            "exact": 1,
+            "same_recording": 1,
+            "best_effort": 0,
+            "skipped": 1,
+            "ambiguous": 0,
+            "library_matches": 1,
+            "provider_matches": 0,
+        },
+        [("Artist - Song", "Artist - Song (Remaster)", "Same recording")],
+        [("Artist - Missing", "No acceptable match")],
+        [],
+        completed=True,
+        builtin_destination=False,
+    )
+
+    assert "## Playlist migration complete" in report
+    assert "| Exact release | 1 |" in report
+    assert "### Substitutions" in report
+    assert "Artist - Missing" in report
+
+
+def test_migration_report_caps_detail_rows() -> None:
+    """Large migrations retain totals without creating unbounded task payloads."""
+    skipped_tracks = [(f"Artist - Track {index}", "No acceptable match") for index in range(201)]
+    report = PlaylistController._build_migration_report(
+        "Source",
+        "Migrated",
+        "Tidal",
+        0,
+        {
+            "total": 201,
+            "exact": 0,
+            "same_recording": 0,
+            "best_effort": 0,
+            "skipped": 201,
+            "ambiguous": 0,
+            "library_matches": 0,
+            "provider_matches": 0,
+        },
+        [],
+        skipped_tracks,
+        [],
+        completed=True,
+        builtin_destination=False,
+    )
+
+    assert "_1 additional rows omitted._" in report
+    assert "| Artist - Track 199 |" in report
+    assert "| Artist - Track 200 |" not in report
+
+
+@pytest.mark.parametrize(
+    ("actual_target_ids", "confirmed_indexes", "destination_mismatch"),
+    [
+        (["tidal-a", "tidal-b"], {0, 1}, False),
+        (["tidal-b"], {1}, False),
+        (["tidal-b", "tidal-a"], {1}, True),
+        (["tidal-a", "unexpected"], {0}, True),
+    ],
+)
+def test_migration_reconciliation_preserves_order(
+    actual_target_ids: list[str],
+    confirmed_indexes: set[int],
+    destination_mismatch: bool,
+) -> None:
+    """Migration verification distinguishes omissions from reordered or unexpected tracks."""
+    source_a = create_track("spotify_1", "source-a")
+    source_b = create_track("spotify_1", "source-b")
+    target_a = create_track("tidal_1", "tidal-a")
+    target_b = create_track("tidal_1", "tidal-b")
+    target_results = [
+        (
+            source_a,
+            _PlaylistMigrationTrackResult(
+                track=target_a,
+                mapping=next(iter(target_a.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+        (
+            source_b,
+            _PlaylistMigrationTrackResult(
+                track=target_b,
+                mapping=next(iter(target_b.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        ),
+    ]
+
+    result = PlaylistController._reconcile_migration_results(
+        actual_target_ids,
+        target_results,
+    )
+
+    assert result == (confirmed_indexes, destination_mismatch)
+
+
+async def test_migration_verification_retries_stale_provider_read(
+    music: MusicController,
+) -> None:
+    """Destination verification retries until successful writes become visible."""
+    source = create_track("spotify_1", "source")
+    target = create_track("tidal_1", "target")
+    target_results = [
+        (
+            source,
+            _PlaylistMigrationTrackResult(
+                track=target,
+                mapping=next(iter(target.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            ),
+        )
+    ]
+    responses = iter(((), (target,)))
+
+    async def iter_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Track]:
+        for track in next(responses):
+            yield track
+
+    with (
+        patch.object(music.playlists, "tracks", iter_tracks),
+        patch(
+            "music_assistant.controllers.music.media.playlists._MIGRATION_VERIFY_RETRY_DELAYS",
+            (1,),
+        ),
+        patch(
+            "music_assistant.controllers.music.media.playlists.asyncio.sleep",
+            AsyncMock(),
+        ) as sleep,
+    ):
+        result = await music.playlists._verify_migration_results(
+            "playlist",
+            "tidal_1",
+            target_results,
+        )
+
+    assert result == ({0}, False)
+    sleep.assert_awaited_once_with(1)
+
+
+async def test_provider_playlist_additions_are_batched_in_order() -> None:
+    """Large playlist writes respect common provider request limits."""
+    provider = MagicMock(spec=MusicProvider)
+    provider.add_playlist_tracks = AsyncMock()
+    track_ids = [str(index) for index in range(205)]
+
+    await PlaylistController._add_provider_playlist_tracks(
+        provider,
+        "playlist",
+        track_ids,
+    )
+
+    batches = [call.args[1] for call in provider.add_playlist_tracks.await_args_list]
+    assert [len(batch) for batch in batches] == [100, 100, 5]
+    assert [track_id for batch in batches for track_id in batch] == track_ids
+
+
+async def test_migration_resolves_tracks_in_bounded_batches(
+    music: MusicController,
+) -> None:
+    """Large playlists create at most five concurrent track resolutions."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    source_tracks = [create_track("spotify_1", f"source-{index}") for index in range(12)]
+    destination_playlist = _playlist("2", "Migrated", "builtin", "migrated")
+    builtin_provider = MagicMock(spec=MusicProvider)
+    builtin_provider.instance_id = "builtin"
+    builtin_provider.domain = "builtin"
+    builtin_provider.name = "Music Assistant"
+    builtin_provider.available = True
+    source_provider = MagicMock(spec=MusicProvider)
+    source_provider.instance_id = "spotify_1"
+    source_provider.domain = "spotify"
+    source_provider.available = True
+    active_resolutions = 0
+    max_active_resolutions = 0
+
+    async def iter_source_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Track]:
+        for track in source_tracks:
+            yield track
+
+    async def enrich_track(
+        track: Track,
+        **_kwargs: object,
+    ) -> TrackProviderEnrichment:
+        nonlocal active_resolutions, max_active_resolutions
+        active_resolutions += 1
+        max_active_resolutions = max(
+            max_active_resolutions,
+            active_resolutions,
+        )
+        await asyncio.sleep(0)
+        active_resolutions -= 1
+        return TrackProviderEnrichment(
+            track=track,
+            matches=(),
+            ambiguous_providers=(),
+            failed_providers=(),
+            used_library_item=False,
+        )
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(music.playlists, "tracks", iter_source_tracks),
+        patch.object(
+            music.tracks,
+            "enrich_provider_mappings",
+            AsyncMock(side_effect=enrich_track),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "builtin": builtin_provider,
+                "spotify_1": source_provider,
+            }[provider_instance_id],
+        ),
+        patch.object(
+            music.playlists,
+            "_create_builtin_migration_playlist",
+            AsyncMock(return_value=destination_playlist),
+        ),
+    ):
+        await music.playlists._handle_migrate_playlist(
+            source_playlist.item_id,
+            "source",
+            "spotify_1",
+            builtin_provider.instance_id,
+            "Migrated",
+            PlaylistMatchPolicy.SAME_RECORDING,
+            ("builtin", "spotify_1"),
+        )
+
+    assert max_active_resolutions == 5
+
+
+async def test_migrate_playlist_queues_validated_task(
+    music: MusicController,
+) -> None:
+    """The public command validates its destination and queues a managed task."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    target_provider = MagicMock(spec=MusicProvider)
+    target_provider.instance_id = "tidal_1"
+    target_provider.domain = "tidal"
+    target_provider.name = "Tidal"
+    target_provider.available = True
+    target_provider.is_streaming_provider = True
+    target_provider.supported_features = {
+        ProviderFeature.PLAYLIST_CREATE,
+        ProviderFeature.PLAYLIST_TRACKS_EDIT,
+    }
+    target_provider.supported_media_types = {MediaType.TRACK}
+    source_provider = MagicMock(spec=MusicProvider)
+    source_provider.instance_id = "spotify_1"
+    source_provider.domain = "spotify"
+    source_provider.available = True
+    queued_task = MagicMock()
+    tasks = MagicMock()
+    tasks.run_background_task.return_value = queued_task
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "spotify_1": source_provider,
+                "tidal_1": target_provider,
+            }[provider_instance_id],
+        ) as get_provider,
+        patch.object(
+            MusicController,
+            "providers",
+            new_callable=PropertyMock,
+            return_value=[source_provider, target_provider],
+        ),
+        patch.object(
+            music.mass,
+            "tasks",
+            tasks,
+            create=True,
+        ),
+        patch.object(
+            music.playlists,
+            "_handle_migrate_playlist",
+            AsyncMock(),
+        ) as handle_migration,
+    ):
+        result = await music.playlists.migrate_playlist(
+            source_playlist.item_id,
+            destination_provider=target_provider.domain,
+            name="Migrated",
+            match_policy=PlaylistMatchPolicy.BEST_EFFORT,
+        )
+        await tasks.run_background_task.call_args.kwargs["handler"]()
+
+    assert result is queued_task
+    get_provider.assert_called_once_with(
+        "spotify_1",
+        return_unavailable=True,
+    )
+    assert "task_id" not in tasks.run_background_task.call_args.kwargs
+    assert tasks.run_background_task.call_args.kwargs["metadata"]["match_policy"] == "best_effort"
+    handle_migration.assert_awaited_once_with(
+        "1",
+        "source",
+        "spotify_1",
+        "tidal_1",
+        "Migrated",
+        PlaylistMatchPolicy.BEST_EFFORT,
+        ("spotify_1", "tidal_1"),
+    )
+
+
+async def test_migrate_playlist_rejects_unavailable_destination_instance(
+    music: MusicController,
+) -> None:
+    """An unavailable destination instance can not be selected by domain, even if loaded."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    unavailable_target = MagicMock(spec=MusicProvider)
+    unavailable_target.instance_id = "tidal_1"
+    unavailable_target.domain = "tidal"
+    unavailable_target.available = False
+    source_provider = MagicMock(spec=MusicProvider)
+    source_provider.instance_id = "spotify_1"
+    source_provider.domain = "spotify"
+    source_provider.available = True
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(
+            MusicController,
+            "providers",
+            new_callable=PropertyMock,
+            return_value=[source_provider, unavailable_target],
+        ),
+        pytest.raises(ProviderUnavailableError),
+    ):
+        await music.playlists.migrate_playlist(
+            source_playlist.item_id,
+            destination_provider="tidal",
+        )
+
+
+async def test_migrate_playlist_accepts_static_plugin_source(
+    music: MusicController,
+) -> None:
+    """Static plugin playlists can be queued with untrusted source mappings."""
+    source_playlist = _playlist("1", "Smart", "smart_playlist_1", "source")
+    source_provider = MagicMock(spec=PluginProvider)
+    source_provider.instance_id = "smart_playlist_1"
+    source_provider.available = True
+    target_provider = MagicMock(spec=MusicProvider)
+    target_provider.instance_id = "tidal_1"
+    target_provider.domain = "tidal"
+    target_provider.name = "Tidal"
+    target_provider.available = True
+    target_provider.is_streaming_provider = True
+    target_provider.supported_features = {
+        ProviderFeature.PLAYLIST_CREATE,
+        ProviderFeature.PLAYLIST_TRACKS_EDIT,
+    }
+    target_provider.supported_media_types = {MediaType.TRACK}
+    tasks = MagicMock()
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(
+            MusicController,
+            "providers",
+            new_callable=PropertyMock,
+            return_value=[target_provider],
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            return_value=source_provider,
+        ) as get_provider,
+        patch.object(music.mass, "tasks", tasks, create=True),
+        patch.object(
+            music.playlists,
+            "_handle_migrate_playlist",
+            AsyncMock(),
+        ) as handle_migration,
+    ):
+        await music.playlists.migrate_playlist(
+            source_playlist.item_id,
+            destination_provider="tidal_1",
+        )
+        await tasks.run_background_task.call_args.kwargs["handler"]()
+
+    get_provider.assert_called_once_with(
+        "smart_playlist_1",
+        return_unavailable=True,
+    )
+    handle_migration.assert_awaited_once_with(
+        "1",
+        "source",
+        "smart_playlist_1",
+        "tidal_1",
+        "Smart",
+        PlaylistMatchPolicy.SAME_RECORDING,
+        ("tidal_1",),
+    )
+
+
+async def test_migrate_playlist_rejects_filtered_source_provider(
+    music: MusicController,
+) -> None:
+    """A deferred migration can not expand the initiating user's provider scope."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    source_provider = MagicMock(spec=MusicProvider)
+    source_provider.instance_id = "spotify_1"
+    source_provider.domain = "spotify"
+    source_provider.available = True
+    target_provider = MagicMock(spec=MusicProvider)
+    target_provider.instance_id = "tidal_1"
+    target_provider.domain = "tidal"
+    target_provider.name = "Tidal"
+    target_provider.available = True
+    target_provider.is_streaming_provider = True
+    target_provider.supported_features = {
+        ProviderFeature.PLAYLIST_CREATE,
+        ProviderFeature.PLAYLIST_TRACKS_EDIT,
+    }
+    target_provider.supported_media_types = {MediaType.TRACK}
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(
+            MusicController,
+            "providers",
+            new_callable=PropertyMock,
+            return_value=[target_provider],
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            return_value=source_provider,
+        ),
+        pytest.raises(ProviderUnavailableError, match="spotify_1"),
+    ):
+        await music.playlists.migrate_playlist(
+            source_playlist.item_id,
+            destination_provider=target_provider.instance_id,
+        )
+
+
+async def test_migrate_playlist_rejects_dynamic_source(
+    music: MusicController,
+) -> None:
+    """A changing dynamic playlist can not be copied as a stable migration."""
+    source_playlist = _playlist("1", "Dynamic", "spotify_1", "source")
+    source_playlist.is_dynamic = True
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        pytest.raises(InvalidDataError, match="Dynamic playlists"),
+    ):
+        await music.playlists.migrate_playlist(source_playlist.item_id)
+
+
+async def test_migration_handler_revalidates_dynamic_source(
+    music: MusicController,
+) -> None:
+    """A queued migration stops if its source playlist becomes dynamic."""
+    source_playlist = _playlist("1", "Dynamic", "spotify_1", "source")
+    source_playlist.is_dynamic = True
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        pytest.raises(InvalidDataError, match="Dynamic playlists"),
+    ):
+        await music.playlists._handle_migrate_playlist(
+            source_playlist.item_id,
+            "source",
+            "spotify_1",
+            "tidal_1",
+            "Migrated",
+            PlaylistMatchPolicy.SAME_RECORDING,
+            ("spotify_1", "tidal_1"),
+        )
+
+
+async def test_migration_handler_rejects_unavailable_destination_instance(
+    music: MusicController,
+) -> None:
+    """A deferred migration can not switch to another destination account."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    unavailable_provider = MagicMock(spec=MusicProvider)
+    unavailable_provider.instance_id = "qobuz_1"
+    unavailable_provider.available = False
+    outside_scope_provider = MagicMock(spec=MusicProvider)
+    outside_scope_provider.instance_id = "qobuz_2"
+    outside_scope_provider.available = True
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda _provider_instance_id, return_unavailable=False: (
+                unavailable_provider if return_unavailable else outside_scope_provider
+            ),
+        ),
+        pytest.raises(ProviderUnavailableError, match="qobuz_1"),
+    ):
+        await music.playlists._handle_migrate_playlist(
+            source_playlist.item_id,
+            "source",
+            "spotify_1",
+            "qobuz_1",
+            "Migrated",
+            PlaylistMatchPolicy.SAME_RECORDING,
+            ("qobuz_1", "spotify_1"),
+        )
+
+
+async def test_playlist_tracks_strict_provider_lookup_rejects_fallback(
+    music: MusicController,
+) -> None:
+    """A strict playlist read can not switch to another provider account."""
+    unavailable_provider = MagicMock(spec=MusicProvider)
+    unavailable_provider.instance_id = "qobuz_1"
+    unavailable_provider.available = False
+    outside_scope_provider = MagicMock(spec=MusicProvider)
+    outside_scope_provider.instance_id = "qobuz_2"
+    outside_scope_provider.available = True
+
+    with (
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda _provider_instance_id, return_unavailable=False: (
+                unavailable_provider if return_unavailable else outside_scope_provider
+            ),
+        ),
+        pytest.raises(ProviderUnavailableError, match="qobuz_1"),
+    ):
+        _ = [
+            item
+            async for item in music.playlists.tracks(
+                "source",
+                "qobuz_1",
+                strict_provider_instance=True,
+            )
+        ]
+
+
+async def test_create_playlist_strict_provider_lookup_rejects_fallback(
+    music: MusicController,
+) -> None:
+    """Strict playlist creation can not switch to another provider account."""
+    unavailable_provider = MagicMock(spec=MusicProvider)
+    unavailable_provider.instance_id = "qobuz_1"
+    unavailable_provider.available = False
+    outside_scope_provider = MagicMock(spec=MusicProvider)
+    outside_scope_provider.instance_id = "qobuz_2"
+    outside_scope_provider.available = True
+
+    with (
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda _provider_instance_id, return_unavailable=False: (
+                unavailable_provider if return_unavailable else outside_scope_provider
+            ),
+        ),
+        pytest.raises(ProviderUnavailableError),
+    ):
+        await music.playlists.create_playlist(
+            "Migrated",
+            provider_instance_or_domain="qobuz_1",
+            strict_provider_instance=True,
+        )
+
+
+async def test_migration_reports_unsupported_source_items(
+    music: MusicController,
+) -> None:
+    """Mixed playlists include unsupported entries in skipped totals and reports."""
+    source_playlist = _playlist("1", "Source", "smart_playlist_1", "source")
+    source_track = create_track("spotify_1", "track")
+    source_radio = Radio(
+        item_id="radio",
+        provider="spotify_1",
+        name="Test Radio",
+        provider_mappings=set(),
+    )
+    destination_playlist = _playlist("2", "Migrated", "builtin", "migrated")
+    builtin_provider = MagicMock(spec=MusicProvider)
+    builtin_provider.instance_id = "builtin"
+    builtin_provider.domain = "builtin"
+    builtin_provider.name = "Music Assistant"
+    builtin_provider.available = True
+    source_provider = MagicMock(spec=PluginProvider)
+    source_provider.instance_id = "smart_playlist_1"
+    source_provider.domain = "smart_playlist"
+    source_provider.available = True
+    enrichment = TrackProviderEnrichment(
+        track=source_track,
+        matches=(),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=False,
+    )
+
+    async def iter_source_items(*_args: object, **_kwargs: object) -> AsyncGenerator[Track | Radio]:
+        yield source_track
+        yield source_radio
+
+    with (
+        patch.object(
+            music.playlists,
+            "get_library_item",
+            AsyncMock(return_value=source_playlist),
+        ),
+        patch.object(music.playlists, "tracks", iter_source_items),
+        patch.object(
+            music.tracks,
+            "enrich_provider_mappings",
+            AsyncMock(return_value=enrichment),
+        ) as enrich,
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "builtin": builtin_provider,
+                "smart_playlist_1": source_provider,
+            }[provider_instance_id],
+        ),
+        patch.object(
+            music.playlists,
+            "_create_builtin_migration_playlist",
+            AsyncMock(return_value=destination_playlist),
+        ),
+        patch(
+            "music_assistant.controllers.music.media.playlists.report_current_task_failure"
+        ) as report_failure,
+        patch(
+            "music_assistant.controllers.music.media.playlists.set_current_task_report"
+        ) as set_report,
+    ):
+        await music.playlists._handle_migrate_playlist(
+            source_playlist.item_id,
+            "source",
+            "smart_playlist_1",
+            "builtin",
+            "Migrated",
+            PlaylistMatchPolicy.SAME_RECORDING,
+            ("builtin", "spotify_1"),
+        )
+
+    report_failure.assert_called_once_with("Test Radio: radio entries are not supported")
+    assert enrich.await_args is not None
+    assert enrich.await_args.kwargs["trust_track_mappings"] is False
+    final_report = set_report.call_args.args[0]
+    assert "Migrated **1** of **2** playlist items" in final_report
+    assert "| Skipped | 1 |" in final_report
+    assert "### Skipped items" in final_report
+    assert "Test Radio" in final_report
+
+
+@pytest.mark.parametrize(
+    (
+        "duplicates_supported",
+        "expected_target_ids",
+        "actual_target_ids",
+        "expected_verification_failures",
+    ),
+    [
+        (
+            True,
+            ["tidal-one", "tidal-two", "tidal-one"],
+            ["tidal-one", "tidal-two", "tidal-one"],
+            [],
+        ),
+        (
+            False,
+            ["tidal-one", "tidal-two"],
+            ["tidal-one", "tidal-two"],
+            [],
+        ),
+        (
+            True,
+            ["tidal-one", "tidal-two", "tidal-one"],
+            ["tidal-one", "tidal-one"],
+            ["Test Artist - Test Track: tidal did not add this track in the expected order"],
+        ),
+        (
+            True,
+            ["tidal-one", "tidal-two", "tidal-one"],
+            None,
+            ["Could not verify destination playlist: Verification failed (TimeoutError)"],
+        ),
+        (
+            True,
+            ["tidal-one", "tidal-two", "tidal-one"],
+            ["tidal-two", "tidal-one", "tidal-one"],
+            [
+                "Test Artist - Test Track: tidal did not add this track in the expected order",
+                "Destination playlist contains unexpected or reordered tracks",
+            ],
+        ),
+    ],
+)
+async def test_streaming_migration_handles_provider_duplicate_policy(
+    music: MusicController,
+    duplicates_supported: bool,
+    expected_target_ids: list[str],
+    actual_target_ids: list[str] | None,
+    expected_verification_failures: list[str],
+) -> None:
+    """A provider migration preserves supported duplicates and reports unsupported ones."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    source_one = create_track("spotify_1", "one")
+    source_two = create_track("spotify_1", "two")
+    source_missing = create_track("spotify_1", "missing")
+    target_one = create_track("tidal_1", "tidal-one")
+    target_two = create_track("tidal_1", "tidal-two")
+    target_playlist = _playlist("2", "Migrated", "tidal_1", "target")
+    target_provider = MagicMock(spec=MusicProvider)
+    target_provider.instance_id = "tidal_1"
+    target_provider.domain = "tidal"
+    target_provider.name = "Tidal"
+    target_provider.available = True
+    target_provider.playlist_duplicates_supported = duplicates_supported
+    target_provider.add_playlist_tracks = AsyncMock()
+    source_provider = MagicMock(spec=MusicProvider)
+    source_provider.instance_id = "spotify_1"
+    source_provider.domain = "spotify"
+    source_provider.available = True
+    track_requests: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    async def iter_playlist_tracks(*args: object, **kwargs: object) -> AsyncGenerator[Track]:
+        track_requests.append((args, kwargs))
+        tracks: tuple[Track, ...]
+        if args == ("source", "spotify_1"):
+            tracks = (
+                source_one,
+                source_two,
+                source_one,
+                source_missing,
+                source_missing,
+            )
+        else:
+            if actual_target_ids is None:
+                raise TimeoutError
+            target_tracks = {
+                "tidal-one": target_one,
+                "tidal-two": target_two,
+            }
+            tracks = tuple(target_tracks[item_id] for item_id in actual_target_ids)
+        for track in tracks:
+            yield track
+
+    matches = {
+        "one": TrackProviderMatchResult(
+            match=TrackProviderMatch(
+                track=target_one,
+                mapping=next(iter(target_one.provider_mappings)),
+                confidence=TrackMatchConfidence.EXACT,
+            )
+        ),
+        "two": TrackProviderMatchResult(
+            match=TrackProviderMatch(
+                track=target_two,
+                mapping=next(iter(target_two.provider_mappings)),
+                confidence=TrackMatchConfidence.LIKELY,
+            )
+        ),
+        "missing": TrackProviderMatchResult(),
+    }
+    find_match = AsyncMock(side_effect=lambda track, *_args, **_kwargs: matches[track.item_id])
+
+    with (
+        patch.object(music.playlists, "get_library_item", AsyncMock(return_value=source_playlist)),
+        patch.object(music.playlists, "tracks", iter_playlist_tracks),
+        patch.object(music.tracks, "get_library_match", AsyncMock(return_value=None)),
+        patch.object(music.tracks, "find_provider_match", find_match),
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "spotify_1": source_provider,
+                "tidal_1": target_provider,
+            }[provider_instance_id],
+        ),
+        patch.object(
+            music.playlists,
+            "create_playlist",
+            AsyncMock(return_value=target_playlist),
+        ) as create_playlist,
+        patch.object(
+            music.playlists,
+            "_select_provider_id",
+            return_value=("tidal_1", "target"),
+        ),
+        patch.object(music.playlists, "update_item_in_library", AsyncMock()),
+        patch(
+            "music_assistant.controllers.music.media.playlists._MIGRATION_VERIFY_RETRY_DELAYS",
+            (),
+        ),
+        patch(
+            "music_assistant.controllers.music.media.playlists.report_current_task_failure"
+        ) as report_failure,
+        patch(
+            "music_assistant.controllers.music.media.playlists.set_current_task_report"
+        ) as set_report,
+    ):
+        await music.playlists._handle_migrate_playlist(
+            source_playlist.item_id,
+            "source",
+            "spotify_1",
+            target_provider.instance_id,
+            "Migrated",
+            PlaylistMatchPolicy.SAME_RECORDING,
+            ("spotify_1", "tidal_1"),
+        )
+
+    create_playlist.assert_awaited_once_with(
+        "Migrated",
+        media_types=[MediaType.TRACK],
+        provider_instance_or_domain="tidal_1",
+        strict_provider_instance=True,
+    )
+    assert track_requests == [
+        (
+            ("source", "spotify_1"),
+            {"force_refresh": True, "strict_provider_instance": True},
+        ),
+        (
+            ("target", "tidal_1"),
+            {"force_refresh": True, "strict_provider_instance": True},
+        ),
+    ]
+    target_provider.add_playlist_tracks.assert_awaited_once_with(
+        "target",
+        expected_target_ids,
+    )
+    assert find_match.await_count == 3
+    assert all(
+        call.kwargs["allowed_provider_instances"] == {"spotify_1", "tidal_1"}
+        for call in find_match.await_args_list
+    )
+    expected_failures = [
+        call("Test Artist - Test Track: no acceptable match"),
+    ]
+    if not duplicates_supported:
+        expected_failures.append(
+            call("Test Artist - Test Track: tidal does not support duplicate playlist entries")
+        )
+    expected_failures.extend(call(message) for message in expected_verification_failures)
+    assert report_failure.call_args_list == expected_failures
+    assert set_report.call_count == 2
+    final_report = set_report.call_args.args[0]
+    assert "### Skipped items" in final_report
+    if actual_target_ids == ["tidal-one", "tidal-one"]:
+        assert "### Substitutions" not in final_report
+
+
+async def test_builtin_migration_keeps_all_enriched_mappings(
+    music: MusicController,
+) -> None:
+    """A Music Assistant playlist stores every resolved mapping without deduplication."""
+    source_playlist = _playlist("1", "Source", "spotify_1", "source")
+    source = create_track("spotify_1", "one")
+    enriched = deepcopy(source)
+    tidal_mapping = ProviderMapping(
+        item_id="tidal-one",
+        provider_domain="tidal",
+        provider_instance="tidal_1",
+    )
+    enriched.provider_mappings.add(tidal_mapping)
+    builtin_provider = MagicMock(spec=MusicProvider)
+    builtin_provider.instance_id = "builtin"
+    builtin_provider.domain = "builtin"
+    builtin_provider.name = "Music Assistant"
+    builtin_provider.available = True
+    source_provider = MagicMock(spec=MusicProvider)
+    source_provider.instance_id = "spotify_1"
+    source_provider.domain = "spotify"
+    source_provider.available = True
+    destination_playlist = _playlist("2", "Migrated", "builtin", "migrated")
+
+    async def iter_source_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Track]:
+        yield source
+        yield source
+
+    enrichment = TrackProviderEnrichment(
+        track=enriched,
+        matches=(
+            TrackProviderMatch(
+                track=enriched,
+                mapping=tidal_mapping,
+                confidence=TrackMatchConfidence.LIKELY,
+            ),
+        ),
+        ambiguous_providers=(),
+        failed_providers=(),
+        used_library_item=True,
+    )
+
+    with (
+        patch.object(music.playlists, "get_library_item", AsyncMock(return_value=source_playlist)),
+        patch.object(music.playlists, "tracks", iter_source_tracks),
+        patch.object(
+            music.tracks,
+            "enrich_provider_mappings",
+            AsyncMock(return_value=enrichment),
+        ) as enrich,
+        patch.object(
+            music.mass,
+            "get_provider",
+            side_effect=lambda provider_instance_id, **_kwargs: {
+                "builtin": builtin_provider,
+                "spotify_1": source_provider,
+            }[provider_instance_id],
+        ),
+        patch.object(
+            music.playlists,
+            "_create_builtin_migration_playlist",
+            AsyncMock(return_value=destination_playlist),
+        ) as create_builtin,
+    ):
+        await music.playlists._handle_migrate_playlist(
+            source_playlist.item_id,
+            "source",
+            "spotify_1",
+            builtin_provider.instance_id,
+            "Migrated",
+            PlaylistMatchPolicy.BEST_EFFORT,
+            ("builtin", "spotify_1"),
+        )
+
+    enrich.assert_awaited_once_with(
+        source,
+        minimum_confidence=TrackMatchConfidence.LOOSE,
+        provider_instance_ids={"builtin", "spotify_1"},
+        trust_track_mappings=True,
+        failed_provider_instances=set(),
+    )
+    assert create_builtin.await_args is not None
+    entries = create_builtin.await_args.args[1]
+    assert len(entries) == 2
+    assert [{provider.domain for provider in entry.providers} for entry in entries] == [
+        {"spotify", "tidal"},
+        {"spotify", "tidal"},
+    ]
+
+
+async def test_builtin_resolution_does_not_return_unfiltered_track_on_failure(
+    music: MusicController,
+) -> None:
+    """A failed enrichment can not serialize the original out-of-scope mappings."""
+    source = create_track("spotify_1", "source")
+    builtin_provider = MagicMock(spec=MusicProvider)
+    builtin_provider.instance_id = "builtin"
+    builtin_provider.domain = "builtin"
+    builtin_provider.name = "Music Assistant"
+    failed_provider_instances: set[str] = set()
+
+    with patch.object(
+        music.tracks,
+        "enrich_provider_mappings",
+        AsyncMock(side_effect=TimeoutError()),
+    ):
+        result = await music.playlists._resolve_migration_track(
+            source,
+            builtin_provider,
+            TrackMatchConfidence.LIKELY,
+            {"builtin"},
+            False,
+            failed_provider_instances,
+        )
+
+    assert result.track is None
+    assert result.error == "Matching failed on Music Assistant (TimeoutError)"

--- a/tests/helpers/test_playlists.py
+++ b/tests/helpers/test_playlists.py
@@ -32,6 +32,7 @@ from music_assistant.helpers.playlists import (
     PlaylistItem,
     ProviderMappingInfo,
     construct_media_item_from_playlist_item,
+    escape_markdown,
     fetch_playlist,
     generate_m3u,
     media_item_to_playlist_item,
@@ -396,6 +397,22 @@ def test_generate_m3u_leaves_values_without_line_breaks_alone() -> None:
     assert sanitize_m3u_value(title) == title
     items = [PlaylistItem(path="spotify://track/abc123", title=title, length="240")]
     assert f"#EXTINF:240,{title}\n" in generate_m3u("My Playlist", items)
+
+
+@pytest.mark.parametrize("line_break", ["\n", "\r", "\r\n"])
+def test_escape_markdown_normalizes_all_line_breaks(line_break: str) -> None:
+    """A lone CR must be neutralized the same as a LF, or it can escape a report row."""
+    escaped = escape_markdown(f"Artist{line_break}Name", table=True)
+    assert "\n" not in escaped
+    assert "\r" not in escaped
+    assert escaped == "Artist Name"
+
+
+def test_escape_markdown_escapes_markdown_and_table_syntax() -> None:
+    """Provider text must not be able to inject Markdown formatting or break a table cell."""
+    assert escape_markdown("a|b") == "a|b"
+    assert escape_markdown("a|b", table=True) == "a\\|b"
+    assert escape_markdown("*bold* `code` [link](url)") == "\\*bold\\* \\`code\\` \\[link\\](url)"
 
 
 def test_generate_m3u_no_extinf_without_title() -> None:

--- a/tests/providers/ytmusic/test_helpers.py
+++ b/tests/providers/ytmusic/test_helpers.py
@@ -72,3 +72,23 @@ async def test_search_passes_auth_headers_and_user() -> None:
     with patch.object(ytmusicapi, "YTMusic", return_value=mock_ytm) as mock_ytmusic:
         await helpers.search(query="test", headers=headers, user="123")
     mock_ytmusic.assert_called_once_with(auth=headers, language="en", user="123")
+
+
+async def test_add_playlist_tracks_allows_duplicates() -> None:
+    """Playlist writes must opt into duplicate entries."""
+    mock_ytm = MagicMock()
+    headers = {"cookie": "abc"}
+    with patch.object(ytmusicapi, "YTMusic", return_value=mock_ytm):
+        await helpers.add_remove_playlist_tracks(
+            headers=headers,
+            prov_playlist_id="playlist",
+            prov_track_ids=["track", "track"],
+            add=True,
+            user="123",
+        )
+
+    mock_ytm.add_playlist_items.assert_called_once_with(
+        playlistId="playlist",
+        videoIds=["track", "track"],
+        duplicates=True,
+    )


### PR DESCRIPTION
## What does this implement/fix?

Adds the ability to copy a playlist to another provider, or into Music Assistant itself. Builds on top of the playlist import matching work in #5986, reusing the same track matching policies and resolver logic instead of duplicating them.

- New `music/playlists/migrate_playlist` API command, run as a managed background task with progress reporting and a Markdown migration report.
- Same `match_policy` levels as playlist import (`exact`, `same_recording`, `best_effort`) control how loose a match on the destination is allowed to be.
- Adds a `playlist_duplicates_supported` capability flag so providers that reject repeated tracks (Tidal, YouSee, Nicovideo) are handled correctly, and lets YouTube Music playlists keep duplicates.
- Verifies the destination playlist after writing, with retries, and reports any tracks that didn't make it across.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository.