### PR TITLE
Keep the home page in step when played state changes

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -48,7 +48,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 59
+API_SCHEMA_VERSION: Final[int] = 60
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -52,6 +52,7 @@ from music_assistant_models.media_items import (
     Track,
 )
 from music_assistant_models.media_items.media_item import MediaCollection
+from music_assistant_models.playlog_update import PlaylogUpdate
 
 from music_assistant.constants import (
     CONF_ENTRY_LIBRARY_SYNC_BACK,
@@ -1569,6 +1570,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             for user_id in user_ids:
                 params["userid"] = user_id
                 await self._upsert_playlog(params)
+            self._signal_playlog_updated(
+                reference, fully_played=fully_played, seconds_played=seconds_played or 0
+            )
 
         # Set seconds_played in accordance with fully_played, if the media_item has
         # a duration, before it is forwarded to music_providers
@@ -1695,6 +1699,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             if row := await self.database.get_row(DB_TABLE_PLAYLOG, params):
                 counted_play_removed = counted_play_removed or bool(row["fully_played"])
             await self.database.delete(DB_TABLE_PLAYLOG, params)
+        self._signal_playlog_updated(reference, fully_played=False, seconds_played=0)
 
         # forward to provider(s) to sync resume state (e.g. for audiobooks)
         for prov_mapping in media_item.provider_mappings:
@@ -3032,6 +3037,31 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             entry,
         )
 
