### PR TITLE
Stop logging an ordinary Spotify seek as a failure

### DIFF
--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -916,7 +916,7 @@ class _SoloistSession:
             # claimed channels, and the outgoing one is closed below
             item.claim()
             self._current = item
-            outgoing.close(discarded=True)
+            outgoing.close(superseded=True)
             try:
                 # seeded from where the engine actually is: a fresh channel has
                 # observed no position of its own, and a backward seek judged
@@ -1147,7 +1147,7 @@ class _SoloistSession:
             raise self._session_error()
         if not item.playing_seen:
             raise AudioError(f"Spotify Soloist never started playing {item.uri}")
-        if item.discarded or item.duration_ms is None:
+        if item.superseded or item.duration_ms is None:
             return
         tolerance_ms = min(_INCOMPLETE_TOLERANCE_MS, item.duration_ms // 2)
         if item.last_position_ms is None or item.last_position_ms + tolerance_ms < item.duration_ms:
@@ -1168,7 +1168,7 @@ class _SoloistSession:
             return
         self._stopped = True
         for item in self._channels:
-            item.close(discarded=True)
+            item.close(superseded=True)
         if self._client is not None and self._proc is not None:
             # commands travel over the events connection, so this has to happen
             # before that task is cancelled; stopping playback lets the engine
@@ -2008,7 +2008,9 @@ class _SoloistSession:
             self._pending.remove(item)
         self._current = item
         self._app_pauses = 0
-        if self._discard_until is item:
+        # a jump Music Assistant asked for, rather than a boundary the engine reached
+        commanded = self._discard_until is item
+        if commanded:
             self._discard_until = None
             # The engine confirms a jump over the WebSocket within a few
             # milliseconds, long before the audio it describes reaches the
@@ -2023,7 +2025,7 @@ class _SoloistSession:
             # A channel still waiting to start is not over - the engine simply
             # reported its own state before getting to it - and closing it would
             # end that item's stream before it had delivered anything.
-            current.close()
+            current.close(superseded=commanded)
         if not item.claimed:
             self._signal_ready(uri)
 
@@ -2192,8 +2194,8 @@ class _ItemAudio:
         self.claimed = False
         # served once already: its audio was handed over and cannot be replayed
         self.spent = False
-        # cut before the engine was done with the item, rather than played out
-        self.discarded = False
+        # cut by Music Assistant rather than ended by the engine
+        self.superseded = False
         self.drain_task: asyncio.Task[None] | None = None
         self._last_write = 0.0
         self._chunks: deque[bytes] = deque()
@@ -2312,17 +2314,18 @@ class _ItemAudio:
         self.draining = False
         self._tail_target = None
 
-    def close(self, *, discarded: bool = False) -> None:
+    def close(self, *, superseded: bool = False) -> None:
         """
         Close the channel: its stream ends once the buffered audio is drained.
 
-        :param discarded: Whether the channel is being cut while the engine is
-            still on the item, so what it delivered is short by construction.
-            Only honoured for a channel that is still open: one that already
-            ended keeps the verdict it ended with.
+        :param superseded: Whether Music Assistant is cutting the channel rather
+            than the engine having ended it, so what it delivered is short by
+            construction.
         """
-        if discarded and not self._closed:
-            self.discarded = True
+        # a channel that already ended keeps the verdict it ended with: a
+        # teardown closes every channel, including ones the engine was done with
+        if superseded and not self._closed:
+            self.superseded = True
         self._closed = True
         # a closed channel no longer holds the capture sink open for its tail
         self.draining = False

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -916,7 +916,7 @@ class _SoloistSession:
             # claimed channels, and the outgoing one is closed below
             item.claim()
             self._current = item
-            outgoing.close()
+            outgoing.close(discarded=True)
             try:
                 # seeded from where the engine actually is: a fresh channel has
                 # observed no position of its own, and a backward seek judged
@@ -1137,7 +1137,8 @@ class _SoloistSession:
 
         A starved session pads with silence rather than failing, so completeness
         is judged by the furthest playback position the engine reported while
-        the item was current.
+        the item was current. A channel Music Assistant cut itself is not judged
+        that way: it stops short by construction.
 
         :param item: The item whose stream just finished.
         :raises AudioError: When the item was cut short.
@@ -1146,7 +1147,7 @@ class _SoloistSession:
             raise self._session_error()
         if not item.playing_seen:
             raise AudioError(f"Spotify Soloist never started playing {item.uri}")
-        if item.duration_ms is None:
+        if item.discarded or item.duration_ms is None:
             return
         tolerance_ms = min(_INCOMPLETE_TOLERANCE_MS, item.duration_ms // 2)
         if item.last_position_ms is None or item.last_position_ms + tolerance_ms < item.duration_ms:
@@ -1167,7 +1168,7 @@ class _SoloistSession:
             return
         self._stopped = True
         for item in self._channels:
-            item.close()
+            item.close(discarded=True)
         if self._client is not None and self._proc is not None:
             # commands travel over the events connection, so this has to happen
             # before that task is cancelled; stopping playback lets the engine
@@ -2191,6 +2192,8 @@ class _ItemAudio:
         self.claimed = False
         # served once already: its audio was handed over and cannot be replayed
         self.spent = False
+        # cut before the engine was done with the item, rather than played out
+        self.discarded = False
         self.drain_task: asyncio.Task[None] | None = None
         self._last_write = 0.0
         self._chunks: deque[bytes] = deque()
@@ -2309,8 +2312,17 @@ class _ItemAudio:
         self.draining = False
         self._tail_target = None
 
-    def close(self) -> None:
-        """Close the channel: its stream ends once the buffered audio is drained."""
+    def close(self, *, discarded: bool = False) -> None:
+        """
+        Close the channel: its stream ends once the buffered audio is drained.
+
+        :param discarded: Whether the channel is being cut while the engine is
+            still on the item, so what it delivered is short by construction.
+            Only honoured for a channel that is still open: one that already
+            ended keeps the verdict it ended with.
+        """
+        if discarded and not self._closed:
+            self.discarded = True
         self._closed = True
         # a closed channel no longer holds the capture sink open for its tail
         self.draining = False

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -1187,6 +1187,40 @@ async def test_skipping_from_the_app_to_the_fed_item_is_followed(tmp_path: Path)
     assert session.item_for(TRACK_B) is fed
 
 
+async def test_a_skip_leaves_the_outgoing_stream_nothing_to_report(tmp_path: Path) -> None:
+    """A jump Music Assistant asked for cuts the outgoing item, which is not starving."""
+    session = _make_session(tmp_path)
+    item = session._open_channel(TRACK_A)
+    item.duration_ms = 200_000
+    item.playing_seen = True
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
+    item.observe_position(20_000)
+    fed = _feed(session, TRACK_B)
+    # what skip_to arms before telling the engine to jump
+    session._discard_until = fed
+
+    await session._observe_current(TRACK_B, 180_000, track_changed=True)
+    assert session.current is fed
+    assert item.superseded
+    await session.validate_item(item)
+
+
+async def test_a_boundary_the_engine_drove_is_still_judged(tmp_path: Path) -> None:
+    """Nobody asked the engine to leave this item, so what it delivered still counts."""
+    session = _make_session(tmp_path)
+    item = session._open_channel(TRACK_A)
+    item.duration_ms = 200_000
+    item.playing_seen = True
+    await session._observe_current(TRACK_A, 200_000, track_changed=True)
+    item.observe_position(20_000)
+    _feed(session, TRACK_B)
+
+    await session._observe_current(TRACK_B, 180_000, track_changed=True)
+    assert item.superseded is False
+    with pytest.raises(AudioError, match="incomplete"):
+        await session.validate_item(item)
+
+
 async def test_a_takeover_snapshot_stops_pinning_volume_and_options(tmp_path: Path) -> None:
     """Once the app has the session, the rest of its snapshot must not reach the daemon."""
     session = _make_session(tmp_path)
@@ -2123,23 +2157,23 @@ async def test_a_duration_less_item_is_not_judged(tmp_path: Path) -> None:
     await session.validate_item(item)
 
 
-async def test_a_discarded_item_is_not_judged_incomplete(tmp_path: Path) -> None:
+async def test_a_superseded_item_is_not_judged_incomplete(tmp_path: Path) -> None:
     """A channel cut part-way is short on purpose, so it is no evidence of starving."""
     session = _make_session(tmp_path)
     item = _ItemAudio(TRACK_A, session)
     item.playing_seen = True
     item.duration_ms = 200_000
     item.last_position_ms = 30_000
-    item.close(discarded=True)
+    item.close(superseded=True)
     await session.validate_item(item)
 
 
-async def test_a_discarded_item_that_never_played_is_still_rejected(tmp_path: Path) -> None:
+async def test_a_superseded_item_that_never_played_is_still_rejected(tmp_path: Path) -> None:
     """Cutting a channel excuses a short delivery, not one that carried nothing."""
     session = _make_session(tmp_path)
     item = _ItemAudio(TRACK_A, session)
     item.duration_ms = 200_000
-    item.close(discarded=True)
+    item.close(superseded=True)
     with pytest.raises(AudioError, match="never started playing"):
         await session.validate_item(item)
 
@@ -2147,13 +2181,13 @@ async def test_a_discarded_item_that_never_played_is_still_rejected(tmp_path: Pa
 async def test_an_item_the_engine_moved_on_from_keeps_its_verdict(tmp_path: Path) -> None:
     """A later teardown must not excuse a channel the engine already starved."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item = session._open_channel(TRACK_A)
     item.playing_seen = True
     item.duration_ms = 200_000
     item.last_position_ms = 30_000
-    # the boundary the engine drove, before the session is torn down behind it
+    # the boundary the engine drove, with the teardown following behind it
     item.close()
-    item.close(discarded=True)
+    await session.stop()
     with pytest.raises(AudioError, match="incomplete"):
         await session.validate_item(item)
 
@@ -2268,14 +2302,14 @@ async def test_a_cancelled_teardown_still_closes_the_daemon(tmp_path: Path) -> N
 async def test_a_teardown_leaves_the_running_stream_nothing_to_report(tmp_path: Path) -> None:
     """Stopping the session cuts the item being played; that is not a starved item."""
     session = _make_session(tmp_path)
-    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item = session._current = session._open_channel(TRACK_A)
     item.started.set()
     item.duration_ms = 260_000
     item.playing_seen = True
     item.observe_position(30_000)
     await session.stop()
 
-    assert item.discarded
+    assert item.superseded
     await session.validate_item(item)
 
 
@@ -2811,9 +2845,7 @@ async def test_a_seek_leaves_the_outgoing_stream_nothing_to_report(tmp_path: Pat
     engine is nowhere near the end of an item being seeked away from.
     """
     session = _make_session(tmp_path)
-    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
-    playing.started.set()
-    playing.claim()
+    playing = _streamed(session)
     playing.duration_ms = 260_000
     playing.playing_seen = True
     playing.observe_position(30_000)
@@ -2825,7 +2857,7 @@ async def test_a_seek_leaves_the_outgoing_stream_nothing_to_report(tmp_path: Pat
     await session.seek_current(TRACK_A, 120_000)
     playing.release()
 
-    assert playing.discarded
+    assert playing.superseded
     await session.validate_item(playing)
 
 

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -2123,6 +2123,41 @@ async def test_a_duration_less_item_is_not_judged(tmp_path: Path) -> None:
     await session.validate_item(item)
 
 
+async def test_a_discarded_item_is_not_judged_incomplete(tmp_path: Path) -> None:
+    """A channel cut part-way is short on purpose, so it is no evidence of starving."""
+    session = _make_session(tmp_path)
+    item = _ItemAudio(TRACK_A, session)
+    item.playing_seen = True
+    item.duration_ms = 200_000
+    item.last_position_ms = 30_000
+    item.close(discarded=True)
+    await session.validate_item(item)
+
+
+async def test_a_discarded_item_that_never_played_is_still_rejected(tmp_path: Path) -> None:
+    """Cutting a channel excuses a short delivery, not one that carried nothing."""
+    session = _make_session(tmp_path)
+    item = _ItemAudio(TRACK_A, session)
+    item.duration_ms = 200_000
+    item.close(discarded=True)
+    with pytest.raises(AudioError, match="never started playing"):
+        await session.validate_item(item)
+
+
+async def test_an_item_the_engine_moved_on_from_keeps_its_verdict(tmp_path: Path) -> None:
+    """A later teardown must not excuse a channel the engine already starved."""
+    session = _make_session(tmp_path)
+    item = session._items[TRACK_A] = _ItemAudio(TRACK_A, session)
+    item.playing_seen = True
+    item.duration_ms = 200_000
+    item.last_position_ms = 30_000
+    # the boundary the engine drove, before the session is torn down behind it
+    item.close()
+    item.close(discarded=True)
+    with pytest.raises(AudioError, match="incomplete"):
+        await session.validate_item(item)
+
+
 def test_an_unread_session_expires(tmp_path: Path) -> None:
     """A session no item stream reads from is ended so its daemon does not linger."""
     session = _make_session(tmp_path)
@@ -2228,6 +2263,20 @@ async def test_a_cancelled_teardown_still_closes_the_daemon(tmp_path: Path) -> N
     assert session._sink is None
     proc.close.assert_awaited()
     sink.unload.assert_awaited()
+
+
+async def test_a_teardown_leaves_the_running_stream_nothing_to_report(tmp_path: Path) -> None:
+    """Stopping the session cuts the item being played; that is not a starved item."""
+    session = _make_session(tmp_path)
+    item = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    item.started.set()
+    item.duration_ms = 260_000
+    item.playing_seen = True
+    item.observe_position(30_000)
+    await session.stop()
+
+    assert item.discarded
+    await session.validate_item(item)
 
 
 def test_a_failed_session_is_torn_down(tmp_path: Path) -> None:
@@ -2752,6 +2801,32 @@ async def test_seeking_the_playing_item_keeps_the_session(tmp_path: Path) -> Non
     # the outgoing channel is closed, which is what ends the stream reading it
     assert playing._closed
     _client_of(session).seek.assert_awaited_once_with(120_000, await_result=True)
+
+
+async def test_a_seek_leaves_the_outgoing_stream_nothing_to_report(tmp_path: Path) -> None:
+    """
+    The superseded channel validates clean, so an ordinary seek stays out of the log.
+
+    Its stream is still attached and validates the channel when it ends, and the
+    engine is nowhere near the end of an item being seeked away from.
+    """
+    session = _make_session(tmp_path)
+    playing = session._items[TRACK_A] = session._current = _ItemAudio(TRACK_A, session)
+    playing.started.set()
+    playing.claim()
+    playing.duration_ms = 260_000
+    playing.playing_seen = True
+    playing.observe_position(30_000)
+
+    async def _engine_seeks(position_ms: int, **_kwargs: Any) -> None:
+        _current_of(session).observe_position(position_ms)
+
+    _client_of(session).seek.side_effect = _engine_seeks
+    await session.seek_current(TRACK_A, 120_000)
+    playing.release()
+
+    assert playing.discarded
+    await session.validate_item(playing)
 
 
 async def test_a_seek_of_the_playing_item_is_sent_only_once(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Every seek of a Spotify track played through the Soloist backend logged two scary-looking warnings:

```
WARNING [ffmpeg.NNN] The stdin feeder task ended with error: Spotify Soloist delivered
incomplete audio for spotify:track:... (reached 17287ms of 259946ms)
```

Nothing was actually wrong — the audio played fine. Seeking replaces the outgoing audio channel with a fresh one, and the check that guards against the engine starving us was still judging that replaced channel: cut on purpose part-way through, so it always looked short.

Now a channel Music Assistant cuts itself is marked as such and skipped by that check, so the warning is left for a channel that really was starved.

- Mark a channel that a seek, a skip or a session teardown replaces
- Skip the completeness check for those, keep it for every other channel
- Tests for both directions, so an engine-driven boundary still reports

Verified on a Spotify rig: the warning appears on `dev` for an ordinary seek and is gone here, with playback and seeking unchanged.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
