### PR TITLE
Add tests for where Spotify Soloist splits one track from the next

### DIFF
--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -1866,6 +1866,51 @@ async def test_a_state_report_does_not_move_a_repeated_track_on(tmp_path: Path) 
     assert session.pending_item(TRACK_A) is second
 
 
+async def test_the_track_change_event_moves_a_repeated_track_on(tmp_path: Path) -> None:
+    """The track_changed event is the one that carries a repeat across its boundary."""
+    session = _make_session(tmp_path)
+    first = _streamed(session)
+    first.duration_ms = 200_000
+    first.observe_position(199_000)
+    second = _feed(session, TRACK_A)
+    await session._handle_event(_current_item_event("track_changed", TRACK_A, 200_000))
+    assert session.current is second
+    assert first.closed is True
+
+
+@pytest.mark.parametrize("event_type", ["playback_state", "playback_changed"])
+async def test_a_state_event_does_not_move_a_repeated_track_on(
+    tmp_path: Path, event_type: str
+) -> None:
+    """A snapshot near the end of the first occurrence describes it, it does not end it."""
+    session = _make_session(tmp_path)
+    first = _streamed(session)
+    first.duration_ms = 200_000
+    first.observe_position(199_000)
+    second = _feed(session, TRACK_A)
+    await session._handle_event(_current_item_event(event_type, TRACK_A, 200_000))
+    assert session.current is first
+    assert first.closed is False
+    assert session.pending_item(TRACK_A) is second
+
+
+@pytest.mark.parametrize("event_type", ["track_changed", "playback_state", "playback_changed"])
+async def test_an_event_naming_another_item_cuts_at_the_boundary(
+    tmp_path: Path, event_type: str
+) -> None:
+    """Whichever event reports the move, the item played out ends and the next one takes over."""
+    session = _make_session(tmp_path)
+    first = _streamed(session)
+    first.duration_ms = 200_000
+    first.observe_position(199_000)
+    second = _feed(session, TRACK_B)
+    await session._handle_event(_current_item_event(event_type, TRACK_B, 180_000))
+    assert session.usable is True
+    assert session.current is second
+    assert second.duration_ms == 180_000
+    assert first.closed is True
+
+
 async def test_a_seek_in_flight_is_not_cut_short_by_a_repeat_boundary(tmp_path: Path) -> None:
     """A channel opened for a seek has no position of its own, which is not a played-out one."""
     session = _make_session(tmp_path)
@@ -2624,6 +2669,26 @@ def _playback_event(status: str, position_ms: int = 0) -> SoloistEvent:
             position=SoloistPosition(position_ms=position_ms, timestamp_ms=0),
         ),
         raw={},
+    )
+
+
+def _current_item_event(event_type: str, uri: str, duration_ms: int | None = None) -> SoloistEvent:
+    """
+    Return an event reporting the given item as the one the engine is on.
+
+    :param event_type: ``track_changed``, ``playback_state`` or ``playback_changed``.
+    :param uri: The Spotify URI the event names.
+    :param duration_ms: The duration to decorate the item with, when it has one.
+    """
+    item = SoloistEntity(
+        uri=uri,
+        entity_type="track",
+        decorations={"playback": {"duration_ms": duration_ms}} if duration_ms else {},
+    )
+    if event_type == "track_changed":
+        return SoloistEvent(type=event_type, data=SoloistTrackChanged(item=item), raw={})
+    return SoloistEvent(
+        type=event_type, data=SoloistPlaybackState(status="playing", item=item), raw={}
     )
 
 

--- a/tests/providers/spotify/test_soloist_backend.py
+++ b/tests/providers/spotify/test_soloist_backend.py
@@ -69,6 +69,7 @@ from music_assistant.providers.spotify_connect.soloist.runtime import (
     SoloistPlaybackOptions,
     SoloistPlaybackState,
     SoloistPosition,
+    SoloistPositionSync,
     SoloistTrackChanged,
     SoloistVolumeChanged,
 )
@@ -1898,17 +1899,32 @@ async def test_a_state_event_does_not_move_a_repeated_track_on(
 async def test_an_event_naming_another_item_cuts_at_the_boundary(
     tmp_path: Path, event_type: str
 ) -> None:
-    """Whichever event reports the move, the item played out ends and the next one takes over."""
+    """Whichever event reports the move, the item being left ends and the next one takes over."""
     session = _make_session(tmp_path)
     first = _streamed(session)
     first.duration_ms = 200_000
-    first.observe_position(199_000)
+    first.observe_position(20_000)
     second = _feed(session, TRACK_B)
     await session._handle_event(_current_item_event(event_type, TRACK_B, 180_000))
+    # the engine left the previous item part-way through, but for one it was fed:
+    # the queue moving on, not the Spotify app taking the session over
     assert session.usable is True
     assert session.current is second
     assert second.duration_ms == 180_000
     assert first.closed is True
+
+
+async def test_a_position_report_tells_the_current_item_where_the_engine_is(
+    tmp_path: Path,
+) -> None:
+    """Where the engine got to is what tells an item played out from one it was pulled off."""
+    session = _make_session(tmp_path)
+    item = _streamed(session)
+    item.duration_ms = 200_000
+    assert item.mid_play is False  # no position reported yet, so nothing to judge by
+    await session._handle_event(_position_event(20_000))
+    assert item.last_position_ms == 20_000
+    assert item.mid_play is True
 
 
 async def test_a_seek_in_flight_is_not_cut_short_by_a_repeat_boundary(tmp_path: Path) -> None:
@@ -2668,6 +2684,15 @@ def _playback_event(status: str, position_ms: int = 0) -> SoloistEvent:
             item=SoloistEntity(uri=TRACK_A, entity_type="track"),
             position=SoloistPosition(position_ms=position_ms, timestamp_ms=0),
         ),
