### PR TITLE
Keep the AirPlay connection alive when seeking

### DIFF
--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -90,12 +90,24 @@ class AsyncProcess:
         self._stdout_lock = asyncio.Lock()
         self._stdin_lock = asyncio.Lock()
         self._close_called = False
+        self._stdin_eof = False
         self._returncode: int | None = None
 
     @property
     def closed(self) -> bool:
         """Return if the process was closed."""
         return self._close_called or self.returncode is not None
+
+    @property
+    def stdin_closed(self) -> bool:
+        """
+        Return if stdin can no longer be written to.
+
+        True once end of file was written: that closes the pipe for good while the
+        process itself lives on, so a caller that means to keep feeding it has to
+        read this rather than :attr:`closed`.
+        """
+        return self._stdin_eof or self.closed
 
     @property
     def returncode(self) -> int | None:
@@ -190,6 +202,10 @@ class AsyncProcess:
         if self.proc.stdin is None:
             return
         async with self._stdin_lock:
+            # checked under the lock: a write that waited here while end of file
+            # was written has missed its pipe, which the transport closed behind it
+            if self._stdin_eof:
+                return
             self.proc.stdin.write(data)
             await self.proc.stdin.drain()
 
@@ -214,7 +230,7 @@ class AsyncProcess:
 
         :param timeout: Seconds to wait for the buffer to empty.
         """
-        if self._close_called or self.proc is None or self.proc.stdin is None:
+        if self._close_called or self._stdin_eof or self.proc is None or self.proc.stdin is None:
             yield True
             return
         async with self._stdin_lock:
@@ -222,14 +238,18 @@ class AsyncProcess:
 
     async def write_eof(self) -> None:
         """Write end of file to to process stdin."""
-        if self._close_called or self.proc is None:
+        if self._close_called or self._stdin_eof or self.proc is None:
             return
         if self.proc.stdin is None:
             return
         async with self._stdin_lock:
+            if not self.proc.stdin.can_write_eof():
+                return
+            # whatever the write below does, stdin is spent: the transport closes
+            # the pipe on eof, and every error it raises is a pipe already gone
+            self._stdin_eof = True
             try:
-                if self.proc.stdin.can_write_eof():
-                    self.proc.stdin.write_eof()
+                self.proc.stdin.write_eof()
                 await self.proc.stdin.drain()
             except (
                 AttributeError,

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -278,6 +278,17 @@ class AirPlayStream:
         )
 
     @property
+    def accepts_audio(self) -> bool:
+        """
+        Return boolean if this stream can still be fed audio.
+
+        The binary treats a closed stdin as the end of the stream and there is no
+        reopening it, so a stream that has been sent its audio EOF stays running
+        (playing out what it holds) while no longer taking anything new.
+        """
+        return self.running and self._cli_proc is not None and not self._cli_proc.stdin_closed
+
+    @property
     def connected(self) -> bool:
         """Return boolean if the device connection has been established."""
         return self._connected.is_set()

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -235,8 +235,8 @@ class AirPlayStreamSession:
         Return whether this live session can absorb a new play_media warm.
 
         A warm replacement needs the same member set, the same session PCM
-        format and a connected stream on every member; anything else takes the
-        cold path.
+        format and a connected stream still taking audio on every member;
+        anything else takes the cold path.
         """
         if {p.player_id for p in sync_clients} != {p.player_id for p in self.sync_clients}:
             return False
@@ -245,7 +245,7 @@ class AirPlayStreamSession:
         if pcm_format != self.pcm_format:
             return False
         return all(
-            p.stream is not None and p.stream.running and p.stream.connected
+            p.stream is not None and p.stream.accepts_audio and p.stream.connected
             for p in self.sync_clients
         )
 
@@ -313,12 +313,12 @@ class AirPlayStreamSession:
 
         The next play_media (resume or seek) replaces the media warm over the
         live connections — the same coordinated flush-refill as seek/next.
