### PR TITLE
Document which Spotify Soloist pairing failures are detected

### DIFF
--- a/music_assistant/providers/spotify/README.md
+++ b/music_assistant/providers/spotify/README.md
@@ -38,6 +38,29 @@ audio prefs, wire models) is shared infrastructure owned by the Spotify Connect 
   id lowercased), which is the only place that identity is written down. Checked after
   pairing and before keeping an existing pairing on reconfigure; a session whose account
   cannot be read never blocks setup, mirroring the librespot credential check.
+- **A lost pairing is caught from the engine's own report.** The daemon narrates its
+  startup on stdout — `restoring session`, then `logged in as <username>` — and with
+  nothing to restore it advertises itself for pairing instead (`waiting for login -
+  connect to "<name>" from your Spotify app`) and sits there. That line fails the item and
+  raises `LoginFailed(soloist_pairing_required)`, which takes the provider out of service
+  and sends the user back through setup — but only once it is confirmed against the stored
+  session: a daemon still restoring one can announce itself the same way, and acting on
+  the line alone would fail playback on a perfectly good pairing.
+- **A pairing Spotify no longer accepts** — a password change, "sign out everywhere", a
+  revoked device — **is a blind spot.** What the engine does then has never been captured,
+  and the first thing to establish is whether it wipes the stored session — which the case
+  above catches only if the daemon announces itself for pairing afterwards, since that
+  line is what triggers the check — or keeps it, which nothing detects. `auth_state`
+  cannot carry that decision on its own: `logged_in=false` is also what a healthy daemon
+  reports before it finishes restoring, and nothing tells it apart from a daemon that
+  simply cannot reach Spotify. Nor can a guessed stdout marker, which would fail healthy
+  playback. So playback fails with a plain `Timeout waiting for audio data`: the queue's
+  readiness budget (`BUFFER_READY_TIMEOUT`, plus any capacity wait) starts before the
+  session's own `_STARTUP_TIMEOUT_S` and runs out first, cancelling the producer where it
+  waits. That also leaves `_raise_startup_error`'s "never logged in" branch to the case it
+  can still reach — a login lost after it was established. The daemon's own output is
+  logged at DEBUG behind the `[soloist]` prefix; capturing a real revocation is what
+  unblocks handling it.
 - **Streaming quality** is a provider option, shared with the Spotify Connect provider's
   tiers and defaulting to lossless. It is a ceiling: Spotify serves the best the account
   is entitled to below it. Hidden on librespot, which passes Spotify's own file through.


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #5987, documentation only. That PR made Spotify playback notice a Soloist
pairing that is *gone*. A pairing that is still stored but that Spotify no longer accepts
(password change, "sign out everywhere") looks identical to a healthy daemon that has not
finished restoring its session yet, so it still ends in a plain "Timeout waiting for audio
data". Nothing in the code said so, so the next person would have to work it out again.

- Write down the engine's startup output and how a lost pairing is detected from it
- Write down the refused-pairing case that is not detected, why it cannot be told apart
  today, and what capturing a real revocation would take

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
