### PR TITLE
Use album loudness only for albums you actually played

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1040,7 +1040,6 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                         continue  # guard
                     await self._load_item(
                         queue_item,
-                        self._get_next_index(queue_id, index),
                         is_start=True,
                         seek_position=seek_position if attempt == 0 else 0,
                         fade_in=fade_in if attempt == 0 else False,
@@ -1378,7 +1377,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                 # we only allow 10 retries to prevent infinite loops
                 raise QueueEmpty("No more (playable) tracks left in the queue.")
             try:
-                await self._load_item(queue_item, self._get_next_index(queue_id, next_index))
+                await self._load_item(queue_item)
                 # we're all set, this is our next item
                 next_item = queue_item
                 break

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -321,7 +321,6 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         if not queue_item.available:
             raise MediaNotFoundError(f"Item {queue_item.uri} is not available")
 
-        playing_album_tracks = self._plays_as_album_track(queue_item)
         if queue_item.media_item and isinstance(queue_item.media_item, Track):
             album = queue_item.media_item.album
             # prefer the full library media item so we have all metadata and provider(quality) info
@@ -361,6 +360,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                         *org_images,
                     ]
                 )
+        # decided once the album above is resolved: a queue item can hold a slim mapping of its
+        # album, which carries none of the provider ids the enqueued album is matched on
+        playing_album_tracks = self._plays_as_album_track(queue_item)
         if is_start:
             # a track skip should hand its source slot to the item the user is starting
             await self._abort_superseded_source_buffers(queue_item)

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -292,7 +292,6 @@ class QueueLoaderMixin(_PlayerQueuesBase):
     async def _load_item(
         self,
         queue_item: QueueItem,
-        next_index: int | None,
         is_start: bool = False,
         seek_position: int = 0,
         fade_in: bool = False,
@@ -301,7 +300,6 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         Try to load the stream details for the given queue item.
 
         :param queue_item: The queue item to load.
-        :param next_index: Index of the item that plays after this one, if any.
         :param is_start: Whether this item starts playback, rather than following another item.
         :param seek_position: Position (in seconds) to start playback from.
         :param fade_in: Whether to fade in the audio.
@@ -322,15 +320,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         if not queue_item.available:
             raise MediaNotFoundError(f"Item {queue_item.uri} is not available")
 
-        # an item is played as part of its album when the item before or after it belongs to
-        # that same album, in which case the album loudness is the one to normalize on. A single
-        # track on repeat never is, no matter which album its queue neighbours belong to.
-        current_index = self.index_by_id(queue_id, queue_item.queue_item_id)
-        previous_index = current_index - 1 if current_index is not None else None
-        playing_album_tracks = queue.repeat_mode != RepeatMode.ONE and (
-            self._is_same_album(queue_item, next_index)
-            or self._is_same_album(queue_item, previous_index)
-        )
+        playing_album_tracks = self._plays_as_album_track(queue_item)
         if queue_item.media_item and isinstance(queue_item.media_item, Track):
             album = queue_item.media_item.album
             # prefer the full library media item so we have all metadata and provider(quality) info
@@ -399,27 +389,26 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             # provider did not report is known before playback starts
             self._apply_probed_duration(queue_item)
 
-    def _is_same_album(self, queue_item: QueueItem, other_index: int | None) -> bool:
+    def _plays_as_album_track(self, queue_item: QueueItem) -> bool:
         """
-        Check whether the queue item at the given index holds a track from the same album.
+        Check whether the given item plays as part of an album the user enqueued.
 
-        :param queue_item: The queue item to compare against.
-        :param other_index: Index of the neighbouring queue item, if there is one.
+        :param queue_item: The queue item to decide the loudness reference for.
         """
-        if other_index is None or other_index < 0:
-            return False
-        other_item = self.get_item(queue_item.queue_id, other_index)
-        # repeating a single item, or a one-item queue, wraps right back onto this item
-        if other_item is None or other_item.queue_item_id == queue_item.queue_item_id:
+        queue_data = self._queue_data[queue_item.queue_id]
+        # a track repeating on its own is its own playback, whatever seeded the queue around it
+        if queue_data.queue.repeat_mode == RepeatMode.ONE:
             return False
         album = getattr(queue_item.media_item, "album", None)
-        other_album = getattr(other_item.media_item, "album", None)
-        if album is None or other_album is None:
+        if album is None:
             return False
-        # an item picks up its library album only once it is loaded, so the neighbour may hold
-        # a different representation of the same album. Matching on the provider mappings
+        # the album the user pressed play on keeps the shape of the listing it was picked from,
+        # while the queue's tracks carry the library album. Matching on the provider mappings
         # recognises both shapes, plain item_id equality does not.
-        return compare_item_ids(album, other_album)
+        return any(
+            isinstance(item, Album) and compare_item_ids(item, album)
+            for item in queue_data.enqueued_media_items
+        )
 
     def _apply_probed_duration(self, queue_item: QueueItem) -> None:
         """
@@ -728,8 +717,10 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             ]
             radio_mode = False
 
-        # Clear the 'enqueued media item' list when a new queue is requested
-        if option not in (QueueOption.ADD, QueueOption.NEXT):
+        # Clear the 'enqueued media item' list when a new queue is requested. A caller that left
+        # the option to the config gets this once the first item resolved it, below: it is the
+        # option that says whether this is a new queue or an addition to the current one.
+        if option is not None and option not in (QueueOption.ADD, QueueOption.NEXT):
             queue_data.enqueued_media_items.clear()
             queue_data.credited_albums.clear()
         # An ADD/NEXT onto a queue that is already a managed pool (has a dynamic source): a finite
@@ -769,9 +760,24 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                         raise InvalidDataError("ItemMapping has no URI")
                     media_item = await self.mass.music.get_item_by_uri(media_item.uri)
 
+                # handle default enqueue option if needed
+                if option is None:
+                    # Radio + AudioSource share a single "live_sources" enqueue default —
+                    # both are live infinite streams where REPLACE is almost always the
+                    # right semantic. Other media types use their per-type config key.
+                    if media_item.media_type in (MediaType.RADIO, MediaType.AUDIO_SOURCE):
+                        config_key = CONF_DEFAULT_ENQUEUE_OPTION_LIVE_SOURCES
+                    else:
+                        config_key = f"default_enqueue_option_{media_item.media_type.value}"
+                    config_value = self.get_config_value(config_key, return_type=str)
+                    option = QueueOption(config_value)
+                    if option not in (QueueOption.ADD, QueueOption.NEXT):
+                        queue_data.enqueued_media_items.clear()
+
                 # Save requested media item to play on the queue so we can use it as a seed
                 # for Autoplay's music refill (the podcast/audiobook continuations resolve
-                # their successor from the queue's last item instead).
+                # their successor from the queue's last item instead) and to tell which of its
+                # tracks play as part of an album the user picked.
                 # Use FIFO list to keep track of the last 10 played items
                 # Skip ItemMapping and BrowseFolder - only queue full MediaItemType objects
                 if not isinstance(media_item, BrowseFolder) and (
@@ -794,18 +800,6 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                     if is_dynamic_source(media_item):
                         # a dynamic playlist/station is always a self-managing dynamic source
                         source_items.append(media_item)
-
-                # handle default enqueue option if needed
-                if option is None:
-                    # Radio + AudioSource share a single "live_sources" enqueue default —
-                    # both are live infinite streams where REPLACE is almost always the
-                    # right semantic. Other media types use their per-type config key.
-                    if media_item.media_type in (MediaType.RADIO, MediaType.AUDIO_SOURCE):
-                        config_key = CONF_DEFAULT_ENQUEUE_OPTION_LIVE_SOURCES
-                    else:
-                        config_key = f"default_enqueue_option_{media_item.media_type.value}"
-                    config_value = self.get_config_value(config_key, return_type=str)
-                    option = QueueOption(config_value)
 
                 # The shuffle state has to be settled before the items are resolved below: a
                 # shuffled queue keeps the items preceding a start_item (chosen track pinned

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -786,6 +786,11 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                     option = QueueOption(config_value)
                     if option not in (QueueOption.ADD, QueueOption.NEXT):
                         self._reset_enqueued_media_items(queue_data)
+                    # settled from the resolved option for the same reason as the reset above
+                    already_dynamic = queue.is_dynamic and option in (
+                        QueueOption.ADD,
+                        QueueOption.NEXT,
+                    )
 
                 # Save requested media item to play on the queue so we can use it as a seed
                 # for Autoplay's music refill (the podcast/audiobook continuations resolve

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     from music_assistant_models.media_items.metadata import MediaItemImage
     from music_assistant_models.queue_item import QueueItem
 
+    from music_assistant.controllers.player_queues.state import PlayerQueueData
     from music_assistant.providers.radio_playlist import RadioPlaylistProvider
 
 
@@ -410,6 +411,17 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             for item in queue_data.enqueued_media_items
         )
 
+    def _reset_enqueued_media_items(self, queue_data: PlayerQueueData) -> None:
+        """
+        Forget what was enqueued on a queue that is being replaced by a new one.
+
+        :param queue_data: The queue whose enqueued items are no longer what it plays.
+        """
+        queue_data.enqueued_media_items.clear()
+        # the credits only mark which of those enqueued albums were already counted, so they
+        # are meaningless once the items they refer to are gone
+        queue_data.credited_albums.clear()
+
     def _apply_probed_duration(self, queue_item: QueueItem) -> None:
         """
         Apply a duration determined while streaming to the queue item and its media item.
@@ -717,12 +729,11 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             ]
             radio_mode = False
 
