### PR TITLE
Keep translation syncs and backport PRs out of the release notes

### DIFF
--- a/.github/actions/generate-release-notes/generate_notes.py
+++ b/.github/actions/generate-release-notes/generate_notes.py
@@ -216,12 +216,16 @@ def categorize_prs(prs, config) -> tuple[dict[str, list[Any]], list[Any]]:
     include_labels = config.get("include-labels")
     if include_labels:
         include_labels = set(include_labels)
+    exclude_title_prefixes = tuple(config.get("exclude-title-prefixes", []))
 
     for pr in prs:
         # Check if PR should be excluded
         pr_labels = {label.name for label in pr.labels}
 
         if exclude_labels and pr_labels & exclude_labels:
+            continue
+
+        if exclude_title_prefixes and pr.title.startswith(exclude_title_prefixes):
             continue
 
         if include_labels and not (pr_labels & include_labels):
@@ -312,6 +316,9 @@ def extract_frontend_changes(prs) -> tuple[list[str], set[str]]:
                     continue
                 # Skip "No changes" entries
                 if re.match(r"^[•\-\*]\s*No changes\s*$", stripped_line, re.IGNORECASE):
+                    continue
+                # Skip translation-sync noise
+                if re.match(r"^[•\-\*]\s*Lokalise", stripped_line, re.IGNORECASE):
                     continue
 
                 # Add the change

--- a/.github/release-notes-config.yml
+++ b/.github/release-notes-config.yml
@@ -17,6 +17,11 @@ exclude-contributors:
   - github-actions[bot]
   - musicassistant-bot[bot]
 
+# PRs whose title starts with one of these never appear in the release notes
+exclude-title-prefixes:
+  - 'Lokalise'
+  - '[Backport to stable]'
+
 categories:
 
   - title: "⚠ Breaking Changes"

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -77,6 +77,7 @@ class FakePR:
         title: str = "",
         author: str = "someone",
         labels: tuple[str, ...] = (),
+        body: str = "",
     ) -> None:
         """Initialize fake pull request."""
         self.number = number
@@ -85,6 +86,7 @@ class FakePR:
         self.title = title
         self.user = types.SimpleNamespace(login=author)
         self.labels = [types.SimpleNamespace(name=label) for label in labels]
+        self.body = body
         self.html_url = f"https://github.com/music-assistant/server/pull/{number}"
 
 
@@ -310,3 +312,49 @@ def test_notes_are_shrunk_to_fit_body_limit(
         assert f"#{number})" in notes
     assert 0 < len(maintenance) < 40
     assert "compare/2.9.13...2.10.0" in notes
+
+
+def test_categorize_prs_excludes_title_prefixes(generate_notes: types.ModuleType) -> None:
+    """PRs matching an excluded title prefix never appear in the notes."""
+    merged_at = datetime(2026, 6, 1, tzinfo=UTC)
+    config = {
+        "categories": [{"title": "🐛 Bugfixes", "labels": ["bugfix"]}],
+        "exclude-title-prefixes": ["Lokalise", "[Backport to stable]"],
+    }
+    prs = [
+        FakePR(1, merged_at, "Fix a bug", labels=("bugfix",)),
+        FakePR(2, merged_at, "Lokalise translations update"),
+        FakePR(3, merged_at, "Lokalise: Translations update"),
+        FakePR(4, merged_at, "[Backport to stable] 2.9.4"),
+        FakePR(5, merged_at, "Add a feature"),
+    ]
+
+    categories, uncategorized = generate_notes.categorize_prs(prs, config)
+
+    assert [pr.number for pr in categories["🐛 Bugfixes"]] == [1]
+    assert [pr.number for pr in uncategorized] == [5]
+
+
+def test_extract_frontend_changes_skips_lokalise_bullets(
+    generate_notes: types.ModuleType,
+) -> None:
+    """Lokalise translation-sync bullets in frontend PR bodies are skipped."""
+    merged_at = datetime(2026, 6, 1, tzinfo=UTC)
+    prs = [
+        FakePR(
+            1,
+            merged_at,
+            "⬆️ Update music-assistant-frontend to 2.17.294",
+            body=(
+                "## What's changed\n"
+                "- Fix the player card layout (by @someone in #100)\n"
+                "- Lokalise translations update (by @github-actions[bot] in #101)\n"
+                "- Lokalise: Translations update (by @marcelveldt in #102)\n"
+            ),
+        ),
+    ]
+
+    changes, contributors = generate_notes.extract_frontend_changes(prs)
+
+    assert changes == ["- Fix the player card layout (by @someone in #100)"]
+    assert contributors == {"someone"}


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #6041: the 2.10.0 release notes still contained noise entries — "Lokalise translations update" PRs (both as server PRs and as bullets inlined from the frontend changelogs) and "[Backport to stable] X.Y.Z" batch PRs picked up through commit references. Neither tells a user anything; patch releases already list the original PRs, not the backport wrapper.

- New `exclude-title-prefixes` option in `release-notes-config.yml` (set to `Lokalise` and `[Backport to stable]`) — matching PRs never appear in the notes
- Lokalise bullets from frontend PR bodies are skipped in the frontend changes section

**Related issue (if applicable):**

- follow-up on #6041 / https://github.com/music-assistant/server/releases/tag/2.10.0

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
