### PR TITLE
Stop leaving a subprocess running when closing it is cancelled

### DIFF
--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -291,7 +291,7 @@ class AsyncProcess:
 
         An enclosing timeout is not a reliable bound on this call: the cleanup may
         swallow the cancellation and run to completion, and a cancellation that does
-        land is only re-raised once the process has been reaped.
+        land is only re-raised after the terminate/SIGKILL escalation has run.
         """
         if self._close_called and self.returncode is not None:
             # Already closed and reaped, so there is nothing left to signal or
@@ -324,7 +324,7 @@ class AsyncProcess:
         with suppress(TimeoutError, asyncio.CancelledError):
             await asyncio.wait_for(self._stdout_lock.acquire(), 5)
         if self.proc.stdout and not self.proc.stdout.at_eof():
-            cancelled = await self._drain_pipe(self.proc.stdout) or cancelled
+            cancelled = await self._drain_pipe(self.proc.stdout, cancelled)
         # if we have a stderr task active, allow it to finish
         if self._stderr_reader_task:
             with suppress(TimeoutError, asyncio.CancelledError):
@@ -333,7 +333,7 @@ class AsyncProcess:
             with suppress(TimeoutError, asyncio.CancelledError):
                 await asyncio.wait_for(self._stderr_lock.acquire(), 5)
             # drain stderr
-            cancelled = await self._drain_pipe(self.proc.stderr) or cancelled
+            cancelled = await self._drain_pipe(self.proc.stderr, cancelled)
 
         # make sure the process is really cleaned up.
         # especially with pipes this can cause deadlocks if not properly guarded
@@ -349,7 +349,7 @@ class AsyncProcess:
                     cancelled = cancelled or err
                 terminate_attempts += 1
                 self.logger.debug(
-                    "Process %s with PID %s did not stop in time (attempt %d). Sending SIGKILL...",
+                    "Process %s with PID %s is still running (attempt %d). Sending SIGKILL...",
                     self.name,
                     pid,
                     terminate_attempts,
@@ -493,20 +493,23 @@ class AsyncProcess:
             if line := raw.decode("utf-8", errors="ignore").strip():
                 yield line
 
-    async def _drain_pipe(self, stream: asyncio.StreamReader) -> asyncio.CancelledError | None:
+    async def _drain_pipe(
+        self, stream: asyncio.StreamReader, cancelled: asyncio.CancelledError | None
+    ) -> asyncio.CancelledError | None:
         """
         Read whatever is left in one of the process' pipes, bounded by the drain timeout.
 
         :param stream: The stream to drain.
-        :return: The cancellation that landed on the read, for the caller to re-raise
-            once the process is reaped, or None when none did.
+        :param cancelled: A cancellation the caller already recorded, if any.
+        :return: The first cancellation seen, so the caller can re-raise it once the
+            process is reaped, or None when none has landed yet.
         """
         try:
             with suppress(Exception):
                 await asyncio.wait_for(stream.read(-1), PIPE_DRAIN_TIMEOUT)
         except asyncio.CancelledError as err:
-            return err
-        return None
+            return cancelled or err
+        return cancelled
 
     async def _drain_stdin_locked(self, timeout: float) -> bool:
         """

--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -291,7 +291,7 @@ class AsyncProcess:
 
         An enclosing timeout is not a reliable bound on this call: the cleanup may
         swallow the cancellation and run to completion, and a cancellation that does
-        land leaves the process unreaped.
+        land is only re-raised once the process has been reaped.
         """
         if self._close_called and self.returncode is not None:
             # Already closed and reaped, so there is nothing left to signal or
@@ -316,12 +316,15 @@ class AsyncProcess:
             with suppress(ProcessLookupError, OSError):
                 self.proc.send_signal(SIGINT)
 
+        # Cancellation landing on the drains or the reap below must not walk away from a
+        # child that is still running, so it is held here and re-raised at the very end.
+        cancelled: asyncio.CancelledError | None = None
+
         # ensure we have no more readers active and stdout is drained
         with suppress(TimeoutError, asyncio.CancelledError):
             await asyncio.wait_for(self._stdout_lock.acquire(), 5)
         if self.proc.stdout and not self.proc.stdout.at_eof():
-            with suppress(Exception):
-                await asyncio.wait_for(self.proc.stdout.read(-1), PIPE_DRAIN_TIMEOUT)
+            cancelled = await self._drain_pipe(self.proc.stdout) or cancelled
         # if we have a stderr task active, allow it to finish
         if self._stderr_reader_task:
             with suppress(TimeoutError, asyncio.CancelledError):
@@ -330,8 +333,7 @@ class AsyncProcess:
             with suppress(TimeoutError, asyncio.CancelledError):
                 await asyncio.wait_for(self._stderr_lock.acquire(), 5)
             # drain stderr
-            with suppress(Exception):
-                await asyncio.wait_for(self.proc.stderr.read(-1), PIPE_DRAIN_TIMEOUT)
+            cancelled = await self._drain_pipe(self.proc.stderr) or cancelled
 
         # make sure the process is really cleaned up.
         # especially with pipes this can cause deadlocks if not properly guarded
@@ -342,7 +344,9 @@ class AsyncProcess:
             try:
                 # use communicate to flush all pipe buffers
                 await asyncio.wait_for(self.proc.communicate(), 2)
-            except TimeoutError:
+            except (TimeoutError, asyncio.CancelledError) as err:
+                if isinstance(err, asyncio.CancelledError):
+                    cancelled = cancelled or err
                 terminate_attempts += 1
                 self.logger.debug(
                     "Process %s with PID %s did not stop in time (attempt %d). Sending SIGKILL...",
@@ -369,6 +373,8 @@ class AsyncProcess:
             self.proc.pid,
             self.returncode,
         )
+        if cancelled is not None:
+            raise cancelled
 
     async def kill(self) -> None:
         """
