### PR TITLE
Fix an AirPlay speaker going silent when it joins a group

### DIFF
--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -706,26 +706,12 @@ class SendspinAirPlayBridge:
                 return
 
             # A player stream the bridge does not own is a live native session
-            # being displaced by this start (the controller's handover never
-            # stops a solo player's native session). Stop it before the new
-            # process pairs with the receiver: two cli processes on one receiver
-            # reset each other's RTSP channel and both sessions die.
+            # being displaced by this start. Stop it before the new process
+            # pairs with the receiver: two cli processes on one receiver reset
+            # each other's RTSP channel and both sessions die.
             displaced_stream = self.airplay_player.stream
             if displaced_stream is not None and displaced_stream is not self._airplay_stream:
-                self.logger.debug(
-                    "Stopping the native session of %s before bridging it to Sendspin",
-                    self.airplay_player.display_name,
-                )
-                with suppress(Exception):
-                    if displaced_stream.session is not None:
-                        # Release just this member: a synced native group plays
-                        # on without it, and a solo session winds down its audio
-                        # source along with the stream.
-                        await displaced_stream.session.remove_client(
-                            self.airplay_player, reason="displaced by sendspin bridge"
-                        )
-                    else:
-                        await displaced_stream.stop(force=True)
+                await self._stop_displaced_stream(displaced_stream)
                 if self.airplay_player.stream is displaced_stream:
                     self.airplay_player.stream = None
                 if asyncio.current_task() is not self._airplay_stream_start_task:
@@ -772,6 +758,36 @@ class SendspinAirPlayBridge:
                 )
                 return
             self._abandon_streaming()
+
+    async def _stop_displaced_stream(self, stream: AirPlayStream) -> None:
+        """
+        Release the speaker from a session the bridge is taking it away from.
+
+        Raises when the transport cannot be released, so the caller never adds a
+        second cli process to a receiver that is still serving one.
+
+        :param stream: The stream currently published on the AirPlay player.
+        """
+        self.logger.debug(
+            "Stopping the session already running on %s before bridging it to Sendspin",
+            self.airplay_player.display_name,
+        )
+        await stream.stop(force=True)
+        if stream.session is None:
+            return
+        try:
+            # Bookkeeping only, the transport is already gone: this releases the
+            # speaker from the session's client list and ends a session left
+            # without clients, so its audio source is not left running.
+            await stream.session.remove_client(
+                self.airplay_player, reason="displaced by sendspin bridge"
+            )
+        except Exception as err:
+            self.logger.warning(
+                "Could not release %s from its previous session: %s",
+                self.airplay_player.display_name,
+                err,
+            )
 
     async def _start_cold_stream(self, stream: AirPlayStream) -> bool:
         """
@@ -1558,7 +1574,10 @@ class SendspinAirPlayBridge:
         self._airplay_stream = None
         self._writer_task = None
         self._airplay_stream_start_task = None
-        if stream is not None:
+        # Only unpublish what this bridge put there: a deferred teardown can fire
+        # after the native path already replaced the player's stream, and dropping
+        # that reference would strand a session the bridge never owned.
+        if stream is not None and self.airplay_player.stream is stream:
             self.airplay_player.stream = None
         self._is_streaming = False
         self._use_shared_ptp = None

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -597,7 +597,12 @@ class SendspinAirPlayBridge:
 
         if not keep_stream:
             self._airplay_stream = None
-            self.airplay_player.stream = None
+            # A player stream the bridge does not own is a live native session:
+            # its reference is left in place for the start task to stop before
+            # it spawns a new process (dropping it here would orphan that
+            # session's cli process alongside the new one).
+            if self.airplay_player.stream is old_stream:
+                self.airplay_player.stream = None
             self._use_shared_ptp = None
         self._writer_task = None
         self._airplay_stream_start_task = None
@@ -651,7 +656,10 @@ class SendspinAirPlayBridge:
 
         if not keep_stream:
             self._airplay_stream = None
-            self.airplay_player.stream = None
+            # Leave a native session's reference in place for the start task to
+            # stop, exactly as in _on_stream_start.
+            if self.airplay_player.stream is old_stream:
+                self.airplay_player.stream = None
             self._use_shared_ptp = None
         self._writer_task = None
         self._airplay_stream_start_task = None
@@ -697,6 +705,34 @@ class SendspinAirPlayBridge:
                 # neither the kept stream nor the receiver is this task's to touch.
                 return
 
+            # A player stream the bridge does not own is a live native session
+            # being displaced by this start (the controller's handover never
+            # stops a solo player's native session). Stop it before the new
+            # process pairs with the receiver: two cli processes on one receiver
+            # reset each other's RTSP channel and both sessions die.
+            displaced_stream = self.airplay_player.stream
+            if displaced_stream is not None and displaced_stream is not self._airplay_stream:
+                self.logger.debug(
+                    "Stopping the native session of %s before bridging it to Sendspin",
+                    self.airplay_player.display_name,
+                )
+                with suppress(Exception):
+                    if displaced_stream.session is not None:
+                        # Release just this member: a synced native group plays
+                        # on without it, and a solo session winds down its audio
+                        # source along with the stream.
+                        await displaced_stream.session.remove_client(
+                            self.airplay_player, reason="displaced by sendspin bridge"
+                        )
+                    else:
+                        await displaced_stream.stop(force=True)
+                if self.airplay_player.stream is displaced_stream:
+                    self.airplay_player.stream = None
+                if asyncio.current_task() is not self._airplay_stream_start_task:
+                    # A newer stream start took the bridge over while the
+                    # displaced session was being stopped.
+                    return
+
             # A kept, still-connected stream (see _stream_is_warm_eligible,
             # checked by the stream-start callbacks) absorbs the new media via a
             # flush-refill on the SAME cli stdin instead of a cold reconnect.
@@ -713,7 +749,8 @@ class SendspinAirPlayBridge:
                 with suppress(Exception):
                     await kept_stream.stop(force=True)
                 self._airplay_stream = None
-                self.airplay_player.stream = None
+                if self.airplay_player.stream is kept_stream:
+                    self.airplay_player.stream = None
                 self._use_shared_ptp = None
 
             # On a rapid skip, _on_bridge_stream_start snapshots self._airplay_stream

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -763,15 +763,18 @@ class SendspinAirPlayBridge:
         """
         Release the speaker from a session the bridge is taking it away from.
 
