### PR TITLE
Count an album as played once, however its tracks are ordered in the queue

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1186,6 +1186,9 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         self._queue_data[target_queue_id].enqueued_media_items = list(
             self._queue_data[source_queue_id].enqueued_media_items
         )
+        self._queue_data[target_queue_id].credited_albums = set(
+            self._queue_data[source_queue_id].credited_albums
+        )
         target_queue.resume_pos = source_resume_pos
         target_queue.current_index = source_current_index
         if source_current_item:

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -685,9 +685,7 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
                 )
             )
             if fully_played and not is_playing:
-                if credit_album := self._enqueued_album_for_track(
-                    queue_data, item_to_report, media_item
-                ):
+                if credit_album := self._enqueued_album_for_track(queue_data, media_item):
                     self.mass.create_task(
                         self._mark_album_played(credit_album, media_item, queue_data)
                     )
@@ -736,14 +734,14 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
         )
 
     def _enqueued_album_for_track(
-        self, queue_data: PlayerQueueData, item_to_report: QueueItem, media_item: MediaItemType
+        self, queue_data: PlayerQueueData, media_item: MediaItemType
     ) -> Album | None:
         """
         Return the album to credit for this played track, or None.
 
-        Only an album the user explicitly enqueued is eligible, and only on the first
-        track of a contiguous run of its tracks (the previous queue item must belong to
-        a different album), so a single album play is credited once.
+        Only an album the user explicitly enqueued is eligible, and only the first of its
+        tracks to complete since it was enqueued, so a single album play is credited once
+        however its tracks ended up ordered in the queue.
         """
         album = getattr(media_item, "album", None)
         if album is None:
@@ -759,19 +757,9 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
             ),
             None,
         )
-        if enqueued is None:
+        if enqueued is None or enqueued in queue_data.credited_albums:
             return None
-        queue_id = queue_data.queue.queue_id
-        index = self.index_by_id(queue_id, item_to_report.queue_item_id)
-        if index:
-            prev_item = self.get_item(queue_id, index - 1)
-            prev_album = (
-                getattr(prev_item.media_item, "album", None)
-                if prev_item and prev_item.media_item
-                else None
-            )
-            if prev_album == album:
-                return None
+        queue_data.credited_albums.add(enqueued)
         # credit the album the track carries, which is the library one whenever the album is
         # in the library, so the play lands on the row an explicit library play writes instead
         # of a second provider-scoped one.

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -685,7 +685,7 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
                 )
             )
             if fully_played and not is_playing:
-                if credit_album := self._enqueued_album_for_track(queue_data, media_item):
+                if credit_album := self._claim_enqueued_album_credit(queue_data, media_item):
                     self.mass.create_task(
                         self._mark_album_played(credit_album, media_item, queue_data)
                     )
@@ -733,26 +733,29 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
             ),
         )
 
