### PR TITLE
Show the right bit-perfect badge when two speakers share one live source

### DIFF
--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -529,9 +529,12 @@ class AudioProcessingManager:
             volume_normalization_mode=processing.volume_normalization_mode,
             outputs=_group_outputs(
                 _player_output_details(
-                    streamdetails, _source_processing_item(processing, entry), player_id, entry
+                    streamdetails,
+                    _source_processing_item(processing, entry),
+                    consumer_player_id,
+                    entry,
                 )
-                for player_id, entry in sorted(self._get_outputs(processing, None).items())
+                for consumer_player_id, entry in sorted(self._get_outputs(processing, None).items())
             ),
         )
         if source_session.active_source_audio == details:

--- a/music_assistant/controllers/streams/audio_processing.py
+++ b/music_assistant/controllers/streams/audio_processing.py
@@ -86,7 +86,6 @@ class _AudioSourceProcessingSession:
 
     session_id: str
     context_ready: bool = False
-    pcm_format: AudioFormat | None = None
     crossfade_mode: CrossfadeMode = CrossfadeMode.UNKNOWN
     volume_normalization_mode: VolumeNormalizationMode = VolumeNormalizationMode.UNKNOWN
     outputs: dict[str | None, dict[str, _AudioOutputEntry]] = field(default_factory=dict)
@@ -206,7 +205,6 @@ class AudioProcessingManager:
         player_id: str,
         session_id: str,
         *,
-        pcm_format: AudioFormat,
         crossfade_enabled: bool | None,
         volume_normalization_enabled: bool | None,
     ) -> None:
@@ -215,7 +213,6 @@ class AudioProcessingManager:
 
         :param player_id: Player that owns the source selection.
         :param session_id: Source playback session that owns the update.
-        :param pcm_format: PCM format the source's audio is decoded to.
         :param crossfade_enabled: Whether the source applies crossfade, or None if unknown.
         :param volume_normalization_enabled: Whether the source normalizes, or None if unknown.
         """
@@ -223,7 +220,6 @@ class AudioProcessingManager:
         if session is None:
             return
         session.context_ready = True
-        session.pcm_format = deepcopy(pcm_format)
         if crossfade_enabled is None:
             session.crossfade_mode = CrossfadeMode.UNKNOWN
         elif crossfade_enabled:
@@ -531,10 +527,11 @@ class AudioProcessingManager:
             input_fidelity=AudioFidelity(quality=get_audio_quality(streamdetails.audio_format)),
             crossfade_mode=processing.crossfade_mode,
             volume_normalization_mode=processing.volume_normalization_mode,
-            outputs=self._group_outputs(
-                streamdetails,
-                self._get_outputs(processing, None),
-                item=_source_processing_item(processing),
+            outputs=_group_outputs(
+                _player_output_details(
+                    streamdetails, _source_processing_item(processing, entry), player_id, entry
+                )
+                for player_id, entry in sorted(self._get_outputs(processing, None).items())
             ),
         )
         if source_session.active_source_audio == details:
@@ -564,10 +561,9 @@ class AudioProcessingManager:
                     quality=get_audio_quality(queue_item.streamdetails.audio_format)
                 ),
                 queue_processing=deepcopy(item.queue_processing),
-                outputs=self._group_outputs(
-                    queue_item.streamdetails,
-                    output_entries,
-                    item=item,
+                outputs=_group_outputs(
+                    _player_output_details(queue_item.streamdetails, item, player_id, entry)
+                    for player_id, entry in sorted(output_entries.items())
                 ),
             )
         previous = queue_item.streamdetails.audio_processing
@@ -583,26 +579,6 @@ class AudioProcessingManager:
         ):
             self.mass.player_queues.signal_update(queue_id)
         return True
-
-    def _group_outputs(
-        self,
-        streamdetails: StreamDetails,
-        player_outputs: dict[str, _AudioOutputEntry],
-        item: _AudioProcessingItem,
-    ) -> list[AudioOutputDetails]:
-        """Group players with identical effective output processing."""
-        grouped: list[AudioOutputDetails] = []
-        for player_id, entry in sorted(player_outputs.items()):
-            output = deepcopy(entry.details)
-            output.player_ids = [player_id]
-            output.fidelity = _get_output_fidelity(streamdetails, item, entry)
-            for existing in grouped:
-                if _output_details_equal_ignoring_players(existing, output):
-                    existing.player_ids.append(player_id)
-                    break
-            else:
-                grouped.append(output)
-        return grouped
 
     @staticmethod
     def _get_outputs(
@@ -734,11 +710,13 @@ def get_normalization_details(
 
 def _source_processing_item(
     processing: _AudioSourceProcessingSession,
+    output: _AudioOutputEntry,
 ) -> _AudioProcessingItem:
     """
