### PR TITLE
Hide non-audio players from the scrobbler player picker

### DIFF
--- a/music_assistant/helpers/scrobbler.py
+++ b/music_assistant/helpers/scrobbler.py
@@ -13,6 +13,8 @@ from music_assistant_models.config_entries import (
 )
 from music_assistant_models.enums import ConfigEntryType, MediaType
 
+from music_assistant.helpers.config_entries import PLAYBACK_TARGET_TYPES
+
 if TYPE_CHECKING:
     from music_assistant_models.event import MassEvent
     from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
@@ -205,7 +207,9 @@ def create_scrobble_players_config_entry(mass: MusicAssistant) -> ConfigEntry:
         key=lambda player: player.display_name.lower(),
     )
     player_options = [
-        ConfigValueOption(player.player_id, title=player.display_name) for player in ma_player_list
+        ConfigValueOption(player.player_id, title=player.display_name)
+        for player in ma_player_list
+        if player.type in PLAYBACK_TARGET_TYPES
     ]
     return ConfigEntry(
         key=CONF_SCROBBLE_PLAYERS,

--- a/music_assistant/providers/music_quiz/__init__.py
+++ b/music_assistant/providers/music_quiz/__init__.py
@@ -68,7 +68,7 @@ from music_assistant_models.config_entries import (
     ConfigEntry,
     ProviderConfig,
 )
-from music_assistant_models.enums import ConfigEntryType, PlayerType, ProviderFeature, QueueOption
+from music_assistant_models.enums import ConfigEntryType, ProviderFeature, QueueOption
 from music_assistant_models.errors import (
     AudioError,
     InvalidDataError,
@@ -84,6 +84,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
     impersonated_user,
 )
 from music_assistant.helpers import guest_access
+from music_assistant.helpers.config_entries import PLAYBACK_TARGET_TYPES
 from music_assistant.helpers.json import SerializableType
 from music_assistant.helpers.plugin_engines import (
     create_ai_engine_config_entries,
@@ -1802,7 +1803,7 @@ class MusicQuizPlugin(PluginProvider):
             and not state.needs_setup
             and state.synced_to is None
             and state.active_group is None
-            and state.type in (PlayerType.PLAYER, PlayerType.STEREO_PAIR, PlayerType.GROUP)
+            and state.type in PLAYBACK_TARGET_TYPES
             and any(protocol.available for protocol in state.output_protocols)
             and not is_remote_session_host(self.mass, player.player_id)
         )

--- a/tests/helpers/test_scrobbler.py
+++ b/tests/helpers/test_scrobbler.py
@@ -1,4 +1,4 @@
-"""Tests the event handling for LastFM Plugin Provider."""
+"""Tests for the scrobbler helpers."""
 
 import logging
 from unittest import mock

--- a/tests/helpers/test_scrobbler.py
+++ b/tests/helpers/test_scrobbler.py
@@ -1,13 +1,18 @@
 """Tests the event handling for LastFM Plugin Provider."""
 
 import logging
+from unittest import mock
 
 import pytest
-from music_assistant_models.enums import EventType, MediaType
+from music_assistant_models.enums import EventType, MediaType, PlayerType
 from music_assistant_models.event import MassEvent
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
 
-from music_assistant.helpers.scrobbler import ScrobblerConfig, ScrobblerHelper
+from music_assistant.helpers.scrobbler import (
+    ScrobblerConfig,
+    ScrobblerHelper,
+    create_scrobble_players_config_entry,
+)
 
 
 class DummyHandler(ScrobblerHelper):
@@ -217,6 +222,33 @@ async def test_it_propagates_unexpected_scrobble_exceptions() -> None:
 
     with pytest.raises(ValueError, match="unexpected bug"):
         await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=176))
+
+
+def test_it_only_offers_playback_capable_scrobble_players() -> None:
+    """The scrobble-players picker only lists players that can render audio."""
+    mass = mock.Mock()
+    mass.players.all_players.return_value = [
+        _player("wall-panel", "Wall Panel", PlayerType.DISPLAY),
+        _player("living-room", "Living Room"),
+        _player("turntable", "Turntable", PlayerType.SOURCE),
+        _player("kitchen", "Kitchen"),
+    ]
+
+    entry = create_scrobble_players_config_entry(mass)
+
+    assert entry.options is not None
+    assert [option.value for option in entry.options] == ["kitchen", "living-room"]
+
+
+def _player(
+    player_id: str, display_name: str, player_type: PlayerType = PlayerType.PLAYER
+) -> mock.Mock:
+    """Return a minimal player for config-entry option generation."""
+    player = mock.Mock()
+    player.player_id = player_id
+    player.display_name = display_name
+    player.type = player_type
+    return player
 
 
 def create_report(


### PR DESCRIPTION
# What does this implement/fix?

Follow-up cleanup from #6035, which introduced `PLAYBACK_TARGET_TYPES` as the shared allowlist of player types that can actually render audio.

- The music quiz venue-player check now reuses the shared constant instead of its own hardcoded copy of the same player types.
- The scrobble-players picker now only lists playback-capable players, so capture-only, display and lighting clients no longer show up as scrobble candidates.

**Related issue (if applicable):**

- follow-up of #6035

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
