### PR TITLE
Log how long a stream takes to deliver its first audio

### DIFF
--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -652,12 +652,7 @@ class AudioBuffer:
                 self._discarded_chunks + len(self._chunks) >= self._ready_at_chunk
                 or len(self._chunks) >= self.max_size_seconds
             ):
-                self.ready.set()
-                LOGGER.debug(
-                    "AudioBuffer: %s became ready after %.2fs",
-                    self._source_name,
-                    time.monotonic() - self._fill_started,
-                )
+                self._mark_ready()
 
             self._data_available.notify_all()
 
@@ -671,9 +666,21 @@ class AudioBuffer:
             )
             self._eof_received = True
             if not self.ready.is_set():
-                self.ready.set()
+                self._mark_ready()
             self._data_available.notify_all()
             self._space_available.notify_all()
+
+    def _mark_ready(self) -> None:
+        """Signal that the buffer holds audio a consumer can start playing."""
+        self.ready.set()
+        # a source that ended without delivering anything also lands here,
+        # and never became playable
+        if self._chunks:
+            LOGGER.debug(
+                "AudioBuffer: %s became ready after %.2fs",
+                self._source_name,
+                time.monotonic() - self._fill_started,
+            )
 
     async def _get(self, chunk_number: int = 0) -> bytes:
         """

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -673,9 +673,9 @@ class AudioBuffer:
     def _mark_ready(self) -> None:
         """Signal that the buffer holds audio a consumer can start playing."""
         self.ready.set()
-        # a source that ended without delivering anything also lands here,
-        # and never became playable
-        if self._chunks:
+        # a source that failed or ended empty also lands here, without the
+        # buffer ever having become playable
+        if self._chunks and not self.has_error:
             LOGGER.debug(
                 "AudioBuffer: %s became ready after %.2fs",
                 self._source_name,

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -469,7 +469,9 @@ class AudioBuffer:
                     existing_buffer._discarded_chunks,
                 )
                 if wait_ready:
-                    await existing_buffer._wait_until_ready(streamdetails, ready_timeout)
+                    await existing_buffer._wait_until_ready(
+                        streamdetails, ready_timeout, log_prefix
+                    )
                 return existing_buffer
 
         # convert ms to seconds for get_media_stream (FFmpeg works in seconds)
@@ -556,31 +558,38 @@ class AudioBuffer:
         audio_buffer.fill(audio_source, source_name=streamdetails.uri)
 
         if wait_ready:
-            await audio_buffer._wait_until_ready(streamdetails, ready_timeout)
+            await audio_buffer._wait_until_ready(streamdetails, ready_timeout, log_prefix)
 
         return audio_buffer
 
     # -- Private methods --
 
-    async def _wait_until_ready(self, streamdetails: StreamDetails, ready_timeout: float) -> None:
+    async def _wait_until_ready(
+        self, streamdetails: StreamDetails, ready_timeout: float, log_prefix: str
+    ) -> None:
         """
         Wait until this buffer can serve playback or raise its producer failure.
 
         :param streamdetails: Stream details currently referencing this buffer.
         :param ready_timeout: Maximum seconds to wait for enough buffered audio.