+    def _signal_playlog_updated(
+        self,
+        item: MediaItemType | ItemMapping,
+        *,
+        fully_played: bool,
+        seconds_played: int,
+    ) -> None:
+        """
+        Signal that the playlog entry of the given item changed.
+
+        :param item: The item as it is keyed in the playlog.
+        :param fully_played: The new fully played state of the item.
+        :param seconds_played: The new resume position of the item.
+        """
+        self.mass.signal_event(
+            EventType.PLAYLOG_UPDATED,
+            object_id=item.uri,
+            data=PlaylogUpdate(
+                uri=item.uri,
+                media_type=item.media_type,
+                fully_played=fully_played,
+                seconds_played=seconds_played,
+            ),
+        )
+
     async def _credit_artist_plays(
         self,
         artists: Iterable[Artist | ItemMapping],
@@ -3071,6 +3101,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             for user_id in user_ids:
                 playlog_entry["userid"] = user_id
                 await self._upsert_playlog(playlog_entry)
+            self._signal_playlog_updated(db_artist, fully_played=True, seconds_played=0)
 
     async def _credit_podcast_play(
         self,
@@ -3105,6 +3136,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         for user_id in user_ids:
             playlog_entry["userid"] = user_id
             await self._upsert_playlog(playlog_entry)
+        self._signal_playlog_updated(credited_podcast, fully_played=True, seconds_played=0)
 
     async def _get_item_by_name(
         self,

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -3051,7 +3051,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param fully_played: The new fully played state of the item.
         :param seconds_played: The new resume position of the item.
         """
-        assert item.uri is not None  # auto-generated in __post_init__
+        assert item.uri is not None
         self.mass.signal_event(
             EventType.PLAYLOG_UPDATED,
             object_id=item.uri,

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -3051,6 +3051,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param fully_played: The new fully played state of the item.
         :param seconds_played: The new resume position of the item.
         """
+        assert item.uri is not None  # auto-generated in __post_init__
         self.mass.signal_event(
             EventType.PLAYLOG_UPDATED,
             object_id=item.uri,

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -1571,7 +1571,10 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 params["userid"] = user_id
                 await self._upsert_playlog(params)
             self._signal_playlog_updated(
-                reference, fully_played=fully_played, seconds_played=seconds_played or 0
+                reference,
+                fully_played=fully_played,
+                seconds_played=seconds_played or 0,
+                userid=user.user_id if user else None,
             )
 
         # Set seconds_played in accordance with fully_played, if the media_item has
@@ -1699,7 +1702,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             if row := await self.database.get_row(DB_TABLE_PLAYLOG, params):
                 counted_play_removed = counted_play_removed or bool(row["fully_played"])
             await self.database.delete(DB_TABLE_PLAYLOG, params)
-        self._signal_playlog_updated(reference, fully_played=False, seconds_played=0)
+        self._signal_playlog_updated(
+            reference, fully_played=False, seconds_played=0, userid=user.user_id if user else None
+        )
 
         # forward to provider(s) to sync resume state (e.g. for audiobooks)
         for prov_mapping in media_item.provider_mappings:
@@ -3043,6 +3048,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         *,
         fully_played: bool,
         seconds_played: int,
+        userid: str | None,
     ) -> None:
         """
         Signal that the playlog entry of the given item changed.
@@ -3050,6 +3056,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param item: The item as it is keyed in the playlog.
         :param fully_played: The new fully played state of the item.
         :param seconds_played: The new resume position of the item.
+        :param userid: The user the change applies to, or None for all users.
         """
         assert item.uri is not None
         self.mass.signal_event(
@@ -3060,6 +3067,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 media_type=item.media_type,
                 fully_played=fully_played,
                 seconds_played=seconds_played,
+                userid=userid,
             ),
         )
 
@@ -3102,7 +3110,12 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             for user_id in user_ids:
                 playlog_entry["userid"] = user_id
                 await self._upsert_playlog(playlog_entry)
-            self._signal_playlog_updated(db_artist, fully_played=True, seconds_played=0)
+            self._signal_playlog_updated(
+                db_artist,
+                fully_played=True,
+                seconds_played=0,
+                userid=user_ids[0] if len(user_ids) == 1 else None,
+            )
 
     async def _credit_podcast_play(
         self,
@@ -3137,7 +3150,12 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         for user_id in user_ids:
             playlog_entry["userid"] = user_id
             await self._upsert_playlog(playlog_entry)
-        self._signal_playlog_updated(credited_podcast, fully_played=True, seconds_played=0)
+        self._signal_playlog_updated(
+            credited_podcast,
+            fully_played=True,
+            seconds_played=0,
+            userid=user_ids[0] if len(user_ids) == 1 else None,
+        )
 
     async def _get_item_by_name(
         self,

--- a/tests/controllers/music/test_playlog_updated_event.py
+++ b/tests/controllers/music/test_playlog_updated_event.py
@@ -40,18 +40,6 @@ def _provider_mapping(provider: str = "test_prov") -> set[ProviderMapping]:
     }
 
 
-def _library_mapping() -> set[ProviderMapping]:
-    """Create a single library provider mapping with a unique item id."""
-    return {
-        ProviderMapping(
-            item_id=uuid4().hex,
-            provider_domain="library",
-            provider_instance="library",
-            in_library=True,
-        )
-    }
-
-
 def _collect_events(mass: MusicAssistant) -> list[MassEvent]:
     """Return a list that collects the playlog updated events as they are signalled."""
     events: list[MassEvent] = []
@@ -88,6 +76,7 @@ async def test_mark_played_signals_playlog_updated(mass: MusicAssistant) -> None
         media_type=MediaType.TRACK,
         fully_played=True,
         seconds_played=0,
+        userid=user.user_id,
     )
 
 
@@ -121,6 +110,7 @@ async def test_progress_report_signals_resume_position(mass: MusicAssistant) -> 
             media_type=MediaType.PODCAST_EPISODE,
             fully_played=False,
             seconds_played=120,
+            userid=user.user_id,
         )
     ]
 
@@ -174,8 +164,27 @@ async def test_mark_unplayed_signals_playlog_updated(mass: MusicAssistant) -> No
             media_type=MediaType.PODCAST_EPISODE,
             fully_played=False,
             seconds_played=0,
+            userid=user.user_id,
         )
     ]
