### PR TITLE
Keep Spotify playing without a gap when a track repeats or the queue changes

### DIFF
--- a/music_assistant/providers/spotify/README.md
+++ b/music_assistant/providers/spotify/README.md
@@ -82,17 +82,24 @@ audio prefs, wire models) is shared infrastructure owned by the Spotify Connect 
   item's stream ends where the session reports moving on, and the next item's stream
   begins there. Played back to back the items reproduce the session's audio sample for
   sample, so the cut position does not matter. Only consecutive tracks are stitched; a
-  podcast episode or audiobook chapter is played on its own.
+  podcast episode or audiobook chapter is played on its own. Channels are per
+  occurrence rather than per track, so a queue holding the same track twice in a row
+  stitches through it like any other pair — the engine names both under one URI, and
+  the order they were fed in is what tells them apart.
 - **Use the engine's transport before respawning it.** A next-track lands on the item
   that was fed one ahead, so the engine is told to skip to it and the session
-  survives. Tearing a session down and spawning another costs a login, an
-  activate and a re-feed, which is seconds — and the daemon never exits on its own, so
-  nothing is gained by waiting for it either: it is closed straight away.
+  survives. A next item the session was *not* fed — the queue was reordered after the
+  feed, or the user picked something else — is queued and skipped to in the same way,
+  as long as the engine has nothing else queued behind what it plays: its queue offers
+  no way to remove or replace an entry, only to append one and move past it. Tearing a
+  session down and spawning another costs a login, an activate and a re-feed, which is
+  seconds — and the daemon never exits on its own, so nothing is gained by waiting for
+  it either: it is closed straight away.
 - **A session in use is never cut short**: the engine allows one session, so an item
   the running one cannot serve would otherwise restart it and truncate whatever it is
   still delivering. That happens at boundaries the session does not drive — a podcast
-  episode or audiobook chapter (never stitched), the same track twice in a row, or
-  another player — so those are reported as `ProviderStreamLimitError` instead. A
+  episode or audiobook chapter (never stitched) or another player — so those are
+  reported as `ProviderStreamLimitError` instead. A
   speculative prepare then gives up softly, and the real request, made once the other
   item has been released, gets the session. The cost is a cold start at those
   boundaries rather than a warm buffer.

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -131,6 +131,11 @@ _READ_SLICE_S: Final[float] = 1.0
 _STALL_TIMEOUT_S: Final[float] = 30.0
 # waiting for the daemon's WS endpoint, events and the requested item to appear
 _STARTUP_TIMEOUT_S: Final[float] = 30.0
+# How long a jump on a live session is given to land. Generous against the
+# milliseconds the engine actually takes, but short enough that a jump which
+# will not land still leaves the queue patience for the fresh session that
+# serves the item instead.
+_JUMP_TIMEOUT_S: Final[float] = 5.0
 # how often to check whether the events task has the WebSocket up yet
 _CONNECT_POLL_S: Final[float] = 0.05
 _SEEK_CONFIRM_TIMEOUT_S: Final[float] = 15.0
@@ -430,7 +435,7 @@ class SoloistBackend(SpotifyPlaybackBackend):
             # settling on a fresh start, or the next item still being resolved)
             # is asked for again while the item streams.
             boundary_settled = streamdetails is None or await session.feed_after(
-                streamdetails, spotify_uri
+                streamdetails, item
             )
             next_feed_attempt = 0.0
             async for chunk in item.read():
@@ -438,7 +443,7 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     now = time.monotonic()
                     if now >= next_feed_attempt:
                         next_feed_attempt = now + _FEED_RETRY_INTERVAL_S
-                        boundary_settled = await session.feed_after(streamdetails, spotify_uri)
+                        boundary_settled = await session.feed_after(streamdetails, item)
                 yield chunk
         finally:
             item.release()
@@ -532,10 +537,10 @@ class SoloistBackend(SpotifyPlaybackBackend):
         """
         Return the session and audio channel to stream this item from.
 
-        Continues the running session when it already plays (or has been fed)
-        this item for this queue, seeking it in place when a position is asked
-        for; anything else — another queue, a skipped-to item, a session that is
-        gone — starts a fresh session.
+        Continues the running session when it can still reach this item for
+        this queue — playing it, fed it, or able to be sent to it — and seeks it
+        in place when it is the one the engine is on; anything else — another
+        queue, a session that is gone — starts a fresh session.
         """
         async with self._session_lock:
             self._raise_if_app_controlled()
@@ -551,17 +556,24 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     # claimed only once the engine is there: a refused skip
                     # would otherwise leave the channel claimed for good, and
                     # the session busy and unable to expire
-                    await session.skip_to(pending)
-                    pending.claim()
-                    return session, pending
+                    try:
+                        await session.skip_to(pending)
+                    except AudioError as err:
+                        # a fresh session starts on the item instead
+                        self.logger.debug(
+                            "The soloist session would not jump to the fed item, restarting it: %s",
+                            err,
+                        )
+                    else:
+                        pending.claim()
+                        return session, pending
                 if session.is_playing(spotify_uri):
                     # The engine is on this item already, so it can be seeked
                     # where it stands instead of paying a whole respawn - which
                     # would also have to claim the Connect device back. Not
-                    # gated on a non-zero position: the branches above have
-                    # returned by now, so reaching here means re-opening the
-                    # item being played, and back to its very start is as much
-                    # a seek as any other.
+                    # gated on a non-zero position: re-opening the item being
+                    # played is a seek of it whatever the target, back to its
+                    # very start included.
                     try:
                         item = await session.seek_current(spotify_uri, seek_position * 1000)
                     except ProviderStreamLimitError:
@@ -575,6 +587,16 @@ class SoloistBackend(SpotifyPlaybackBackend):
                         )
                     else:
                         return session, item
