### PR TITLE
Fix an AirPlay speaker going silent when two things start it at once

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -118,8 +118,8 @@ class AirPlayPlayer(Player):
         # moment either decides to displace what is published until it publishes
         # its own stream. Two processes on one receiver reset each other's RTSP
         # channel and both sessions die. Always taken INSIDE self._lock, never
-        # around it: an explicit stop holds self._lock while it tears a stream
-        # down, and the reverse order would deadlock against it.
+        # around it: play_media holds self._lock across the whole session start,
+        # which takes this lock for every member.
         self.stream_spawn_lock = asyncio.Lock()
         self.last_command_sent = 0.0
         self._volume_reports_ignored_until = 0.0

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -113,6 +113,14 @@ class AirPlayPlayer(Player):
         super().__init__(provider, player_id)
         self.address = address
         self.stream: AirPlayStream | None = None
+        # Serializes the two paths that can put a cliairplay process on this
+        # receiver (the native stream session and the Sendspin bridge), from the
+        # moment either decides to displace what is published until it publishes
+        # its own stream. Two processes on one receiver reset each other's RTSP
+        # channel and both sessions die. Always taken INSIDE self._lock, never
+        # around it: an explicit stop holds self._lock while it tears a stream
+        # down, and the reverse order would deadlock against it.
+        self.stream_spawn_lock = asyncio.Lock()
         self.last_command_sent = 0.0
         self._volume_reports_ignored_until = 0.0
         self._lock = asyncio.Lock()

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -337,7 +337,11 @@ class AirPlayPlayer(Player):
         """Return True if the player is rendering audio an announcement can mix into."""
         if self.playback_state != PlaybackState.PLAYING:
             return False
-        return self.stream is not None and self.stream.running and self.stream.connected
+        if self.stream is None or self.stream.superseded:
+            # A stream handed to a teardown stays published until its process is
+            # off the receiver, and a clip mixed into it dies with it.
+            return False
+        return self.stream.running and self.stream.connected
 
     @property
     def applies_announcement_volume(self) -> bool:
@@ -613,8 +617,14 @@ class AirPlayPlayer(Player):
             if self.stream and self.stream.running and self.stream.session:
                 # Set transitioning flag to ignore stale DACP messages (like prevent-playback)
                 self._transitioning = True
+                stopped_stream = self.stream
                 await self.stream.session.stop()
-                self.stream = None
+                # Only drop what this call stopped: tearing a group session down
+                # awaits every member, and a bridge can publish its own stream
+                # here. Erasing that would leave the start below with nothing to
+                # displace and a live process still on the speaker.
+                if self.stream is stopped_stream:
+                    self.stream = None
 
             # select audio source
             audio_source = self.mass.streams.get_stream(media, session_pcm_format, self.player_id)

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -1315,10 +1315,10 @@ class SendspinAirPlayBridge:
             stream_start_task.cancel()
         if writer_task and not writer_task.done():
             writer_task.cancel()
-        # The player's stream reference was dropped when this teardown was
-        # detached, but the process is still on the receiver until stop() below
-        # returns. Held so a native start cannot read that empty reference and
-        # pair a second cli process with a receiver this one has not let go of.
+        # The player still points at this stream: that reference is what tells a
+        # start there is a process to displace, so it is only dropped below,
+        # together with the release itself. Held so no start can land between
+        # the two and read the speaker as free.
         async with self.airplay_player.stream_spawn_lock:
             if stream_start_task:
                 with suppress(asyncio.CancelledError, Exception):

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -706,44 +706,53 @@ class SendspinAirPlayBridge:
                 # neither the kept stream nor the receiver is this task's to touch.
                 return
 
-            # A player stream the bridge does not own is a live native session
-            # being displaced by this start. Stop it before the new process
-            # pairs with the receiver: two cli processes on one receiver reset
-            # each other's RTSP channel and both sessions die.
-            displaced_stream = self.airplay_player.stream
-            if displaced_stream is not None and displaced_stream is not self._airplay_stream:
-                await self._stop_displaced_stream(displaced_stream)
-                if self.airplay_player.stream is displaced_stream:
-                    self.airplay_player.stream = None
+            # The native start path takes the same lock around its own displace-
+            # connect-publish sequence, so the two can no longer interleave into
+            # two cli processes on one receiver.
+            async with self.airplay_player.stream_spawn_lock:
                 if asyncio.current_task() is not self._airplay_stream_start_task:
-                    # A newer stream start took the bridge over while the
-                    # displaced session was being stopped.
+                    # A newer stream start took the bridge over while this one
+                    # waited for the spawn lock.
                     return
 
-            # A kept, still-connected stream (see _stream_is_warm_eligible,
-            # checked by the stream-start callbacks) absorbs the new media via a
-            # flush-refill on the SAME cli stdin instead of a cold reconnect.
-            kept_stream = self._airplay_stream
-            if kept_stream is not None:
-                if await self._start_warm_stream(kept_stream):
-                    return
-                if asyncio.current_task() is not self._airplay_stream_start_task:
-                    # Not a failure: a newer stream start owns the bridge and the
-                    # kept stream, so neither is this task's to tear down.
-                    return
-                # Warm handover failed - tear down the kept stream and fall through
-                # to the cold path below, which spawns a fresh process.
-                with suppress(Exception):
-                    await kept_stream.stop(force=True)
-                self._airplay_stream = None
-                if self.airplay_player.stream is kept_stream:
-                    self.airplay_player.stream = None
-                self._use_shared_ptp = None
+                # A player stream the bridge does not own is a live native session
+                # being displaced by this start. Stop it before the new process
+                # pairs with the receiver: two cli processes on one receiver reset
+                # each other's RTSP channel and both sessions die.
+                displaced_stream = self.airplay_player.stream
+                if displaced_stream is not None and displaced_stream is not self._airplay_stream:
+                    await self._stop_displaced_stream(displaced_stream)
+                    if self.airplay_player.stream is displaced_stream:
+                        self.airplay_player.stream = None
+                    if asyncio.current_task() is not self._airplay_stream_start_task:
+                        # A newer stream start took the bridge over while the
+                        # displaced session was being stopped.
+                        return
 
