### PR TITLE
Retry Sonic Analysis when a track loses its CLAP windows

### DIFF
--- a/music_assistant/providers/sonic_analysis/__init__.py
+++ b/music_assistant/providers/sonic_analysis/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass, field
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -12,6 +13,7 @@ import soxr
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, ContentType
 
+from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.util import (
     system_meets_requirements,
     verify_system_meets_requirements,
@@ -78,6 +80,8 @@ MIN_CPU_CORES: int = 2
 # informational notice (see get_config_entries) as it may be tight under load.
 RECOMMENDED_RAM_GB: float = 6.0
 RECOMMENDED_CPU_CORES: int = 4
+
+MODEL_FAILURE_RETRY_DELAY: timedelta = timedelta(hours=24)
 
 
 @dataclass
@@ -551,21 +555,37 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
     async def _run_live_clap_if_eligible(
         self, session: SonicSessionData, analysis: AudioAnalysisData
     ) -> None:
-        """Finalize CLAP analysis for the session, writing scalar attributes and the embedding onto analysis."""
+        """
+        Finalize CLAP analysis, writing the scalar attributes and embedding onto the analysis.
+
+        :param session: The analysis session.
+        :param analysis: Analysis object the CLAP scalars and embedding are written onto.
+        :raises AudioAnalysisError: Retryable, when fewer windows completed than were planned.
+        """
         if not session.clap_target_starts:
             return
         if session.clap_inference_tasks:
             await asyncio.gather(*session.clap_inference_tasks, return_exceptions=True)
         n = session.clap_completed_count
+        planned = len(session.clap_target_starts)
         sd = session.streamdetails
-        if n == 0 or session.clap_sum_embedding is None or session.clap_sum_similarities is None:
+        if (
+            n < planned
+            or session.clap_sum_embedding is None
+            or session.clap_sum_similarities is None
+        ):
             self.logger.warning(
-                "Live CLAP for %s/%s: no windows completed (planned %d)",
+                "Live CLAP for %s/%s: only %d of %d planned windows completed — "
+                "failing the analysis so it is retried",
                 sd.provider,
                 sd.item_id,
-                len(session.clap_target_starts),
+                n,
+                planned,
             )
-            return
+            raise AudioAnalysisError(
+                f"live CLAP completed {n} of {planned} planned windows",
+                retry_at=utc() + MODEL_FAILURE_RETRY_DELAY,
+            )
 
         mean_emb = session.clap_sum_embedding / n
         norm = float(np.linalg.norm(mean_emb))
@@ -623,6 +643,8 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
         if not session.accumulated.rms_frames:
             raise AudioAnalysisError("no usable audio frames extracted")
 
+        self._flush_incomplete_clap_windows(session, af.sample_rate)
+
         t0 = time.monotonic()
         analysis = await self._run_offloaded(
             collapse_to_analysis, session.accumulated, ANALYSIS_SAMPLE_RATE
@@ -651,6 +673,25 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
             session.clap_preset,
         )
         return analysis
+
+    def _flush_incomplete_clap_windows(self, session: SonicSessionData, source_sr: int) -> None:
+        """
+        Dispatch every planned CLAP window that buffered audio but never filled to 7 seconds.
+
+        :param session: The analysis session; the buffers of flushed windows are consumed.
+        :param source_sr: Sample rate the buffered PCM was captured at.
+        """
+        # The vendored wrapper repeat-pads short input, so a partial window still embeds.
+        for i, buffered in enumerate(session.clap_target_buffers):
+            if session.clap_target_complete[i] or not buffered:
+                continue
+            window_audio = np.concatenate(buffered)
+            session.clap_target_buffers[i] = []
+            session.clap_target_complete[i] = True
+            task = self.mass.create_task(
+                self._run_single_clap_window(session, window_audio, source_sr)
+            )
+            session.clap_inference_tasks.append(task)
 
     def _single_window_inference_sync(
         self,

--- a/music_assistant/providers/sonic_analysis/__init__.py
+++ b/music_assistant/providers/sonic_analysis/__init__.py
@@ -59,6 +59,7 @@ EXTRA_DATA_CLAP_EMBEDDING: str = "clap_embedding"
 # CLAP's HTSAT audio encoder takes a fixed 7-second input at 44.1 kHz.
 CLAP_WINDOW_SECONDS: int = 7
 CLAP_SKIP_SECONDS: int = 45
+CLAP_MIN_WINDOW_SECONDS: float = 1.0
 
 CLAP_SAMPLING_FAST: str = "fast"
 CLAP_SAMPLING_BALANCED: str = "balanced"
@@ -140,7 +141,7 @@ def compute_clap_target_starts(
     :returns: Sample-position offsets at source_sr; length is the effective N
         (capped at what the track length supports without near-duplicates).
     """
-    if track_duration_s < 1.0:
+    if track_duration_s < CLAP_MIN_WINDOW_SECONDS:
         return []
     if track_duration_s < CLAP_WINDOW_SECONDS:
         return [0]
@@ -681,9 +682,13 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
         :param session: The analysis session; the buffers of flushed windows are consumed.
         :param source_sr: Sample rate the buffered PCM was captured at.
         """
-        # The vendored wrapper repeat-pads short input, so a partial window still embeds.
+        # The vendored wrapper repeat-pads short input, so anything below the floor would
+        # blow a sliver of audio up into a full window and embed noise.
+        min_samples = int(CLAP_MIN_WINDOW_SECONDS * source_sr)
         for i, buffered in enumerate(session.clap_target_buffers):
-            if session.clap_target_complete[i] or not buffered:
+            if session.clap_target_complete[i]:
+                continue
+            if sum(len(arr) for arr in buffered) < min_samples:
                 continue
             window_audio = np.concatenate(buffered)
             session.clap_target_buffers[i] = []

--- a/tests/providers/sonic_analysis/test_clap_flush.py
+++ b/tests/providers/sonic_analysis/test_clap_flush.py
@@ -69,13 +69,13 @@ def test_multiple_buffered_chunks_are_concatenated() -> None:
     p, dispatched = _make_provider()
     session = _make_session([0])
     session.clap_target_buffers[0] = [
-        np.arange(0, 100, dtype=np.float32),
-        np.arange(100, 250, dtype=np.float32),
+        np.arange(0, SR, dtype=np.float32),
+        np.arange(SR, 2 * SR, dtype=np.float32),
     ]
 
     p._flush_incomplete_clap_windows(session, SR)
 
-    np.testing.assert_array_equal(dispatched[0], np.arange(0, 250, dtype=np.float32))
+    np.testing.assert_array_equal(dispatched[0], np.arange(0, 2 * SR, dtype=np.float32))
 
 
 def test_already_complete_window_is_not_redispatched() -> None:

--- a/tests/providers/sonic_analysis/test_clap_flush.py
+++ b/tests/providers/sonic_analysis/test_clap_flush.py
@@ -1,0 +1,114 @@
+"""Unit tests for the finalize-time flush of partially filled CLAP windows."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from music_assistant.providers.sonic_analysis import (
+    CLAP_WINDOW_SECONDS,
+    SonicAnalysisProvider,
+    SonicSessionData,
+)
+
+SR = 22050
+WINDOW_SAMPLES = CLAP_WINDOW_SECONDS * SR
+
+
+def _make_provider() -> tuple[SonicAnalysisProvider, list[np.ndarray]]:
+    """
+    Stub provider whose create_task records the window each dispatch was handed.
+
+    :returns: ``(provider, dispatched_windows)``.
+    """
+    dispatched: list[np.ndarray] = []
+    p = SonicAnalysisProvider.__new__(SonicAnalysisProvider)
+    p.logger = MagicMock()
+    p.mass = MagicMock()
+    p.mass.create_task = MagicMock(side_effect=lambda _coro: MagicMock())
+
+    def _record(_session: SonicSessionData, window_audio: np.ndarray, _source_sr: int) -> MagicMock:
+        """Capture the window instead of running inference on it."""
+        dispatched.append(window_audio)
+        return MagicMock()
+
+    p._run_single_clap_window = _record  # type: ignore[method-assign,assignment]
+    return p, dispatched
+
+
+def _make_session(target_starts: list[int]) -> SonicSessionData:
+    """Build a SonicSessionData with the given target starts and matching buffer lists."""
+    return SonicSessionData(
+        streamdetails=MagicMock(),
+        audio_format=MagicMock(),
+        clap_target_starts=list(target_starts),
+        clap_target_buffers=[[] for _ in target_starts],
+        clap_target_complete=[False] * len(target_starts),
+    )
+
+
+def test_partial_window_is_flushed() -> None:
+    """A window holding under 7s of audio is dispatched and marked complete."""
+    p, dispatched = _make_provider()
+    session = _make_session([0])
+    partial = np.ones(SR * 3, dtype=np.float32)
+    session.clap_target_buffers[0] = [partial]
+
+    p._flush_incomplete_clap_windows(session, SR)
+
+    assert len(dispatched) == 1
+    assert len(dispatched[0]) == SR * 3
+    assert session.clap_target_complete == [True]
+    assert session.clap_target_buffers[0] == []
+    assert len(session.clap_inference_tasks) == 1
+
+
+def test_multiple_buffered_chunks_are_concatenated() -> None:
+    """Chunks accumulated across dispatches are joined in order for the flush."""
+    p, dispatched = _make_provider()
+    session = _make_session([0])
+    session.clap_target_buffers[0] = [
+        np.arange(0, 100, dtype=np.float32),
+        np.arange(100, 250, dtype=np.float32),
+    ]
+
+    p._flush_incomplete_clap_windows(session, SR)
+
+    np.testing.assert_array_equal(dispatched[0], np.arange(0, 250, dtype=np.float32))
+
+
+def test_already_complete_window_is_not_redispatched() -> None:
+    """Windows that already reached the 7s gate are left alone."""
+    p, dispatched = _make_provider()
+    session = _make_session([0, WINDOW_SAMPLES])
+    session.clap_target_complete = [True, False]
+    session.clap_target_buffers = [[], [np.ones(SR, dtype=np.float32)]]
+
+    p._flush_incomplete_clap_windows(session, SR)
+
+    assert len(dispatched) == 1
+    assert len(dispatched[0]) == SR
+
+
+def test_window_with_no_audio_stays_incomplete() -> None:
+    """A planned window the stream never reached is not faked as complete."""
+    p, dispatched = _make_provider()
+    session = _make_session([0, WINDOW_SAMPLES])
+    session.clap_target_buffers = [[np.ones(SR, dtype=np.float32)], []]
+
+    p._flush_incomplete_clap_windows(session, SR)
+
+    assert len(dispatched) == 1
+    assert session.clap_target_complete == [True, False]
+
+
+def test_no_targets_is_a_no_op() -> None:
+    """A session with no planned windows dispatches nothing."""
+    p, dispatched = _make_provider()
+    session = _make_session([])
+
+    p._flush_incomplete_clap_windows(session, SR)
+
+    assert dispatched == []
+    assert session.clap_inference_tasks == []

--- a/tests/providers/sonic_analysis/test_finalize_integration.py
+++ b/tests/providers/sonic_analysis/test_finalize_integration.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import struct
 import time
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
@@ -13,6 +15,7 @@ from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.models.audio_analysis import AudioAnalysisData, AudioAnalysisError
 from music_assistant.providers.sonic_analysis import SonicAnalysisProvider, SonicSessionData
+from music_assistant.providers.sonic_analysis.clap_prompts import SCALAR_PROMPT_PAIRS
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -237,3 +240,85 @@ async def test_finalize_raises_when_no_feature_blocks() -> None:
 
     with pytest.raises(AudioAnalysisError, match="no usable audio"):
         await provider._finalize(session_id)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: a partially completed CLAP plan fails retryably instead of persisting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_records_failure_when_clap_windows_incomplete() -> None:
+    """An incomplete CLAP plan must reach record_analysis_failure and suppress persistence."""
+    provider, set_aa, post_analysis = _make_provider()
+    session_id = "test-session-clap-incomplete"
+
+    session = _make_session(provider, session_id)
+    af = session.audio_format
+    # Both windows sit past the end of the 12s stream below, so neither is ever reached.
+    session.clap_target_starts = [100 * af.sample_rate, 120 * af.sample_rate]
+    session.clap_target_buffers = [[], []]
+    session.clap_target_complete = [False, False]
+
+    await provider.process_pcm_chunk(
+        session_id, _make_pcm_sine(sample_rate=af.sample_rate, duration_sec=12.0)
+    )
+
+    await provider.finalize(session_id)
+
+    set_aa.assert_not_called()
+    post_analysis.assert_not_called()
+    record_failure = cast("AsyncMock", provider.mass.streams.audio_analysis.record_analysis_failure)
+    record_failure.assert_called_once()
+    call_kwargs = record_failure.call_args.kwargs
+    assert call_kwargs["retry_at"] is not None
+    assert "0 of 2" in call_kwargs["reason"]
+    assert session_id not in provider._sessions
+
+
+# ---------------------------------------------------------------------------
+# Test 6: a sub-7s window completes through the finalize flush
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_flush_completes_short_window_and_persists() -> None:
+    """A window that never fills to 7s is flushed at finalize, so the analysis persists."""
+    provider, set_aa, _post_analysis = _make_provider()
+    provider.mass.create_task = MagicMock(side_effect=asyncio.create_task)  # type: ignore[method-assign]
+    session_id = "test-session-clap-flush"
+
+    session = _make_session(provider, session_id)
+    af = session.audio_format
+    # Starting at 8s of a 12s stream, this window tops out at 4s of audio.
+    session.clap_target_starts = [8 * af.sample_rate]
+    session.clap_target_buffers = [[]]
+    session.clap_target_complete = [False]
+
+    n_pairs = len(SCALAR_PROMPT_PAIRS)
+    flushed: list[int] = []
+
+    def _fake_inference(window_audio: np.ndarray, _source_sr: int) -> tuple[np.ndarray, np.ndarray]:
+        flushed.append(len(window_audio))
+        return (
+            np.ones(1024, dtype=np.float32),
+            np.zeros(2 * n_pairs, dtype=np.float32),
+        )
+
+    provider._single_window_inference_sync = _fake_inference  # type: ignore[method-assign,assignment]
+    provider._clap_model = MagicMock()
+    provider._clap_prompt_order = list(SCALAR_PROMPT_PAIRS.items())
+
+    await provider.process_pcm_chunk(
+        session_id, _make_pcm_sine(sample_rate=af.sample_rate, duration_sec=12.0)
+    )
+    await provider.finalize(session_id)
+
+    assert len(flushed) == 1
+    assert 0 < flushed[0] < 7 * af.sample_rate
+
+    set_aa.assert_called_once()
+    analysis_arg = set_aa.call_args.kwargs["analysis"]
+    assert analysis_arg.danceability is not None
+    assert analysis_arg.extra_data is not None
+    assert "clap_embedding" in analysis_arg.extra_data

--- a/tests/providers/sonic_analysis/test_run_live_clap.py
+++ b/tests/providers/sonic_analysis/test_run_live_clap.py
@@ -9,8 +9,10 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
-from music_assistant.models.audio_analysis import AudioAnalysisData
+from music_assistant.helpers.datetime import utc
+from music_assistant.models.audio_analysis import AudioAnalysisData, AudioAnalysisError
 from music_assistant.providers.sonic_analysis import (
+    MODEL_FAILURE_RETRY_DELAY,
     SonicAnalysisProvider,
     SonicSessionData,
 )
@@ -60,14 +62,19 @@ async def test_no_targets_short_circuits_silently() -> None:
 
 
 @pytest.mark.asyncio
-async def test_no_completions_logs_warning() -> None:
-    """Targets planned but zero windows completed → warning, no scalar updates."""
+async def test_no_completions_raises_retryable() -> None:
+    """Targets planned but zero windows completed → retryable failure, no scalar updates."""
     p, fake_logger = _make_provider()
     session = _make_session(target_starts=[0, 100, 200])
     # No tasks added, no completed_count incremented
     analysis = AudioAnalysisData()
 
-    await p._run_live_clap_if_eligible(session, analysis)
+    before = utc()
+    with pytest.raises(AudioAnalysisError) as excinfo:
+        await p._run_live_clap_if_eligible(session, analysis)
+
+    assert excinfo.value.retry_at is not None
+    assert excinfo.value.retry_at >= before + MODEL_FAILURE_RETRY_DELAY
 
     assert analysis.danceability is None
     assert analysis.valence is None
@@ -75,6 +82,27 @@ async def test_no_completions_logs_warning() -> None:
     assert analysis.instrumentalness is None
     assert analysis.acousticness is None
     assert analysis.speechiness is None
+    assert analysis.extra_data is None or "clap_embedding" not in (analysis.extra_data or {})
+    fake_logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_partial_completions_raises_retryable() -> None:
+    """Some but not all planned windows completed → retryable failure, nothing written."""
+    p, fake_logger = _make_provider()
+    session = _make_session(target_starts=[0, 100, 200])
+
+    n_pairs = len(SCALAR_PROMPT_PAIRS)
+    session.clap_completed_count = 2
+    session.clap_sum_embedding = np.ones(1024, dtype=np.float32)
+    session.clap_sum_similarities = np.zeros(2 * n_pairs, dtype=np.float32)
+
+    analysis = AudioAnalysisData()
+
+    with pytest.raises(AudioAnalysisError, match="2 of 3"):
+        await p._run_live_clap_if_eligible(session, analysis)
+
+    assert analysis.danceability is None
     assert analysis.extra_data is None or "clap_embedding" not in (analysis.extra_data or {})
     fake_logger.warning.assert_called_once()
 


### PR DESCRIPTION
# What does this implement/fix?

When a Sonic Analysis session planned CLAP windows but completed none, it still
returned a populated analysis. The base `finalize()` persisted that at the current
`analysis_version` and cleared any prior failure row, so the track was permanently
done with librosa scalars but no CLAP embedding — the thing `sonic_similarity`
needs. Both the session gate and the background-scan query skip anything already at
the current version, so nothing ever picked it up again.

#6012 and #6024 each removed a trigger for losing windows, and #6012's description
names this consequence, but the silent-loss path itself stayed: any remaining
transient failure — a one-off torch error killing an inference, a stream that ends
short — still lands a track in that permanent state.

An incomplete CLAP plan now fails retryably instead of persisting, so the existing
failure/re-queue machinery brings the track back. Partially filled windows are
flushed at finalize first, so the two windows that can never reach the 7s dispatch
gate on their own still complete rather than failing forever.

No `analysis_version` change — existing libraries are not forced into a re-analysis.
Repairing rows already persisted without CLAP data is out of scope; those sit at the
current version and are invisible to both gates, so a separate task covers them.

**Related issue (if applicable):**

- No tracker issue; follows on from #6012 and #6024

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
