### PR TITLE
Keep other players' Spotify Connect and AirPlay devices alive when one daemon fails

### DIFF
--- a/music_assistant/providers/airplay_receiver/provider.py
+++ b/music_assistant/providers/airplay_receiver/provider.py
@@ -615,22 +615,34 @@ class AirPlayReceiverProvider(PluginProvider):
             # Clean up pipes and config
             await self._cleanup_pipes_and_config(daemon)
 
-            if daemon.stop_called:
-                # deliberately stopped (unload, rename restart or player removal)
-                pass
-            elif not daemon.started.is_set():
-                self.unload_with_error("Unable to initialize shairport-sync daemon.")
-            # Auto restart if not stopped manually
-            elif daemon.runner_error_count >= 5:
-                # scheduled as a task: this runner task is what the give-up stops
-                self.mass.create_task(
-                    self._give_up_receiver(
-                        daemon, "shairport-sync daemon failed to start multiple times."
-                    )
-                )
-            else:
-                daemon.runner_error_count += 1
-                self.mass.call_later(2, self._setup_shairport_daemon, daemon)
+            self._handle_runner_exit(daemon)
+
+    def _handle_runner_exit(self, daemon: _ReceiverDaemon) -> None:
+        """
+        Decide how to follow up on a receiver's daemon exit (restart, give up or unload).
+
+        :param daemon: The receiver daemon whose shairport-sync process exited.
+        """
+        if daemon.stop_called:
+            # deliberately stopped (unload, rename restart or player removal)
+            return
+        if not daemon.started.is_set():
+            # the binary produced no output at all: an environment-level problem
+            # every receiver would hit alike
+            self.unload_with_error("Unable to initialize shairport-sync daemon.")
+        # Auto restart if not stopped manually
+        elif daemon.runner_error_count >= 5:
+            # deferred task (no eager start): this runs on the daemon's own
+            # runner task, which the give-up is about to stop
+            self.mass.create_task(
+                self._give_up_receiver(
+                    daemon, "shairport-sync daemon failed to start multiple times."
+                ),
+                eager_start=False,
+            )
+        else:
+            daemon.runner_error_count += 1
+            self.mass.call_later(2, self._setup_shairport_daemon, daemon)
 
     def _process_shairport_log_line(self, daemon: _ReceiverDaemon, line: str) -> None:
         """
@@ -639,6 +651,11 @@ class AirPlayReceiverProvider(PluginProvider):
         :param daemon: The receiver daemon the log line originates from.
         :param line: The log line to process.
         """
+        # any output proves the binary runs: a subsequent exit is then handled by
+        # the supervised restart path (per receiver) instead of unloading the
+        # provider as uninitializable
+        if not daemon.started.is_set():
+            daemon.started.set()
         # Check for fatal errors (log them, but process will exit on its own)
         if "fatal error:" in line.lower() or "unknown option" in line.lower():
             self.logger.error("Fatal error from shairport-sync: %s", line)
@@ -650,8 +667,6 @@ class AirPlayReceiverProvider(PluginProvider):
             # Note: Play begin/stop events are now handled via sessioncontrol hooks
             # through the metadata pipe, so we don't need to parse stderr logs
             self.logger.debug(line)
