### PR TITLE
Fix release creation failing on very large release notes

### DIFF
--- a/.github/actions/generate-release-notes/README.md
+++ b/.github/actions/generate-release-notes/README.md
@@ -26,7 +26,7 @@ This is a complete, self-contained GitHub Action that handles everything:
 - `github-token`: GitHub token for API access
 
 **Outputs:**
-- `release-notes`: Complete release notes including server changes, frontend changes, and merged contributors
+- `release-notes-file`: Path to a file with the complete release notes including server changes, frontend changes, and merged contributors
 
 **What it does internally:**
 1. Generates base release notes from server PRs

--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -26,9 +26,9 @@ inputs:
     required: false
     default: ''
 outputs:
-  release-notes:
-    description: 'The complete generated release notes including frontend changes'
-    value: ${{ steps.generate.outputs.release-notes }}
+  release-notes-file:
+    description: 'Path to a file with the complete generated release notes including frontend changes'
+    value: ${{ steps.generate.outputs.release-notes-file }}
 runs:
   using: 'composite'
   steps:
@@ -55,6 +55,7 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_SERVER_URL: ${{ github.server_url }}
         IMPORTANT_NOTES: ${{ inputs.important-notes }}
+        RELEASE_NOTES_FILE: ${{ runner.temp }}/release-notes.md
       run: |
         cd "${{ inputs.repository-path }}"
         chmod +x ${{ github.action_path }}/generate_notes.py

--- a/.github/actions/generate-release-notes/generate_notes.py
+++ b/.github/actions/generate-release-notes/generate_notes.py
@@ -21,13 +21,10 @@ from github import Github, GithubException
 # under so the release create/update calls can never fail on size.
 MAX_BODY_CHARS = 124_000
 
-# Matches bot-generated bumps like "⬆️ Update music-assistant-frontend to 2.17.294"
-# and dependabot bumps like "Bump pytest from 9.0.3 to 9.1.1"; the from/to anchor
-# keeps human-written "Bump ..." titles out.
-BUMP_TITLE_PATTERNS = (
-    re.compile(r"^⬆️\s*(?:Update|Bump)\s+(\S+)"),
-    re.compile(r"^Bump\s+(\S+)\s+from\s+\S+\s+to\s+\S+"),
-)
+# Extracts the dependency name from bump titles like
+# "⬆️ Update music-assistant-frontend to 2.17.294", "Bump pytest from 9.0.3 to 9.1.1"
+# or "Bump `aiosendspin` to 9.1.1"
+BUMP_TITLE_PATTERN = re.compile(r"^(?:⬆️\s*)?(?:Update|Bump)\s+`?([^\s`]+)`?\s+(?:from|to)\s+\S+")
 
 # Bump PRs whose contents already surface elsewhere in the notes: frontend changes
 # are inlined in their own section and models changes ship with the server PRs
@@ -163,13 +160,15 @@ def get_prs_between_tags(repo, previous_tag, head_sha) -> list[Any]:
     return prs
 
 
+def is_dependency_bump(pr) -> bool:
+    """Whether the PR is a dependency bump (carries the "dependencies" label)."""
+    return any(label.name == "dependencies" for label in pr.labels)
+
+
 def get_bumped_dependency(title) -> str | None:
-    """Return the dependency name from a bump PR title, or None for other PRs."""
-    for pattern in BUMP_TITLE_PATTERNS:
-        match = pattern.match(title)
-        if match:
-            return match.group(1)
-    return None
+    """Return the dependency name from a bump PR title, or None if not parseable."""
+    match = BUMP_TITLE_PATTERN.match(title)
+    return match.group(1) if match else None
 
 
 def filter_dependency_bumps(prs, drop_all=False) -> list[Any]:
@@ -182,6 +181,8 @@ def filter_dependency_bumps(prs, drop_all=False) -> list[Any]:
     """
     latest: dict[str, Any] = {}
     for pr in prs:
+        if not is_dependency_bump(pr):
+            continue
         dependency = get_bumped_dependency(pr.title)
         if dependency:
             # PRs are ordered oldest to newest, so the last match wins
@@ -189,11 +190,12 @@ def filter_dependency_bumps(prs, drop_all=False) -> list[Any]:
 
     filtered = []
     for pr in prs:
-        dependency = get_bumped_dependency(pr.title)
-        if dependency and (
-            drop_all or dependency in INLINED_BUMP_DEPS or latest[dependency] is not pr
-        ):
-            continue
+        if is_dependency_bump(pr):
+            dependency = get_bumped_dependency(pr.title)
+            if drop_all or (
+                dependency and (dependency in INLINED_BUMP_DEPS or latest[dependency] is not pr)
+            ):
+                continue
         filtered.append(pr)
 
     if len(filtered) != len(prs):

--- a/.github/actions/generate-release-notes/generate_notes.py
+++ b/.github/actions/generate-release-notes/generate_notes.py
@@ -21,8 +21,13 @@ from github import Github, GithubException
 # under so the release create/update calls can never fail on size.
 MAX_BODY_CHARS = 124_000
 
-# Matches dependency-bump PR titles like "⬆️ Update music-assistant-frontend to 2.17.294"
-BUMP_TITLE_PATTERN = re.compile(r"^⬆️\s*(?:Update|Bump)\s+(\S+)")
+# Matches bot-generated bumps like "⬆️ Update music-assistant-frontend to 2.17.294"
+# and dependabot bumps like "Bump pytest from 9.0.3 to 9.1.1"; the from/to anchor
+# keeps human-written "Bump ..." titles out.
+BUMP_TITLE_PATTERNS = (
+    re.compile(r"^⬆️\s*(?:Update|Bump)\s+(\S+)"),
+    re.compile(r"^Bump\s+(\S+)\s+from\s+\S+\s+to\s+\S+"),
+)
 
 # Bump PRs whose contents already surface elsewhere in the notes: frontend changes
 # are inlined in their own section and models changes ship with the server PRs
@@ -158,6 +163,15 @@ def get_prs_between_tags(repo, previous_tag, head_sha) -> list[Any]:
     return prs
 
 
+def get_bumped_dependency(title) -> str | None:
+    """Return the dependency name from a bump PR title, or None for other PRs."""
+    for pattern in BUMP_TITLE_PATTERNS:
+        match = pattern.match(title)
+        if match:
+            return match.group(1)
+    return None
+
+
 def filter_dependency_bumps(prs, drop_all=False) -> list[Any]:
     """
     Drop dependency-bump PRs that add no information to the notes.