+
+
+async def test_mark_played_without_user_applies_to_all_users(mass: MusicAssistant) -> None:
+    """Without a determinable user the playlog changes for everyone, so userid is None."""
+    track = Track(
+        item_id="track-003",
+        provider="test_prov",
+        name="Shared Track",
+        provider_mappings=_provider_mapping(),
+        duration=200,
+    )
+    events = _collect_events(mass)
+
+    await mass.music.mark_item_played(track, fully_played=True)
+
+    updates = await _updates(events)
+    assert len(updates) == 1
+    assert updates[0].userid is None
 
 
 async def test_credited_artist_signals_playlog_updated(mass: MusicAssistant) -> None:
@@ -183,7 +192,7 @@ async def test_credited_artist_signals_playlog_updated(mass: MusicAssistant) -> 
     user = await mass.webserver.auth.create_user("playlogartist")
     artist = await mass.music.artists.add_item_to_library(
         Artist(
-            item_id="0", provider="library", name="Credited", provider_mappings=_library_mapping()
+            item_id="0", provider="library", name="Credited", provider_mappings=_provider_mapping()
         )
     )
     added = await mass.music.tracks.add_item_to_library(
@@ -191,7 +200,7 @@ async def test_credited_artist_signals_playlog_updated(mass: MusicAssistant) -> 
             item_id="0",
             provider="library",
             name="Credited Track",
-            provider_mappings=_library_mapping(),
+            provider_mappings=_provider_mapping(),
             artists=UniqueList([artist]),
         )
     )
@@ -203,6 +212,7 @@ async def test_credited_artist_signals_playlog_updated(mass: MusicAssistant) -> 
     updates = await _updates(events)
     assert [update.uri for update in updates] == [track.uri, artist.uri]
     assert updates[1].media_type == MediaType.ARTIST
+    assert updates[1].userid == user.user_id
 
 
 async def test_credited_podcast_signals_playlog_updated(mass: MusicAssistant) -> None:

--- a/tests/controllers/music/test_playlog_updated_event.py
+++ b/tests/controllers/music/test_playlog_updated_event.py
@@ -1,0 +1,225 @@
+"""
+Tests for the playlog updated event.
+
+The integration tests use the ``mass`` fixture from ``tests/conftest.py`` which
+creates a full MusicAssistant instance with a real SQLite database in a
+temporary directory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+from music_assistant_models.enums import EventType, MediaType
+from music_assistant_models.event import MassEvent
+from music_assistant_models.media_items import (
+    Artist,
+    Podcast,
+    PodcastEpisode,
+    ProviderMapping,
+    Track,
+)
+from music_assistant_models.playlog_update import PlaylogUpdate
+from music_assistant_models.unique_list import UniqueList
+
+from music_assistant.mass import MusicAssistant
+
+
+def _provider_mapping(provider: str = "test_prov") -> set[ProviderMapping]:
+    """Create a single provider mapping with a unique item id."""
+    return {
+        ProviderMapping(
+            item_id=uuid4().hex,
+            provider_domain=provider,
+            provider_instance=provider,
+        )
+    }
+
+
+def _library_mapping() -> set[ProviderMapping]:
+    """Create a single library provider mapping with a unique item id."""
+    return {
+        ProviderMapping(
+            item_id=uuid4().hex,
+            provider_domain="library",
+            provider_instance="library",
+            in_library=True,
+        )
+    }
+
+
+def _collect_events(mass: MusicAssistant) -> list[MassEvent]:
+    """Return a list that collects the playlog updated events as they are signalled."""
+    events: list[MassEvent] = []
+    mass.subscribe(events.append, EventType.PLAYLOG_UPDATED)
+    return events
+
+
+async def _updates(events: list[MassEvent]) -> list[PlaylogUpdate]:
+    """Let the pending event callbacks run and return the collected payloads."""
+    await asyncio.sleep(0)
+    return [event.data for event in events]
+
+
+async def test_mark_played_signals_playlog_updated(mass: MusicAssistant) -> None:
+    """Marking an item played signals the new playlog state for that item."""
+    user = await mass.webserver.auth.create_user("playloguser")
+    track = Track(
+        item_id="track-001",
+        provider="test_prov",
+        name="Test Track",
+        provider_mappings=_provider_mapping(),
+        duration=200,
+    )
+    events = _collect_events(mass)
+
+    await mass.music.mark_item_played(track, fully_played=True, userid=user.user_id)
+
+    updates = await _updates(events)
+    assert len(updates) == 1
+    assert events[0].object_id == track.uri
+    assert updates[0] == PlaylogUpdate(
+        uri=track.uri,
+        media_type=MediaType.TRACK,
+        fully_played=True,
+        seconds_played=0,
+    )
+
+
+async def test_progress_report_signals_resume_position(mass: MusicAssistant) -> None:
+    """A partial play reports the resume position, so clients can update an in progress row."""
+    user = await mass.webserver.auth.create_user("playlogpartial")
+    episode = PodcastEpisode(
+        item_id="ep-010",
+        provider="test_podcast_prov",
+        name="Episode 10",
+        provider_mappings=_provider_mapping("test_podcast_prov"),
+        position=1,
+        podcast=Podcast(
+            item_id="show-011",
+            provider="test_podcast_prov",
+            name="Progress Show",
+            provider_mappings=_provider_mapping("test_podcast_prov"),
+        ),
+    )
+    events = _collect_events(mass)
+
+    await mass.music.mark_item_played(
+        episode, fully_played=False, seconds_played=120, userid=user.user_id
+    )
+
+    updates = await _updates(events)
+    assert updates == [
+        PlaylogUpdate(
+            uri=episode.uri,
+            media_type=MediaType.PODCAST_EPISODE,
+            fully_played=False,
+            seconds_played=120,
+        )
+    ]
+
+
+async def test_playing_progress_report_signals_nothing(mass: MusicAssistant) -> None:
+    """The frequent progress reports during playback do not touch the playlog, so stay quiet."""
+    user = await mass.webserver.auth.create_user("playlogplaying")
+    track = Track(
+        item_id="track-002",
+        provider="test_prov",
+        name="Playing Track",
+        provider_mappings=_provider_mapping(),
+        duration=200,
+    )
+    events = _collect_events(mass)
+
+    await mass.music.mark_item_played(
+        track, fully_played=False, seconds_played=30, is_playing=True, userid=user.user_id
+    )
+
+    assert await _updates(events) == []
+
+
+async def test_mark_unplayed_signals_playlog_updated(mass: MusicAssistant) -> None:
+    """Marking an item unplayed signals it as neither played nor in progress."""
+    user = await mass.webserver.auth.create_user("playlogunplayed")
+    episode = PodcastEpisode(
+        item_id="ep-011",
+        provider="test_podcast_prov",
+        name="Episode 11",
+        provider_mappings=_provider_mapping("test_podcast_prov"),
+        position=1,
+        podcast=Podcast(
+            item_id="show-012",
+            provider="test_podcast_prov",
+            name="Unplayed Show",
+            provider_mappings=_provider_mapping("test_podcast_prov"),
+        ),
+    )
+    await mass.music.mark_item_played(
+        episode, fully_played=False, seconds_played=120, userid=user.user_id
+    )
+    events = _collect_events(mass)
+
+    await mass.music.mark_item_unplayed(episode, userid=user.user_id)
+
+    assert await _updates(events) == [
+        PlaylogUpdate(
+            uri=episode.uri,
+            media_type=MediaType.PODCAST_EPISODE,
+            fully_played=False,
+            seconds_played=0,
+        )
+    ]
+
+
+async def test_credited_artist_signals_playlog_updated(mass: MusicAssistant) -> None:
+    """An artist credited by a played track gets its own playlog update."""
+    user = await mass.webserver.auth.create_user("playlogartist")
+    artist = await mass.music.artists.add_item_to_library(
+        Artist(
+            item_id="0", provider="library", name="Credited", provider_mappings=_library_mapping()
+        )
+    )
+    added = await mass.music.tracks.add_item_to_library(
+        Track(
+            item_id="0",
+            provider="library",
+            name="Credited Track",
+            provider_mappings=_library_mapping(),
+            artists=UniqueList([artist]),
+        )
+    )
+    track = await mass.music.tracks.get_library_item(added.item_id)
+    events = _collect_events(mass)
+
+    await mass.music.mark_item_played(track, fully_played=True, userid=user.user_id)
+
+    updates = await _updates(events)
+    assert [update.uri for update in updates] == [track.uri, artist.uri]
+    assert updates[1].media_type == MediaType.ARTIST
+
+
+async def test_credited_podcast_signals_playlog_updated(mass: MusicAssistant) -> None:
+    """The parent podcast credited by a played episode gets its own playlog update."""
+    user = await mass.webserver.auth.create_user("playlogpodcast")
+    podcast = Podcast(
+        item_id="show-010",
+        provider="test_podcast_prov",
+        name="Credited Show",
+        provider_mappings=_provider_mapping("test_podcast_prov"),
+    )
+    episode = PodcastEpisode(
+        item_id="ep-012",
+        provider="test_podcast_prov",
+        name="Episode 12",
+        provider_mappings=_provider_mapping("test_podcast_prov"),
+        position=1,
+        podcast=podcast,
+    )
+    events = _collect_events(mass)
+
+    await mass.music.mark_item_played(episode, fully_played=True, userid=user.user_id)
+
+    updates = await _updates(events)
+    assert [update.uri for update in updates] == [episode.uri, podcast.uri]
+    assert updates[1].media_type == MediaType.PODCAST

--- a/tests/controllers/music/test_playlog_updated_event.py
+++ b/tests/controllers/music/test_playlog_updated_event.py
@@ -9,10 +9,10 @@ temporary directory.
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from music_assistant_models.enums import EventType, MediaType
-from music_assistant_models.event import MassEvent
 from music_assistant_models.media_items import (
     Artist,
     Podcast,
@@ -24,6 +24,9 @@ from music_assistant_models.playlog_update import PlaylogUpdate
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.mass import MusicAssistant
+
+if TYPE_CHECKING:
+    from music_assistant_models.event import MassEvent
 
 
 def _provider_mapping(provider: str = "test_prov") -> set[ProviderMapping]:
@@ -72,6 +75,7 @@ async def test_mark_played_signals_playlog_updated(mass: MusicAssistant) -> None
         provider_mappings=_provider_mapping(),
         duration=200,
     )
+    assert track.uri is not None
     events = _collect_events(mass)
 
     await mass.music.mark_item_played(track, fully_played=True, userid=user.user_id)
@@ -103,6 +107,7 @@ async def test_progress_report_signals_resume_position(mass: MusicAssistant) -> 
             provider_mappings=_provider_mapping("test_podcast_prov"),
         ),
     )
+    assert episode.uri is not None
     events = _collect_events(mass)
 
     await mass.music.mark_item_played(
@@ -155,6 +160,7 @@ async def test_mark_unplayed_signals_playlog_updated(mass: MusicAssistant) -> No
             provider_mappings=_provider_mapping("test_podcast_prov"),
         ),
     )
+    assert episode.uri is not None
     await mass.music.mark_item_played(
         episode, fully_played=False, seconds_played=120, userid=user.user_id
     )


### PR DESCRIPTION
# What does this implement/fix?

The home page has an "In progress" row built from the playlog. Nothing told clients when that log changed, so a card could keep sitting in the row after the item was finished, marked played, or synced back from another app, until the page was reloaded.

The server now sends an event whenever an item's playlog entry changes, so a client can refresh just the rows that are built on played state.

- new event sent when an item is marked played or reported as played, when it is marked unplayed, and when an artist or podcast is credited by a played track or episode
- the frequent progress reports while something is playing write nothing to the playlog, so they stay quiet
- the payload carries the item uri, media type, fully played flag and seconds played
- tests for each of the above

Note this needs the models change to be released first, so mypy and CI will fail here until the pin is bumped. Frontend change follows.

**Related issue (if applicable):**

- models change music-assistant/models#381
- follow up to music-assistant/frontend#2624
- related discussion https://github.com/orgs/music-assistant/discussions/6158

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes. (mypy fails until the models release lands and the pin is bumped)
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