-        # Clear the 'enqueued media item' list when a new queue is requested. A caller that left
-        # the option to the config gets this once the first item resolved it, below: it is the
+        # Forget the previous queue's enqueued items when a new queue is requested. A caller that
+        # left the option to the config gets this once the first item resolved it, below: it is the
         # option that says whether this is a new queue or an addition to the current one.
         if option is not None and option not in (QueueOption.ADD, QueueOption.NEXT):
-            queue_data.enqueued_media_items.clear()
-            queue_data.credited_albums.clear()
+            self._reset_enqueued_media_items(queue_data)
         # An ADD/NEXT onto a queue that is already a managed pool (has a dynamic source): a finite
         # item is kept only as a source (the bounded pool materializes it) instead of being expanded
         # into the queue. Any other enqueue (PLAY/REPLACE, or onto a linear queue) expands finite
@@ -772,7 +783,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                     config_value = self.get_config_value(config_key, return_type=str)
                     option = QueueOption(config_value)
                     if option not in (QueueOption.ADD, QueueOption.NEXT):
-                        queue_data.enqueued_media_items.clear()
+                        self._reset_enqueued_media_items(queue_data)
 
                 # Save requested media item to play on the queue so we can use it as a seed
                 # for Autoplay's music refill (the podcast/audiobook continuations resolve