-    def _enqueued_album_for_track(
+    def _claim_enqueued_album_credit(
         self, queue_data: PlayerQueueData, media_item: MediaItemType
     ) -> Album | None:
         """
-        Return the album to credit for this played track, or None.
+        Claim the album play this track credits, or None when there is nothing to credit.
 
         Only an album the user explicitly enqueued is eligible, and only the first of its
         tracks to complete since it was enqueued, so a single album play is credited once
-        however its tracks ended up ordered in the queue.
+        however its tracks ended up ordered in the queue. Claiming marks the album as
+        credited on this queue, so a second call for the same enqueue returns None.
         """
         album = getattr(media_item, "album", None)
         if album is None:
             return None
         # the album the user pressed play on keeps the shape of the listing it was picked
         # from, while the queue's tracks carry the library album. Matching on the provider
-        # mappings recognises both shapes as the same album.
+        # mappings recognises both shapes as the same album. The most recent enqueue wins,
+        # because that is the one whose credit was just armed; an earlier entry for the same
+        # album may still be a differently shaped (and therefore separately keyed) object.
         enqueued = next(
             (
                 item
-                for item in queue_data.enqueued_media_items
+                for item in reversed(queue_data.enqueued_media_items)
                 if isinstance(item, Album) and compare_item_ids(item, album)
             ),
             None,

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -781,7 +781,13 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                 ):
                     queue_data.enqueued_media_items.append(media_item)
                     if len(queue_data.enqueued_media_items) > 10:
-                        queue_data.enqueued_media_items.pop(0)
+                        evicted = queue_data.enqueued_media_items.pop(0)
+                        # an album that dropped off the list can no longer be matched, so its
+                        # credit is dead weight unless another entry still stands for it
+                        if isinstance(evicted, Album) and evicted not in (
+                            queue_data.enqueued_media_items
+                        ):
+                            queue_data.credited_albums.discard(evicted)
                     # enqueueing an album again is a new play of it, so let it be credited again
                     if isinstance(media_item, Album):
                         queue_data.credited_albums.discard(media_item)

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -731,6 +731,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         # Clear the 'enqueued media item' list when a new queue is requested
         if option not in (QueueOption.ADD, QueueOption.NEXT):
             queue_data.enqueued_media_items.clear()
+            queue_data.credited_albums.clear()
         # An ADD/NEXT onto a queue that is already a managed pool (has a dynamic source): a finite
         # item is kept only as a source (the bounded pool materializes it) instead of being expanded
         # into the queue. Any other enqueue (PLAY/REPLACE, or onto a linear queue) expands finite
@@ -781,6 +782,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                     queue_data.enqueued_media_items.append(media_item)
                     if len(queue_data.enqueued_media_items) > 10:
                         queue_data.enqueued_media_items.pop(0)
+                    # enqueueing an album again is a new play of it, so let it be credited again
+                    if isinstance(media_item, Album):
+                        queue_data.credited_albums.discard(media_item)
                     if is_dynamic_source(media_item):
                         # a dynamic playlist/station is always a self-managing dynamic source
                         source_items.append(media_item)

--- a/music_assistant/controllers/player_queues/state.py
+++ b/music_assistant/controllers/player_queues/state.py
@@ -53,6 +53,10 @@ class PlayerQueueData:
     # the parent media items the user enqueued; the seed for autoplay's "similar" mode.
     # Persisted so autoplay survives a restart.
     enqueued_media_items: list[MediaItemType] = field(default_factory=list)
+    # the enqueued albums already credited as played; an album is credited once per time it is
+    # enqueued, so re-enqueueing it (or a new play that clears the enqueued list) arms it again.
+    # Persisted alongside the enqueued items, so a restart does not re-credit the same enqueue.
+    credited_albums: set[Album] = field(default_factory=set)
     # the user this queue plays for (drives per-user recency/filtering). Persisted.
     userid: str | None = None
 
@@ -61,10 +65,6 @@ class PlayerQueueData:
     transitioning: bool = False
     play_action_refcount: int = 0
     last_counted_play: str | None = None
-    # the enqueued albums already credited as played on this queue; an album is credited once
-    # per time it is enqueued, so re-enqueueing it (or a new play that clears the enqueued
-    # list) arms it again
-    credited_albums: set[Album] = field(default_factory=set)
     # session_id whose flow stream was fully generated
     flow_buffer_completed: str | None = None
     # session_id whose flow stream ended because the queue ran out of items, as opposed
@@ -106,6 +106,9 @@ class PlayerQueueData:
             "cache_format_version": CACHE_FORMAT_VERSION,
             "queue": queue,
             "enqueued_media_items": [item.to_dict() for item in self.enqueued_media_items],
+            "credited_albums": sorted(
+                uri for album in self.credited_albums if (uri := album.uri) is not None
+            ),
             "source_items": [item.to_dict() for item in self.source_items],
             "userid": self.userid,
         }
@@ -171,6 +174,14 @@ class PlayerQueueData:
             )
             if not isinstance(item, ItemMapping)
         ]
+        # only an album still in the enqueued list can be looked up again, so the credits are
+        # restored by matching the persisted uris against it
+        credited_uris = set(state_data.get("credited_albums") or [])
+        credited_albums = {
+            item
+            for item in enqueued_media_items
+            if isinstance(item, Album) and item.uri in credited_uris
+        }
         source_items = cls._source_items_from_cache(state_data, queue, enqueued_media_items)
         queue.is_dynamic = has_dynamic_source(source_items)
         items: list[QueueItem] = []
@@ -187,6 +198,7 @@ class PlayerQueueData:
             items=items,
             source_items=source_items,
             enqueued_media_items=enqueued_media_items,
