### PR TITLE
Keep the Smart Fades models as a single set

### DIFF
--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -98,6 +98,21 @@ class SmartFadesData:
     vocal_feature_blocks: list[np.ndarray] = field(default_factory=list)
 
 
+@dataclass(frozen=True, slots=True)
+class LoadedModels:
+    """The model components Smart Fades infers with; loaded and released as one set."""
+
+    beat_this: Spect2Frames
+    beat_this_post_processor: DBNDownBeatTracker
+    skey_vqt: VQT
+    skey_chromanet: ChromaNet
+    skey_crop: CropCQT
+    spectral_centroid: SpectralCentroid
+    firered: torch.nn.Module
+    firered_cmvn_means: npt.NDArray[np.float64]
+    firered_cmvn_inverse_std: npt.NDArray[np.float64]
+
+
 class SmartFadesProvider(AudioAnalysisProvider):
     """Smart fades audio analysis provider using Beat This for beat tracking."""
 
@@ -118,16 +133,8 @@ class SmartFadesProvider(AudioAnalysisProvider):
         self._data: dict[str, SmartFadesData] = {}
         self._device = "cpu"
         # Populated by _load_models and cleared again by _free_models, so every use goes
-        # through _require_loaded rather than assuming the models are resident.
-        self._beat_this_model: Spect2Frames | None = None
-        self._beat_this_post_processor: DBNDownBeatTracker | None = None
-        self._skey_vqt: VQT | None = None
-        self._skey_chromanet: ChromaNet | None = None
-        self._skey_crop: CropCQT | None = None
-        self._spectral_centroid: SpectralCentroid | None = None
-        self._firered_model: torch.nn.Module | None = None
-        self._firered_cmvn_means: npt.NDArray[np.float64] | None = None
-        self._firered_cmvn_inverse_std: npt.NDArray[np.float64] | None = None
+        # through _require_models rather than assuming the models are resident.
+        self._models: LoadedModels | None = None
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
         """Return config entries for this provider."""
@@ -191,43 +198,13 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
     async def _load_models(self) -> None:
         """Load the Beat This, S-KEY, and FireRed AED models into memory."""
-        (
-            self._beat_this_model,
-            self._beat_this_post_processor,
-            self._skey_vqt,
-            self._skey_chromanet,
-            self._skey_crop,
-            self._spectral_centroid,
-            self._firered_model,
-            self._firered_cmvn_means,
-            self._firered_cmvn_inverse_std,
-        ) = await asyncio.to_thread(self._initialize_models)
+        self._models = await asyncio.to_thread(self._initialize_models)
 
     def _free_models(self) -> None:
         """Release the Beat This, S-KEY, and FireRed AED models."""
-        self._beat_this_model = None
-        self._beat_this_post_processor = None
-        self._skey_vqt = None
-        self._skey_chromanet = None
-        self._skey_crop = None
-        self._spectral_centroid = None
-        self._firered_model = None
-        self._firered_cmvn_means = None
-        self._firered_cmvn_inverse_std = None
+        self._models = None
 
-    def _initialize_models(
-        self,
-    ) -> tuple[
-        Spect2Frames,
-        DBNDownBeatTracker,
-        VQT,
-        ChromaNet,
-        CropCQT,
-        SpectralCentroid,
-        torch.nn.Module,
-        npt.NDArray[np.float64],
-        npt.NDArray[np.float64],
-    ]:
+    def _initialize_models(self) -> LoadedModels:
         """Initialize ML models (runs in a thread to avoid blocking the event loop)."""
         beat_this_model = Spect2Frames(checkpoint_path="small0", device=self._device)
         # torch aarch64 wheels advertise fbgemm in supported_engines but its kernels are x86-only.
@@ -247,34 +224,29 @@ class SmartFadesProvider(AudioAnalysisProvider):
         firered_model, firered_cmvn_means, firered_cmvn_inverse_std = load_firered_components(
             device=self._device
         )