-    Describe a live source's audio path in the shared processing shape.
+    Describe a live source's audio path to one consumer in the shared processing shape.
 
     :param processing: Runtime processing state of the live source selection.
+    :param output: Output entry of the consumer being described.
     """
     # Music Assistant mixes nothing into a live source: whatever the source
     # reported applying reaches us already mixed, and a step it did not report
@@ -746,7 +724,9 @@ def _source_processing_item(
     # so the shared check stays the one deciding what a source-applied step costs.
     return _AudioProcessingItem(
         queue_processing=AudioQueueProcessing(
-            pcm_format=processing.pcm_format,
+            # every consumer decodes the live source for itself, so the format
+            # entering its output is the one the source was decoded to for it
+            pcm_format=output.input_format,
             normalization=(
                 AudioNormalizationDetails(mode=VolumeNormalizationMode.SOURCE)
                 if processing.volume_normalization_mode == VolumeNormalizationMode.SOURCE
@@ -759,6 +739,43 @@ def _source_processing_item(
             ),
         ),
     )
+
+
+def _player_output_details(
+    streamdetails: StreamDetails,
+    item: _AudioProcessingItem,
+    player_id: str,
+    output: _AudioOutputEntry,
+) -> AudioOutputDetails:
+    """
+    Describe the effective output of one player.
+
+    :param streamdetails: Stream details of the audio being played.
+    :param item: Processing shape of the audio entering the player's own output.
+    :param player_id: Player receiving this output.
+    :param output: Prepared output of that player.
+    """
+    details = deepcopy(output.details)
+    details.player_ids = [player_id]
+    details.fidelity = _get_output_fidelity(streamdetails, item, output)
+    return details
+
+
+def _group_outputs(outputs: Iterable[AudioOutputDetails]) -> list[AudioOutputDetails]:
+    """
+    Merge players whose effective output processing is identical.
+
+    :param outputs: Effective output of each single player.
+    """
+    grouped: list[AudioOutputDetails] = []
+    for output in outputs:
+        for existing in grouped:
+            if _output_details_equal_ignoring_players(existing, output):
+                existing.player_ids.extend(output.player_ids)
+                break
+        else:
+            grouped.append(output)
+    return grouped
 
 
 def _get_output_fidelity(

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1826,7 +1826,7 @@ class StreamsController(CoreController):
             queue_id=session.player_id,
             session_id=session.playback_session_id,
         ).filter_params
-        self._update_audio_source_processing_context(session, provider, pcm_format)
+        self._update_audio_source_processing_context(session, provider)
         if (
             output_format.content_type == ContentType.WAV
             and not filter_params
@@ -1901,7 +1901,7 @@ class StreamsController(CoreController):
                     session.source_id, MediaType.AUDIO_SOURCE
                 )
                 session.attach_streamdetails(streamdetails)
-            self._update_audio_source_processing_context(session, prov, pcm_format)
+            self._update_audio_source_processing_context(session, prov)
             serving = True
             async for chunk in self.audio.get_audio_source_stream(
                 streamdetails=streamdetails,
@@ -2076,21 +2076,18 @@ class StreamsController(CoreController):
         self,
         session: AudioSourceSession,
         provider: PluginProvider,
-        pcm_format: AudioFormat,
     ) -> None:
         """
         Publish source-owned processing for a live AudioSource.
 
         :param session: Active source session to publish.
         :param provider: Plugin delivering the live source.
