### PR TITLE
Clean up snapcast mdns records when the provider unloads

### DIFF
--- a/music_assistant/providers/snapcast/provider.py
+++ b/music_assistant/providers/snapcast/provider.py
@@ -97,6 +97,7 @@ class SnapCastProvider(PlayerProvider):
     _snapcast_ma_streams_lock: asyncio.Lock
     _last_status_refresh: float
     _snapcast_stream_format: AudioFormat
+    _zc_services: dict[str, AsyncServiceInfo]
 
     @property
     def stream_audio_format(self) -> AudioFormat:
@@ -255,6 +256,7 @@ class SnapCastProvider(PlayerProvider):
         self._use_builtin_server = not self.config.get_value(CONF_USE_EXTERNAL_SERVER)
         self._stop_called = False
         self._controlscript_available = False
+        self._zc_services = {}
         if self._use_builtin_server:
             if Path(DEFAULT_SNAPSERVER_CONFIG_FILE).exists():
                 self._snapcast_server_config_file = DEFAULT_SNAPSERVER_CONFIG_FILE
@@ -353,6 +355,11 @@ class SnapCastProvider(PlayerProvider):
 
         self._snapserver.stop()
         await self._stop_builtin_server()
+
+        # unregister the snapcast mdns services
+        for info in self._zc_services.values():
+            await self.mass.discovery.aiozc.async_unregister_service(info)
+        self._zc_services.clear()
 
     async def get_diagnostics(self) -> dict[str, SerializableType]:
         """Return diagnostics info for this provider to include in diagnostics reports."""
@@ -472,12 +479,11 @@ class SnapCastProvider(PlayerProvider):
                     port=port,
                     server=f"{socket.gethostname()}.local",
                 )
-                attr_name = f"zc_service_set{name}"
-                if getattr(self, attr_name, None):
+                if name in self._zc_services:
                     await self.mass.discovery.aiozc.async_update_service(info)
                 else:
                     await self.mass.discovery.aiozc.async_register_service(info, strict=False)
-                setattr(self, attr_name, True)
+                self._zc_services[name] = info
             except NonUniqueNameException:
                 self.logger.debug(
                     "Could not register mdns record for %s as its already in use",

--- a/tests/providers/snapcast/test_provider.py
+++ b/tests/providers/snapcast/test_provider.py
@@ -54,6 +54,24 @@ async def test_log_level_config_update_realigns_snapcast_logger() -> None:
     set_log_level.assert_called_once_with()
 
 
+async def test_unload_unregisters_mdns_services() -> None:
+    """Unloading the provider unregisters the mdns records of the built-in Snapserver."""
+    provider = _provider_with_log_level(logging.INFO)
+    provider.mass = MagicMock()
+    unregister = AsyncMock()
+    provider.mass.discovery.aiozc.async_unregister_service = unregister
+    provider._snapserver = MagicMock(clients=[])
+    provider._snapcast_ma_streams = {}
+    provider._snapserver_runner = None
+    infos = {"-http": MagicMock(), "": MagicMock()}
+    provider._zc_services = dict(infos)
+
+    await provider.unload()
+
+    assert [call.args[0] for call in unregister.await_args_list] == list(infos.values())
+    assert provider._zc_services == {}
+
+
 def test_lost_connection_arms_the_reload_under_the_load_task_id() -> None:
     """A lost SnapServer connection arms the reload so a (re)load starting first cancels it."""
     provider = _provider_with_log_level(logging.INFO)


### PR DESCRIPTION
# What does this implement/fix?

The snapcast provider registers five mdns records for the built-in snapserver but never unregistered them. After the server was renamed (via the new server name setting), records under the old name lingered until a full server shutdown.

- Store the created `AsyncServiceInfo` objects instead of only tracking a "registered" flag
- Unregister the mdns records when the provider unloads (same pattern as the airplay DACP record)

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
