### PR TITLE
Prevent accidental stable auto-release while a release candidate is pending

### DIFF
--- a/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
+++ b/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
@@ -21,7 +21,9 @@ frontend-version extraction even if the branch advances during the run.
 Automatic versions come from Git tags, not release records. The workflow validates the
 previous channel tag's relationship to `source_sha` and counts its Git commit range.
 Deleted release records therefore cannot make a tag/version reusable. Stable automatic
-releases continue to increment the patch component only. Nightlies require at least two
+releases continue to increment the patch component only. A stable auto-release fails
+early while an RC newer than the latest stable tag exists; dispatch the next stable
+release manually via the Create Release workflow instead. Nightlies require at least two
 commits after the previous nightly tag.
 
 ## Publishing sequence

--- a/scripts/release_workflow.py
+++ b/scripts/release_workflow.py
@@ -187,6 +187,15 @@ def determine_auto_release(
     latest_nightly = _first(nightly_tags)
 
     if channel == "stable":
+        # during an RC window the stable branch already carries next-minor content
+        if latest_rc is not None and (
+            latest_stable is None or compare_release_versions(latest_rc, latest_stable) == "newer"
+        ):
+            msg = (
+                f"An RC newer than the latest stable release exists ({latest_rc}); "
+                "create the next stable release manually via the Create Release workflow"
+            )
+            raise ReleaseWorkflowError(msg)
         previous_tag = latest_stable
         commits_since = repository.commits_since(previous_tag, source_sha, allow_diverged=True)
         version = _next_stable(latest_stable)

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -154,6 +154,51 @@ def test_stable_preserves_patch_versioning_across_diverged_branches(
     assert decision.should_release is True
 
 
+def test_stable_auto_release_fails_when_unreleased_rc_exists(
+    repository: tuple[Path, GitRepository],
+) -> None:
+    """An RC ahead of the latest stable tag blocks the automatic patch release."""
+    path, git_repository = repository
+    _git(path, "tag", "2.9.9")
+    _commit(path, "rc work")
+    _git(path, "tag", "2.10.0rc2")
+
+    with pytest.raises(ReleaseWorkflowError, match="Create Release"):
+        determine_auto_release(git_repository, "stable", "HEAD")
+
+
+def test_stable_auto_release_continues_after_rc_base_released(
+    repository: tuple[Path, GitRepository],
+) -> None:
+    """Patch releases resume once the RC's base version has shipped as stable."""
+    path, git_repository = repository
+    _git(path, "tag", "2.10.0rc2")
+    _commit(path, "release work")
+    _git(path, "tag", "2.10.0")
+    _commit(path, "patch work")
+
+    decision = determine_auto_release(git_repository, "stable", "HEAD")
+
+    assert decision.version == "2.10.1"
+    assert decision.previous_tag == "2.10.0"
+
+
+def test_rc_auto_release_ignores_the_stable_only_guard(
+    repository: tuple[Path, GitRepository],
+) -> None:
+    """The RC-window guard only blocks the stable channel, not the RC channel itself."""
+    path, git_repository = repository
+    _git(path, "tag", "2.9.9")
+    _commit(path, "beta work")
+    _git(path, "tag", "2.10.0b1")
+    _commit(path, "rc work")
+    _git(path, "tag", "2.10.0rc1")
+
+    decision = determine_auto_release(git_repository, "rc", "HEAD")
+
+    assert decision.version == "2.10.0rc2"
+
+
 def test_current_release_combines_beta_and_rc_channels(
     repository: tuple[Path, GitRepository],
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

While preparing the 2.10.0 release we accidentally started the Auto Release pipeline on the stable channel, which would have published a wrong 2.9.x build from the RC content on the stable branch. This adds an early guard: a stable auto-release now fails immediately when an RC newer than the latest stable release exists, with an error pointing to the Create Release workflow for the manual minor release.

- Fail the stable auto-version calculation when an unreleased RC exists (e.g. latest stable is 2.9.13 and 2.10.0rc2 is tagged)
- Patch releases resume automatically once the RC's version has shipped as stable
- Tests for both cases, plus a note in the release workflow guide

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