-        if not daemon.started.is_set():
-            daemon.started.set()
 
     async def _setup_pipes_and_config(self, daemon: _ReceiverDaemon) -> None:
         """

--- a/music_assistant/providers/airplay_receiver/provider.py
+++ b/music_assistant/providers/airplay_receiver/provider.py
@@ -159,6 +159,9 @@ class AirPlayReceiverProvider(PluginProvider):
         super().__init__(mass, manifest, config, SUPPORTED_FEATURES)
         self._shairport_bin: str | None = None
         self._daemons: dict[str, _ReceiverDaemon] = {}
+        # players whose daemon gave up permanently; skipped by reconcile until the
+        # player re-registers or the provider reloads
+        self._failed_player_ids: set[str] = set()
         self._reconcile_lock = asyncio.Lock()
         self._unload_called = False
         self._unsubscribe: Callable[[], None] | None = None
@@ -398,6 +401,9 @@ class AirPlayReceiverProvider(PluginProvider):
                     self._clear_active_player(daemon)
                     await self._stop_receiver(daemon)
             return
+        if event.event == EventType.PLAYER_ADDED and event.object_id:
+            # a re-registered player earns a permanently failed daemon a fresh start
+            self._failed_player_ids.discard(event.object_id)
         await self._reconcile()
 
     async def _reconcile(self) -> None:
@@ -412,6 +418,10 @@ class AirPlayReceiverProvider(PluginProvider):
                 return
             template = self.get_config_value(CONF_PUBLISH_NAME_TEMPLATE)
             for player_id in self._assigned_player_ids:
+                if player_id in self._failed_player_ids:
+                    # this daemon gave up permanently; blocked from restarts until the
+                    # player re-registers or the provider reloads
+                    continue
                 player = self.mass.players.get_player(player_id)
                 if player is None:
                     # not (yet) registered: never start a daemon for it; an already
@@ -517,6 +527,33 @@ class AirPlayReceiverProvider(PluginProvider):
         daemon.shairport_proc = None
         daemon.started.clear()
 
+    async def _give_up_receiver(self, daemon: _ReceiverDaemon, error: str) -> None:
+        """
+        Permanently stop a single failed receiver, leaving the other receivers running.
+
+        :param daemon: The receiver whose daemon failed permanently.
+        :param error: The daemon's failure description.
+        """
+        async with self._reconcile_lock:
+            # a rename restart, player removal or unload may have replaced or
+            # stopped the receiver meanwhile; only the live one gives up
+            if self._daemons.get(daemon.player_id) is not daemon:
+                return
+            del self._daemons[daemon.player_id]
+            self._failed_player_ids.add(daemon.player_id)
+            self.logger.warning(
+                "Giving up on AirPlay receiver '%s' for player %s: %s "
+                "Other players are unaffected; reload the provider to retry.",
+                daemon.airplay_name,
+                daemon.player_id,
+                error,
+            )
+            # release a consuming player so it is not left bound to a dead source
+            self._clear_active_player(daemon)
+            await self._stop_receiver(daemon)
+        # drop the standing source entry from the player's cached source list
+        self.mass.players.trigger_player_update(daemon.player_id)
+
     def _setup_shairport_daemon(self, daemon: _ReceiverDaemon) -> None:
         """Handle setup of the shairport-sync daemon for a receiver."""
         # a delayed restart can fire after the receiver was stopped or replaced
@@ -585,7 +622,12 @@ class AirPlayReceiverProvider(PluginProvider):
                 self.unload_with_error("Unable to initialize shairport-sync daemon.")
             # Auto restart if not stopped manually
             elif daemon.runner_error_count >= 5:
-                self.unload_with_error("shairport-sync daemon failed to start multiple times.")
+                # scheduled as a task: this runner task is what the give-up stops
+                self.mass.create_task(
+                    self._give_up_receiver(
+                        daemon, "shairport-sync daemon failed to start multiple times."
+                    )
+                )
             else:
                 daemon.runner_error_count += 1
                 self.mass.call_later(2, self._setup_shairport_daemon, daemon)

--- a/music_assistant/providers/spotify_connect/go_librespot/README.md
+++ b/music_assistant/providers/spotify_connect/go_librespot/README.md
@@ -47,9 +47,10 @@ and quoting pitfalls:
   credentials persisted per daemon.
 - The local HTTP/WS API binds to `127.0.0.1` on a free port per daemon.
 
-The daemon is supervised: restarts on exit, a fatal event (→ `unload_with_error`) after
-repeated failures. A self-healing WebSocket listener reconnects across daemon restarts and
-translates `/events` messages into normalized `BackendEvent`s.
+The daemon is supervised: restarts on exit, a fatal event after repeated failures — on which
+the provider gives up this one daemon (stopping it and keeping the other players' daemons
+running). A self-healing WebSocket listener reconnects across daemon restarts and translates
+`/events` messages into normalized `BackendEvent`s.
 
 ## Audio transport
 

--- a/music_assistant/providers/spotify_connect/models.py
+++ b/music_assistant/providers/spotify_connect/models.py
@@ -39,7 +39,8 @@ class BackendEventType(StrEnum):
     CONNECTION_LOST = "connection_lost"
     # a non-fatal backend error worth surfacing (message in the ``error`` field)
     ERROR = "error"
-    # the backend failed permanently and the provider must unload with an error
+    # the backend failed permanently: the provider gives up this daemon, or unloads
+    # entirely when the event's ``provider_wide`` flag is set
     FATAL_ERROR = "fatal_error"
     # any other backend activity; carries at most refreshed context/track uris
     OTHER = "other"
@@ -139,7 +140,8 @@ class BackendEvent:
     percentage (VOLUME events), ``error`` the failure description (ERROR and
     FATAL_ERROR events), ``queue`` the session's queue view (QUEUE_CHANGED
     events) and ``options`` the session's playback options (OPTIONS_CHANGED
-    events).
+    events). ``provider_wide`` applies to FATAL_ERROR events only: it marks a
+    failure of the engine as a whole rather than of this one daemon.
     """
 
     type: BackendEventType