--- a/tests/controllers/player_queues/test_prefer_album_loudness.py
+++ b/tests/controllers/player_queues/test_prefer_album_loudness.py
@@ -245,3 +245,22 @@ async def test_next_item_is_loaded_with_the_album_decision() -> None:
     await controller.load_next_queue_item(QUEUE_ID, items[0].queue_item_id)
     get_stream_details = cast("AsyncMock", controller.mass.streams.audio.get_stream_details)
     assert get_stream_details.call_args.kwargs["prefer_album_loudness"]
+
+
+async def test_enqueued_album_survives_a_restart() -> None:
+    """
+    An album queue restored from cache still plays as an album.
+
+    The decision reads the enqueued parent, which is only recognised as an album while it
+    round-trips as one; a mapping-shaped restore would silently drop to track loudness.
+    """
+    items = [_queue_item("track-1", PROVIDER_ALBUM)]
+    controller = _controller(items, enqueued=[LIBRARY_ALBUM])
+    queue_data = controller._queue_data[QUEUE_ID]
+    restored = PlayerQueueData.from_cache(queue_data.to_cache(), queue_data.items_to_cache())
+
+    controller._queue_data[QUEUE_ID] = restored
+    await controller._load_item(restored.items[0])
+
+    get_stream_details = cast("AsyncMock", controller.mass.streams.audio.get_stream_details)
+    assert get_stream_details.call_args.kwargs["prefer_album_loudness"]

--- a/tests/controllers/player_queues/test_prefer_album_loudness.py
+++ b/tests/controllers/player_queues/test_prefer_album_loudness.py
@@ -96,9 +96,17 @@ def _queue_item(item_id: str, album: Album | ItemMapping | None) -> QueueItem:
 
 
 def _controller(
-    items: list[QueueItem], enqueued: list[Album | Playlist | Track] | None = None
+    items: list[QueueItem],
+    enqueued: list[Album | Playlist | Track] | None = None,
+    library_album: Album | None = None,
 ) -> PlayerQueuesController:
-    """Build a bare controller whose queue holds the given items and enqueued parents."""
+    """
+    Build a bare controller whose queue holds the given items and enqueued parents.
+
+    :param items: The items the queue holds.
+    :param enqueued: The parent media items the user enqueued on it.
+    :param library_album: The library album the items' own album resolves to while loading.
+    """
     controller = PlayerQueuesController.__new__(PlayerQueuesController)
     controller.logger = MagicMock()
     controller._queue_data = {
@@ -116,7 +124,9 @@ def _controller(
     }
     tracks_by_uri = {item.uri: item.media_item for item in items}
     mass = MagicMock()
-    mass.music.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    mass.music.get_library_item_by_prov_id = AsyncMock(
+        side_effect=lambda media_type, *_: library_album if media_type == MediaType.ALBUM else None
+    )
     mass.music.get_item_by_uri = AsyncMock(side_effect=lambda uri: tracks_by_uri[uri])
     mass.streams.audio.get_stream_details = AsyncMock(return_value=MagicMock(duration=None))
     controller.mass = mass
@@ -261,6 +271,41 @@ async def test_enqueued_album_survives_a_restart() -> None:
 
     controller._queue_data[QUEUE_ID] = restored
     await controller._load_item(restored.items[0])
+
+    get_stream_details = cast("AsyncMock", controller.mass.streams.audio.get_stream_details)
+    assert get_stream_details.call_args.kwargs["prefer_album_loudness"]
+
+
+async def test_enqueued_provider_album_matches_an_items_slim_library_album() -> None:
+    """
+    A queue item may hold only a slim mapping of its album until it is loaded.
+
+    That mapping carries no provider ids of its own, so it can only be matched against the
+    album the user enqueued once loading resolved it to the full library album.
+    """
+    library_album_mapping = ItemMapping(
+        media_type=MediaType.ALBUM,
+        item_id="7",
+        provider="library",
+        name="Kind of Blue",
+    )
+    provider_album = Album(
+        item_id="album-prov-1",
+        provider="spotify--abc",
+        name="Kind of Blue",
+        provider_mappings={
+            ProviderMapping(
+                item_id="album-prov-1",
+                provider_domain="spotify",
+                provider_instance="spotify--abc",
+            )
+        },
+    )
+    items = [_queue_item("track-1", library_album_mapping)]
+    # loading resolves that slim mapping to the full library album, which does carry them
+    controller = _controller(items, enqueued=[provider_album], library_album=LIBRARY_ALBUM)
+
+    await controller._load_item(items[0])
 
     get_stream_details = cast("AsyncMock", controller.mass.streams.audio.get_stream_details)
     assert get_stream_details.call_args.kwargs["prefer_album_loudness"]

--- a/tests/controllers/player_queues/test_prefer_album_loudness.py
+++ b/tests/controllers/player_queues/test_prefer_album_loudness.py
@@ -6,7 +6,13 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 from music_assistant_models.enums import MediaType, RepeatMode
-from music_assistant_models.media_items import Album, ItemMapping, ProviderMapping, Track
+from music_assistant_models.media_items import (
+    Album,
+    ItemMapping,
+    Playlist,
+    ProviderMapping,
+    Track,
+)
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 
@@ -39,9 +45,33 @@ LIBRARY_ALBUM = Album(
         )
     },
 )
+OTHER_LIBRARY_ALBUM = Album(
+    item_id="8",
+    provider="library",
+    name="Sketches of Spain",
+    provider_mappings={
+        ProviderMapping(
+            item_id="album-prov-2",
+            provider_domain="spotify",
+            provider_instance="spotify--abc",
+        )
+    },
+)
+PLAYLIST = Playlist(
+    item_id="playlist-1",
+    provider="spotify--abc",
+    name="Jazz essentials",
+    provider_mappings={
+        ProviderMapping(
+            item_id="playlist-1",
+            provider_domain="spotify",
+            provider_instance="spotify--abc",
+        )
+    },
+)
 
 
-def _queue_item(item_id: str, album: Album | ItemMapping) -> QueueItem:
+def _queue_item(item_id: str, album: Album | ItemMapping | None) -> QueueItem:
     """Build a queue item holding a track on the given album."""
     return QueueItem(
         queue_id=QUEUE_ID,
@@ -65,8 +95,10 @@ def _queue_item(item_id: str, album: Album | ItemMapping) -> QueueItem:
     )
 
 
-def _controller(items: list[QueueItem]) -> PlayerQueuesController:
-    """Build a bare controller whose queue holds the given items."""
+def _controller(
+    items: list[QueueItem], enqueued: list[Album | Playlist | Track] | None = None
+) -> PlayerQueuesController:
+    """Build a bare controller whose queue holds the given items and enqueued parents."""
     controller = PlayerQueuesController.__new__(PlayerQueuesController)
     controller.logger = MagicMock()
     controller._queue_data = {
@@ -79,6 +111,7 @@ def _controller(items: list[QueueItem]) -> PlayerQueuesController:
                 items=len(items),
             ),
             items=items,
+            enqueued_media_items=list(enqueued or []),
         )
     }
     tracks_by_uri = {item.uri: item.media_item for item in items}