@@ -168,18 +182,18 @@ def filter_dependency_bumps(prs, drop_all=False) -> list[Any]:
     """
     latest: dict[str, Any] = {}
     for pr in prs:
-        match = BUMP_TITLE_PATTERN.match(pr.title)
-        if match:
+        dependency = get_bumped_dependency(pr.title)
+        if dependency:
             # PRs are ordered oldest to newest, so the last match wins
-            latest[match.group(1)] = pr
+            latest[dependency] = pr
 
     filtered = []
     for pr in prs:
-        match = BUMP_TITLE_PATTERN.match(pr.title)
-        if match:
-            dependency = match.group(1)
-            if drop_all or dependency in INLINED_BUMP_DEPS or latest[dependency] is not pr:
-                continue
+        dependency = get_bumped_dependency(pr.title)
+        if dependency and (
+            drop_all or dependency in INLINED_BUMP_DEPS or latest[dependency] is not pr
+        ):
+            continue
         filtered.append(pr)
 
     if len(filtered) != len(prs):

--- a/.github/actions/generate-release-notes/generate_notes.py
+++ b/.github/actions/generate-release-notes/generate_notes.py
@@ -9,12 +9,25 @@ import os
 import re
 import sys
 from collections import defaultdict
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import yaml
 from github import Github, GithubException
+
+# GitHub rejects release bodies longer than 125,000 characters; stay slightly
+# under so the release create/update calls can never fail on size.
+MAX_BODY_CHARS = 124_000
+
+# Matches dependency-bump PR titles like "⬆️ Update music-assistant-frontend to 2.17.294"
+BUMP_TITLE_PATTERN = re.compile(r"^⬆️\s*(?:Update|Bump)\s+(\S+)")
+
+# Bump PRs whose contents already surface elsewhere in the notes: frontend changes
+# are inlined in their own section and models changes ship with the server PRs
+# that use them.
+INLINED_BUMP_DEPS = {"music-assistant-frontend", "music-assistant-models"}
 
 
 def load_config() -> dict[str, Any]:
@@ -143,6 +156,35 @@ def get_prs_between_tags(repo, previous_tag, head_sha) -> list[Any]:
         print(f"Filtered out {skipped} PRs already released before/in {previous_tag}")  # noqa: T201
 
     return prs
+
+
+def filter_dependency_bumps(prs, drop_all=False) -> list[Any]:
+    """
+    Drop dependency-bump PRs that add no information to the notes.
+
+    Bumps of dependencies whose contents are inlined elsewhere are always
+    dropped and only the latest bump per other dependency is kept. With
+    drop_all, every dependency bump is dropped.
+    """
+    latest: dict[str, Any] = {}
+    for pr in prs:
+        match = BUMP_TITLE_PATTERN.match(pr.title)
+        if match:
+            # PRs are ordered oldest to newest, so the last match wins
+            latest[match.group(1)] = pr
+
+    filtered = []
+    for pr in prs:
+        match = BUMP_TITLE_PATTERN.match(pr.title)
+        if match:
+            dependency = match.group(1)
+            if drop_all or dependency in INLINED_BUMP_DEPS or latest[dependency] is not pr:
+                continue
+        filtered.append(pr)
+
+    if len(filtered) != len(prs):
+        print(f"Dropped {len(prs) - len(filtered)} dependency-bump PRs from the notes")  # noqa: T201
+    return filtered
 
 
 def categorize_prs(prs, config) -> tuple[dict[str, list[Any]], list[Any]]:
@@ -398,6 +440,62 @@ def generate_release_notes(  # noqa: PLR0915
     return "\n".join(lines)
 
 
+def shrink_notes_to_limit(
+    render: Callable[[], str],
+    config,
+    categories,
+    uncategorized,
+    previous_tag,
+    version,
+) -> str:
+    """
+    Trim the least important sections until the notes fit the release body limit.
+
+    The render callable regenerates the notes from the section lists, which are
+    trimmed in place from the bottom up.
+    """
+    footer_lines = ["", "---", "", "_Some changes were omitted to fit these notes on the release._"]
+    if previous_tag:
+        repo_url = (
+            os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+            + "/"
+            + os.environ["GITHUB_REPOSITORY"]
+        )
+        footer_lines[-1] = (
+            "_Some changes were omitted to fit these notes on the release. "
+            f"See the [full changelog]({repo_url}/compare/{previous_tag}...{version}) "
+            "for the complete list._"
+        )
+    footer = "\n".join(footer_lines)
+    budget = MAX_BODY_CHARS - len(footer) - 1
+
+    # Drop entries from the bottom up: deferred (maintenance) sections first,
+    # then "Other Changes", then the regular categories in reverse order
+    category_configs = config.get("categories", [])
+    deferred = [c.get("title", "Other") for c in category_configs if c.get("after-other", False)]
+    regular = [c.get("title", "Other") for c in category_configs if not c.get("after-other", False)]
+    drop_lists = (
+        [categories[title] for title in deferred if title in categories]
+        + [uncategorized]
+        + [categories[title] for title in reversed(regular) if title in categories]
+    )
+
+    notes = render()
+    dropped = 0
+    for entries in drop_lists:
+        while entries and len(notes) > budget:
+            # Drop a chunk proportional to the overflow before re-rendering
+            count = min(len(entries), max(1, (len(notes) - budget) // 100))
+            del entries[-count:]
+            dropped += count
+            notes = render()
+        if len(notes) <= budget:
+            break
+
+    print(f"Omitted {dropped} changes to fit the release body limit")  # noqa: T201
+    return notes + "\n" + footer
+
+
 def main() -> None:
     """Generate release notes for the target version."""
     # Get environment variables
@@ -436,8 +534,13 @@ def main() -> None:
         notes = no_changes
         contributors_list = []
     else:
+        # A stable X.Y.0 release aggregates months of dependency bumps: drop them
+        # all there, elsewhere only the redundant ones
+        drop_all_bumps = channel == "stable" and re.fullmatch(r"\d+\.\d+\.0", version) is not None
+        prs_for_notes = filter_dependency_bumps(prs, drop_all=drop_all_bumps)
+
         # Categorize PRs
-        categories, uncategorized = categorize_prs(prs, config)
+        categories, uncategorized = categorize_prs(prs_for_notes, config)
         print(f"Categorized into {len(categories)} categories, {len(uncategorized)} uncategorized")  # noqa: T201
 
         # Extract frontend changes and contributors
@@ -458,24 +561,48 @@ def main() -> None:
         )
 
         # Generate formatted notes
-        notes = generate_release_notes(
-            config,
-            categories,
-            uncategorized,
-            contributors_list,
-            previous_tag,
-            frontend_changes_list,
-            important_notes,
-        )
+        def render_notes() -> str:
+            return generate_release_notes(
+                config,
+                categories,
+                uncategorized,
+                contributors_list,
+                previous_tag,
+                frontend_changes_list,
+                important_notes,
+            )
 
-    # Output to GitHub Actions
-    # Use multiline output format
+        notes = render_notes()
+        if len(notes) > MAX_BODY_CHARS:
+            notes = shrink_notes_to_limit(
+                render_notes,
+                config,
+                categories,
+                uncategorized,
+                previous_tag,
+                version,
+            )
+
+    write_outputs(notes, contributors_list)
+
+
+def write_outputs(notes, contributors_list) -> None:
+    """
+    Write the generated notes and the GitHub Actions step outputs.
+
+    The notes are handed to the workflow through a file: passing them through
+    a step output means they end up in an env var or command argument, which
+    hits the kernel argument-size limit on big releases.
+    """
+    notes_file = os.environ.get("RELEASE_NOTES_FILE")
+    if notes_file:
+        with open(notes_file, "w") as f:
+            f.write(notes)
     output_file = os.environ.get("GITHUB_OUTPUT")
     if output_file:
         with open(output_file, "a") as f:
-            f.write("release-notes<<EOF\n")
-            f.write(notes)
-            f.write("\nEOF\n")
+            if notes_file:
+                f.write(f"release-notes-file={notes_file}\n")
             f.write("contributors<<EOF\n")
             f.write(",".join(contributors_list))
             f.write("\nEOF\n")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -609,7 +609,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           IS_PRERELEASE: ${{ needs.resolve.outputs.is_prerelease }}
           RELEASE_ID: ${{ needs.resolve.outputs.release_id }}
-          RELEASE_NOTES: ${{ steps.notes.outputs.release-notes }}
+          RELEASE_NOTES_FILE: ${{ steps.notes.outputs.release-notes-file }}
           RELEASE_TITLE: ${{ steps.title.outputs.title }}
           SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
           VERSION: ${{ inputs.version }}
@@ -635,7 +635,7 @@ jobs:
             --arg tag "$VERSION" \
             --arg target "$SOURCE_SHA" \
             --arg name "$RELEASE_TITLE" \
-            --arg body "$RELEASE_NOTES" \
+            --rawfile body "$RELEASE_NOTES_FILE" \
             --argjson prerelease "$IS_PRERELEASE" \
             '{
               tag_name: $tag,

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -208,9 +208,9 @@ def test_filter_dependency_bumps(generate_notes: types.ModuleType) -> None:
     prs = [
         FakePR(1, merged_at, "⬆️ Update music-assistant-frontend to 2.17.1"),
         FakePR(2, merged_at, "Fix a bug"),
-        FakePR(3, merged_at, "⬆️ Bump aiohttp from 3.11 to 3.12"),
+        FakePR(3, merged_at, "Bump aiohttp from 3.11.0 to 3.12.0"),
         FakePR(4, merged_at, "⬆️ Update music-assistant-models to 1.1.100"),
-        FakePR(5, merged_at, "⬆️ Bump aiohttp from 3.12 to 3.13"),
+        FakePR(5, merged_at, "Bump aiohttp from 3.12.0 to 3.13.0"),
         FakePR(6, merged_at, "⬆️ Update music-assistant-frontend to 2.17.2"),
         FakePR(7, merged_at, "Add a feature"),
     ]
@@ -221,17 +221,19 @@ def test_filter_dependency_bumps(generate_notes: types.ModuleType) -> None:
 
 
 def test_filter_dependency_bumps_drop_all(generate_notes: types.ModuleType) -> None:
-    """With drop_all every dependency bump is dropped from the notes."""
+    """With drop_all every dependency bump is dropped, but human titles never match."""
     merged_at = datetime(2026, 6, 1, tzinfo=UTC)
     prs = [
-        FakePR(1, merged_at, "⬆️ Bump aiohttp from 3.12 to 3.13"),
+        FakePR(1, merged_at, "Bump pytest from 9.0.3 to 9.1.1"),
         FakePR(2, merged_at, "Fix a bug"),
         FakePR(3, merged_at, "⬆️ Update music-assistant-frontend to 2.17.2"),
+        FakePR(4, merged_at, "Bump stages for various providers"),
+        FakePR(5, merged_at, "Bump `aiosendspin` to 9.1.1"),
     ]
 
     filtered = generate_notes.filter_dependency_bumps(prs, drop_all=True)
 
-    assert [pr.number for pr in filtered] == [2]
+    assert [pr.number for pr in filtered] == [2, 4, 5]
 
 
 def test_notes_are_shrunk_to_fit_body_limit(

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -7,6 +7,7 @@ import sys
 import types
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -69,11 +70,22 @@ class FakeComparison:
 class FakePR:
     """Mimics PyGithub PullRequest."""
 
-    def __init__(self, number: int, merged_at: datetime) -> None:
+    def __init__(
+        self,
+        number: int,
+        merged_at: datetime,
+        title: str = "",
+        author: str = "someone",
+        labels: tuple[str, ...] = (),
+    ) -> None:
         """Initialize fake pull request."""
         self.number = number
         self.merged = True
         self.merged_at = merged_at
+        self.title = title
+        self.user = types.SimpleNamespace(login=author)
+        self.labels = [types.SimpleNamespace(name=label) for label in labels]
+        self.html_url = f"https://github.com/music-assistant/server/pull/{number}"
 
 
 class FakeRepo:
@@ -188,3 +200,87 @@ def test_minor_release_with_diverged_previous_tag(
     prs = generate_notes.get_prs_between_tags(repo, "2.8.9", "headsha")
 
     assert [pr.number for pr in prs] == [100, 120]
+
+
+def test_filter_dependency_bumps(generate_notes: types.ModuleType) -> None:
+    """Inlined bumps are always dropped; other bumps keep only the latest one."""
+    merged_at = datetime(2026, 6, 1, tzinfo=UTC)
+    prs = [
+        FakePR(1, merged_at, "⬆️ Update music-assistant-frontend to 2.17.1"),
+        FakePR(2, merged_at, "Fix a bug"),
+        FakePR(3, merged_at, "⬆️ Bump aiohttp from 3.11 to 3.12"),
+        FakePR(4, merged_at, "⬆️ Update music-assistant-models to 1.1.100"),
+        FakePR(5, merged_at, "⬆️ Bump aiohttp from 3.12 to 3.13"),
+        FakePR(6, merged_at, "⬆️ Update music-assistant-frontend to 2.17.2"),
+        FakePR(7, merged_at, "Add a feature"),
+    ]
+
+    filtered = generate_notes.filter_dependency_bumps(prs)
+
+    assert [pr.number for pr in filtered] == [2, 5, 7]
+
+
+def test_filter_dependency_bumps_drop_all(generate_notes: types.ModuleType) -> None:
+    """With drop_all every dependency bump is dropped from the notes."""
+    merged_at = datetime(2026, 6, 1, tzinfo=UTC)
+    prs = [
+        FakePR(1, merged_at, "⬆️ Bump aiohttp from 3.12 to 3.13"),
+        FakePR(2, merged_at, "Fix a bug"),
+        FakePR(3, merged_at, "⬆️ Update music-assistant-frontend to 2.17.2"),
+    ]
+
+    filtered = generate_notes.filter_dependency_bumps(prs, drop_all=True)
+
+    assert [pr.number for pr in filtered] == [2]
+
+
+def test_notes_are_shrunk_to_fit_body_limit(
+    generate_notes: types.ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Oversized notes lose maintenance entries first and gain a full-changelog link."""
+    monkeypatch.setenv("GITHUB_REPOSITORY", "music-assistant/server")
+    merged_at = datetime(2026, 6, 1, tzinfo=UTC)
+    config = {
+        "categories": [
+            {"title": "🐛 Bugfixes", "labels": ["bugfix"]},
+            {
+                "title": "🧰 Maintenance",
+                "labels": ["maintenance"],
+                "after-other": True,
+                "collapse-after": 3,
+            },
+        ],
+    }
+    categories = {
+        "🐛 Bugfixes": [
+            FakePR(number, merged_at, f"Fix issue number {number}") for number in range(1, 4)
+        ],
+        "🧰 Maintenance": [
+            FakePR(number, merged_at, f"Maintenance chore number {number}")
+            for number in range(100, 140)
+        ],
+    }
+    uncategorized: list[FakePR] = []
+    maintenance = categories["🧰 Maintenance"]
+
+    def render() -> str:
+        return cast(
+            "str",
+            generate_notes.generate_release_notes(
+                config, categories, uncategorized, [], "2.9.13", None, None
+            ),
+        )
+
+    limit = len(render()) - 500
+    monkeypatch.setattr(generate_notes, "MAX_BODY_CHARS", limit)
+
+    notes = generate_notes.shrink_notes_to_limit(
+        render, config, categories, uncategorized, "2.9.13", "2.10.0"
+    )
+
+    assert len(notes) <= limit
+    # All bugfixes survive; only the maintenance tail was dropped
+    for number in range(1, 4):
+        assert f"#{number})" in notes
+    assert 0 < len(maintenance) < 40
+    assert "compare/2.9.13...2.10.0" in notes

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -205,13 +205,14 @@ def test_minor_release_with_diverged_previous_tag(
 def test_filter_dependency_bumps(generate_notes: types.ModuleType) -> None:
     """Inlined bumps are always dropped; other bumps keep only the latest one."""
     merged_at = datetime(2026, 6, 1, tzinfo=UTC)
+    deps = ("dependencies",)
     prs = [
-        FakePR(1, merged_at, "⬆️ Update music-assistant-frontend to 2.17.1"),
+        FakePR(1, merged_at, "⬆️ Update music-assistant-frontend to 2.17.1", labels=deps),
         FakePR(2, merged_at, "Fix a bug"),
-        FakePR(3, merged_at, "Bump aiohttp from 3.11.0 to 3.12.0"),
-        FakePR(4, merged_at, "⬆️ Update music-assistant-models to 1.1.100"),
-        FakePR(5, merged_at, "Bump aiohttp from 3.12.0 to 3.13.0"),
-        FakePR(6, merged_at, "⬆️ Update music-assistant-frontend to 2.17.2"),
+        FakePR(3, merged_at, "Bump aiohttp from 3.11.0 to 3.12.0", labels=deps),
+        FakePR(4, merged_at, "⬆️ Update music-assistant-models to 1.1.100", labels=deps),
+        FakePR(5, merged_at, "Bump aiohttp from 3.12.0 to 3.13.0", labels=deps),
+        FakePR(6, merged_at, "⬆️ Update music-assistant-frontend to 2.17.2", labels=deps),
         FakePR(7, merged_at, "Add a feature"),
     ]
 
@@ -221,19 +222,42 @@ def test_filter_dependency_bumps(generate_notes: types.ModuleType) -> None:
 
 
 def test_filter_dependency_bumps_drop_all(generate_notes: types.ModuleType) -> None:
-    """With drop_all every dependency bump is dropped, but human titles never match."""
+    """With drop_all every labeled dependency bump is dropped, unlabeled PRs never."""
     merged_at = datetime(2026, 6, 1, tzinfo=UTC)
+    deps = ("dependencies",)
     prs = [
-        FakePR(1, merged_at, "Bump pytest from 9.0.3 to 9.1.1"),
+        FakePR(1, merged_at, "Bump pytest from 9.0.3 to 9.1.1", labels=deps),
         FakePR(2, merged_at, "Fix a bug"),
-        FakePR(3, merged_at, "⬆️ Update music-assistant-frontend to 2.17.2"),
+        FakePR(3, merged_at, "⬆️ Update music-assistant-frontend to 2.17.2", labels=deps),
         FakePR(4, merged_at, "Bump stages for various providers"),
-        FakePR(5, merged_at, "Bump `aiosendspin` to 9.1.1"),
+        FakePR(5, merged_at, "Bump `aiosendspin` to 9.1.1", labels=deps),
+        FakePR(6, merged_at, "Bump the music-assistant-libs group with 2 updates", labels=deps),
     ]
 
     filtered = generate_notes.filter_dependency_bumps(prs, drop_all=True)
 
-    assert [pr.number for pr in filtered] == [2, 4, 5]
+    assert [pr.number for pr in filtered] == [2, 4]
+
+
+def test_write_outputs_hands_notes_over_via_file(
+    generate_notes: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The notes land in the file; the step output only carries the file path."""
+    notes_file = tmp_path / "release-notes.md"
+    output_file = tmp_path / "github-output"
+    monkeypatch.setenv("RELEASE_NOTES_FILE", str(notes_file))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    notes = "# Notes\n" + ("- a change\n" * 10_000)
+
+    generate_notes.write_outputs(notes, ["alice", "bob"])
+
+    assert notes_file.read_text() == notes
+    output = output_file.read_text()
+    assert f"release-notes-file={notes_file}" in output
+    assert "- a change" not in output
+    assert "contributors<<EOF\nalice,bob\nEOF" in output
 
 
 def test_notes_are_shrunk_to_fit_body_limit(


### PR DESCRIPTION
# What does this implement/fix?

The 2.10.0 stable release failed before it could create the draft release: the workflow passes the generated release notes to the draft step through an environment variable, and for a release aggregating ~1700 PRs that exceeds the kernel's argument size limit ("Argument list too long"). Even with that fixed, the notes would still be rejected by GitHub's 125,000-character release body limit.

- Hand the release notes from the generator to the workflow through a file instead of a step output/env var
- Drop dependency-bump PRs that add no information to the notes: frontend/models bumps always (their changes are inlined elsewhere), all bumps on a stable X.Y.0 release, and superseded bumps everywhere else
- Trim the least important sections when the notes still exceed GitHub's release body size limit, adding a full-changelog link

**Related issue (if applicable):**

- failed release run: https://github.com/music-assistant/server/actions/runs/33015653361

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