@@ -151,6 +153,7 @@ class BackendEvent:
     error: str | None = None
     queue: BackendQueueState | None = None
     options: BackendPlaybackOptions | None = None
+    provider_wide: bool = False
 
 
 # Awaited by the backend for every normalized event, in emit order.

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -1110,13 +1110,13 @@ class SpotifyConnectProvider(PluginProvider):
         :param daemon: The daemon the event originates from.
         :param event: The FATAL_ERROR event to handle.
         """
-        error = event.error or "Spotify Connect backend failed"
+        error = event.error or "Spotify Connect backend failed."
         if event.provider_wide:
             self.unload_with_error(error)
             return
-        # scheduled as a task: this callback runs on the backend's own runner
-        # task, which the give-up is about to stop
-        self.mass.create_task(self._give_up_daemon(daemon, error))
+        # deferred task (no eager start): this callback runs on the backend's
+        # own runner task, which the give-up is about to stop
+        self.mass.create_task(self._give_up_daemon(daemon, error), eager_start=False)
 
     def _remember_context_uris(self, daemon: _PlayerDaemon, event: BackendEvent) -> None:
         """

--- a/music_assistant/providers/spotify_connect/provider.py
+++ b/music_assistant/providers/spotify_connect/provider.py
@@ -192,6 +192,9 @@ class SpotifyConnectProvider(PluginProvider):
         """Initialize MusicProvider."""
         super().__init__(mass, manifest, config, SUPPORTED_FEATURES)
         self._daemons: dict[str, _PlayerDaemon] = {}
+        # players whose daemon gave up permanently; skipped by reconcile until the
+        # player re-registers or the provider reloads
+        self._failed_player_ids: set[str] = set()
         self._reconcile_lock = asyncio.Lock()
         self._unload_called = False
         self._unsubscribe: Callable[[], None] | None = None
@@ -625,6 +628,9 @@ class SpotifyConnectProvider(PluginProvider):
                     self._clear_active_player(daemon)
                     await self._stop_daemon(daemon)
             return
+        if event.event == EventType.PLAYER_ADDED and event.object_id:
+            # a re-registered player earns a permanently failed daemon a fresh start
+            self._failed_player_ids.discard(event.object_id)
         await self._reconcile()
 
     async def _reconcile(self) -> None:
@@ -639,6 +645,10 @@ class SpotifyConnectProvider(PluginProvider):
                 return
             template = self.get_config_value(CONF_PUBLISH_NAME_TEMPLATE)
             for player_id in self._assigned_player_ids:
+                if player_id in self._failed_player_ids:
+                    # this daemon gave up permanently; blocked from restarts until the
+                    # player re-registers or the provider reloads
+                    continue
                 player = self.mass.players.get_player(player_id)
                 if player is None:
                     # not (yet) registered: never start a daemon for it; an already