-        return (
-            beat_this_model,
-            beat_this_post_processor,
-            skey_vqt,
-            skey_chromanet,
-            skey_crop,
-            spectral_centroid,
-            firered_model,
-            firered_cmvn_means,
-            firered_cmvn_inverse_std,
+        return LoadedModels(
+            beat_this=beat_this_model,
+            beat_this_post_processor=beat_this_post_processor,
+            skey_vqt=skey_vqt,
+            skey_chromanet=skey_chromanet,
+            skey_crop=skey_crop,
+            spectral_centroid=spectral_centroid,
+            firered=firered_model,
+            firered_cmvn_means=firered_cmvn_means,
+            firered_cmvn_inverse_std=firered_cmvn_inverse_std,
         )
 
-    def _require_loaded[ComponentT](self, component: ComponentT | None, name: str) -> ComponentT:
-        """
-        Return a loaded model component, failing the analysis when it is not resident.
-
-        :param component: The component to resolve; None while the models are unloaded.
-        :param name: Name of the component, used in the failure reason.
-        """
-        if component is None:
+    def _require_models(self) -> LoadedModels:
+        """Return the resident model set, failing the analysis when it has been unloaded."""
+        if self._models is None:
             # The recorder that handles AudioAnalysisError does not log, so warn here or the
             # unload race leaves nothing behind but a row in the failures table.
-            self.logger.warning("%s is not loaded; analysis will be retried later", name)
+            self.logger.warning("Models are not loaded; analysis will be retried later")
             raise AudioAnalysisError(
-                f"{name} is not loaded",
+                "models are not loaded",
                 retry_at=utc() + MODEL_FAILURE_RETRY_DELAY,
             )
-        return component
+        return self._models
 
     async def _start_analysis(
         self,
@@ -287,6 +259,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
             # We only want to analyze tracks
             return False
 
+        models = self._require_models()
         block_seconds = 10.0
 
         needs_resample = audio_format.sample_rate != ANALYSIS_SAMPLE_RATE
@@ -317,10 +290,8 @@ class SmartFadesProvider(AudioAnalysisProvider):
             if audio_format.sample_rate != FIRERED_SAMPLE_RATE
             else None,
             vocal_fbank=FireRedFbank(
-                self._require_loaded(self._firered_cmvn_means, "FireRed AED CMVN means"),
-                self._require_loaded(
-                    self._firered_cmvn_inverse_std, "FireRed AED CMVN inverse deviations"
-                ),
+                models.firered_cmvn_means,
+                models.firered_cmvn_inverse_std,
             ),
         )
         self.logger.debug("Started beat tracking session %s", session_id)
@@ -520,9 +491,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
         # Spectral centroid: keep per-frame (hop_length=512, ~43 frames/s)
         # Skip short tail buffers: STFT reflect-pad requires len > n_fft // 2.
-        spectral_centroid = self._require_loaded(
-            self._spectral_centroid, "SpectralCentroid transform"
-        )
+        spectral_centroid = self._require_models().spectral_centroid
         if len(pcm_22k) >= spectral_centroid.n_fft:
             pcm_tensor = torch.from_numpy(pcm_22k)
             centroid_frames = spectral_centroid(pcm_tensor.unsqueeze(0)).squeeze(0).numpy()
@@ -585,12 +554,14 @@ class SmartFadesProvider(AudioAnalysisProvider):
         key_features: torch.Tensor | None,
     ) -> tuple[np.ndarray, np.ndarray, int, str | None, str | None]:
         """Run beat inference followed by musical key inference."""
-        # Resolved before the beat stage: an idle unload may clear the field while it runs.
-        chromanet = self._require_loaded(self._skey_chromanet, "S-KEY ChromaNet")
+        # Resolved before the beat stage: an idle unload may clear the models while it runs.
+        models = self._require_models()
         beats, downbeats, beats_per_bar = await self._infer_beat_timings(beat_features)
         if len(beats) < 2:
             raise AudioAnalysisError("no rhythmic beat detected")
-        key, mode = await self._run_offloaded(self._infer_musical_key, chromanet, key_features)
+        key, mode = await self._run_offloaded(
+            self._infer_musical_key, models.skey_chromanet, key_features
+        )
         return beats, downbeats, beats_per_bar, key, mode
 
     async def _infer_vocal_activity(
@@ -599,7 +570,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
         duration: float,
     ) -> np.ndarray:
         """Run FireRed AED inference and return the 100 ms vocal timeline."""
-        model = self._require_loaded(self._firered_model, "FireRed AED model")
+        model = self._require_models().firered
         try:
             compute_seconds = 0.0
             chunks = []
@@ -636,15 +607,14 @@ class SmartFadesProvider(AudioAnalysisProvider):
         self, pcm_mono: np.ndarray, sample_rate: int, data: SmartFadesData
     ) -> None:
         """Extract VQT features for S-KEY key detection."""
-        vqt = self._require_loaded(self._skey_vqt, "S-KEY VQT")
-        crop = self._require_loaded(self._skey_crop, "S-KEY CropCQT")
+        models = self._require_models()
         if sample_rate != ANALYSIS_SAMPLE_RATE:
             pcm_mono = soxr.resample(pcm_mono, sample_rate, ANALYSIS_SAMPLE_RATE)
         pcm_tensor = torch.from_numpy(pcm_mono)
         with torch.inference_mode():
             vqt_input = pcm_tensor.unsqueeze(0).unsqueeze(0)  # (1, 1, samples)