-        Returns False when any member lacks a running, connected stream or its
-        standby command cannot be delivered so the caller can fall back to a
-        full stop.
+        Returns False when any member lacks a connected stream that still takes
+        audio, or its standby command cannot be delivered, so the caller can fall
+        back to a full stop.
         """
         if not all(
-            p.stream is not None and p.stream.running and p.stream.connected
+            p.stream is not None and p.stream.accepts_audio and p.stream.connected
             for p in self.sync_clients
         ):
             return False
@@ -890,10 +890,18 @@ class AirPlayStreamSession:
                 self.prov.logger.warning(
                     "Stream ended prematurely due to error - notifying players"
                 )
+        # A source that ends is not the same thing as a stream that is over: a
+        # seek or a next-track ends this one while the queue is already loading
+        # the stream that takes over. Closing the binary's stdin there would end
+        # the stream for good - it cannot be reopened - and cost that replacement
+        # a full cold restart. Everywhere else the EOF is what ends playback: the
+        # binary plays out, reports eof and exits, and only that makes the player
+        # report idle, which a queue waiting to restart its flow depends on.
+        end_of_stream = not self._replacement_expected()
         async with self._lock:
             await asyncio.gather(
                 *[
-                    self._write_eof_to_player(x)
+                    self._retire_player_ffmpeg(x, end_of_stream=end_of_stream)
                     for x in self.sync_clients
                     if x.stream and x.stream.running
                 ],
@@ -976,13 +984,51 @@ class AirPlayStreamSession:
                 return
             await asyncio.wait_for(ffmpeg.write(chunk), timeout=35.0)
 
-    async def _write_eof_to_player(self, airplay_player: AirPlayPlayer) -> None:
-        """Write EOF to a specific player."""
-        if ffmpeg := self._player_ffmpeg.pop(airplay_player.player_id, None):
-            await ffmpeg.write_eof()
-            await ffmpeg.wait_with_timeout(30)
-            if airplay_player.stream:
-                await airplay_player.stream.write_audio_eof()
+    def _replacement_expected(self) -> bool:
+        """
+        Return whether the queue is loading a stream that takes this session over.
+
+        A seek or a next-track starts the new stream while the old one is still
+        playing: the queue rotates its stream session at the beginning of that,
+        well before the play_media carrying it arrives, and the flow stream it
+        supersedes ends as soon as it notices. A flow that ends on its own -
+        the queue played out, the source failed, or it broke off to be restarted
+        once the player reports idle - leaves the queue between transitions.
+        """
+        queue_id = self.media.source_id
+        session_id = get_media_session_id(self.media)
+        if not queue_id or not session_id:
+            return False
+        queue_data = self.mass.player_queues.queue_data_or_none(queue_id)
+        return (
+            queue_data is not None
+            and queue_data.transitioning
+            and queue_data.session_id != session_id
+        )
+
+    async def _retire_player_ffmpeg(
+        self, airplay_player: AirPlayPlayer, *, end_of_stream: bool
+    ) -> None:
+        """
+        Retire a member's ffmpeg now that the source feeding it has ended.
+
+        :param airplay_player: The member whose ffmpeg is retired.
+        :param end_of_stream: Whether this ends the stream for good. The audio the
+            ffmpeg still holds is then handed over and the binary's stdin closed
+            behind it, which makes it play out, report eof and exit. A session a
+            replacement is coming for drops that audio instead: the flush the
+            replacement opens with discards it anyway, and no byte may reach the
+            binary between the old ffmpeg dying and that flush.
+        """
+        if not (ffmpeg := self._player_ffmpeg.pop(airplay_player.player_id, None)):
+            return
+        if not end_of_stream:
+            await ffmpeg.kill()
+            return
+        await ffmpeg.write_eof()
+        await ffmpeg.wait_with_timeout(30)
+        if airplay_player.stream:
+            await airplay_player.stream.write_audio_eof()
 
     async def _member_start_step(
         self, airplay_player: AirPlayPlayer, step: str, awaitable: Coroutine[Any, Any, None]

--- a/tests/helpers/test_process.py
+++ b/tests/helpers/test_process.py
@@ -190,6 +190,30 @@ async def test_iter_stdout_drains_lines_buffered_after_exit() -> None:
 
 
 @pytest.mark.asyncio
+async def test_write_eof_marks_stdin_closed_while_the_process_lives() -> None:
+    """
+    A process that was sent EOF keeps running but can no longer be fed.
+
+    Writing EOF closes the pipe for good, so a caller that hands the write end to
+    someone else (or means to keep feeding it) has to be able to tell.
+    """
+    proc = AsyncProcess(["cat"], stdin=True, stdout=True)
+    await proc.start()
+    await proc.write(b"hello\n")
+
+    await proc.write_eof()
+
+    assert proc.stdin_closed
+    assert not proc.closed
+    assert proc.returncode is None
+    # neither a further write nor a second EOF may reach the closed pipe
+    await proc.write(b"more\n")
+    await proc.write_eof()
+    assert await proc.read_stdout() == b"hello\n"
+    await proc.close()
+
+
+@pytest.mark.asyncio
 async def test_read_stdout_stops_once_the_process_is_closed() -> None:
     """A closed process reports EOF instead of waiting on a stream it no longer owns."""
     proc = AsyncProcess(["sh", "-c", "sleep 30"], stdout=True, stderr=asyncio.subprocess.STDOUT)

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -18,6 +18,7 @@ from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.helpers.named_pipe import WRITE_POLL_INTERVAL_MS, AsyncNamedPipeWriter
+from music_assistant.helpers.process import AsyncProcess
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_ARTWORK_SIZE,
     AIRPLAY_JOIN_START_ACK_TIMEOUT_MS,
@@ -3860,3 +3861,28 @@ async def test_password_preflight_skipped_for_raop() -> None:
     player.get_setup_value = MagicMock(return_value=None)
 
     AirPlayStream(player)._check_password_preflight()
+
+
+@pytest.mark.asyncio
+async def test_accepts_audio_ends_with_the_audio_eof() -> None:
+    """
+    A stream that was sent its audio EOF keeps running but takes no more audio.
+
+    The EOF closes the binary's stdin for good while the process itself plays out
+    and exits, so a warm refill has to read this rather than the process state.
+    """
+    player = _make_player()
+    stream = AirPlayStream(player)
+    cli_proc = AsyncProcess(["cat"], stdin=True, stdout=True)
+    await cli_proc.start()
+    stream._cli_proc = cli_proc
+    try:
+        assert stream.running
+        assert stream.accepts_audio
+
+        await stream.write_audio_eof()
+
+        assert stream.running
+        assert not stream.accepts_audio
+    finally:
+        await cli_proc.close()

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -44,6 +44,8 @@ def _stream_defaults(stream: MagicMock) -> MagicMock:
     directly.
     """
     stream.start = AsyncMock(side_effect=_ack_commanded_instant)
