### PR TITLE
Add an icon for the `sendspin_source` provider

### DIFF
--- a/music_assistant/providers/sendspin_source/icon.svg
+++ b/music_assistant/providers/sendspin_source/icon.svg
@@ -1,0 +1,1 @@
+<svg fill="black" xmlns="http://www.w3.org/2000/svg" id="mdi-audio-input-stereo-minijack" viewBox="0 0 24 24"><path d="M11 4V3C11 2.45 11.45 2 12 2S13 2.45 13 3V4H11M13 9V5H11V9H9V15C9 16.3 9.84 17.4 11 17.82V22H13V17.82C14.16 17.4 15 16.3 15 15V9H13Z" /></svg>

--- a/music_assistant/providers/sendspin_source/icon_dark.svg
+++ b/music_assistant/providers/sendspin_source/icon_dark.svg
@@ -1,0 +1,1 @@
+<svg fill="white" xmlns="http://www.w3.org/2000/svg" id="mdi-audio-input-stereo-minijack" viewBox="0 0 24 24"><path d="M11 4V3C11 2.45 11.45 2 12 2S13 2.45 13 3V4H11M13 9V5H11V9H9V15C9 16.3 9.84 17.4 11 17.82V22H13V17.82C14.16 17.4 15 16.3 15 15V9H13Z" /></svg>

--- a/music_assistant/providers/sendspin_source/manifest.json
+++ b/music_assistant/providers/sendspin_source/manifest.json
@@ -9,5 +9,5 @@
   "depends_on": "sendspin",
   "requirements": ["soxr==1.1.0"],
   "builtin": true,
-  "icon": "audio-input-rca"
+  "icon": "audio-input-stereo-minijack"
 }


### PR DESCRIPTION
# What does this implement/fix?

The `sendspin_source` provider shipped no icon image, only an `icon` name in its manifest, so clients that render provider icons from the image files had nothing to show for it.

This adds `icon.svg` and `icon_dark.svg` using MDI's `audio-input-stereo-minijack`, matching the light/dark pair that every other glyph-based provider ships. The manifest `icon` key moves from `audio-input-rca` to the same minijack so the name and the images agree. A 3.5mm jack rather than the Sendspin logo, to keep the source plugin visually distinct from the Sendspin player provider.

<img width="933" height="93" alt="image" src="https://github.com/user-attachments/assets/fd8d5ad8-d632-4abb-95b4-1e75420ecd86" />

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
