### PR TITLE
Selecting a source no longer takes five seconds to start playing

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -4411,8 +4411,15 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         prev_source = player.state.active_source
         if prev_source and source != prev_source:
             with suppress(PlayerCommandFailed, RuntimeError):
-                # just try to stop (regardless of state)
-                async with self.wait_for_player_update(player_id, timeout=5):
+                # just try to stop (regardless of state) and let it settle, so the
+                # new source does not race the teardown. A player that already
+                # reports idle has nothing to tear down and does not wait at all.
+                async with self.wait_for_player_update(
+                    player_id,
+                    attribute_name="playback_state",
+                    attribute_value=PlaybackState.IDLE,
+                    timeout=5,
+                ):
                     await self._handle_cmd_stop(player_id)
         # an audio source uri selects the live source itself, which plays on the
         # player while its queue keeps its own items and goes inactive

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -109,6 +109,39 @@ async def test_selecting_a_source_on_an_idle_player_is_not_held_up_by_a_stop() -
     controller._handle_play_media.assert_awaited_once()
 
 
+async def test_selecting_a_source_waits_for_a_playing_player_to_stop() -> None:
+    """A player that was playing is settled before the new source is started on it."""
+    controller, _provider, player = _controller(_source())
+    player.state.active_source = "some_other_source"
+    player.state.playback_state = PlaybackState.PLAYING
+    state_at_start: list[PlaybackState] = []
+    settle_task: asyncio.Task[None] | None = None
+
+    async def _stop(_player_id: str) -> None:
+        # a real device reports back a moment after the stop command returns
+        async def _settle() -> None:
+            await asyncio.sleep(0.1)
+            player.state.playback_state = PlaybackState.IDLE
+            controller._dispatch_state_update_subscribers(
+                player, {"playback_state": (PlaybackState.PLAYING, PlaybackState.IDLE)}
+            )
+
+        nonlocal settle_task
+        settle_task = asyncio.create_task(_settle())
+
+    async def _play_media(*_args: Any, **_kwargs: Any) -> None:
+        state_at_start.append(player.state.playback_state)
+
+    controller._handle_cmd_stop = AsyncMock(side_effect=_stop)
+    controller._handle_play_media = AsyncMock(side_effect=_play_media)
+
+    async with asyncio.timeout(2):
+        await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+
+    controller._handle_cmd_stop.assert_awaited_once_with(PLAYER_ID)
+    assert state_at_start == [PlaybackState.IDLE]
+
+
 async def test_selecting_a_source_does_not_touch_the_queue() -> None:
     """The queue is not cleared, replaced or loaded — it just stops being the active source."""
     controller, _provider, _player = _controller(_source())

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -94,6 +94,21 @@ async def test_selecting_a_source_starts_it_and_names_it_on_the_player() -> None
     assert media.queue_item_id is None
 
 
+async def test_selecting_a_source_on_an_idle_player_is_not_held_up_by_a_stop() -> None:
+    """An idle player has no teardown to settle, so the selection starts straight away."""
+    controller, _provider, player = _controller(_source())
+    player.state.active_source = "some_other_source"
+    player.state.playback_state = PlaybackState.IDLE
+
+    # waiting on a state change that a no-op stop never reports would burn the
+    # full 5s timeout; this bound sits well below that and well above a prompt return
+    async with asyncio.timeout(2):
+        await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+
+    controller._handle_cmd_stop.assert_awaited_once_with(PLAYER_ID)
+    controller._handle_play_media.assert_awaited_once()
+
+
 async def test_selecting_a_source_does_not_touch_the_queue() -> None:
     """The queue is not cleared, replaced or loaded — it just stops being the active source."""
     controller, _provider, _player = _controller(_source())


### PR DESCRIPTION
# What does this implement/fix?

Picking a source on a player that was sitting idle took five seconds before anything started playing. Switching source stops whatever was playing first and then waits for the player to report the change — but an idle player has nothing to stop, so no report ever arrived and the wait ran out its full timeout every single time.

The wait now watches for the player to actually reach a stopped state, which a player that already reports idle satisfies straight away.

- Selecting a source on an idle player starts playing right away.
- A player that was playing is still stopped, and still settled, before the new source starts.

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