+    # on the real stream this follows `running` until the audio EOF is written
+    stream.accepts_audio = bool(stream.running)
     stream.wait_clock_ready = AsyncMock(return_value=(ClockReadiness.UNREPORTED, 0))
     stream.warm_lead_ms = 0
     stream.flushed_head_unix_ms = 0
@@ -923,7 +925,68 @@ async def test_start_player_ffmpeg_wires_persistent_cli_stdin() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("stream_state", ["missing", "stopped", "disconnected"])
+@pytest.mark.parametrize(
+    ("transitioning", "live_session_id", "ends_stream"),
+    [
+        # a seek/next: the queue rotates its session while it loads the new stream
+        (True, "session-2", False),
+        # the queue played out, or the flow broke off for the queue to restart once
+        # the player reports idle - which only the audio EOF can bring about
+        (False, "session-1", True),
+        # not this session's transition (the queue is starting the one we play)
+        (True, "session-1", True),
+        # a transition that already finished cannot be waiting on this session
+        (False, "session-2", True),
+    ],
+)
+async def test_source_end_only_keeps_stdin_open_for_a_pending_replacement(
+    transitioning: bool, live_session_id: str, ends_stream: bool
+) -> None:
+    """
+    The binary's stdin is closed unless the queue is mid-handover to a new stream.
+
+    Closing it ends the stream for good - it cannot be reopened - so a seek would
+    be left with a cold restart as its only option. Everywhere else the EOF is
+    what makes the binary end and the player report idle.
+    """
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.stream.write_audio_eof = AsyncMock()
+    session.media = MagicMock(source_id="queue-1", queue_session_id="session-1")
+    queues: Any = session.mass.player_queues
+    queues.queue_data_or_none = MagicMock(
+        return_value=MagicMock(session_id=live_session_id, transitioning=transitioning)
+    )
+    ffmpeg = MagicMock(closed=False)
+    ffmpeg.write_eof = AsyncMock()
+    ffmpeg.wait_with_timeout = AsyncMock()
+    ffmpeg.kill = AsyncMock()
+    session._player_ffmpeg[player.player_id] = ffmpeg
+
+    no_chunks: list[bytes] = []
+
+    async def exhausted_source() -> AsyncGenerator[bytes]:
+        for chunk in no_chunks:
+            yield chunk
+
+    await session._audio_streamer(exhausted_source())
+
+    assert player.player_id not in session._player_ffmpeg
+    assert player.stream.write_audio_eof.await_count == (1 if ends_stream else 0)
+    if ends_stream:
+        # the audio ffmpeg still holds is handed over before the binary is told
+        ffmpeg.write_eof.assert_awaited_once()
+        ffmpeg.wait_with_timeout.assert_awaited_once()
+        ffmpeg.kill.assert_not_awaited()
+    else:
+        # the replacement flushes that audio away, and nothing may reach the
+        # binary between the old ffmpeg dying and that flush
+        ffmpeg.kill.assert_awaited_once()
+        ffmpeg.write_eof.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream_state", ["missing", "stopped", "disconnected", "audio_ended"])
 async def test_standby_requires_every_member_running_and_connected(stream_state: str) -> None:
     """Standby is unavailable when any member lacks a reusable connected session."""
     session = _make_session(0, 0)