@@ -91,97 +124,124 @@ def _controller(items: list[QueueItem]) -> PlayerQueuesController:
 
 
 async def _prefer_album_loudness(
-    items: list[QueueItem], current_index: int, repeat_mode: RepeatMode = RepeatMode.OFF
+    items: list[QueueItem],
+    index: int,
+    enqueued: list[Album | Playlist | Track] | None = None,
+    repeat_mode: RepeatMode = RepeatMode.OFF,
 ) -> bool:
-    """Load the item after the given index the way a player asks for it, and read the decision."""
-    controller = _controller(items)
+    """Load the item at the given index and read the loudness decision taken for it."""
+    controller = _controller(items, enqueued)
     controller._queue_data[QUEUE_ID].queue.repeat_mode = repeat_mode
-    await controller.load_next_queue_item(QUEUE_ID, items[current_index].queue_item_id)
+    await controller._load_item(items[index])
     get_stream_details = cast("AsyncMock", controller.mass.streams.audio.get_stream_details)
     return cast("bool", get_stream_details.call_args.kwargs["prefer_album_loudness"])
 
 
-async def test_standalone_track_uses_track_loudness() -> None:
-    """A track surrounded by other albums is normalized on its own loudness."""
-    items = [
-        _queue_item("track-1", OTHER_PROVIDER_ALBUM),
-        _queue_item("track-2", PROVIDER_ALBUM),
-    ]
-    assert not await _prefer_album_loudness(items, current_index=0)
-
-
-async def test_second_track_of_an_album_uses_album_loudness() -> None:
-    """The track right after the first one of an album is still part of that album."""
+async def test_track_of_an_enqueued_album_uses_album_loudness() -> None:
+    """The tracks of an album the user pressed play on are normalized on the album loudness."""
     items = [
         _queue_item("track-1", PROVIDER_ALBUM),
         _queue_item("track-2", PROVIDER_ALBUM),
     ]
-    assert await _prefer_album_loudness(items, current_index=0)
+    assert await _prefer_album_loudness(items, 0, enqueued=[LIBRARY_ALBUM])
 
 
-async def test_library_album_matches_provider_album_of_previous_item() -> None:
-    """
-    A loaded previous item carries the library album while the item being loaded has the provider one.
-
-    Both describe the same album, so the album loudness applies.
-    """
-    items = [
-        _queue_item("track-1", LIBRARY_ALBUM),
-        _queue_item("track-2", PROVIDER_ALBUM),
-    ]
-    assert await _prefer_album_loudness(items, current_index=0)
-
-
-async def test_library_album_matches_provider_album_of_next_item() -> None:
-    """The same album seen from both representations is recognised on the next-item side too."""
-    items = [
-        _queue_item("track-1", OTHER_PROVIDER_ALBUM),
-        _queue_item("track-2", PROVIDER_ALBUM),
-        _queue_item("track-3", LIBRARY_ALBUM),
-    ]
-    assert await _prefer_album_loudness(items, current_index=0)
-
-
-async def test_different_albums_use_track_loudness() -> None:
-    """Neighbouring tracks from genuinely different albums do not form an album."""
+async def test_shuffled_album_still_uses_album_loudness() -> None:
+    """An album played on shuffle is still that album, however its tracks end up ordered."""
     items = [
         _queue_item("track-1", PROVIDER_ALBUM),
         _queue_item("track-2", OTHER_PROVIDER_ALBUM),
         _queue_item("track-3", PROVIDER_ALBUM),
     ]
-    assert not await _prefer_album_loudness(items, current_index=0)
+    assert await _prefer_album_loudness(items, 0, enqueued=[LIBRARY_ALBUM])
 
 
-async def test_first_item_of_the_queue_has_no_previous_item() -> None:
-    """Starting at the first item, nothing plays before it, least of all the end of the queue."""
-    items = [
-        _queue_item("track-1", OTHER_PROVIDER_ALBUM),
-        _queue_item("track-2", PROVIDER_ALBUM),
-        _queue_item("track-3", OTHER_PROVIDER_ALBUM),
-    ]
-    controller = _controller(items)
-    await controller._load_item(items[0], next_index=1)
-    get_stream_details = cast("AsyncMock", controller.mass.streams.audio.get_stream_details)
-    assert not get_stream_details.call_args.kwargs["prefer_album_loudness"]
-
-
-async def test_track_on_repeat_single_is_not_an_album() -> None:
-    """A track repeating on its own is not played as part of its album."""
-    items = [_queue_item("track-1", PROVIDER_ALBUM)]
-    assert not await _prefer_album_loudness(items, current_index=0, repeat_mode=RepeatMode.ONE)
-
-
-async def test_repeat_single_ignores_the_album_around_it() -> None:
-    """Repeating one track of an album does not play the rest of that album."""
+async def test_adjacent_playlist_tracks_of_one_album_use_track_loudness() -> None:
+    """A playlist that happens to place two tracks of one album together is no album play."""
     items = [
         _queue_item("track-1", PROVIDER_ALBUM),
         _queue_item("track-2", PROVIDER_ALBUM),
-        _queue_item("track-3", PROVIDER_ALBUM),
     ]
