### PR TITLE
Make the Smart Fades unloaded-model guards actually work

### DIFF
--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -34,7 +34,7 @@ from .helpers import (
     decode_pcm_chunk_to_mono,
 )
 from .resources.skey_model import KEY_MAP as SKEY_KEY_MAP
-from .resources.skey_model import load_skey_components
+from .resources.skey_model import VQT, ChromaNet, CropCQT, load_skey_components
 from .vocal_activity import (
     FIRERED_SAMPLE_RATE,
     FireRedFbank,
@@ -45,6 +45,7 @@ from .vocal_activity import (
 )
 
 if TYPE_CHECKING:
+    import numpy.typing as npt
     from music_assistant_models.config_entries import ProviderConfig
     from music_assistant_models.enums import ProviderFeature
     from music_assistant_models.media_items import AudioFormat
@@ -68,6 +69,10 @@ BEAT_WINDOW_OVERLAP_MODE = "keep_first"
 # While a player streams, wait this many times a window's own compute time before starting the
 # next one, so beat inference does not occupy a core continuously.
 BEAT_WINDOW_PACE_RATIO = 1.0
+# A model failure is often transient: an idle unload frees the models while an analysis that
+# outlived its own session is still running, or a one-off torch/hardware error. Record those
+# with this retry horizon instead of a permanent row that blocks the track forever.
+MODEL_FAILURE_RETRY_DELAY = timedelta(hours=24)
 
 
 @dataclass
@@ -112,6 +117,17 @@ class SmartFadesProvider(AudioAnalysisProvider):
         super().__init__(mass, manifest, config, supported_features)
         self._data: dict[str, SmartFadesData] = {}
         self._device = "cpu"
+        # Populated by _load_models and cleared again by _free_models, so every use goes
+        # through _require_loaded rather than assuming the models are resident.
+        self._beat_this_model: Spect2Frames | None = None
+        self._beat_this_post_processor: DBNDownBeatTracker | None = None
+        self._skey_vqt: VQT | None = None
+        self._skey_chromanet: ChromaNet | None = None
+        self._skey_crop: CropCQT | None = None
+        self._spectral_centroid: SpectralCentroid | None = None
+        self._firered_model: torch.nn.Module | None = None
+        self._firered_cmvn_means: npt.NDArray[np.float64] | None = None
+        self._firered_cmvn_inverse_std: npt.NDArray[np.float64] | None = None
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return config entries for this provider."""
@@ -199,7 +215,19 @@ class SmartFadesProvider(AudioAnalysisProvider):
         self._firered_cmvn_means = None
         self._firered_cmvn_inverse_std = None
 
-    def _initialize_models(self) -> tuple[Any, ...]:
+    def _initialize_models(
+        self,
+    ) -> tuple[
+        Spect2Frames,
+        DBNDownBeatTracker,
+        VQT,
+        ChromaNet,
+        CropCQT,
+        SpectralCentroid,
+        torch.nn.Module,
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+    ]:
         """Initialize ML models (runs in a thread to avoid blocking the event loop)."""
         beat_this_model = Spect2Frames(checkpoint_path="small0", device=self._device)
         # torch aarch64 wheels advertise fbgemm in supported_engines but its kernels are x86-only.
@@ -230,6 +258,23 @@ class SmartFadesProvider(AudioAnalysisProvider):
             firered_cmvn_means,
             firered_cmvn_inverse_std,
         )
+
+    def _require_loaded[ComponentT](self, component: ComponentT | None, name: str) -> ComponentT:
+        """
+        Return a loaded model component, failing the analysis when it is not resident.
+
+        :param component: The component to resolve; None while the models are unloaded.
+        :param name: Name of the component, used in the failure reason.
+        """
+        if component is None:
+            # The recorder that handles AudioAnalysisError does not log, so warn here or the
+            # unload race leaves nothing behind but a row in the failures table.
+            self.logger.warning("%s is not loaded; analysis will be retried later", name)
+            raise AudioAnalysisError(
+                f"{name} is not loaded",
+                retry_at=utc() + MODEL_FAILURE_RETRY_DELAY,
+            )
+        return component
 
     async def _start_analysis(
         self,
@@ -272,8 +317,10 @@ class SmartFadesProvider(AudioAnalysisProvider):
             if audio_format.sample_rate != FIRERED_SAMPLE_RATE
             else None,
             vocal_fbank=FireRedFbank(
-                self._firered_cmvn_means,
-                self._firered_cmvn_inverse_std,
+                self._require_loaded(self._firered_cmvn_means, "FireRed AED CMVN means"),
+                self._require_loaded(
+                    self._firered_cmvn_inverse_std, "FireRed AED CMVN inverse deviations"
+                ),
             ),
         )
         self.logger.debug("Started beat tracking session %s", session_id)
@@ -473,9 +520,12 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
         # Spectral centroid: keep per-frame (hop_length=512, ~43 frames/s)
         # Skip short tail buffers: STFT reflect-pad requires len > n_fft // 2.
-        if len(pcm_22k) >= self._spectral_centroid.n_fft:
+        spectral_centroid = self._require_loaded(
+            self._spectral_centroid, "SpectralCentroid transform"
+        )
+        if len(pcm_22k) >= spectral_centroid.n_fft:
             pcm_tensor = torch.from_numpy(pcm_22k)
-            centroid_frames = self._spectral_centroid(pcm_tensor.unsqueeze(0)).squeeze(0).numpy()
+            centroid_frames = spectral_centroid(pcm_tensor.unsqueeze(0)).squeeze(0).numpy()
             # digitally-silent frames divide 0/0 into NaN; treat them as 0 Hz like
             # other negligible-energy frames so no non-finite value is ever stored
             np.nan_to_num(centroid_frames, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
@@ -536,8 +586,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
     ) -> tuple[np.ndarray, np.ndarray, int, str | None, str | None]:
         """Run beat inference followed by musical key inference."""
         # Resolved before the beat stage: an idle unload may clear the field while it runs.
-        chromanet = self._skey_chromanet
-        assert chromanet is not None
+        chromanet = self._require_loaded(self._skey_chromanet, "S-KEY ChromaNet")
         beats, downbeats, beats_per_bar = await self._infer_beat_timings(beat_features)
         if len(beats) < 2:
             raise AudioAnalysisError("no rhythmic beat detected")
@@ -550,10 +599,8 @@ class SmartFadesProvider(AudioAnalysisProvider):
         duration: float,
     ) -> np.ndarray:
         """Run FireRed AED inference and return the 100 ms vocal timeline."""
+        model = self._require_loaded(self._firered_model, "FireRed AED model")
         try:
-            model = self._firered_model
-            if model is None:
-                raise RuntimeError("FireRed AED model is not loaded")
             compute_seconds = 0.0
             chunks = []
             for chunk, core_offset, core_length in split_firered_features(features):
@@ -575,7 +622,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
             # Avoid permanently suppressing beat and key results for transient model failures.
             raise AudioAnalysisError(
                 f"FireRed vocal inference failed: {err}",
-                retry_at=utc() + timedelta(hours=24),
+                retry_at=utc() + MODEL_FAILURE_RETRY_DELAY,
             ) from err
         self.logger.log(
             VERBOSE_LOG_LEVEL,
@@ -589,13 +636,15 @@ class SmartFadesProvider(AudioAnalysisProvider):
         self, pcm_mono: np.ndarray, sample_rate: int, data: SmartFadesData
     ) -> None:
         """Extract VQT features for S-KEY key detection."""
+        vqt = self._require_loaded(self._skey_vqt, "S-KEY VQT")
+        crop = self._require_loaded(self._skey_crop, "S-KEY CropCQT")
         if sample_rate != ANALYSIS_SAMPLE_RATE:
             pcm_mono = soxr.resample(pcm_mono, sample_rate, ANALYSIS_SAMPLE_RATE)
         pcm_tensor = torch.from_numpy(pcm_mono)
         with torch.inference_mode():
             vqt_input = pcm_tensor.unsqueeze(0).unsqueeze(0)  # (1, 1, samples)
-            vqt_out = self._skey_vqt(vqt_input)  # (1, 1, n_bins, T)
-            cropped = self._skey_crop(vqt_out, torch.zeros(1))  # (1, 1, 84, T)
+            vqt_out = vqt(vqt_input)  # (1, 1, n_bins, T)
+            cropped = crop(vqt_out, torch.zeros(1))  # (1, 1, 84, T)
             data.musical_key_feature_blocks.append(cropped.cpu())
 
     def _infer_musical_key(
@@ -632,10 +681,10 @@ class SmartFadesProvider(AudioAnalysisProvider):
         """
         # Resolved once and passed down: an idle unload may clear the fields while the
         # windows below are still being dispatched.
-        beat_this = self._beat_this_model
-        post_processor = self._beat_this_post_processor
-        assert beat_this is not None
-        assert post_processor is not None
+        beat_this = self._require_loaded(self._beat_this_model, "Beat This model")
+        post_processor = self._require_loaded(
+            self._beat_this_post_processor, "Beat This post-processor"
+        )
 
         spect = torch.from_numpy(feats).to(self._device)
         windows, starts = split_piece(

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -8,6 +8,7 @@ from collections.abc import Callable, Generator
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import numpy as np
@@ -20,6 +21,7 @@ from music_assistant_models.media_items import AudioFormat
 from torchaudio.transforms import SpectralCentroid
 
 from music_assistant.models.audio_analysis import AudioAnalysisData, AudioAnalysisError
+from music_assistant.providers.smart_fades.dbn_postprocessor import DBNDownBeatTracker
 from music_assistant.providers.smart_fades.provider import (
     ANALYSIS_SAMPLE_RATE,
     BEAT_WINDOW_PACE_RATIO,
@@ -799,6 +801,57 @@ async def test_vocal_inference_with_unloaded_model_is_retryable(
     assert excinfo.value.retry_at is not None
 
 
+@pytest.mark.parametrize(
+    "field",
+    ["_beat_this_model", "_beat_this_post_processor", "_skey_chromanet"],
+)
+async def test_beats_and_key_with_unloaded_model_is_retryable(
+    provider: SmartFadesProvider,
+    field: str,
+) -> None:
+    """The beat/key branch decides permanent vs retryable, so an unloaded model must retry."""
+    setattr(provider, field, None)
+
+    with pytest.raises(AudioAnalysisError, match="is not loaded") as excinfo:
+        await provider._infer_beats_and_key(np.zeros((10, 128), dtype=np.float32), None)
+
+    assert excinfo.value.retry_at is not None
+
+
+async def test_spectral_centroid_with_unloaded_transform_is_retryable(
+    deterministic_provider: SmartFadesProvider,
+) -> None:
+    """The block path also runs during finalize, so it must not record a permanent failure."""
+    audio_format = AudioFormat(
+        content_type=ContentType.PCM_F32LE,
+        bit_depth=32,
+        sample_rate=44100,
+        channels=2,
+    )
+
+    stream_details = Mock()
+    stream_details.item_id = "test_unloaded_centroid"
+    stream_details.provider = "test"
+    stream_details.queue_id = "test"
+    stream_details.uri = "test://unloaded_centroid"
+    stream_details.media_type = MediaType.TRACK
+    stream_details.duration = 120
+
+    session_id = "test:test:test_unloaded_centroid"
+    await deterministic_provider.start_analysis(session_id, stream_details, audio_format)
+    # Stay under the 10s block size so the buffered PCM is only flushed by _finalize.
+    await deterministic_provider.process_pcm_chunk(
+        session_id, FIXTURE_PCM.read_bytes()[: 44100 * 2 * 4]
+    )
+    # The models are freed while the (detached) finalize is still running.
+    deterministic_provider._spectral_centroid = None
+
+    with pytest.raises(AudioAnalysisError, match="is not loaded") as excinfo:
+        await deterministic_provider._finalize(session_id)
+
+    assert excinfo.value.retry_at is not None
+
+
 class _StubBeatModel(torch.nn.Module):
     """Beat This stand-in whose logits depend on where a frame sits inside its window."""
 
@@ -825,7 +878,7 @@ async def test_windowed_inference_matches_whole_track_prediction(
         captured.append(activations)
         return np.array([[0.0, 1.0], [0.5, 2.0]]), 4
 
-    provider._beat_this_post_processor = post_processor
+    provider._beat_this_post_processor = cast("DBNDownBeatTracker", post_processor)
 
     async def run_offloaded_timed(func: Callable[..., object], *args: object) -> object:
         return func(*args), 0.0


### PR DESCRIPTION
# What does this implement/fix?

The Smart Fades provider's nine model attributes were never declared: they existed only once
`_load_models()` had unpacked them, and `_free_models()` set them back to `None`. The models
are freed again while idle, so an analysis that outlives its own session can find them gone —
and when that happened the guards raised `AssertionError`, which the base class records as a
**permanent** analysis failure (`next_retry = NULL`). That track is then never analysed again.

The guards were meant to catch exactly this; they just raised the wrong kind of error to be
handled properly. Declaring the fields makes the optionality visible to the type checker as
well, so a new model field can no longer slip through unguarded.

## Changes

- Declare all nine model fields with their real types and a `None` default.
- Resolve every model through one `_require_loaded()` helper that logs and raises a *retryable*
  `AudioAnalysisError`, replacing the `assert`s and the one hand-written `None` check.
- Type the `_initialize_models()` return tuple instead of `tuple[Any, ...]`, so the unpack in
  `_load_models()` is checked.
- Add tests for both paths that reach the failure recorder (beat/key inference and the block
  path that finalize flushes through).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