@@ -486,6 +492,21 @@ class AsyncProcess:
                 break
             if line := raw.decode("utf-8", errors="ignore").strip():
                 yield line
+
+    async def _drain_pipe(self, stream: asyncio.StreamReader) -> asyncio.CancelledError | None:
+        """
+        Read whatever is left in one of the process' pipes, bounded by the drain timeout.
+
+        :param stream: The stream to drain.
+        :return: The cancellation that landed on the read, for the caller to re-raise
+            once the process is reaped, or None when none did.
+        """
+        try:
+            with suppress(Exception):
+                await asyncio.wait_for(stream.read(-1), PIPE_DRAIN_TIMEOUT)
+        except asyncio.CancelledError as err:
+            return err
+        return None
 
     async def _drain_stdin_locked(self, timeout: float) -> bool:
         """

--- a/tests/helpers/test_process.py
+++ b/tests/helpers/test_process.py
@@ -310,3 +310,28 @@ async def test_close_reaps_a_child_when_cancelled_mid_drain() -> None:
             await proc.close()
 
     assert proc.returncode is not None
+
+
+@pytest.mark.asyncio
+async def test_close_reaps_a_child_when_cancelled_while_waiting_for_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Cancellation landing while waiting for the process to exit must still reap it.
+
+    That wait is where close() spends most of its time, so it is the likeliest place
+    for a cancellation to land, and giving up there skips the SIGKILL escalation.
+    """
+    # short enough that the drain is over well before the cancellation below
+    monkeypatch.setattr(process_module, "PIPE_DRAIN_TIMEOUT", 0.2)
+    proc = AsyncProcess(
+        [sys.executable, "-c", _WEDGED_CHILD], stdout=True, stderr=asyncio.subprocess.STDOUT
+    )
+    await proc.start()
+    assert await proc.read_stdout() == b"ready\n"
+
+    with pytest.raises(TimeoutError):
+        async with asyncio.timeout(0.5):
+            await proc.close()
+
+    assert proc.returncode is not None

--- a/tests/helpers/test_process.py
+++ b/tests/helpers/test_process.py
@@ -288,3 +288,25 @@ async def test_close_reaps_a_child_that_never_closes_its_pipes(
         await proc.close()
 
     assert proc.returncode is not None
+
+
+@pytest.mark.asyncio
+async def test_close_reaps_a_child_when_cancelled_mid_drain() -> None:
+    """
+    Cancellation landing while a pipe is draining must not leave the child running.
+
+    Walking away there skips the terminate/SIGKILL escalation, and nothing else
+    ever comes back for the process.
+    """
+    proc = AsyncProcess(
+        [sys.executable, "-c", _WEDGED_CHILD], stdout=True, stderr=asyncio.subprocess.STDOUT
+    )
+    await proc.start()
+    assert await proc.read_stdout() == b"ready\n"
+
+    # well inside PIPE_DRAIN_TIMEOUT, so the cancellation lands on the stdout drain
+    with pytest.raises(TimeoutError):
+        async with asyncio.timeout(0.5):
+            await proc.close()
+
+    assert proc.returncode is not None


### PR DESCRIPTION
# What does this implement/fix?

Closing a subprocess could leave it running forever.

`AsyncProcess.close()` drains the process' pipes and then escalates to terminate/SIGKILL to
actually reap the child. If the surrounding task was cancelled while one of those drains (or the
wait for the process to exit) was in progress, `close()` gave up right there and the escalation
never ran, so a process that had wedged was simply left behind.

Reproduced against the real class: with a child that ignores SIGINT and never closes its pipes,
`close()` under a 2s timeout returned with `returncode is None` and the child still alive.

Follow-up to #5999.

## Changes

- Hold on to a cancellation that lands on a pipe drain or on the wait for the process to exit,
  finish reaping the process, and re-raise it afterwards. Callers see the same cancellation at the
  same point as before, just once the process is really gone.
- On cancellation the wait now escalates to SIGKILL instead of walking away.
- Added regression tests for both spots.

Note that a cancelled `close()` now takes a little longer to return - only in the case that used to
leak the process. For a healthy child it is unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