@@ -700,6 +710,33 @@ class SpotifyConnectProvider(PluginProvider):
             with suppress(asyncio.CancelledError):
                 await task
         await daemon.backend.stop()
+
+    async def _give_up_daemon(self, daemon: _PlayerDaemon, error: str) -> None:
+        """
+        Permanently stop a single failed daemon, leaving the other daemons running.
+
+        :param daemon: The daemon whose backend failed permanently.
+        :param error: The backend's failure description.
+        """
+        async with self._reconcile_lock:
+            # a rename restart, player removal or unload may have replaced or
+            # stopped the daemon meanwhile; only the live daemon gives up
+            if self._daemons.get(daemon.player_id) is not daemon:
+                return
+            del self._daemons[daemon.player_id]
+            self._failed_player_ids.add(daemon.player_id)
+            self.logger.warning(
+                "Giving up on Spotify Connect device '%s' for player %s: %s "
+                "Other players are unaffected; reload the provider to retry.",
+                daemon.publish_name,
+                daemon.player_id,
+                error,
+            )
+            # release a consuming player so it is not left bound to a dead source
+            self._clear_active_player(daemon)
+            await self._stop_daemon(daemon)
+        # drop the standing source entry from the player's cached source list
+        self.mass.players.trigger_player_update(daemon.player_id)
 
     def _create_backend(self, daemon: _PlayerDaemon, player_name: str) -> SpotifyConnectBackend:
         """
@@ -971,7 +1008,7 @@ class SpotifyConnectProvider(PluginProvider):
             daemon.last_playback_options = None
             return
         if event.type is BackendEventType.FATAL_ERROR:
-            self.unload_with_error(event.error or "Spotify Connect backend failed")
+            self._handle_fatal_error(daemon, event)
             return
         if event.type is BackendEventType.ERROR:
             # non-fatal backend error: surface it in the log only
@@ -1065,6 +1102,21 @@ class SpotifyConnectProvider(PluginProvider):
                 self.instance_id,
                 daemon.stream_metadata,
             )
+
+    def _handle_fatal_error(self, daemon: _PlayerDaemon, event: BackendEvent) -> None:
+        """
+        Act on a backend that failed permanently.
+
+        :param daemon: The daemon the event originates from.
+        :param event: The FATAL_ERROR event to handle.
+        """
+        error = event.error or "Spotify Connect backend failed"
+        if event.provider_wide:
+            self.unload_with_error(error)
+            return
+        # scheduled as a task: this callback runs on the backend's own runner
+        # task, which the give-up is about to stop
+        self.mass.create_task(self._give_up_daemon(daemon, error))
 
     def _remember_context_uris(self, daemon: _PlayerDaemon, event: BackendEvent) -> None:
         """

--- a/music_assistant/providers/spotify_connect/soloist/backend.py
+++ b/music_assistant/providers/spotify_connect/soloist/backend.py
@@ -667,6 +667,10 @@ class SoloistBackend(SpotifyConnectBackend):
                         # fatal errors are plain (non-localized) strings for now,
                         # matching the go-librespot backend
                         error="soloist daemon failed to start multiple times.",
+                        # repeated soloist exits are dominated by engine-level
+                        # problems (e.g. a bad or revoked API key) that hit every
+                        # daemon alike
+                        provider_wide=True,
                     )
                 )
                 return
@@ -771,6 +775,8 @@ class SoloistBackend(SpotifyConnectBackend):
                         "installed. Check the server's internet connection and reload "
                         "this provider."
                     ),
+                    # the binary (and its expiry) is shared by every daemon
+                    provider_wide=True,
                 )
             )
             return False

