### PR TITLE
Let a cancelled virtual player creation finish cleaning up

### DIFF
--- a/music_assistant/helpers/shared_playback.py
+++ b/music_assistant/helpers/shared_playback.py
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
 SENDSPIN_DOMAIN = "sendspin"
 REMOTE_CREATION_CLEANUP_TIMEOUT = 15.0
 REMOTE_REMOVAL_CLEANUP_DELAYS = (0.0, 1.0, 5.0)
-REMOTE_REMOVAL_CLEANUP_TIMEOUT = 5.0
 
 LOGGER = logging.getLogger(__name__)
 
@@ -334,8 +333,11 @@ class SharedPlaybackSession:
             try:
                 if not sendspin.is_virtual_player(player_id):
                     return
-                async with asyncio.timeout(REMOTE_REMOVAL_CLEANUP_TIMEOUT):
-                    await sendspin.remove_virtual_player(player_id)
+                # awaited to completion on purpose: a timeout is no reliable bound on
+                # the teardown - parts of it swallow the cancellation (see
+                # AsyncProcess.close), and one that does land leaves the player
+                # half torn down for the next attempt to trip over
+                await sendspin.remove_virtual_player(player_id)
                 return
             except Exception as err:
                 last_error = err

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -139,7 +139,6 @@ DEFAULT_SENDSPIN_CLIENT_PORT = 8928
 DEFAULT_SENDSPIN_CLIENT_PATH = "/sendspin"
 VIRTUAL_PLAYER_REGISTER_TIMEOUT = 10.0
 VIRTUAL_PLAYER_CLEANUP_DELAYS = (0.0, 0.5, 2.0)
-VIRTUAL_PLAYER_CLEANUP_TIMEOUT = 2.0
 WEB_PLAYER_CONNECT_TIMEOUT = 10.0
 # Grace period so a network blip keeps the pairing record.
 SESSION_PAIRING_EVICTION_GRACE = 120.0
@@ -1745,8 +1744,11 @@ class SendspinProvider(PlayerProvider):
             if delay:
                 await asyncio.sleep(delay)
             try:
-                async with asyncio.timeout(VIRTUAL_PLAYER_CLEANUP_TIMEOUT):
-                    await self.remove_virtual_player(player_id)
+                # awaited to completion on purpose: a timeout is no reliable bound on
+                # the teardown - parts of it swallow the cancellation (see
+                # AsyncProcess.close), and one that does land leaves the player
+                # half torn down for the next attempt to trip over
+                await self.remove_virtual_player(player_id)
                 return
             except Exception as err:
                 last_error = err

--- a/tests/helpers/test_shared_playback.py
+++ b/tests/helpers/test_shared_playback.py
@@ -604,20 +604,15 @@ async def test_cancelled_remote_creation_retries_cleanup() -> None:
     assert sendspin.remove_virtual_player.await_count == 2
 
 
-async def test_cancelled_remote_creation_bounds_hung_removal() -> None:
-    """Bound cleanup when virtual-player removal does not finish."""
+async def test_cancelled_remote_creation_awaits_a_slow_removal() -> None:
+    """Await a slow virtual-player removal to completion instead of abandoning it."""
     sendspin = MagicMock()
     mass = MagicMock()
-    removal_started = asyncio.Event()
-    removal_cancelled = asyncio.Event()
-    never_finish = asyncio.Event()
+    removal_completed = asyncio.Event()
 
     async def _remove_virtual_player(_player_id: str, **_kwargs: object) -> None:
-        removal_started.set()
-        try:
-            await never_finish.wait()
-        finally:
-            removal_cancelled.set()
+        await asyncio.sleep(0.1)
+        removal_completed.set()
 
     sendspin.is_virtual_player.return_value = True
     sendspin.remove_virtual_player = AsyncMock(side_effect=_remove_virtual_player)
@@ -633,9 +628,12 @@ async def test_cancelled_remote_creation_bounds_hung_removal() -> None:
             "music_assistant.helpers.shared_playback.REMOTE_REMOVAL_CLEANUP_DELAYS",
             (0.0,),
         ),
