### PR TITLE
Spotify Connect no longer disappears when a different account connects

### DIFF
--- a/music_assistant/providers/spotify_connect/models.py
+++ b/music_assistant/providers/spotify_connect/models.py
@@ -39,8 +39,6 @@ class BackendEventType(StrEnum):
     CONNECTION_LOST = "connection_lost"
     # a non-fatal backend error worth surfacing (message in the ``error`` field)
     ERROR = "error"
-    # the backend lost its Spotify authentication and needs the user to log in again
-    AUTH_REQUIRED = "auth_required"
     # the backend failed permanently and the provider must unload with an error
     FATAL_ERROR = "fatal_error"
     # any other backend activity; carries at most refreshed context/track uris

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -857,6 +857,7 @@ class SpotifyConnectProvider(PluginProvider):
             # non-fatal backend error: surface it in the log only
             self.logger.warning("Spotify Connect backend error: %s", event.error)
             return
+
         self._remember_context_uris(event)
 
         if event.type is BackendEventType.QUEUE_CHANGED:

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -23,7 +23,7 @@ from music_assistant_models.enums import (
     RepeatMode,
     SourceControl,
 )
-from music_assistant_models.errors import AudioError, LoginFailed, MediaNotFoundError
+from music_assistant_models.errors import AudioError, MediaNotFoundError
 from music_assistant_models.media_items import (
     AudioSource,
     ProviderMapping,
@@ -857,10 +857,6 @@ class SpotifyConnectProvider(PluginProvider):
             # non-fatal backend error: surface it in the log only
             self.logger.warning("Spotify Connect backend error: %s", event.error)
             return
-        if event.type is BackendEventType.AUTH_REQUIRED:
-            self._handle_auth_required()
-            return
-
         self._remember_context_uris(event)
 
         if event.type is BackendEventType.QUEUE_CHANGED:
@@ -962,23 +958,6 @@ class SpotifyConnectProvider(PluginProvider):
             self._last_context_uri = event.context_uri
         if event.track_uri:
             self._last_track_uri = event.track_uri
-
-    def _handle_auth_required(self) -> None:
-        """Handle a lost Spotify login: reset session state and unload with an auth error."""
-        # the backend lost its Spotify login mid-session: stop treating the
-        # device as active and unload with an auth error so the UI flags
-        # the provider and routes the user through the setup flow
-        self._playing = False
-        self._spotify_session_active = False
-        self._last_playback_options = None
-        self.logger.warning("Spotify Connect backend for %s requires (re)authentication", self.name)
-        self.unload_with_error(
-            LoginFailed(
-                "Spotify authentication required",
-                translation_key="soloist_auth_required",
-                translation_owner=self.translation_owner,
-            )
-        )
 
     def _handle_options_changed(self, event: BackendEvent) -> None:
         """

--- a/music_assistant/providers/spotify_connect/soloist/README.md
+++ b/music_assistant/providers/spotify_connect/soloist/README.md
@@ -101,9 +101,10 @@ acknowledged FIFO per command type. `play()` claims active device status first
 (`activate`) — a bare play would start local playback without a Connect transfer, leaving
 the Spotify apps unaware.
 
-An `auth_state` reporting `logged_in: false` after a previously seen login raises
-`AUTH_REQUIRED` (→ provider unloads with a login error routing the user through setup);
-a fresh daemon reporting `logged_in: false` while awaiting pairing is normal.
+An `auth_state` reporting `logged_in: false` is always a `SESSION_INACTIVE`, never an
+error: the daemon keeps advertising itself for Connect while logged out, so awaiting a
+first pairing, the user signing out and another account taking the device over all leave
+it usable. MA never signs the daemon in — any Spotify account may claim it from its app.
 
 ## Audio behavior settings
 

--- a/music_assistant/providers/spotify_connect/soloist/backend.py
+++ b/music_assistant/providers/spotify_connect/soloist/backend.py
@@ -925,14 +925,12 @@ class SoloistBackend(SpotifyConnectBackend):
         """Map a raw soloist event onto the normalized BackendEvent model."""
         data = event.data
         if isinstance(data, SoloistAuthState):
-            # a logged-out daemon keeps advertising itself for Connect, so this is
-            # just a session that ended: awaiting a first pairing, the user signing
-            # out, or another account taking the device over
-            if not data.logged_in:
-                return self._make_event(BackendEventType.SESSION_INACTIVE)
+            # a logged-out daemon keeps advertising itself for Connect, so being
+            # signed out is just a session that ended: awaiting a first pairing,
+            # the user signing out, or another account taking the device over
             return self._make_event(
                 BackendEventType.SESSION_ACTIVE
-                if data.is_active
+                if data.logged_in and data.is_active
                 else BackendEventType.SESSION_INACTIVE
             )
         if isinstance(data, SoloistDeviceChanged):

--- a/music_assistant/providers/spotify_connect/soloist/backend.py
+++ b/music_assistant/providers/spotify_connect/soloist/backend.py
@@ -212,9 +212,6 @@ class SoloistBackend(SpotifyConnectBackend):
         self._spotify_volume: int | None = None
         # guards the player_only 100%-pin so overlapping resets are not issued
         self._pin_in_flight: bool = False
-        # whether an auth_state ever reported a completed login; a fresh daemon
-        # reports logged_in=False while advertising for pairing, which is normal
-        self._was_logged_in: bool = False
         self._last_context_uri: str | None = None
         self._last_track_uri: str | None = None
         # the capture sink delivers fixed s32le/44.1kHz/2ch PCM — that is what
@@ -928,15 +925,11 @@ class SoloistBackend(SpotifyConnectBackend):
         """Map a raw soloist event onto the normalized BackendEvent model."""
         data = event.data
         if isinstance(data, SoloistAuthState):
+            # a logged-out daemon keeps advertising itself for Connect, so this is
+            # just a session that ended: awaiting a first pairing, the user signing
+            # out, or another account taking the device over
             if not data.logged_in:
-                if self._was_logged_in:
-                    # an established login was lost mid-session: real auth loss
-                    self._was_logged_in = False
-                    return self._make_event(BackendEventType.AUTH_REQUIRED)
-                # a fresh daemon reports logged_in=False while advertising for
-                # pairing; that is the normal pre-pairing state, not an auth loss
                 return self._make_event(BackendEventType.SESSION_INACTIVE)
-            self._was_logged_in = True
             return self._make_event(
                 BackendEventType.SESSION_ACTIVE
                 if data.is_active

--- a/music_assistant/providers/spotify_connect/strings.json
+++ b/music_assistant/providers/spotify_connect/strings.json
@@ -81,7 +81,6 @@
     "soloist_consent_required": "Spotify Soloist can only be used after you allow the download. Select Spotify Soloist again to review that step, or choose go-librespot (community) instead.",
     "soloist_api_key_invalid": "This does not look like a complete API key. Copy the entire key from the Spotify page and paste it again.",
     "soloist_unsupported_platform": "Spotify Soloist is not available for this system. Choose go-librespot (community) instead.",
-    "soloist_auth_required": "The Spotify sign-in for this Spotify Connect device was lost. Run the setup again to reconnect it.",
     "soloist_download_failed": "The Spotify Soloist app could not be downloaded from Spotify. Check the server's internet connection and try again.",
     "soloist_invalid_archive": "The Spotify Soloist app downloaded from Spotify could not be used. Try again later.",
     "soloist_build_expired": "Spotify's current Soloist app version has expired and no newer version is available yet. Try again later."

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -2377,7 +2377,6 @@
   "provider.spotify_connect.config_entries.volume_mode.options.sync_spotify": "Sync Spotify app volume",
   "provider.spotify_connect.errors.not_active_device": "'{0}' is not the active Spotify playback device. Open the Spotify app, select it as the playback device, and try again.",
   "provider.spotify_connect.errors.soloist_api_key_invalid": "This does not look like a complete API key. Copy the entire key from the Spotify page and paste it again.",
-  "provider.spotify_connect.errors.soloist_auth_required": "The Spotify sign-in for this Spotify Connect device was lost. Run the setup again to reconnect it.",
   "provider.spotify_connect.errors.soloist_build_expired": "Spotify's current Soloist app version has expired and no newer version is available yet. Try again later.",
   "provider.spotify_connect.errors.soloist_consent_required": "Spotify Soloist can only be used after you allow the download. Select Spotify Soloist again to review that step, or choose go-librespot (community) instead.",
   "provider.spotify_connect.errors.soloist_download_failed": "The Spotify Soloist app could not be downloaded from Spotify. Check the server's internet connection and try again.",

--- a/tests/providers/spotify_connect/test_backend_contract.py
+++ b/tests/providers/spotify_connect/test_backend_contract.py
@@ -428,6 +428,8 @@ async def test_session_inactive_stops_active_player() -> None:
     assert provider._in_use_by_player is None
     assert provider._active_session_id is None
     mass.players.cmd_stop.assert_called_once_with("player1")
+    # signing out is not a provider failure: it must never schedule an unload
+    mass.call_later.assert_not_called()
 
 
 async def test_stream_teardown_while_playing_releases_spotify() -> None:

--- a/tests/providers/spotify_connect/test_backend_contract.py
+++ b/tests/providers/spotify_connect/test_backend_contract.py
@@ -22,7 +22,7 @@ from music_assistant_models.enums import (
     SourceControl,
     StreamType,
 )
-from music_assistant_models.errors import AudioError, LoginFailed
+from music_assistant_models.errors import AudioError
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamMetadata
 
@@ -515,21 +515,6 @@ async def test_fatal_error_unloads_provider_with_error() -> None:
     mass.call_later.assert_called_once_with(
         1, mass.unload_provider_with_error, _INSTANCE_ID, "daemon kaput"
     )
-
-
-async def test_auth_required_resets_session_and_unloads_with_auth_error() -> None:
-    """AUTH_REQUIRED resets session state and unloads the provider with an auth error."""
-    backend = FakeBackend()
-    provider, mass = _make_provider(backend, playing=True, session_active=True)
-
-    await provider._handle_backend_event(BackendEvent(BackendEventType.AUTH_REQUIRED))
-
-    assert provider._playing is False
-    assert provider._spotify_session_active is False
-    mass.call_later.assert_called_once()
-    error = mass.call_later.call_args.args[3]
-    assert isinstance(error, LoginFailed)
-    assert error.translation_key == "soloist_auth_required"
 
 
 async def test_source_control_commands_dispatch_to_backend() -> None:

--- a/tests/providers/spotify_connect/test_soloist_backend.py
+++ b/tests/providers/spotify_connect/test_soloist_backend.py
@@ -442,7 +442,7 @@ async def test_five_daemon_failures_report_fatal_error(
         pytest.param(
             SoloistAuthState(logged_in=False, is_active=False),
             BackendEventType.SESSION_INACTIVE,
-            id="auth_state-initial-logged_out",
+            id="auth_state-logged_out",
         ),
         pytest.param(
             SoloistAuthState(logged_in=True, is_active=True),

--- a/tests/providers/spotify_connect/test_soloist_backend.py
+++ b/tests/providers/spotify_connect/test_soloist_backend.py
@@ -508,25 +508,22 @@ async def test_event_adaptation(data: Any, expected_type: BackendEventType) -> N
     assert [event.type for event in events] == [expected_type]
 
 
-async def test_auth_required_only_after_login_loss() -> None:
-    """AUTH_REQUIRED is only emitted when an established login is lost, not before pairing."""
+async def test_account_takeover_is_a_session_change_not_an_auth_loss() -> None:
+    """Another account claiming the device reports sessions ending and starting, no error."""
     backend, events = _make_backend()
 
-    # a fresh daemon reports logged_in=False while advertising for pairing
-    await backend._handle_event(
-        _event("auth_state", SoloistAuthState(logged_in=False, is_active=False))
-    )
-    await backend._handle_event(
-        _event("auth_state", SoloistAuthState(logged_in=True, is_active=True))
-    )
-    await backend._handle_event(
-        _event("auth_state", SoloistAuthState(logged_in=False, is_active=False))
-    )
+    # a fresh daemon advertising for pairing, then one account, then a takeover
+    # by another: the daemon signs the first one out and the second one in
+    for logged_in, is_active in ((False, False), (True, True), (False, False), (True, True)):
+        await backend._handle_event(
+            _event("auth_state", SoloistAuthState(logged_in=logged_in, is_active=is_active))
+        )
 
     assert [event.type for event in events] == [
         BackendEventType.SESSION_INACTIVE,
         BackendEventType.SESSION_ACTIVE,
-        BackendEventType.AUTH_REQUIRED,
+        BackendEventType.SESSION_INACTIVE,
+        BackendEventType.SESSION_ACTIVE,
     ]
 
 


### PR DESCRIPTION
# What does this implement/fix?

Selecting Music Assistant in the Spotify app from a different account made the Spotify Connect provider disappear. The daemon signs the previous account out and the new one in a fraction of a second later, but Music Assistant treated that momentary sign-out as a lost login and unloaded the provider with a "run the setup again to reconnect it" error.

A Spotify Connect device is not tied to an account — any Spotify app can claim it — and the setup never signs anyone in, so that error could not be acted on anyway. A sign-out is now simply the end of a session: the daemon keeps advertising itself and the next account can connect right away.

- A signed-out Spotify Connect daemon now reports an inactive session instead of an authentication error.
- Removed the authentication-error path and its message, which no longer had a way to occur.
- Playback still stops for the account that signed out.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

