### PR TITLE
Faster seeking on Spotify tracks played through Soloist

### DIFF
--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -554,10 +554,14 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     await session.skip_to(pending)
                     pending.claim()
                     return session, pending
-                if seek_position and session.is_playing(spotify_uri):
-                    # the engine is on this item already, so it can be seeked
+                if session.is_playing(spotify_uri):
+                    # The engine is on this item already, so it can be seeked
                     # where it stands instead of paying a whole respawn - which
-                    # would also have to claim the Connect device back
+                    # would also have to claim the Connect device back. Not
+                    # gated on a non-zero position: the branches above have
+                    # returned by now, so reaching here means re-opening the
+                    # item being played, and back to its very start is as much
+                    # a seek as any other.
                     try:
                         item = await session.seek_current(spotify_uri, seek_position * 1000)
                     except ProviderStreamLimitError:

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -780,6 +780,9 @@ class _SoloistSession:
         self._demand_started = False
         self._engine_playing = False
         self._sink_running = False
+        # set when a cancelled transition left the sink's real state unknown, so
+        # the next application re-issues it instead of trusting _sink_running
+        self._sink_state_unknown = False
         self._backpressured = False
         self._sink_lock = asyncio.Lock()
         self._idle_since: float | None = None
@@ -862,6 +865,10 @@ class _SoloistSession:
         self._seeking = True
         try:
             await self._apply_sink_state()
+            if self._error:
+                # the app took the session over while the sink was being held; a
+                # replacement would claim the Connect device straight back off it
+                raise self._session_error()
             if self._current is not outgoing:
                 # the engine reached this item's own end while the sink was
                 # being held: it is not on the item this seek was asked for
@@ -902,6 +909,8 @@ class _SoloistSession:
                     async with asyncio.timeout(_SEEK_CONFIRM_TIMEOUT_S):
                         await item.seek_confirmed.wait()
                 except TimeoutError:
+                    if self._error:
+                        raise self._session_error() from None
                     raise AudioError(
                         f"Spotify Soloist did not confirm seeking {spotify_uri} to {target_ms}ms"
                     ) from None
@@ -912,6 +921,11 @@ class _SoloistSession:
                 # measured now the engine has moved: what the sink rendered up
                 # to here is pre-seek audio still on its way to the reader
                 self._stale_budget = self._stale_bytes()
+                # cleared before the sink is let go, and inside this block: a
+                # cancellation out here would otherwise leave the channel
+                # claimed with the session still looking usable
+                self._seeking = False
+                await self._apply_sink_state()
             except BaseException:
                 # Past the swap the item the session was playing is closed and
                 # cannot be put back, so a half-seeked session is ended rather
@@ -923,7 +937,6 @@ class _SoloistSession:
                 raise
         finally:
             self._seeking = False
-        await self._apply_sink_state()
         return item
 
     def is_playing(self, spotify_uri: str) -> bool:
@@ -1445,6 +1458,9 @@ class _SoloistSession:
                 async with asyncio.timeout(_SEEK_RETRY_INTERVAL_S):
                     await item.seek_confirmed.wait()
             if item.seek_confirmed.is_set():
+                if self._error:
+                    # the session failed, which releases the wait as well
+                    raise self._session_error()
                 return
             if asyncio.get_running_loop().time() >= deadline:
                 raise AudioError(f"Spotify Soloist did not confirm seeking to {target_ms}ms")
@@ -1718,7 +1734,7 @@ class _SoloistSession:
                 want = self._retained_bytes() < limit * _BYTES_PER_SECOND
                 backpressured = not want
             self._backpressured = backpressured
-            if want == self._sink_running:
+            if want == self._sink_running and not self._sink_state_unknown:
                 return
             try:
                 if want:
@@ -1730,7 +1746,15 @@ class _SoloistSession:
                 # silence into (or withhold audio from) the delivered PCM
                 self._fail(f"capture sink control failed: {err}")
                 return
+            except asyncio.CancelledError:
+                # The transition may have landed or not, and nothing here can
+                # tell. Left unknown rather than guessed: assuming it did not
+                # land would let a sink that actually suspended read as already
+                # running, and nothing would ever resume it.
+                self._sink_state_unknown = True
+                raise
             self._sink_running = want