+        raw={},
+    )
+
+
+def _position_event(position_ms: int) -> SoloistEvent:
+    """Return a position_sync event reporting the given playback position."""
+    return SoloistEvent(
+        type="position_sync",
+        data=SoloistPositionSync(position=SoloistPosition(position_ms=position_ms, timestamp_ms=0)),
         raw={},
     )
 

--- a/tests/providers/spotify_connect/test_soloist.py
+++ b/tests/providers/spotify_connect/test_soloist.py
@@ -33,6 +33,7 @@ from music_assistant.providers.spotify_connect.soloist.runtime import (
     SoloistPlaybackState,
     SoloistPositionSync,
     SoloistQueueChanged,
+    SoloistTrackChanged,
     SoloistVolumeChanged,
     UnsupportedPlatformError,
 )
@@ -722,6 +723,38 @@ async def test_event_dispatch_decodes_documented_payloads(tmp_path: Path) -> Non
     assert queue.upcoming[0].source == "queue"
     assert queue.upcoming[0].item is not None
     assert queue.upcoming[0].item.uri == "spotify:track:upcoming"
+
+
+async def test_the_item_boundary_events_keep_their_own_payload_types(tmp_path: Path) -> None:
+    """The events the playback backend cuts items on must not decode into each other."""
+    _publish_endpoint(tmp_path)
+    ws = _FakeWebSocket()
+    client = _make_client(tmp_path, ws)
+    item = {"uri": "spotify:track:2JRo0gjbX4GrCqBYdRohoo", "entity_type": "track"}
+    for payload in (
+        {"type": "track_changed", "item": item},
+        {"type": "playback_state", "status": "playing", "item": item},
+        {"type": "playback_changed", "status": "playing", "item": item},
+    ):
+        ws.queue.put_nowait(_text_msg(payload))
+    ws.queue.put_nowait(None)
+    events: list[SoloistEvent] = []
+
+    async def on_event(event: SoloistEvent) -> None:
+        events.append(event)
+
+    await client.listen_events(on_event)
+
+    assert [event.type for event in events] == [
+        "track_changed",
+        "playback_state",
+        "playback_changed",
+    ]
+    assert isinstance(events[0].data, SoloistTrackChanged)
+    # the snapshot and the delta share one payload, so the event type is all a
+    # consumer has to tell a full state report from a partial one
+    assert isinstance(events[1].data, SoloistPlaybackState)
+    assert isinstance(events[2].data, SoloistPlaybackState)
 
 
 async def test_event_dispatch_tolerates_malformed_and_unknown(tmp_path: Path) -> None:

--- a/tests/providers/spotify_connect/test_soloist.py
+++ b/tests/providers/spotify_connect/test_soloist.py
@@ -725,8 +725,8 @@ async def test_event_dispatch_decodes_documented_payloads(tmp_path: Path) -> Non
     assert queue.upcoming[0].item.uri == "spotify:track:upcoming"
 
 
-async def test_the_item_boundary_events_keep_their_own_payload_types(tmp_path: Path) -> None:
-    """The events the playback backend cuts items on must not decode into each other."""
+async def test_the_item_boundary_events_decode_to_the_expected_payloads(tmp_path: Path) -> None:
+    """The events the playback backend cuts items on each decode to the payload it expects."""
     _publish_endpoint(tmp_path)
     ws = _FakeWebSocket()
     client = _make_client(tmp_path, ws)


### PR DESCRIPTION
# What does this implement/fix?

The Spotify Soloist backend decides where one track's audio ends and the next begins from two different engine events: a track change, and a playback state report. The difference matters — a track queued twice in a row is reported under the same track ID on both sides of the boundary, so only a track change may move on to the second play. A state report arriving in the last seconds of the first one must not, or it would cut that track short.

That distinction had no test covering it: every boundary test called the internal handler directly, so swapping the two event kinds around passed the whole suite. These tests drive the real events instead, so the mix-up cannot come back unnoticed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- A track change for the track already playing moves on to its queued repeat.
- A playback state report for that same track does not, so the first play keeps its tail.
- An event of either kind naming another track still cuts at the boundary and carries the new track's duration over.
- Both `playback_state` snapshots and `playback_changed` deltas are covered, since they decode to the same payload and only the event type tells them apart.
- The engine events also decode to the payload each one expects, so they cannot start decoding into each other unnoticed.
- The position report the boundary check reads was untested too, and is now covered: it is what tells a track that played out from one the engine was pulled off.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