--- a/tests/providers/airplay_receiver/test_provider.py
+++ b/tests/providers/airplay_receiver/test_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 from music_assistant_models.enums import EventType
@@ -76,6 +77,7 @@ def _reconcile_provider(
     prov.config = MagicMock()
     prov.mass = mass = MagicMock()
     prov._daemons = {}
+    prov._failed_player_ids = set()
     prov._reconcile_lock = asyncio.Lock()
     prov._unload_called = False
     prov._unsubscribe = None
@@ -93,8 +95,13 @@ def _reconcile_provider(
     mass.players.get_player.side_effect = get_player
 
     def start_receiver(player: MagicMock, airplay_name: str) -> None:
+        # stop_called / active_player_id are spelled out: a bare MagicMock attribute is
+        # truthy, which would trip the stopped-daemon guard and the deselect path
         prov._daemons[player.player_id] = MagicMock(
-            player_id=player.player_id, airplay_name=airplay_name
+            player_id=player.player_id,
+            airplay_name=airplay_name,
+            stop_called=False,
+            active_player_id=None,
         )
 
     start_mock = MagicMock(side_effect=start_receiver)
@@ -216,3 +223,59 @@ async def test_unload_stops_all_daemons() -> None:
     unsubscribe.assert_called_once()
     assert mocks.stop_receiver.await_count == 2
     assert not prov._daemons
+
+
+async def test_give_up_receiver_stops_only_the_failed_daemon() -> None:
+    """A permanently failed receiver is dropped while the other receivers keep running."""
+    prov, mocks = _reconcile_provider(("p1", "p2"), {"p1": "Kitchen", "p2": "Garage"})
+    await prov._reconcile()
+    daemon = prov._daemons["p1"]
+    daemon.active_player_id = "consumer"
+
+    await prov._give_up_receiver(daemon, "shairport-sync daemon failed to start multiple times.")
+
+    assert "p1" not in prov._daemons
+    assert "p2" in prov._daemons
+    mocks.stop_receiver.assert_awaited_once_with(daemon)
+    assert prov._failed_player_ids == {"p1"}
+    mocks.mass.players.trigger_player_update.assert_called_with("p1")
+    mocks.mass.players.deselect_source.assert_called_once()
+    cast("MagicMock", prov.logger).warning.assert_called_once()
+
+
+async def test_reconcile_skips_a_given_up_receiver() -> None:
+    """A receiver that gave up permanently is not relaunched by an ordinary reconcile."""
+    prov, mocks = _reconcile_provider(("p1",), {"p1": "Kitchen"})
+    prov._failed_player_ids = {"p1"}
+
+    await prov._reconcile()
+
+    mocks.start_receiver.assert_not_called()
+    assert "p1" not in prov._daemons
+
+
+async def test_player_added_gives_a_failed_receiver_a_fresh_start() -> None:
+    """A player re-registering lifts the block and starts its receiver again."""
+    prov, mocks = _reconcile_provider(("p1",), {"p1": "Kitchen"})
+    prov._failed_player_ids = {"p1"}
+
+    await prov._on_player_event(MassEvent(event=EventType.PLAYER_ADDED, object_id="p1"))
+
+    assert "p1" not in prov._failed_player_ids
+    mocks.start_receiver.assert_called_once()
+    assert "p1" in prov._daemons
+
+
+async def test_give_up_on_a_replaced_receiver_is_a_noop() -> None:
+    """A give-up landing after the receiver was replaced leaves the replacement running."""
+    prov, mocks = _reconcile_provider(("p1",), {"p1": "Kitchen"})
+    await prov._reconcile()
+    old_daemon = prov._daemons["p1"]
+    replacement = MagicMock(player_id="p1", airplay_name="Kitchen | Music Assistant")
+    prov._daemons["p1"] = replacement
+
+    await prov._give_up_receiver(old_daemon, "boom")
+
+    mocks.stop_receiver.assert_not_awaited()
+    assert not prov._failed_player_ids
+    assert prov._daemons["p1"] is replacement

--- a/tests/providers/airplay_receiver/test_provider.py
+++ b/tests/providers/airplay_receiver/test_provider.py
@@ -279,3 +279,81 @@ async def test_give_up_on_a_replaced_receiver_is_a_noop() -> None:
     mocks.stop_receiver.assert_not_awaited()
     assert not prov._failed_player_ids
     assert prov._daemons["p1"] is replacement
+
+
+async def test_runner_exit_retries_before_the_restart_budget_is_spent() -> None:
+    """A daemon exit within the restart budget schedules a delayed restart."""
+    prov, mocks = _reconcile_provider(("p1",), {"p1": "Kitchen"})
+    await prov._reconcile()
+    daemon = prov._daemons["p1"]
+    daemon.started = asyncio.Event()
+    daemon.started.set()
+    daemon.runner_error_count = 0
+
+    prov._handle_runner_exit(daemon)
+
+    assert daemon.runner_error_count == 1
+    mocks.mass.call_later.assert_called_once_with(2, prov._setup_shairport_daemon, daemon)
+
+
+async def test_runner_exit_gives_up_once_the_restart_budget_is_spent() -> None:
+    """Exhausting the restart budget gives up this receiver instead of unloading."""
+    prov, mocks = _reconcile_provider(("p1",), {"p1": "Kitchen"})
+    unload_with_error = MagicMock()
+    prov.unload_with_error = unload_with_error  # type: ignore[method-assign]
+    await prov._reconcile()
+    daemon = prov._daemons["p1"]
+    daemon.started = asyncio.Event()
+    daemon.started.set()
+    daemon.runner_error_count = 5
+
+    prov._handle_runner_exit(daemon)
+    # the give-up runs as a deferred task so it never stops its own runner task
+    assert mocks.mass.create_task.call_args.kwargs == {"eager_start": False}
+    await mocks.mass.create_task.call_args.args[0]
+
+    assert "p1" not in prov._daemons
+    assert prov._failed_player_ids == {"p1"}
+    unload_with_error.assert_not_called()
+
+
+async def test_runner_exit_without_any_output_unloads_the_provider() -> None:
+    """A daemon that never produced any output is an environment-level provider failure."""
+    prov, mocks = _reconcile_provider(("p1",), {"p1": "Kitchen"})
+    unload_with_error = MagicMock()
+    prov.unload_with_error = unload_with_error  # type: ignore[method-assign]
+    await prov._reconcile()
+    daemon = prov._daemons["p1"]
+    daemon.started = asyncio.Event()
+
+    prov._handle_runner_exit(daemon)
+
+    unload_with_error.assert_called_once()
+    mocks.mass.create_task.assert_not_called()
+
+
+async def test_runner_exit_after_a_deliberate_stop_does_nothing() -> None:
+    """A deliberately stopped receiver never restarts, gives up or unloads."""
+    prov, mocks = _reconcile_provider(("p1",), {"p1": "Kitchen"})
+    unload_with_error = MagicMock()
+    prov.unload_with_error = unload_with_error  # type: ignore[method-assign]
+    await prov._reconcile()
+    daemon = prov._daemons["p1"]
+    daemon.started = asyncio.Event()
+    daemon.stop_called = True
+
+    prov._handle_runner_exit(daemon)
+
+    unload_with_error.assert_not_called()
+    mocks.mass.create_task.assert_not_called()
+    mocks.mass.call_later.assert_not_called()
+
+
+def test_a_fatal_log_line_marks_the_daemon_started() -> None:
+    """A fatal-error log line still proves the binary runs, routing exits to the restart path."""
+    prov, _mocks = _reconcile_provider(("p1",), {})
+    daemon = MagicMock(started=asyncio.Event())
+
+    prov._process_shairport_log_line(daemon, "fatal error: Could not bind any listening ports")
+
+    assert daemon.started.is_set()

--- a/tests/providers/spotify_connect/test_backend_contract.py
+++ b/tests/providers/spotify_connect/test_backend_contract.py
@@ -551,13 +551,14 @@ async def test_connection_lost_resets_session_without_stopping_players() -> None
     mass.players.cmd_stop.assert_not_called()
 
 
-async def test_fatal_error_unloads_provider_with_error() -> None:
-    """A FATAL_ERROR event unloads the provider with the backend's error message."""
+async def test_provider_wide_fatal_error_unloads_provider_with_error() -> None:
+    """A provider-wide FATAL_ERROR unloads the provider with the backend's error message."""
     backend = FakeBackend()
     provider, daemon, mass = _make_provider(backend)
 
     await provider._handle_backend_event(
-        daemon, BackendEvent(BackendEventType.FATAL_ERROR, error="daemon kaput")
+        daemon,
+        BackendEvent(BackendEventType.FATAL_ERROR, error="daemon kaput", provider_wide=True),
     )
 
     mass.call_later.assert_called_once_with(

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -585,6 +585,7 @@ def _reconcile_provider(
     prov.config = MagicMock()
     prov.mass = mass = MagicMock()
     prov._daemons = {}
+    prov._failed_player_ids = set()
     prov._reconcile_lock = asyncio.Lock()
     prov._unload_called = False
     prov._unsubscribe = None
@@ -602,8 +603,13 @@ def _reconcile_provider(
     mass.players.get_player.side_effect = get_player
 
     async def start_daemon(player: MagicMock, publish_name: str) -> None:
+        # stop_called / active_player_id are spelled out: a bare MagicMock attribute is
+        # truthy, which would trip the stopped-daemon guard and the deselect path
         prov._daemons[player.player_id] = MagicMock(
-            player_id=player.player_id, publish_name=publish_name
+            player_id=player.player_id,
+            publish_name=publish_name,
+            stop_called=False,
+            active_player_id=None,
         )
 
     start_mock = AsyncMock(side_effect=start_daemon)
@@ -715,3 +721,87 @@ async def test_unload_stops_all_daemons() -> None:
     unsubscribe.assert_called_once()
     assert mocks.stop_daemon.await_count == 2
     assert not prov._daemons
+
+
+async def test_fatal_backend_error_gives_up_only_the_failed_daemon() -> None:
+    """A permanently failed backend drops its own daemon and leaves the others running."""
+    prov, mocks = _reconcile_provider(("p1", "p2"), {"p1": "Kitchen", "p2": "Garage"})
+    unload_with_error = MagicMock()
+    prov.unload_with_error = unload_with_error  # type: ignore[method-assign]
+    await prov._reconcile()
+    daemon = prov._daemons["p1"]
+    daemon.active_player_id = "consumer"
+
+    await prov._handle_backend_event(
+        daemon, BackendEvent(type=BackendEventType.FATAL_ERROR, error="boom")
+    )
+    # the give-up is scheduled so it does not stop the runner task it is called from
+    give_up = mocks.mass.create_task.call_args.args[0]
+    await give_up
+
+    assert "p1" not in prov._daemons
+    assert "p2" in prov._daemons
+    mocks.stop_daemon.assert_awaited_once_with(daemon)
+    assert prov._failed_player_ids == {"p1"}
+    mocks.mass.players.trigger_player_update.assert_called_with("p1")
+    mocks.mass.players.deselect_source.assert_called_once()
+    cast("MagicMock", prov.logger).warning.assert_called_once()
+    unload_with_error.assert_not_called()
+
+
+async def test_provider_wide_fatal_error_unloads_the_provider() -> None:
+    """An engine-level failure keeps taking the whole provider down."""
+    prov, mocks = _reconcile_provider(("p1",), {"p1": "Kitchen"})
+    unload_with_error = MagicMock()
+    prov.unload_with_error = unload_with_error  # type: ignore[method-assign]
+    await prov._reconcile()
+    daemon = prov._daemons["p1"]
+
+    await prov._handle_backend_event(
+        daemon,
+        BackendEvent(
+            type=BackendEventType.FATAL_ERROR, error="api key revoked", provider_wide=True
+        ),
+    )
+
+    unload_with_error.assert_called_once_with("api key revoked")
+    mocks.mass.create_task.assert_not_called()
+    assert "p1" in prov._daemons
+
+
+async def test_reconcile_skips_a_given_up_daemon() -> None:
+    """A daemon that gave up permanently is not relaunched by an ordinary reconcile."""
+    prov, mocks = _reconcile_provider(("p1",), {"p1": "Kitchen"})
+    prov._failed_player_ids = {"p1"}
+
+    await prov._reconcile()
+
+    mocks.start_daemon.assert_not_awaited()
+    assert "p1" not in prov._daemons
+
+
+async def test_player_added_gives_a_failed_daemon_a_fresh_start() -> None:
+    """A player re-registering lifts the block and starts its daemon again."""
+    prov, mocks = _reconcile_provider(("p1",), {"p1": "Kitchen"})
+    prov._failed_player_ids = {"p1"}
+
+    await prov._on_player_event(MassEvent(event=EventType.PLAYER_ADDED, object_id="p1"))
+
+    assert "p1" not in prov._failed_player_ids
+    mocks.start_daemon.assert_awaited_once()
+    assert "p1" in prov._daemons
+
+
+async def test_give_up_on_a_replaced_daemon_is_a_noop() -> None:
+    """A give-up landing after the daemon was replaced leaves the replacement running."""
+    prov, mocks = _reconcile_provider(("p1",), {"p1": "Kitchen"})
+    await prov._reconcile()
+    old_daemon = prov._daemons["p1"]
+    replacement = MagicMock(player_id="p1", publish_name="Kitchen | Music Assistant")
+    prov._daemons["p1"] = replacement
+
+    await prov._give_up_daemon(old_daemon, "boom")
+
+    mocks.stop_daemon.assert_not_awaited()
+    assert not prov._failed_player_ids
+    assert prov._daemons["p1"] is replacement

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -735,7 +735,8 @@ async def test_fatal_backend_error_gives_up_only_the_failed_daemon() -> None:
     await prov._handle_backend_event(
         daemon, BackendEvent(type=BackendEventType.FATAL_ERROR, error="boom")
     )
-    # the give-up is scheduled so it does not stop the runner task it is called from
+    # the give-up is a deferred task so it does not stop the runner task it is called from
+    assert mocks.mass.create_task.call_args.kwargs == {"eager_start": False}
     give_up = mocks.mass.create_task.call_args.args[0]
     await give_up
 

--- a/tests/providers/spotify_connect/test_soloist_backend.py
+++ b/tests/providers/spotify_connect/test_soloist_backend.py
@@ -418,6 +418,8 @@ async def test_exit_code_10_with_failed_refresh_is_fatal(
     assert len(spawned) == 1  # the expired build is never restarted
     assert events[-1].type is BackendEventType.FATAL_ERROR
     assert "expired" in (events[-1].error or "")
+    # the shared binary expiring hits every daemon alike
+    assert events[-1].provider_wide is True
 
 
 async def test_five_daemon_failures_report_fatal_error(
@@ -434,6 +436,8 @@ async def test_five_daemon_failures_report_fatal_error(
     assert len(spawned) == 5
     assert sum(1 for e in events if e.type is BackendEventType.CONNECTION_LOST) == 5
     assert events[-1].type is BackendEventType.FATAL_ERROR
+    # soloist fatals take the whole provider down (engine-level failure)
+    assert events[-1].provider_wide is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

Since #6026, Spotify Connect and AirPlay Receiver run one daemon per connected player. When a single daemon failed permanently (shairport-sync or go-librespot giving up after repeated restarts), the whole provider unloaded — every other player's advertised device disappeared because of one broken daemon.

Now a permanently failing daemon gives up on its own: it is stopped and dropped, a warning names the affected player, and the other players' devices keep working. Genuinely provider-wide failures (Soloist auth/API-key problems, missing binary) still unload the provider with an error.

- go-librespot and shairport-sync restart-budget exhaustion now stops only that player's daemon instead of unloading the provider
- a given-up daemon is blocked from automatic restarts (no crash loops); it gets a fresh start when its player re-registers or the provider is reloaded
- any player consuming the failed source is released so it isn't left bound to a dead source
- shairport-sync startup failures that produce output (e.g. a port already in use) now also retry and give up per receiver; only a binary that produces no output at all still unloads the provider
- Soloist failures stay provider-wide (no per-daemon auth signal; a bad API key hits every daemon alike)
- tests added for both providers (give-up isolation, provider-wide routing, reconcile skip, recovery on player re-registration)

**Related issue (if applicable):**

- fixes https://github.com/music-assistant/backlog/issues/75

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
