### PR TITLE
Seeking or resuming a Spotify track no longer cuts it off mid-song

### DIFF
--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -2128,8 +2128,10 @@ class _ItemAudio:
 
         A seeked item starts part-way in, so only what is left of it is ever
         delivered — the full duration would be a target nothing can reach.
+        Measured from where the engine reported the seek landing, which is not
+        always the position it was asked for.
         """
-        return self._remaining_bytes(self.seek_target_ms or 0)
+        return self._remaining_bytes(self.started_at_ms or self.seek_target_ms or 0)
 
     def _overrun_limit(self) -> int | None:
         """Return the byte count past which this item is considered stuck."""

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -1322,11 +1322,6 @@ class _SoloistSession:
         The sink is still suspended, so no pre-seek audio enters the FIFO; PCM
         demand only starts once a position report confirms the seek landed.
         """
-        # A fresh session restores the account's last playback state before it
-        # takes commands, and a seek into the item that was already playing (a
-        # resume, or a seek of the current track) makes that restored position
-        # the seek target itself. Arming discards it, so only a report that
-        # follows one short of the target counts as the seek landing.
         item.arm_seek(target_ms)
         # the engine silently drops a seek that arrives while the track is still
         # loading (verified via event trace), so re-send it until a position
@@ -1897,6 +1892,7 @@ class _ItemAudio:
         self.seek_target_ms: int | None = None
         self.duration_ms: int | None = None
         self.last_position_ms: int | None = None
+        self.started_at_ms: int | None = None
         self.status: str | None = None
         self.playing_seen = False
         self.claimed = False
@@ -1909,6 +1905,7 @@ class _ItemAudio:
         self._written = 0
         self._delivered = 0
         self._seek_anchored = False
+        self._seek_floor_ms = 0
         self._tail_target: int | None = None
         self.draining = False
         self._available = asyncio.Event()