+                if (
+                    not seek_position
+                    and not session.in_use
+                    and (item := await session.feed_and_skip_to(spotify_uri)) is not None
+                ):
+                    # the queue settled on a next item the session was not fed -
+                    # it was reordered after the feed - and the engine can still
+                    # be sent there, which keeps the session
+                    item.claim()
+                    return session, item
             if session is not None:
                 if session.in_use and (
                     session.queue_id != queue_id or not session.is_playing(spotify_uri)
@@ -587,8 +609,8 @@ class SoloistBackend(SpotifyPlaybackBackend):
                     # softly and the real request, made once the other item has
                     # been released, gets the session.
                     raise SoloistSessionBusyError(self.provider)
-                # re-opening the item that is playing is a seek (or a replay) of
-                # that same item, which is exactly a restart of the session
+                # a seek of the playing item the session could not take, which
+                # a fresh session serves at the target instead
                 await session.stop()
                 self._session = None
             # cheap thanks to the shared verify cache; swaps in a fresh build when
@@ -753,10 +775,11 @@ class _SoloistSession:
         # what the engine was actually told at spawn, which is what the streams
         # core has to agree with - the setting may be toggled while this plays
         self.engine_normalizes = False
-        self._items: dict[str, _ItemAudio] = {}
+        # every channel this session opened, oldest first
+        self._channels: list[_ItemAudio] = []
         self._current: _ItemAudio | None = None
-        # uris handed to the engine that it has not started playing yet
-        self._pending: deque[str] = deque()
+        # channels handed to the engine that it has not started playing yet
+        self._pending: deque[_ItemAudio] = deque()
         self._client: SoloistClient | None = None
         self._sink: PipeSink | None = None
         self._proc: AsyncProcess | None = None
@@ -790,8 +813,8 @@ class _SoloistSession:
         self._backpressured = False
         self._sink_lock = asyncio.Lock()
         self._idle_since: float | None = None
-        # while set, captured audio is dropped until the engine reports this item
-        self._discard_until: str | None = None
+        # while set, captured audio is dropped until the engine reports this channel
+        self._discard_until: _ItemAudio | None = None
         # while set, a seek of the current item is in flight and nothing the
         # engine renders belongs to either side of it
         self._seeking = False
@@ -801,7 +824,7 @@ class _SoloistSession:
     @property
     def in_use(self) -> bool:
         """Return whether an item stream is reading this session right now."""
-        return any(item.claimed for item in self._items.values())
+        return any(item.claimed for item in self._channels)
 
     def pending_item(self, spotify_uri: str) -> _ItemAudio | None:
         """
@@ -810,12 +833,13 @@ class _SoloistSession:
         The engine can be told to jump to it, which keeps the session instead of
         paying a fresh spawn.
 
+        The engine names tracks by URI, so the same track twice in a row is told
+        apart by the order it was fed in: the channel returned is the earliest
+        occurrence still waiting.
+
         :param spotify_uri: The canonical Spotify URI to check.
         """
-        item = self._items.get(spotify_uri)
-        if item is None or item.spent or item.started.is_set():
-            return None
-        return item if spotify_uri in self._pending else None
+        return next((item for item in self._pending if item.uri == spotify_uri), None)
 
     async def skip_to(self, item: _ItemAudio) -> None:
         """
@@ -829,7 +853,7 @@ class _SoloistSession:
             raise AudioError("Spotify Soloist is not connected")
         # armed before the command: everything already rendered belongs to the
         # item being left behind
-        self._discard_until = item.uri
+        self._discard_until = item
         try:
             try:
                 await client.skip_next()
@@ -837,7 +861,7 @@ class _SoloistSession:
                 raise AudioError(
                     f"Spotify Soloist would not skip to {item.uri}: {type(err).__name__} {err}"
                 ) from err
-            async with asyncio.timeout(_STARTUP_TIMEOUT_S):
+            async with asyncio.timeout(_JUMP_TIMEOUT_S):
                 await item.started.wait()
         except TimeoutError:
             raise AudioError(f"Spotify Soloist did not reach {item.uri}") from None
@@ -882,16 +906,14 @@ class _SoloistSession:
                 raise AudioError(f"Spotify Soloist moved on from {spotify_uri}")
             # A fresh channel rather than a reset one: the outgoing stream may
             # still be draining this item, and two readers on one channel would
-            # each take part of the audio. The uri key is what feed_after's
-            # ledger goes by, so replacing the object under it leaves that
-            # untouched.
-            item = self._items[spotify_uri] = _ItemAudio(spotify_uri, self)
+            # each take part of the audio.
+            item = self._open_channel(spotify_uri)
             # both describe the track rather than the position within it
             item.duration_ms = outgoing.duration_ms
             item.playing_seen = outgoing.playing_seen
             item.started.set()
             # claimed here rather than by the caller: _expire_idle only counts
-            # claimed channels, and the outgoing one has left _items
+            # claimed channels, and the outgoing one is closed below
             item.claim()
             self._current = item
             outgoing.close()
@@ -971,19 +993,19 @@ class _SoloistSession:
 
     def item_for(self, spotify_uri: str) -> _ItemAudio | None:
         """
-        Return the audio channel for an item this session plays or was fed, if any.
+        Return the audio channel for the item this session is playing, if it can serve it.
 
-        Two conditions. A channel is served at most once: its audio is handed
-        over as it is consumed, so a stream that already read it — to the end or
-        part-way — cannot be replayed. And the engine has to have reached the
-        item: a fed item the engine is not playing yet means Music Assistant
-        moved somewhere the session has not (a skip), and continuing there would
-        hand over a channel that only fills when the current track ends.
+        Only the item the engine is actually on is answered for: a fed item it
+        has not reached yet would hand over a channel that only fills when the
+        current track ends, and one it has moved on from holds no more than part
+        of its item. A channel is also served at most once — its audio is handed
+        over as it is consumed, so a stream that already read it cannot replay
+        it — which is what tells two occurrences of one track apart.
         """
-        item = self._items.get(spotify_uri)
-        if item is None or item.spent or not item.started.is_set():
+        item = self._current
+        if item is None or item.uri != spotify_uri or item.spent or item.closed:
             return None
-        return item
+        return item if item.started.is_set() else None
 
     async def start(self, spotify_uri: str, seek_position: int) -> _ItemAudio:
         """
@@ -1039,7 +1061,7 @@ class _SoloistSession:
         await self._apply_sink_state(engine_playing=item.status == "playing")
         return item
 
-    async def feed_after(self, streamdetails: StreamDetails, spotify_uri: str) -> bool:
+    async def feed_after(self, streamdetails: StreamDetails, streamed: _ItemAudio) -> bool:
         """
         Hand the engine the item that follows the one being streamed, if any.
 
@@ -1049,11 +1071,65 @@ class _SoloistSession:
 
         :param streamdetails: The StreamDetails of the item being streamed, used
             to locate it in the queue.
-        :param spotify_uri: The URI being streamed (only tracks are fed ahead).
+        :param streamed: The channel of the item being streamed (only tracks are
+            fed ahead).
         :return: Whether the boundary is settled; False means the follower was
             not knowable yet and asking again later may still feed it.
         """
-        return await self._feed_follower(streamdetails, spotify_uri)
+        return await self._feed_follower(streamdetails, streamed)
+
+    async def feed_and_skip_to(self, spotify_uri: str) -> _ItemAudio | None:
+        """
+        Queue an item the engine was not fed and jump to it, keeping the session.
+
+        Serves a next item the queue only settled on after the session had
+        already been fed one - a reordered, inserted or deleted upcoming item -
+        which the engine's own transport can still reach. The engine's queue
+        cannot be rewritten, so this only applies while nothing else is queued
+        behind what it plays.
+
+        :param spotify_uri: Canonical Spotify track URI to move on to.
+        :return: The channel to stream the item from, or None when the session
+            cannot take it and has to be replaced.
+        """
+        client = self._client
+        current = self._current
+        if client is None or self.has_pending or not spotify_uri.startswith("spotify:track:"):
+            return None
+        if not self._engine_playing:
+            # a stopped engine has nothing to skip out of, and waiting one out
+            # costs more than the respawn this is trying to save
+            return None
+        if current is None or current.uri == spotify_uri:
+            # the engine is on this item and seeking it in place was refused, so
+            # a fresh session is what serves it
+            return None
+        item = self._open_channel(spotify_uri)
+        self._pending.append(item)
+        try:
+            # ordered on one connection, so the entry is queued before the jump
+            await client.add_to_queue(spotify_uri)
+            if self._current is not item:
+                # unless the engine reached the end of what it was playing while
+                # the command was in flight and moved on into it by itself
+                await self.skip_to(item)
+        except asyncio.CancelledError:
+            # The commands are already with the engine, and where it ends up is
+            # no longer observable from here: the jump's own marker is gone, so
+            # the audio still in flight from the item left behind could not be
+            # measured off the arrival. Ended rather than reasoned about - by
+            # this point nothing is reading the session anyway.
+            self._fail(f"a jump to {spotify_uri} was abandoned")
+            raise
+        except (TimeoutError, OSError, ClientError, SoloistError, AudioError) as err:
+            if self._current is item:
+                # the engine acted on the commands before the failure got back to
+                # us, so it is on this item after all
+                return item
+            self.logger.debug("Unable to move the soloist session to %s: %s", spotify_uri, err)
+            self._drop_channel(item)
+            return None
+        return item
 
     async def validate_item(self, item: _ItemAudio) -> None:
         """
@@ -1090,7 +1166,7 @@ class _SoloistSession:
         if self._teardown_done:
             return
         self._stopped = True
-        for item in self._items.values():
+        for item in self._channels:
             item.close()
         if self._client is not None and self._proc is not None:
             # commands travel over the events connection, so this has to happen
@@ -1161,7 +1237,7 @@ class _SoloistSession:
         if self._error is not None:
             return
         self._error = message
-        for item in self._items.values():
+        for item in self._channels:
             # started and seek_confirmed too, so an item still waiting to be
             # reported as current - or for a seek to land - fails right away
             # instead of sitting out its timeout
@@ -1189,41 +1265,33 @@ class _SoloistSession:
             != CONF_VALUE_DISABLED
         )
 
-    async def _feed_follower(self, streamdetails: StreamDetails, spotify_uri: str) -> bool:
+    async def _feed_follower(self, streamdetails: StreamDetails, streamed: _ItemAudio) -> bool:
         """
         Feed the engine the track after this one, and report whether it will play on into it.
 
         :param streamdetails: The StreamDetails of the item being streamed.
-        :param spotify_uri: The URI being streamed (only tracks are fed ahead).
+        :param streamed: The channel of the item being streamed (only tracks are
+            fed ahead).
         """
         client = self._client
-        if client is None or not spotify_uri.startswith("spotify:track:"):
+        if client is None or not streamed.uri.startswith("spotify:track:"):
             return False
         next_uri = self._feedable_follower_uri(streamdetails)
         if next_uri is None:
             return False
-        existing = self._items.get(next_uri)
-        if existing is not None and (
-            existing.claimed or existing is self._current or not existing.spent
-        ):
+        if self._engine_plays_on_into(next_uri, streamed):
             # nothing left to send, so whether the engine plays on rests entirely on
             # the channel this session already holds for it
-            return self._engine_plays_on_into(next_uri, spotify_uri)
-        if existing is not None:
-            # a channel left from an earlier play of the same track: its audio was
-            # handed over already, so this occurrence needs its own feed and channel
-            del self._items[next_uri]
-            with suppress(ValueError):
-                self._pending.remove(next_uri)
+            return True
         # Registered before the command goes out: the engine can reach the item
         # while it is still in flight, and the events task has to find its
         # channel rather than mistake it for something nobody asked for.
-        item = self._items[next_uri] = _ItemAudio(next_uri, self)
-        self._pending.append(next_uri)
+        item = self._open_channel(next_uri)
+        self._pending.append(item)
         try:
             await client.add_to_queue(next_uri)
         except (TimeoutError, OSError, ClientError, SoloistError) as err:
-            # a failed feed only costs the crossfade at that boundary: the next
+            # a failed feed only costs the stitch at that boundary: the next
             # item still plays, on a fresh session
             self.logger.debug("Unable to feed %s to the soloist session: %s", next_uri, err)
             if self._current is item:
@@ -1235,27 +1303,27 @@ class _SoloistSession:
                 # channel makes the retry settle on it instead of queueing the
                 # same track a second time
                 return False
-            del self._items[next_uri]
-            with suppress(ValueError):
-                self._pending.remove(next_uri)
+            self._drop_channel(item)
             return False
         self.logger.debug("Fed %s to the soloist session", next_uri)
         return True
 
-    def _engine_plays_on_into(self, next_uri: str, streamed_uri: str) -> bool:
+    def _engine_plays_on_into(self, next_uri: str, streamed: _ItemAudio) -> bool:
         """
         Return whether the engine plays on into a follower this session already holds.
 
-        Only a channel that can still be served across the boundary is played on into:
-        a drained one cannot be replayed, and neither can the item being streamed
-        itself, so both start a fresh session instead.
+        A track occurring twice in a row is fed a channel of its own: the
+        occurrence being streamed answers for itself, never for the one behind
+        it. Anything else the engine is already on or has been handed does.
 
         :param next_uri: URI of the follower.
-        :param streamed_uri: URI of the item being streamed.
+        :param streamed: The channel of the item being streamed.
         """
-        if next_uri == streamed_uri:
-            return False
-        return self.pending_item(next_uri) is not None or self.item_for(next_uri) is not None
+        if self.pending_item(next_uri) is not None or self.item_for(next_uri) is not None:
+            return True
+        # already reached and taken by its own stream, which item_for no longer offers
+        current = self._current
+        return current is not None and current is not streamed and current.uri == next_uri
 
     def _feedable_follower_uri(self, streamdetails: StreamDetails) -> str | None:
         """
@@ -1293,7 +1361,12 @@ class _SoloistSession:
             if item is None:
                 break
             if item.streamdetails is streamdetails:
-                return controller.get_next_item(queue_id, item.queue_item_id)
+                follower = controller.get_next_item(queue_id, item.queue_item_id)
+                if follower is not None and follower.queue_item_id == item.queue_item_id:
+                    # repeating one track: the queue replays this very item from
+                    # the buffer it already holds, so the engine is not fed for it
+                    return None
+                return follower
         # commonly a queue index that has not settled yet (fresh play start);
         # the caller keeps asking while the item streams
         self.logger.debug(
@@ -1323,7 +1396,7 @@ class _SoloistSession:
         """Activate the engine, start the requested item and wait until it is current."""
         client = self._client
         assert client is not None
-        item = self._items[spotify_uri] = _ItemAudio(spotify_uri, self)
+        item = self._open_channel(spotify_uri)
         self._current = item
         # Commands travel over the events connection, and the engine takes them
         # in three stages: it publishes its endpoint, then accepts a connection,
@@ -1621,7 +1694,9 @@ class _SoloistSession:
             return
         if isinstance(data, SoloistTrackChanged):
             if data.item is not None and data.item.uri:
-                await self._observe_current(data.item.uri, _decorated_duration_ms(data.item))
+                await self._observe_current(
+                    data.item.uri, _decorated_duration_ms(data.item), track_changed=True
+                )
             return
         if isinstance(data, SoloistPositionSync):
             if (item := self._current) is not None:
@@ -1642,7 +1717,9 @@ class _SoloistSession:
         # deltas too, so the dedicated device_changed/auth_state reports are the
         # only ones worth following.
         if data.item is not None and data.item.uri:
-            await self._observe_current(data.item.uri, _decorated_duration_ms(data.item))
+            await self._observe_current(
+                data.item.uri, _decorated_duration_ms(data.item), track_changed=False
+            )
             if not self.usable:
                 # the snapshot ended the session; nothing below it should still
                 # be pinning volume or options on what the app is now driving
@@ -1734,7 +1811,7 @@ class _SoloistSession:
                 # sink is held down here is ours, not the user's in the app.
                 want = False
                 backpressured = True
-            elif any(item.draining for item in self._items.values()):
+            elif any(item.draining for item in self._channels):
                 want = True
             elif not self._engine_playing:
                 want = False
@@ -1795,7 +1872,7 @@ class _SoloistSession:
 
     def _retained_bytes(self) -> int:
         """Return how much captured audio is buffered but not delivered yet."""
-        return sum(item.buffered for item in self._items.values())
+        return sum(item.buffered for item in self._channels)
 
     def _drain_last_item(self, item: _ItemAudio) -> None:
         """
@@ -1829,7 +1906,60 @@ class _SoloistSession:
             task.cancel()
         item.cancel_tail_drain()
 
-    async def _observe_current(self, uri: str, duration_ms: int | None) -> None:
+    def _open_channel(self, uri: str) -> _ItemAudio:
+        """Open a channel for one occurrence of an item, dropping any nothing can read."""
+        # A channel the session has moved past and no stream holds can answer
+        # for nothing: it is dropped here rather than carried for the rest of
+        # the run, where its buffer would go on counting against the retention
+        # cap and the capture loop would go on scanning it.
+        self._channels = [
+            item
+            for item in self._channels
+            if not item.closed or item.claimed or item is self._current
+        ]
+        item = _ItemAudio(uri, self)
+        self._channels.append(item)
+        return item
+
+    def _drop_channel(self, item: _ItemAudio) -> None:
+        """Forget a channel the engine never got, so it cannot answer for the item."""
+        with suppress(ValueError):
+            self._channels.remove(item)
+        with suppress(ValueError):
+            self._pending.remove(item)
+
+    def _channel_awaiting(self, uri: str) -> _ItemAudio | None:
+        """Return the earliest channel opened for this item that the engine has not started."""
+        return next(
+            (item for item in self._channels if item.uri == uri and not item.started.is_set()),
+            None,
+        )
+
+    def _moved_on(
+        self, current: _ItemAudio, pending: _ItemAudio | None, *, track_changed: bool
+    ) -> bool:
+        """
+        Return whether a report naming the item already playing means its next occurrence.
+
+        The engine names tracks by URI, so a track queued twice in a row reports
+        the very same one on both sides of the boundary between the two. What
+        tells them apart is that the engine announces a track change, and that
+        the occurrence being left is either played out or the one a jump was
+        aimed past.
+
+        :param current: The channel the engine was playing.
+        :param pending: The channel of an occurrence fed behind it, if any.
+        :param track_changed: Whether the engine announced a track change.
+        :return: False throughout an in-place seek, whose channel has no
+            position of its own to judge the occurrence being left by.
+        """
+        if pending is None or not track_changed or self._seeking:
+            return False
+        return self._discard_until is pending or not current.mid_play
+
+    async def _observe_current(
+        self, uri: str, duration_ms: int | None, *, track_changed: bool
+    ) -> None:
         """
         Follow the engine to the item it reports as current, cutting the previous one.
 
@@ -1837,14 +1967,26 @@ class _SoloistSession:
         carries whatever was read up to that point and the next item's stream
         continues from there, so the two together still reproduce the session's
         audio exactly.
+
+        :param uri: The canonical Spotify URI the engine reports as current.
+        :param duration_ms: The item's duration, when the engine reported one.
+        :param track_changed: Whether the engine announced a track change rather
+            than described the state it is in. Only a track change moves a track
+            occurring twice in a row on to its second occurrence, which the
+            engine reports under the very same URI.
         """
         current = self._current
         if current is not None and current.uri == uri:
-            if duration_ms:
-                current.duration_ms = duration_ms
-            current.started.set()
-            return
-        item = self._items.get(uri)
+            # the same track twice in a row is reported under one uri on both
+            # sides of the boundary between the two occurrences
+            item = self.pending_item(uri)
+            if not self._moved_on(current, item, track_changed=track_changed):
+                if duration_ms:
+                    current.duration_ms = duration_ms
+                current.started.set()
+                return
+        else:
+            item = self._channel_awaiting(uri)
         if (item is None or item.spent) and current is not None and current.mid_play:
             # The engine left an item Music Assistant is part-way through for
             # somewhere it was never sent: the user is driving from the Spotify
@@ -1858,15 +2000,15 @@ class _SoloistSession:
             # starts, or its own autoplay. It gets a channel so the reader has
             # somewhere to put the audio, but it is never offered as an item's
             # audio.
-            item = self._items[uri] = _ItemAudio(uri, self)
+            item = self._open_channel(uri)
             item.spent = True
         if duration_ms:
             item.duration_ms = duration_ms
         with suppress(ValueError):
-            self._pending.remove(uri)
+            self._pending.remove(item)
         self._current = item
         self._app_pauses = 0
-        if self._discard_until == uri:
+        if self._discard_until is item:
             self._discard_until = None
             # The engine confirms a jump over the WebSocket within a few
             # milliseconds, long before the audio it describes reaches the

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -26,6 +26,7 @@ from music_assistant_models.errors import AudioError, LoginFailed
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
+from music_assistant.controllers.streams.audio_buffer import BUFFER_READY_TIMEOUT
 from music_assistant.helpers.pulse_capture import CAPTURE_SAMPLE_RATE
 from music_assistant.models.music_provider import ProviderStreamLimitError
 from music_assistant.providers.spotify.backends import soloist as soloist_backend
@@ -34,6 +35,7 @@ from music_assistant.providers.spotify.backends.soloist import (
     _FRAME_BYTES,
     _IDLE_TIMEOUT_S,
     _ITEM_OVERRUN_S,
+    _JUMP_TIMEOUT_S,
     _MAX_APP_PAUSE_RESUMES,
     _MAX_LEAD_TRIM_S,
     _READ_CHUNK_SIZE,
@@ -73,6 +75,7 @@ from music_assistant.providers.spotify_connect.soloist.runtime import (
 
 TRACK_A = "spotify:track:aaa"
 TRACK_B = "spotify:track:bbb"
+TRACK_C = "spotify:track:ccc"
 
 
 def test_trim_drops_an_all_zero_chunk_within_the_bound() -> None:
@@ -177,18 +180,19 @@ def test_position_never_regresses_and_stops_at_the_cut(tmp_path: Path) -> None:
 async def test_item_stream_ends_where_the_session_moves_on(tmp_path: Path) -> None:
     """An item's audio ends at the track change, and the next item's begins there."""
     session = _make_session(tmp_path)
-    item_a = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item_a = session._open_channel(TRACK_A)
     session._current = item_a
     item_a.started.set()
     item_a.claim()
     item_a.write(b"a" * 16)
-    await session._observe_current(TRACK_B, 200_000)
+    await session._observe_current(TRACK_B, 200_000, track_changed=True)
     item_a.write(b"late" * 4)  # written after the cut: goes nowhere
     chunks = [chunk async for chunk in item_a.read()]
     assert b"".join(chunks) == b"a" * 16
     # the next item exists, carries the duration and now receives the audio
-    item_b = session._items[TRACK_B]
-    assert session.current is item_b
+    item_b = session.current
+    assert item_b is not None
+    assert item_b.uri == TRACK_B
     assert item_b.duration_ms == 200_000
 
 
@@ -197,18 +201,18 @@ async def test_the_engines_restored_state_does_not_cut_a_pending_item(
 ) -> None:
     """A daemon reports the item it restored before playing ours; that is not a boundary."""
     session = _make_session(tmp_path)
-    requested = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    requested = session._open_channel(TRACK_A)
     session._current = requested
     requested.claim()
     # the engine announces the state it came up with, which is someone else's item
-    await session._observe_current("spotify:track:restored", 152_000)
+    await session._observe_current("spotify:track:restored", 152_000, track_changed=False)
     # closing our item here would end its stream before it delivered anything
     assert requested._closed is False
     assert requested.started.is_set() is False
     # ... and the restored item is never offered as an item's audio
     assert session.item_for("spotify:track:restored") is None
     # then ours starts for real, and picks up from there
-    await session._observe_current(TRACK_A, 200_000)
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
     assert session.current is requested
     assert requested.started.is_set() is True
     requested.write(b"\x01" * 32)
@@ -220,15 +224,15 @@ async def test_leaving_the_engines_restored_item_is_not_a_takeover(tmp_path: Pat
     """The restored item is part-way through a track, and we are about to leave it."""
     session = _make_session(tmp_path)
     # as _play leaves it: the channel exists, its stream is not reading it yet
-    requested = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    requested = session._open_channel(TRACK_A)
     session._current = requested
-    await session._observe_current("spotify:track:restored", 152_000)
+    await session._observe_current("spotify:track:restored", 152_000, track_changed=False)
     restored = session.current
     assert restored is not None
     restored.observe_position(20_000)
 
     # our own play() lands and the engine leaves the restored item for ours
-    await session._observe_current(TRACK_A, 200_000)
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
     assert session.usable is True
     assert session.current is requested
 
@@ -236,7 +240,7 @@ async def test_leaving_the_engines_restored_item_is_not_a_takeover(tmp_path: Pat
 async def test_audio_read_before_the_stream_opens_is_kept(tmp_path: Path) -> None:
     """Audio captured before an item's stream opens is buffered, not dropped."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     session._current = item
     item.write(b"head" * 8)
     item.claim()
@@ -248,7 +252,7 @@ async def test_audio_read_before_the_stream_opens_is_kept(tmp_path: Path) -> Non
 async def test_a_channel_is_only_ever_served_once(tmp_path: Path) -> None:
     """A consumed channel cannot be replayed, so the item needs a fresh session."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.started.set()
     assert session.item_for(TRACK_A) is item
     item.claim()
@@ -262,7 +266,7 @@ async def test_a_channel_is_only_ever_served_once(tmp_path: Path) -> None:
 async def test_an_abandoned_channel_cannot_be_continued(tmp_path: Path) -> None:
     """A stream abandoned mid-item cannot resume where it left off either."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.started.set()
     item.claim()
     item.release()
@@ -308,8 +312,8 @@ async def test_buffering_gates_the_sink_once_demand_started(tmp_path: Path) -> N
     """Once PCM demand started, playing runs the sink and buffering suspends it again."""
     session = _make_session(tmp_path)
     session._demand_started = True
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
-    session._pending.append(TRACK_B)
+    session._current = session._open_channel(TRACK_A)
+    _feed(session, TRACK_B)
     sink = _sink_of(session)
     # the sink is created suspended, so there is nothing to suspend yet
     await session._handle_event(_playback_event("buffering"))
@@ -326,7 +330,7 @@ async def test_buffering_gates_the_sink_once_demand_started(tmp_path: Path) -> N
 async def test_sink_is_not_gated_before_demand_started(tmp_path: Path) -> None:
     """Buffering/playing before PCM demand leave the (still suspended) sink alone."""
     session = _make_session(tmp_path)
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    session._current = session._open_channel(TRACK_A)
     sink = _sink_of(session)
     await session._handle_event(_playback_event("buffering"))
     await session._handle_event(_playback_event("playing"))
@@ -342,7 +346,7 @@ async def test_the_last_item_is_drained_rather_than_cut(tmp_path: Path, end_stat
     session = _make_session(tmp_path)
     session._demand_started = True
     session._sink_running = True
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.duration_ms = 1_000
     item.last_position_ms = 1_000
     one_second = 1_000 * CAPTURE_SAMPLE_RATE // 1000 * _FRAME_BYTES
@@ -368,7 +372,7 @@ async def test_an_app_pause_midway_through_the_last_item_is_not_the_end(
     session = _make_session(tmp_path)
     session._demand_started = True
     session._sink_running = True
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.duration_ms = 200_000
     item.last_position_ms = 90_000
     await session._handle_event(_playback_event("paused", position_ms=90_000))
@@ -384,7 +388,7 @@ async def test_a_resumed_item_cancels_its_tail_drain(tmp_path: Path) -> None:
     session = _make_session(tmp_path)
     session._demand_started = True
     session._sink_running = True
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.duration_ms = 200_000
     item.last_position_ms = 199_000
     await session._handle_event(_playback_event("stopped", position_ms=199_000))
@@ -402,7 +406,7 @@ async def test_the_cushion_is_capped_by_suspending_the_sink(tmp_path: Path) -> N
     session._demand_started = True
     session._sink_running = True
     session._engine_playing = True
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.claim()
     sink = _sink_of(session)
     await session._apply_sink_state()
@@ -424,8 +428,8 @@ async def test_a_pause_with_more_queued_suspends_the_sink(tmp_path: Path) -> Non
     session = _make_session(tmp_path)
     session._demand_started = True
     session._sink_running = True
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
-    session._pending.append(TRACK_B)
+    session._current = session._open_channel(TRACK_A)
+    _feed(session, TRACK_B)
     await session._handle_event(_playback_event("paused"))
     _sink_of(session).suspend.assert_awaited_once()
 
@@ -790,6 +794,7 @@ async def test_a_dying_log_reader_fails_the_session(tmp_path: Path) -> None:
 async def test_feeding_never_replaces_a_channel_already_in_use(tmp_path: Path) -> None:
     """If the engine reaches the fed item first, its live channel must survive."""
     session = _make_session(tmp_path, queue_id="player1")
+    streamed = _streamed(session)
     streamdetails = MagicMock()
     playing = _queue_item(TRACK_A, streamdetails=streamdetails)
     queues = _queues_of(session)
@@ -799,15 +804,15 @@ async def test_feeding_never_replaces_a_channel_already_in_use(tmp_path: Path) -
 
     async def _engine_gets_there_first(_uri: str, **_kwargs: Any) -> None:
         # the events task advances to the fed item while the command is in flight
-        await session._observe_current(TRACK_B, 200_000)
+        await session._observe_current(TRACK_B, 200_000, track_changed=True)
 
     _client_of(session).add_to_queue.side_effect = _engine_gets_there_first
-    await session.feed_after(streamdetails, TRACK_A)
+    await session.feed_after(streamdetails, streamed)
     live = session.current
     assert live is not None
     assert live.uri == TRACK_B
     # the channel the reader is writing to is the one a stream will be handed
-    assert session._items[TRACK_B] is live
+    assert [item for item in session._channels if item.uri == TRACK_B] == [live]
     assert session.item_for(TRACK_B) is live
     # and it is not queued as pending, because it already started
     assert session.has_pending is False
@@ -828,7 +833,7 @@ async def test_a_seek_the_session_cannot_take_restarts_it(
     backend._binary = Path("/nonexistent/soloist")
     session = _SoloistSession(backend, "player1")
     backend._session = session
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.started.set()
     # its own stream is still attached when the seek re-opens it
     item.claim()
@@ -868,7 +873,7 @@ async def test_a_session_in_use_is_never_cut_short(
     backend._binary = Path("/nonexistent/soloist")
     session = _SoloistSession(backend, "player1")
     backend._session = session
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.started.set()
     item.claim()
     # the session really is playing TRACK_A, so a same-track request from another
@@ -894,7 +899,7 @@ async def test_a_session_nobody_reads_is_replaced_for_another_item(
     backend._binary = Path("/nonexistent/soloist")
     session = _SoloistSession(backend, "player1")
     backend._session = session
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.started.set()
     item.claim()
     item.close()
@@ -949,7 +954,7 @@ async def test_an_idle_session_is_taken_over(
     backend._server = MagicMock()
     backend._binary = Path("/nonexistent/soloist")
     session = _SoloistSession(backend, "player1")
-    session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    session._open_channel(TRACK_A)
     backend._session = session
     stopped = AsyncMock()
     monkeypatch.setattr(session, "stop", stopped)
@@ -989,8 +994,8 @@ async def test_failed_sink_control_fails_the_session(tmp_path: Path) -> None:
     session = _make_session(tmp_path)
     session._demand_started = True
     session._sink_running = True
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
-    session._pending.append(TRACK_B)
+    session._current = session._open_channel(TRACK_A)
+    _feed(session, TRACK_B)
     _sink_of(session).suspend.side_effect = RuntimeError("pactl failed")
     await session._handle_event(_playback_event("buffering"))
     assert session._error is not None
@@ -1001,8 +1006,8 @@ async def test_app_pause_is_fought_with_a_resume(tmp_path: Path) -> None:
     """A pause from the Spotify app is undone: this session has no user-facing pause."""
     session = _make_session(tmp_path)
     session._demand_started = True
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
-    session._pending.append(TRACK_B)
+    session._current = session._open_channel(TRACK_A)
+    _feed(session, TRACK_B)
     await session._handle_event(_playback_event("paused"))
     _client_of(session).resume.assert_awaited_once()
 
@@ -1011,8 +1016,8 @@ async def test_an_app_pause_is_only_undone_so_many_times(tmp_path: Path) -> None
     """Someone who keeps pausing means it: the session gives up instead of fighting on."""
     session = _make_session(tmp_path)
     session._demand_started = True
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
-    session._pending.append(TRACK_B)
+    session._current = session._open_channel(TRACK_A)
+    _feed(session, TRACK_B)
     for _ in range(_MAX_APP_PAUSE_RESUMES):
         await session._handle_event(_playback_event("playing"))
         await session._handle_event(_playback_event("paused"))
@@ -1030,8 +1035,8 @@ async def test_one_pause_reported_twice_counts_once(tmp_path: Path) -> None:
     """A repeated snapshot of the same pause is not a new pause."""
     session = _make_session(tmp_path)
     session._demand_started = True
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
-    session._pending.append(TRACK_B)
+    session._current = session._open_channel(TRACK_A)
+    _feed(session, TRACK_B)
     for _ in range(_MAX_APP_PAUSE_RESUMES + 2):
         await session._handle_event(_playback_event("paused"))
     assert session.usable is True
@@ -1041,12 +1046,12 @@ async def test_the_pause_budget_resets_on_the_next_item(tmp_path: Path) -> None:
     """Each item gets its own budget; pausing one track does not spend the next one's."""
     session = _make_session(tmp_path)
     session._demand_started = True
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
-    session._pending.append(TRACK_B)
+    session._current = session._open_channel(TRACK_A)
+    _feed(session, TRACK_B)
     for _ in range(_MAX_APP_PAUSE_RESUMES):
         await session._handle_event(_playback_event("playing"))
         await session._handle_event(_playback_event("paused"))
-    await session._observe_current(TRACK_B, 200_000)
+    await session._observe_current(TRACK_B, 200_000, track_changed=True)
     assert session._app_pauses == 0
 
 
@@ -1055,8 +1060,8 @@ async def test_a_pause_is_not_undone_once_the_device_is_gone(tmp_path: Path) -> 
     session = _make_session(tmp_path)
     session._demand_started = True
     session._was_active = False
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
-    session._pending.append(TRACK_B)
+    session._current = session._open_channel(TRACK_A)
+    _feed(session, TRACK_B)
     await session._handle_event(_playback_event("paused"))
     _client_of(session).resume.assert_not_awaited()
 
@@ -1103,7 +1108,7 @@ async def test_the_playback_snapshots_active_flag_is_ignored(tmp_path: Path) -> 
     """It is optional and rides on deltas, so only the dedicated reports are followed."""
     session = _make_session(tmp_path)
     session._demand_started = True
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    session._current = session._open_channel(TRACK_A)
     await session._handle_event(
         SoloistEvent(
             type="playback_changed",
@@ -1120,8 +1125,8 @@ async def test_backpressure_does_not_spend_the_pause_budget(tmp_path: Path) -> N
     session._demand_started = True
     session._engine_playing = True
     session._backpressured = True
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
-    session._pending.append(TRACK_B)
+    session._current = session._open_channel(TRACK_A)
+    _feed(session, TRACK_B)
     await session._handle_event(_playback_event("paused"))
     _client_of(session).resume.assert_not_awaited()
     assert session._app_pauses == 0
@@ -1138,12 +1143,12 @@ async def test_a_lost_login_is_not_reported_as_a_takeover(tmp_path: Path) -> Non
 async def test_a_track_started_from_the_app_ends_the_session(tmp_path: Path) -> None:
     """The engine pulled off an item part-way through is the app playing something else."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.duration_ms = 200_000
-    await session._observe_current(TRACK_A, 200_000)
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
     item.observe_position(20_000)
 
-    await session._observe_current("spotify:track:theirs", 180_000)
+    await session._observe_current("spotify:track:theirs", 180_000, track_changed=True)
     assert session.usable is False
     assert session._app_control is SoloistAppControl.TOOK_OVER
     assert session.current is item
@@ -1154,14 +1159,14 @@ async def test_a_track_played_earlier_started_from_the_app_ends_the_session(
 ) -> None:
     """A known uri is no exemption: only the item fed behind this one is where we sent it."""
     session = _make_session(tmp_path)
-    played = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
+    played = session._open_channel(TRACK_B)
     played.spent = True
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.duration_ms = 200_000
-    await session._observe_current(TRACK_A, 200_000)
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
     item.observe_position(20_000)
 
-    await session._observe_current(TRACK_B, 180_000)
+    await session._observe_current(TRACK_B, 180_000, track_changed=True)
     assert session.usable is False
     assert session._app_control is SoloistAppControl.TOOK_OVER
 
@@ -1169,14 +1174,13 @@ async def test_a_track_played_earlier_started_from_the_app_ends_the_session(
 async def test_skipping_from_the_app_to_the_fed_item_is_followed(tmp_path: Path) -> None:
     """The queue moves to that same track, so following the engine keeps the two in step."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.duration_ms = 200_000
-    await session._observe_current(TRACK_A, 200_000)
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
     item.observe_position(20_000)
-    fed = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
-    session._pending.append(TRACK_B)
+    fed = _feed(session, TRACK_B)
 
-    await session._observe_current(TRACK_B, 180_000)
+    await session._observe_current(TRACK_B, 180_000, track_changed=True)
     assert session.usable is True
     assert session.current is fed
     assert session.item_for(TRACK_B) is fed
@@ -1186,9 +1190,9 @@ async def test_a_takeover_snapshot_stops_pinning_volume_and_options(tmp_path: Pa
     """Once the app has the session, the rest of its snapshot must not reach the daemon."""
     session = _make_session(tmp_path)
     session._demand_started = True
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.duration_ms = 200_000
-    await session._observe_current(TRACK_A, 200_000)
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
     item.observe_position(20_000)
 
     await session._handle_event(
@@ -1211,12 +1215,12 @@ async def test_a_takeover_snapshot_stops_pinning_volume_and_options(tmp_path: Pa
 async def test_the_engine_moving_on_at_a_track_end_is_not_a_takeover(tmp_path: Path) -> None:
     """An unasked-for item the engine reaches at a boundary is its own autoplay."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.duration_ms = 200_000
-    await session._observe_current(TRACK_A, 200_000)
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
     item.observe_position(200_000)
 
-    await session._observe_current("spotify:track:autoplay", 180_000)
+    await session._observe_current("spotify:track:autoplay", 180_000, track_changed=True)
     assert session.usable is True
     assert session.item_for("spotify:track:autoplay") is None
 
@@ -1224,7 +1228,7 @@ async def test_the_engine_moving_on_at_a_track_end_is_not_a_takeover(tmp_path: P
 async def test_an_ended_item_says_what_the_app_did(tmp_path: Path) -> None:
     """The item's stream fails with the takeover, not a generic session error."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     await session._handle_event(_device_event(is_active=False))
     with pytest.raises(SoloistAppControlError) as err:
         await session.validate_item(item)
@@ -1236,8 +1240,8 @@ async def test_a_session_being_torn_down_does_not_hold_off_the_next_one(tmp_path
     """Teardown pauses the daemon; that must not read as the user pausing."""
     session = _make_session(tmp_path)
     session._demand_started = True
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
-    session._pending.append(TRACK_B)
+    session._current = session._open_channel(TRACK_A)
+    _feed(session, TRACK_B)
     session._stopped = True
     for _ in range(_MAX_APP_PAUSE_RESUMES + 1):
         await session._handle_event(_playback_event("playing"))
@@ -1314,8 +1318,8 @@ async def test_track_change_signals_the_queue_when_it_matches_the_next_item(
 ) -> None:
     """Reaching a fed item tells the queue to start filling that item's buffer."""
     session = _make_session(tmp_path, queue_id="player1")
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
-    session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
+    session._current = session._open_channel(TRACK_A)
+    session._open_channel(TRACK_B)
     queues = _queues_of(session)
     queues.get.return_value = MagicMock(next_item=_queue_item(TRACK_B), current_index=0)
     await session._handle_event(
@@ -1331,7 +1335,7 @@ async def test_track_change_signals_the_queue_when_it_matches_the_next_item(
 async def test_track_change_to_another_item_signals_nothing(tmp_path: Path) -> None:
     """An item the queue is not asking for next must not trigger a prebuffer."""
     session = _make_session(tmp_path, queue_id="player1")
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    session._current = session._open_channel(TRACK_A)
     queues = _queues_of(session)
     queues.get.return_value = MagicMock(next_item=_queue_item(TRACK_B), current_index=0)
     await session._handle_event(
@@ -1349,6 +1353,7 @@ async def test_track_change_to_another_item_signals_nothing(tmp_path: Path) -> N
 async def test_the_follower_of_the_streamed_item_is_fed(tmp_path: Path) -> None:
     """The item after the one being streamed is handed to the engine."""
     session = _make_session(tmp_path, queue_id="player1")
+    streamed = _streamed(session)
     streamdetails = MagicMock()
     playing = _queue_item(TRACK_A, streamdetails=streamdetails)
     follower = _queue_item(TRACK_B)
@@ -1356,15 +1361,31 @@ async def test_the_follower_of_the_streamed_item_is_fed(tmp_path: Path) -> None:
     queues.get.return_value = MagicMock(current_index=3)
     queues.get_item.side_effect = lambda _queue_id, index: playing if index == 3 else None
     queues.get_next_item.return_value = follower
-    await session.feed_after(streamdetails, TRACK_A)
+    await session.feed_after(streamdetails, streamed)
     _client_of(session).add_to_queue.assert_awaited_once_with(TRACK_B)
-    assert TRACK_B in session._items
+    assert session.pending_item(TRACK_B) is not None
     assert session.has_pending is True
+
+
+async def test_repeating_one_track_does_not_feed_the_engine(tmp_path: Path) -> None:
+    """Repeat-one replays the item from the buffer the queue holds, so nothing is queued."""
+    session = _make_session(tmp_path, queue_id="player1")
+    streamed = _streamed(session)
+    streamdetails = MagicMock(provider="spotify--test")
+    playing = _queue_item(TRACK_A, streamdetails=streamdetails)
+    queues = _queues_of(session)
+    queues.get.return_value = MagicMock(current_index=0)
+    queues.get_item.side_effect = lambda _queue_id, index: playing if index == 0 else None
+    # repeat-one names the item being streamed as its own follower
+    queues.get_next_item.return_value = playing
+    assert await session.feed_after(streamdetails, streamed) is False
+    _client_of(session).add_to_queue.assert_not_awaited()
 
 
 async def test_an_item_the_queue_resolved_elsewhere_is_not_fed(tmp_path: Path) -> None:
     """A track the queue will stream from another provider must not be queued here."""
     session = _make_session(tmp_path, queue_id="player1")
+    streamed = _streamed(session)
     streamdetails = MagicMock()
     playing = _queue_item(TRACK_A, streamdetails=streamdetails)
     # same track, but the queue already picked a different provider for it
@@ -1373,7 +1394,7 @@ async def test_an_item_the_queue_resolved_elsewhere_is_not_fed(tmp_path: Path) -
     queues.get.return_value = MagicMock(current_index=0)
     queues.get_item.side_effect = lambda _queue_id, index: playing if index == 0 else None
     queues.get_next_item.return_value = follower
-    await session.feed_after(streamdetails, TRACK_A)
+    await session.feed_after(streamdetails, streamed)
     _client_of(session).add_to_queue.assert_not_awaited()
 
 
@@ -1386,14 +1407,13 @@ async def test_skipping_to_the_fed_item_keeps_the_session(tmp_path: Path) -> Non
     session._client = AsyncMock()
     session._logged_in = True
     backend._session = session
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     # fed one ahead and not reached yet, which is where a next-track goes
-    fed = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
-    session._pending.append(TRACK_B)
+    fed = _feed(session, TRACK_B)
 
     async def _engine_gets_there(**_kwargs: Any) -> None:
-        await session._observe_current(TRACK_B, 200_000)
+        await session._observe_current(TRACK_B, 200_000, track_changed=True)
 
     _client_of(session).skip_next.side_effect = _engine_gets_there
     got_session, got_item = await backend._acquire(TRACK_B, 0, "player1")
@@ -1402,6 +1422,147 @@ async def test_skipping_to_the_fed_item_keeps_the_session(tmp_path: Path) -> Non
     assert got_item is fed
     assert backend._session is session
     _client_of(session).skip_next.assert_awaited_once()
+
+
+async def test_a_repeated_track_keeps_the_session(tmp_path: Path) -> None:
+    """The second occurrence of a track is served by the session that played the first."""
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _SoloistSession(backend, "player1")
+    session._client = AsyncMock()
+    backend._session = session
+    # the first occurrence has been delivered and the second was fed behind it
+    first = _streamed(session)
+    first.release()
+    second = _feed(session, TRACK_A)
+
+    async def _engine_gets_there(**_kwargs: Any) -> None:
+        await session._observe_current(TRACK_A, 200_000, track_changed=True)
+
+    _client_of(session).skip_next.side_effect = _engine_gets_there
+    got_session, got_item = await backend._acquire(TRACK_A, 0, "player1")
+    assert got_session is session
+    assert got_item is second
+    assert backend._session is session
+
+
+async def test_a_next_item_the_session_was_not_fed_is_queued_and_skipped_to(
+    tmp_path: Path,
+) -> None:
+    """A queue reordered after the feed is served by sending the engine on, not by respawning."""
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _SoloistSession(backend, "player1")
+    session._client = AsyncMock()
+    session._engine_playing = True
+    backend._session = session
+    # the engine moved on into the item it was fed, which the queue no longer wants
+    stale = session._current = session._open_channel(TRACK_B)
+    stale.started.set()
+
+    async def _engine_gets_there(**_kwargs: Any) -> None:
+        await session._observe_current(TRACK_C, 200_000, track_changed=True)
+
+    _client_of(session).skip_next.side_effect = _engine_gets_there
+    got_session, got_item = await backend._acquire(TRACK_C, 0, "player1")
+    assert got_session is session
+    assert got_item.uri == TRACK_C
+    assert got_item.claimed is True
+    _client_of(session).add_to_queue.assert_awaited_once_with(TRACK_C)
+    _client_of(session).skip_next.assert_awaited_once()
+    assert stale._closed is True
+
+
+async def test_the_item_the_engine_is_on_is_never_jumped_to(tmp_path: Path) -> None:
+    """A jump steps past the item, so the engine is never sent to what it already plays."""
+    session = _make_session(tmp_path)
+    session._engine_playing = True
+    _streamed(session, TRACK_A).release()
+    assert await session.feed_and_skip_to(TRACK_A) is None
+    _client_of(session).add_to_queue.assert_not_awaited()
+    _client_of(session).skip_next.assert_not_awaited()
+
+
+async def test_a_session_delivering_an_item_is_never_sent_to_another(tmp_path: Path) -> None:
+    """A jump would cut short the item being delivered, so capacity is reported instead."""
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _SoloistSession(backend, "player1")
+    session._client = AsyncMock()
+    session._engine_playing = True
+    backend._session = session
+    # an item the engine is on and a stream is reading
+    _streamed(session, TRACK_B)
+    with pytest.raises(ProviderStreamLimitError):
+        await backend._acquire(TRACK_C, 0, "player1")
+    _client_of(session).add_to_queue.assert_not_awaited()
+    _client_of(session).skip_next.assert_not_awaited()
+    assert backend._session is session
+    assert session.usable is True
+
+
+@pytest.mark.parametrize(
+    "blocker",
+    [
+        # one skip steps one entry, so anything queued behind would be landed on
+        "something_queued",
+        # a stopped engine has nothing to skip out of
+        "engine_stopped",
+        # the engine would not take the jump
+        "refused",
+    ],
+)
+async def test_a_session_that_cannot_be_sent_on_is_replaced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, blocker: str
+) -> None:
+    """Where the engine's transport cannot reach the item, a fresh session serves it."""
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _SoloistSession(backend, "player1")
+    session._client = AsyncMock()
+    session._engine_playing = blocker != "engine_stopped"
+    backend._session = session
+    # the engine is on an item whose audio has been handed over already
+    _streamed(session, TRACK_B).release()
+    if blocker == "something_queued":
+        _feed(session, TRACK_A)
+    if blocker == "refused":
+        _client_of(session).skip_next.side_effect = SoloistError("no")
+    _install_fake_binary_manager(monkeypatch)
+    monkeypatch.setattr(
+        soloist_backend._SoloistSession, "start", AsyncMock(side_effect=AudioError("spawn"))
+    )
+    monkeypatch.setattr(session, "stop", AsyncMock())
+    with pytest.raises(AudioError, match="spawn"):
+        await backend._acquire(TRACK_C, 0, "player1")
+    if blocker != "refused":
+        _client_of(session).add_to_queue.assert_not_awaited()
+
+
+async def test_a_jump_to_the_fed_item_that_misses_is_replaced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A jump the engine will not take costs a respawn, not the item."""
+    backend = _make_backend(tmp_path)
+    backend._server = MagicMock()
+    backend._binary = Path("/nonexistent/soloist")
+    session = _SoloistSession(backend, "player1")
+    session._client = AsyncMock()
+    backend._session = session
+    _streamed(session).release()
+    _feed(session, TRACK_B)
+    _client_of(session).skip_next.side_effect = SoloistError("no")
+    _install_fake_binary_manager(monkeypatch)
+    monkeypatch.setattr(
+        soloist_backend._SoloistSession, "start", AsyncMock(side_effect=AudioError("spawn"))
+    )
+    monkeypatch.setattr(session, "stop", AsyncMock())
+    with pytest.raises(AudioError, match="spawn"):
+        await backend._acquire(TRACK_B, 0, "player1")
 
 
 async def test_a_skip_drops_what_arrives_while_the_command_is_in_flight(
@@ -1414,16 +1575,15 @@ async def test_a_skip_drops_what_arrives_while_the_command_is_in_flight(
     answer arrives is measured at the cut instead.
     """
     session = _make_session(tmp_path)
-    leaving = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    leaving = session._current = session._open_channel(TRACK_A)
     leaving.started.set()
-    target = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
-    session._pending.append(TRACK_B)
+    target = _feed(session, TRACK_B)
     captured: list[bytes] = []
 
     async def _engine_gets_there(**_kwargs: Any) -> None:
         # the pipeline still holds the old track while the command is in flight
         session._write_if_wanted(b"\x01" * 32)
-        await session._observe_current(TRACK_B, 200_000)
+        await session._observe_current(TRACK_B, 200_000, track_changed=True)
         # from here on the audio really is the new item's
         session._write_if_wanted(b"\x02" * 32)
 
@@ -1438,22 +1598,27 @@ async def test_a_skip_the_engine_never_reaches_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A skip that does not land is an error, not a wait for the track to end."""
-    monkeypatch.setattr(soloist_backend, "_STARTUP_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(soloist_backend, "_JUMP_TIMEOUT_S", 0.05)
     session = _make_session(tmp_path)
-    fed = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
-    session._pending.append(TRACK_B)
+    fed = _feed(session, TRACK_B)
     with pytest.raises(AudioError, match="did not reach"):
         await session.skip_to(fed)
+
+
+def test_a_jump_gives_up_while_the_queue_is_still_waiting() -> None:
+    """A jump that will not land has to fail in time for a fresh session to serve the item."""
+    assert _JUMP_TIMEOUT_S < BUFFER_READY_TIMEOUT
 
 
 async def test_a_fed_item_the_engine_has_not_reached_is_not_served(tmp_path: Path) -> None:
     """Skipping to an already-fed item must not hand over a channel that fills later."""
     session = _make_session(tmp_path)
-    fed = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
-    # fed, but the engine is still on the previous track
+    # the engine is still on the track before it
+    _streamed(session, TRACK_A)
+    fed = _feed(session, TRACK_B)
     assert session.item_for(TRACK_B) is None
     # once the engine gets there it is servable
-    await session._observe_current(TRACK_B, 200_000)
+    await session._observe_current(TRACK_B, 200_000, track_changed=True)
     assert session.item_for(TRACK_B) is fed
 
 
@@ -1486,7 +1651,7 @@ async def test_only_whole_sample_frames_are_handed_over(
 ) -> None:
     """A read that ends mid-frame must not split a frame across two items."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.started.set()
     item.claim()
     session._demand_started = True
@@ -1507,30 +1672,251 @@ async def test_only_whole_sample_frames_are_handed_over(
     assert item.buffered == _FRAME_BYTES * 2
 
 
-async def test_an_already_known_item_is_not_fed_twice(tmp_path: Path) -> None:
-    """An item the session already plays or was fed is not queued again."""
+@pytest.mark.parametrize("state", ["fed", "reached", "being_read"])
+async def test_an_already_known_item_is_not_fed_twice(tmp_path: Path, state: str) -> None:
+    """An item the session was fed, or has already moved on to, is not queued again."""
     session = _make_session(tmp_path, queue_id="player1")
-    session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
+    streamed = _streamed(session)
+    known = _feed(session, TRACK_B)
+    if state != "fed":
+        # the engine got there while the stream is still reading the item before it
+        await session._observe_current(TRACK_B, 200_000, track_changed=True)
+        assert session.current is known
+    if state == "being_read":
+        # and its own stream opened, which spends the channel
+        known.claim()
     streamdetails = MagicMock()
     playing = _queue_item(TRACK_A, streamdetails=streamdetails)
     queues = _queues_of(session)
     queues.get.return_value = MagicMock(current_index=0)
     queues.get_item.side_effect = lambda _queue_id, index: playing if index == 0 else None
     queues.get_next_item.return_value = _queue_item(TRACK_B)
-    await session.feed_after(streamdetails, TRACK_A)
+    assert await session.feed_after(streamdetails, streamed) is True
     _client_of(session).add_to_queue.assert_not_awaited()
+
+
+async def test_occurrences_of_one_track_are_served_in_the_order_they_were_fed(
+    tmp_path: Path,
+) -> None:
+    """A track queued three times in a row hands each occurrence its own channel."""
+    session = _make_session(tmp_path)
+    first = _streamed(session)
+    second = _feed(session, TRACK_A)
+    third = _feed(session, TRACK_A)
+    # the engine has not moved yet, so the next occurrence is the one fed first
+    assert session.pending_item(TRACK_A) is second
+    first.duration_ms = 200_000
+    first.observe_position(199_000)
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
+    assert session.current is second
+    assert session.pending_item(TRACK_A) is third
+    second.claim()
+    second.duration_ms = 200_000
+    second.observe_position(199_000)
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
+    assert session.current is third
+    assert session.pending_item(TRACK_A) is None
+
+
+async def test_a_track_played_earlier_is_not_answered_with_its_old_channel(
+    tmp_path: Path,
+) -> None:
+    """A track that comes round again is the occurrence fed for it, not the one played."""
+    session = _make_session(tmp_path)
+    played = _feed(session, TRACK_B)
+    await session._observe_current(TRACK_B, 200_000, track_changed=True)
+    # the engine moves on, so that channel is over
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
+    # ... and the track comes round again later in the queue
+    again = _feed(session, TRACK_B)
+    await session._observe_current(TRACK_B, 200_000, track_changed=True)
+    assert session.current is again
+    assert played.closed is True
+
+
+async def test_a_channel_nothing_can_read_is_not_kept(tmp_path: Path) -> None:
+    """A channel the session moved past, with no stream on it, stops counting against the cap."""
+    session = _make_session(tmp_path)
+    passed_by = _feed(session, TRACK_B)
+    await session._observe_current(TRACK_B, 200_000, track_changed=True)
+    session._write_if_wanted(b"\x01" * 4096)
+    assert session._retained_bytes() == 4096
+    # the engine moves on again and no stream ever opened this one
+    await session._observe_current(TRACK_C, 200_000, track_changed=True)
+    assert passed_by.closed is True
+    session._open_channel(TRACK_A)
+    assert passed_by not in session._channels
+    assert session._retained_bytes() == 0
+
+
+async def test_a_channel_a_stream_still_holds_is_never_dropped(tmp_path: Path) -> None:
+    """A stream still draining an item past the cut keeps the session in use."""
+    session = _make_session(tmp_path)
+    reading = _streamed(session)
+    # the engine moves on while that stream is still reading the item
+    await session._observe_current(TRACK_B, 200_000, track_changed=True)
+    assert reading.closed is True
+    assert reading.claimed is True
+    session._open_channel(TRACK_C)
+    assert reading in session._channels
+    assert session.in_use is True
+
+
+async def test_the_channel_the_engine_is_on_is_always_kept(tmp_path: Path) -> None:
+    """The last item of a run is closed by its own drain, but the session is still on it."""
+    session = _make_session(tmp_path)
+    last = _streamed(session)
+    last.release()
+    last.close()
+    session._open_channel(TRACK_B)
+    assert session.current is last
+    assert last in session._channels
+
+
+async def test_a_cancelled_jump_ends_the_session_without_blaming_the_spotify_app(
+    tmp_path: Path,
+) -> None:
+    """A jump nobody is waiting for any more ends the session, but is not a takeover."""
+    session = _make_session(tmp_path)
+    session._engine_playing = True
+    playing = _streamed(session, TRACK_A)
+    playing.release()
+    # part-way through, so an arrival nobody asked for would read as a takeover
+    playing.duration_ms = 200_000
+    playing.observe_position(20_000)
+
+    async def _gives_up(**_kwargs: Any) -> None:
+        raise asyncio.CancelledError
+
+    _client_of(session).skip_next.side_effect = _gives_up
+    with pytest.raises(asyncio.CancelledError):
+        await session.feed_and_skip_to(TRACK_B)
+    # the jump cannot be accounted for any more, so the session ends
+    assert session.usable is False
+    # ... but the engine still getting there is not the app taking over, which
+    # would hold off every session that follows
+    await session._observe_current(TRACK_B, 200_000, track_changed=True)
+    assert session._app_control is None
+    assert session.backend._held_by_app() is None
+
+
+async def test_a_drained_channel_is_not_served(tmp_path: Path) -> None:
+    """The last item of a run ends its channel when its audio is done; it serves nothing after."""
+    session = _make_session(tmp_path)
+    item = session._current = session._open_channel(TRACK_A)
+    item.started.set()
+    assert session.item_for(TRACK_A) is item
+    # nothing follows it, so the session drains the item and closes it
+    item.close()
+    assert session.item_for(TRACK_A) is None
+
+
+async def test_a_channel_the_session_moved_past_is_not_served(tmp_path: Path) -> None:
+    """A channel the session left behind holds only part of its item, so it is never handed out."""
+    session = _make_session(tmp_path)
+    played_past = _feed(session, TRACK_B)
+    await session._observe_current(TRACK_B, 200_000, track_changed=True)
+    # servable while the engine is on it and no stream has taken it
+    assert session.item_for(TRACK_B) is played_past
+    # the engine moves on again before any stream opened it
+    await session._observe_current(TRACK_C, 200_000, track_changed=True)
+    assert played_past.closed is True
+    assert session.item_for(TRACK_B) is None
+
+
+async def test_a_repeated_track_is_fed_a_channel_of_its_own(tmp_path: Path) -> None:
+    """A track that follows itself is queued again, not answered with the channel in use."""
+    session = _make_session(tmp_path, queue_id="player1")
+    streamed = _streamed(session)
+    streamdetails = MagicMock()
+    playing = _queue_item(TRACK_A, streamdetails=streamdetails)
+    queues = _queues_of(session)
+    queues.get.return_value = MagicMock(current_index=0)
+    queues.get_item.side_effect = lambda _queue_id, index: playing if index == 0 else None
+    # the very same track once more, as a queue item of its own
+    queues.get_next_item.return_value = _queue_item(TRACK_A, queue_item_id="qi-again")
+    assert await session.feed_after(streamdetails, streamed) is True
+    _client_of(session).add_to_queue.assert_awaited_once_with(TRACK_A)
+    second = session.pending_item(TRACK_A)
+    assert second is not None
+    assert second is not streamed
+
+
+async def test_a_repeated_track_moves_on_at_its_track_change(tmp_path: Path) -> None:
+    """The boundary between two occurrences of one track is reported under the same uri."""
+    session = _make_session(tmp_path)
+    first = _streamed(session)
+    first.duration_ms = 200_000
+    first.observe_position(199_000)
+    second = _feed(session, TRACK_A)
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
+    assert session.current is second
+    assert first._closed is True
+
+
+async def test_a_state_report_does_not_move_a_repeated_track_on(tmp_path: Path) -> None:
+    """Only a track change crosses that boundary; a state report says where the engine is."""
+    session = _make_session(tmp_path)
+    first = _streamed(session)
+    first.duration_ms = 200_000
+    first.observe_position(199_000)
+    second = _feed(session, TRACK_A)
+    await session._observe_current(TRACK_A, 200_000, track_changed=False)
+    assert session.current is first
+    assert session.pending_item(TRACK_A) is second
+
+
+async def test_a_seek_in_flight_is_not_cut_short_by_a_repeat_boundary(tmp_path: Path) -> None:
+    """A channel opened for a seek has no position of its own, which is not a played-out one."""
+    session = _make_session(tmp_path)
+    seeking = _streamed(session)
+    seeking.duration_ms = 200_000
+    _feed(session, TRACK_A)
+    session._seeking = True
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
+    assert session.current is seeking
+    assert seeking.closed is False
+
+
+async def test_a_repeat_is_not_moved_on_to_part_way_through_the_first(tmp_path: Path) -> None:
+    """A track change reported part-way through the first occurrence is not its boundary."""
+    session = _make_session(tmp_path)
+    first = _streamed(session)
+    first.duration_ms = 200_000
+    first.observe_position(20_000)
+    _feed(session, TRACK_A)
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
+    assert session.current is first
+
+
+async def test_a_jump_to_a_repeat_is_followed_part_way_through(tmp_path: Path) -> None:
+    """Skipping ahead to the second occurrence lands there even mid-track."""
+    session = _make_session(tmp_path)
+    first = _streamed(session)
+    first.duration_ms = 200_000
+    first.observe_position(20_000)
+    second = _feed(session, TRACK_A)
+
+    async def _engine_gets_there(**_kwargs: Any) -> None:
+        await session._observe_current(TRACK_A, 200_000, track_changed=True)
+
+    _client_of(session).skip_next.side_effect = _engine_gets_there
+    await session.skip_to(second)
+    assert session.current is second
+    assert first._closed is True
 
 
 async def test_only_tracks_are_fed_ahead(tmp_path: Path) -> None:
     """A podcast episode or audiobook chapter is played on its own, never stitched."""
     session = _make_session(tmp_path, queue_id="player1")
-    await session.feed_after(MagicMock(), "spotify:episode:xyz")
+    await session.feed_after(MagicMock(), session._open_channel("spotify:episode:xyz"))
     _client_of(session).add_to_queue.assert_not_awaited()
 
 
 async def test_a_non_spotify_follower_is_not_fed(tmp_path: Path) -> None:
     """The run simply ends where the queue leaves this provider."""
     session = _make_session(tmp_path, queue_id="player1")
+    streamed = _streamed(session)
     streamdetails = MagicMock()
     playing = _queue_item(TRACK_A, streamdetails=streamdetails)
     follower = MagicMock(
@@ -1541,13 +1927,14 @@ async def test_a_non_spotify_follower_is_not_fed(tmp_path: Path) -> None:
     queues.get.return_value = MagicMock(current_index=0)
     queues.get_item.side_effect = lambda _queue_id, index: playing if index == 0 else None
     queues.get_next_item.return_value = follower
-    await session.feed_after(streamdetails, TRACK_A)
+    await session.feed_after(streamdetails, streamed)
     _client_of(session).add_to_queue.assert_not_awaited()
 
 
 async def test_a_library_item_is_fed_through_its_spotify_mapping(tmp_path: Path) -> None:
     """A library track is fed with the item id this provider instance knows it by."""
     session = _make_session(tmp_path, queue_id="player1")
+    streamed = _streamed(session)
     streamdetails = MagicMock()
     playing = _queue_item(TRACK_A, streamdetails=streamdetails)
     follower = MagicMock(
@@ -1562,7 +1949,7 @@ async def test_a_library_item_is_fed_through_its_spotify_mapping(tmp_path: Path)
     queues.get.return_value = MagicMock(current_index=0)
     queues.get_item.side_effect = lambda _queue_id, index: playing if index == 0 else None
     queues.get_next_item.return_value = follower
-    await session.feed_after(streamdetails, TRACK_A)
+    await session.feed_after(streamdetails, streamed)
     _client_of(session).add_to_queue.assert_awaited_once_with(TRACK_B)
 
 
@@ -1678,7 +2065,7 @@ async def test_a_duration_less_item_is_not_judged(tmp_path: Path) -> None:
 def test_an_unread_session_expires(tmp_path: Path) -> None:
     """A session no item stream reads from is ended so its daemon does not linger."""
     session = _make_session(tmp_path)
-    session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    session._open_channel(TRACK_A)
     session._expire_idle()
     assert session._idle_since is not None
     assert session.usable is True
@@ -1690,7 +2077,7 @@ def test_an_unread_session_expires(tmp_path: Path) -> None:
 def test_a_session_being_read_never_expires(tmp_path: Path) -> None:
     """An item stream reading the session keeps it alive indefinitely."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.claim()
     session._idle_since = time.monotonic() - _IDLE_TIMEOUT_S * 10
     session._expire_idle()
@@ -1785,7 +2172,7 @@ async def test_a_cancelled_teardown_still_closes_the_daemon(tmp_path: Path) -> N
 def test_a_failed_session_is_torn_down(tmp_path: Path) -> None:
     """A session that fails is discarded, so its daemon does not keep playing to nobody."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.claim()
     session._fail("audio stalled")
     assert session.usable is False
@@ -1808,12 +2195,10 @@ async def test_an_item_the_engine_skipped_past_fails_instead_of_hanging(
     monkeypatch.setattr(soloist_backend, "_READ_SLICE_S", 0.01)
     monkeypatch.setattr(soloist_backend, "_STALL_TIMEOUT_S", 0.05)
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.claim()
     # the engine is playing something else, so nothing is ever written here
-    session._items["spotify:track:other"] = session._current = _ItemAudio(
-        "spotify:track:other", session
-    )
+    session._current = session._open_channel("spotify:track:other")
     with pytest.raises(AudioError, match="no audio"):
         async for _ in item.read():
             pass
@@ -1923,15 +2308,14 @@ def test_session_present_detection(tmp_path: Path) -> None:
 async def test_a_skip_drops_the_audio_still_in_flight(tmp_path: Path) -> None:
     """The item jumped to opens with its own audio, not the tail of the one left behind."""
     session = _make_session(tmp_path)
-    left_behind = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    left_behind = session._open_channel(TRACK_A)
     session._current = left_behind
     left_behind.started.set()
     left_behind.claim()
-    jumped_to = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
-    session._pending.append(TRACK_B)
-    session._discard_until = TRACK_B
+    jumped_to = _feed(session, TRACK_B)
+    session._discard_until = jumped_to
     with _capture_holding(session, fifo_bytes=2 * _FRAME_BYTES, reader_bytes=2 * _FRAME_BYTES):
-        await session._observe_current(TRACK_B, 200_000)
+        await session._observe_current(TRACK_B, 200_000, track_changed=True)
     assert session._stale_budget == 4 * _FRAME_BYTES
     session._write_if_wanted(b"s" * (4 * _FRAME_BYTES))
     session._write_if_wanted(b"n" * (2 * _FRAME_BYTES))
@@ -1944,7 +2328,7 @@ async def test_a_skip_drops_the_stale_audio_across_reads(tmp_path: Path) -> None
     """A budget larger than one read keeps dropping, and resumes on a frame boundary."""
     session = _make_session(tmp_path)
     session._stale_budget = 3 * _FRAME_BYTES
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.claim()
     session._write_if_wanted(b"s" * (2 * _FRAME_BYTES))
     session._write_if_wanted(b"s" * _FRAME_BYTES + b"n" * _FRAME_BYTES)
@@ -1955,9 +2339,9 @@ async def test_a_skip_drops_the_stale_audio_across_reads(tmp_path: Path) -> None
 async def test_the_marker_spends_an_earlier_jumps_budget(tmp_path: Path) -> None:
     """What the marker drops still counts against a budget left from an earlier jump."""
     session = _make_session(tmp_path)
-    session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    session._current = session._open_channel(TRACK_A)
     session._stale_budget = 4 * _FRAME_BYTES
-    session._discard_until = TRACK_B
+    session._discard_until = _feed(session, TRACK_B)
     session._write_if_wanted(b"s" * (3 * _FRAME_BYTES))
     assert session._stale_budget == _FRAME_BYTES
     # a refused command leaves only what is genuinely still in flight to drop
@@ -1972,12 +2356,12 @@ async def test_the_marker_spends_an_earlier_jumps_budget(tmp_path: Path) -> None
 async def test_a_natural_cut_keeps_the_audio_in_flight(tmp_path: Path) -> None:
     """Nothing is dropped without a jump: what is in flight is the continuation."""
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    playing = session._open_channel(TRACK_A)
     session._current = playing
     playing.started.set()
     playing.claim()
     with _capture_holding(session, fifo_bytes=4 * _FRAME_BYTES, reader_bytes=4 * _FRAME_BYTES):
-        await session._observe_current(TRACK_B, 200_000)
+        await session._observe_current(TRACK_B, 200_000, track_changed=True)
     assert session._stale_budget == 0
 
 
@@ -2000,12 +2384,12 @@ async def test_a_channel_abandoned_at_the_cut_stops_holding_the_cushion(
 ) -> None:
     """A skip closes the channel first and only then unwinds its stream."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.started.set()
     item.claim()
     item.write(b"x" * 4096)
     # the cut lands while the abandoned stream is still unwinding
-    await session._observe_current(TRACK_B, 200_000)
+    await session._observe_current(TRACK_B, 200_000, track_changed=True)
     assert session._retained_bytes() == 4096
     item.release()
     assert session._retained_bytes() == 0
@@ -2014,7 +2398,7 @@ async def test_a_channel_abandoned_at_the_cut_stops_holding_the_cushion(
 def test_an_abandoned_channel_stops_holding_the_cushion(tmp_path: Path) -> None:
     """A channel skipped away from frees its buffer instead of gating the sink for good."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.claim()
     item.write(b"x" * 4096)
     assert session._retained_bytes() == 4096
@@ -2027,7 +2411,7 @@ def test_an_abandoned_channel_stops_holding_the_cushion(tmp_path: Path) -> None:
 async def test_a_channel_still_being_read_keeps_its_tail(tmp_path: Path) -> None:
     """Closing the playing item at a cut must not discard what its stream is still owed."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.claim()
     item.write(b"tail" * 4)
     item.close()
@@ -2134,19 +2518,34 @@ def _streamdetails_for(
     )
 
 
+def _feed(session: _SoloistSession, uri: str) -> _ItemAudio:
+    """Return the channel of an item handed to the engine that it has not started."""
+    item = session._open_channel(uri)
+    session._pending.append(item)
+    return item
+
+
+def _streamed(session: _SoloistSession, uri: str = TRACK_A) -> _ItemAudio:
+    """Return the channel of the item the engine plays and a stream is reading."""
+    item = session._current = session._open_channel(uri)
+    item.started.set()
+    item.claim()
+    return item
+
+
 def _make_item(tmp_path: Path, uri: str) -> _ItemAudio:
     """Return a bare item channel on a mocked session."""
     return _ItemAudio(uri, _make_session(tmp_path))
 
 
-def _queue_item(uri: str, streamdetails: Any = None) -> MagicMock:
+def _queue_item(uri: str, streamdetails: Any = None, queue_item_id: str | None = None) -> MagicMock:
     """Return a queue item stand-in for a Spotify track on the test instance."""
     item_id = uri.rsplit(":", 1)[1]
     media_item = MagicMock(media_type=MediaType.TRACK, provider="spotify--test", item_id=item_id)
     media_item.provider_mappings = []
     return MagicMock(
         media_item=media_item,
-        queue_item_id=f"qi-{item_id}",
+        queue_item_id=queue_item_id or f"qi-{item_id}",
         streamdetails=streamdetails,
     )
 
@@ -2223,7 +2622,7 @@ def _install_fake_binary_manager(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_seeking_the_playing_item_keeps_the_session(tmp_path: Path) -> None:
     """The engine is moved where it stands rather than the session being respawned."""
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     playing.claim()
     playing.duration_ms = 260_000
@@ -2258,7 +2657,7 @@ async def test_a_seek_of_the_playing_item_is_sent_only_once(tmp_path: Path) -> N
     have fired several times over before the confirmation arrives.
     """
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     playing.observe_position(30_000)
     pending: list[asyncio.Task[None]] = []
@@ -2282,7 +2681,7 @@ async def test_seeking_back_is_not_confirmed_by_the_position_seeked_away_from(
 ) -> None:
     """A report still describing the pre-seek position cannot land a backward seek."""
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     playing.duration_ms = 260_000
     playing.observe_position(200_000)
@@ -2307,7 +2706,7 @@ async def test_seeking_back_is_not_confirmed_by_the_position_seeked_away_from(
 async def test_audio_in_flight_across_an_in_place_seek_is_dropped(tmp_path: Path) -> None:
     """Only audio from past the seek reaches the fresh channel."""
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     playing.observe_position(30_000)
 
@@ -2334,7 +2733,7 @@ async def test_the_sink_is_suspended_while_a_seek_is_in_flight(tmp_path: Path) -
     session._demand_started = True
     session._engine_playing = True
     session._sink_running = True
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     playing.observe_position(30_000)
     suspended_during_seek = False
@@ -2353,7 +2752,7 @@ async def test_the_sink_is_suspended_while_a_seek_is_in_flight(tmp_path: Path) -
 async def test_a_seek_the_engine_never_confirms_fails_the_item(tmp_path: Path) -> None:
     """An unconfirmed seek is reported rather than served from the wrong position."""
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     playing.observe_position(30_000)
     with (
@@ -2366,7 +2765,7 @@ async def test_a_seek_the_engine_never_confirms_fails_the_item(tmp_path: Path) -
 async def test_a_refused_seek_command_reports_soloist(tmp_path: Path) -> None:
     """A rejected seek names the engine, so the caller can fall back."""
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     _client_of(session).seek.side_effect = SoloistError("nope")
     with pytest.raises(AudioError, match="would not seek"):
@@ -2376,7 +2775,7 @@ async def test_a_refused_seek_command_reports_soloist(tmp_path: Path) -> None:
 async def test_seeking_an_item_the_engine_is_not_on_is_refused(tmp_path: Path) -> None:
     """Only the item the session is actually playing can be seeked in place."""
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     with pytest.raises(AudioError, match="is not playing"):
         await session.seek_current(TRACK_B, 120_000)
@@ -2391,7 +2790,7 @@ async def test_a_seek_of_the_playing_item_is_served_by_the_running_session(
     backend._binary = Path("/nonexistent/soloist")
     session = _make_session(tmp_path)
     backend._session = session
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.started.set()
     # its own stream is still attached when the seek re-opens it
     item.claim()
@@ -2421,7 +2820,7 @@ async def test_a_cancelled_seek_does_not_leave_the_session_wedged(tmp_path: Path
     unable to expire, and refusing every later item as busy.
     """
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     playing.observe_position(30_000)
     seeking = asyncio.create_task(session.seek_current(TRACK_A, 120_000))
@@ -2440,7 +2839,7 @@ async def test_a_seek_cancelled_before_the_channel_is_swapped_keeps_the_session(
 ) -> None:
     """Nothing has been given up yet while the sink is still being held."""
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     held = asyncio.Event()
 
@@ -2463,9 +2862,9 @@ async def test_a_seek_cancelled_before_the_channel_is_swapped_keeps_the_session(
 async def test_a_seek_is_refused_once_the_engine_has_moved_on(tmp_path: Path) -> None:
     """The item seeked must still be the one the engine is on when the sink settles."""
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
-    follower = session._items[TRACK_B] = _ItemAudio(TRACK_B, session)
+    follower = session._open_channel(TRACK_B)
 
     async def _boundary_lands(**_kwargs: Any) -> None:
         session._current = follower
@@ -2477,7 +2876,8 @@ async def test_a_seek_is_refused_once_the_engine_has_moved_on(tmp_path: Path) ->
         await session.seek_current(TRACK_A, 120_000)
     # the follower the engine actually reached keeps its own channel
     assert session.current is follower
-    assert session._items[TRACK_A] is playing
+    # ... and the refused seek opened no channel of its own
+    assert [item for item in session._channels if item.uri == TRACK_A] == [playing]
 
 
 async def test_a_seek_that_fails_part_way_restarts_the_session(
@@ -2489,7 +2889,7 @@ async def test_a_seek_that_fails_part_way_restarts_the_session(
     backend._binary = Path("/nonexistent/soloist")
     session = _make_session(tmp_path)
     backend._session = session
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.started.set()
     item.claim()
     _client_of(session).seek.side_effect = SoloistError("refused")
@@ -2513,7 +2913,7 @@ async def test_a_seek_refused_because_the_app_took_over_does_not_respawn(
     backend._binary = Path("/nonexistent/soloist")
     session = _make_session(tmp_path)
     backend._session = session
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.started.set()
     item.claim()
     item.observe_position(30_000)
@@ -2536,7 +2936,7 @@ async def test_a_seek_is_abandoned_when_the_app_took_over_during_the_suspend(
 ) -> None:
     """Nothing is seeked on a session the Spotify app has already taken over."""
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
 
     async def _app_takes_over(**_kwargs: Any) -> None:
@@ -2581,7 +2981,7 @@ async def test_a_seek_cancelled_at_the_final_resume_does_not_leave_the_session_u
 ) -> None:
     """The channel is claimed by then, so an abandoned seek must still end the session."""
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     playing.observe_position(30_000)
     calls = 0
@@ -2609,7 +3009,7 @@ async def test_a_seek_cancelled_at_the_final_resume_does_not_leave_the_session_u
 async def test_a_cold_seek_does_not_read_a_failed_session_as_landed(tmp_path: Path) -> None:
     """The wake-up a fatal failure gives every channel is not a confirmed seek."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
 
     async def _engine_dies(_position_ms: int, **_kwargs: Any) -> None:
         session._fail("the session exited")
@@ -2634,7 +3034,7 @@ async def test_seeking_the_playing_item_back_to_its_start_keeps_the_session(
     backend._binary = Path("/nonexistent/soloist")
     session = _make_session(tmp_path)
     backend._session = session
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.started.set()
     item.claim()
     item.observe_position(200_000)
@@ -2666,7 +3066,7 @@ async def test_a_short_forward_seek_still_confirms(tmp_path: Path) -> None:
     engine drop below that mark would never be satisfied by a seek forward.
     """
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     playing.duration_ms = 260_000
     # the engine is at 49s while only ~30s has been delivered
@@ -2690,7 +3090,7 @@ async def test_a_seek_does_not_arm_the_last_items_drain(tmp_path: Path) -> None:
     """
     session = _make_session(tmp_path)
     session._demand_started = True
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing = session._current = session._open_channel(TRACK_A)
     playing.started.set()
     playing.duration_ms = 260_000
     playing.observe_position(30_000)
@@ -2720,7 +3120,7 @@ async def test_the_item_a_finished_run_stopped_on_is_not_seeked_in_place(
     seek would wait out its confirmation on an engine that has stopped.
     """
     session = _make_session(tmp_path)
-    ended = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    ended = session._current = session._open_channel(TRACK_A)
     ended.started.set()
     ended.close()
     with pytest.raises(AudioError, match="is not playing"):


### PR DESCRIPTION
# What does this implement/fix?

The Spotify Soloist backend runs one playback session per queue and feeds it one track ahead. Its per-item audio channels were identified by Spotify URI alone, so a track queued twice in a row collided with itself: the second occurrence was never handed to the engine and had to cold-start a whole new session. A queue reordered after the feed cost the same.

**Related issue (if applicable):**

- n/a

## Changes

- Audio channels are now per occurrence rather than per track, so the same track twice in a row plays on without a break.
- A next item the session was not fed — the queue was reordered, or the user picked something else — is queued and skipped to instead of respawning the engine.
- Repeating a single track no longer queues a copy of the track the queue replays itself.
- A jump on a live session gives up after 5s rather than 30s, so a fresh session still starts within the time the queue waits for audio.
- Corrected the provider README, which still claimed a guard for repeated tracks that no longer existed.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate. (n/a)