+            credited_albums=credited_albums,
             userid=state_data.get("userid"),
         )
 

--- a/music_assistant/controllers/player_queues/state.py
+++ b/music_assistant/controllers/player_queues/state.py
@@ -16,7 +16,12 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.media_items import ItemMapping, MediaItemType, media_from_dict
+from music_assistant_models.media_items import (
+    Album,
+    ItemMapping,
+    MediaItemType,
+    media_from_dict,
+)
 from music_assistant_models.player_queue import PlayerQueue, PlayLogEntry
 from music_assistant_models.queue_item import QueueItem
 
@@ -56,6 +61,10 @@ class PlayerQueueData:
     transitioning: bool = False
     play_action_refcount: int = 0
     last_counted_play: str | None = None
+    # the enqueued albums already credited as played on this queue; an album is credited once
+    # per time it is enqueued, so re-enqueueing it (or a new play that clears the enqueued
+    # list) arms it again
+    credited_albums: set[Album] = field(default_factory=set)
     # session_id whose flow stream was fully generated
     flow_buffer_completed: str | None = None
     # session_id whose flow stream ended because the queue ran out of items, as opposed

--- a/tests/controllers/music/test_artist_play_credit.py
+++ b/tests/controllers/music/test_artist_play_credit.py
@@ -14,7 +14,6 @@ from uuid import uuid4
 
 from music_assistant_models.enums import AlbumType, MediaType
 from music_assistant_models.media_items import Album, Artist, ItemMapping, ProviderMapping, Track
-from music_assistant_models.queue_item import QueueItem
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.constants import DB_TABLE_ALBUMS, DB_TABLE_ARTISTS, DB_TABLE_PLAYLOG
@@ -72,6 +71,14 @@ async def _add_album(mass: MusicAssistant, name: str, artists: list[Artist]) -> 
         )
     )
     return await mass.music.albums.get_library_item(added.item_id)
+
+
+def _queue_data(enqueued: list[Album]) -> PlayerQueueData:
+    """Build the queue record the album-credit decision reads (only the enqueued items matter)."""
+    return PlayerQueueData(
+        queue=cast("PlayerQueue", Mock(queue_id="q1")),
+        enqueued_media_items=list(enqueued),
+    )
 
 
 async def _play_count(mass: MusicAssistant, table: str, item_id: str) -> int:
@@ -164,7 +171,7 @@ async def test_explicit_artist_play_survives_track_credit(mass: MusicAssistant) 
 
 
 def test_enqueued_album_decision() -> None:
-    """An album is credited only when enqueued and only on the first track of its run."""
+    """An album is credited only when enqueued, and only once per enqueue."""
     album_x = Album(
         item_id="ax",
         provider="library",
@@ -182,19 +189,62 @@ def test_enqueued_album_decision() -> None:
     t1 = Track(item_id="t1", provider="library", name="T1", provider_mappings=set(), album=album_x)
     t2 = Track(item_id="t2", provider="library", name="T2", provider_mappings=set(), album=album_x)
     t3 = Track(item_id="t3", provider="library", name="T3", provider_mappings=set(), album=album_y)
-    items = [QueueItem.from_media_item("q1", track) for track in (t1, t2, t3)]
 
     tracker = PlayerQueuesController.__new__(PlayerQueuesController)
-    queue = cast("PlayerQueue", Mock(queue_id="q1"))
-    data = PlayerQueueData(queue=queue, items=items, enqueued_media_items=[album_x])
-    tracker._queue_data = {"q1": data}
+    data = _queue_data(enqueued=[album_x])
 
-    # first track of the enqueued album -> credit it
-    assert tracker._enqueued_album_for_track(data, items[0], t1) is album_x
-    # second track shares the previous queue item's album -> already handled
-    assert tracker._enqueued_album_for_track(data, items[1], t2) is None
+    # first of the album's tracks to complete -> credit it
+    assert tracker._enqueued_album_for_track(data, t1) is album_x
+    # any further track of the same album -> already credited for this enqueue
+    assert tracker._enqueued_album_for_track(data, t2) is None
     # a track whose album was never enqueued -> not credited
-    assert tracker._enqueued_album_for_track(data, items[2], t3) is None
+    assert tracker._enqueued_album_for_track(data, t3) is None
+    # enqueueing the album again arms it for another play
+    data.credited_albums.discard(album_x)
+    assert tracker._enqueued_album_for_track(data, t2) is album_x
+
+
+def test_enqueued_album_credited_once_however_its_tracks_are_ordered() -> None:
+    """Album tracks split up or reordered in the queue still credit the album exactly once."""
+    album_x = Album(
+        item_id="ax",
+        provider="library",
+        name="X",
+        provider_mappings=set(),
+        album_type=AlbumType.ALBUM,
+    )
+    album_y = Album(
+        item_id="ay",
+        provider="library",
+        name="Y",
+        provider_mappings=set(),
+        album_type=AlbumType.ALBUM,
+    )
+    x_tracks = [
+        Track(
+            item_id=f"x{i}",
+            provider="library",
+            name=f"X{i}",
+            provider_mappings=set(),
+            album=album_x,
+        )
+        for i in range(4)
+    ]
+    y_track = Track(
+        item_id="y1", provider="library", name="Y1", provider_mappings=set(), album=album_y
+    )
+
+    tracker = PlayerQueuesController.__new__(PlayerQueuesController)
+    # 'play next' on a track from another album splits the album's run in two
+    data = _queue_data(enqueued=[album_x])
+    played = [x_tracks[0], x_tracks[1], y_track, x_tracks[2], x_tracks[3]]
+    credited = [tracker._enqueued_album_for_track(data, track) for track in played]
+    assert [c for c in credited if c is not None] == [album_x]
+
+    # the album's first track is skipped, so the first one that completes has a same-album
+    # predecessor; the album is still credited
+    data = _queue_data(enqueued=[album_x])
+    assert tracker._enqueued_album_for_track(data, x_tracks[1]) is album_x
 
 
 def test_enqueued_provider_album_credits_its_library_tracks() -> None:
@@ -234,24 +284,21 @@ def test_enqueued_provider_album_credits_its_library_tracks() -> None:
     t1 = Track(item_id="t1", provider="library", name="T1", provider_mappings=set())
     t2 = Track(item_id="t2", provider="library", name="T2", provider_mappings=set())
     t3 = Track(item_id="t3", provider="library", name="T3", provider_mappings=set())
-    items = [QueueItem.from_media_item("q1", track) for track in (t1, t2, t3)]
     # loading an item for playback puts the full library album on it
     t1.album = library_album
     t2.album = library_album
     t3.album = other_album
 
     tracker = PlayerQueuesController.__new__(PlayerQueuesController)
-    queue = cast("PlayerQueue", Mock(queue_id="q1"))
-    data = PlayerQueueData(queue=queue, items=items, enqueued_media_items=[provider_album])
-    tracker._queue_data = {"q1": data}
+    data = _queue_data(enqueued=[provider_album])
 
-    # the enqueued album is credited on the first track of its run, under the library
-    # identity so it shares the row an explicit library play writes
-    assert tracker._enqueued_album_for_track(data, items[0], t1) is library_album
-    # and only once for that run
-    assert tracker._enqueued_album_for_track(data, items[1], t2) is None
+    # the enqueued album is credited on the first of its tracks to complete, under the
+    # library identity so it shares the row an explicit library play writes
+    assert tracker._enqueued_album_for_track(data, t1) is library_album
+    # and only once for that enqueue
+    assert tracker._enqueued_album_for_track(data, t2) is None
     # a track from an album the user never enqueued is not credited
-    assert tracker._enqueued_album_for_track(data, items[2], t3) is None
+    assert tracker._enqueued_album_for_track(data, t3) is None
 
 
 def test_album_outside_the_library_is_credited_as_the_provider_album() -> None:
@@ -270,13 +317,10 @@ def test_album_outside_the_library_is_credited_as_the_provider_album() -> None:
         album_type=AlbumType.ALBUM,
     )
     track = Track(item_id="t1", provider="spotify--abc", name="T1", provider_mappings=set())
-    items = [QueueItem.from_media_item("q1", track)]
     # with no library album to swap in, the track keeps the provider album as a mapping
     track.album = ItemMapping.from_item(provider_album)
 
     tracker = PlayerQueuesController.__new__(PlayerQueuesController)