@@ -2030,7 +2027,16 @@ class _ItemAudio:
         """
         self.seek_target_ms = target_ms
         self.seek_confirmed.clear()
-        self._seek_anchored = False
+        self.started_at_ms = None
+        reported_ms = self.last_position_ms or 0
+        # A fresh session restores the account's last playback state, so seeking
+        # the item it was already playing - a resume, or a seek of the current
+        # track - makes that restored position indistinguishable from the seek
+        # landing. Only a position already inside the target's window has to be
+        # disproved that way, by seeing the engine back below where it was;
+        # every other start confirms on the first report that reaches the window.
+        self._seek_floor_ms = reported_ms
+        self._seek_anchored = reported_ms < max(1, target_ms - _SEEK_TOLERANCE_MS)
 
     def observe_position(self, position_ms: int) -> None:
         """Record a reported playback position (and confirm a pending seek)."""
@@ -2041,16 +2047,20 @@ class _ItemAudio:
         # of an item reports position 0 and must not erase the progress the
         # completeness validation relies on (verified live)
         self.last_position_ms = max(self.last_position_ms or 0, position_ms)
-        if self.seek_target_ms is None:
+        if self.seek_target_ms is None or self.seek_confirmed.is_set():
+            return
+        if position_ms < self._seek_floor_ms:
+            # back below where the engine was when the seek went out: it has
+            # restarted the item, so what it reports from here on describes
+            # where the seek is taking it
+            self._seek_anchored = True
             return
         # the floor of 1 keeps a report of position 0 from landing inside the
         # tolerance window of a small seek target
-        window_start = max(1, self.seek_target_ms - _SEEK_TOLERANCE_MS)
-        if position_ms < window_start:
-            # short of the target, so every report after this one describes the
-            # item the seek is moving
-            self._seek_anchored = True
-        elif self._seek_anchored:
+        if self._seek_anchored and position_ms >= max(1, self.seek_target_ms - _SEEK_TOLERANCE_MS):
+            # what the engine reports as the seek lands is where this item's own
+            # audio begins
+            self.started_at_ms = position_ms
             self.seek_confirmed.set()
 
     async def read(self) -> AsyncGenerator[bytes]:
@@ -2121,20 +2131,12 @@ class _ItemAudio:
 
     def _overrun_limit(self) -> int | None:
         """Return the byte count past which this item is considered stuck."""
-        # measured rather than assumed: a seek the engine did not make would
-        # otherwise shrink this bound by an offset the item never started at,
-        # and cut a track that is still playing perfectly well
-        if (own_audio := self._remaining_bytes(self._played_from_ms())) is None:
+        # reported rather than requested: an offset the engine never confirmed
+        # would otherwise shrink this bound by audio the item does deliver, and
+        # cut a track that is still playing perfectly well
+        if (own_audio := self._remaining_bytes(self.started_at_ms or 0)) is None:
             return None
         return own_audio + int(_ITEM_OVERRUN_S * _BYTES_PER_SECOND)
-
-    def _played_from_ms(self) -> int:
-        """Return where in the item the engine actually started playing it."""
-        if self.last_position_ms is None:
-            # nothing reported back yet: the requested position is all there is to go on
-            return self.seek_target_ms or 0
-        delivered_ms = self._delivered * 1000 // _BYTES_PER_SECOND
-        return max(0, self.last_position_ms - delivered_ms)
 
     def _remaining_bytes(self, start_ms: int) -> int | None:
         """Return the bytes of this item's audio left from the given position, when known."""

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -1322,7 +1322,12 @@ class _SoloistSession:
         The sink is still suspended, so no pre-seek audio enters the FIFO; PCM
         demand only starts once a position report confirms the seek landed.
         """
-        item.seek_target_ms = target_ms
+        # A fresh session restores the account's last playback state before it
+        # takes commands, and a seek into the item that was already playing (a
+        # resume, or a seek of the current track) makes that restored position
+        # the seek target itself. Arming discards it, so only a report that
+        # follows one short of the target counts as the seek landing.
+        item.arm_seek(target_ms)
         # the engine silently drops a seek that arrives while the track is still
         # loading (verified via event trace), so re-send it until a position
         # anchor confirms it landed
@@ -1903,6 +1908,7 @@ class _ItemAudio:
         self._buffered = 0
         self._written = 0
         self._delivered = 0
+        self._seek_anchored = False
         self._tail_target: int | None = None
         self.draining = False
         self._available = asyncio.Event()
@@ -2016,6 +2022,16 @@ class _ItemAudio:
         self._available.set()
         self._drop_undelivered()
 
+    def arm_seek(self, target_ms: int) -> None:
+        """
+        Arm a seek to the given position, so position reports can confirm it.
+
+        :param target_ms: The position the engine is being seeked to.
+        """
+        self.seek_target_ms = target_ms
+        self.seek_confirmed.clear()
+        self._seek_anchored = False
+
     def observe_position(self, position_ms: int) -> None:
         """Record a reported playback position (and confirm a pending seek)."""
         if self._closed:
@@ -2025,11 +2041,16 @@ class _ItemAudio:
         # of an item reports position 0 and must not erase the progress the
         # completeness validation relies on (verified live)
         self.last_position_ms = max(self.last_position_ms or 0, position_ms)
-        # the floor of 1 keeps a pre-seek report of position 0 from confirming a
-        # small seek target that falls inside the tolerance window
-        if self.seek_target_ms is not None and position_ms >= max(
-            1, self.seek_target_ms - _SEEK_TOLERANCE_MS
-        ):
+        if self.seek_target_ms is None:
+            return
+        # the floor of 1 keeps a report of position 0 from landing inside the
+        # tolerance window of a small seek target
+        window_start = max(1, self.seek_target_ms - _SEEK_TOLERANCE_MS)
+        if position_ms < window_start:
+            # short of the target, so every report after this one describes the
+            # item the seek is moving
+            self._seek_anchored = True
+        elif self._seek_anchored:
             self.seek_confirmed.set()
 
     async def read(self) -> AsyncGenerator[bytes]:
@@ -2096,16 +2117,30 @@ class _ItemAudio:
         A seeked item starts part-way in, so only what is left of it is ever
         delivered — the full duration would be a target nothing can reach.
         """
-        if self.duration_ms is None:
-            return None
-        remaining_ms = max(0, self.duration_ms - (self.seek_target_ms or 0))
-        return remaining_ms * CAPTURE_SAMPLE_RATE // 1000 * _FRAME_BYTES
+        return self._remaining_bytes(self.seek_target_ms or 0)
 
     def _overrun_limit(self) -> int | None:
         """Return the byte count past which this item is considered stuck."""
-        if (own_audio := self._duration_bytes()) is None:
+        # measured rather than assumed: a seek the engine did not make would
+        # otherwise shrink this bound by an offset the item never started at,
+        # and cut a track that is still playing perfectly well
+        if (own_audio := self._remaining_bytes(self._played_from_ms())) is None:
             return None
         return own_audio + int(_ITEM_OVERRUN_S * _BYTES_PER_SECOND)