-            # On a rapid skip, _on_bridge_stream_start snapshots self._airplay_stream
-            # for cleanup. If we assigned it earlier, the new stream would be missed
-            # and leaked. Only publish once connect() succeeds and this task is current.
-            await self._start_cold_stream(AirPlayStream(self.airplay_player))
+                # A kept, still-connected stream (see _stream_is_warm_eligible,
+                # checked by the stream-start callbacks) absorbs the new media via a
+                # flush-refill on the SAME cli stdin instead of a cold reconnect.
+                kept_stream = self._airplay_stream
+                if kept_stream is not None:
+                    if await self._start_warm_stream(kept_stream):
+                        return
+                    if asyncio.current_task() is not self._airplay_stream_start_task:
+                        # Not a failure: a newer stream start owns the bridge and the
+                        # kept stream, so neither is this task's to tear down.
+                        return
+                    # Warm handover failed - tear down the kept stream and fall through
+                    # to the cold path below, which spawns a fresh process.
+                    with suppress(Exception):
+                        await kept_stream.stop(force=True)
+                    self._airplay_stream = None
+                    if self.airplay_player.stream is kept_stream:
+                        self.airplay_player.stream = None
+                    self._use_shared_ptp = None
+
+                # On a rapid skip, _on_bridge_stream_start snapshots self._airplay_stream
+                # for cleanup. If we assigned it earlier, the new stream would be missed
+                # and leaked. Only publish once connect() succeeds and this task is current.
+                await self._start_cold_stream(AirPlayStream(self.airplay_player))
         except Exception as err:
             self.logger.error(
                 "Failed to start AirPlay protocol for %s: %s",

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -1303,20 +1303,33 @@ class SendspinAirPlayBridge:
             with suppress(Exception):
                 await prev_cleanup
 
+        # Cancelled before the spawn lock is taken: a start task holding it only
+        # lets go once it unwinds, so waiting for the lock first would leave
+        # nobody to ask it to. Neither cancel awaits, so the lock is claimed
+        # ahead of any start that arrives from here on.
         if stream_start_task and not stream_start_task.done():
             stream_start_task.cancel()
-            with suppress(asyncio.CancelledError, Exception):
-                await stream_start_task
         if writer_task and not writer_task.done():
             writer_task.cancel()
-            with suppress(asyncio.CancelledError, Exception):
-                await writer_task
-        if stream:
-            with suppress(Exception):
-                await stream.stop(force=True)
-            # Restore the IDLE reset that stop() dropped because the stream was detached first
-            if self.airplay_player.stream is None:
-                self.airplay_player.set_state_from_stream(state=PlaybackState.IDLE, elapsed_time=0)
+        # The player's stream reference was dropped when this teardown was
+        # detached, but the process is still on the receiver until stop() below
+        # returns. Held so a native start cannot read that empty reference and
+        # pair a second cli process with a receiver this one has not let go of.
+        async with self.airplay_player.stream_spawn_lock:
+            if stream_start_task:
+                with suppress(asyncio.CancelledError, Exception):
+                    await stream_start_task
+            if writer_task:
+                with suppress(asyncio.CancelledError, Exception):
+                    await writer_task
+            if stream:
+                with suppress(Exception):
+                    await stream.stop(force=True)
+                # Restore the IDLE reset that stop() dropped because the stream was detached first
+                if self.airplay_player.stream is None:
+                    self.airplay_player.set_state_from_stream(
+                        state=PlaybackState.IDLE, elapsed_time=0
+                    )
 
     def _on_audio_chunk(self, chunk: AudioChunk) -> None:
         """Handle audio chunk from Sendspin PushStream."""

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -598,12 +598,10 @@ class SendspinAirPlayBridge:
 
         if not keep_stream:
             self._airplay_stream = None
-            # A player stream the bridge does not own is a live native session:
-            # its reference is left in place for the start task to stop before
-            # it spawns a new process (dropping it here would orphan that
-            # session's cli process alongside the new one).
-            if self.airplay_player.stream is old_stream:
-                self.airplay_player.stream = None
+            # The player's reference is left in place either way: a native
+            # session is the start task's to stop before it spawns, and the
+            # bridge's own old stream stays published until the cleanup below
+            # actually has it off the receiver.
             self._use_shared_ptp = None
         self._writer_task = None
         self._airplay_stream_start_task = None
@@ -657,10 +655,8 @@ class SendspinAirPlayBridge:
 
         if not keep_stream:
             self._airplay_stream = None
-            # Leave a native session's reference in place for the start task to
-            # stop, exactly as in _on_stream_start.
-            if self.airplay_player.stream is old_stream:
-                self.airplay_player.stream = None
+            # Left published for the start task or the cleanup to clear, exactly
+            # as in _on_stream_start.
             self._use_shared_ptp = None
         self._writer_task = None
         self._airplay_stream_start_task = None
@@ -1323,6 +1319,12 @@ class SendspinAirPlayBridge:
                 with suppress(asyncio.CancelledError, Exception):
                     await writer_task
             if stream:
+                # Only unpublish what this bridge put there: a deferred teardown
+                # can fire after the native path already replaced the player's
+                # stream, and dropping that reference would strand a session the
+                # bridge never owned.
+                if self.airplay_player.stream is stream:
+                    self.airplay_player.stream = None
                 with suppress(Exception):
                     await stream.stop(force=True)
                 # Restore the IDLE reset that stop() dropped because the stream was detached first
@@ -1650,11 +1652,10 @@ class SendspinAirPlayBridge:
         self._airplay_stream = None
         self._writer_task = None
         self._airplay_stream_start_task = None
-        # Only unpublish what this bridge put there: a deferred teardown can fire
-        # after the native path already replaced the player's stream, and dropping
-        # that reference would strand a session the bridge never owned.
-        if stream is not None and self.airplay_player.stream is stream:
-            self.airplay_player.stream = None
+        # The player's reference stays until the teardown has the process off the
+        # receiver (see _cleanup_old_stream): it is what a start reads to decide
+        # there is something to displace, and clearing it here would tell one
+        # that the speaker is free while the old process still holds it.
         self._is_streaming = False
         self._use_shared_ptp = None
         self._queued_frames = 0

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -600,6 +600,8 @@ class SendspinAirPlayBridge:
         old_stream_start_task = self._airplay_stream_start_task
 
         if not keep_stream:
+            if old_stream is not None:
+                old_stream.superseded = True
             self._airplay_stream = None
             # The player's reference is left in place either way: a native
             # session is the start task's to stop before it spawns, and the
@@ -657,6 +659,8 @@ class SendspinAirPlayBridge:
         old_stream_start_task = self._airplay_stream_start_task
 
         if not keep_stream:
+            if old_stream is not None:
+                old_stream.superseded = True
             self._airplay_stream = None
             # Left published for the start task or the cleanup to clear, exactly
             # as in _on_stream_start.
@@ -1653,6 +1657,8 @@ class SendspinAirPlayBridge:
         stream = self._airplay_stream
         writer_task = self._writer_task
         start_task = self._airplay_stream_start_task
+        if stream is not None:
+            stream.superseded = True
         self._airplay_stream = None
         self._writer_task = None
         self._airplay_stream_start_task = None

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -326,6 +326,9 @@ class SendspinAirPlayBridge:
         # teardown across that gap lets the next stream reuse the connected
         # binary via flush-refill instead of a cold reconnect.
         self._teardown_timer_id = f"bridge_teardown_{airplay_player.player_id}"
+        # Guards the bridge's own registration teardown. Held across the stream
+        # teardown, which takes the player's stream_spawn_lock, so a start path
+        # must never be wrapped in this one: that would invert the two.
         self._lock = asyncio.Lock()
 
     @property
@@ -692,7 +695,9 @@ class SendspinAirPlayBridge:
         try:
             # Ensure the old CLI process is fully stopped before starting a new one.
             # Without this, both old and new processes could try to connect to the
-            # same AirPlay device simultaneously.
+            # same AirPlay device simultaneously. Awaited BEFORE the spawn lock
+            # below and never under it: the cleanup takes that same lock, so the
+            # two orders cannot be swapped.
             cleanup = self._cleanup_task
             if cleanup and not cleanup.done():
                 await cleanup
@@ -1301,8 +1306,7 @@ class SendspinAirPlayBridge:
 
         # Cancelled before the spawn lock is taken: a start task holding it only
         # lets go once it unwinds, so waiting for the lock first would leave
-        # nobody to ask it to. Neither cancel awaits, so the lock is claimed
-        # ahead of any start that arrives from here on.
+        # nobody to ask it to.
         if stream_start_task and not stream_start_task.done():
             stream_start_task.cancel()
         if writer_task and not writer_task.done():

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -1331,11 +1331,15 @@ class SendspinAirPlayBridge:
                 # can fire after the native path already replaced the player's
                 # stream, and dropping that reference would strand a session the
                 # bridge never owned.
+                # Cleared ahead of the release rather than after it so stop()
+                # reports through the reset below instead of its own, which the
+                # clear would drop anyway. Both sit under the lock, so no start
+                # can read the speaker as free in between.
                 if self.airplay_player.stream is stream:
                     self.airplay_player.stream = None
                 with suppress(Exception):
                     await stream.stop(force=True)
-                # Restore the IDLE reset that stop() dropped because the stream was detached first
+                # Restore the IDLE reset that stop() dropped over the clear above
                 if self.airplay_player.stream is None:
                     self.airplay_player.set_state_from_stream(
                         state=PlaybackState.IDLE, elapsed_time=0

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -264,6 +264,11 @@ class AirPlayStream:
         # clock_ready update of this stream session.
         self._clock_stall_warned: bool = False
         self._native_control_failure_warned: bool = False
+        # Set when the owner hands this stream to a teardown. It stays published
+        # until that teardown has the process off the receiver, so ownership
+        # alone no longer tells the reporting guards below that the stream is on
+        # its way out.
+        self.superseded: bool = False
 
     @property
     def running(self) -> bool:
@@ -1409,11 +1414,12 @@ class AirPlayStream:
             self._stopped = True
             try:
                 if not self.ended_cleanly:
-                    if player.stream is not self:
-                        # A newer session (native or Sendspin bridge) owns this
-                        # player, so this process's death says nothing about the
-                        # device: ungrouping or scheduling a re-join over it
-                        # would tear down the session that replaced it.
+                    if self.superseded or player.stream is not self:
+                        # This stream is on its way out, or a newer session
+                        # (native or Sendspin bridge) owns the player, so this
+                        # process's death says nothing about the device:
+                        # ungrouping or scheduling a re-join over it would tear
+                        # down the session that replaced it.
                         logger.debug(
                             "superseded cliairplay process stopped for %s", player.display_name
                         )
@@ -1903,10 +1909,10 @@ class AirPlayStream:
         """Warn once that the receiver dropped the native AirPlay 2 control channel."""
         if self._native_control_failure_warned:
             return
-        if self.player.stream is not self:
+        if self.superseded or self.player.stream is not self:
             # Not evidence about the device: either a newer session reset the
-            # control channel on the receiver, or this stream is still coming up
-            # and has not been published yet. The binary keeps reporting while
+            # control channel on the receiver, this stream is on its way out, or
+            # it is still coming up and has not been published yet. The binary keeps reporting while
             # the failure lasts, so leaving the once-only latch unset here keeps
             # a genuine failure reportable once the stream does own the player.
             return

--- a/music_assistant/providers/airplay/stream.py
+++ b/music_assistant/providers/airplay/stream.py
@@ -264,10 +264,10 @@ class AirPlayStream:
         # clock_ready update of this stream session.
         self._clock_stall_warned: bool = False
         self._native_control_failure_warned: bool = False
-        # Set when the owner hands this stream to a teardown. It stays published
-        # until that teardown has the process off the receiver, so ownership
-        # alone no longer tells the reporting guards below that the stream is on
-        # its way out.
+        # Set when the Sendspin bridge hands this stream to a teardown, which
+        # leaves it published until that teardown has the process off the
+        # receiver. Native teardowns need no flag: they stop the stream first,
+        # and stop() marks it before it touches the receiver.
         self.superseded: bool = False
 
     @property
@@ -1419,7 +1419,9 @@ class AirPlayStream:
                         # (native or Sendspin bridge) owns the player, so this
                         # process's death says nothing about the device:
                         # ungrouping or scheduling a re-join over it would tear
-                        # down the session that replaced it.
+                        # down the session that replaced it. The teardown flags
+                        # are not consulted here: this branch runs from the
+                        # reader that sets them.
                         logger.debug(
                             "superseded cliairplay process stopped for %s", player.display_name
                         )
@@ -1905,16 +1907,30 @@ class AirPlayStream:
             # password would otherwise be left demanding one forever.
             self.player.set_password_invalid(True)
 
+    def _describes_the_device(self) -> bool:
+        """
+        Return whether what this stream reports is evidence about the receiver.
+
+        False while the stream is coming up, on its way out, or already replaced
+        on the player: a control channel that drops because the session is going
+        away says nothing about the device, so reporting it would tell the user
+        to go and fix a speaker that is fine.
+        """
+        return (
+            not self.superseded
+            and not self._stopping
+            and not self._stopped
+            and self.player.stream is self
+        )
+
     def _handle_native_control_failure(self) -> None:
         """Warn once that the receiver dropped the native AirPlay 2 control channel."""
         if self._native_control_failure_warned:
             return
-        if self.superseded or self.player.stream is not self:
-            # Not evidence about the device: either a newer session reset the
-            # control channel on the receiver, this stream is on its way out, or
-            # it is still coming up and has not been published yet. The binary keeps reporting while
-            # the failure lasts, so leaving the once-only latch unset here keeps
-            # a genuine failure reportable once the stream does own the player.
+        if not self._describes_the_device():
+            # The binary keeps reporting while the failure lasts, so leaving the
+            # once-only latch unset here keeps a genuine failure reportable once
+            # the stream does own the player.
             return
         self._native_control_failure_warned = True
         # Deliberately no automatic streaming-mode change here: the usual cause
@@ -2085,7 +2101,7 @@ class AirPlayStream:
         # taken over: neither its verdict nor its advice describes what the user
         # is hearing. The clock-ready wait below is still resolved, so its own
         # start path is not left hanging on evidence that will not arrive.
-        if stalled and not self._clock_stall_warned and self.player.stream is self:
+        if stalled and not self._clock_stall_warned and self._describes_the_device():
             # The receiver is not slaving to our clock at all, so it renders
             # silence while everything else about the session looks healthy.
             # Deliberately no automatic streaming-mode change: the streaming

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -1090,7 +1090,11 @@ class AirPlayStreamSession:
             airplay_player.stream = AirPlayStream(airplay_player, pcm_format=stream_pcm_format)
             airplay_player.stream.session = self
             await airplay_player.stream.connect(use_shared_ptp)
-        await self._start_player_ffmpeg(airplay_player, self.media)
+            # Wiring the audio producer to the cli stdin belongs to the same
+            # claim: a displacement landing between the connect and this would
+            # leave an ffmpeg feeding a process that is already gone, with
+            # nothing tracking it to clean up.
+            await self._start_player_ffmpeg(airplay_player, self.media)
 
     def _anchor_start_unix_ms(self, *, warm: bool = False, ready_at_unix_ms: int = 0) -> int:
         """

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -1080,12 +1080,16 @@ class AirPlayStreamSession:
         # joining a session supersedes any pending automatic group re-join
         airplay_player.cancel_group_rejoin()
         airplay_player.release_foreign_mute_latch()
-        if airplay_player.stream and airplay_player.stream.running:
-            await airplay_player.stream.stop()
-        stream_pcm_format = airplay_player.get_stream_pcm_format(self.pcm_format)
-        airplay_player.stream = AirPlayStream(airplay_player, pcm_format=stream_pcm_format)
-        airplay_player.stream.session = self
-        await airplay_player.stream.connect(use_shared_ptp)
+        # Held from the decision to displace whatever is published until the new
+        # process is connected and published, so a Sendspin bridge start cannot
+        # put a second cli process on the same receiver in between.
+        async with airplay_player.stream_spawn_lock:
+            if airplay_player.stream and airplay_player.stream.running:
+                await airplay_player.stream.stop()
+            stream_pcm_format = airplay_player.get_stream_pcm_format(self.pcm_format)
+            airplay_player.stream = AirPlayStream(airplay_player, pcm_format=stream_pcm_format)
+            airplay_player.stream.session = self
+            await airplay_player.stream.connect(use_shared_ptp)
         await self._start_player_ffmpeg(airplay_player, self.media)
 
     def _anchor_start_unix_ms(self, *, warm: bool = False, ready_at_unix_ms: int = 0) -> int:

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -1084,7 +1084,12 @@ class AirPlayStreamSession:
         # process is connected and published, so a Sendspin bridge start cannot
         # put a second cli process on the same receiver in between.
         async with airplay_player.stream_spawn_lock:
-            if airplay_player.stream and airplay_player.stream.running:
+            if airplay_player.stream:
+                # Stopped unconditionally, not just while it reads as running: a
+                # stream stops reporting that the moment its own stop() starts,
+                # while its process can still be on the receiver. stop() is
+                # idempotent, so this joins a teardown already under way and
+                # returns at once for one that finished.
                 await airplay_player.stream.stop()
             stream_pcm_format = airplay_player.get_stream_pcm_format(self.pcm_format)
             airplay_player.stream = AirPlayStream(airplay_player, pcm_format=stream_pcm_format)

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -91,6 +91,66 @@ def airplay_player() -> AirPlayPlayer:
     )
 
 
+async def test_cold_restart_keeps_a_stream_published_while_it_was_stopping(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """
+    A cold restart only drops the stream it stopped, not one published meanwhile.
+
+    Tearing a group session down awaits every member, which is long enough for a
+    Sendspin bridge to take the speaker and publish its own stream. Dropping that
+    reference would leave the start that follows with nothing to displace and a
+    live process still on the speaker.
+    """
+    old_session = MagicMock()
+    old_stream = MagicMock(running=True, superseded=False)
+    old_stream.session = old_session
+    old_session.can_replace = MagicMock(return_value=False)
+    bridge_stream = MagicMock(running=True, superseded=False, session=None)
+
+    async def _stop_session() -> None:
+        # the bridge takes the speaker while the group teardown is still running
+        airplay_player.stream = bridge_stream
+
+    old_session.stop = AsyncMock(side_effect=_stop_session)
+    airplay_player.stream = old_stream
+
+    with (
+        patch.object(airplay_player, "_get_sync_clients", return_value=[airplay_player]),
+        patch.object(airplay_player, "_get_session_pcm_format", new_callable=AsyncMock),
+        patch.object(airplay_player.mass.streams, "get_stream", MagicMock()),
+        patch(
+            "music_assistant.providers.airplay.player.AirPlayStreamSession",
+            return_value=MagicMock(start=AsyncMock()),
+        ),
+    ):
+        await airplay_player.play_media(MagicMock())
+
+    assert airplay_player.stream is bridge_stream
+
+
+def test_has_live_audio_ignores_a_stream_being_torn_down(
+    airplay_player: AirPlayPlayer,
+) -> None:
+    """
+    A clip cannot be mixed into a stream whose process is on its way out.
+
+    The stream stays published until its teardown has the process off the
+    receiver, so a clip armed against it would die with it instead of playing.
+    """
+    airplay_player._attr_playback_state = PlaybackState.PLAYING
+    stream = MagicMock()
+    stream.running = True
+    stream.connected = True
+    stream.superseded = False
+    airplay_player.stream = stream
+    assert airplay_player.has_live_audio is True
+
+    stream.superseded = True
+
+    assert airplay_player.has_live_audio is False
+
+
 @pytest.mark.parametrize(
     ("manufacturer", "model", "expected"),
     [
@@ -1049,9 +1109,11 @@ def test_announcements_are_advertised_only_with_live_audio(
     assert airplay_player.stream is None
     assert PlayerFeature.PLAY_ANNOUNCEMENT not in airplay_player.supported_features
     # a stream that is up but not yet connected renders nothing
-    airplay_player.stream = MagicMock(running=True, connected=False)
+    airplay_player.stream = MagicMock(running=True, connected=False, superseded=False)
     assert PlayerFeature.PLAY_ANNOUNCEMENT not in airplay_player.supported_features
-    airplay_player.stream = MagicMock(running=True, connected=True)
+    # A real bool for superseded: a bare MagicMock reads as a stream already handed
+    # to a teardown, which renders nothing either.
+    airplay_player.stream = MagicMock(running=True, connected=True, superseded=False)
     assert PlayerFeature.PLAY_ANNOUNCEMENT in airplay_player.supported_features
     # the bridge's own stream is a regular AirPlayStream the clip mixes into, so a
     # Sendspin-bridged player streaming through it keeps the feature

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -892,6 +892,8 @@ async def _bridge_start_racing_a_native_start(
     :param interleave_at: "displacement" starts the native path while the bridge
         releases the session it is displacing, "connect" starts it while the
         bridge's own cold connect is in flight.
+    :return: The bridge, its receiver process counter, the stream the bridge
+        started and the still-pending native start task.
     """
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
@@ -928,6 +930,9 @@ async def _bridge_start_racing_a_native_start(
     player.stream = displaced_stream
 
     bridge_stream = _make_anchor_stream()
+    # A real bool: the native start behind the lock only stops what it reads as
+    # live, and this stream is what it finds published once the bridge is done.
+    bridge_stream.running = True
     bridge_stream.stop = AsyncMock(side_effect=processes.kill)
 
     async def _connect(*_args: object, **_kwargs: object) -> None:
@@ -980,6 +985,148 @@ async def test_a_native_start_cannot_slip_into_a_bridge_start(interleave_at: str
     assert processes.peak == 1
     assert processes.live == 1
     bridge_stream.stop.assert_awaited()
+
+
+async def test_a_bridge_start_cannot_slip_into_a_native_start() -> None:
+    """
+    A bridge start racing a native start waits for it instead of joining it.
+
+    The mirror of the case above: the native path's own displacement stop is a
+    real await, and a bridge start landing inside it would connect its own
+    process and publish over a native start still in flight.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    player = bridge.airplay_player
+    processes = _ReceiverProcesses()
+    bridge_task: asyncio.Task[None] | None = None
+
+    bridge_stream = _make_anchor_stream()
+    bridge_stream.running = True
+    bridge_stream.connect = AsyncMock(side_effect=processes.spawn)
+    bridge_stream.stop = AsyncMock(side_effect=processes.kill)
+
+    displaced_stream = _make_native_stream()
+    displaced_stream.running = True
+    processes.spawn()
+
+    async def _stop_displaced(**_kwargs: object) -> None:
+        """Fire the bridge start from inside the native path's displacement stop."""
+        nonlocal bridge_task
+        displaced_stream.running = False
+        processes.kill()
+        if bridge_task is not None:
+            # the bridge displaces this same stream once it gets the lock; only
+            # the native path's own stop is the interleaving under test
+            return
+        bridge_task = asyncio.create_task(bridge._start_protocol_from_chunk())
+        # published before the task runs: the start path compares itself against
+        # this handle to tell whether it still owns the bridge
+        bridge._airplay_stream_start_task = bridge_task
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+    displaced_stream.stop = AsyncMock(side_effect=_stop_displaced)
+    player.stream = displaced_stream
+
+    native_stream = _make_native_stream()
+    native_stream.running = True
+    native_stream.connect = AsyncMock(side_effect=processes.spawn)
+    native_stream.stop = AsyncMock(side_effect=processes.kill)
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=bridge_stream,
+        ),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.time",
+            return_value=UNIX_NOW_S,
+        ),
+    ):
+        await _run_native_start(player, native_stream)
+
+        # the native start finished on its own process, with the bridge still
+        # queued behind the lock
+        assert processes.peak == 1
+        assert bridge_task is not None
+        assert not bridge_task.done()
+        assert cast("MagicMock", player).stream is native_stream
+
+        await bridge_task
+
+    # the bridge then displaces the native session in turn, still one at a time
+    assert processes.peak == 1
+    assert cast("MagicMock", player).stream is bridge_stream
+
+
+def _run_bridge_tasks_for_real(bridge: SendspinAirPlayBridge) -> list[asyncio.Task[None]]:
+    """
+    Let the bridge schedule real tasks instead of MagicMock ones.
+
+    :return: The list the scheduled tasks are appended to, to await at the end
+        of the test.
+    """
+    loop = asyncio.get_running_loop()
+    started: list[asyncio.Task[None]] = []
+
+    def create_task(
+        coro: Coroutine[None, None, None], *, eager_start: bool = True, **_kwargs: object
+    ) -> asyncio.Task[None]:
+        # mirrors mass.create_task, whose default eager start would run the
+        # coroutine to its first await before this returns
+        task = asyncio.Task(coro, loop=loop, eager_start=eager_start)
+        started.append(task)
+        return task
+
+    cast("MagicMock", bridge.mass).create_task = create_task
+    return started
+
+
+async def test_a_native_start_waits_for_the_bridge_to_let_go_of_the_receiver() -> None:
+    """
+    A native start after a stop waits for the bridge process to actually be gone.
+
+    A stop hands the transport to the cleanup path, which unpublishes it at once
+    but only kills the process a few awaits later. A play arriving in between
+    reads no published stream, so it has nothing to displace and would otherwise
+    pair its own process with a receiver the old one is still holding.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    player = bridge.airplay_player
+    processes = _ReceiverProcesses()
+    scheduled = _run_bridge_tasks_for_real(bridge)
+
+    bridge_stream = _make_anchor_stream()
+
+    async def _slow_stop(**_kwargs: object) -> None:
+        # a real teardown writes ACTION=STOP, drops the command pipe and kills
+        # the process, none of which is instant
+        for _ in range(4):
+            await asyncio.sleep(0)
+        processes.kill()
+
+    bridge_stream.stop = AsyncMock(side_effect=_slow_stop)
+    bridge._airplay_stream = bridge_stream
+    player.stream = bridge_stream
+    processes.spawn()
+
+    native_stream = _make_native_stream()
+    native_stream.running = False
+    native_stream.connect = AsyncMock(side_effect=processes.spawn)
+    native_stream.stop = AsyncMock(side_effect=processes.kill)
+
+    bridge._release_streaming()
+    # the reference is already gone while the process is not
+    assert cast("MagicMock", player).stream is None
+    assert processes.live == 1
+
+    await _run_native_start(player, native_stream)
+
+    assert processes.peak == 1
+    assert cast("MagicMock", player).stream is native_stream
+    await asyncio.gather(*scheduled, return_exceptions=True)
+    assert processes.live == 1
 
 
 async def test_a_displaced_stream_that_cannot_be_stopped_blocks_the_start() -> None:

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -2392,7 +2392,7 @@ def test_lost_transport_rearms_a_cold_start_on_the_current_chunk() -> None:
     only visible on the stream itself. The chunk that exposes it is also the one
     the fresh transport anchors to, which is where the group is playing now.
     """
-    bridge, _ = _make_anchored_bridge(running=False)
+    bridge, dead_stream = _make_anchored_bridge(running=False)
     chunk_ts = SENDSPIN_EPOCH_US + 30_000_000
 
     bridge._on_audio_chunk(_pcm_chunk(chunk_ts))
@@ -2400,7 +2400,8 @@ def test_lost_transport_rearms_a_cold_start_on_the_current_chunk() -> None:
     assert bridge._airplay_stream is None
     # released from the bridge, but still published until the teardown that owns
     # it has the dead process cleared
-    assert bridge.airplay_player.stream is not None
+    assert bridge.airplay_player.stream is dead_stream
+    assert dead_stream.superseded is True
     assert bridge._started is False
     assert bridge._anchor_settled is False
     # a fresh start is armed and anchored where the group is playing right now

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -1016,8 +1016,10 @@ async def test_a_bridge_start_cannot_slip_into_a_native_start() -> None:
         displaced_stream.running = False
         processes.kill()
         if bridge_task is not None:
-            # the bridge displaces this same stream once it gets the lock; only
-            # the native path's own stop is the interleaving under test
+            # Only the first call is the interleaving under test. Without the
+            # spawn lock the bridge start finds this same stream still published
+            # and re-enters here; starting another bridge task would supersede
+            # the one under test and the race would go unnoticed.
             return
         bridge_task = asyncio.create_task(bridge._start_protocol_from_chunk())
         # published before the task runs: the start path compares itself against
@@ -1087,10 +1089,10 @@ async def test_a_native_start_waits_for_the_bridge_to_let_go_of_the_receiver() -
     """
     A native start after a stop waits for the bridge process to actually be gone.
 
-    A stop hands the transport to the cleanup path, which unpublishes it at once
-    but only kills the process a few awaits later. A play arriving in between
-    reads no published stream, so it has nothing to displace and would otherwise
-    pair its own process with a receiver the old one is still holding.
+    A stop (stop_streaming, or a give-up through _abandon_streaming) hands the
+    transport to the cleanup path, which only kills the process a few awaits
+    later. A play arriving in between would otherwise pair its own process with
+    a receiver the old one is still holding.
     """
     bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
     player = bridge.airplay_player

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -48,6 +48,7 @@ from music_assistant.providers.airplay.constants import (
     ClockReadiness,
     StreamingProtocol,
 )
+from music_assistant.providers.airplay.player import AirPlayPlayer
 from music_assistant.providers.airplay.sendspin_bridge import (
     BRIDGE_COLD_START_LEAD_MS,
     BRIDGE_MIN_BUFFER_MS,
@@ -64,6 +65,7 @@ from music_assistant.providers.airplay.sendspin_bridge import (
     sendspin_audible_instant_to_unix_ms,
     unix_ms_to_sendspin_audible_instant,
 )
+from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
 from music_assistant.providers.sendspin.bridge_role import (
     BRIDGE_BYTES_PER_SAMPLE,
     BRIDGE_CHANNELS,
@@ -216,6 +218,9 @@ def _make_bridge(
     # A real None: the start path stops whatever stream the player already holds
     # before it spawns a process, and a bare MagicMock reads as a live session.
     airplay_player.stream = None
+    # A real lock: it is what keeps the bridge and native spawn paths off the
+    # same receiver, and `async with` on a MagicMock does not even work.
+    airplay_player.stream_spawn_lock = asyncio.Lock()
     # A real int: the anchor math guards sync_adjust with isinstance(..., int), so
     # a MagicMock would silently read as 0 and pass the test for the wrong reason.
     airplay_player.config.get_value = MagicMock(return_value=sync_adjust)
@@ -840,6 +845,141 @@ async def test_cold_start_stops_a_native_session_before_it_spawns_a_process() ->
     assert order == ["stop", "remove_client", "connect"]
     assert session.remove_client.await_args.args[0] is bridge.airplay_player
     assert bridge.airplay_player.stream is stream
+
+
+class _ReceiverProcesses:
+    """
+    Counts the cli processes live on one receiver.
+
+    Two of them reset each other's RTSP channel and both sessions die, so
+    ``peak`` is the value the collision tests assert on.
+    """
+
+    def __init__(self) -> None:
+        self.live = 0
+        self.peak = 0
+
+    def spawn(self, *_args: object, **_kwargs: object) -> None:
+        """Record a cli process pairing with the receiver."""
+        self.live += 1
+        self.peak = max(self.peak, self.live)
+
+    def kill(self, *_args: object, **_kwargs: object) -> None:
+        """Record a cli process letting go of the receiver."""
+        self.live = max(0, self.live - 1)
+
+
+async def _run_native_start(player: AirPlayPlayer, stream: MagicMock) -> None:
+    """Run the real native start path for a player against a throwaway session."""
+    pcm_format = MagicMock(sample_rate=44100, bit_depth=16, channels=2)
+    session = AirPlayStreamSession(MagicMock(), [player], pcm_format, MagicMock(elapsed_time=0))
+    with (
+        patch.object(session, "_start_player_ffmpeg", new_callable=AsyncMock),
+        patch(
+            "music_assistant.providers.airplay.stream_session.AirPlayStream",
+            return_value=stream,
+        ),
+    ):
+        await session._start_client(player, False)
+
+
+async def _bridge_start_racing_a_native_start(
+    interleave_at: str,
+) -> tuple[SendspinAirPlayBridge, _ReceiverProcesses, MagicMock, asyncio.Task[None]]:
+    """
+    Drive a bridge start and let a native start in at one of its awaits.
+
+    :param interleave_at: "displacement" starts the native path while the bridge
+        releases the session it is displacing, "connect" starts it while the
+        bridge's own cold connect is in flight.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    bridge._airplay_stream_start_task = asyncio.current_task()
+    player = bridge.airplay_player
+    processes = _ReceiverProcesses()
+    native_task: asyncio.Task[None] | None = None
+
+    native_stream = _make_native_stream()
+    native_stream.running = False
+    native_stream.connect = AsyncMock(side_effect=processes.spawn)
+    native_stream.stop = AsyncMock(side_effect=processes.kill)
+
+    async def _start_native() -> None:
+        """Fire the native start and let it run until it can get no further."""
+        nonlocal native_task
+        native_task = asyncio.create_task(_run_native_start(player, native_stream))
+        # Three passes through the loop: enough for the native start to reach
+        # the spawn lock and, without one, to spawn its process outright.
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+    displaced_stream = _make_native_stream(MagicMock(remove_client=AsyncMock()))
+    displaced_stream.running = True
+    processes.spawn()
+
+    async def _stop_displaced(**_kwargs: object) -> None:
+        displaced_stream.running = False
+        processes.kill()
+        if interleave_at == "displacement":
+            await _start_native()
+
+    displaced_stream.stop = AsyncMock(side_effect=_stop_displaced)
+    player.stream = displaced_stream
+
+    bridge_stream = _make_anchor_stream()
+    bridge_stream.stop = AsyncMock(side_effect=processes.kill)
+
+    async def _connect(*_args: object, **_kwargs: object) -> None:
+        processes.spawn()
+        if interleave_at == "connect":
+            await _start_native()
+
+    bridge_stream.connect = AsyncMock(side_effect=_connect)
+
+    with (
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.AirPlayStream",
+            return_value=bridge_stream,
+        ),
+        patch(
+            "music_assistant.providers.airplay.sendspin_bridge.time.time",
+            return_value=UNIX_NOW_S,
+        ),
+    ):
+        await bridge._start_protocol_from_chunk()
+
+    assert native_task is not None
+    return bridge, processes, bridge_stream, native_task
+
+
+@pytest.mark.parametrize("interleave_at", ["displacement", "connect"])
+async def test_a_native_start_cannot_slip_into_a_bridge_start(interleave_at: str) -> None:
+    """
+    A native start racing a bridge start waits for it instead of joining it.
+
+    Both paths spawn a cli process for the same receiver, and neither the
+    displacement nor the cold connect is instant. Without the shared spawn lock
+    the native start publishes its own stream inside one of those awaits and the
+    bridge then connects a second process over it - two sessions on one receiver,
+    with the native one orphaned by the bridge's later publication.
+    """
+    bridge, processes, bridge_stream, native_task = await _bridge_start_racing_a_native_start(
+        interleave_at
+    )
+
+    # the bridge start finished on its own process, with the native one still
+    # queued behind the lock rather than paired with the same receiver
+    assert processes.peak == 1
+    assert not native_task.done()
+    assert bridge.airplay_player.stream is bridge_stream
+
+    await native_task
+
+    # the native start then displaces the bridge in turn, still one at a time
+    assert processes.peak == 1
+    assert processes.live == 1
+    bridge_stream.stop.assert_awaited()
 
 
 async def test_a_displaced_stream_that_cannot_be_stopped_blocks_the_start() -> None:

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -1129,6 +1129,62 @@ async def test_a_native_start_waits_for_the_bridge_to_let_go_of_the_receiver() -
     assert processes.live == 1
 
 
+async def test_a_teardown_does_not_lose_the_receiver_to_a_queued_native_start() -> None:
+    """
+    A native start already queued for the lock still finds the process to displace.
+
+    The lock is handed out in arrival order, so a teardown that only queues for
+    it after cancelling the start holding it lands behind a native start that
+    was already waiting. That start has to see the stream the teardown has not
+    released yet, or it reads the speaker as free and pairs a second process
+    with it.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._drop_until_us = SENDSPIN_EPOCH_US + COLD_LEAD_MS * 1_000
+    player = bridge.airplay_player
+    processes = _ReceiverProcesses()
+    scheduled = _run_bridge_tasks_for_real(bridge)
+
+    kept_stream = _make_kept_stream()
+    flush_gate = asyncio.Event()
+
+    async def _blocking_flush(**_kwargs: object) -> bool:
+        await flush_gate.wait()
+        return True
+
+    kept_stream.flush = AsyncMock(side_effect=_blocking_flush)
+    kept_stream.stop = AsyncMock(side_effect=lambda **_kw: processes.kill())
+    bridge._airplay_stream = kept_stream
+    # a legacy RAOP process carries no timing decision, so it stays warm eligible
+    bridge._use_shared_ptp = None
+    player.stream = kept_stream
+    processes.spawn()
+
+    warm_task = asyncio.create_task(bridge._start_protocol_from_chunk())
+    bridge._airplay_stream_start_task = warm_task
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert player.stream_spawn_lock.locked()
+
+    native_stream = _make_native_stream()
+    native_stream.running = False
+    native_stream.connect = AsyncMock(side_effect=processes.spawn)
+    native_stream.stop = AsyncMock(side_effect=processes.kill)
+    native_task = asyncio.create_task(_run_native_start(player, native_stream))
+    for _ in range(3):
+        await asyncio.sleep(0)
+    assert not native_task.done()
+
+    # the speaker is stopped: the teardown cancels the warm start that holds the
+    # lock, and can only queue for it behind the native start already waiting
+    bridge._release_streaming()
+
+    await asyncio.gather(warm_task, native_task, *scheduled, return_exceptions=True)
+
+    assert processes.peak == 1
+    assert cast("MagicMock", player).stream is native_stream
+
+
 async def test_a_displaced_stream_that_cannot_be_stopped_blocks_the_start() -> None:
     """
     A transport the bridge cannot release stops it from spawning a second process.
@@ -2003,7 +2059,9 @@ def test_on_bridge_stream_start_replaces_uncommitted_stream() -> None:
     bridge._on_bridge_stream_start()
 
     assert bridge._airplay_stream is None
-    assert bridge.airplay_player.stream is None  # type: ignore[unreachable]
+    # the player keeps the reference until the scheduled teardown has the process
+    # off the receiver, so nothing reads the speaker as free while it is not
+    assert bridge.airplay_player.stream is old_stream  # type: ignore[unreachable]
 
 
 def test_on_stream_start_keeps_warm_eligible_stream() -> None:
@@ -2301,7 +2359,9 @@ def test_lost_transport_rearms_a_cold_start_on_the_current_chunk() -> None:
     bridge._on_audio_chunk(_pcm_chunk(chunk_ts))
 
     assert bridge._airplay_stream is None
-    assert bridge.airplay_player.stream is None
+    # released from the bridge, but still published until the teardown that owns
+    # it has the dead process cleared
+    assert bridge.airplay_player.stream is not None
     assert bridge._started is False
     assert bridge._anchor_settled is False
     # a fresh start is armed and anchored where the group is playing right now

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -1187,6 +1187,43 @@ async def test_a_teardown_does_not_lose_the_receiver_to_a_queued_native_start() 
     assert cast("MagicMock", player).stream is native_stream
 
 
+async def test_a_native_start_joins_a_teardown_already_under_way() -> None:
+    """
+    A start waits out a stop that is already running on the stream it displaces.
+
+    A stream stops reporting itself as running the moment its own stop() begins,
+    which is before the STOP write and the process kill. Reading that as "gone"
+    would let the start pair a process with a receiver the old one has not let
+    go of yet.
+    """
+    player = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US).airplay_player
+    processes = _ReceiverProcesses()
+
+    # mid-teardown: no longer reporting itself as running, process still alive
+    stopping_stream = _make_native_stream()
+    stopping_stream.running = False
+    processes.spawn()
+
+    async def _finish_teardown(**_kwargs: object) -> None:
+        for _ in range(4):
+            await asyncio.sleep(0)
+        processes.kill()
+
+    stopping_stream.stop = AsyncMock(side_effect=_finish_teardown)
+    player.stream = stopping_stream
+
+    native_stream = _make_native_stream()
+    native_stream.running = False
+    native_stream.connect = AsyncMock(side_effect=processes.spawn)
+    native_stream.stop = AsyncMock(side_effect=processes.kill)
+
+    await _run_native_start(player, native_stream)
+
+    stopping_stream.stop.assert_awaited_once()
+    assert processes.peak == 1
+    assert cast("MagicMock", player).stream is native_stream
+
+
 async def test_a_displaced_stream_that_cannot_be_stopped_blocks_the_start() -> None:
     """
     A transport the bridge cannot release stops it from spawning a second process.

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2092,6 +2092,28 @@ def test_native_control_failure_on_a_superseded_stream_stays_silent() -> None:
     player.provider.mass.config.set_raw_player_config_value.assert_not_called()
 
 
+def test_clock_stall_on_a_stream_being_torn_down_stays_silent() -> None:
+    """
+    A stream handed to a teardown does not report its stalled clock.
+
+    It stays published until the teardown has its process off the receiver, so a
+    clock that stops answering there describes the session going away, not the
+    device. Reporting it would send the user after a speaker that is fine.
+    """
+    player = _make_player()
+    stream = AirPlayStream(player)
+    player.stream = stream
+    stream.superseded = True
+
+    stream._handle_status_line(
+        "[STATUS] clock_ready mode=ptp state=stalled streak_ms=0 exchanges=0 "
+        "ready_in_ms=0 ready_at_unix_ms=0"
+    )
+
+    # the one-shot is still there for a stall that does describe the device
+    assert stream._clock_stall_warned is False
+
+
 def test_native_control_failure_on_a_stream_being_torn_down_stays_silent() -> None:
     """
     A stream handed to a teardown does not report its lost control channel.

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2092,18 +2092,22 @@ def test_native_control_failure_on_a_superseded_stream_stays_silent() -> None:
     player.provider.mass.config.set_raw_player_config_value.assert_not_called()
 
 
-def test_clock_stall_on_a_stream_being_torn_down_stays_silent() -> None:
+@pytest.mark.parametrize("teardown_flag", ["superseded", "_stopping"])
+def test_clock_stall_on_a_stream_being_torn_down_stays_silent(teardown_flag: str) -> None:
     """
-    A stream handed to a teardown does not report its stalled clock.
+    A stream being torn down does not report its stalled clock.
 
     It stays published until the teardown has its process off the receiver, so a
     clock that stops answering there describes the session going away, not the
     device. Reporting it would send the user after a speaker that is fine.
+
+    :param teardown_flag: How the stream is on its way out - handed to the
+        bridge's teardown, or already inside its own stop().
     """
     player = _make_player()
     stream = AirPlayStream(player)
     player.stream = stream
-    stream.superseded = True
+    setattr(stream, teardown_flag, True)
 
     stream._handle_status_line(
         "[STATUS] clock_ready mode=ptp state=stalled streak_ms=0 exchanges=0 "
@@ -2114,18 +2118,24 @@ def test_clock_stall_on_a_stream_being_torn_down_stays_silent() -> None:
     assert stream._clock_stall_warned is False
 
 
-def test_native_control_failure_on_a_stream_being_torn_down_stays_silent() -> None:
+@pytest.mark.parametrize("teardown_flag", ["superseded", "_stopping"])
+def test_native_control_failure_on_a_stream_being_torn_down_stays_silent(
+    teardown_flag: str,
+) -> None:
     """
-    A stream handed to a teardown does not report its lost control channel.
+    A stream being torn down does not report its lost control channel.
 
     It stays published until the teardown has its process off the receiver, so
     owning the player no longer means the failure describes the device: the
     channel is going away because the session is.
+
+    :param teardown_flag: How the stream is on its way out - handed to the
+        bridge's teardown, or already inside its own stop().
     """
     player = _make_player()
     stream = AirPlayStream(player)
     player.stream = stream
-    stream.superseded = True
+    setattr(stream, teardown_flag, True)
 
     stream._handle_status_line("[ERROR] AirPlay 2 control channel failed")
 

--- a/tests/providers/airplay/test_stream.py
+++ b/tests/providers/airplay/test_stream.py
@@ -2092,6 +2092,25 @@ def test_native_control_failure_on_a_superseded_stream_stays_silent() -> None:
     player.provider.mass.config.set_raw_player_config_value.assert_not_called()
 
 
+def test_native_control_failure_on_a_stream_being_torn_down_stays_silent() -> None:
+    """
+    A stream handed to a teardown does not report its lost control channel.
+
+    It stays published until the teardown has its process off the receiver, so
+    owning the player no longer means the failure describes the device: the
+    channel is going away because the session is.
+    """
+    player = _make_player()
+    stream = AirPlayStream(player)
+    player.stream = stream
+    stream.superseded = True
+
+    stream._handle_status_line("[ERROR] AirPlay 2 control channel failed")
+
+    # the one-shot is still there for a failure that does describe the device
+    assert stream._native_control_failure_warned is False
+
+
 def test_native_control_failure_before_publication_stays_reportable(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #6051. That PR stopped a Sendspin bridge from putting a second cliairplay process on a receiver that was already serving a native session, but only for the deterministic case. The two paths that start a stream for a speaker still ran without any mutual exclusion, so a native start arriving while the bridge was releasing the displaced session (or connecting its own transport) published its stream inside that window. The bridge then connected a second process over it and overwrote the publication, leaving two sessions fighting over one receiver's RTSP channel and the native process orphaned with nothing able to stop it. The speaker goes silent, same symptom as #6051.

A stop had the same problem from the other side: it drops the player's stream reference straight away but only kills the process in a background task, so a play arriving in between found nothing to displace and connected on top of a process that was still there.

Everything that starts or releases a stream for a speaker now takes a dedicated per-player lock, so only one thing is ever pairing with (or letting go of) a receiver at a time.

**Related issue (if applicable):**

- follow-up to #6051

## Changes

- Added `AirPlayPlayer.stream_spawn_lock`, taken by `AirPlayStreamSession._start_client` and by the Sendspin bridge's `_start_protocol_from_chunk`
- The bridge's background cleanup holds the same lock while it actually releases the speaker, so a start can no longer sneak in behind a stop
- Only the teardown that owns a speaker's stream unpublishes it, holding that same lock, so no start can find the speaker free while a process is still on it
- A member's ffmpeg is wired to its speaker under the same lock, so a displacement in between cannot leave an untracked ffmpeg behind
- A start now waits out a stop already running on the speaker, instead of treating a stream that has begun stopping as already gone
- Because a speaker's stream now outlives its teardown, the checks that used to read "still ours" as "still healthy" ask directly whether the stream still describes the device. Without this a routine teardown would warn that a perfectly fine speaker had stopped answering, and lose an announcement into a stream that was about to be killed
- The lock is always acquired inside `AirPlayPlayer._lock`, never around it
- Added tests for every way the paths can overlap, each asserting only one process is ever paired with the receiver

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