-    queue = cast("PlayerQueue", Mock(queue_id="q1"))
-    data = PlayerQueueData(queue=queue, items=items, enqueued_media_items=[provider_album])
-    tracker._queue_data = {"q1": data}
+    data = _queue_data(enqueued=[provider_album])
 
-    assert tracker._enqueued_album_for_track(data, items[0], track) is provider_album
+    assert tracker._enqueued_album_for_track(data, track) is provider_album

--- a/tests/controllers/music/test_artist_play_credit.py
+++ b/tests/controllers/music/test_artist_play_credit.py
@@ -194,14 +194,11 @@ def test_enqueued_album_decision() -> None:
     data = _queue_data(enqueued=[album_x])
 
     # first of the album's tracks to complete -> credit it
-    assert tracker._enqueued_album_for_track(data, t1) is album_x
+    assert tracker._claim_enqueued_album_credit(data, t1) is album_x
     # any further track of the same album -> already credited for this enqueue
-    assert tracker._enqueued_album_for_track(data, t2) is None
+    assert tracker._claim_enqueued_album_credit(data, t2) is None
     # a track whose album was never enqueued -> not credited
-    assert tracker._enqueued_album_for_track(data, t3) is None
-    # enqueueing the album again arms it for another play
-    data.credited_albums.discard(album_x)
-    assert tracker._enqueued_album_for_track(data, t2) is album_x
+    assert tracker._claim_enqueued_album_credit(data, t3) is None
 
 
 def test_enqueued_album_credited_once_however_its_tracks_are_ordered() -> None:
@@ -238,13 +235,48 @@ def test_enqueued_album_credited_once_however_its_tracks_are_ordered() -> None:
     # 'play next' on a track from another album splits the album's run in two
     data = _queue_data(enqueued=[album_x])
     played = [x_tracks[0], x_tracks[1], y_track, x_tracks[2], x_tracks[3]]
-    credited = [tracker._enqueued_album_for_track(data, track) for track in played]
+    credited = [tracker._claim_enqueued_album_credit(data, track) for track in played]
     assert [c for c in credited if c is not None] == [album_x]
 
-    # the album's first track is skipped, so the first one that completes has a same-album
-    # predecessor; the album is still credited
+    # the album's first track is skipped, so it never completes and the claim arrives from a
+    # later track that sits behind a same-album predecessor; the album is still credited once
     data = _queue_data(enqueued=[album_x])
-    assert tracker._enqueued_album_for_track(data, x_tracks[1]) is album_x
+    played = x_tracks[1:]
+    credited = [tracker._claim_enqueued_album_credit(data, track) for track in played]
+    assert [c for c in credited if c is not None] == [album_x]
+
+
+def test_reenqueued_album_in_another_shape_is_credited_again() -> None:
+    """Re-enqueueing an album from a different listing arms its credit again."""
+    mapping = ProviderMapping(
+        item_id="album-prov-1", provider_domain="spotify", provider_instance="spotify--abc"
+    )
+    provider_album = Album(
+        item_id="album-prov-1",
+        provider="spotify--abc",
+        name="Kind of Blue",
+        provider_mappings={mapping},
+        album_type=AlbumType.ALBUM,
+    )
+    library_album = Album(
+        item_id="7",
+        provider="library",
+        name="Kind of Blue",
+        provider_mappings={mapping},
+        album_type=AlbumType.ALBUM,
+    )
+    track = Track(
+        item_id="t1", provider="library", name="T1", provider_mappings=set(), album=library_album
+    )
+
+    tracker = PlayerQueuesController.__new__(PlayerQueuesController)
+    # played from the provider listing first, then queued again from the library view
+    data = _queue_data(enqueued=[provider_album])
+    assert tracker._claim_enqueued_album_credit(data, track) is library_album
+    data.enqueued_media_items.append(library_album)
+    data.credited_albums.discard(library_album)
+
+    assert tracker._claim_enqueued_album_credit(data, track) is library_album
 
 
 def test_enqueued_provider_album_credits_its_library_tracks() -> None:
@@ -294,11 +326,11 @@ def test_enqueued_provider_album_credits_its_library_tracks() -> None:
 
     # the enqueued album is credited on the first of its tracks to complete, under the
     # library identity so it shares the row an explicit library play writes
