### PR TITLE
Tidy up playback task handling when a Connect/AirPlay daemon is replaced

### DIFF
--- a/music_assistant/providers/airplay_receiver/provider.py
+++ b/music_assistant/providers/airplay_receiver/provider.py
@@ -485,13 +485,19 @@ class AirPlayReceiverProvider(PluginProvider):
         daemon.stop_called = True
 
         # a pending stop or deferred start must not wake after the teardown and
-        # act on the replaced daemon's session; awaited so a cancellation-delayed
-        # player command cannot land after the daemon is gone
-        for pending_task in (daemon.pending_stop_task, daemon.pending_start_task):
-            if pending_task and not pending_task.done():
-                pending_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await pending_task
+        # act on the replaced daemon's session; cancel BOTH before awaiting either
+        # (awaiting first could let the other progress meanwhile), and await so a
+        # cancellation-delayed player command cannot land after the daemon is gone
+        pending_tasks = [
+            task
+            for task in (daemon.pending_stop_task, daemon.pending_start_task)
+            if task and not task.done()
+        ]
+        for pending_task in pending_tasks:
+            pending_task.cancel()
+        for pending_task in pending_tasks:
+            with suppress(asyncio.CancelledError):
+                await pending_task
         daemon.pending_stop_task = None
         daemon.pending_start_task = None
 
@@ -746,6 +752,11 @@ class AirPlayReceiverProvider(PluginProvider):
         :param metadata: Dictionary containing metadata updates.
         """
         self.logger.log(VERBOSE_LOG_LEVEL, "Received metadata update: %s", metadata)
+
+        # the metadata reader outlives the cancelled tasks for a moment during
+        # teardown; a stopped daemon must not schedule new work from late events
+        if daemon.stop_called:
+            return
 
         # Handle play state changes from sessioncontrol hooks
         if "play_state" in metadata:

--- a/music_assistant/providers/airplay_receiver/provider.py
+++ b/music_assistant/providers/airplay_receiver/provider.py
@@ -485,10 +485,13 @@ class AirPlayReceiverProvider(PluginProvider):
         daemon.stop_called = True
 
         # a pending stop or deferred start must not wake after the teardown and
-        # act on the replaced daemon's session
+        # act on the replaced daemon's session; awaited so a cancellation-delayed
+        # player command cannot land after the daemon is gone
         for pending_task in (daemon.pending_stop_task, daemon.pending_start_task):
             if pending_task and not pending_task.done():
                 pending_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await pending_task
         daemon.pending_stop_task = None
         daemon.pending_start_task = None
 
@@ -784,6 +787,10 @@ class AirPlayReceiverProvider(PluginProvider):
             daemon.first_volume_event_received = False
             # Initiate playback via the standard play_media flow on the target player
             if not daemon.in_use_by_player:
+                if daemon.pending_start_task and not daemon.pending_start_task.done():
+                    # a start is already in flight; a second one would double play_media
+                    # and leave the first task untracked for teardown cancellation
+                    return
                 # an explicitly selected player wins, else the receiver's own player
                 target_player_id = daemon.active_player_id or daemon.player_id
                 self.logger.info("Starting AirPlay playback on player %s", target_player_id)

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -956,6 +956,11 @@ class SpotifyConnectProvider(PluginProvider):
 
     async def _handle_backend_event(self, daemon: _PlayerDaemon, event: BackendEvent) -> None:
         """Dispatch a single normalized event received from a daemon's backend."""
+        if daemon.stop_called:
+            # a deliberately stopped daemon (unload, rename restart, player removal)
+            # must not schedule new work or tear down the whole provider from a
+            # late event of its dying backend
+            return
         if event.type is BackendEventType.CONNECTION_LOST:
             # The backend's Spotify session is gone (e.g. daemon exit). Reset
             # session state so a dead/restarting backend isn't treated as active
@@ -966,10 +971,7 @@ class SpotifyConnectProvider(PluginProvider):
             daemon.last_playback_options = None
             return
         if event.type is BackendEventType.FATAL_ERROR:
-            # a deliberately stopped daemon (unload, rename restart, player
-            # removal) must not tear down the whole provider
-            if not daemon.stop_called:
-                self.unload_with_error(event.error or "Spotify Connect backend failed")
+            self.unload_with_error(event.error or "Spotify Connect backend failed")
             return
         if event.type is BackendEventType.ERROR:
             # non-fatal backend error: surface it in the log only

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import re
 import time
+from contextlib import suppress
 from dataclasses import dataclass, field
 from functools import partial
 from typing import TYPE_CHECKING, Final, cast
@@ -687,8 +688,17 @@ class SpotifyConnectProvider(PluginProvider):
     async def _stop_daemon(self, daemon: _PlayerDaemon) -> None:
         """Stop a daemon's backend and cancel its pending tasks."""
         daemon.stop_called = True
+        pending_tasks = [
+            task
+            for task in (daemon.pending_play_media_task, daemon.pending_pause_stop_task)
+            if task is not None and not task.done()
+        ]
         self._cancel_pending_play_media(daemon)
         self._cancel_pending_pause_stop(daemon)
+        # await the cancelled tasks so no late player command outlives the daemon
+        for task in pending_tasks:
+            with suppress(asyncio.CancelledError):
+                await task
         await daemon.backend.stop()
 
     def _create_backend(self, daemon: _PlayerDaemon, player_name: str) -> SpotifyConnectBackend:
@@ -914,9 +924,9 @@ class SpotifyConnectProvider(PluginProvider):
             target_player_id,
         )
         daemon.active_player_id = target_player_id