-        Raises when the transport cannot be released, so the caller never adds a
-        second cli process to a receiver that is still serving one.
+        Lets a failure to release the transport propagate, so the caller never
+        adds a second cli process to a receiver that is still serving one.
 
         :param stream: The stream currently published on the AirPlay player.
         """
-        self.logger.debug(
-            "Stopping the session already running on %s before bridging it to Sendspin",
-            self.airplay_player.display_name,
-        )
+        if stream.running:
+            # An idle player keeps its last stream published, so only a live one
+            # is worth reporting as displaced.
+            self.logger.debug(
+                "Stopping the session already running on %s before bridging it to Sendspin",
+                self.airplay_player.display_name,
+            )
         await stream.stop(force=True)
         if stream.session is None:
             return

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -2089,7 +2089,11 @@ class AirPlayStream:
             # keeps reporting until one exists.
             return
         stalled = state == "stalled" and mode != "ntp"
-        if stalled and not self._clock_stall_warned:
+        # A superseded stream is judging a receiver a newer session has already
+        # taken over: neither its verdict nor its advice describes what the user
+        # is hearing. The clock-ready wait below is still resolved, so its own
+        # start path is not left hanging on evidence that will not arrive.
+        if stalled and not self._clock_stall_warned and self.player.stream is self:
             # The receiver is not slaving to our clock at all, so it renders
             # silence while everything else about the session looks healthy.
             self._clock_stall_warned = True
@@ -2100,7 +2104,6 @@ class AirPlayStream:
             if (
                 self.player.streaming_mode == STREAMING_MODE_AUTO
                 and ntp_offered
-                and self.player.stream is self
                 and not self.player.synced_to
                 and not self.player.group_members
             ):

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -1400,6 +1400,15 @@ class AirPlayStream:
             self._stopped = True
             try:
                 if not self.ended_cleanly:
+                    if player.stream is not self:
+                        # A newer session (native or Sendspin bridge) owns this
+                        # player, so this process's death says nothing about the
+                        # device: ungrouping or scheduling a re-join over it
+                        # would tear down the session that replaced it.
+                        logger.debug(
+                            "superseded cliairplay process stopped for %s", player.display_name
+                        )
+                        return
                     logger.warning(
                         "cliairplay process stopped unexpectedly for %s", player.display_name
                     )
@@ -1913,6 +1922,10 @@ class AirPlayStream:
         if self._native_control_failure_handled:
             return
         self._native_control_failure_handled = True
+        if self.player.stream is not self:
+            # A superseded process losing its control channel (a newer session
+            # reset it on the receiver) is not evidence about the device.
+            return
         if self.player.streaming_mode != STREAMING_MODE_AUTO:
             return
         self.player.logger.warning(

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -2100,6 +2100,7 @@ class AirPlayStream:
             if (
                 self.player.streaming_mode == STREAMING_MODE_AUTO
                 and ntp_offered
+                and self.player.stream is self
                 and not self.player.synced_to
                 and not self.player.group_members
             ):

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -1921,11 +1921,14 @@ class AirPlayStream:
         """Switch an automatic native AirPlay 2 route to compatibility mode."""
         if self._native_control_failure_handled:
             return
-        self._native_control_failure_handled = True
         if self.player.stream is not self:
-            # A superseded process losing its control channel (a newer session
-            # reset it on the receiver) is not evidence about the device.
+            # Not evidence about the device: either a newer session reset the
+            # control channel on the receiver, or this stream is still coming up
+            # and has not been published yet. The binary keeps reporting while
+            # the failure lasts, so leaving the once-only latch unset here keeps
+            # a genuine failure actionable once the stream does own the player.
             return
+        self._native_control_failure_handled = True
         if self.player.streaming_mode != STREAMING_MODE_AUTO:
             return
         self.player.logger.warning(

--- a/tests/providers/airplay/test_protocol_crash.py
+++ b/tests/providers/airplay/test_protocol_crash.py
@@ -43,6 +43,7 @@ def _make_stream(
     player.provider.logger = logging.getLogger("test.airplay.prov")
 
     stream = AirPlayStream(player)
+    player.stream = stream
 
     # Mock a CLI process whose stderr is already exhausted: the reader loop
     # exits immediately without seeing an end-of-stream marker, i.e. an

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -213,6 +213,9 @@ def _make_bridge(
     airplay_player.player_id = "apc43875e9e53a"
     airplay_player.display_name = "Test Player"
     airplay_player.protocol = protocol
+    # A real None: the start path stops whatever stream the player already holds
+    # before it spawns a process, and a bare MagicMock reads as a live session.
+    airplay_player.stream = None
     # A real int: the anchor math guards sync_adjust with isinstance(..., int), so
     # a MagicMock would silently read as 0 and pass the test for the wrong reason.
     airplay_player.config.get_value = MagicMock(return_value=sync_adjust)
@@ -789,6 +792,118 @@ async def test_superseded_cold_stream_teardown_spares_the_newer_owner() -> None:
     newer_stream.stop.assert_not_awaited()
     assert bridge._airplay_stream is newer_stream
     assert bridge.airplay_player.stream is newer_stream
+
+
+# --- Displacing a native session the bridge does not own ---
+
+
+def _make_native_stream(session: MagicMock | None = None) -> MagicMock:
+    """Build a live native AirPlayStream mock the bridge has to displace."""
+    stream = MagicMock()
+    stream.stop = AsyncMock()
+    stream.session = session
+    return stream
+
+
+async def test_cold_start_stops_a_native_session_before_it_spawns_a_process() -> None:
+    """
+    A native session on the same player is stopped before the bridge connects.
+
+    Two cliairplay processes on one receiver reset each other's control
+    channel, so the displaced session has to be gone before the new pair-setup.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    session = MagicMock()
+    order: list[str] = []
+    session.remove_client = AsyncMock(side_effect=lambda *_a, **_kw: order.append("remove_client"))
+    bridge.airplay_player.stream = _make_native_stream(session)
+    stream = _make_anchor_stream()
+    stream.connect = AsyncMock(side_effect=lambda *_a, **_kw: order.append("connect"))
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=stream,
+        ),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.time",
+            return_value=UNIX_NOW_S,
+        ),
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    assert order == ["remove_client", "connect"]
+    session.remove_client.assert_awaited_once()
+    assert session.remove_client.await_args.args[0] is bridge.airplay_player
+    assert bridge.airplay_player.stream is stream
+
+
+async def test_cold_start_stops_a_sessionless_native_stream_directly() -> None:
+    """A displaced stream with no session behind it is stopped on its own."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    native_stream = _make_native_stream()
+    bridge.airplay_player.stream = native_stream
+    stream = _make_anchor_stream()
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=stream,
+        ),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.time",
+            return_value=UNIX_NOW_S,
+        ),
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    native_stream.stop.assert_awaited_once_with(force=True)
+    assert bridge.airplay_player.stream is stream
+
+
+async def test_warm_reuse_never_displaces_the_stream_it_reuses() -> None:
+    """The stream a warm handover rides is the bridge's own, so it is not stopped."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + WARM_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    kept_stream = _make_anchor_stream(ack=UNIX_NOW_MS + WARM_LEAD_MS)
+    bridge._airplay_stream = kept_stream
+    bridge.airplay_player.stream = kept_stream
+
+    with patch(
+        "music_assistant.providers.airplay.sendspin_bridge.time.time",
+        return_value=UNIX_NOW_S,
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    kept_stream.stop.assert_not_awaited()
+    kept_stream.flush.assert_awaited_once()
+    assert bridge.airplay_player.stream is kept_stream
+
+
+@pytest.mark.parametrize("server_side", [False, True])
+def test_stream_start_callbacks_leave_a_native_session_published(server_side: bool) -> None:
+    """
+    Both Sendspin stream-start callbacks leave a native stream on the player.
+
+    Dropping the reference there would strand its cli process: the start task
+    stops what the player still points at, and only that.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    native_stream = _make_native_stream()
+    bridge.airplay_player.stream = native_stream
+
+    if server_side:
+        bridge._on_stream_start(MagicMock())
+    else:
+        bridge._on_bridge_stream_start()
+
+    assert bridge._airplay_stream is None
+    assert bridge.airplay_player.stream is native_stream
 
 
 # --- Teardown player state reset ---

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -870,6 +870,8 @@ async def test_a_displaced_stream_that_cannot_be_stopped_blocks_the_start() -> N
         await bridge._start_protocol_from_chunk()
 
     stream.connect.assert_not_awaited()
+    # the session we could not stop stays published, so it is not lost track of
+    assert bridge.airplay_player.stream is native_stream
 
 
 async def test_failed_session_bookkeeping_still_lets_the_start_proceed() -> None:

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -807,10 +807,11 @@ def _make_native_stream(session: MagicMock | None = None) -> MagicMock:
 
 async def test_cold_start_stops_a_native_session_before_it_spawns_a_process() -> None:
     """
-    A native session on the same player is stopped before the bridge connects.
+    A native session on the same player is released before the bridge connects.
 
     Two cliairplay processes on one receiver reset each other's control
-    channel, so the displaced session has to be gone before the new pair-setup.
+    channel, so the displaced transport has to be gone before the new
+    pair-setup; the session bookkeeping follows it.
     """
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
@@ -818,7 +819,9 @@ async def test_cold_start_stops_a_native_session_before_it_spawns_a_process() ->
     session = MagicMock()
     order: list[str] = []
     session.remove_client = AsyncMock(side_effect=lambda *_a, **_kw: order.append("remove_client"))
-    bridge.airplay_player.stream = _make_native_stream(session)
+    native_stream = _make_native_stream(session)
+    native_stream.stop = AsyncMock(side_effect=lambda **_kw: order.append("stop"))
+    bridge.airplay_player.stream = native_stream
     stream = _make_anchor_stream()
     stream.connect = AsyncMock(side_effect=lambda *_a, **_kw: order.append("connect"))
 
@@ -834,10 +837,87 @@ async def test_cold_start_stops_a_native_session_before_it_spawns_a_process() ->
     ):
         await bridge._start_protocol_from_chunk()
 
-    assert order == ["remove_client", "connect"]
-    session.remove_client.assert_awaited_once()
+    assert order == ["stop", "remove_client", "connect"]
     assert session.remove_client.await_args.args[0] is bridge.airplay_player
     assert bridge.airplay_player.stream is stream
+
+
+async def test_a_displaced_stream_that_cannot_be_stopped_blocks_the_start() -> None:
+    """
+    A transport the bridge cannot release stops it from spawning a second process.
+
+    Carrying on would put the new cli process on a receiver that is still
+    serving the old one, which is the collision this guard exists to prevent.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    native_stream = _make_native_stream()
+    native_stream.stop = AsyncMock(side_effect=RuntimeError("device unreachable"))
+    bridge.airplay_player.stream = native_stream
+    stream = _make_anchor_stream()
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=stream,
+        ),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.time",
+            return_value=UNIX_NOW_S,
+        ),
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    stream.connect.assert_not_awaited()
+
+
+async def test_failed_session_bookkeeping_still_lets_the_start_proceed() -> None:
+    """The transport is what matters: a failed client removal does not block the start."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    session = MagicMock()
+    session.remove_client = AsyncMock(side_effect=RuntimeError("session already gone"))
+    bridge.airplay_player.stream = _make_native_stream(session)
+    stream = _make_anchor_stream()
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=stream,
+        ),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.time",
+            return_value=UNIX_NOW_S,
+        ),
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    stream.connect.assert_awaited_once()
+    assert bridge.airplay_player.stream is stream
+
+
+async def test_deferred_teardown_spares_a_native_stream_that_replaced_the_bridge() -> None:
+    """
+    A teardown that fires after the native path took the speaker leaves it alone.
+
+    The grace window between a Sendspin stream ending and its cleanup is long
+    enough for native playback to start, and unpublishing its stream here would
+    strand the process behind it.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge_stream = MagicMock()
+    bridge_stream.stop = AsyncMock()
+    bridge._airplay_stream = bridge_stream
+    native_stream = _make_native_stream()
+    bridge.airplay_player.stream = native_stream
+
+    await bridge._stop_streaming()
+
+    assert bridge.airplay_player.stream is native_stream
+    native_stream.stop.assert_not_awaited()
+    cast("MagicMock", bridge.airplay_player).set_state_from_stream.assert_not_called()
 
 
 async def test_cold_start_stops_a_sessionless_native_stream_directly() -> None:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2051,21 +2051,26 @@ async def test_clock_stall_switches_solo_auto_player_to_ntp() -> None:
     grouped_player = _make_player()
     grouped_player.synced_to = "apleader"
     grouped = AirPlayStream(grouped_player)