-    assert not await _prefer_album_loudness(items, current_index=1, repeat_mode=RepeatMode.ONE)
+    assert not await _prefer_album_loudness(items, 0, enqueued=[PLAYLIST])
 
 
-async def test_single_track_on_repeat_all_is_not_an_album() -> None:
-    """Repeating a one-item queue wraps onto the item itself, which is no album."""
+async def test_track_added_beside_an_enqueued_album_uses_track_loudness() -> None:
+    """On a mixed queue only the enqueued album's own tracks play as part of an album."""
+    items = [
+        _queue_item("track-1", PROVIDER_ALBUM),
+        _queue_item("track-2", OTHER_PROVIDER_ALBUM),
+    ]
+    enqueued: list[Album | Playlist | Track] = [
+        LIBRARY_ALBUM,
+        cast("Track", items[1].media_item),
+    ]
+    assert await _prefer_album_loudness(items, 0, enqueued=enqueued)
+    assert not await _prefer_album_loudness(items, 1, enqueued=enqueued)
+
+
+async def test_a_different_enqueued_album_does_not_apply() -> None:
+    """Only the album a track actually belongs to counts, not any album on the queue."""
     items = [_queue_item("track-1", PROVIDER_ALBUM)]
-    assert not await _prefer_album_loudness(items, current_index=0, repeat_mode=RepeatMode.ALL)
+    assert not await _prefer_album_loudness(items, 0, enqueued=[OTHER_LIBRARY_ALBUM])
+
+
+async def test_queue_without_an_enqueued_album_uses_track_loudness() -> None:
+    """A queue that records no album parent (a browsed folder, a restored queue) is no album play."""
+    items = [
+        _queue_item("track-1", PROVIDER_ALBUM),
+        _queue_item("track-2", PROVIDER_ALBUM),
+    ]
+    assert not await _prefer_album_loudness(items, 0)
+
+
+async def test_library_album_enqueued_matches_the_provider_album_on_the_item() -> None:
+    """The enqueued album and the queue's tracks may hold different shapes of the same album."""
+    items = [_queue_item("track-1", PROVIDER_ALBUM)]
+    assert await _prefer_album_loudness(items, 0, enqueued=[LIBRARY_ALBUM])
+
+
+async def test_provider_album_enqueued_matches_the_library_album_on_the_item() -> None:
+    """The same album seen from both representations is recognised the other way around too."""
+    items = [_queue_item("track-1", LIBRARY_ALBUM)]
+    provider_album = Album(
+        item_id="album-prov-1",
+        provider="spotify--abc",
+        name="Kind of Blue",
+        provider_mappings={
+            ProviderMapping(
+                item_id="album-prov-1",
+                provider_domain="spotify",
+                provider_instance="spotify--abc",
+            )
+        },
+    )
+    assert await _prefer_album_loudness(items, 0, enqueued=[provider_album])
+
+
+async def test_item_without_an_album_uses_track_loudness() -> None:
+    """An item that carries no album at all has no album loudness to prefer."""
+    items = [_queue_item("track-1", None)]
+    assert not await _prefer_album_loudness(items, 0, enqueued=[LIBRARY_ALBUM])
+
+
+async def test_repeat_single_ignores_the_enqueued_album() -> None:
+    """A track repeating on its own is not played as part of the album it was enqueued with."""
+    items = [
+        _queue_item("track-1", PROVIDER_ALBUM),
+        _queue_item("track-2", PROVIDER_ALBUM),
+    ]
+    assert not await _prefer_album_loudness(
+        items, 0, enqueued=[LIBRARY_ALBUM], repeat_mode=RepeatMode.ONE
+    )
+
+
+async def test_next_item_is_loaded_with_the_album_decision() -> None:
+    """The preload of the item that plays next takes the same decision as the current one."""
+    items = [
+        _queue_item("track-1", PROVIDER_ALBUM),
+        _queue_item("track-2", PROVIDER_ALBUM),
+    ]
+    controller = _controller(items, enqueued=[LIBRARY_ALBUM])
+    await controller.load_next_queue_item(QUEUE_ID, items[0].queue_item_id)
+    get_stream_details = cast("AsyncMock", controller.mass.streams.audio.get_stream_details)
+    assert get_stream_details.call_args.kwargs["prefer_album_loudness"]

