### PR TITLE
Hide the Sendspin legacy clients option

### DIFF
--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -405,6 +405,7 @@ class SendspinProvider(PlayerProvider):
                 key=CONF_ALLOW_LEGACY_CLIENTS,
                 type=ConfigEntryType.BOOLEAN,
                 default_value=True,
+                hidden=True,
             ),
             ConfigEntry(
                 key=CONF_MIN_PIN_LENGTH,


### PR DESCRIPTION
# What does this implement/fix?

The Sendspin provider shows an "Allow legacy clients" toggle that is enabled by default, and leaving it visible invites two problems: client authors read it as a promise that the spec as it stands today is the target to implement, and anyone who switches it off is left with a stored `false` that turns into a breaking change the moment a patch release bumps the supported Sendspin version.

The option is now hidden in the UI while the config entry itself stays declared, so the stored value, the API, and the provider reload on change all behave exactly as before. It gets unhidden again in the release that lands the protocol changes.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