-    assert tracker._enqueued_album_for_track(data, t1) is library_album
+    assert tracker._claim_enqueued_album_credit(data, t1) is library_album
     # and only once for that enqueue
-    assert tracker._enqueued_album_for_track(data, t2) is None
+    assert tracker._claim_enqueued_album_credit(data, t2) is None
     # a track from an album the user never enqueued is not credited
-    assert tracker._enqueued_album_for_track(data, t3) is None
+    assert tracker._claim_enqueued_album_credit(data, t3) is None
 
 
 def test_album_outside_the_library_is_credited_as_the_provider_album() -> None:
@@ -323,4 +355,4 @@ def test_album_outside_the_library_is_credited_as_the_provider_album() -> None:
     tracker = PlayerQueuesController.__new__(PlayerQueuesController)
     data = _queue_data(enqueued=[provider_album])
 
-    assert tracker._enqueued_album_for_track(data, track) is provider_album
+    assert tracker._claim_enqueued_album_credit(data, track) is provider_album

--- a/tests/controllers/player_queues/test_player_queue_data.py
+++ b/tests/controllers/player_queues/test_player_queue_data.py
@@ -76,18 +76,19 @@ def _queue(**kwargs: object) -> PlayerQueue:
 def _data_with_dynamic_source() -> PlayerQueueData:
     """Build a PlayerQueueData for a queue playing a dynamic radio playlist plus one queued track."""
     playlist = _dynamic_playlist()
+    album = _album("a1")
     queue = _queue(is_dynamic=True, sources=[ItemMapping.from_item(playlist)])
     return PlayerQueueData(
         queue=queue,
         items=[QueueItem.from_media_item("q1", _track("t1"))],
         source_items=[playlist],
-        enqueued_media_items=[playlist],
+        enqueued_media_items=[playlist, album],
+        credited_albums={album},
         userid="user-1",
         # runtime-only fields set to non-defaults to prove they do not survive the round-trip
         transitioning=True,
         play_action_refcount=3,
         last_counted_play="t1",
-        credited_albums={_album("a1")},
         flow_buffer_completed="sess-1",
     )
 
@@ -109,13 +110,16 @@ def test_cache_round_trip_restores_queue_items_and_sources() -> None:
         item.uri for item in data.enqueued_media_items
     ]
     assert restored.userid == "user-1"
+    # a credited album survives, so a restart does not re-credit the same enqueue
+    assert {item.uri for item in restored.credited_albums} == {
+        item.uri for item in data.credited_albums
+    }
     # is_dynamic is recomputed from the restored source items (a dynamic playlist is present)
     assert restored.queue.is_dynamic is True
     # runtime-only fields are reset to their defaults, never persisted
     assert restored.transitioning is False
     assert restored.play_action_refcount == 0
     assert restored.last_counted_play is None
-    assert restored.credited_albums == set()
     assert restored.flow_buffer_completed is None
 
 

--- a/tests/controllers/player_queues/test_player_queue_data.py
+++ b/tests/controllers/player_queues/test_player_queue_data.py
@@ -3,8 +3,14 @@
 from __future__ import annotations
 
 import pytest
-from music_assistant_models.enums import RepeatMode
-from music_assistant_models.media_items import ItemMapping, Playlist, ProviderMapping, Track
+from music_assistant_models.enums import AlbumType, RepeatMode
+from music_assistant_models.media_items import (
+    Album,
+    ItemMapping,
+    Playlist,
+    ProviderMapping,
+    Track,
+)
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 
@@ -21,6 +27,19 @@ def _track(item_id: str) -> Track:
         provider_mappings={
             ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
         },
+    )
+
+
+def _album(item_id: str) -> Album:
+    """Build a minimal library Album."""
+    return Album(
+        item_id=item_id,
+        provider="library",
+        name=f"Album {item_id}",
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
+        },
+        album_type=AlbumType.ALBUM,
     )
 
 
@@ -68,6 +87,7 @@ def _data_with_dynamic_source() -> PlayerQueueData:
         transitioning=True,
         play_action_refcount=3,
         last_counted_play="t1",
+        credited_albums={_album("a1")},
         flow_buffer_completed="sess-1",
     )
 