--- a/tests/controllers/player_queues/test_user_initiated_plays.py
+++ b/tests/controllers/player_queues/test_user_initiated_plays.py
@@ -305,3 +305,44 @@ async def test_configured_replace_default_clears_the_previously_enqueued_items()
     assert ctrl._queue_data["q1"].enqueued_media_items == [track]
     # the credits only mark which enqueued albums were counted, so they go with them
     assert ctrl._queue_data["q1"].credited_albums == set()
+
+
+async def test_configured_add_default_feeds_a_dynamic_queue() -> None:
+    """An add onto a managed pool keeps the item as a source, config default or not."""
+    track = Track(
+        item_id="t1",
+        provider="library",
+        name="T1",
+        provider_mappings={
+            ProviderMapping(
+                item_id="track-prov-1",
+                provider_domain="spotify",
+                provider_instance="spotify--abc",
+            )
+        },
+    )
+    dynamic_playlist = Playlist(
+        item_id="p1",
+        provider="spotify--abc",
+        name="Mix",
+        provider_mappings={
+            ProviderMapping(
+                item_id="p1", provider_domain="spotify", provider_instance="spotify--abc"
+            )
+        },
+        is_dynamic=True,
+    )
+    ctrl = _play_media_controller(track, QueueOption.ADD.value)
+    ctrl._enter_dynamic_mode = AsyncMock()  # type: ignore[method-assign]
+    queue_data = ctrl._queue_data["q1"]
+    queue_data.source_items = [dynamic_playlist]
+    queue_data.queue.is_dynamic = True
+    ctrl.store_sources = Mock(  # type: ignore[method-assign]
+        side_effect=lambda _queue, items: setattr(queue_data, "source_items", list(items))
+    )
+
+    await ctrl._handle_play_media("q1", track)
+
+    # expanding it into the queue would only have the pool rebuild discard those tracks again
+    cast("AsyncMock", ctrl._media_resolver._resolve_media_items).assert_not_called()
+    assert track in queue_data.source_items

--- a/tests/controllers/player_queues/test_user_initiated_plays.py
+++ b/tests/controllers/player_queues/test_user_initiated_plays.py
@@ -290,7 +290,10 @@ async def test_configured_replace_default_clears_the_previously_enqueued_items()
     )
     ctrl = _play_media_controller(track, QueueOption.REPLACE.value)
     ctrl._queue_data["q1"].enqueued_media_items.append(album)
+    ctrl._queue_data["q1"].credited_albums.add(album)
 
     await ctrl._handle_play_media("q1", track)
 
     assert ctrl._queue_data["q1"].enqueued_media_items == [track]
+    # the credits only mark which enqueued albums were counted, so they go with them
+    assert ctrl._queue_data["q1"].credited_albums == set()

--- a/tests/controllers/player_queues/test_user_initiated_plays.py
+++ b/tests/controllers/player_queues/test_user_initiated_plays.py
@@ -264,7 +264,11 @@ async def test_configured_add_default_keeps_the_previously_enqueued_items() -> N
         provider="library",
         name="T1",
         provider_mappings={
-            ProviderMapping(item_id="t1", provider_domain="library", provider_instance="library")
+            ProviderMapping(
+                item_id="track-prov-1",
+                provider_domain="spotify",
+                provider_instance="spotify--abc",
+            )
         },
     )
     ctrl = _play_media_controller(track, QueueOption.ADD.value)
@@ -285,7 +289,11 @@ async def test_configured_replace_default_clears_the_previously_enqueued_items()
         provider="library",
         name="T1",
         provider_mappings={
-            ProviderMapping(item_id="t1", provider_domain="library", provider_instance="library")
+            ProviderMapping(
+                item_id="track-prov-1",
+                provider_domain="spotify",
+                provider_instance="spotify--abc",
+            )
         },
     )
     ctrl = _play_media_controller(track, QueueOption.REPLACE.value)

--- a/tests/controllers/player_queues/test_user_initiated_plays.py
+++ b/tests/controllers/player_queues/test_user_initiated_plays.py
@@ -226,3 +226,71 @@ def test_library_ids_are_not_matched_across_media_types() -> None:
 
     tracker = PlayerQueuesController.__new__(PlayerQueuesController)
     assert tracker._is_user_initiated_play(data, track) is False