-            vqt_out = vqt(vqt_input)  # (1, 1, n_bins, T)
-            cropped = crop(vqt_out, torch.zeros(1))  # (1, 1, 84, T)
+            vqt_out = models.skey_vqt(vqt_input)  # (1, 1, n_bins, T)
+            cropped = models.skey_crop(vqt_out, torch.zeros(1))  # (1, 1, 84, T)
             data.musical_key_feature_blocks.append(cropped.cpu())
 
     def _infer_musical_key(
@@ -679,12 +649,9 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
         :param feats: Log-mel features for the whole track, shaped (frames, mel bins).
         """
-        # Resolved once and passed down: an idle unload may clear the fields while the
+        # Resolved once and passed down: an idle unload may clear the models while the
         # windows below are still being dispatched.
-        beat_this = self._require_loaded(self._beat_this_model, "Beat This model")
-        post_processor = self._require_loaded(
-            self._beat_this_post_processor, "Beat This post-processor"
-        )
+        models = self._require_models()
 
         spect = torch.from_numpy(feats).to(self._device)
         windows, starts = split_piece(
@@ -697,14 +664,18 @@ class SmartFadesProvider(AudioAnalysisProvider):
         model_seconds = 0.0
         for window in windows:
             prediction, elapsed = await self._run_offloaded_timed(
-                self._infer_beat_window, beat_this.model, window
+                self._infer_beat_window, models.beat_this.model, window
             )
             predictions.append(prediction)
             model_seconds += elapsed
             await self._pace_beat_windows(elapsed)
 
         (beats, downbeats, beats_per_bar), post_seconds = await self._run_offloaded_timed(
-            self._decode_beat_timings, post_processor, predictions, starts, len(spect)
+            self._decode_beat_timings,
+            models.beat_this_post_processor,
+            predictions,
+            starts,
+            len(spect),
         )
         self.logger.log(
             VERBOSE_LOG_LEVEL,

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -830,6 +830,31 @@ async def test_beats_and_key_with_unloaded_models_is_retryable(
     assert excinfo.value.retry_at is not None
 
 
+async def test_beats_and_key_survives_an_unload_during_beat_inference(
+    provider: SmartFadesProvider,
+) -> None:
+    """The models resolve before the beat stage, so an unload during it cannot lose the key."""
+    assert provider._models is not None
+    chromanet = provider._models.skey_chromanet
+
+    async def unload_during_beat_stage(
+        _feats: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, int]:
+        provider._models = None
+        return np.zeros(4, dtype=np.float32), np.zeros(1, dtype=np.float32), 4
+
+    with (
+        patch.object(provider, "_infer_beat_timings", new=unload_during_beat_stage),
+        patch.object(provider, "_infer_musical_key", return_value=("C", "major")) as infer_key,
+    ):
+        *_, key, mode = await provider._infer_beats_and_key(
+            np.zeros((10, 128), dtype=np.float32), None
+        )
+
+    assert (key, mode) == ("C", "major")
+    assert infer_key.call_args.args[0] is chromanet
+
+
 async def test_spectral_centroid_with_unloaded_models_is_retryable(
     deterministic_provider: SmartFadesProvider,
 ) -> None:

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import math
 from collections.abc import Callable, Generator
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -25,6 +26,7 @@ from music_assistant.providers.smart_fades.dbn_postprocessor import DBNDownBeatT
 from music_assistant.providers.smart_fades.provider import (
     ANALYSIS_SAMPLE_RATE,
     BEAT_WINDOW_PACE_RATIO,
+    LoadedModels,
     SmartFadesProvider,
 )
 from music_assistant.providers.smart_fades.vocal_activity import (
@@ -125,22 +127,28 @@ def config_mock() -> Mock:
     return config
 
 
+def _stub_models() -> LoadedModels:
+    """Return a model set with stand-ins for every component; the centroid is the real one."""
+    return LoadedModels(
+        beat_this=Mock(),
+        beat_this_post_processor=Mock(),
+        skey_vqt=Mock(),
+        skey_chromanet=Mock(),
+        skey_crop=Mock(),
+        spectral_centroid=SpectralCentroid(sample_rate=ANALYSIS_SAMPLE_RATE, hop_length=512),
+        firered=Mock(),
+        firered_cmvn_means=np.zeros(FIRERED_MEL_BINS, dtype=np.float64),
+        firered_cmvn_inverse_std=np.ones(FIRERED_MEL_BINS, dtype=np.float64),
+    )
+
+
 @pytest.fixture
 async def provider(mass_mock: Mock, manifest_mock: Mock, config_mock: Mock) -> SmartFadesProvider:
     """Return a SmartFadesProvider without loading external model assets."""
     prov = SmartFadesProvider(mass_mock, manifest_mock, config_mock, set())
     with patch.object(prov, "_load_models", new=AsyncMock()):
         await prov.handle_async_init()
-    prov._spectral_centroid = SpectralCentroid(
-        sample_rate=ANALYSIS_SAMPLE_RATE,
-        hop_length=512,
-    )
-    prov._beat_this_model = Mock()
-    prov._beat_this_post_processor = Mock()
-    prov._skey_chromanet = Mock()
-    prov._firered_model = Mock()
-    prov._firered_cmvn_means = np.zeros(FIRERED_MEL_BINS, dtype=np.float64)
-    prov._firered_cmvn_inverse_std = np.ones(FIRERED_MEL_BINS, dtype=np.float64)
+    prov._models = _stub_models()
     return prov
 
 
@@ -455,13 +463,11 @@ def test_initialize_models_uses_expected_components(provider: SmartFadesProvider
     original_beat_module = beat_model.model
     quantized_beat_module = Mock()
     beat_post_processor = Mock()
-    skey_components = (Mock(), Mock(), Mock())
+    skey_vqt, skey_chromanet, skey_crop = Mock(), Mock(), Mock()
     spectral_centroid = Mock()
-    firered_components = (
-        Mock(),
-        np.zeros(FIRERED_MEL_BINS, dtype=np.float64),
-        np.ones(FIRERED_MEL_BINS, dtype=np.float64),
-    )
+    firered_model = Mock()
+    cmvn_means = np.zeros(FIRERED_MEL_BINS, dtype=np.float64)
+    cmvn_inverse_std = np.ones(FIRERED_MEL_BINS, dtype=np.float64)
 
     with (
         patch(
@@ -478,7 +484,7 @@ def test_initialize_models_uses_expected_components(provider: SmartFadesProvider
         ),
         patch(
             "music_assistant.providers.smart_fades.provider.load_skey_components",
-            return_value=skey_components,
+            return_value=(skey_vqt, skey_chromanet, skey_crop),
         ),
         patch(
             "music_assistant.providers.smart_fades.provider.SpectralCentroid",
@@ -486,10 +492,10 @@ def test_initialize_models_uses_expected_components(provider: SmartFadesProvider
         ),
         patch(
             "music_assistant.providers.smart_fades.provider.load_firered_components",
-            return_value=firered_components,
+            return_value=(firered_model, cmvn_means, cmvn_inverse_std),
         ),
     ):
-        components = provider._initialize_models()
+        models = provider._initialize_models()
 
     spect2frames.assert_called_once_with(checkpoint_path="small0", device="cpu")
     quantize_dynamic.assert_called_once_with(
@@ -498,13 +504,24 @@ def test_initialize_models_uses_expected_components(provider: SmartFadesProvider
         dtype=torch.qint8,
     )
     assert beat_model.model is quantized_beat_module
-    assert components == (
-        beat_model,
-        beat_post_processor,
-        *skey_components,
-        spectral_centroid,
-        *firered_components,
-    )
+    assert models.beat_this is beat_model
+    assert models.beat_this_post_processor is beat_post_processor
+    assert models.skey_vqt is skey_vqt
+    assert models.skey_chromanet is skey_chromanet
+    assert models.skey_crop is skey_crop
+    assert models.spectral_centroid is spectral_centroid
+    assert models.firered is firered_model
+    assert models.firered_cmvn_means is cmvn_means
+    assert models.firered_cmvn_inverse_std is cmvn_inverse_std
+
+
+def test_free_models_releases_the_whole_set(provider: SmartFadesProvider) -> None:
+    """Every component goes at once, so an analysis can never run on a half-unloaded set."""
+    assert provider._models is not None
+
+    provider._free_models()
+
+    assert provider._models is None
 
 
 async def test_analysis_version_is_3(provider: SmartFadesProvider) -> None:
@@ -789,11 +806,11 @@ async def test_vocal_inference_failure_is_retryable(provider: SmartFadesProvider
     assert excinfo.value.retry_at > datetime.now(UTC)
 
 
-async def test_vocal_inference_with_unloaded_model_is_retryable(
+async def test_vocal_inference_with_unloaded_models_is_retryable(
     provider: SmartFadesProvider,
 ) -> None:
     """The idle-unload race (models freed mid-finalize) must not poison the track forever."""
-    provider._firered_model = None
+    provider._models = None
 
     with pytest.raises(AudioAnalysisError) as excinfo:
         await provider._infer_vocal_activity(np.zeros((10, 80), dtype=np.float32), 0.1)
@@ -801,24 +818,19 @@ async def test_vocal_inference_with_unloaded_model_is_retryable(
     assert excinfo.value.retry_at is not None
 
 
-@pytest.mark.parametrize(
-    "field",
-    ["_beat_this_model", "_beat_this_post_processor", "_skey_chromanet"],
-)
-async def test_beats_and_key_with_unloaded_model_is_retryable(
+async def test_beats_and_key_with_unloaded_models_is_retryable(
     provider: SmartFadesProvider,
-    field: str,
 ) -> None:
-    """The beat/key branch decides permanent vs retryable, so an unloaded model must retry."""
-    setattr(provider, field, None)
+    """The beat/key branch decides permanent vs retryable, so unloaded models must retry."""
+    provider._models = None
 
-    with pytest.raises(AudioAnalysisError, match="is not loaded") as excinfo:
+    with pytest.raises(AudioAnalysisError, match="not loaded") as excinfo:
         await provider._infer_beats_and_key(np.zeros((10, 128), dtype=np.float32), None)
 
     assert excinfo.value.retry_at is not None
 
 
-async def test_spectral_centroid_with_unloaded_transform_is_retryable(
+async def test_spectral_centroid_with_unloaded_models_is_retryable(
     deterministic_provider: SmartFadesProvider,
 ) -> None:
     """The block path also runs during finalize, so it must not record a permanent failure."""
@@ -844,9 +856,9 @@ async def test_spectral_centroid_with_unloaded_transform_is_retryable(
         session_id, FIXTURE_PCM.read_bytes()[: 44100 * 2 * 4]
     )
     # The models are freed while the (detached) finalize is still running.
-    deterministic_provider._spectral_centroid = None
+    deterministic_provider._models = None
 
-    with pytest.raises(AudioAnalysisError, match="is not loaded") as excinfo:
+    with pytest.raises(AudioAnalysisError, match="not loaded") as excinfo:
         await deterministic_provider._finalize(session_id)
 
     assert excinfo.value.retry_at is not None
@@ -871,14 +883,17 @@ async def test_windowed_inference_matches_whole_track_prediction(
     rng = np.random.default_rng(3)
     feats = rng.normal(size=(4000, 128)).astype(np.float32)
     stub = _StubBeatModel()
-    provider._beat_this_model = Mock(model=stub)
     captured: list[np.ndarray] = []
 
     def post_processor(activations: np.ndarray) -> tuple[np.ndarray, int]:
         captured.append(activations)
         return np.array([[0.0, 1.0], [0.5, 2.0]]), 4
 
-    provider._beat_this_post_processor = cast("DBNDownBeatTracker", post_processor)
+    provider._models = replace(
+        _stub_models(),
+        beat_this=Mock(model=stub),
+        beat_this_post_processor=cast("DBNDownBeatTracker", post_processor),
+    )
 
     async def run_offloaded_timed(func: Callable[..., object], *args: object) -> object:
         return func(*args), 0.0


### PR DESCRIPTION
# What does this implement/fix?

Smart Fades loads nine model components, and adding or removing one meant editing four
hand-synced lists: the attribute declarations, the tuple unpack in `_load_models()`, the
`= None` assignments in `_free_models()`, and the return-tuple annotation on
`_initialize_models()`. Miss one and a model either stays in memory after an unload or gets
wired to the wrong slot — the two FireRed CMVN arrays share a type, so swapping them would
type-check fine and silently produce garbage features.

The models are loaded and freed as one set, so they now live in one frozen `LoadedModels`
dataclass behind a single field. Adding a model is one line, and mypy points at the one
place that still needs updating. No behaviour change.

## Changes

- Collapse the nine model attributes into a frozen `LoadedModels` dataclass held in one field.
- Build it with keyword arguments, so components can no longer be wired to the wrong slot.
- Replace the nine per-component `_require_loaded()` guards with a single `_require_models()`
  that resolves the whole set once per code path.
- Reduce the test fixture to one stub set, and cover that unloading releases all of it.
- Pin the "models resolve before the beat stage" contract with a test that frees them
  mid-inference, so that race can no longer be broken silently.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