+            self._sink_state_unknown = False
 
     def _stale_bytes(self) -> int:
         """

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -860,7 +860,10 @@ class _SoloistSession:
         outgoing = self._current
         if client is None:
             raise AudioError("Spotify Soloist is not connected")
-        if outgoing is None or outgoing.uri != spotify_uri:
+        if outgoing is None or outgoing.uri != spotify_uri or outgoing.closed:
+            # A closed channel is the run having ended on this item, which the
+            # uri still matching does not tell apart: the engine has stopped and
+            # would not start again for a seek.
             raise AudioError(f"Spotify Soloist is not playing {spotify_uri}")
         # armed before the command: what the sink has already rendered, and
         # everything still travelling here, belongs to the position seeked away
@@ -1667,10 +1670,12 @@ class _SoloistSession:
         if playing:
             # the engine picked the item back up: it was only rebuffering after all
             self._cancel_tail_drain(item)
-        elif item.finishing and item.at_own_end:
+        elif item.finishing and item.at_own_end and not self._seeking:
             # The run's last item, played out: the engine reports no track change
             # to cut it on, so end it here. This is also the branch a finished run
             # actually arrives on — its snapshot is stopped/idle, not paused.
+            # Never while a seek is in flight: the channel opened for it has no
+            # position of its own yet, which reads as an item with nothing left.
             self._drain_last_item(item)
             return
         await self._apply_sink_state(engine_playing=playing)
@@ -2057,6 +2062,11 @@ class _ItemAudio:
         self.draining = False
         self._available = asyncio.Event()
         self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        """Return whether this channel has been cut and can deliver no more."""
+        return self._closed
 
     @property
     def finishing(self) -> bool:

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -2177,7 +2177,17 @@ class _ItemAudio:
         self.seek_target_ms = target_ms
         self.seek_confirmed.clear()
         self.started_at_ms = None
-        reported_ms = (self.last_position_ms if floor_ms is None else floor_ms) or 0
+        if floor_ms is not None:
+            # A live position, not one a fresh session restored, so there is
+            # nothing to disprove. Only a seek BACK has to see the engine come
+            # below the mark first: a report from before the command would
+            # otherwise pass for the landing. A seek forward cannot be confused
+            # that way, and demanding the engine drop below a mark it is never
+            # going back past would leave a short one unable to confirm at all.
+            self._seek_floor_ms = floor_ms
+            self._seek_anchored = target_ms >= floor_ms
+            return
+        reported_ms = self.last_position_ms or 0
         # A fresh session restores the account's last playback state, so seeking
         # the item it was already playing - a resume, or a seek of the current
         # track - makes that restored position indistinguishable from the seek

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -412,9 +412,9 @@ class SoloistBackend(SpotifyPlaybackBackend):
 
         :param spotify_uri: Canonical Spotify URI (``spotify:track:<id>`` or
             ``spotify:episode:<id>``).
-        :param seek_position: Position in seconds to start from. Any seek
-            restarts the session at that position (a continuous run cannot be
-            rewound without disrupting it).
+        :param seek_position: Position in seconds to start from. Seeking the
+            item the session is already playing moves the engine where it
+            stands; anything else starts the session at that position.
         :param streamdetails: The StreamDetails this audio is requested for.
             They tell the session which queue it serves and which item of it is
             being streamed, so it can feed the engine the following track.
@@ -533,8 +533,9 @@ class SoloistBackend(SpotifyPlaybackBackend):
         Return the session and audio channel to stream this item from.
 
         Continues the running session when it already plays (or has been fed)
-        this item for this queue; anything else — a seek, another queue, a
-        skipped-to item, a session that is gone — starts a fresh session.
+        this item for this queue, seeking it in place when a position is asked
+        for; anything else — another queue, a skipped-to item, a session that is
+        gone — starts a fresh session.
         """
         async with self._session_lock:
             self._raise_if_app_controlled()
@@ -553,6 +554,19 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     await session.skip_to(pending)
                     pending.claim()
                     return session, pending
