### PR TITLE
Keep a live source on its player when moving it to another one fails

### DIFF
--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -40,9 +40,11 @@ class AudioSourceSession:
 
     ``streamdetails`` and ``stream_session_id`` are independent of the session's
     own existence: a paused external source keeps the player while its stream is
-    torn down, so both fall back to None without the session ending. The
-    ``playback_session_id`` identifies the current selection through pauses and
-    stream reconnects, and is refreshed when the source is explicitly reselected.
+    torn down, so neither is cleared by a stream ending. Both are None until the
+    first stream request, which is what makes ``stream_session_id`` the record of
+    whether this selection was ever streamed. The ``playback_session_id``
+    identifies the current selection through pauses and stream reconnects, and is
+    refreshed when the source is explicitly reselected.
     """
 
     player_id: str
@@ -164,11 +166,12 @@ class AudioSourceMixin:
         """
         Register a stream request as the one serving a live source session.
 
-        The claim is the point of no return for a source moving between players:
-        whichever other player still held the source is evicted here, so a
-        takeover that never produces a stream request leaves it untouched on the
-        player that has it. Returns False when the session is no longer the live
-        one on its player, in which case the caller must not serve it.
+        Called once the owning plugin has accepted the stream request, which is
+        where a source moving between players commits: whichever other player
+        still held it is evicted here, so a takeover that never gets a stream
+        request leaves it untouched on the player that has it. Returns False when
+        the session is no longer the live one on its player, in which case the
+        caller must not serve it.
 
         :param session: The session the stream request resolved.
         :param playback_session_id: The playback session the request set out to serve.

--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -105,6 +105,7 @@ class AudioSourceMixin:
 
     Handles:
     - Tracking which external AudioSource is playing on which player
+    - Committing a source's move between players once its stream is claimed
     - Resolving that source (and its owning plugin) for command proxying
     - Receiving the live metadata the owning plugin pushes about the source
 
@@ -153,6 +154,45 @@ class AudioSourceMixin:
         if ProviderFeature.AUDIO_SOURCE not in provider.supported_features:
             return None
         return session.source, provider