+    grouped_player.stream = grouped
     grouped._handle_status_line(
         "[STATUS] clock_ready mode=ptp state=stalled streak_ms=0 exchanges=0 "
         "ready_in_ms=0 ready_at_unix_ms=0"
     )
     grouped_player.provider.mass.config.set_raw_player_config_value.assert_not_called()
+    # the warn-only path was taken, rather than the block being skipped entirely
+    assert grouped._clock_stall_warned is True
 
     # An explicitly pinned mode is the user's choice: warn only.
     pinned_player = _make_player()
     pinned_player.streaming_mode = STREAMING_MODE_AP2_PTP
     pinned = AirPlayStream(pinned_player)
+    pinned_player.stream = pinned
     pinned._handle_status_line(
         "[STATUS] clock_ready mode=ptp state=stalled streak_ms=0 exchanges=0 "
         "ready_in_ms=0 ready_at_unix_ms=0"
     )
     pinned_player.provider.mass.config.set_raw_player_config_value.assert_not_called()
+    assert pinned._clock_stall_warned is True
 
 
 def test_native_control_failure_switches_automatic_player_to_compatibility() -> None:

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2019,6 +2019,7 @@ async def test_clock_stall_switches_solo_auto_player_to_ntp() -> None:
     """
     player = _make_player()
     stream = AirPlayStream(player)
+    player.stream = stream
     stream._handle_status_line(
         "[STATUS] clock_ready mode=ptp state=stalled streak_ms=0 exchanges=0 "
         "ready_in_ms=0 ready_at_unix_ms=0"
@@ -2028,6 +2029,17 @@ async def test_clock_stall_switches_solo_auto_player_to_ntp() -> None:
         player.player_id, CONF_STREAMING_MODE, STREAMING_MODE_AP2_NTP
     )
     assert mass.create_task.called
+
+    # A superseded stream's stalled clock is the newer session resetting it on
+    # the receiver, not a verdict about the device.
+    superseded_player = _make_player()
+    superseded = AirPlayStream(superseded_player)
+    superseded_player.stream = AirPlayStream(superseded_player)
+    superseded._handle_status_line(
+        "[STATUS] clock_ready mode=ptp state=stalled streak_ms=0 exchanges=0 "
+        "ready_in_ms=0 ready_at_unix_ms=0"
+    )
+    superseded_player.provider.mass.config.set_raw_player_config_value.assert_not_called()
 
     # A grouped member is reported, never moved: restarting one member of a
     # live sync group would desync it.

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2099,6 +2099,28 @@ def test_native_control_failure_on_a_superseded_stream_changes_nothing() -> None
     player.provider.mass.config.set_raw_player_config_value.assert_not_called()
 
 
+def test_native_control_failure_before_publication_stays_actionable() -> None:
+    """
+    A failure reported before the stream owns the player does not spend the one-shot.
+
+    A bridge stream is published only once its process has connected, so a
+    verdict dropped during that window must not stop the same failure from
+    being acted on afterwards.
+    """
+    player = _make_player()
+    stream = AirPlayStream(player)
+
+    stream._handle_status_line("[ERROR] AirPlay 2 control channel failed")
+    player.provider.mass.config.set_raw_player_config_value.assert_not_called()
+
+    player.stream = stream
+    stream._handle_status_line("[ERROR] AirPlay 2 control channel failed")
+
+    player.provider.mass.config.set_raw_player_config_value.assert_called_once_with(
+        player.player_id, CONF_STREAMING_MODE, STREAMING_MODE_AP2_COMPAT
+    )
+
+
 def test_native_control_failure_does_not_override_pinned_mode() -> None:
     """A terminal native control failure leaves an explicit streaming mode unchanged."""
     player = _make_player()

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2055,6 +2055,7 @@ def test_native_control_failure_switches_automatic_player_to_compatibility() -> 
     """A terminal native control failure persists the compatibility route once."""
     player = _make_player()
     stream = AirPlayStream(player)
+    player.stream = stream
 
     stream._handle_status_line("[ERROR] AirPlay 2 control channel failed")
     stream._handle_status_line("[ERROR] AirPlay 2 control channel failed")
@@ -2065,11 +2066,28 @@ def test_native_control_failure_switches_automatic_player_to_compatibility() -> 
     player.provider.mass.create_task.assert_not_called()
 
 
+def test_native_control_failure_on_a_superseded_stream_changes_nothing() -> None:
+    """
+    A superseded stream's lost control channel does not pin the player to compatibility.
+
+    A second session on the same receiver resets the first one's control
+    channel, so the verdict describes the collision, not the device.
+    """
+    player = _make_player()
+    stream = AirPlayStream(player)
+    player.stream = AirPlayStream(player)
+
+    stream._handle_status_line("[ERROR] AirPlay 2 control channel failed")
+
+    player.provider.mass.config.set_raw_player_config_value.assert_not_called()
+
+
 def test_native_control_failure_does_not_override_pinned_mode() -> None:
     """A terminal native control failure leaves an explicit streaming mode unchanged."""
     player = _make_player()
     player.streaming_mode = STREAMING_MODE_AP2_PTP
     stream = AirPlayStream(player)
+    player.stream = stream
 
     stream._handle_status_line("[ERROR] AirPlay 2 control channel failed")
 
@@ -2701,9 +2719,18 @@ async def test_process_eof_cleans_up_command_pipe() -> None:
     player.schedule_group_rejoin.assert_not_called()
 
 
-async def _run_unexpected_process_death(player: MagicMock) -> AirPlayStream:
-    """Drive the stderr reader through an unexpected process exit."""
+async def _run_unexpected_process_death(
+    player: MagicMock, *, still_owned: bool = True
+) -> AirPlayStream:
+    """
+    Drive the stderr reader through an unexpected process exit.
+
+    :param still_owned: Whether the dying stream is still the player's current
+        one. False models a stream a newer session already superseded.
+    """
     stream = AirPlayStream(player)
+    if still_owned:
+        player.stream = stream
     process = MagicMock()
     stream._cli_proc = process
 
@@ -2793,6 +2820,29 @@ async def test_unexpected_death_of_static_group_member_drops_member_only() -> No
     )
     players_controller.cmd_ungroup.assert_not_called()
     player.schedule_group_rejoin.assert_called_once_with(["leader"])
+
+
+@pytest.mark.asyncio
+async def test_unexpected_death_of_superseded_stream_leaves_the_group_alone() -> None:
+    """
+    A superseded process dying does not ungroup the player or schedule a re-join.
+
+    Its death is the newer session taking the receiver over, so acting on it
+    would tear down the healthy session that replaced it.
+    """
+    player = _make_player()
+    player.synced_to = "leader"
+    player.group_members = []
+    player.stream = AirPlayStream(player)
+
+    stream = await _run_unexpected_process_death(player, still_owned=False)
+
+    players_controller = player.provider.mass.players
+    players_controller.cmd_ungroup.assert_not_called()
+    players_controller.cmd_set_members.assert_not_called()
+    player.schedule_group_rejoin.assert_not_called()
+    player.set_state_from_stream.assert_not_called()
+    assert stream._stopped is True
 
 
 @pytest.mark.asyncio

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -82,6 +82,9 @@ def _make_player() -> MagicMock:
     ]
     player.synced_to = None
     player.group_members = []
+    # A real None: a stream only speaks for the player while it is the published
+    # one, and a bare MagicMock reads as some other stream having taken over.
+    player.stream = None
 
     airplay_info = MagicMock()
     airplay_info.port = 7000
@@ -2031,7 +2034,8 @@ async def test_clock_stall_switches_solo_auto_player_to_ntp() -> None:
     assert mass.create_task.called
 
     # A superseded stream's stalled clock is the newer session resetting it on
-    # the receiver, not a verdict about the device.
+    # the receiver, not a verdict about the device: it neither switches the
+    # player nor reports a speaker that is playing fine as silent.
     superseded_player = _make_player()
     superseded = AirPlayStream(superseded_player)
     superseded_player.stream = AirPlayStream(superseded_player)
@@ -2040,6 +2044,7 @@ async def test_clock_stall_switches_solo_auto_player_to_ntp() -> None:
         "ready_in_ms=0 ready_at_unix_ms=0"
     )
     superseded_player.provider.mass.config.set_raw_player_config_value.assert_not_called()
+    assert superseded._clock_stall_warned is False
 
     # A grouped member is reported, never moved: restarting one member of a
     # live sync group would desync it.
@@ -2194,6 +2199,7 @@ async def test_clock_ready_stalled_state_warns_once(caplog: pytest.LogCaptureFix
     grouped_player = _make_player()
     grouped_player.synced_to = "apleader"
     stream = AirPlayStream(grouped_player)
+    grouped_player.stream = stream
 
     with caplog.at_level(logging.DEBUG):
         ended = stream._handle_status_line(


### PR DESCRIPTION
# What does this implement/fix?

Grouping an AirPlay speaker (a HomePod, for example) with a Sendspin speaker could leave it silent, and afterwards it would keep playing in compatibility mode.

Starting the group asked the speaker to play a second time while it was still playing the first stream. The speaker accepted the new connection and dropped the old one. Music Assistant then read that dropped connection as the speaker failing, so it took the speaker out of the group it had just joined and remembered it as a device that needs compatibility mode. The result was silence, and a setting the user never chose that stuck around for every following playback.

A log from one report shows six streaming processes started for a single speaker in seven minutes, with three of them sending audio to it at the same time.

**Related issue (if applicable):**

- found while investigating a "no audio, then lost the queue" report

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- the Sendspin bridge stops a speaker's running stream before it starts its own, and gives up rather than starting a second one when that stream cannot be stopped
- the bridge no longer loses track of a stream that the normal playback path started in the meantime
- a stream that has already been replaced no longer removes the speaker from its group or tries to rejoin it
- a stream that has already been replaced no longer switches the speaker to compatibility mode or to NTP timing

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
