### PR TITLE
Keep the position shown for a live source in step with the player

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -3037,12 +3037,10 @@ class Player(ABC):
             else None
         )
         image_url = (metadata.image_url if metadata else None) or source_image_url
-        elapsed_time, elapsed_time_last_updated = _resolve_position(
-            metadata.elapsed_time if metadata else None,
-            metadata.elapsed_time_last_updated if metadata else None,
-            self.elapsed_time,
-            self.elapsed_time_last_updated,
-        )
+        # the final playback state already resolves the source's own position against
+        # the clock this player reports (protocol player, or its own) - taking it from
+        # there is what keeps current_media and PlayerState.elapsed_time in agreement
+        _, elapsed_time, elapsed_time_last_updated = self.__final_playback_state
         return PlayerMedia(
             uri=session.source_uri or session.source_id,
             media_type=MediaType.AUDIO_SOURCE,
@@ -3057,7 +3055,7 @@ class Player(ABC):
             # carried so this object can be handed back to the player and still
             # resolve, as the announcement restore does
             queue_session_id=session.playback_session_id,
-            elapsed_time=elapsed_time,
+            elapsed_time=int(elapsed_time) if elapsed_time is not None else None,
             elapsed_time_last_updated=elapsed_time_last_updated,
         )
 

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -750,6 +750,8 @@ async def test_the_reported_media_can_be_handed_back_to_the_player() -> None:
     assert session is not None
 
     media = controller._handle_play_media.await_args.args[1]
+    # the reported position is taken from the player's final playback state
+    _player._Player__final_playback_state = (PlaybackState.PLAYING, None, None)
     reported = Player._Player__audio_source_media(_player, session)  # type: ignore[attr-defined]
 
     assert reported.queue_session_id == session.playback_session_id

--- a/tests/controllers/streams/test_audio_sources.py
+++ b/tests/controllers/streams/test_audio_sources.py
@@ -659,6 +659,43 @@ class TestAudioSourceElapsedTimeOverride:
         assert player.state.elapsed_time_last_updated >= before
         assert player.state.elapsed_time_last_updated <= after
 
+    def test_audio_source_media_position_follows_the_player(
+        self,
+        provider: MockProvider,
+        controller: PlayerController,
+        mock_mass: MagicMock,
+    ) -> None:
+        """A source reporting no position of its own reports the player's own position."""
+        protocol_player = MockPlayer(
+            provider, "airplay_1", "AirPlay", player_type=PlayerType.PROTOCOL
+        )
+        protocol_player._attr_playback_state = PlaybackState.PLAYING
+        protocol_player._attr_elapsed_time = 5.0
+        protocol_player._attr_elapsed_time_last_updated = time.time()
+        # the owner's own clock is stale: the audio is rendered by the protocol player
+        player = MockPlayer(provider, "player_1", "Test Player")
+        player._attr_playback_state = PlaybackState.PLAYING
+        player._attr_elapsed_time = 8.0
+        player._attr_elapsed_time_last_updated = time.time()
+        player._attr_active_source = "player_1"
+        player.set_active_output_protocol("airplay_1")
+
+        controller._players = {"player_1": player, "airplay_1": protocol_player}
+
+        session = _make_audio_source_session(elapsed_time=None)
+        mock_mass.players.get_audio_source_session = MagicMock(return_value=session)
+
+        protocol_player.update_state(signal_event=False)
+        player.refresh_state(signal_event=False)
+
+        assert player.state.current_media is not None
+        assert player.state.elapsed_time == 5.0
+        assert player.state.current_media.elapsed_time == 5
+        assert (
+            player.state.current_media.elapsed_time_last_updated
+            == player.state.elapsed_time_last_updated
+        )
+
 
 # ----------------------------------------------- silence-keepalive wrapper
 

--- a/tests/controllers/streams/test_audio_sources.py
+++ b/tests/controllers/streams/test_audio_sources.py
@@ -629,6 +629,8 @@ class TestAudioSourceElapsedTimeOverride:
 
         # The override is layered AFTER protocol/sync resolution, so it wins
         assert player.state.elapsed_time == 42
+        assert player.state.current_media is not None
+        assert player.state.current_media.elapsed_time == 42
 
     def test_audio_source_elapsed_time_last_updated_fallback(
         self,


### PR DESCRIPTION
# What does this implement/fix?

The position shown for a live external source (Spotify Connect, AirPlay, Yandex Ynison) could disagree with the position the player itself reports. When the source does not report a position of its own and the audio is rendered through a linked protocol player, the player reported the protocol player's position while the "now playing" info stayed on the owner's own (stale) clock.

The now playing info now takes its position from the same clock the player reports, so both always show the same thing.

**Related issue (if applicable):**

- follow-up on #5914

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- The media reported for a live source now takes its position from the player's final playback clock instead of the owner's raw one.
- Drops the duplicated position resolution: preferring the source's own position already happens in one place.
- Added a test covering a live source without its own position on a player using an output protocol.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