-        self.mass.create_task(
-            self.mass.player_queues.play_media(target_player_id, str(daemon.audio_source.uri))
-        )
+        # awaited inline so the tracked deferred task covers the whole start and
+        # a daemon teardown can still cancel an in-flight source selection
+        await self.mass.player_queues.play_media(target_player_id, str(daemon.audio_source.uri))
 
     def _clear_active_player(self, daemon: _PlayerDaemon) -> None:
         """Clear the active player and reset playback state when a session ends."""

--- a/tests/providers/airplay_receiver/test_stop_play_race.py
+++ b/tests/providers/airplay_receiver/test_stop_play_race.py
@@ -150,3 +150,42 @@ async def test_concurrent_starts_all_wait_for_pending_stop(provider: MagicMock) 
     assert events[0] == "stop_done"
     assert events.count("play") == 2
     assert provider.daemon.pending_stop_task is None
+
+
+async def test_teardown_cancels_inflight_start_and_ignores_late_events(
+    provider: MagicMock,
+) -> None:
+    """_stop_receiver awaits the in-flight start; a late play-state event schedules nothing."""
+    play_started = asyncio.Event()
+    release = asyncio.Event()
+    play_calls: list[str] = []
+
+    async def blocking_play(player_id: str, _media: str) -> None:
+        play_calls.append(player_id)
+        play_started.set()
+        await release.wait()
+
+    provider.mass.players.cmd_stop = AsyncMock()
+    provider.mass.player_queues.play_media = blocking_play
+    provider.daemon.in_use_by_player = None
+    provider.daemon.stop_called = False
+    provider.daemon.pending_start_task = None
+    provider.daemon.metadata_reader = None
+    provider.daemon.runner_task = None
+
+    _handle(provider, "playing")
+    await asyncio.wait_for(play_started.wait(), 1)
+    start_task = provider.daemon.pending_start_task
+    assert start_task is not None
+    assert not start_task.done()
+
+    await AirPlayReceiverProvider._stop_receiver(provider, provider.daemon)
+
+    # the in-flight start was cancelled and awaited (else the teardown would hang)
+    assert start_task.cancelled()
+    # a late play-state event on the stopped daemon schedules no replacement work
+    AirPlayReceiverProvider._on_metadata_update(
+        provider, provider.daemon, {"play_state": "playing"}
+    )
+    assert provider.daemon.pending_start_task is None
+    assert play_calls == ["player1"]

--- a/tests/providers/airplay_receiver/test_stop_play_race.py
+++ b/tests/providers/airplay_receiver/test_stop_play_race.py
@@ -179,6 +179,10 @@ async def test_teardown_cancels_inflight_start_and_ignores_late_events(
     assert start_task is not None
     assert not start_task.done()
 
+    # a duplicate 'playing' while the start is in flight must not spawn a second task
+    _handle(provider, "playing")
+    assert provider.daemon.pending_start_task is start_task
+
     await AirPlayReceiverProvider._stop_receiver(provider, provider.daemon)
 
     # the in-flight start was cancelled and awaited (else the teardown would hang)

--- a/tests/providers/spotify_connect/test_backend_contract.py
+++ b/tests/providers/spotify_connect/test_backend_contract.py
@@ -191,6 +191,8 @@ def _make_provider(
     """Build a provider with one daemon wired to the fake backend, mirroring the start defaults."""
     mass = MagicMock()
     mass.create_task.side_effect = _create_task
+    # awaited inline by the deferred play_media trigger
+    mass.player_queues.play_media = AsyncMock()
     provider = object.__new__(SpotifyConnectProvider)
     provider.mass = mass
     provider.logger = MagicMock()

--- a/tests/providers/spotify_connect/test_backend_contract.py
+++ b/tests/providers/spotify_connect/test_backend_contract.py
@@ -267,6 +267,43 @@ async def test_playing_fires_play_media_after_debounce(monkeypatch: pytest.Monke
     mass.player_queues.play_media.assert_called_once_with("player1", _SOURCE_URI)
 
 
+async def test_stop_daemon_awaits_inflight_play_and_ignores_late_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Teardown awaits an in-flight play_media; late backend events schedule nothing."""
+    monkeypatch.setattr(provider_mod, "PLAY_MEDIA_DEBOUNCE_S", 0.01)
+    backend = FakeBackend()
+    provider, daemon, mass = _make_provider(
+        backend, session_active=True, active_player_id="player1"
+    )
+    mass.players.get_player.return_value = MagicMock()
+    play_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocking_play(_player_id: str, _uri: str) -> None:
+        play_started.set()
+        await release.wait()
+
+    mass.player_queues.play_media = AsyncMock(side_effect=blocking_play)
+
+    await provider._handle_backend_event(daemon, BackendEvent(BackendEventType.PLAYING))
+    await asyncio.wait_for(play_started.wait(), 1)
+    task = daemon.pending_play_media_task
+    assert task is not None
+    assert not task.done()
+
+    await provider._stop_daemon(daemon)
+
+    # the in-flight play was cancelled and awaited (else _stop_daemon would hang on
+    # the release event), and only then was the backend stopped
+    assert task.cancelled()
+    assert ("stop", None) in backend.calls
+    # a late backend event on the stopped daemon schedules no replacement work
+    await provider._handle_backend_event(daemon, BackendEvent(BackendEventType.PLAYING))
+    assert daemon.pending_play_media_task is None
+    mass.player_queues.play_media.assert_awaited_once()
+
+
 async def test_playing_before_session_active_fires_play_media(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #6026: two commits from the final review round missed the merge. A daemon teardown (rename/removal of a connected player) now awaits its cancelled playback tasks, so a cancellation-delayed player command can never land after the daemon is gone, and repeated 'playing' events no longer leave an untracked start task behind.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
