### PR TITLE
Keep analysis models loaded while a track is still being analysed

### DIFF
--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -238,6 +238,8 @@ class AudioAnalysisController:
         # Monotonic time of the last analysis start, and the monitor that unloads idle models.
         self._last_analysis_activity: float = 0.0
         self._idle_unload_task: asyncio.Task[None] | None = None
+        # In-flight provider finalizes: their session is already gone, but the models are not.
+        self._finalize_tasks: set[asyncio.Task[None]] = set()
 
     def setup(self) -> None:
         """Register the nightly background scan task."""
@@ -1337,7 +1339,11 @@ class AudioAnalysisController:
         for provider_id in provider_ids:
             provider = self.mass.get_provider(provider_id)
             if provider and isinstance(provider, AudioAnalysisProvider) and provider.available:
-                self.mass.create_task(provider.finalize(session_key))
+                # finalize runs the whole-track inference, long after the session was popped
+                # above, so track it: it is what keeps the models in use from here on.
+                task = self.mass.create_task(provider.finalize(session_key))
+                self._finalize_tasks.add(task)
+                task.add_done_callback(self._finalize_tasks.discard)
 
     def _cancel_providers(self, session_key: str) -> None:
         """Cancel each provider in the session."""
@@ -1369,7 +1375,7 @@ class AudioAnalysisController:
         """Unload heavy models once no analysis has run for MODEL_IDLE_UNLOAD_SECONDS."""
         while True:
             await asyncio.sleep(MODEL_IDLE_CHECK_INTERVAL_SECONDS)
-            if self._active_sessions:
+            if self._active_sessions or self._finalize_tasks:
                 # Keep the timer fresh while analysis is running.
                 self._last_analysis_activity = time.monotonic()
                 continue

--- a/tests/controllers/streams/test_audio_analysis_controller.py
+++ b/tests/controllers/streams/test_audio_analysis_controller.py
@@ -430,6 +430,44 @@ async def test_idle_monitor_keeps_models_while_sessions_active(
     await asyncio.gather(controller._idle_unload_task, return_exceptions=True)
 
 
+@pytest.mark.asyncio
+async def test_idle_monitor_keeps_models_while_finalize_in_flight(
+    controller: AudioAnalysisController,
+    mock_mass: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An in-flight finalize keeps the models loaded, and releases them once it completes."""
+    prov = _unloadable_provider()
+    prov.instance_id = "prov_1"
+    release = asyncio.Event()
+
+    async def _blocking_finalize(_session_id: str) -> None:
+        await release.wait()
+
+    prov.finalize = AsyncMock(side_effect=_blocking_finalize)
+    mock_mass.get_provider = MagicMock(return_value=prov)
+    monkeypatch.setattr(controller.__class__, "providers", property(lambda _self: [prov]))
+    monkeypatch.setattr(
+        "music_assistant.controllers.streams.audio_analysis.MODEL_IDLE_CHECK_INTERVAL_SECONDS", 0.01
+    )
+    monkeypatch.setattr(
+        "music_assistant.controllers.streams.audio_analysis.MODEL_IDLE_UNLOAD_SECONDS", 0.0
+    )
+
+    controller._active_sessions["sess"] = {"prov_1"}
+    controller._mark_analysis_activity()
+    controller._finalize_providers("sess")
+    assert "sess" not in controller._active_sessions
+
+    await asyncio.sleep(0.05)  # several monitor ticks while the finalize is still running
+    prov.unload_idle_models.assert_not_called()
+
+    release.set()
+    assert controller._idle_unload_task is not None
+    await asyncio.wait_for(controller._idle_unload_task, timeout=2.0)
+    prov.unload_idle_models.assert_awaited_once()
+
+
 # -- Edge cases --
 
 


### PR DESCRIPTION
# What does this implement/fix?

The audio-analysis controller frees a provider's ML models after 5 minutes with nothing being
analysed. It decides "nothing is being analysed" from the active-session list — but a session is
removed from that list the moment `finalize()` is *dispatched*, and `finalize()` is exactly where
the heavy whole-track work runs (beat inference, DBN decode, vocal inference, CLAP windows).

So a track whose analysis takes longer than the idle window has its models freed out from under
it. Smart Fades then records a retryable failure and skips that track for 24 hours; Sonic
Analysis silently drops the CLAP windows that were still queued and stores the track without
them — permanently, since the track counts as analysed.

Measured on an M-series core (single thread, the same per-op budget a 4-core Pi gets), the
finalize inference alone is ~21s for a 5-minute track, ~38s for 10 minutes and ~111s for 30
minutes — and it doubles again while a player is streaming, because of the beat-window pacing.
On the ARM/low-power hardware Music Assistant targets that comfortably passes the 5-minute
window for longer tracks, and tracks up to 30 minutes are analysed.

The fix is to stop lying about what "idle" means: in-flight finalizes now count as activity, so
the models stay loaded until the analysis that is using them is actually done.

## Changes

- Track the dispatched `finalize()` tasks in the controller.
- The idle-model monitor treats an in-flight finalize like an active session and keeps its timer
  fresh, so the models are only freed once the last analysis has finished.
- Add a regression test covering both halves: no unload while a finalize is running, and the
  unload happening once it completes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