-        :param pcm_format: PCM format the source's audio is decoded to.
         """
         if session.streamdetails is None:
             return
         self.audio_processing.update_source_context(
             session.player_id,
             session.playback_session_id,
-            pcm_format=pcm_format,
             crossfade_enabled=provider.delivers_crossfaded_audio(session.streamdetails),
             volume_normalization_enabled=provider.delivers_normalized_audio(session.streamdetails),
         )

--- a/tests/controllers/streams/test_audio_processing.py
+++ b/tests/controllers/streams/test_audio_processing.py
@@ -308,12 +308,11 @@ def test_shared_output_destinations_are_registered_atomically() -> None:
 
 def test_live_source_context_publishes_input_and_source_processing() -> None:
     """A live source publishes its input and the processing it applies itself."""
-    manager, mass, source_session, _lossless_plan, pcm_format = _source_manager_context()
+    manager, mass, source_session, _lossless_plan = _source_manager_context()
 
     manager.update_source_context(
         "source-player",
         "source-session",
-        pcm_format=pcm_format,
         crossfade_enabled=True,
         volume_normalization_enabled=True,
     )
@@ -333,7 +332,7 @@ def test_live_source_context_publishes_input_and_source_processing() -> None:
 
 def test_live_source_output_registered_before_context_is_published() -> None:
     """An output prepared before source details arrive is retained and published."""
-    manager, _mass, source_session, lossless_plan, pcm_format = _source_manager_context()
+    manager, _mass, source_session, lossless_plan = _source_manager_context()
 
     assert manager.update_output(
         "player-1",
@@ -347,7 +346,6 @@ def test_live_source_output_registered_before_context_is_published() -> None:
     manager.update_source_context(
         "source-player",
         "source-session",
-        pcm_format=pcm_format,
         crossfade_enabled=False,
         volume_normalization_enabled=None,
     )
@@ -366,9 +364,69 @@ def test_live_source_output_registered_before_context_is_published() -> None:
     assert details.outputs[0].fidelity.bit_perfect is True
 
 
+def test_live_source_publishes_a_new_consumer_with_its_own_format() -> None:
+    """A consumer joining a live source is published with the format it receives."""
+    manager, mass, source_session, native_plan = _source_manager_context()
+    manager.update_output(
+        "player-1",
+        _source_consumer_plan(48000),
+        queue_id="source-player",
+        session_id="source-session",
+    )
+    manager.update_source_context(
+        "source-player",
+        "source-session",
+        crossfade_enabled=False,
+        volume_normalization_enabled=False,
+    )
+
+    # a second player takes the same source at its native rate
+    manager.update_output(
+        "player-2",
+        native_plan,
+        queue_id="source-player",
+        session_id="source-session",
+    )
+
+    assert _source_bit_perfect(source_session) == {"player-1": False, "player-2": True}
+    assert mass.players.trigger_player_update.call_count == 2
+
+
+def test_live_source_consumers_keep_their_own_bit_perfect_verdict() -> None:
+    """A consumer that resamples the source does not cost another one its badge."""
+    manager, _mass, source_session, native_plan = _source_manager_context()
+    manager.update_output(
+        "player-1",
+        native_plan,
+        queue_id="source-player",
+        session_id="source-session",
+    )
+    manager.update_source_context(
+        "source-player",
+        "source-session",
+        crossfade_enabled=False,
+        volume_normalization_enabled=False,
+    )
+
+    manager.update_output(
+        "player-2",
+        _source_consumer_plan(48000),
+        queue_id="source-player",
+        session_id="source-session",
+    )
+    manager.update_source_context(
+        "source-player",
+        "source-session",
+        crossfade_enabled=False,
+        volume_normalization_enabled=False,
+    )
+
+    assert _source_bit_perfect(source_session) == {"player-1": True, "player-2": False}
+
+
 def test_a_source_that_crossfades_itself_stays_bit_perfect() -> None:
     """A fade the source mixed itself reaches us already mixed, so nothing is lost."""
-    manager, _mass, source_session, lossless_plan, pcm_format = _source_manager_context()
+    manager, _mass, source_session, lossless_plan = _source_manager_context()
     manager.update_output(
         "player-1",
         lossless_plan,
@@ -379,7 +437,6 @@ def test_a_source_that_crossfades_itself_stays_bit_perfect() -> None:
     manager.update_source_context(
         "source-player",
         "source-session",
-        pcm_format=pcm_format,
         crossfade_enabled=True,
         volume_normalization_enabled=True,
     )
@@ -395,7 +452,7 @@ def test_a_source_that_crossfades_itself_stays_bit_perfect() -> None:
 
 def test_unreported_source_processing_does_not_cost_the_bit_perfect_badge() -> None:
     """A source that never says what it applies still hands us its samples untouched."""
-    manager, _mass, source_session, lossless_plan, pcm_format = _source_manager_context()
+    manager, _mass, source_session, lossless_plan = _source_manager_context()
     manager.update_output(
         "player-1",
         lossless_plan,
@@ -406,7 +463,6 @@ def test_unreported_source_processing_does_not_cost_the_bit_perfect_badge() -> N
     manager.update_source_context(
         "source-player",
         "source-session",
-        pcm_format=pcm_format,
         crossfade_enabled=None,
         volume_normalization_enabled=None,
     )
@@ -423,7 +479,7 @@ def test_unreported_source_processing_does_not_cost_the_bit_perfect_badge() -> N
 
 def test_a_player_that_cannot_take_the_source_rate_is_not_bit_perfect() -> None:
     """A source rate the player cannot take is snapped down, which loses samples."""
-    manager, _mass, source_session, lossless_plan, _pcm_format = _source_manager_context()
+    manager, _mass, source_session, lossless_plan = _source_manager_context()
     # the source arrives at 96 kHz but the player tops out at 48 kHz
     snapped = _format(ContentType.PCM_S24LE, 48000, 24)
     lossless_plan.input_format = snapped
@@ -438,7 +494,6 @@ def test_a_player_that_cannot_take_the_source_rate_is_not_bit_perfect() -> None:
     manager.update_source_context(
         "source-player",
         "source-session",
-        pcm_format=snapped,
         crossfade_enabled=False,
         volume_normalization_enabled=False,
     )
@@ -453,7 +508,7 @@ def test_a_player_that_cannot_take_the_source_rate_is_not_bit_perfect() -> None:
 
 def test_a_live_source_output_narrower_than_the_source_is_not_bit_perfect() -> None:
     """Dropping a 24-bit source to a 16-bit output loses bits for a live source too."""
-    manager, _mass, source_session, lossless_plan, pcm_format = _source_manager_context()
+    manager, _mass, source_session, lossless_plan = _source_manager_context()
     lossless_plan.output_details.output_format = _format(ContentType.FLAC, 96000, 16)
     manager.update_output(
         "player-1",
@@ -465,7 +520,6 @@ def test_a_live_source_output_narrower_than_the_source_is_not_bit_perfect() -> N
     manager.update_source_context(
         "source-player",
         "source-session",
-        pcm_format=pcm_format,
         crossfade_enabled=False,
         volume_normalization_enabled=False,
     )
@@ -480,12 +534,11 @@ def test_a_live_source_output_narrower_than_the_source_is_not_bit_perfect() -> N
 
 def test_stale_live_source_updates_are_rejected() -> None:
     """A superseded source session cannot publish context or outputs."""
-    manager, _mass, source_session, lossless_plan, pcm_format = _source_manager_context()
+    manager, _mass, source_session, lossless_plan = _source_manager_context()
 
     manager.update_source_context(
         "source-player",
         "stale-session",
-        pcm_format=pcm_format,
         crossfade_enabled=True,
         volume_normalization_enabled=True,
     )
@@ -501,11 +554,10 @@ def test_stale_live_source_updates_are_rejected() -> None:
 
 def test_clearing_live_source_processing_removes_the_snapshot() -> None:
     """Ending a source selection clears its published audio details."""
-    manager, mass, source_session, _lossless_plan, pcm_format = _source_manager_context()
+    manager, mass, source_session, _lossless_plan = _source_manager_context()
     manager.update_source_context(
         "source-player",
         "source-session",
-        pcm_format=pcm_format,
         crossfade_enabled=False,
         volume_normalization_enabled=False,
     )
@@ -519,7 +571,7 @@ def test_clearing_live_source_processing_removes_the_snapshot() -> None:
 
 def test_live_source_outputs_follow_current_group_members() -> None:
     """A departed group member is removed from the live source output snapshot."""
-    manager, mass, source_session, lossless_plan, pcm_format = _source_manager_context()
+    manager, mass, source_session, lossless_plan = _source_manager_context()
     manager.update_output(
         "player-1",
         lossless_plan,
@@ -530,7 +582,6 @@ def test_live_source_outputs_follow_current_group_members() -> None:
     manager.update_source_context(
         "source-player",
         "source-session",
-        pcm_format=pcm_format,
         crossfade_enabled=False,
         volume_normalization_enabled=False,
     )
@@ -1642,9 +1693,8 @@ def _source_manager_context() -> tuple[
     MagicMock,
     Any,
     AudioOutputPlan,
-    AudioFormat,
 ]:
-    """Return one active live source, a lossless output plan and its PCM format."""
+    """Return one active live source and a lossless output plan for it."""
     mass = MagicMock()
     streamdetails = StreamDetails(
         provider="source-provider",
@@ -1661,16 +1711,30 @@ def _source_manager_context() -> tuple[
         source_session if player_id == "source-player" else None
     )
     manager = AudioProcessingManager(mass)
-    pcm_format = _format(ContentType.PCM_S24LE, 96000, 24)
-    output_plan = AudioOutputPlan(
+    return manager, mass, source_session, _source_consumer_plan(96000)
+
+
+def _source_consumer_plan(sample_rate: int) -> AudioOutputPlan:
+    """Return a lossless output plan for a live source consumer at one sample rate."""
+    return AudioOutputPlan(
         filter_params=[],
         output_details=AudioOutputDetails(
             dsp=AudioDSPDetails(state=DSPState.DISABLED),
-            output_format=_format(ContentType.FLAC, 96000, 24),
+            output_format=_format(ContentType.FLAC, sample_rate, 24),
         ),
-        input_format=pcm_format,
+        input_format=_format(ContentType.PCM_S24LE, sample_rate, 24),
     )
-    return manager, mass, source_session, output_plan, pcm_format
+
+
+def _source_bit_perfect(source_session: Any) -> dict[str, bool | None]:
+    """Return the published bit-perfect verdict of every live source consumer."""
+    details = cast("ActiveSourceAudioDetails | None", source_session.active_source_audio)
+    assert details is not None
+    return {
+        player_id: output.fidelity.bit_perfect
+        for output in details.outputs
+        for player_id in output.player_ids
+    }
 
 
 def _source_handled_soloist_item(

--- a/tests/controllers/streams/test_audio_source_route.py
+++ b/tests/controllers/streams/test_audio_source_route.py
@@ -374,7 +374,6 @@ async def test_direct_pcm_stream_stops_when_the_session_is_reselected() -> None:
     ctrl.audio_processing.update_source_context.assert_called_once_with(
         OWNER_ID,
         session.playback_session_id,
-        pcm_format=pcm_format,
         crossfade_enabled=provider.delivers_crossfaded_audio.return_value,
         volume_normalization_enabled=provider.delivers_normalized_audio.return_value,
     )


### PR DESCRIPTION
# What does this implement/fix?

When a live source (Spotify Connect, AirPlay-in, line-in, ...) plays on a speaker, we
publish which audio each listening player receives and whether that audio is bit perfect.
That report kept a single "decoded to" format for the whole source, not one per player.

So as soon as a second speaker started listening to the same source at a different sample
rate, it overwrote the format of the first one, and the first speaker's bit-perfect badge
flipped to the wrong answer. The snapshot published the moment the second speaker joined
was built from the previous speaker's format as well, so it briefly showed the wrong badge
for the new speaker too.

Each listening player's output already records the format it receives, so the check now
reads it from there.

**Related issue (if applicable):**

- follow-up on #5983

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- the bit-perfect check for a live source uses each listening player's own audio format
  instead of one format shared by the whole source selection
- the source snapshot no longer carries a PCM format, so it can no longer go stale
- tests for two players listening to the same source at different sample rates

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