+
+    def claim_audio_source_session(
+        self,
+        session: AudioSourceSession,
+        playback_session_id: str,
+        stream_session_id: str,
+    ) -> bool:
+        """
+        Register a stream request as the one serving a live source session.
+
+        The claim is the point of no return for a source moving between players:
+        whichever other player still held the source is evicted here, so a
+        takeover that never produces a stream request leaves it untouched on the
+        player that has it. Returns False when the session is no longer the live
+        one on its player, in which case the caller must not serve it.
+
+        :param session: The session the stream request resolved.
+        :param playback_session_id: The playback session the request set out to serve.
+        :param stream_session_id: Token identifying this stream request.
+        """
+        if (
+            self._source_sessions.get(session.player_id) is not session
+            or session.playback_session_id != playback_session_id
+        ):
+            return False
+        # a source plays on one player at a time, so it leaves whichever other player
+        # was holding it: two players both reporting it would let a command on the one
+        # that lost it drive the one that has it
+        for other_id, other in list(self._source_sessions.items()):
+            if (
+                other_id != session.player_id
+                and other.source_id == session.source_id
+                and other.provider_instance_id == session.provider_instance_id
+            ):
+                self.mass.streams.audio_processing.clear_source(other_id, other.playback_session_id)
+                del self._source_sessions[other_id]
+                self.trigger_player_update(other_id)
+        session.stream_session_id = stream_session_id
+        return True
 
     def update_source_metadata(
         self,
@@ -281,7 +321,10 @@ class AudioSourceMixin:
         and stream details it had. The source object itself is always taken from
         this call: a plugin rebuilds it whenever its capability flags change, and
         the session has to report the current ones. Selecting a different source
-        replaces the session: a player outputs one source at a time.
+        replaces the session: a player outputs one source at a time. A source
+        playing on another player stays there for now: that player is only
+        evicted when a stream request claims the new session, so a start that
+        never gets that far leaves the source where it was.
 
         :param player_id: The player the source plays on.
         :param source: The AudioSource that was selected.
@@ -304,18 +347,6 @@ class AudioSourceMixin:
             return session
         if session is not None:
             self.mass.streams.audio_processing.clear_source(player_id, session.playback_session_id)
-        # a source plays on one player at a time, so it leaves whichever other player
-        # was holding it: two players both reporting it would let a command on the one
-        # that lost it drive the one that has it
-        for other_id, other in list(self._source_sessions.items()):
-            if (
-                other_id != player_id
-                and other.source_id == source.item_id
-                and other.provider_instance_id == provider_instance_id
-            ):
-                self.mass.streams.audio_processing.clear_source(other_id, other.playback_session_id)
-                del self._source_sessions[other_id]
-                self.trigger_player_update(other_id)
         session = AudioSourceSession(
             player_id=player_id,
             source=source,

--- a/music_assistant/controllers/players/audio_sources.py
+++ b/music_assistant/controllers/players/audio_sources.py
@@ -168,10 +168,10 @@ class AudioSourceMixin:
 
         Called once the owning plugin has accepted the stream request, which is
         where a source moving between players commits: whichever other player
-        still held it is evicted here, so a takeover that never gets a stream
-        request leaves it untouched on the player that has it. Returns False when
-        the session is no longer the live one on its player, in which case the
-        caller must not serve it.
+        still held it is evicted on the selection's first stream request, so a
+        takeover that never gets one leaves it untouched on the player that has
+        it. Returns False when the session is no longer the live one on its
+        player, in which case the caller must not serve it.
 
         :param session: The session the stream request resolved.
         :param playback_session_id: The playback session the request set out to serve.
@@ -184,16 +184,22 @@ class AudioSourceMixin:
             return False
         # a source plays on one player at a time, so it leaves whichever other player
         # was holding it: two players both reporting it would let a command on the one
-        # that lost it drive the one that has it
-        for other_id, other in list(self._source_sessions.items()):
-            if (
-                other_id != session.player_id
-                and other.source_id == session.source_id
-                and other.provider_instance_id == session.provider_instance_id
-            ):
-                self.mass.streams.audio_processing.clear_source(other_id, other.playback_session_id)
-                del self._source_sessions[other_id]
-                self.trigger_player_update(other_id)
+        # that lost it drive the one that has it. Only the first request for this
+        # selection evicts: a reconnect on the player already streaming the source
+        # would otherwise take away a player it is being handed to, before that one
+        # has had its chance to start.
+        if session.stream_session_id is None:
+            for other_id, other in list(self._source_sessions.items()):
+                if (
+                    other_id != session.player_id
+                    and other.source_id == session.source_id
+                    and other.provider_instance_id == session.provider_instance_id
+                ):
+                    self.mass.streams.audio_processing.clear_source(
+                        other_id, other.playback_session_id
+                    )
+                    del self._source_sessions[other_id]
+                    self.trigger_player_update(other_id)
         session.stream_session_id = stream_session_id
         return True
 

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -152,6 +152,10 @@ POSITION_ANCHOR_KEYS = frozenset(
 # back some time later, short enough for a change made on the device itself to win again.
 VOLUME_TARGET_EXPIRY = 2.0
 
+# How long a freshly started source session may wait for its first stream request
+# before it is considered never started and released.
+AUDIO_SOURCE_CLAIM_TIMEOUT = 30
+
 # Sentinel used to detect omitted optional arguments where ``None`` is a valid value.
 _SENTINEL: Any = object()
 
@@ -4321,6 +4325,40 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                 exc_info=True,
             )
 
+    async def _release_unclaimed_audio_source(
+        self, player_id: str, session: AudioSourceSession, playback_session_id: str
+    ) -> None:
+        """
+        Release a source whose renderer never requested the stream.
+
+        The play command returned without error, so the late-start release in the
+        streams controller never fires: no stream request means no failed stream
+        request either. Without this the player would keep publishing a source
+        that never started, with its own queue held inactive behind it.
+
+        :param player_id: The player the source was started on.
+        :param session: The session that was started for it.
+        :param playback_session_id: Playback session active when it was started.
+        """
+        current = self.get_audio_source_session(player_id)
+        if (
+            current is not session
+            or current.playback_session_id != playback_session_id
+            or current.stream_session_id is not None
+        ):
+            return
+        self.logger.info(
+            "AudioSource %s was never streamed by player %s, releasing it",
+            session.source_id,
+            player_id,
+        )
+        await self.deselect_source(
+            player_id,
+            provider_instance_id=session.provider_instance_id,
+            source_id=session.source_id,
+            playback_session_id=playback_session_id,
+        )
+
     async def _resolve_audio_source_uri(
         self, source: str
     ) -> tuple[AudioSource, PluginProvider] | None:
@@ -4392,6 +4430,18 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
             if self.get_audio_source_session(player.player_id) is session:
                 await self._release_audio_source(player.player_id)
             raise
+        # the play command returning does not mean the renderer ever fetched the
+        # stream url: until a stream request claims the session nothing will evict
+        # the player the source may be moving from, and nothing else would ever
+        # clear a session that is never streamed
+        self.mass.call_later(
+            AUDIO_SOURCE_CLAIM_TIMEOUT,
+            self._release_unclaimed_audio_source,
+            player.player_id,
+            session,
+            session.playback_session_id,
+            task_id=f"release_unclaimed_audio_source_{player.player_id}",
+        )
 
     async def _handle_select_source(self, player_id: str, source: str | None) -> None:
         """

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1050,12 +1050,10 @@ class StreamsController(CoreController):
                     source_player_id,
                     stream_session_id,
                 )
-                if (
-                    self.mass.players.get_audio_source_session(source_player_id) is not session
-                    or session.playback_session_id != playback_session_id
+                if not self.mass.players.claim_audio_source_session(
+                    session, playback_session_id, stream_session_id
                 ):
                     raise web.HTTPNotFound(reason="AudioSource session was superseded")
-                session.stream_session_id = stream_session_id
             except RuntimeError as err:
                 # the plugin refuses this player (e.g. it just redirected playback
                 # elsewhere); a 404 makes the renderer drop the connection instead of
@@ -1890,12 +1888,10 @@ class StreamsController(CoreController):
             except RuntimeError as err:
                 # the plugin refuses this consumer, e.g. it just redirected playback
                 raise AudioError(str(err)) from err
-            if (
-                self.mass.players.get_audio_source_session(session.player_id) is not session
-                or session.playback_session_id != playback_session_id
+            if not self.mass.players.claim_audio_source_session(
+                session, playback_session_id, stream_session_id
             ):
                 raise AudioError("AudioSource session was superseded")
-            session.stream_session_id = stream_session_id
             if (streamdetails := session.streamdetails) is None:
                 streamdetails = await prov.get_stream_details(
                     session.source_id, MediaType.AUDIO_SOURCE

--- a/tests/controllers/players/test_audio_source_session.py
+++ b/tests/controllers/players/test_audio_source_session.py
@@ -380,6 +380,32 @@ def test_claiming_a_session_stamps_the_stream_token() -> None:
     assert session.stream_session_id == "tok-1"
 
 
+def test_a_reconnect_does_not_take_away_a_player_the_source_is_moving_to() -> None:
+    """
+    Only the first stream request for a selection evicts the other players.
+
+    A player already streaming the source reconnects through the same claim, and
+    it must not undo a handover whose target has not started streaming yet.
+    """
+    ctrl = _Controller(_plugin_provider())
+    source = _audio_source()
+    session_a = ctrl._start_audio_source_session("player-a", source, PROVIDER_INSTANCE)
+    ctrl.claim_audio_source_session(session_a, session_a.playback_session_id, "tok-a1")
+    session_b = ctrl._start_audio_source_session("player-b", source, PROVIDER_INSTANCE)
+
+    # player-a's renderer drops and re-opens the stream while the move is pending
+    assert ctrl.claim_audio_source_session(session_a, session_a.playback_session_id, "tok-a2")
+
+    assert ctrl.get_audio_source_session("player-b") is session_b
+    assert "player-b" not in ctrl.updated_players
+
+    # the handover still completes once player-b actually streams
+    assert ctrl.claim_audio_source_session(session_b, session_b.playback_session_id, "tok-b1")
+
+    assert ctrl.get_audio_source_session("player-a") is None
+    assert ctrl.updated_players == ["player-a"]
+
+
 def test_a_claimed_token_outlives_the_stream_that_stamped_it() -> None:
     """
     The stream token records that a selection was streamed, not that it still is.

--- a/tests/controllers/players/test_audio_source_session.py
+++ b/tests/controllers/players/test_audio_source_session.py
@@ -371,6 +371,59 @@ def test_a_fallback_only_source_follows_a_changed_placeholder() -> None:
     assert session.stream_metadata_reported is False
 
 
+def test_claiming_a_session_stamps_the_stream_token() -> None:
+    """A stream request claiming the live session becomes the one serving it."""
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+
+    assert ctrl.claim_audio_source_session(session, session.playback_session_id, "tok-1") is True
+    assert session.stream_session_id == "tok-1"
+
+
+def test_claiming_a_superseded_session_is_refused() -> None:
+    """A stream request set up for a session the player has left behind is turned away."""
+    ctrl = _Controller(_plugin_provider())
+    first = ctrl._start_audio_source_session(PLAYER_ID, _audio_source("first"), PROVIDER_INSTANCE)
+    second = ctrl._start_audio_source_session(PLAYER_ID, _audio_source("second"), PROVIDER_INSTANCE)
+
+    assert ctrl.claim_audio_source_session(first, first.playback_session_id, "tok-1") is False
+    assert first.stream_session_id is None
+    # the live session is not claimable with a stale playback token either
+    assert ctrl.claim_audio_source_session(second, "a-token-from-before", "tok-2") is False
+    assert second.stream_session_id is None
+
+
+def test_a_handover_evicts_the_old_player_only_on_claim() -> None:
+    """
+    A source moving between players leaves the old one only when the stream claims it.
+
+    Starting the new session is not the commit: a takeover that never produces a
+    stream request must leave the source untouched on the player that has it.
+    """
+    ctrl = _Controller(_plugin_provider())
+    source = _audio_source()
+    session_a = ctrl._start_audio_source_session("player-a", source, PROVIDER_INSTANCE)
+    session_b = ctrl._start_audio_source_session("player-b", source, PROVIDER_INSTANCE)
+
+    clear_source = cast("MagicMock", ctrl.mass.streams.audio_processing.clear_source)
+    assert ctrl.get_audio_source_session("player-a") is session_a
+    assert ctrl.get_audio_source_session("player-b") is session_b
+    assert "player-a" not in ctrl.updated_players
+    clear_source.assert_not_called()
+
+    assert ctrl.claim_audio_source_session(session_b, session_b.playback_session_id, "tok-1")
+
+    assert ctrl.get_audio_source_session("player-a") is None
+    assert ctrl.updated_players == ["player-a"]
+    clear_source.assert_called_once_with("player-a", session_a.playback_session_id)
+
+    # a renderer reconnect re-claims the same session without another eviction
+    assert ctrl.claim_audio_source_session(session_b, session_b.playback_session_id, "tok-2")
+
+    assert ctrl.updated_players == ["player-a"]
+    clear_source.assert_called_once()
+
+
 def test_a_reported_track_is_not_replaced_by_a_later_placeholder() -> None:
     """Once the source has reported, stream details stop overriding it."""
     ctrl = _Controller(_plugin_provider())

--- a/tests/controllers/players/test_audio_source_session.py
+++ b/tests/controllers/players/test_audio_source_session.py
@@ -380,6 +380,22 @@ def test_claiming_a_session_stamps_the_stream_token() -> None:
     assert session.stream_session_id == "tok-1"
 
 
+def test_a_claimed_token_outlives_the_stream_that_stamped_it() -> None:
+    """
+    The stream token records that a selection was streamed, not that it still is.
+
+    A paused source keeps the player while its stream is torn down, and what
+    separates it from one that was never streamed at all is this token.
+    """
+    ctrl = _Controller(_plugin_provider())
+    session = ctrl._start_audio_source_session(PLAYER_ID, _audio_source(), PROVIDER_INSTANCE)
+    ctrl.claim_audio_source_session(session, session.playback_session_id, "tok-1")
+
+    session.attach_streamdetails(_streamdetails(StreamMetadata(title="Take Five")))
+
+    assert session.stream_session_id == "tok-1"
+
+
 def test_claiming_a_superseded_session_is_refused() -> None:
     """A stream request set up for a session the player has left behind is turned away."""
     ctrl = _Controller(_plugin_provider())

--- a/tests/controllers/players/test_live_source_selection.py
+++ b/tests/controllers/players/test_live_source_selection.py
@@ -20,6 +20,7 @@ from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.controllers.players import PlayerController
 from music_assistant.controllers.players.constants import PlayerLockPurpose
+from music_assistant.controllers.players.controller import AUDIO_SOURCE_CLAIM_TIMEOUT
 from music_assistant.models.player import Player, PlayerMedia
 from music_assistant.models.plugin import PluginProvider
 
@@ -712,6 +713,121 @@ async def test_a_source_that_fails_to_start_is_not_left_on_the_player() -> None:
 
     assert controller.get_audio_source_session(PLAYER_ID) is None
     provider.on_source_released.assert_awaited_once_with("main", PLAYER_ID)
+
+
+async def test_a_failed_handover_leaves_the_source_on_the_old_player() -> None:
+    """
+    A move that never starts leaves the source where it was.
+
+    Evicting the displaced player before the new one has started would leave the
+    source on neither player when the start fails.
+    """
+    controller, provider, _player = _controller(_source())
+    old_session = controller._start_audio_source_session("player_2", _source(), PROVIDER_INSTANCE)
+    controller._handle_play_media = AsyncMock(side_effect=PlayerCommandFailed("no route"))
+
+    with pytest.raises(PlayerCommandFailed):
+        await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+
+    assert controller.get_audio_source_session("player_2") is old_session
+    assert controller.get_audio_source_session(PLAYER_ID) is None
+    # the rollback releases the new player only, which plugins ignore per contract:
+    # they still hold the old player
+    provider.on_source_released.assert_awaited_once_with("main", PLAYER_ID)
+
+
+async def test_a_successful_handover_evicts_the_old_player_on_the_stream_claim() -> None:
+    """
+    The displaced player keeps the source until a stream request claims the new session.
+
+    That claim is the plugin's commit to the new player (on_source_selected), so the
+    eviction is deliberately silent: no release reaches the plugin for it.
+    """
+    controller, provider, _player = _controller(_source())
+    old_session = controller._start_audio_source_session("player_2", _source(), PROVIDER_INSTANCE)
+
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+
+    new_session = controller.get_audio_source_session(PLAYER_ID)
+    assert new_session is not None
+    assert controller.get_audio_source_session("player_2") is old_session
+    provider.on_source_released.assert_not_awaited()
+
+    assert (
+        controller.claim_audio_source_session(new_session, new_session.playback_session_id, "tok-1")
+        is True
+    )
+
+    assert controller.get_audio_source_session("player_2") is None
+    assert controller.get_audio_source_session(PLAYER_ID) is new_session
+    provider.on_source_released.assert_not_awaited()
+
+
+async def test_starting_a_source_arms_the_never_claimed_release() -> None:
+    """A started source schedules the check that releases it if no stream ever claims it."""
+    controller, _provider, _player = _controller(_source())
+
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+
+    session = controller.get_audio_source_session(PLAYER_ID)
+    assert session is not None
+    controller.mass.call_later.assert_called_once_with(
+        AUDIO_SOURCE_CLAIM_TIMEOUT,
+        controller._release_unclaimed_audio_source,
+        PLAYER_ID,
+        session,
+        session.playback_session_id,
+        task_id=f"release_unclaimed_audio_source_{PLAYER_ID}",
+    )
+
+
+async def test_a_source_never_claimed_is_released_after_the_grace_period() -> None:
+    """A renderer that never fetched the stream does not hold the source forever."""
+    controller, provider, _player = _controller(_source())
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    session = controller.get_audio_source_session(PLAYER_ID)
+    assert session is not None
+
+    await controller._release_unclaimed_audio_source(
+        PLAYER_ID, session, session.playback_session_id
+    )
+
+    assert controller.get_audio_source_session(PLAYER_ID) is None
+    provider.on_source_released.assert_awaited_once_with("main", PLAYER_ID)
+    controller._handle_cmd_stop.assert_awaited_once()
+
+
+async def test_a_claimed_source_survives_the_grace_period_check() -> None:
+    """A source whose stream was claimed in time is left playing."""
+    controller, provider, _player = _controller(_source())
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    session = controller.get_audio_source_session(PLAYER_ID)
+    assert session is not None
+    # what a stream request claiming the session stamps
+    session.stream_session_id = "tok-1"
+
+    await controller._release_unclaimed_audio_source(
+        PLAYER_ID, session, session.playback_session_id
+    )
+
+    assert controller.get_audio_source_session(PLAYER_ID) is session
+    provider.on_source_released.assert_not_awaited()
+
+
+async def test_a_reselected_source_is_not_released_by_a_stale_grace_period_check() -> None:
+    """A check armed for an earlier selection cannot release a newer one."""
+    controller, provider, _player = _controller(_source())
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    session = controller.get_audio_source_session(PLAYER_ID)
+    assert session is not None
+    stale_playback_session_id = session.playback_session_id
+
+    # the re-select re-stamps the playback token, making the armed check stale
+    await controller._handle_select_source(PLAYER_ID, SOURCE_URI)
+    await controller._release_unclaimed_audio_source(PLAYER_ID, session, stale_playback_session_id)
+
+    assert controller.get_audio_source_session(PLAYER_ID) is session
+    provider.on_source_released.assert_not_awaited()
 
 
 async def test_an_announcement_does_not_take_the_source_off_the_player() -> None:

--- a/tests/controllers/streams/test_audio_source_route.py
+++ b/tests/controllers/streams/test_audio_source_route.py
@@ -310,11 +310,14 @@ async def test_a_session_already_superseded_is_not_released() -> None:
     """A newer session on the player is not this request's to take away."""
     session = _session()
     ctrl, provider, _player, store = _controller(session)
-    provider.on_source_selected = AsyncMock(side_effect=RuntimeError("nope"))
-    # the player moved on to a different session while this request was setting up
-    store._source_sessions[OWNER_ID] = _session()
 
-    with pytest.raises(web.HTTPNotFound):
+    async def supersede_session(*_args: Any) -> None:
+        # another selection landed on the player while this request was setting up
+        store._source_sessions[OWNER_ID] = _session()
+
+    provider.on_source_selected = AsyncMock(side_effect=supersede_session)
+
+    with pytest.raises(web.HTTPNotFound, match="superseded"):
         await ctrl.serve_audio_source_stream(_request(session_id=session.playback_session_id))
 
     ctrl.mass.players.deselect_source.assert_not_awaited()

--- a/tests/controllers/streams/test_audio_source_route.py
+++ b/tests/controllers/streams/test_audio_source_route.py
@@ -19,7 +19,7 @@ from music_assistant_models.enums import ContentType, MediaType
 from music_assistant_models.errors import AudioError
 from music_assistant_models.media_items import AudioFormat, AudioSource
 
-from music_assistant.controllers.players.audio_sources import AudioSourceSession
+from music_assistant.controllers.players.audio_sources import AudioSourceMixin, AudioSourceSession
 from music_assistant.controllers.streams import StreamsController
 from music_assistant.models.player import PlayerMedia
 from music_assistant.models.plugin import PluginProvider
@@ -39,7 +39,23 @@ def _session(player_id: str = OWNER_ID) -> AudioSourceSession:
     )
 
 
-def _controller(session: AudioSourceSession | None) -> tuple[Any, MagicMock, MagicMock]:
+class _SessionStore(AudioSourceMixin):
+    """Real session bookkeeping for the mocked player controller."""
+
+    def __init__(self) -> None:
+        self._source_sessions: dict[str, AudioSourceSession] = {}
+        self.mass = MagicMock()
+        self.logger = MagicMock()
+        self.updated_players: list[str] = []
+
+    def trigger_player_update(self, player_id: str) -> None:
+        """Record that a player update was signalled."""
+        self.updated_players.append(player_id)
+
+
+def _controller(
+    session: AudioSourceSession | None,
+) -> tuple[Any, MagicMock, MagicMock, _SessionStore]:
     """Build a bare streams controller whose player controller holds ``session``."""
     ctrl = StreamsController.__new__(StreamsController)
     ctrl.mass = MagicMock()
@@ -54,15 +70,17 @@ def _controller(session: AudioSourceSession | None) -> tuple[Any, MagicMock, Mag
     provider.delivers_crossfaded_audio.return_value = True
     provider.delivers_normalized_audio.return_value = False
     ctrl.mass.get_provider = MagicMock(return_value=provider)
-    ctrl.mass.players.get_audio_source_session = MagicMock(
-        return_value=session, side_effect=lambda pid: session if pid == OWNER_ID else None
-    )
+    store = _SessionStore()
+    if session is not None:
+        store._source_sessions[session.player_id] = session
+    ctrl.mass.players.get_audio_source_session = store.get_audio_source_session
+    ctrl.mass.players.claim_audio_source_session = store.claim_audio_source_session
     player = MagicMock()
     player.player_id = CONSUMER_ID
     ctrl.mass.players.get_player = MagicMock(return_value=player)
     ctrl.mass.players.deselect_source = AsyncMock()
     ctrl.audio_processing = MagicMock()
-    return ctrl, provider, player
+    return ctrl, provider, player, store
 
 
 def _request(*, session_id: str, source_player_id: str = OWNER_ID) -> Any:
@@ -84,7 +102,7 @@ def _request(*, session_id: str, source_player_id: str = OWNER_ID) -> Any:
 def test_the_url_resolves_to_the_session_it_names() -> None:
     """A url carrying the live session's own token resolves to it."""
     session = _session()
-    ctrl, provider, player = _controller(session)
+    ctrl, provider, player, _store = _controller(session)
 
     resolved, resolved_player, resolved_prov = ctrl._resolve_audio_source_request(
         _request(session_id=session.playback_session_id)
@@ -102,7 +120,7 @@ def test_a_url_from_a_superseded_session_is_turned_away() -> None:
     The token is what separates the session the url was built for from whatever the
     player happens to be playing now.
     """
-    ctrl, _provider, _player = _controller(_session())
+    ctrl, _provider, _player, _store = _controller(_session())
 
     with pytest.raises(web.HTTPNotFound):
         ctrl._resolve_audio_source_request(_request(session_id="a-token-from-before"))
@@ -110,7 +128,7 @@ def test_a_url_from_a_superseded_session_is_turned_away() -> None:
 
 def test_a_url_for_a_player_playing_nothing_is_turned_away() -> None:
     """Without a session there is nothing to serve."""
-    ctrl, _provider, _player = _controller(None)
+    ctrl, _provider, _player, _store = _controller(None)
 
     with pytest.raises(web.HTTPNotFound):
         ctrl._resolve_audio_source_request(_request(session_id="anything"))
@@ -119,7 +137,7 @@ def test_a_url_for_a_player_playing_nothing_is_turned_away() -> None:
 def test_an_unknown_consuming_player_is_turned_away() -> None:
     """The url also names who is consuming, which has to exist."""
     session = _session()
-    ctrl, _provider, _player = _controller(session)
+    ctrl, _provider, _player, _store = _controller(session)
     ctrl.mass.players.get_player = MagicMock(return_value=None)
 
     with pytest.raises(web.HTTPNotFound):
@@ -134,7 +152,7 @@ async def test_a_head_probe_does_not_trigger_the_plugin() -> None:
     switch — none of which a probe should cause.
     """
     session = _session()
-    ctrl, provider, _player = _controller(session)
+    ctrl, provider, _player, _store = _controller(session)
     ctrl._serve_audio_source_head = AsyncMock(return_value="head-response")
     request = _request(session_id=session.playback_session_id)
     request.method = "HEAD"
@@ -150,7 +168,7 @@ async def test_http_output_is_registered_to_the_source_session(
 ) -> None:
     """The HTTP output plan is owned by the live source playback session."""
     session = _session()
-    ctrl, provider, player = _controller(session)
+    ctrl, provider, player, _store = _controller(session)
     ctrl.audio = MagicMock()
     pcm_format = AudioFormat(
         content_type=ContentType.PCM_S24LE,
@@ -206,7 +224,7 @@ def test_a_direct_pcm_request_from_a_superseded_session_is_refused() -> None:
     stale request would silently attach to whichever source is playing now.
     """
     session = _session()
-    ctrl, _provider, _player = _controller(session)
+    ctrl, _provider, _player, _store = _controller(session)
 
     with pytest.raises(AudioError, match="Unknown"):
         ctrl.get_stream(
@@ -224,7 +242,7 @@ def test_a_direct_pcm_request_from_a_superseded_session_is_refused() -> None:
 async def test_a_direct_pcm_request_carrying_the_live_token_is_served() -> None:
     """A consumer naming the session that is playing gets its stream."""
     session = _session()
-    ctrl, _provider, _player = _controller(session)
+    ctrl, _provider, _player, _store = _controller(session)
 
     async def _session_stream() -> AsyncGenerator[bytes]:
         yield b"pcm-stream"
@@ -257,7 +275,7 @@ async def test_a_plugin_refusing_the_stream_takes_the_source_off_the_player() ->
     (Ynison raises from the hook when it redirects to its configured target).
     """
     session = _session()
-    ctrl, provider, _player = _controller(session)
+    ctrl, provider, _player, _store = _controller(session)
     provider.on_source_selected = AsyncMock(side_effect=RuntimeError("switching disabled"))
 
     with pytest.raises(web.HTTPNotFound):
@@ -274,7 +292,7 @@ async def test_a_plugin_refusing_the_stream_takes_the_source_off_the_player() ->
 async def test_failing_stream_details_also_takes_the_source_off_the_player() -> None:
     """The same holds when the plugin claims the source but cannot describe its stream."""
     session = _session()
-    ctrl, provider, _player = _controller(session)
+    ctrl, provider, _player, _store = _controller(session)
     provider.get_stream_details = AsyncMock(side_effect=OSError("daemon gone"))
 
     with pytest.raises(web.HTTPNotFound):
@@ -291,10 +309,10 @@ async def test_failing_stream_details_also_takes_the_source_off_the_player() -> 
 async def test_a_session_already_superseded_is_not_released() -> None:
     """A newer session on the player is not this request's to take away."""
     session = _session()
-    ctrl, provider, _player = _controller(session)
+    ctrl, provider, _player, store = _controller(session)
     provider.on_source_selected = AsyncMock(side_effect=RuntimeError("nope"))
     # the player moved on to a different session while this request was setting up
-    ctrl.mass.players.get_audio_source_session = MagicMock(return_value=_session())
+    store._source_sessions[OWNER_ID] = _session()
 
     with pytest.raises(web.HTTPNotFound):
         await ctrl.serve_audio_source_stream(_request(session_id=session.playback_session_id))
@@ -305,7 +323,7 @@ async def test_a_session_already_superseded_is_not_released() -> None:
 async def test_a_reselected_session_is_not_released_after_setup_failure() -> None:
     """A failed request cannot release a newer selection using the same session object."""
     session = _session()
-    ctrl, provider, _player = _controller(session)
+    ctrl, provider, _player, _store = _controller(session)
 
     async def supersede_session(*_args: Any) -> None:
         session.playback_session_id = "replacement-session"
@@ -322,7 +340,7 @@ async def test_a_reselected_session_is_not_released_after_setup_failure() -> Non
 async def test_http_setup_stops_when_the_session_is_reselected() -> None:
     """HTTP setup cannot stamp its stream token onto a newer source selection."""
     session = _session()
-    ctrl, provider, _player = _controller(session)
+    ctrl, provider, _player, _store = _controller(session)
     request_session_id = session.playback_session_id
 
     async def supersede_session(*_args: Any) -> None:
@@ -341,7 +359,7 @@ async def test_http_setup_stops_when_the_session_is_reselected() -> None:
 async def test_direct_pcm_setup_stops_when_the_session_is_reselected() -> None:
     """PCM setup cannot stamp its stream token onto a newer source selection."""
     session = _session()
-    ctrl, provider, _player = _controller(session)
+    ctrl, provider, _player, _store = _controller(session)
 
     async def supersede_session(*_args: Any) -> None:
         session.playback_session_id = "replacement-session"
@@ -359,7 +377,7 @@ async def test_direct_pcm_stream_stops_when_the_session_is_reselected() -> None:
     """A running PCM stream ends before yielding audio for a newer selection."""
     session = _session()
     session.streamdetails = MagicMock()
-    ctrl, provider, _player = _controller(session)
+    ctrl, provider, _player, _store = _controller(session)
     ctrl.audio = MagicMock()
 
     async def chunks() -> AsyncGenerator[bytes]:
@@ -378,6 +396,33 @@ async def test_direct_pcm_stream_stops_when_the_session_is_reselected() -> None:
         volume_normalization_enabled=provider.delivers_normalized_audio.return_value,
     )
     session.playback_session_id = "replacement-session"
+
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+
+
+async def test_the_pcm_claim_evicts_the_other_player() -> None:
+    """
+    The PCM path's claim is where a source moving between players commits.
+
+    Once the new player's stream is claimed, the player the source came from
+    stops publishing it.
+    """
+    session = _session()
+    session.streamdetails = MagicMock()
+    ctrl, _provider, _player, store = _controller(session)
+    store._source_sessions["old_player"] = _session("old_player")
+    ctrl.audio = MagicMock()
+
+    async def chunks() -> AsyncGenerator[bytes]:
+        yield b"first"
+
+    ctrl.audio.get_audio_source_stream = MagicMock(return_value=chunks())
+    stream = ctrl._get_audio_source_session_stream(session, AudioFormat(), CONSUMER_ID)
+
+    assert await anext(stream) == b"first"
+    assert store.get_audio_source_session("old_player") is None
+    assert store.updated_players == ["old_player"]
 
     with pytest.raises(StopAsyncIteration):
         await anext(stream)


### PR DESCRIPTION
# What does this implement/fix?

Moving a live external source (Spotify Connect, AirPlay Receiver, VBAN, ...) from one player to another took it off the old player before the new player had actually started playing it. If the new player then failed to start, the source ended up on neither player and had to be picked again by hand.

The handover is now only completed once the new player's stream is actually requested — the moment the plugin has committed to the new player. Until then the source simply stays where it was. A source that is started but never streamed (renderer never fetches the url) is now cleaned up as well, instead of leaving the player stuck showing a source that never played.

**Related issue (if applicable):**

- follow-up on #5914

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- The old player keeps the source until the new player's stream request claims it
- Both stream paths (http url and direct PCM) go through the same claim
- A source that is never streamed within 30 seconds is released, so the player goes back to its own queue
- Tests for a failed handover, a successful one, and the never-streamed case

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
