### PR TITLE
Cancel in-flight finalizes before freeing analysis models

### DIFF
--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -116,8 +116,7 @@ class AudioAnalysisProvider(Provider):
         # Serializes (re)loading of heavy models so concurrent session starts load them once.
         self._models_lock = asyncio.Lock()
         self._models_loaded = False
-        # In-flight finalize() calls, so unload() can cancel them before freeing the models
-        # they are still running inference against.
+        # Tracked so unload() can cancel them before freeing the models they infer against.
         self._finalize_tasks: set[asyncio.Task[None]] = set()
 
     async def start_analysis(
@@ -205,8 +204,7 @@ class AudioAnalysisProvider(Provider):
     async def finalize(self, session_id: str) -> None:
         """Finalize analysis, persist the result, fire post_analysis, then clean up."""
         if self.unloading:
-            # unload() has already snapshotted what to cancel, so a finalize starting now
-            # would run its inference against models that are about to be freed.
+            # Too late to be cancelled by unload(); the models are about to be freed.
             self._sessions.pop(session_id, None)
             return
         task = asyncio.current_task()
@@ -286,9 +284,8 @@ class AudioAnalysisProvider(Provider):
         """Handle unload, cancelling in-flight analysis work and freeing models."""
         for session_id in list(self._sessions):
             await self.cancel(session_id)
-        # Cancel rather than wait out the whole-track inference a finalize is still running:
-        # it can take minutes, and a cancelled finalize records no failure, so the track is
-        # simply analyzed again on its next play.
+        # Cancelled, not awaited: inference runs for minutes and records no failure, so the
+        # track is simply analyzed again on its next play.
         current_task = asyncio.current_task()
         # Reaching unload() from inside a finalize must not cancel that finalize itself.
         finalize_tasks = [task for task in self._finalize_tasks if task is not current_task]

--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -204,6 +204,11 @@ class AudioAnalysisProvider(Provider):
 
     async def finalize(self, session_id: str) -> None:
         """Finalize analysis, persist the result, fire post_analysis, then clean up."""
+        if self.unloading:
+            # unload() has already snapshotted what to cancel, so a finalize starting now
+            # would run its inference against models that are about to be freed.
+            self._sessions.pop(session_id, None)
+            return
         task = asyncio.current_task()
         if task is not None:
             self._finalize_tasks.add(task)

--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -116,6 +116,9 @@ class AudioAnalysisProvider(Provider):
         # Serializes (re)loading of heavy models so concurrent session starts load them once.
         self._models_lock = asyncio.Lock()
         self._models_loaded = False
+        # In-flight finalize() calls, so unload() can cancel them before freeing the models
+        # they are still running inference against.
+        self._finalize_tasks: set[asyncio.Task[None]] = set()
 
     async def start_analysis(
         self,
@@ -201,48 +204,57 @@ class AudioAnalysisProvider(Provider):
 
     async def finalize(self, session_id: str) -> None:
         """Finalize analysis, persist the result, fire post_analysis, then clean up."""
-        analysis: AudioAnalysisData | None = None
-        session = self._sessions.get(session_id)
+        task = asyncio.current_task()
+        if task is not None:
+            self._finalize_tasks.add(task)
         try:
-            analysis = await self._finalize(session_id)
-        except AudioAnalysisError as err:
-            if session is not None:
-                await self._record_failure(session, err.reason, err.retry_at)
-        except asyncio.CancelledError:
-            # Cancellation is not an analysis failure: let it propagate without recording.
-            raise
-        except Exception as err:
-            # _finalize is provider-implemented (torch/ffmpeg inference); its failure
-            # surface is open-ended, so the catch stays broad — logged and recorded.
-            self.logger.error("_finalize raised for session %s: %s", session_id, err, exc_info=err)
-            if session is not None:
-                await self._record_failure(session, str(err), None)
-        if analysis is not None and session is not None:
+            analysis: AudioAnalysisData | None = None
+            session = self._sessions.get(session_id)
             try:
-                await self.mass.streams.audio_analysis.set_audio_analysis(
-                    item_id=session.streamdetails.item_id,
-                    provider_instance_id_or_domain=session.streamdetails.provider,
-                    aa_provider_domain=self.domain,
-                    analysis=analysis,
-                    analysis_version=self.analysis_version,
-                    media_type=session.streamdetails.media_type,
-                )
+                analysis = await self._finalize(session_id)
+            except AudioAnalysisError as err:
+                if session is not None:
+                    await self._record_failure(session, err.reason, err.retry_at)
+            except asyncio.CancelledError:
+                # Cancellation is not an analysis failure: let it propagate without recording.
+                raise
             except Exception as err:
-                # Persisting (DB write + provider lookup) must never break session
-                # cleanup below, so the catch stays broad — logged and skipped.
-                self.logger.warning(
-                    "set_audio_analysis raised for %s: %s", self.domain, err, exc_info=err
+                # _finalize is provider-implemented (torch/ffmpeg inference); its failure
+                # surface is open-ended, so the catch stays broad — logged and recorded.
+                self.logger.error(
+                    "_finalize raised for session %s: %s", session_id, err, exc_info=err
                 )
-            else:
+                if session is not None:
+                    await self._record_failure(session, str(err), None)
+            if analysis is not None and session is not None:
                 try:
-                    await self.post_analysis(session.streamdetails, analysis)
-                except Exception as err:
-                    # post_analysis is a provider-implemented hook with an open-ended
-                    # failure surface; a failing side effect must not break cleanup.
-                    self.logger.warning(
-                        "post_analysis raised for %s: %s", self.domain, err, exc_info=err
+                    await self.mass.streams.audio_analysis.set_audio_analysis(
+                        item_id=session.streamdetails.item_id,
+                        provider_instance_id_or_domain=session.streamdetails.provider,
+                        aa_provider_domain=self.domain,
+                        analysis=analysis,
+                        analysis_version=self.analysis_version,
+                        media_type=session.streamdetails.media_type,
                     )
-        self._sessions.pop(session_id, None)
+                except Exception as err:
+                    # Persisting (DB write + provider lookup) must never break session
+                    # cleanup below, so the catch stays broad — logged and skipped.
+                    self.logger.warning(
+                        "set_audio_analysis raised for %s: %s", self.domain, err, exc_info=err
+                    )
+                else:
+                    try:
+                        await self.post_analysis(session.streamdetails, analysis)
+                    except Exception as err:
+                        # post_analysis is a provider-implemented hook with an open-ended
+                        # failure surface; a failing side effect must not break cleanup.
+                        self.logger.warning(
+                            "post_analysis raised for %s: %s", self.domain, err, exc_info=err
+                        )
+            self._sessions.pop(session_id, None)
+        finally:
+            if task is not None:
+                self._finalize_tasks.discard(task)
 
     async def post_analysis(
         self,
@@ -266,9 +278,18 @@ class AudioAnalysisProvider(Provider):
         self._sessions.pop(session_id, None)
 
     async def unload(self, is_removed: bool = False) -> None:
-        """Handle unload, cancelling any active analysis sessions and freeing models."""
+        """Handle unload, cancelling in-flight analysis work and freeing models."""
         for session_id in list(self._sessions):
             await self.cancel(session_id)
+        # Cancel rather than wait out the whole-track inference a finalize is still running:
+        # it can take minutes, and a cancelled finalize records no failure, so the track is
+        # simply analyzed again on its next play.
+        current_task = asyncio.current_task()
+        # Reaching unload() from inside a finalize must not cancel that finalize itself.
+        finalize_tasks = [task for task in self._finalize_tasks if task is not current_task]
+        for task in finalize_tasks:
+            task.cancel()
+        await asyncio.gather(*finalize_tasks, return_exceptions=True)
         async with self._models_lock:
             self._free_models()
             self._models_loaded = False

--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -134,6 +134,10 @@ class AudioAnalysisProvider(Provider):
         :param streamdetails: The stream details for the item being analyzed.
         :param audio_format: PCM format of the audio stream.
         """
+        if self.unloading:
+            # The controller snapshots providers up front and awaits between them, so a
+            # session can still arrive for a provider that is already on its way out.
+            return False
         if (
             self.max_analysis_duration is not None
             and streamdetails.duration
@@ -302,9 +306,14 @@ class AudioAnalysisProvider(Provider):
         Load this provider's heavy models if they are not resident, returning success.
 
         Safe to call from concurrent sessions: the models are loaded once. Returns False
-        when loading fails, so the caller can decline the session.
+        when loading fails, or when the provider is unloading, so the caller can decline
+        the session.
         """
         async with self._models_lock:
+            # Checked under the lock unload() frees within: the lock alone only serializes
+            # the two, so a loader that wins it afterwards would strand the models.
+            if self.unloading:
+                return False
             if self._models_loaded:
                 return True
             try:

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -69,9 +69,9 @@ BEAT_WINDOW_OVERLAP_MODE = "keep_first"
 # While a player streams, wait this many times a window's own compute time before starting the
 # next one, so beat inference does not occupy a core continuously.
 BEAT_WINDOW_PACE_RATIO = 1.0
-# A model failure is often transient: an idle unload frees the models while an analysis that
-# outlived its own session is still running, or a one-off torch/hardware error. Record those
-# with this retry horizon instead of a permanent row that blocks the track forever.
+# A model failure is often transient: a provider reload or shutdown frees the models while an
+# analysis is still running, or a one-off torch/hardware error. Record those with this retry
+# horizon instead of a permanent row that blocks the track forever.
 MODEL_FAILURE_RETRY_DELAY = timedelta(hours=24)
 
 
@@ -554,7 +554,8 @@ class SmartFadesProvider(AudioAnalysisProvider):
         key_features: torch.Tensor | None,
     ) -> tuple[np.ndarray, np.ndarray, int, str | None, str | None]:
         """Run beat inference followed by musical key inference."""
-        # Resolved before the beat stage: an idle unload may clear the models while it runs.
+        # Resolved before the beat stage: a provider reload or shutdown can free the models
+        # while it runs.
         models = self._require_models()
         beats, downbeats, beats_per_bar = await self._infer_beat_timings(beat_features)
         if len(beats) < 2:
@@ -649,8 +650,8 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
         :param feats: Log-mel features for the whole track, shaped (frames, mel bins).
         """
-        # Resolved once and passed down: an idle unload may clear the models while the
-        # windows below are still being dispatched.
+        # Resolved once and passed down: a provider reload or shutdown can free the models
+        # while the windows below are still being dispatched.
         models = self._require_models()
 
         spect = torch.from_numpy(feats).to(self._device)

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -554,8 +554,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
         key_features: torch.Tensor | None,
     ) -> tuple[np.ndarray, np.ndarray, int, str | None, str | None]:
         """Run beat inference followed by musical key inference."""
-        # Resolved before the beat stage: a provider reload or shutdown can free the models
-        # while it runs.
+        # Resolved before the beat stage: a reload or shutdown can free the models mid-run.
         models = self._require_models()
         beats, downbeats, beats_per_bar = await self._infer_beat_timings(beat_features)
         if len(beats) < 2:
@@ -650,8 +649,8 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
         :param feats: Log-mel features for the whole track, shaped (frames, mel bins).
         """
-        # Resolved once and passed down: a provider reload or shutdown can free the models
-        # while the windows below are still being dispatched.
+        # Resolved once and passed down: a reload or shutdown can free the models while the
+        # windows below are still being dispatched.
         models = self._require_models()
 
         spect = torch.from_numpy(feats).to(self._device)

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -69,9 +69,8 @@ BEAT_WINDOW_OVERLAP_MODE = "keep_first"
 # While a player streams, wait this many times a window's own compute time before starting the
 # next one, so beat inference does not occupy a core continuously.
 BEAT_WINDOW_PACE_RATIO = 1.0
-# A model failure is often transient: a provider reload or shutdown frees the models while an
-# analysis is still running, or a one-off torch/hardware error. Record those with this retry
-# horizon instead of a permanent row that blocks the track forever.
+# Model failures such as one-off torch/hardware errors are often transient. Record them with
+# this retry horizon instead of a permanent row that blocks the track forever.
 MODEL_FAILURE_RETRY_DELAY = timedelta(hours=24)
 
 

--- a/tests/controllers/streams/test_audio_analysis_controller.py
+++ b/tests/controllers/streams/test_audio_analysis_controller.py
@@ -618,6 +618,7 @@ async def test_finalize_cleans_up_provider_sessions() -> None:
     provider = MagicMock(spec=AudioAnalysisProvider)
     provider.logger = MagicMock()
     provider._sessions = {"test_session": MagicMock(spec=AnalysisSessionData)}
+    provider._finalize_tasks = set()
     provider._finalize = AsyncMock(return_value=None)
 
     await AudioAnalysisProvider.finalize(provider, "test_session")
@@ -670,6 +671,7 @@ async def test_finalize_swallows_finalize_exception_and_cleans_up() -> None:
     provider = MagicMock(spec=AudioAnalysisProvider)
     provider.logger = MagicMock()
     provider._sessions = {"test_session": MagicMock(spec=AnalysisSessionData)}
+    provider._finalize_tasks = set()
     provider._finalize = AsyncMock(side_effect=RuntimeError("analysis failed"))
 
     # MUST NOT raise — exception is swallowed and logged

--- a/tests/controllers/streams/test_audio_analysis_controller.py
+++ b/tests/controllers/streams/test_audio_analysis_controller.py
@@ -619,6 +619,7 @@ async def test_finalize_cleans_up_provider_sessions() -> None:
     provider.logger = MagicMock()
     provider._sessions = {"test_session": MagicMock(spec=AnalysisSessionData)}
     provider._finalize_tasks = set()
+    provider.unloading = False
     provider._finalize = AsyncMock(return_value=None)
 
     await AudioAnalysisProvider.finalize(provider, "test_session")
@@ -672,6 +673,7 @@ async def test_finalize_swallows_finalize_exception_and_cleans_up() -> None:
     provider.logger = MagicMock()
     provider._sessions = {"test_session": MagicMock(spec=AnalysisSessionData)}
     provider._finalize_tasks = set()
+    provider.unloading = False
     provider._finalize = AsyncMock(side_effect=RuntimeError("analysis failed"))
 
     # MUST NOT raise — exception is swallowed and logged

--- a/tests/controllers/streams/test_audio_analysis_controller.py
+++ b/tests/controllers/streams/test_audio_analysis_controller.py
@@ -639,6 +639,7 @@ async def test_provider_start_analysis_uses_media_type_for_version_gating() -> N
     provider.domain = "test_domain"
     provider.analysis_version = 1
     provider.max_analysis_duration = None
+    provider.unloading = False
 
     streamdetails = MagicMock()
     streamdetails.item_id = "shared_id"

--- a/tests/models/test_audio_analysis_provider.py
+++ b/tests/models/test_audio_analysis_provider.py
@@ -696,3 +696,61 @@ async def test_unload_from_within_finalize_does_not_cancel_itself() -> None:
 
     assert provider._models_loaded is False
     assert not provider._finalize_tasks
+
+
+@pytest.mark.asyncio
+async def test_finalize_is_skipped_while_unloading() -> None:
+    """A finalize issued while unloading runs no inference, registers nothing, clears its session."""
+    provider = _make_provider()
+    provider._finalize = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    provider._sessions["s-gate"] = MagicMock()
+    provider.unloading = True
+
+    await provider.finalize("s-gate")
+
+    provider._finalize.assert_not_awaited()
+    assert not provider._finalize_tasks
+    assert "s-gate" not in provider._sessions
+
+
+@pytest.mark.asyncio
+async def test_finalize_started_during_unload_does_not_run_inference() -> None:
+    """A finalize registered while unload() unwinds must not infer against models being freed."""
+    provider = _make_provider()
+    provider.has_unloadable_models = True
+    finalized: list[str] = []
+    late_task: asyncio.Task[None] | None = None
+    started = asyncio.Event()
+
+    async def _finalize(session_id: str) -> AudioAnalysisData | None:
+        nonlocal late_task
+        finalized.append(session_id)
+        if session_id != "s-first":
+            return None
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            # mirrors the controller resolving the provider and finalizing another session
+            # while unload() is suspended awaiting this cancellation
+            late_task = asyncio.create_task(provider.finalize("s-late"))
+            raise
+        return None
+
+    provider._load_models = AsyncMock()  # type: ignore[method-assign]
+    provider._free_models = MagicMock()  # type: ignore[method-assign]
+    provider._finalize = _finalize  # type: ignore[method-assign]
+
+    await provider.ensure_models_loaded()
+    first = asyncio.create_task(provider.finalize("s-first"))
+    await started.wait()
+
+    # mass.unload_provider sets this before it awaits provider.unload()
+    provider.unloading = True
+    await asyncio.wait_for(provider.unload(), timeout=5)
+
+    assert late_task is not None
+    await asyncio.wait_for(late_task, timeout=5)
+    assert finalized == ["s-first"]
+    assert first.cancelled()
+    assert not provider._finalize_tasks

--- a/tests/models/test_audio_analysis_provider.py
+++ b/tests/models/test_audio_analysis_provider.py
@@ -604,3 +604,95 @@ async def test_start_analysis_rejects_when_model_load_fails() -> None:
     assert await provider.start_analysis("s", streamdetails, MagicMock()) is False
     provider._start_analysis.assert_not_awaited()
     assert provider._models_loaded is False
+
+
+@pytest.mark.asyncio
+async def test_unload_cancels_in_flight_finalize_before_freeing_models() -> None:
+    """unload() cancels a running finalize and frees the models only once it has unwound."""
+    provider = _make_provider()
+    provider.has_unloadable_models = True
+    started = asyncio.Event()
+    running = False
+    cancelled = False
+    freed_while_running = False
+
+    async def _finalize(session_id: str) -> AudioAnalysisData | None:  # noqa: ARG001
+        nonlocal running, cancelled
+        running = True
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
+        finally:
+            running = False
+        return None
+
+    def _free() -> None:
+        nonlocal freed_while_running
+        if running:
+            freed_while_running = True
+
+    provider._load_models = AsyncMock()  # type: ignore[method-assign]
+    provider._free_models = _free  # type: ignore[method-assign]
+    provider._finalize = _finalize  # type: ignore[method-assign]
+
+    await provider.ensure_models_loaded()
+    task = asyncio.create_task(provider.finalize("s-inflight"))
+    await started.wait()
+    assert provider._finalize_tasks == {task}
+
+    await asyncio.wait_for(provider.unload(), timeout=5)
+
+    assert cancelled is True
+    assert freed_while_running is False
+    assert task.cancelled()
+    assert not provider._finalize_tasks
+    assert provider._models_loaded is False
+    recorder = cast("AsyncMock", provider.mass.streams.audio_analysis.record_analysis_failure)
+    recorder.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unload_frees_models_when_no_finalize_in_flight() -> None:
+    """unload() with nothing in flight frees the models as before."""
+    provider = _make_provider()
+    provider.has_unloadable_models = True
+    free_calls = 0
+
+    def _free() -> None:
+        nonlocal free_calls
+        free_calls += 1
+
+    provider._load_models = AsyncMock()  # type: ignore[method-assign]
+    provider._free_models = _free  # type: ignore[method-assign]
+
+    await provider.ensure_models_loaded()
+    assert provider._models_loaded is True
+
+    await asyncio.wait_for(provider.unload(), timeout=5)
+
+    assert free_calls == 1
+    assert provider._models_loaded is False
+
+
+@pytest.mark.asyncio
+async def test_unload_from_within_finalize_does_not_cancel_itself() -> None:
+    """A finalize that reaches unload() must not cancel the task it is running on."""
+    provider = _make_provider()
+    provider.has_unloadable_models = True
+
+    async def _finalize(session_id: str) -> AudioAnalysisData | None:  # noqa: ARG001
+        await provider.unload()
+        return None
+
+    provider._load_models = AsyncMock()  # type: ignore[method-assign]
+    provider._free_models = MagicMock()  # type: ignore[method-assign]
+    provider._finalize = _finalize  # type: ignore[method-assign]
+
+    await provider.ensure_models_loaded()
+    await asyncio.wait_for(provider.finalize("s-self"), timeout=5)
+
+    assert provider._models_loaded is False
+    assert not provider._finalize_tasks

--- a/tests/models/test_audio_analysis_provider.py
+++ b/tests/models/test_audio_analysis_provider.py
@@ -754,3 +754,60 @@ async def test_finalize_started_during_unload_does_not_run_inference() -> None:
     assert finalized == ["s-first"]
     assert first.cancelled()
     assert not provider._finalize_tasks
+
+
+@pytest.mark.asyncio
+async def test_start_analysis_declines_while_unloading() -> None:
+    """A session arriving from a stale provider snapshot must not start on a dying provider."""
+    provider = _make_provider()
+    provider._start_analysis = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    provider.unloading = True
+
+    accepted = await provider.start_analysis("s", MagicMock(), MagicMock())
+
+    assert accepted is False
+    provider._start_analysis.assert_not_awaited()
+    # The gate comes first, so nothing downstream of it runs either.
+    version_lookup = provider.mass.streams.audio_analysis.get_audio_analysis_version
+    version_lookup.assert_not_awaited()  # type: ignore[attr-defined]
+    assert "s" not in provider._sessions
+
+
+@pytest.mark.asyncio
+async def test_ensure_models_loaded_declines_while_unloading() -> None:
+    """Models must never be reloaded onto a provider that is on its way out."""
+    provider = _make_provider()
+    provider._load_models = AsyncMock()  # type: ignore[method-assign]
+    provider.unloading = True
+
+    assert await provider.ensure_models_loaded() is False
+    provider._load_models.assert_not_awaited()
+    assert provider._models_loaded is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_models_loaded_declines_when_queued_behind_unload() -> None:
+    """A loader already waiting on the models lock must decline once unload() has run."""
+    provider = _make_provider()
+    provider.has_unloadable_models = True
+    loaded = False
+
+    async def _load() -> None:
+        nonlocal loaded
+        loaded = True
+
+    provider._load_models = _load  # type: ignore[method-assign]
+    provider._free_models = MagicMock()  # type: ignore[method-assign]
+
+    # Hold the lock so the loader is queued behind the unload that follows.
+    await provider._models_lock.acquire()
+    loader = asyncio.create_task(provider.ensure_models_loaded())
+    await asyncio.sleep(0)
+    # mass.unload_provider sets this before it awaits provider.unload()
+    provider.unloading = True
+    provider._models_lock.release()
+    await provider.unload()
+
+    assert await loader is False
+    assert loaded is False
+    assert provider._models_loaded is False

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -809,7 +809,7 @@ async def test_vocal_inference_failure_is_retryable(provider: SmartFadesProvider
 async def test_vocal_inference_with_unloaded_models_is_retryable(
     provider: SmartFadesProvider,
 ) -> None:
-    """The idle-unload race (models freed mid-finalize) must not poison the track forever."""
+    """A reload or shutdown freeing the models mid-finalize must not poison the track forever."""
     provider._models = None
 
     with pytest.raises(AudioAnalysisError) as excinfo:

--- a/tests/providers/sonic_analysis/test_finalize_integration.py
+++ b/tests/providers/sonic_analysis/test_finalize_integration.py
@@ -46,6 +46,7 @@ def _make_provider() -> tuple[SonicAnalysisProvider, AsyncMock, AsyncMock]:
     p.manifest = manifest
     p._sessions = {}
     p._finalize_tasks = set()
+    p.unloading = False
     p._clap_model = None
     p._clap_prompt_order = []
     p._clap_text_embeddings = None

--- a/tests/providers/sonic_analysis/test_finalize_integration.py
+++ b/tests/providers/sonic_analysis/test_finalize_integration.py
@@ -45,6 +45,7 @@ def _make_provider() -> tuple[SonicAnalysisProvider, AsyncMock, AsyncMock]:
     p.mass = mass
     p.manifest = manifest
     p._sessions = {}
+    p._finalize_tasks = set()
     p._clap_model = None
     p._clap_prompt_order = []
     p._clap_text_embeddings = None


### PR DESCRIPTION
# What does this implement/fix?

Canceling a provider's in-flight analysis finalizes before its models are freed, so a provider reload, disable/remove or shutdown can no longer free the models out from under a running analysis.

Also corrects the Smart Fades comments that blamed this race on an idle unload.

**Related issue (if applicable):**


## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.