@@ -95,6 +115,7 @@ def test_cache_round_trip_restores_queue_items_and_sources() -> None:
     assert restored.transitioning is False
     assert restored.play_action_refcount == 0
     assert restored.last_counted_play is None
+    assert restored.credited_albums == set()
     assert restored.flow_buffer_completed is None
 
 

--- a/tests/controllers/player_queues/test_transfer_queue.py
+++ b/tests/controllers/player_queues/test_transfer_queue.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
-from music_assistant_models.enums import PlaybackState
+from music_assistant_models.enums import AlbumType, PlaybackState
+from music_assistant_models.media_items import Album, Track
 from music_assistant_models.player_queue import PlayerQueue
 
 from music_assistant.controllers.player_queues import PlayerQueuesController
@@ -138,6 +139,38 @@ def _shuffle_controller(
     fake.mass.players.get_player = MagicMock(return_value=target_player)
     fake.mass.streams.is_smart_fades_active = MagicMock(return_value=False)
     return fake
+
+
+async def test_transfer_queue_carries_the_album_credit_bookkeeping() -> None:
+    """A credited album stays credited on the player the queue is handed to."""
+    fake = _shuffle_controller(source_shuffle_enabled=False)
+    album = Album(
+        item_id="a1",
+        provider="library",
+        name="A",
+        provider_mappings=set(),
+        album_type=AlbumType.ALBUM,
+    )
+    track = Track(item_id="t1", provider="library", name="T1", provider_mappings=set(), album=album)
+    source_data = fake._queue_data["src"]
+    source_data.enqueued_media_items = [album]
+    source_data.credited_albums = {album}
+
+    await PlayerQueuesController.transfer_queue(
+        cast("PlayerQueuesController", fake), "src", "tgt", auto_play=False
+    )
+
+    target_data = fake._queue_data["tgt"]
+    # the target holds its own copy, so the source's set no longer drives it
+    assert target_data.credited_albums == {album}
+    assert target_data.credited_albums is not source_data.credited_albums
+    # and the album is not credited a second time on the new player
+    assert (
+        PlayerQueuesController._claim_enqueued_album_credit(
+            cast("PlayerQueuesController", fake), target_data, track
+        )
+        is None
+    )
 
 
 async def test_transfer_queue_overwrites_the_targets_own_shuffle() -> None:

--- a/tests/integration/test_album_play_credit_e2e.py
+++ b/tests/integration/test_album_play_credit_e2e.py
@@ -85,3 +85,26 @@ async def test_album_credit_is_cleared_when_a_new_play_replaces_the_queue(
 
     await _play(e2e_mass, queue_id, other_album)
     assert queue_data.credited_albums == set()
+
+
+@pytest.mark.asyncio
+async def test_album_credit_is_dropped_when_the_album_leaves_the_enqueued_list(
+    e2e_mass: MusicAssistant,
+) -> None:
+    """A credit is forgotten once its album falls off the (capped) enqueued list."""
+    queue_id = demo_players(e2e_mass)[2].player_id
+    album, track = await _album_with_track(e2e_mass, "0_0")
+    tracker = e2e_mass.player_queues
+
+    await _play(e2e_mass, queue_id, album)
+    queue_data = tracker.queue_data(queue_id)
+    assert tracker._claim_enqueued_album_credit(queue_data, track) is not None
+    assert queue_data.credited_albums == {album}
+
+    # push the album out of the enqueued list, which holds the last 10 items
+    for index in range(1, 12):
+        other, _ = await _album_with_track(e2e_mass, f"{index}_0")
+        await _play(e2e_mass, queue_id, other, option=QueueOption.ADD)
+
+    assert album not in queue_data.enqueued_media_items
+    assert queue_data.credited_albums == set()

--- a/tests/integration/test_album_play_credit_e2e.py
+++ b/tests/integration/test_album_play_credit_e2e.py
@@ -1,0 +1,87 @@
+"""
+End-to-end tests for the bookkeeping that credits an enqueued album as played.
+
+Boots a hermetic MusicAssistant (fake `test` provider + demo players) and drives the real
+``play_media`` path, so the wiring that arms and re-arms an album's credit is exercised
+rather than the decision helper alone.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from music_assistant_models.enums import QueueOption
+
+from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
+
+from .conftest import demo_players, wait_for
+
+if TYPE_CHECKING:
+    from music_assistant_models.media_items import Album, ItemMapping, MediaItemType, Track
+
+
+async def _album_with_track(mass: MusicAssistant, album_id: str) -> tuple[Album, Track]:
+    """Return a fake-provider album together with one of its tracks."""
+    test_prov = cast("MusicProvider", mass.get_provider("test"))
+    assert test_prov is not None
+    album = await test_prov.get_album(album_id)
+    tracks = await test_prov.get_album_tracks(album_id)
+    return album, tracks[0]
+
+
+async def _play(mass: MusicAssistant, queue_id: str, album: Album, **kwargs: object) -> None:
+    """Play (or enqueue) an album and wait until the queue has picked it up."""
+    await mass.player_queues.play_media(
+        queue_id,
+        cast("MediaItemType | ItemMapping | str", album),
+        **kwargs,  # type: ignore[arg-type]
+    )
+    assert await wait_for(
+        lambda: (q := mass.player_queues.get(queue_id)) is not None and q.items > 0
+    ), "album never reached the queue"
+
+
+@pytest.mark.asyncio
+async def test_album_credit_is_armed_and_rearmed_through_play_media(
+    e2e_mass: MusicAssistant,
+) -> None:
+    """Playing an album arms its credit once; queueing it again arms it for another play."""
+    queue_id = demo_players(e2e_mass)[0].player_id
+    album, track = await _album_with_track(e2e_mass, "0_0")
+    tracker = e2e_mass.player_queues
+
+    await _play(e2e_mass, queue_id, album)
+    queue_data = tracker.queue_data(queue_id)
+    assert queue_data.credited_albums == set()
+
+    # the first of the album's tracks to complete claims the credit
+    assert tracker._claim_enqueued_album_credit(queue_data, track) is not None
+    assert queue_data.credited_albums == {album}
+    # every later track of the same album finds it already claimed
+    assert tracker._claim_enqueued_album_credit(queue_data, track) is None
+
+    # queueing the same album again is a new play of it
+    await _play(e2e_mass, queue_id, album, option=QueueOption.ADD)
+    assert queue_data.credited_albums == set()
+    assert tracker._claim_enqueued_album_credit(queue_data, track) is not None
+
+
+@pytest.mark.asyncio
+async def test_album_credit_is_cleared_when_a_new_play_replaces_the_queue(
+    e2e_mass: MusicAssistant,
+) -> None:
+    """A play that replaces the queue drops the credits recorded for the previous one."""
+    queue_id = demo_players(e2e_mass)[1].player_id
+    album, track = await _album_with_track(e2e_mass, "0_0")
+    other_album, _ = await _album_with_track(e2e_mass, "1_0")
+    tracker = e2e_mass.player_queues
+
+    await _play(e2e_mass, queue_id, album)
+    queue_data = tracker.queue_data(queue_id)
+    assert tracker._claim_enqueued_album_credit(queue_data, track) is not None
+    assert queue_data.credited_albums == {album}
+
+    await _play(e2e_mass, queue_id, other_album)
+    assert queue_data.credited_albums == set()


### PR DESCRIPTION
# What does this implement/fix?

When you play an album, Music Assistant counts it as played once. It worked out which track
should trigger that by looking at the previous item in the queue — which only holds up while
the album's tracks sit back-to-back.

They often don't:

- Pressing "play next" on a track from another album splits the album's run, so the album is
  counted a second time.
- With shuffle on, adding an album mixes its tracks in with the rest of the queue, so it can
  be counted once per track.
- The other way round: skip the album's first track (or start partway in) and every remaining
  track has a same-album predecessor, so the album is never counted at all.

The album's play count and its album artists' play counts were inflated or missed accordingly,
and `last_played` was re-stamped each time. The play log entry itself and scrobbling were not
affected.

**Related issue (if applicable):**

- Found while reviewing #5984, which fixed an unrelated defect in the same function.

## Changes

- Credit an enqueued album on the first of its tracks that plays to completion, tracked per
  queue, instead of inferring it from the previous queue item.
- Re-arm the credit when the album is queued again, or when a new play replaces the queue.
- Carry the bookkeeping over when a queue is transferred to another player.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