@@ -935,6 +998,9 @@ async def test_standby_requires_every_member_running_and_connected(stream_state:
     if stream_state != "missing":
         unavailable_player.stream = MagicMock(
             running=stream_state != "stopped",
+            # a stream that was sent its audio EOF is still running, but its
+            # stdin is closed for good so it can never be refilled
+            accepts_audio=stream_state not in ("stopped", "audio_ended"),
             connected=stream_state != "disconnected",
         )
         unavailable_player.stream.send_cli_command = AsyncMock()


### PR DESCRIPTION
# What does this implement/fix?

Seeking tore down the whole AirPlay connection and built it up again: a new streaming process plus a clock probe, roughly two seconds before the audio came back, with a "Warm replacement failed" warning in the log every time.

The queue ends a stream not only when it has played the queue out, but also when it is about to start the next one right away. The AirPlay session treated both the same and told the speaker "this was the last of the audio", which cannot be taken back — so the new stream that arrived a moment later had no connection left to reuse.

It now only says that while the queue is starting a stream to take over, so a seek reuses the live connection instead. Most noticeable on sources that hand over their audio at playback pace (Spotify through the Soloist backend), where the new stream always takes long enough for the old one to hit this.

**Related issue (if applicable):**

- found while investigating #5918

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- the audio EOF is written only when the queue is not replacing the session
- `AsyncProcess` tracks that stdin was closed, so `can_replace`/`standby` stop claiming a stream that can no longer be fed
- tests for both

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