+                if seek_position and session.is_playing(spotify_uri):
+                    # the engine is on this item already, so it can be seeked
+                    # where it stands instead of paying a whole respawn - which
+                    # would also have to claim the Connect device back
+                    try:
+                        item = await session.seek_current(spotify_uri, seek_position * 1000)
+                    except AudioError as err:
+                        # a fresh session starts at the target instead
+                        self.logger.debug(
+                            "Seeking the running soloist session failed, restarting it: %s", err
+                        )
+                    else:
+                        return session, item
             if session is not None:
                 if session.in_use and (
                     session.queue_id != queue_id or not session.is_playing(spotify_uri)
@@ -767,6 +781,9 @@ class _SoloistSession:
         self._idle_since: float | None = None
         # while set, captured audio is dropped until the engine reports this item
         self._discard_until: str | None = None
+        # while set, a seek of the current item is in flight and nothing the
+        # engine renders belongs to either side of it
+        self._seeking = False
         # bytes of the item jumped away from still to drop, measured at the jump
         self._stale_budget = 0
 
@@ -815,6 +832,76 @@ class _SoloistSession:
             raise AudioError(f"Spotify Soloist did not reach {item.uri}") from None
         finally:
             self._discard_until = None
+
+    async def seek_current(self, spotify_uri: str, target_ms: int) -> _ItemAudio:
+        """
+        Seek the item the engine is playing, on a fresh audio channel.
+
+        Keeps the session instead of paying a respawn (which also has to reclaim
+        the Connect device). The returned channel is already claimed: it starts
+        at the seek point and carries nothing from before it.
+
+        :param spotify_uri: The item to seek, which the engine must be playing.
+        :param target_ms: The position to seek to.
+        :raises AudioError: When the engine does not confirm the seek.
+        """
+        client = self._client
+        outgoing = self._current
+        if client is None:
+            raise AudioError("Spotify Soloist is not connected")
+        if outgoing is None or outgoing.uri != spotify_uri:
+            raise AudioError(f"Spotify Soloist is not playing {spotify_uri}")
+        # armed before the command: what the sink has already rendered, and
+        # everything still travelling here, belongs to the position seeked away
+        # from. Unlike _discard_until this cannot key on the uri - an in-place
+        # seek reports no track change to clear it on.
+        self._seeking = True
+        await self._apply_sink_state()
+        # A fresh channel rather than a reset one: the outgoing stream may still
+        # be draining this item, and two readers on one channel would each take
+        # part of the audio. The uri key is what feed_after's ledger goes by, so
+        # replacing the object under it leaves that untouched.
+        item = self._items[spotify_uri] = _ItemAudio(spotify_uri, self)
+        # both describe the track rather than the position within it
+        item.duration_ms = outgoing.duration_ms
+        item.playing_seen = outgoing.playing_seen
+        item.started.set()
+        # claimed here rather than by the caller: _expire_idle only counts
+        # claimed channels, and the outgoing one has left _items
+        item.claim()
+        self._current = item
+        outgoing.close()
+        # seeded from where the engine actually is: a fresh channel has observed
+        # no position of its own, and a backward seek judged against a floor of
+        # zero would take the pre-seek report as its landing
+        item.arm_seek(target_ms, floor_ms=outgoing.last_position_ms or 0)
+        try:
+            try:
+                await client.seek(target_ms, await_result=True)
+            except (TimeoutError, OSError, ClientError, SoloistError) as err:
+                raise AudioError(
+                    f"Spotify Soloist would not seek {spotify_uri}: {type(err).__name__} {err}"
+                ) from err
+            # Deliberately no re-send loop, unlike the cold seek: the engine only
+            # drops a seek that arrives while the track is still loading, and a
+            # repeat of one it already took restarts the item - audible here,
+            # where the audio is live rather than held behind a suspended sink.
+            try:
+                async with asyncio.timeout(_SEEK_CONFIRM_TIMEOUT_S):
+                    await item.seek_confirmed.wait()
+            except TimeoutError:
+                if self._error:
+                    raise self._session_error() from None
+                raise AudioError(
+                    f"Spotify Soloist did not confirm seeking {spotify_uri} to {target_ms}ms"
+                ) from None
+            # measured now the engine has moved: what the sink rendered up to
+            # here is pre-seek audio still on its way to the reader
+            self._stale_budget = self._stale_bytes()
+        finally:
+            self._seeking = False
+        await self._apply_sink_state()
+        return item
 
     def is_playing(self, spotify_uri: str) -> bool:
         """
@@ -1414,7 +1501,7 @@ class _SoloistSession:
 
         :param chunk: Whole sample frames just read from the capture FIFO.
         """
-        if self._discard_until is not None:
+        if self._discard_until is not None or self._seeking:
             # the marker drops everything, an earlier jump's remainder included
             self._stale_budget = max(0, self._stale_budget - len(chunk))
             return
@@ -1590,7 +1677,11 @@ class _SoloistSession:
             if engine_playing is not None:
                 self._engine_playing = engine_playing
             backpressured = False
-            if any(item.draining for item in self._items.values()):
+            if self._seeking:
+                # keeps pre-seek audio out of the capture entirely, so what the
+                # reader still holds can be sized once the engine has moved
+                want = False
+            elif any(item.draining for item in self._items.values()):
                 want = True
             elif not self._engine_playing:
                 want = False
@@ -2019,16 +2110,18 @@ class _ItemAudio:
         self._available.set()
         self._drop_undelivered()
 
-    def arm_seek(self, target_ms: int) -> None:
+    def arm_seek(self, target_ms: int, floor_ms: int | None = None) -> None:
         """
         Arm a seek to the given position, so position reports can confirm it.
 
         :param target_ms: The position the engine is being seeked to.
+        :param floor_ms: Where the engine is now, for a channel that has not
+            observed a position itself (one opened for an in-place seek).
         """
         self.seek_target_ms = target_ms
         self.seek_confirmed.clear()
         self.started_at_ms = None
-        reported_ms = self.last_position_ms or 0
+        reported_ms = (self.last_position_ms if floor_ms is None else floor_ms) or 0
         # A fresh session restores the account's last playback state, so seeking
         # the item it was already playing - a resume, or a seek of the current
         # track - makes that restored position indistinguishable from the seek

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -560,6 +560,10 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     # would also have to claim the Connect device back
                     try:
                         item = await session.seek_current(spotify_uri, seek_position * 1000)
+                    except ProviderStreamLimitError:
+                        # the Spotify app took the session over: a replacement
+                        # would claim the Connect device straight back off it
+                        raise
                     except AudioError as err:
                         # a fresh session starts at the target instead
                         self.logger.debug(
@@ -856,48 +860,67 @@ class _SoloistSession:
         # from. Unlike _discard_until this cannot key on the uri - an in-place
         # seek reports no track change to clear it on.
         self._seeking = True
-        await self._apply_sink_state()
-        # A fresh channel rather than a reset one: the outgoing stream may still
-        # be draining this item, and two readers on one channel would each take
-        # part of the audio. The uri key is what feed_after's ledger goes by, so
-        # replacing the object under it leaves that untouched.
-        item = self._items[spotify_uri] = _ItemAudio(spotify_uri, self)
-        # both describe the track rather than the position within it
-        item.duration_ms = outgoing.duration_ms
-        item.playing_seen = outgoing.playing_seen
-        item.started.set()
-        # claimed here rather than by the caller: _expire_idle only counts
-        # claimed channels, and the outgoing one has left _items
-        item.claim()
-        self._current = item
-        outgoing.close()
-        # seeded from where the engine actually is: a fresh channel has observed
-        # no position of its own, and a backward seek judged against a floor of
-        # zero would take the pre-seek report as its landing
-        item.arm_seek(target_ms, floor_ms=outgoing.last_position_ms or 0)
         try:
+            await self._apply_sink_state()
+            if self._current is not outgoing:
+                # the engine reached this item's own end while the sink was
+                # being held: it is not on the item this seek was asked for
+                raise AudioError(f"Spotify Soloist moved on from {spotify_uri}")
+            # A fresh channel rather than a reset one: the outgoing stream may
+            # still be draining this item, and two readers on one channel would
+            # each take part of the audio. The uri key is what feed_after's
+            # ledger goes by, so replacing the object under it leaves that
+            # untouched.
+            item = self._items[spotify_uri] = _ItemAudio(spotify_uri, self)
+            # both describe the track rather than the position within it
+            item.duration_ms = outgoing.duration_ms
+            item.playing_seen = outgoing.playing_seen
+            item.started.set()
+            # claimed here rather than by the caller: _expire_idle only counts
+            # claimed channels, and the outgoing one has left _items
+            item.claim()
+            self._current = item
+            outgoing.close()
             try:
-                await client.seek(target_ms, await_result=True)
-            except (TimeoutError, OSError, ClientError, SoloistError) as err:
-                raise AudioError(
-                    f"Spotify Soloist would not seek {spotify_uri}: {type(err).__name__} {err}"
-                ) from err
-            # Deliberately no re-send loop, unlike the cold seek: the engine only
-            # drops a seek that arrives while the track is still loading, and a
-            # repeat of one it already took restarts the item - audible here,
-            # where the audio is live rather than held behind a suspended sink.
-            try:
-                async with asyncio.timeout(_SEEK_CONFIRM_TIMEOUT_S):
-                    await item.seek_confirmed.wait()
-            except TimeoutError:
+                # seeded from where the engine actually is: a fresh channel has
+                # observed no position of its own, and a backward seek judged
+                # against a floor of zero would take the pre-seek report as its
+                # landing
+                item.arm_seek(target_ms, floor_ms=outgoing.last_position_ms or 0)
+                try:
+                    await client.seek(target_ms, await_result=True)
+                except (TimeoutError, OSError, ClientError, SoloistError) as err:
+                    raise AudioError(
+                        f"Spotify Soloist would not seek {spotify_uri}: {type(err).__name__} {err}"
+                    ) from err
+                # Deliberately no re-send loop, unlike the cold seek: the engine
+                # only drops a seek that arrives while the track is still
+                # loading, and a repeat of one it already took restarts the item
+                # - audible here, where the audio is live rather than held
+                # behind a suspended sink.
+                try:
+                    async with asyncio.timeout(_SEEK_CONFIRM_TIMEOUT_S):
+                        await item.seek_confirmed.wait()
+                except TimeoutError:
+                    raise AudioError(
+                        f"Spotify Soloist did not confirm seeking {spotify_uri} to {target_ms}ms"
+                    ) from None
                 if self._error:
-                    raise self._session_error() from None
-                raise AudioError(
-                    f"Spotify Soloist did not confirm seeking {spotify_uri} to {target_ms}ms"
-                ) from None
-            # measured now the engine has moved: what the sink rendered up to
-            # here is pre-seek audio still on its way to the reader
-            self._stale_budget = self._stale_bytes()
+                    # the session died while the seek was in flight, which also
+                    # releases the wait above
+                    raise self._session_error()
+                # measured now the engine has moved: what the sink rendered up
+                # to here is pre-seek audio still on its way to the reader
+                self._stale_budget = self._stale_bytes()
+            except BaseException:
+                # Past the swap the item the session was playing is closed and
+                # cannot be put back, so a half-seeked session is ended rather
+                # than reasoned about. A cancellation here is the ordinary case
+                # - a second seek supersedes this one's stream - and leaving it
+                # would keep the channel claimed for good, with the session
+                # unable to expire and refusing every later item.
+                self._fail(f"an in-place seek of {spotify_uri} did not complete")
+                raise
         finally:
             self._seeking = False
         await self._apply_sink_state()
@@ -1119,9 +1142,11 @@ class _SoloistSession:
             return
         self._error = message
         for item in self._items.values():
-            # started too, so an item still waiting to be reported as current
-            # fails right away instead of sitting out its startup timeout
+            # started and seek_confirmed too, so an item still waiting to be
+            # reported as current - or for a seek to land - fails right away
+            # instead of sitting out its timeout
             item.started.set()
+            item.seek_confirmed.set()
             item.close()
         self.mass.create_task(self.backend.discard_session, self)
 
@@ -1679,8 +1704,11 @@ class _SoloistSession:
             backpressured = False
             if self._seeking:
                 # keeps pre-seek audio out of the capture entirely, so what the
-                # reader still holds can be sized once the engine has moved
+                # reader still holds can be sized once the engine has moved.
+                # Counted as backpressure: a pause the engine reports while its
+                # sink is held down here is ours, not the user's in the app.
                 want = False
+                backpressured = True
             elif any(item.draining for item in self._items.values()):
                 want = True
             elif not self._engine_playing:

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -2164,27 +2164,17 @@ class _ItemAudio:
         if self._closed:
             # positions reported after the cut describe the next item
             return
+        if self.seek_target_ms is not None and not self.seek_confirmed.is_set():
+            # Until the seek lands, a report says where the engine still is, not
+            # how far this channel has got. Recording it would let the position
+            # being seeked away from stand in for progress this item never made,
+            # which is what at_own_end and the completeness check read.
+            self._anchor_seek(position_ms)
+            return
         # keep the furthest position: the engine's stop/idle snapshot at the end
         # of an item reports position 0 and must not erase the progress the
         # completeness validation relies on (verified live)
         self.last_position_ms = max(self.last_position_ms or 0, position_ms)
-        if self.seek_target_ms is None or self.seek_confirmed.is_set():
-            return
-        if not self._seek_anchored:
-            # anchor on the engine dropping back below where it was when the
-            # seek went out: it has restarted the item, so what it reports from
-            # here on describes where the seek is taking it. A backward seek
-            # lands below that mark too, so this only ever gates the first
-            # report - past it, position is judged against the target alone.
-            self._seek_anchored = position_ms < self._seek_floor_ms
-            return
-        # the floor of 1 keeps a report of position 0 from landing inside the
-        # tolerance window of a small seek target
-        if position_ms >= max(1, self.seek_target_ms - _SEEK_TOLERANCE_MS):
-            # what the engine reports as the seek lands is where this item's own
-            # audio begins
-            self.started_at_ms = position_ms
-            self.seek_confirmed.set()
 
     async def read(self) -> AsyncGenerator[bytes]:
         """
@@ -2229,6 +2219,26 @@ class _ItemAudio:
             starving_for += _READ_SLICE_S
             if starving_for >= _STALL_TIMEOUT_S:
                 raise AudioError(f"Spotify Soloist delivered no audio for {self.uri}")
+
+    def _anchor_seek(self, position_ms: int) -> None:
+        """Judge a position report against the seek this channel is waiting on."""
+        assert self.seek_target_ms is not None
+        if not self._seek_anchored:
+            # anchor on the engine dropping back below where it was when the
+            # seek went out: it has restarted the item, so what it reports from
+            # here on describes where the seek is taking it. A backward seek
+            # lands below that mark too, so this only ever gates the first
+            # report - past it, position is judged against the target alone.
+            self._seek_anchored = position_ms < self._seek_floor_ms
+            return
+        # the floor of 1 keeps a report of position 0 from landing inside the
+        # tolerance window of a small seek target
+        if position_ms >= max(1, self.seek_target_ms - _SEEK_TOLERANCE_MS):
+            # what the engine reports as the seek lands is both where this
+            # item's own audio begins and the first progress it has made
+            self.started_at_ms = position_ms
+            self.last_position_ms = position_ms
+            self.seek_confirmed.set()
 
     def _drop_undelivered(self) -> None:
         """

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -813,14 +813,15 @@ async def test_feeding_never_replaces_a_channel_already_in_use(tmp_path: Path) -
     assert session.has_pending is False
 
 
-async def test_seeking_the_playing_item_restarts_the_session(
+async def test_a_seek_the_session_cannot_take_restarts_it(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """
-    A seek re-opens the item that is playing, which is a restart of the session.
+    A seek the running session cannot serve falls back to restarting it.
 
     A realtime source has not captured anything past the play position, so any
-    forward seek lands outside the buffer and comes back here.
+    forward seek lands outside the buffer and comes back here; the session is
+    seeked in place when it can be, and replaced when it cannot.
     """
     backend = _make_backend(tmp_path)
     backend._server = MagicMock()
@@ -2166,6 +2167,13 @@ def _client_of(session: _SoloistSession) -> AsyncMock:
     return cast("AsyncMock", session._client)
 
 
+def _current_of(session: _SoloistSession) -> _ItemAudio:
+    """Return the channel the session is playing, which the caller knows exists."""
+    item = session._current
+    assert item is not None
+    return item
+
+
 def _sink_of(session: _SoloistSession) -> AsyncMock:
     """Return the session's mocked capture sink."""
     return cast("AsyncMock", session._sink)
@@ -2210,3 +2218,179 @@ def _install_fake_binary_manager(monkeypatch: pytest.MonkeyPatch) -> None:
     manager = MagicMock()
     manager.ensure_fresh = AsyncMock(return_value=Path("/nonexistent/soloist"))
     monkeypatch.setattr(soloist_backend, "SoloistBinaryManager", MagicMock(return_value=manager))
+
+
+async def test_seeking_the_playing_item_keeps_the_session(tmp_path: Path) -> None:
+    """The engine is moved where it stands rather than the session being respawned."""
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    playing.claim()
+    playing.duration_ms = 260_000
+    playing.playing_seen = True
+    playing.observe_position(30_000)
+    # the pre-seek audio nobody may hear again
+    playing.write(b"\x01" * 32)
+
+    async def _engine_seeks(position_ms: int, **_kwargs: Any) -> None:
+        _current_of(session).observe_position(position_ms)
+
+    _client_of(session).seek.side_effect = _engine_seeks
+    item = await session.seek_current(TRACK_A, 120_000)
+
+    assert item is not playing
+    assert session.current is item
+    assert item.claimed
+    # what the track is stays with it; where it was does not
+    assert item.duration_ms == 260_000
+    assert item.playing_seen
+    assert item.started_at_ms == 120_000
+    assert not item._chunks
+    _client_of(session).seek.assert_awaited_once_with(120_000, await_result=True)
+
+
+async def test_a_seek_of_the_playing_item_is_sent_only_once(tmp_path: Path) -> None:
+    """A landed seek is never repeated: a repeat restarts the item, audibly."""
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    playing.observe_position(30_000)
+
+    async def _engine_seeks(position_ms: int, **_kwargs: Any) -> None:
+        _current_of(session).observe_position(position_ms)
+
+    _client_of(session).seek.side_effect = _engine_seeks
+    await session.seek_current(TRACK_A, 120_000)
+    assert _client_of(session).seek.await_count == 1
+
+
+async def test_seeking_back_is_not_confirmed_by_the_position_seeked_away_from(
+    tmp_path: Path,
+) -> None:
+    """A report still describing the pre-seek position cannot land a backward seek."""
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    playing.duration_ms = 260_000
+    playing.observe_position(200_000)
+
+    async def _engine_seeks(position_ms: int, **_kwargs: Any) -> None:
+        item = _current_of(session)
+        # a report from before the seek is still in flight; it sits above the
+        # target's tolerance window and must not pass for the landing
+        item.observe_position(200_000)
+        assert not item.seek_confirmed.is_set()
+        item.observe_position(position_ms)
+        item.observe_position(position_ms + 2)
+
+    _client_of(session).seek.side_effect = _engine_seeks
+    item = await session.seek_current(TRACK_A, 60_000)
+    assert item.started_at_ms == 60_002
+
+
+async def test_audio_in_flight_across_an_in_place_seek_is_dropped(tmp_path: Path) -> None:
+    """Only audio from past the seek reaches the fresh channel."""
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    playing.observe_position(30_000)
+
+    async def _engine_seeks(position_ms: int, **_kwargs: Any) -> None:
+        # still rendering the position being left behind
+        session._write_if_wanted(b"\x01" * 32)
+        _current_of(session).observe_position(position_ms)
+
+    _client_of(session).seek.side_effect = _engine_seeks
+    with _capture_holding(session, fifo_bytes=2 * _FRAME_BYTES, reader_bytes=_FRAME_BYTES):
+        item = await session.seek_current(TRACK_A, 120_000)
+    # nothing rendered while the engine was being moved reached the channel
+    assert not item._chunks
+    # and what the pipeline still held at the confirmation is dropped after it
+    assert session._stale_budget == 3 * _FRAME_BYTES
+    session._write_if_wanted(b"\x02" * (3 * _FRAME_BYTES))
+    session._write_if_wanted(b"\x03" * 16)
+    assert b"".join(item._chunks) == b"\x03" * 16
+
+
+async def test_the_sink_is_suspended_while_a_seek_is_in_flight(tmp_path: Path) -> None:
+    """No pre-seek audio enters the capture while the engine is being moved."""
+    session = _make_session(tmp_path)
+    session._demand_started = True
+    session._engine_playing = True
+    session._sink_running = True
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    playing.observe_position(30_000)
+    suspended_during_seek = False
+
+    async def _engine_seeks(position_ms: int, **_kwargs: Any) -> None:
+        nonlocal suspended_during_seek
+        suspended_during_seek = not session._sink_running
+        _current_of(session).observe_position(position_ms)
+
+    _client_of(session).seek.side_effect = _engine_seeks
+    await session.seek_current(TRACK_A, 120_000)
+    assert suspended_during_seek
+    _sink_of(session).suspend.assert_awaited()
+
+
+async def test_a_seek_the_engine_never_confirms_fails_the_item(tmp_path: Path) -> None:
+    """An unconfirmed seek is reported rather than served from the wrong position."""
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    playing.observe_position(30_000)
+    with (
+        patch.object(soloist_backend, "_SEEK_CONFIRM_TIMEOUT_S", 0.01),
+        pytest.raises(AudioError, match="did not confirm"),
+    ):
+        await session.seek_current(TRACK_A, 120_000)
+
+
+async def test_a_refused_seek_command_reports_soloist(tmp_path: Path) -> None:
+    """A rejected seek names the engine, so the caller can fall back."""
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    _client_of(session).seek.side_effect = SoloistError("nope")
+    with pytest.raises(AudioError, match="would not seek"):
+        await session.seek_current(TRACK_A, 120_000)
+
+
+async def test_seeking_an_item_the_engine_is_not_on_is_refused(tmp_path: Path) -> None:
+    """Only the item the session is actually playing can be seeked in place."""
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    with pytest.raises(AudioError, match="is not playing"):
+        await session.seek_current(TRACK_B, 120_000)
+
+
+async def test_a_seek_of_the_playing_item_is_served_by_the_running_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The session is seeked where it stands instead of being replaced."""
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _make_session(tmp_path)
+    backend._session = session
+    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item.started.set()
+    # its own stream is still attached when the seek re-opens it
+    item.claim()
+    item.observe_position(30_000)
+    stopped = AsyncMock()
+    monkeypatch.setattr(session, "stop", stopped)
+
+    async def _engine_seeks(position_ms: int, **_kwargs: Any) -> None:
+        _current_of(session).observe_position(position_ms)
+
+    _client_of(session).seek.side_effect = _engine_seeks
+    got_session, got_item = await backend._acquire(TRACK_A, 90, "player1")
+
+    assert got_session is session
+    assert got_item is not item
+    assert got_item.claimed
+    stopped.assert_not_awaited()
+    _client_of(session).seek.assert_awaited_once_with(90_000, await_result=True)

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -2245,22 +2245,35 @@ async def test_seeking_the_playing_item_keeps_the_session(tmp_path: Path) -> Non
     assert item.duration_ms == 260_000
     assert item.playing_seen
     assert item.started_at_ms == 120_000
-    assert not item._chunks
+    # the outgoing channel is closed, which is what ends the stream reading it
+    assert playing._closed
     _client_of(session).seek.assert_awaited_once_with(120_000, await_result=True)
 
 
 async def test_a_seek_of_the_playing_item_is_sent_only_once(tmp_path: Path) -> None:
-    """A landed seek is never repeated: a repeat restarts the item, audibly."""
+    """
+    A landed seek is never repeated: a repeat restarts the item, audibly.
+
+    The engine answers late on purpose, so a re-send loop around the wait would
+    have fired several times over before the confirmation arrives.
+    """
     session = _make_session(tmp_path)
     playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
     playing.started.set()
     playing.observe_position(30_000)
+    pending: list[asyncio.Task[None]] = []
 
     async def _engine_seeks(position_ms: int, **_kwargs: Any) -> None:
-        _current_of(session).observe_position(position_ms)
+        async def _confirm_late() -> None:
+            await asyncio.sleep(0.05)
+            _current_of(session).observe_position(position_ms)
+
+        pending.append(asyncio.create_task(_confirm_late()))
 
     _client_of(session).seek.side_effect = _engine_seeks
-    await session.seek_current(TRACK_A, 120_000)
+    with patch.object(soloist_backend, "_SEEK_RETRY_INTERVAL_S", 0.01):
+        await session.seek_current(TRACK_A, 120_000)
+    await asyncio.gather(*pending)
     assert _client_of(session).seek.await_count == 1
 
 
@@ -2394,3 +2407,122 @@ async def test_a_seek_of_the_playing_item_is_served_by_the_running_session(
     assert got_item.claimed
     stopped.assert_not_awaited()
     _client_of(session).seek.assert_awaited_once_with(90_000, await_result=True)
+
+
+async def test_a_cancelled_seek_does_not_leave_the_session_wedged(tmp_path: Path) -> None:
+    """
+    A superseded seek ends the session instead of holding it claimed for good.
+
+    A second seek cancels the stream the first one is being made for, and the
+    channel it had already claimed would otherwise keep the session in use:
+    unable to expire, and refusing every later item as busy.
+    """
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    playing.observe_position(30_000)
+    seeking = asyncio.create_task(session.seek_current(TRACK_A, 120_000))
+    # let it get as far as waiting for the engine to confirm
+    while not _client_of(session).seek.await_count:
+        await asyncio.sleep(0)
+    seeking.cancel()
+    with suppress(asyncio.CancelledError):
+        await seeking
+    assert not session.usable
+    assert not session._seeking
+
+
+async def test_a_seek_cancelled_before_the_channel_is_swapped_keeps_the_session(
+    tmp_path: Path,
+) -> None:
+    """Nothing has been given up yet while the sink is still being held."""
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    held = asyncio.Event()
+
+    async def _slow_suspend(**_kwargs: Any) -> None:
+        held.set()
+        await asyncio.sleep(60)
+
+    with patch.object(session, "_apply_sink_state", _slow_suspend):
+        seeking = asyncio.create_task(session.seek_current(TRACK_A, 120_000))
+        await held.wait()
+        seeking.cancel()
+        with suppress(asyncio.CancelledError):
+            await seeking
+    # the session is untouched and, crucially, not left dropping every chunk
+    assert session.usable
+    assert not session._seeking
+    assert session.current is playing
+
+
+async def test_a_seek_is_refused_once_the_engine_has_moved_on(tmp_path: Path) -> None:
+    """The item seeked must still be the one the engine is on when the sink settles."""
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    follower = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
+
+    async def _boundary_lands(**_kwargs: Any) -> None:
+        session._current = follower
+
+    with (
+        patch.object(session, "_apply_sink_state", _boundary_lands),
+        pytest.raises(AudioError, match="moved on from"),
+    ):
+        await session.seek_current(TRACK_A, 120_000)
+    # the follower the engine actually reached keeps its own channel
+    assert session.current is follower
+    assert session._items[TRACK_A] is playing
+
+
+async def test_a_seek_that_fails_part_way_restarts_the_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A seek the engine refuses after the channel was swapped still gets its audio."""
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _make_session(tmp_path)
+    backend._session = session
+    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item.started.set()
+    item.claim()
+    _client_of(session).seek.side_effect = SoloistError("refused")
+    stopped = AsyncMock()
+    monkeypatch.setattr(session, "stop", stopped)
+    _install_fake_binary_manager(monkeypatch)
+    monkeypatch.setattr(
+        soloist_backend._SoloistSession, "start", AsyncMock(side_effect=AudioError("spawn"))
+    )
+    with pytest.raises(AudioError, match="spawn"):
+        await backend._acquire(TRACK_A, 90, "player1")
+    stopped.assert_awaited_once()
+
+
+async def test_a_seek_refused_because_the_app_took_over_does_not_respawn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A replacement would claim the Connect device back off the Spotify app."""
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _make_session(tmp_path)
+    backend._session = session
+    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item.started.set()
+    item.claim()
+    item.observe_position(30_000)
+    started = AsyncMock()
+    monkeypatch.setattr(soloist_backend._SoloistSession, "start", started)
+
+    async def _app_takes_over(_position_ms: int, **_kwargs: Any) -> None:
+        # the user moved playback elsewhere from their Spotify app while the
+        # seek was in flight; the wait is released by the session ending
+        session._end_on_app_control(SoloistAppControl.TOOK_OVER)
+
+    _client_of(session).seek.side_effect = _app_takes_over
+    with pytest.raises(SoloistAppControlError):
+        await backend._acquire(TRACK_A, 120, "player1")
+    started.assert_not_awaited()

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -2679,3 +2679,50 @@ async def test_a_short_forward_seek_still_confirms(tmp_path: Path) -> None:
     item = await session.seek_current(TRACK_A, 50_500)
     assert item.seek_confirmed.is_set()
     assert item.started_at_ms == 50_500
+
+
+async def test_a_seek_does_not_arm_the_last_items_drain(tmp_path: Path) -> None:
+    """
+    The channel opened for a seek has no position yet, which is not an ended item.
+
+    Holding the sink can make the engine report a state that is not playing, and
+    the run's last item would then be drained out from under the seek.
+    """
+    session = _make_session(tmp_path)
+    session._demand_started = True
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    playing.duration_ms = 260_000
+    playing.observe_position(30_000)
+    armed: list[bool] = []
+
+    async def _engine_seeks(position_ms: int, **_kwargs: Any) -> None:
+        # nothing to judge the fresh channel by yet, and no follower queued
+        await session._handle_playback_state(
+            SoloistPlaybackState(status="buffering", item=None, position=None)
+        )
+        armed.append(_current_of(session).draining)
+        _current_of(session).observe_position(position_ms)
+
+    _client_of(session).seek.side_effect = _engine_seeks
+    item = await session.seek_current(TRACK_A, 120_000)
+    assert armed == [False]
+    assert not item.draining
+
+
+async def test_the_item_a_finished_run_stopped_on_is_not_seeked_in_place(
+    tmp_path: Path,
+) -> None:
+    """
+    A matching uri is not proof the engine is still playing it.
+
+    The channel stays current through the idle grace after the run ended, and a
+    seek would wait out its confirmation on an engine that has stopped.
+    """
+    session = _make_session(tmp_path)
+    ended = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    ended.started.set()
+    ended.close()
+    with pytest.raises(AudioError, match="is not playing"):
+        await session.seek_current(TRACK_A, 0)
+    _client_of(session).seek.assert_not_awaited()

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -2529,3 +2529,91 @@ async def test_a_seek_refused_because_the_app_took_over_does_not_respawn(
     with pytest.raises(SoloistAppControlError):
         await backend._acquire(TRACK_A, 120, "player1")
     started.assert_not_awaited()
+
+
+async def test_a_seek_is_abandoned_when_the_app_took_over_during_the_suspend(
+    tmp_path: Path,
+) -> None:
+    """Nothing is seeked on a session the Spotify app has already taken over."""
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+
+    async def _app_takes_over(**_kwargs: Any) -> None:
+        session._end_on_app_control(SoloistAppControl.TOOK_OVER)
+
+    with (
+        patch.object(session, "_apply_sink_state", _app_takes_over),
+        pytest.raises(SoloistAppControlError),
+    ):
+        await session.seek_current(TRACK_A, 120_000)
+    # the engine was never asked to move
+    _client_of(session).seek.assert_not_awaited()
+
+
+async def test_a_cancelled_sink_transition_is_re_issued(tmp_path: Path) -> None:
+    """
+    A suspend that may or may not have landed is never taken as done.
+
+    A sink that did suspend would otherwise still read as running, and the
+    resume that should follow would be skipped as a no-op: silence for good.
+    """
+    session = _make_session(tmp_path)
+    session._demand_started = True
+    session._engine_playing = True
+    session._sink_running = True
+    session._seeking = True
+
+    async def _cancelled_suspend() -> None:
+        raise asyncio.CancelledError
+
+    _sink_of(session).suspend.side_effect = _cancelled_suspend
+    with suppress(asyncio.CancelledError):
+        await session._apply_sink_state()
+    # the engine plays on and the sink is wanted running again
+    session._seeking = False
+    await session._apply_sink_state()
+    _sink_of(session).resume.assert_awaited_once()
+
+
+async def test_a_seek_cancelled_at_the_final_resume_does_not_leave_the_session_usable(
+    tmp_path: Path,
+) -> None:
+    """The channel is claimed by then, so an abandoned seek must still end the session."""
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    playing.observe_position(30_000)
+    calls = 0
+    real_apply = session._apply_sink_state
+
+    async def _cancel_on_the_way_out(**kwargs: Any) -> None:
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise asyncio.CancelledError
+        await real_apply(**kwargs)
+
+    async def _engine_seeks(position_ms: int, **_kwargs: Any) -> None:
+        _current_of(session).observe_position(position_ms)
+
+    _client_of(session).seek.side_effect = _engine_seeks
+    with (
+        patch.object(session, "_apply_sink_state", _cancel_on_the_way_out),
+        suppress(asyncio.CancelledError),
+    ):
+        await session.seek_current(TRACK_A, 120_000)
+    assert not session.usable
+
+
+async def test_a_cold_seek_does_not_read_a_failed_session_as_landed(tmp_path: Path) -> None:
+    """The wake-up a fatal failure gives every channel is not a confirmed seek."""
+    session = _make_session(tmp_path)
+    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+
+    async def _engine_dies(_position_ms: int, **_kwargs: Any) -> None:
+        session._fail("the session exited")
+
+    _client_of(session).seek.side_effect = _engine_dies
+    with pytest.raises(AudioError, match="the session exited"):
+        await session._cold_seek(_client_of(session), item, 60_000)

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -2299,6 +2299,9 @@ async def test_seeking_back_is_not_confirmed_by_the_position_seeked_away_from(
     _client_of(session).seek.side_effect = _engine_seeks
     item = await session.seek_current(TRACK_A, 60_000)
     assert item.started_at_ms == 60_002
+    # and the pre-seek report is not left standing in for progress this item
+    # never made, which at_own_end and the completeness check would believe
+    assert item.last_position_ms == 60_002
 
 
 async def test_audio_in_flight_across_an_in_place_seek_is_dropped(tmp_path: Path) -> None:

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -2617,3 +2617,40 @@ async def test_a_cold_seek_does_not_read_a_failed_session_as_landed(tmp_path: Pa
     _client_of(session).seek.side_effect = _engine_dies
     with pytest.raises(AudioError, match="the session exited"):
         await session._cold_seek(_client_of(session), item, 60_000)
+
+
+async def test_seeking_the_playing_item_back_to_its_start_keeps_the_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A seek to zero is a seek: reachable once an earlier one moved the buffer.
+
+    The buffer only hands a position to the provider when it cannot serve it
+    itself, so seeking back before an earlier seek's target arrives here with a
+    target of zero.
+    """
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _make_session(tmp_path)
+    backend._session = session
+    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item.started.set()
+    item.claim()
+    item.observe_position(200_000)
+    stopped = AsyncMock()
+    monkeypatch.setattr(session, "stop", stopped)
+
+    async def _engine_seeks(position_ms: int, **_kwargs: Any) -> None:
+        current = _current_of(session)
+        current.observe_position(position_ms)
+        current.observe_position(position_ms + 2)
+
+    _client_of(session).seek.side_effect = _engine_seeks
+    got_session, got_item = await backend._acquire(TRACK_A, 0, "player1")
+
+    assert got_session is session
+    assert got_item is not item
+    stopped.assert_not_awaited()
+    _client_of(session).seek.assert_awaited_once_with(0, await_result=True)
+    assert got_item.started_at_ms == 2

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -2654,3 +2654,28 @@ async def test_seeking_the_playing_item_back_to_its_start_keeps_the_session(
     stopped.assert_not_awaited()
     _client_of(session).seek.assert_awaited_once_with(0, await_result=True)
     assert got_item.started_at_ms == 2
+
+
+async def test_a_short_forward_seek_still_confirms(tmp_path: Path) -> None:
+    """
+    A seek only a little past where the engine is must not wait itself out.
+
+    Reachable because the engine runs ahead of what has been delivered - up to
+    the retained cushion - so a target the buffer will not serve can still be
+    inside the tolerance window of the engine's own position. Demanding the
+    engine drop below that mark would never be satisfied by a seek forward.
+    """
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    playing.duration_ms = 260_000
+    # the engine is at 49s while only ~30s has been delivered
+    playing.observe_position(49_000)
+
+    async def _engine_seeks(position_ms: int, **_kwargs: Any) -> None:
+        _current_of(session).observe_position(position_ms)
+
+    _client_of(session).seek.side_effect = _engine_seeks
+    item = await session.seek_current(TRACK_A, 50_500)
+    assert item.seek_confirmed.is_set()
+    assert item.started_at_ms == 50_500


### PR DESCRIPTION
# What does this implement/fix?

Seeking a Spotify track played through the Soloist backend restarted the whole
session: the daemon was killed and a fresh one had to spawn, log in, claim the
Connect device back and reload the track. Now the session that is already
playing the track is simply seeked where it stands.

Measured on the test rig, same track and same seek (26s -> 120s): **2.70s ->
1.53s** from the seek to audio being ready, and the Spotify Connect device is no
longer taken back off whatever else the account was using.

Only seeks that actually reach the provider change: the buffer still serves any
position it already holds, so this affects a seek forward past what has been
captured, or back beyond an earlier seek. Playback that is merely resumed still
starts a fresh session, since the idle session is already gone by then.

- Seek the running session in place instead of respawning it, for the item it is
  already playing
- Give the item a fresh audio channel so nothing from before the seek is served,
  and drop what the capture pipeline still holds when the engine moves
- Hold the capture sink while the seek is in flight
- Send the seek once: a repeat of one the engine already took restarts the track
  audibly
- Fall back to restarting the session when it cannot take the seek

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