+        :param log_prefix: Caller context for logging.
         """
         async with self._ready_wait_lock:
             if not self.ready.is_set():
                 try:
                     await asyncio.wait_for(self.ready.wait(), timeout=ready_timeout)
                 except TimeoutError as err:
-                    LOGGER.warning(
-                        "Gave up after %.1fs waiting for audio from %s (%s), %ss buffered",
-                        time.monotonic() - self._fill_started,
-                        streamdetails.provider,
-                        streamdetails.uri,
-                        self.seconds_available,
-                    )
+                    # clear() does not wake this wait, so a buffer released elsewhere
+                    # (to free a stream slot) lands here on an abort of our own making
+                    if not self.cancelled:
+                        LOGGER.warning(
+                            "%s: Gave up on %s (%s) after %.2fs, %ss buffered",
+                            log_prefix,
+                            streamdetails.provider,
+                            streamdetails.uri,
+                            time.monotonic() - self._fill_started,
+                            self.seconds_available,
+                        )
                     producer_error = await self._clear_failed_buffer(streamdetails)
                     if isinstance(producer_error, AudioError):
                         raise producer_error from err

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -579,9 +579,12 @@ class AudioBuffer:
                 try:
                     await asyncio.wait_for(self.ready.wait(), timeout=ready_timeout)
                 except TimeoutError as err:
-                    # clear() does not wake this wait, so a buffer released elsewhere
-                    # (to free a stream slot) lands here on an abort of our own making
-                    if not self.cancelled:
+                    # clear() does not wake this wait, and only marks the buffer cancelled
+                    # once the producer is gone - so a buffer released elsewhere (to free a
+                    # stream slot) lands here on an abort of our own making
+                    producer = self._producer_task
+                    releasing = self.cancelled or bool(producer and producer.cancelling())
+                    if not releasing:
                         LOGGER.warning(
                             "%s: Gave up on %s (%s) after %.2fs, %ss buffered",
                             log_prefix,

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -106,6 +106,8 @@ class AudioBuffer:
         self._space_available = asyncio.Condition(self._lock)
         self._eof_received = False
         self._producer_task: asyncio.Task[None] | None = None
+        self._fill_started = time.monotonic()
+        self._source_name = "unknown"
         self._last_access_time: float = time.time()
         self._inactivity_task: asyncio.Task[None] | None = None
         self._cancelled = False
@@ -309,6 +311,8 @@ class AudioBuffer:
         :param audio_source: Async generator yielding 1-second PCM audio chunks.
         :param source_name: Name for logging purposes.
         """
+        self._fill_started = time.monotonic()
+        self._source_name = source_name
 
         async def _fill_task() -> None:
             chunk_count = 0
@@ -570,6 +574,13 @@ class AudioBuffer:
                 try:
                     await asyncio.wait_for(self.ready.wait(), timeout=ready_timeout)
                 except TimeoutError as err:
+                    LOGGER.warning(
+                        "Gave up after %.1fs waiting for audio from %s (%s), %ss buffered",
+                        time.monotonic() - self._fill_started,
+                        streamdetails.provider,
+                        streamdetails.uri,
+                        self.seconds_available,
+                    )
                     producer_error = await self._clear_failed_buffer(streamdetails)
                     if isinstance(producer_error, AudioError):
                         raise producer_error from err
@@ -633,6 +644,11 @@ class AudioBuffer:
                 or len(self._chunks) >= self.max_size_seconds
             ):
                 self.ready.set()
