### PR TITLE
Free a cut Spotify channel's buffer as soon as nothing is reading it

### DIFF
--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -1910,8 +1910,7 @@ class _SoloistSession:
         """Open a channel for one occurrence of an item, dropping any nothing can read."""
         # A channel the session has moved past and no stream holds can answer
         # for nothing: it is dropped here rather than carried for the rest of
-        # the run, where its buffer would go on counting against the retention
-        # cap and the capture loop would go on scanning it.
+        # the run, where every walk of the channel list would keep visiting it.
         self._channels = [
             item
             for item in self._channels
@@ -2434,9 +2433,10 @@ class _ItemAudio:
         """
         Free audio nothing can read any more, so it stops gating the capture sink.
 
-        A closed channel is never handed to a stream again; without this the
-        buffer it had filled would count against ``_MAX_RETAINED_S`` for the rest
-        of the session, and enough of them would suspend the sink for good.
+        A closed channel is not offered to a stream again, so once nothing holds
+        it its buffer can only count against ``_MAX_RETAINED_S`` - and the item a
+        run ends on stays current, so it would do so for the rest of the session
+        and suspend the sink for good.
         """
         if self.claimed or not self._closed:
             return

--- a/music_assistant/providers/spotify/backends/soloist.py
+++ b/music_assistant/providers/spotify/backends/soloist.py
@@ -2434,11 +2434,11 @@ class _ItemAudio:
         """
         Free audio nothing can read any more, so it stops gating the capture sink.
 
-        A skip leaves its channel closed with its reader gone; without this the
+        A closed channel is never handed to a stream again; without this the
         buffer it had filled would count against ``_MAX_RETAINED_S`` for the rest
         of the session, and enough of them would suspend the sink for good.
         """
-        if self.claimed or not self._closed or not self.spent:
+        if self.claimed or not self._closed:
             return
         self._chunks.clear()
         self._buffered = 0

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -2408,6 +2408,21 @@ def test_an_abandoned_channel_stops_holding_the_cushion(tmp_path: Path) -> None:
     assert session._retained_bytes() == 0
 
 
+async def test_a_channel_no_stream_ever_took_stops_holding_the_cushion(
+    tmp_path: Path,
+) -> None:
+    """A channel the session cuts with nothing reading it frees its buffer right away."""
+    session = _make_session(tmp_path)
+    item = _feed(session, TRACK_B)
+    await session._observe_current(TRACK_B, 200_000, track_changed=True)
+    session._write_if_wanted(b"\x01" * 4096)
+    assert session._retained_bytes() == 4096
+    # cut while it is still the current channel, which the prune deliberately keeps
+    item.close()
+    assert item in session._channels
+    assert session._retained_bytes() == 0
+
+
 async def test_a_channel_still_being_read_keeps_its_tail(tmp_path: Path) -> None:
     """Closing the playing item at a cut must not discard what its stream is still owed."""
     session = _make_session(tmp_path)

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -2417,7 +2417,7 @@ async def test_a_channel_no_stream_ever_took_stops_holding_the_cushion(
     await session._observe_current(TRACK_B, 200_000, track_changed=True)
     session._write_if_wanted(b"\x01" * 4096)
     assert session._retained_bytes() == 4096
-    # cut while it is still the current channel, which the prune deliberately keeps
+    # still the current channel, so the prune cannot be what frees the cushion
     item.close()
     assert item in session._channels
     assert session._retained_bytes() == 0


### PR DESCRIPTION
# What does this implement/fix?

Spotify Soloist buffers each track's captured audio on its own channel. Once a channel is cut it can never be handed to a stream again, but it kept holding whatever it had buffered. That audio still counted towards the session's retention cap, so a few dead channels could eat the whole budget and leave the capture sink suspended — which stalls playback.

Now a channel frees its buffer as soon as it is cut and nothing is reading it. A channel a stream is still draining is untouched, so no audio is lost mid-track.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
