### PR TITLE
Shuffle and repeat now work on a source your speaker runs itself

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 58
+API_SCHEMA_VERSION: Final[int] = 59
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -736,45 +736,77 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
 
     @api_command("players/cmd/shuffle", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
-    async def cmd_shuffle(self, player_id: str, shuffle_enabled: bool) -> None:
+    async def cmd_shuffle(
+        self, player_id: str, shuffle_enabled: bool, source_id: str | None = None
+    ) -> None:
         """
         Handle SHUFFLE command for given player.
 
         Applies to whatever the player is playing: a live external source orders its
-        own session, and Music Assistant's queue orders its own items.
+        own session, a source the device runs itself orders its own content, and
+        Music Assistant's queue orders its own items.
 
         :param player_id: player_id of the player to handle the command.
         :param shuffle_enabled: Whether to play the current content shuffled.
+        :param source_id: Optional source (id) the command is aimed at, as listed in the
+            player's source_list. Given one, the command is refused when that source is
+            no longer playing, so it can never land on whatever took the player since.
         """
         player = self._get_player_with_redirect(player_id)
+        active_source_id = self._resolve_command_target(player, source_id)
         if await self._forward_to_external_source(player, SourceControl.SHUFFLE, shuffle_enabled):
             return
         if active_queue := self.get_active_queue(player):
             await self.mass.player_queues.set_shuffle(active_queue.queue_id, shuffle_enabled)
+            return
+        if active_source := next(
+            (x for x in player.state.source_list if x.id == active_source_id), None
+        ):
+            # the source belongs to the player itself (its own Spotify Connect, a device input)
+            if not active_source.can_shuffle:
+                msg = "This action is (currently) unavailable for this source."
+                raise PlayerCommandFailed(msg)
+            await player.set_shuffle(shuffle_enabled)
             return
         msg = f"There is nothing playing on {player.state.name} to shuffle."
         raise PlayerCommandFailed(msg)
 
     @api_command("players/cmd/repeat", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
-    async def cmd_repeat(self, player_id: str, repeat_mode: RepeatMode) -> None:
+    async def cmd_repeat(
+        self, player_id: str, repeat_mode: RepeatMode, source_id: str | None = None
+    ) -> None:
         """
         Handle REPEAT command for given player.
 
         Applies to whatever the player is playing: a live external source repeats
-        within its own session, and Music Assistant's queue repeats its own items.
+        within its own session, a source the device runs itself repeats its own
+        content, and Music Assistant's queue repeats its own items.
 
         :param player_id: player_id of the player to handle the command.
         :param repeat_mode: The repeat mode to apply.
+        :param source_id: Optional source (id) the command is aimed at, as listed in the
+            player's source_list. Given one, the command is refused when that source is
+            no longer playing, so it can never land on whatever took the player since.
         """
         if repeat_mode == RepeatMode.UNKNOWN:
             # not a mode to set: it is what a source reports when it cannot say
             raise InvalidCommand("Cannot set an unknown repeat mode")
         player = self._get_player_with_redirect(player_id)
+        active_source_id = self._resolve_command_target(player, source_id)
         if await self._forward_to_external_source(player, SourceControl.REPEAT, repeat_mode):
             return
         if active_queue := self.get_active_queue(player):
             await self.mass.player_queues.set_repeat(active_queue.queue_id, repeat_mode)
+            return
+        if active_source := next(
+            (x for x in player.state.source_list if x.id == active_source_id), None
+        ):
+            # the source belongs to the player itself (its own Spotify Connect, a device input)
+            if not active_source.can_repeat:
+                msg = "This action is (currently) unavailable for this source."
+                raise PlayerCommandFailed(msg)
+            await player.set_repeat(repeat_mode)
             return
         msg = f"There is nothing playing on {player.state.name} to repeat."
         raise PlayerCommandFailed(msg)
@@ -4190,6 +4222,23 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         if not isinstance(provider, PluginProvider):
             return
         await provider.on_volume_change(session.source_id, volume_level)
+
+    def _resolve_command_target(self, player: Player, source_id: str | None) -> str:
+        """
+        Return the source (id) a command issued to a player applies to.
+
+        :param player: The player the command was issued to.
+        :param source_id: The source the caller aimed the command at, if it named one.
+        :return: The id of the player's active source, which is the id of Music
+            Assistant's own queue when nothing else is playing on it.
+        :raises PlayerCommandFailed: When the caller named a source that is no longer
+            the one playing.
+        """
+        active_source_id = player.state.active_source or player.player_id
+        if source_id is not None and source_id != active_source_id:
+            msg = f"The source this was meant for is no longer playing on {player.state.name}."
+            raise PlayerCommandFailed(msg)
+        return active_source_id
 
     async def _forward_to_external_source(
         self,

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
         ConfigEntry,
         PlayerConfig,
     )
+    from music_assistant_models.enums import RepeatMode
     from music_assistant_models.media_items import MediaItemPalette
     from music_assistant_models.player_queue import PlayerQueue
 
@@ -891,6 +892,32 @@ class Player(ABC):
         :param position: The position to seek to, in seconds.
         """
         raise NotImplementedError("seek needs to be implemented when PlayerFeature.SEEK is set")
+
+    async def set_shuffle(self, shuffle_enabled: bool) -> None:
+        """
+        Handle SET SHUFFLE command on the player.
+
+        Will only be called if the player's currently selected source declares
+        ``can_shuffle``.
+
+        :param shuffle_enabled: Whether the source should play its content shuffled.
+        """
+        raise NotImplementedError(
+            "set_shuffle needs to be implemented when a source declares can_shuffle"
+        )
+
+    async def set_repeat(self, repeat_mode: RepeatMode) -> None:
+        """
+        Handle SET REPEAT command on the player.
+
+        Will only be called if the player's currently selected source declares
+        ``can_repeat``.
+
+        :param repeat_mode: The repeat mode the source should apply.
+        """
+        raise NotImplementedError(
+            "set_repeat needs to be implemented when a source declares can_repeat"
+        )
 
     async def play_media(
         self,

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -897,7 +897,7 @@ class Player(ABC):
         """
         Handle SET SHUFFLE command on the player.
 
-        Will only be called if the player's currently selected source declares
+        Will only be called if the player's currently active source declares
         ``can_shuffle``.
 
         :param shuffle_enabled: Whether the source should play its content shuffled.
@@ -910,7 +910,7 @@ class Player(ABC):
         """
         Handle SET REPEAT command on the player.
 
-        Will only be called if the player's currently selected source declares
+        Will only be called if the player's currently active source declares
         ``can_repeat``.
 
         :param repeat_mode: The repeat mode the source should apply.

--- a/music_assistant/models/protocol_backed_player.py
+++ b/music_assistant/models/protocol_backed_player.py
@@ -18,6 +18,7 @@ from music_assistant.constants import EXTERNAL_SOURCES
 from music_assistant.models.player import Player
 
 if TYPE_CHECKING:
+    from music_assistant_models.enums import RepeatMode
     from music_assistant_models.player import PlayerMedia, PlayerSource
 
 # Protocol domains where an external source (e.g. Spotify Connect) can play
@@ -156,6 +157,16 @@ class ProtocolBackedPlayer(Player):
         if ext_player := self._get_protocol_player_with_external_source():
             await ext_player.seek(position)
             self.mass.players.trigger_player_update(ext_player.player_id, debounce_delay=2)
+
+    async def set_shuffle(self, shuffle_enabled: bool) -> None:
+        """Handle SET SHUFFLE command on the player."""
+        if ext_player := self._get_protocol_player_with_external_source():
+            await ext_player.set_shuffle(shuffle_enabled)
+
+    async def set_repeat(self, repeat_mode: RepeatMode) -> None:
+        """Handle SET REPEAT command on the player."""
+        if ext_player := self._get_protocol_player_with_external_source():
+            await ext_player.set_repeat(repeat_mode)
 
     def _backing_protocol_player_ids(self) -> list[str]:
         """Return the ids of the protocol players backing this player."""

--- a/tests/controllers/players/test_live_source_dispatch.py
+++ b/tests/controllers/players/test_live_source_dispatch.py
@@ -11,17 +11,26 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import ProviderFeature, RepeatMode, SourceControl
+from music_assistant_models.enums import (
+    PlaybackState,
+    ProviderFeature,
+    RepeatMode,
+    SourceControl,
+)
 from music_assistant_models.errors import InvalidCommand, PlayerCommandFailed
 from music_assistant_models.media_items import AudioSource
 from music_assistant_models.media_items.provider_mapping import ProviderMapping
+from music_assistant_models.player import PlayerSource
 
 from music_assistant.controllers.players import PlayerController
 from music_assistant.controllers.players.audio_sources import AudioSourceSession
 from music_assistant.models.plugin import PluginProvider
+from tests.common import MockPlayer, MockProvider
 
 PLAYER_ID = "player_1"
 PROVIDER_INSTANCE = "spotify_connect--abc"
+# a source the player's own device runs, so Music Assistant has no session for it
+NATIVE_SOURCE_ID = "spotify"
 
 
 def _source(
@@ -254,3 +263,125 @@ async def test_an_unknown_repeat_mode_is_refused_before_it_reaches_a_source() ->
         await controller.cmd_repeat(PLAYER_ID, RepeatMode.UNKNOWN)
 
     provider.on_source_control.assert_not_awaited()
+
+
+class _NativeSourcePlayer(MockPlayer):
+    """A player whose device runs a source of its own and orders that source itself."""
+
+    def __init__(self, provider: MockProvider, player_id: str, name: str) -> None:
+        super().__init__(provider, player_id, name)
+        self.shuffle_calls: list[bool] = []
+        self.repeat_calls: list[RepeatMode] = []
+
+    async def set_shuffle(self, shuffle_enabled: bool) -> None:
+        self.shuffle_calls.append(shuffle_enabled)
+
+    async def set_repeat(self, repeat_mode: RepeatMode) -> None:
+        self.repeat_calls.append(repeat_mode)
+
+
+def _native_source_controller(
+    *,
+    can_shuffle: bool = False,
+    can_repeat: bool = False,
+    active_source: str = NATIVE_SOURCE_ID,
+    queue: MagicMock | None = None,
+) -> tuple[PlayerController, _NativeSourcePlayer]:
+    """Build a controller whose player is playing a source its own device runs."""
+    mass = MagicMock()
+    mass.closing = False
+    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
+    mass.config.get = MagicMock(return_value=[])
+    mass.signal_event = MagicMock()
+    controller = PlayerController(mass)
+    mass.players = controller
+    mass.player_queues = MagicMock()
+    mass.player_queues.get = MagicMock(return_value=queue)
+    provider = MockProvider("test_provider", instance_id="test", mass=mass)
+    player = _NativeSourcePlayer(provider, PLAYER_ID, "Player 1")
+    player._attr_source_list = [
+        PlayerSource(
+            id=NATIVE_SOURCE_ID,
+            name="Spotify",
+            can_shuffle=can_shuffle,
+            can_repeat=can_repeat,
+        )
+    ]
+    player._attr_active_source = active_source
+    # a device only counts as playing its own source while it is not idle
+    player._attr_playback_state = PlaybackState.PLAYING
+    player._cache.clear()
+    controller._players[PLAYER_ID] = player
+    player.update_state(signal_event=False)
+    return controller, player
+
+
+async def test_a_device_native_source_orders_its_own_content() -> None:
+    """A source the device runs itself has no session, so the player is asked directly."""
+    controller, player = _native_source_controller(can_shuffle=True, can_repeat=True)
+
+    await controller.cmd_shuffle(PLAYER_ID, shuffle_enabled=True)
+    await controller.cmd_repeat(PLAYER_ID, RepeatMode.ONE)
+
+    assert player.shuffle_calls == [True]
+    assert player.repeat_calls == [RepeatMode.ONE]
+
+
+@pytest.mark.parametrize(
+    ("command", "kwargs"),
+    [("cmd_shuffle", {"shuffle_enabled": True}), ("cmd_repeat", {"repeat_mode": RepeatMode.ALL})],
+)
+async def test_a_device_native_source_without_the_capability_is_refused(
+    command: str, kwargs: dict[str, Any]
+) -> None:
+    """A source that does not claim to order its own content is told no, not left waiting."""
+    controller, player = _native_source_controller()
+
+    with pytest.raises(PlayerCommandFailed, match="unavailable for this source"):
+        await getattr(controller, command)(PLAYER_ID, **kwargs)
+
+    assert not player.shuffle_calls
+    assert not player.repeat_calls
+
+
+async def test_a_command_aimed_at_a_source_that_stopped_is_refused() -> None:
+    """
+    Naming the source keeps a command off whatever took the player since.
+
+    A client builds its shuffle control against the source it is showing. If that
+    source ends before the click, Music Assistant's queue takes the player back -
+    and the setting would surprise the user whenever that queue next resumes.
+    """
+    queue = MagicMock()
+    queue.queue_id = PLAYER_ID
+    controller, player = _native_source_controller(
+        can_shuffle=True, active_source=PLAYER_ID, queue=queue
+    )
+    controller.mass.player_queues.set_shuffle = AsyncMock()  # type: ignore[method-assign]
+
+    with pytest.raises(PlayerCommandFailed, match="no longer playing"):
+        await controller.cmd_shuffle(PLAYER_ID, shuffle_enabled=True, source_id=NATIVE_SOURCE_ID)
+
+    controller.mass.player_queues.set_shuffle.assert_not_awaited()
+    assert not player.shuffle_calls
+
+
+async def test_a_command_aimed_at_the_queue_still_reaches_it() -> None:
+    """Naming the source it is showing does not stand in a client's way."""
+    queue = MagicMock()
+    queue.queue_id = PLAYER_ID
+    controller, _player = _native_source_controller(active_source=PLAYER_ID, queue=queue)
+    controller.mass.player_queues.set_shuffle = AsyncMock()  # type: ignore[method-assign]
+
+    await controller.cmd_shuffle(PLAYER_ID, shuffle_enabled=True, source_id=PLAYER_ID)
+
+    controller.mass.player_queues.set_shuffle.assert_awaited_once_with(PLAYER_ID, True)
+
+
+async def test_a_command_aimed_at_the_source_still_playing_is_delivered() -> None:
+    """The source named is the one playing, so the command goes through as usual."""
+    controller, player = _native_source_controller(can_repeat=True)
+
+    await controller.cmd_repeat(PLAYER_ID, RepeatMode.ALL, source_id=NATIVE_SOURCE_ID)
+
+    assert player.repeat_calls == [RepeatMode.ALL]

--- a/tests/controllers/players/test_live_source_dispatch.py
+++ b/tests/controllers/players/test_live_source_dispatch.py
@@ -385,3 +385,41 @@ async def test_a_command_aimed_at_the_source_still_playing_is_delivered() -> Non
     await controller.cmd_repeat(PLAYER_ID, RepeatMode.ALL, source_id=NATIVE_SOURCE_ID)
 
     assert player.repeat_calls == [RepeatMode.ALL]
+
+
+async def test_a_command_aimed_at_a_live_source_reaches_its_session() -> None:
+    """
+    Naming a live source does not stand in the way of reaching its session.
+
+    The target is checked before anything is dispatched, so what a client reads as
+    the player's active source has to be the same string the session publishes.
+    """
+    source = _source()
+    controller, provider = _controller(source)
+    player = controller.get_player(PLAYER_ID)
+    player.state.active_source = source.uri
+    controller._get_player_with_redirect = MagicMock(return_value=player)
+
+    await controller.cmd_shuffle(PLAYER_ID, shuffle_enabled=True, source_id=source.uri)
+
+    provider.on_source_control.assert_awaited_once_with("main", SourceControl.SHUFFLE, True)
+
+
+async def test_a_command_aimed_at_a_live_source_that_ended_is_refused() -> None:
+    """A session that is gone gets nothing, and neither does the queue that took over."""
+    controller, provider = _controller(None)
+    player = controller.get_player(PLAYER_ID)
+    player.state.active_source = PLAYER_ID
+    controller._get_player_with_redirect = MagicMock(return_value=player)
+    queue = MagicMock()
+    queue.queue_id = PLAYER_ID
+    controller.get_active_queue = MagicMock(return_value=queue)
+    controller.mass.player_queues.set_shuffle = AsyncMock()
+
+    with pytest.raises(PlayerCommandFailed, match="no longer playing"):
+        await controller.cmd_shuffle(
+            PLAYER_ID, shuffle_enabled=True, source_id="spotify_connect--abc://audio_source/main"
+        )
+
+    provider.on_source_control.assert_not_awaited()
+    controller.mass.player_queues.set_shuffle.assert_not_awaited()

--- a/tests/providers/universal_player/test_player.py
+++ b/tests/providers/universal_player/test_player.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.constants import PLAYER_CONTROL_NATIVE
-from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
+from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType, RepeatMode
 
 from music_assistant.models.player import DeviceInfo, Player
 from music_assistant.models.protocol_backed_player import ProtocolBackedPlayer
@@ -99,6 +99,8 @@ def _make_chromecast_player(
     player.next_track = AsyncMock()
     player.previous_track = AsyncMock()
     player.seek = AsyncMock()
+    player.set_shuffle = AsyncMock()
+    player.set_repeat = AsyncMock()
     _register_players(mass, player)
     return player
 
@@ -178,6 +180,24 @@ async def test_transport_proxied_to_external_source(
     universal, chromecast = setup
     await universal.pause()
     chromecast.pause.assert_awaited_once_with()
+
+
+async def test_ordering_proxied_to_external_source(
+    setup: tuple[UniversalPlayer, MagicMock],
+) -> None:
+    """
+    Shuffle and repeat reach the protocol player playing the source.
+
+    The source_list is taken from that player too, so the capability it declares and
+    the command that acts on it must arrive at the same place.
+    """
+    universal, chromecast = setup
+
+    await universal.set_shuffle(True)
+    await universal.set_repeat(RepeatMode.ALL)
+
+    chromecast.set_shuffle.assert_awaited_once_with(True)
+    chromecast.set_repeat.assert_awaited_once_with(RepeatMode.ALL)
 
 
 def test_no_features_without_external_source() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Shuffle and repeat only ever reached two places: a source Music Assistant bridges itself (a plugin session, like our own Spotify Connect), or the Music Assistant queue. A source the speaker runs on its own — a Sonos playing its own Spotify Connect session, a Bluesound input — has neither, so the command had nowhere to go and failed with "there is nothing playing to shuffle".

The player models already carry `can_shuffle` / `can_repeat` per source and the app already shows the buttons for any source that claims them, so the first player provider to set those flags would have handed users a button that could only fail. This adds the missing path on the server so those providers can be written.

A command can now also name the source it was aimed at. Without it, a shuffle click made while a source was playing could still land on the Music Assistant queue if the source ended in between — harmless at the time, but the setting then surprises you whenever that queue resumes.

Only shuffle and repeat take the source name, not next/previous/seek: those two leave a setting behind that resurfaces later, while a stray skip is visible straight away.

No provider implements this yet, so the new hook is not exercised end to end. The app change to send the source name is a follow-up.

- Dispatch shuffle/repeat to the player when the active source is one its own device runs and declares the capability
- New `set_shuffle` / `set_repeat` on the player model for providers to implement, forwarded by protocol-backed players
- A source that does not claim the capability is now told so, instead of "there is nothing playing"
- `players/cmd/shuffle` and `players/cmd/repeat` take an optional source, and refuse when that source is no longer playing
- API schema version bumped, so the app can tell which servers accept it

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