+
+    def _played_from_ms(self) -> int:
+        """Return where in the item the engine actually started playing it."""
+        if self.last_position_ms is None:
+            # nothing reported back yet: the requested position is all there is to go on
+            return self.seek_target_ms or 0
+        delivered_ms = self._delivered * 1000 // _BYTES_PER_SECOND
+        return max(0, self.last_position_ms - delivered_ms)
+
+    def _remaining_bytes(self, start_ms: int) -> int | None:
+        """Return the bytes of this item's audio left from the given position, when known."""
+        if self.duration_ms is None:
+            return None
+        return max(0, self.duration_ms - start_ms) * CAPTURE_SAMPLE_RATE // 1000 * _FRAME_BYTES
 
 
 def _decorated_duration_ms(item: object) -> int | None:

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -2049,15 +2049,17 @@ class _ItemAudio:
         self.last_position_ms = max(self.last_position_ms or 0, position_ms)
         if self.seek_target_ms is None or self.seek_confirmed.is_set():
             return
-        if position_ms < self._seek_floor_ms:
-            # back below where the engine was when the seek went out: it has
-            # restarted the item, so what it reports from here on describes
-            # where the seek is taking it
-            self._seek_anchored = True
+        if not self._seek_anchored:
+            # anchor on the engine dropping back below where it was when the
+            # seek went out: it has restarted the item, so what it reports from
+            # here on describes where the seek is taking it. A backward seek
+            # lands below that mark too, so this only ever gates the first
+            # report - past it, position is judged against the target alone.
+            self._seek_anchored = position_ms < self._seek_floor_ms
             return
         # the floor of 1 keeps a report of position 0 from landing inside the
         # tolerance window of a small seek target
-        if self._seek_anchored and position_ms >= max(1, self.seek_target_ms - _SEEK_TOLERANCE_MS):
+        if position_ms >= max(1, self.seek_target_ms - _SEEK_TOLERANCE_MS):
             # what the engine reports as the seek lands is where this item's own
             # audio begins
             self.started_at_ms = position_ms

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -104,20 +104,33 @@ def test_trim_passes_silence_through_once_the_bound_is_exceeded() -> None:
 def test_seek_is_confirmed_only_within_tolerance(tmp_path: Path) -> None:
     """A position report confirms a seek only once it reaches the tolerance window."""
     item = _make_item(tmp_path, TRACK_A)
-    item.seek_target_ms = 60_000
+    item.arm_seek(60_000)
     item.observe_position(50_000)
     assert not item.seek_confirmed.is_set()
     item.observe_position(58_500)
     assert item.seek_confirmed.is_set()
+    assert item.started_at_ms == 58_500
 
 
 def test_small_seek_target_is_not_confirmed_by_a_pre_seek_zero_report(tmp_path: Path) -> None:
     """A position-0 report before the seek lands cannot confirm a small target."""
     item = _make_item(tmp_path, TRACK_A)
-    item.seek_target_ms = 1_500
+    item.arm_seek(1_500)
     item.observe_position(0)
     assert not item.seek_confirmed.is_set()
     item.observe_position(1_500)
+    assert item.seek_confirmed.is_set()
+
+
+def test_a_small_seek_is_confirmed_without_a_report_of_exactly_zero(tmp_path: Path) -> None:
+    """A target inside the tolerance window has no room below it to be anchored on."""
+    item = _make_item(tmp_path, TRACK_A)
+    # the engine restored this item a second in, so the seek is short enough
+    # that no report can fall below its tolerance window
+    item.observe_position(1_200)
+    item.arm_seek(2_000)
+    item.observe_position(400)
+    item.observe_position(2_000)
     assert item.seek_confirmed.is_set()
 
 
