### PR TITLE
Report a slow player stop after pausing Spotify Connect

### DIFF
--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -286,7 +286,13 @@ class AsyncProcess:
         return (stdout, stderr)
 
     async def close(self) -> None:
-        """Close/terminate the process and wait for exit."""
+        """
+        Close/terminate the process and wait for exit.
+
+        An enclosing timeout is not a reliable bound on this call: the cleanup may
+        swallow the cancellation and run to completion, and a cancellation that does
+        land leaves the process unreaped.
+        """
         if self._close_called and self.returncode is not None:
             # Already closed and reaped, so there is nothing left to signal or
             # drain. The stream locks below are still held by that first call

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -94,6 +94,10 @@ AUDIO_SOURCE_ID = "main"
 # the player leaves the playing state; the next 'playing' event re-streams.
 PAUSE_EOF_TIMEOUT_S = 0.5
 
+# A stop after a pause runs while the player's playback lock is held, so a slow one
+# delays whatever the user does next; warn when it takes longer than this.
+SLOW_STOP_WARN_S = 10.0
+
 # Seconds to wait for the backend to report 'playing' after a resume request.
 PLAYBACK_START_TIMEOUT_S = 3.0
 
@@ -710,16 +714,18 @@ class SpotifyConnectProvider(PluginProvider):
         :param player_id: The player currently consuming the live source.
         """
         self.logger.debug("Stopping player %s after pause", player_id)
+        started = self.mass.loop.time()
         try:
-            # bounded: an unresponsive player (e.g. a throttled web client) must
-            # not hold this task - and the player's playback lock - indefinitely
-            async with asyncio.timeout(10):
-                await self.mass.players.cmd_stop(player_id)
-            self.logger.debug("Player %s stopped after pause", player_id)
-        except TimeoutError:
-            self.logger.warning("Player %s did not stop within 10s after pause", player_id)
+            await self.mass.players.cmd_stop(player_id)
         except Exception as err:
             self.logger.debug("Failed to stop player %s on pause: %s", player_id, err)
+            return
+        # a timeout around the stop is not enforceable: the process cleanup it waits on
+        # can swallow the cancellation (see AsyncProcess.close), so a slow stop is reported
+        if (elapsed := self.mass.loop.time() - started) > SLOW_STOP_WARN_S:
+            self.logger.warning("Stopping player %s took %.1f seconds", player_id, elapsed)
+        else:
+            self.logger.debug("Player %s stopped after pause", player_id)
 
     def _schedule_play_media(self) -> None:
         """Schedule playback when Spotify is active and no player owns the source."""
@@ -888,8 +894,6 @@ class SpotifyConnectProvider(PluginProvider):
             prev_player_id = self._active_player_id
             self._clear_active_player()
             if prev_player_id:
-                # bounded like the pause path: a slow player must not hold the
-                # stop (and its playback lock) indefinitely
                 self._schedule_pause_stop(prev_player_id)
             return
         elif event.type is BackendEventType.PLAYING:

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -1,9 +1,10 @@
 """Tests for the Spotify Connect provider."""
 
+import asyncio
 import json
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
@@ -282,6 +283,41 @@ async def test_queue_clear_survives_a_failing_release() -> None:
     await provider.on_source_released(AUDIO_SOURCE_ID, "player1")
 
     deactivate.assert_awaited_once()
+
+
+async def test_a_slow_stop_after_pause_is_reported() -> None:
+    """A stop that takes its time is reported, and still runs to completion."""
+    stopped = asyncio.Event()
+
+    async def _slow_stop(_player_id: str) -> None:
+        await asyncio.sleep(0.05)
+        stopped.set()
+
+    provider, _ = _tethered_provider()
+    mass = cast("Any", provider.mass)
+    mass.loop = asyncio.get_running_loop()
+    mass.players.cmd_stop = AsyncMock(side_effect=_slow_stop)
+    logger = cast("MagicMock", provider.logger)
+
+    with patch("music_assistant.providers.spotify_connect.provider.SLOW_STOP_WARN_S", 0.01):
+        await provider._stop_paused_player("player1")
+
+    assert stopped.is_set()
+    logger.warning.assert_called_once()
+
+
+async def test_a_prompt_stop_after_pause_is_not_reported() -> None:
+    """A stop that finishes promptly is not reported as slow."""
+    provider, _ = _tethered_provider()
+    mass = cast("Any", provider.mass)
+    mass.loop = asyncio.get_running_loop()
+    mass.players.cmd_stop = AsyncMock()
+    logger = cast("MagicMock", provider.logger)
+
+    await provider._stop_paused_player("player1")
+
+    mass.players.cmd_stop.assert_awaited_once_with("player1")
+    logger.warning.assert_not_called()
 
 
 def _provider_with_stored_config(


### PR DESCRIPTION
# What does this implement/fix?

Stopping the player after a Spotify Connect pause was wrapped in a 10 second timeout, meant to keep an unresponsive player from holding the player lock. It fails exactly where it is needed: when the stop is waiting on the audio process cleanup - the usual case for a paused stream - that cleanup swallows the cancellation, so a slow stop was logged as a success rather than a warning.

Making the cancellation stick would mean cutting a stop short and leaving the player half torn down with its audio process still running, so the timeout is dropped and a slow stop is simply reported instead.

- Removed the timeout around the stop that follows a pause.
- Log a warning when that stop takes longer than 10 seconds, so a slow one is visible in the log.
- Noted on `AsyncProcess.close()` that a timeout around it is not a reliable bound.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