+
+
+def _play_media_controller(
+    media_item: MediaItemType, default_option: str
+) -> PlayerQueuesController:
+    """Build a bare controller whose play_media resolves its enqueue option from the config."""
+    ctrl = PlayerQueuesController.__new__(PlayerQueuesController)
+    ctrl.logger = Mock()
+    ctrl.mass = Mock()
+    ctrl.mass.music.get_item_by_uri = AsyncMock(return_value=media_item)
+    ctrl.mass.players.get_player = Mock(return_value=Mock(extra_data={}))
+    lock_cm = MagicMock()
+    lock_cm.__aenter__ = AsyncMock(return_value=None)
+    lock_cm.__aexit__ = AsyncMock(return_value=None)
+    ctrl.mass.players.get_player_lock = Mock(return_value=lock_cm)
+    ctrl.get_config_value = Mock(return_value=default_option)  # type: ignore[method-assign]
+    ctrl._set_transitioning = Mock()  # type: ignore[method-assign]
+    ctrl.signal_update = Mock()  # type: ignore[method-assign]
+    ctrl.on_player_update = Mock()  # type: ignore[method-assign]
+    ctrl.store_sources = Mock()  # type: ignore[method-assign]
+    ctrl._apply_shuffle = AsyncMock()  # type: ignore[method-assign]
+    ctrl._enqueue_with_option = AsyncMock()  # type: ignore[method-assign]
+    ctrl._media_resolver = Mock()
+    ctrl._media_resolver._resolve_media_items = AsyncMock(return_value=[media_item])
+    queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+    ctrl.get = Mock(return_value=queue)  # type: ignore[method-assign]
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+    return ctrl
+
+
+async def test_configured_add_default_keeps_the_previously_enqueued_items() -> None:
+    """A caller that leaves the enqueue option to the config still gets an add treated as one."""
+    album = Album(item_id="a1", provider="library", name="A1", provider_mappings=set())
+    track = Track(
+        item_id="t1",
+        provider="library",
+        name="T1",
+        provider_mappings={
+            ProviderMapping(item_id="t1", provider_domain="library", provider_instance="library")
+        },
+    )
+    ctrl = _play_media_controller(track, QueueOption.ADD.value)
+    ctrl._queue_data["q1"].enqueued_media_items.append(album)
+
+    await ctrl._handle_play_media("q1", track)
+
+    # the album the queue is playing is what says its tracks belong together, so an add
+    # must not drop it the way starting a new queue does
+    assert ctrl._queue_data["q1"].enqueued_media_items == [album, track]
+
+
+async def test_configured_replace_default_clears_the_previously_enqueued_items() -> None:
+    """A config default that starts a new queue drops the parents of the previous one."""
+    album = Album(item_id="a1", provider="library", name="A1", provider_mappings=set())
+    track = Track(
+        item_id="t1",
+        provider="library",
+        name="T1",
+        provider_mappings={
+            ProviderMapping(item_id="t1", provider_domain="library", provider_instance="library")
+        },
+    )
+    ctrl = _play_media_controller(track, QueueOption.REPLACE.value)
+    ctrl._queue_data["q1"].enqueued_media_items.append(album)
+
+    await ctrl._handle_play_media("q1", track)
+
+    assert ctrl._queue_data["q1"].enqueued_media_items == [track]


### PR DESCRIPTION
# What does this implement/fix?

Volume normalization can use either a track's own loudness or the loudness measured over its whole album. Until now the server guessed which one applied by looking at the queue: a track got album loudness when the item right before or after it happened to be from the same album.

That guessed wrong both ways. A shuffled playlist that happens to put two tracks of one album next to each other applied album loudness to those two and track loudness to everything around them — an audible level step in the middle of a playlist. And an album played on shuffle got track loudness for most of it, because its neighbours only lined up by luck.

The queue already records which album, playlist or track the user actually pressed play on, and that survives a restart. Album loudness now follows that instead — the same signal the album play-credit already uses.

- Album loudness is used when the track belongs to an album the user enqueued, whatever order the queue plays it in
- Tracks from a playlist, a radio/dynamic source or an autoplay fill now consistently use track loudness
- On a mixed queue (an album plus separately added tracks) only the album's own tracks get album loudness
- A track repeating on its own keeps using track loudness, as before
- Also fixed: enqueueing without an explicit option ignored the configured default of *add* or *play next* — it wiped the "what did the user play" list, and expanded items into a smart-mix queue instead of feeding the mix

Note: playing a folder straight from the browse view never records an album, so those plays now use track loudness.

**Related issue (if applicable):**

- follow-up on #5981

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