@@ -663,18 +676,24 @@ async def test_a_seek_the_engine_ignored_does_not_cut_the_item_short(tmp_path: P
     assert delivered == 89 * _BYTES_PER_SECOND
 
 
-def test_a_seek_that_landed_still_bounds_the_item_at_its_remainder(tmp_path: Path) -> None:
+async def test_a_seek_that_landed_still_bounds_the_item_at_its_remainder(tmp_path: Path) -> None:
     """An item the engine really seeked into stays bounded by what is left of it."""
     session = _make_session(tmp_path)
     item = _ItemAudio(TRACK_A, session)
     item.duration_ms = 176_000
     item.arm_seek(117_000)
-    # ten seconds of the remainder played, and reported from the seek target
-    item._delivered = 10 * _BYTES_PER_SECOND
-    item.observe_position(127_000)
+    item.observe_position(0)
+    item.observe_position(117_000)
+    assert item.seek_confirmed.is_set()
     assert item._overrun_limit() == 59 * _BYTES_PER_SECOND + int(
         _ITEM_OVERRUN_S * _BYTES_PER_SECOND
     )
+    # so it still fails once it runs that far past the seek point
+    item.claim()
+    item.write(b"\x01" * (89 * _BYTES_PER_SECOND))
+    with pytest.raises(AudioError, match="never moved on"):
+        async for _ in item.read():
+            pass
 
 
 def test_the_lead_trim_never_exceeds_its_budget() -> None:

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -150,6 +150,18 @@ def test_the_restored_position_of_the_same_item_cannot_confirm_a_seek(tmp_path: 
     assert item.seek_confirmed.is_set()
 
 
+def test_a_backward_seek_is_confirmed_below_where_the_engine_was(tmp_path: Path) -> None:
+    """Seeking back into an item confirms on the target, not on where it came from."""
+    item = _make_item(tmp_path, TRACK_A)
+    # the engine restored this item well past the point being seeked back to
+    item.observe_position(117_000)
+    item.arm_seek(30_000)
+    item.observe_position(0)
+    item.observe_position(30_000)
+    assert item.seek_confirmed.is_set()
+    assert item.started_at_ms == 30_000
+
+
 def test_position_never_regresses_and_stops_at_the_cut(tmp_path: Path) -> None:
     """The furthest position is kept, and reports after the cut belong to the next item."""
     item = _make_item(tmp_path, TRACK_A)

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -670,6 +670,57 @@ def test_a_seeked_item_only_expects_what_is_left_of_it(tmp_path: Path) -> None:
     assert item.buffered == remainder
 
 
+@pytest.mark.parametrize(
+    ("target_ms", "reports"),
+    [
+        # seeking the restored item to where the engine already was
+        (117_000, (117_000, 0, 117_000)),
+        # seeking back into it, where every report lands below where it was
+        (30_000, (117_000, 0, 30_000)),
+    ],
+)
+async def test_the_seek_retries_until_the_engine_reports_the_target(
+    tmp_path: Path, target_ms: int, reports: tuple[int, ...]
+) -> None:
+    """A seek dropped while the track loads is re-sent until a report confirms it."""
+    session = _make_session(tmp_path)
+    item = _ItemAudio(TRACK_A, session)
+    client = cast("Any", session._client)
+    # the engine restored this item part-way in, before the seek goes out
+    item.observe_position(117_000)
+
+    async def _report_positions() -> None:
+        for position_ms in reports:
+            await asyncio.sleep(0)
+            item.observe_position(position_ms)
+
+    with (
+        patch.object(soloist_backend, "_SEEK_RETRY_INTERVAL_S", 0.01),
+        # bounded so a regression fails fast instead of sitting out the real budget
+        patch.object(soloist_backend, "_SEEK_CONFIRM_TIMEOUT_S", 1.0),
+    ):
+        reporter = asyncio.create_task(_report_positions())
+        await session._cold_seek(client, item, target_ms)
+        await reporter
+    assert item.seek_confirmed.is_set()
+    assert item.started_at_ms == target_ms
+    assert client.seek.await_count >= 1
+
+
+async def test_a_seek_that_only_ever_sees_the_restored_position_fails(tmp_path: Path) -> None:
+    """A seek nothing confirms fails loudly rather than streaming from elsewhere."""
+    session = _make_session(tmp_path)
+    item = _ItemAudio(TRACK_A, session)
+    # the engine sits at the restored position and never reloads the track
+    item.observe_position(117_000)
+    with (
+        patch.object(soloist_backend, "_SEEK_RETRY_INTERVAL_S", 0.01),
+        patch.object(soloist_backend, "_SEEK_CONFIRM_TIMEOUT_S", 0.05),
+        pytest.raises(AudioError, match="did not confirm seeking"),
+    ):
+        await session._cold_seek(cast("Any", session._client), item, 117_000)
+
+
 async def test_a_seek_the_engine_ignored_does_not_cut_the_item_short(tmp_path: Path) -> None:
     """An item the engine plays from its start is bounded by its full duration."""
     session = _make_session(tmp_path)
@@ -700,6 +751,9 @@ async def test_a_seek_that_landed_still_bounds_the_item_at_its_remainder(tmp_pat
     assert item._overrun_limit() == 59 * _BYTES_PER_SECOND + int(
         _ITEM_OVERRUN_S * _BYTES_PER_SECOND
     )
+    # later reports do not move the latch, which would shrink the bound
+    item.observe_position(150_000)
+    assert item.started_at_ms == 117_000
     # so it still fails once it runs that far past the seek point
     item.claim()
     item.write(b"\x01" * (89 * _BYTES_PER_SECOND))

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -33,6 +33,7 @@ from music_assistant.providers.spotify.backends.soloist import (
     _BYTES_PER_SECOND,
     _FRAME_BYTES,
     _IDLE_TIMEOUT_S,
+    _ITEM_OVERRUN_S,
     _MAX_APP_PAUSE_RESUMES,
     _MAX_LEAD_TRIM_S,
     _READ_CHUNK_SIZE,
@@ -117,6 +118,22 @@ def test_small_seek_target_is_not_confirmed_by_a_pre_seek_zero_report(tmp_path: 
     item.observe_position(0)
     assert not item.seek_confirmed.is_set()
     item.observe_position(1_500)
+    assert item.seek_confirmed.is_set()
+
+
+def test_the_restored_position_of_the_same_item_cannot_confirm_a_seek(tmp_path: Path) -> None:
+    """The state a fresh session restores does not pass for the seek landing."""
+    item = _make_item(tmp_path, TRACK_A)
+    item.duration_ms = 176_000
+    # the engine restores the account's last state: this very item, sitting at
+    # the position the seek is aiming for
+    item.observe_position(117_000)
+    item.arm_seek(117_000)
+    item.observe_position(117_000)
+    assert not item.seek_confirmed.is_set()
+    # only once the engine has reloaded the track does its seek count
+    item.observe_position(0)
+    item.observe_position(117_000)
     assert item.seek_confirmed.is_set()
 
 
@@ -626,6 +643,38 @@ def test_a_seeked_item_only_expects_what_is_left_of_it(tmp_path: Path) -> None:
     # and the padding silence after it is refused
     item.write(b"\x00" * 4096)
     assert item.buffered == remainder
+
+
+async def test_a_seek_the_engine_ignored_does_not_cut_the_item_short(tmp_path: Path) -> None:
+    """An item the engine plays from its start is bounded by its full duration."""
+    session = _make_session(tmp_path)
+    item = _ItemAudio(TRACK_A, session)
+    item.duration_ms = 176_000
+    item.arm_seek(117_000)
+    item.claim()
+    # the engine never made the seek and is playing the item from its start, so
+    # the audio it delivers runs well past what the seeked remainder would allow
+    item.observe_position(80_000)
+    item.write(b"\x01" * (89 * _BYTES_PER_SECOND))
+    item.close()
+    delivered = 0
+    async for chunk in item.read():
+        delivered += len(chunk)
+    assert delivered == 89 * _BYTES_PER_SECOND
+
+
+def test_a_seek_that_landed_still_bounds_the_item_at_its_remainder(tmp_path: Path) -> None:
+    """An item the engine really seeked into stays bounded by what is left of it."""
+    session = _make_session(tmp_path)
+    item = _ItemAudio(TRACK_A, session)
+    item.duration_ms = 176_000
+    item.arm_seek(117_000)
+    # ten seconds of the remainder played, and reported from the seek target
+    item._delivered = 10 * _BYTES_PER_SECOND
+    item.observe_position(127_000)
+    assert item._overrun_limit() == 59 * _BYTES_PER_SECOND + int(
+        _ITEM_OVERRUN_S * _BYTES_PER_SECOND
+    )
 
 
 def test_the_lead_trim_never_exceeds_its_budget() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Seeking or resuming a Spotify track (Soloist backend) could restart it from the beginning and then cut it off partway through, jumping to the next track in the queue.

A fresh Soloist session restores the account's last playback state before it accepts commands. When the seek target is the track that was already playing — which is exactly what a resume or a seek of the current track is — that restored position *is* the seek target, so it confirmed a seek the engine had not made yet. Playback then started from the beginning while Music Assistant assumed it started at the seek point, and the stuck-item watchdog cut the track 30s past where it thought it should have ended.

- A seek is only confirmed once the engine has been seen back below where it was when the seek went out, so the state a session restores can no longer pass for the seek landing.
- A seeked item is sized from the position the engine reported as the seek landed, rather than the one it was asked for. That stops an ignored seek cutting a track that is still playing, and stops a seek that landed slightly short truncating the tail of the last track in a queue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
