### PR TITLE
Don't stall cleaning up a virtual player that was already removed

### DIFF
--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -1744,6 +1744,10 @@ class SendspinProvider(PlayerProvider):
             if delay:
                 await asyncio.sleep(delay)
             try:
+                # another teardown won the race; a config it left behind is not ours
+                # to delete, _remove_orphan_virtual_player_configs sweeps it at startup
+                if not self.is_virtual_player(player_id):
+                    return
                 # awaited to completion on purpose: a timeout is no reliable bound on
                 # the teardown - parts of it swallow the cancellation (see
                 # AsyncProcess.close), and one that does land leaves the player

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -1745,7 +1745,8 @@ class SendspinProvider(PlayerProvider):
                 await asyncio.sleep(delay)
             try:
                 # another teardown won the race; a config it left behind is not ours
-                # to delete, _remove_orphan_virtual_player_configs sweeps it at startup
+                # to delete - it is kept for the owner to reclaim, and swept at
+                # startup once that owner is gone
                 if not self.is_virtual_player(player_id):
                     return
                 # awaited to completion on purpose: a timeout is no reliable bound on

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -305,6 +305,30 @@ async def test_cleanup_failed_creation_skips_an_already_removed_player() -> None
     sendspin.logger.warning.assert_not_called()
 
 
+async def test_cleanup_failed_creation_keeps_a_reclaimable_config() -> None:
+    """Test that cleanup leaves a persisted config it did not create in place."""
+    sendspin = SendspinProvider.__new__(SendspinProvider)
+    sendspin.mass = MagicMock()
+    sendspin.server_api = MagicMock()
+    sendspin.logger = MagicMock()
+    sendspin.config = MagicMock(instance_id="sendspin--test")
+    player_id = f"{VIRTUAL_PLAYER_ID_PREFIX}reclaimable"
+    # unloading drops the in-memory entries but keeps the configs on purpose
+    sendspin._virtual_players = {}
+    sendspin.mass.config.get.return_value = {
+        "provider": sendspin.instance_id,
+        "values": {CONF_VIRTUAL_PLAYER_OWNER: "owner--test"},
+    }
+    sendspin.server_api.get_client.return_value = None
+    sendspin.mass.players.unregister = AsyncMock()
+
+    await sendspin._cleanup_failed_virtual_player_creation(player_id)
+
+    sendspin.mass.players.delete_player_config.assert_not_called()
+    sendspin.mass.players.unregister.assert_not_awaited()
+    sendspin.logger.warning.assert_not_called()
+
+
 async def test_remove_virtual_player_rejects_regular_player(mass: MusicAssistant) -> None:
     """Test that removal is refused for players that are not virtual players."""
     sendspin = _get_sendspin_provider(mass)

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -286,6 +286,25 @@ async def test_cleanup_failed_creation_retries_a_raised_teardown() -> None:
     sendspin.logger.warning.assert_not_called()
 
 
+async def test_cleanup_failed_creation_skips_an_already_removed_player() -> None:
+    """Test that cleanup stops immediately when the player is already gone."""
+    sendspin = SendspinProvider.__new__(SendspinProvider)
+    sendspin.mass = MagicMock()
+    sendspin.server_api = MagicMock()
+    sendspin.logger = MagicMock()
+    player_id = f"{VIRTUAL_PLAYER_ID_PREFIX}gone"
+    # already torn down by a racing removal, e.g. the owner-unloaded sweep
+    sendspin._virtual_players = {}
+    sendspin.mass.players.unregister = AsyncMock()
+
+    async with asyncio.timeout(0.5):
+        await sendspin._cleanup_failed_virtual_player_creation(player_id)
+
+    sendspin.mass.players.unregister.assert_not_awaited()
+    sendspin.mass.players.delete_player_config.assert_not_called()
+    sendspin.logger.warning.assert_not_called()
+
+
 async def test_remove_virtual_player_rejects_regular_player(mass: MusicAssistant) -> None:
     """Test that removal is refused for players that are not virtual players."""
     sendspin = _get_sendspin_provider(mass)


### PR DESCRIPTION
# What does this implement/fix?

When creating a virtual Sendspin player fails, the cleanup retries removing it three times. If the player had meanwhile already been removed by another path (for example because its owning provider was unloaded while creation was still in progress), every attempt hits the same "not a virtual player" error — so the cleanup waited 2.5 seconds for nothing and then logged a warning, even though the player was actually gone and there was nothing left to clean up.

The equivalent cleanup for cancelled remote sessions already checks this before each attempt; this makes the Sendspin side do the same.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