+                LOGGER.debug(
+                    "AudioBuffer: %s became ready after %.2fs",
+                    self._source_name,
+                    time.monotonic() - self._fill_started,
+                )
 
             self._data_available.notify_all()
 

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -426,6 +426,41 @@ async def test_ready_timeout_stays_quiet_for_a_released_buffer(
 
 
 @pytest.mark.asyncio
+async def test_ready_timeout_stays_quiet_while_the_source_is_finalizing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A release is not reported as a stall while the source is still cleaning up."""
+    finalized = asyncio.Event()
+
+    async def _slow_to_finalize_source() -> AsyncGenerator[bytes]:
+        try:
+            await asyncio.sleep(10)
+            yield ONE_SECOND_CHUNK
+        finally:
+            await finalized.wait()
+
+    streamdetails = _make_stream_details(MediaType.TRACK, duration=100, allow_seek=True)
+    buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
+    streamdetails.buffer = buf
+    buf.fill(_slow_to_finalize_source(), source_name=streamdetails.uri)
+
+    with caplog.at_level(logging.WARNING):
+        waiter = asyncio.create_task(
+            buf._wait_until_ready(streamdetails, 0.05, "get_buffer[prepare_next]")
+        )
+        await asyncio.sleep(0)
+        assert buf._producer_task is not None
+        buf._producer_task.cancel()
+        # the deadline expires while the source is still inside its cleanup
+        await asyncio.sleep(0.1)
+        finalized.set()
+        with pytest.raises(AudioError, match="Timeout waiting for audio data"):
+            await waiter
+
+    assert "Gave up on" not in caplog.text
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("media_type", [MediaType.SOUND_EFFECT, MediaType.AUDIO_SOURCE])
 async def test_get_buffer_skips_analysis_for_non_analyzed_types(media_type: MediaType) -> None:
     """get_buffer skips audio analysis for sound effects and audio sources."""

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from collections.abc import AsyncGenerator
 from contextlib import suppress
@@ -12,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.errors import AudioError
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.queue_item import QueueItem
 from music_assistant_models.streamdetails import StreamDetails
@@ -320,6 +322,31 @@ async def test_fill_error_no_data() -> None:
 
     with pytest.raises(RuntimeError, match="test error"):
         await _consume()
+
+
+@pytest.mark.asyncio
+async def test_ready_timeout_reports_the_wait(caplog: pytest.LogCaptureFixture) -> None:
+    """The readiness deadline reports the provider, the wait and how much audio arrived."""
+
+    async def _silent_source() -> AsyncGenerator[bytes]:
+        await asyncio.sleep(10)
+        yield ONE_SECOND_CHUNK
+
+    streamdetails = _make_stream_details(MediaType.TRACK, duration=100, allow_seek=True)
+    buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
+    streamdetails.buffer = buf
+    buf.fill(_silent_source(), source_name=streamdetails.uri)
+
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(AudioError, match="Timeout waiting for audio data"),
+    ):
+        await buf._wait_until_ready(streamdetails, ready_timeout=0.05)
+
+    assert "Gave up after" in caplog.text
+    assert "waiting for audio from builtin" in caplog.text
+    assert "0s buffered" in caplog.text
+    assert streamdetails.buffer is None
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -324,14 +324,26 @@ async def test_fill_error_no_data() -> None:
         await _consume()
 
 
+async def _silent_source() -> AsyncGenerator[bytes]:
+    """Create an async generator that never delivers audio."""
+    await asyncio.sleep(10)
+    yield ONE_SECOND_CHUNK
+
+
+@pytest.mark.asyncio
+async def test_logs_time_to_first_playable_audio(caplog: pytest.LogCaptureFixture) -> None:
+    """A buffer reports how long its first playable audio took."""
+    buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
+    with caplog.at_level(logging.DEBUG, logger="music_assistant.audio_buffer"):
+        buf.fill(_make_source(2), source_name="test://item")
+        await buf.ready.wait()
+
+    assert "test://item became ready after" in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_ready_timeout_reports_the_wait(caplog: pytest.LogCaptureFixture) -> None:
-    """The readiness deadline reports the provider, the wait and how much audio arrived."""
-
-    async def _silent_source() -> AsyncGenerator[bytes]:
-        await asyncio.sleep(10)
-        yield ONE_SECOND_CHUNK
-
+    """The readiness deadline reports the caller, provider and how much audio arrived."""
     streamdetails = _make_stream_details(MediaType.TRACK, duration=100, allow_seek=True)
     buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
     streamdetails.buffer = buf
@@ -341,12 +353,33 @@ async def test_ready_timeout_reports_the_wait(caplog: pytest.LogCaptureFixture) 
         caplog.at_level(logging.WARNING),
         pytest.raises(AudioError, match="Timeout waiting for audio data"),
     ):
-        await buf._wait_until_ready(streamdetails, ready_timeout=0.05)
+        await buf._wait_until_ready(streamdetails, 0.05, "get_buffer[prepare]")
 
-    assert "Gave up after" in caplog.text
-    assert "waiting for audio from builtin" in caplog.text
-    assert "0s buffered" in caplog.text
+    assert "get_buffer[prepare]: Gave up on builtin" in caplog.text
+    assert ", 0s buffered" in caplog.text
     assert streamdetails.buffer is None
+
+
+@pytest.mark.asyncio
+async def test_ready_timeout_stays_quiet_for_a_released_buffer(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A buffer released to free a stream slot is not reported as a provider stall."""
+    streamdetails = _make_stream_details(MediaType.TRACK, duration=100, allow_seek=True)
+    buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
+    streamdetails.buffer = buf
+    buf.fill(_silent_source(), source_name=streamdetails.uri)
+
+    with caplog.at_level(logging.WARNING):
+        waiter = asyncio.create_task(
+            buf._wait_until_ready(streamdetails, 0.05, "get_buffer[prepare_next]")
+        )
+        await asyncio.sleep(0)
+        await buf.clear()
+        with pytest.raises(AudioError, match="Timeout waiting for audio data"):
+            await waiter
+
+    assert "Gave up on" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -342,6 +342,30 @@ async def test_logs_time_to_first_playable_audio(caplog: pytest.LogCaptureFixtur
 
 
 @pytest.mark.asyncio
+async def test_logs_time_to_ready_for_a_stream_below_its_threshold(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A stream that ends before reaching its ready threshold still reports its startup time."""
+    buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL, ready_threshold=8)
+    with caplog.at_level(logging.DEBUG, logger="music_assistant.audio_buffer"):
+        buf.fill(_make_source(2), source_name="test://short")
+        await buf.ready.wait()
+
+    assert "test://short became ready after" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_empty_stream_is_not_reported_as_ready(caplog: pytest.LogCaptureFixture) -> None:
+    """A source that ends without delivering audio never became playable."""
+    buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
+    with caplog.at_level(logging.DEBUG, logger="music_assistant.audio_buffer"):
+        buf.fill(_make_source(0), source_name="test://empty")
+        await buf.ready.wait()
+
+    assert "became ready after" not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_ready_timeout_reports_the_wait(caplog: pytest.LogCaptureFixture) -> None:
     """The readiness deadline reports the caller, provider and how much audio arrived."""
     streamdetails = _make_stream_details(MediaType.TRACK, duration=100, allow_seek=True)

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -366,6 +366,25 @@ async def test_empty_stream_is_not_reported_as_ready(caplog: pytest.LogCaptureFi
 
 
 @pytest.mark.asyncio
+async def test_failed_stream_below_threshold_is_not_reported_as_ready(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A source that fails before reaching its threshold never became playable."""
+
+    async def _failing_source() -> AsyncGenerator[bytes]:
+        yield ONE_SECOND_CHUNK
+        msg = "test error"
+        raise RuntimeError(msg)
+
+    buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL, ready_threshold=8)
+    with caplog.at_level(logging.DEBUG, logger="music_assistant.audio_buffer"):
+        buf.fill(_failing_source(), source_name="test://failing")
+        await buf.ready.wait()
+
+    assert "became ready after" not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_ready_timeout_reports_the_wait(caplog: pytest.LogCaptureFixture) -> None:
     """The readiness deadline reports the caller, provider and how much audio arrived."""
     streamdetails = _make_stream_details(MediaType.TRACK, duration=100, allow_seek=True)


### PR DESCRIPTION
# What does this implement/fix?

When a stream fails to deliver audio in time, the log only says `Timeout waiting for audio data` — not which provider it was waiting on, how long it actually waited, or whether any audio had arrived at all. And nothing anywhere records how long a stream normally takes to start, so there is no way to tell a genuinely stuck source from one that was simply a little slow.

Two log lines, no behaviour change:

- when a buffer becomes playable, log how long its first audio took
- when the readiness deadline expires, log the provider, the elapsed wait and how much audio had arrived

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