+        # the bound this path used to carry, patched back in so the removal is
+        # cut short - and this test fails - if it ever returns
         patch(
             "music_assistant.helpers.shared_playback.REMOTE_REMOVAL_CLEANUP_TIMEOUT",
             0.01,
+            create=True,
         ),
         patch("music_assistant.helpers.shared_playback.LOGGER") as logger,
     ):
@@ -646,9 +644,9 @@ async def test_cancelled_remote_creation_bounds_hung_removal() -> None:
             cleanup_required,
         )
 
-    assert removal_started.is_set()
-    assert removal_cancelled.is_set()
-    logger.warning.assert_called_once()
+    assert removal_completed.is_set()
+    assert sendspin.remove_virtual_player.await_count == 1
+    logger.warning.assert_not_called()
 
 
 async def test_remote_close_is_idempotent(mass: MusicAssistant) -> None:

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -242,6 +242,50 @@ async def test_remove_virtual_player_retries_after_partial_failure() -> None:
     sendspin.mass.players.delete_player_config.assert_called_once_with(player_id)
 
 
+async def test_cleanup_failed_creation_awaits_a_slow_teardown() -> None:
+    """Test that a slow teardown is awaited to completion instead of being retried."""
+    sendspin = SendspinProvider.__new__(SendspinProvider)
+    sendspin.mass = MagicMock()
+    sendspin.server_api = MagicMock()
+    sendspin.logger = MagicMock()
+    player_id = f"{VIRTUAL_PLAYER_ID_PREFIX}slow"
+    sendspin._virtual_players = {player_id: "owner--test"}
+    sendspin.server_api.get_client.return_value = None
+
+    async def _slow_unregister(_player_id: str, **_kwargs: object) -> None:
+        # outlasts the 2 second bound this path used to carry
+        await asyncio.sleep(2.5)
+
+    sendspin.mass.players.unregister = AsyncMock(side_effect=_slow_unregister)
+
+    await sendspin._cleanup_failed_virtual_player_creation(player_id)
+
+    assert sendspin.mass.players.unregister.await_count == 1
+    assert not sendspin.is_virtual_player(player_id)
+    sendspin.mass.players.delete_player_config.assert_called_once_with(player_id)
+    sendspin.logger.warning.assert_not_called()
+
+
+async def test_cleanup_failed_creation_retries_a_raised_teardown() -> None:
+    """Test that a teardown raising once is retried and then reported as cleaned up."""
+    sendspin = SendspinProvider.__new__(SendspinProvider)
+    sendspin.mass = MagicMock()
+    sendspin.server_api = MagicMock()
+    sendspin.logger = MagicMock()
+    player_id = f"{VIRTUAL_PLAYER_ID_PREFIX}flaky"
+    sendspin._virtual_players = {player_id: "owner--test"}
+    sendspin.server_api.get_client.return_value = None
+    sendspin.mass.players.unregister = AsyncMock(
+        side_effect=[RuntimeError("teardown failed"), None]
+    )
+
+    await sendspin._cleanup_failed_virtual_player_creation(player_id)
+
+    assert sendspin.mass.players.unregister.await_count == 2
+    assert not sendspin.is_virtual_player(player_id)
+    sendspin.logger.warning.assert_not_called()
+
+
 async def test_remove_virtual_player_rejects_regular_player(mass: MusicAssistant) -> None:
     """Test that removal is refused for players that are not virtual players."""
     sendspin = _get_sendspin_provider(mass)


### PR DESCRIPTION
# What does this implement/fix?

Cleaning up a virtual player left behind by a failed or cancelled creation was
wrapped in a timeout, in two places. `AsyncProcess.close()` documents that an
enclosing timeout is no reliable bound on a teardown that reaches it: parts of
it swallow the cancellation, and one that does land only surfaces after the
process escalation has run, leaving the player half torn down for the next
attempt to trip over.

Neither cleanup has anything running to wait for - both run against a player
that has never played - so the bound guards nothing, and it is dropped in both.
The retry on a teardown that actually raises stays as it was.

- Removed the timeout around the teardown in the Sendspin virtual-player
  cleanup and in the shared-playback remote-session cleanup.
- Reworked the test that asserted the old bound into one that asserts the
  teardown is awaited to completion.
- Added coverage for the retry, which is now the retry loop's only job.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
