### PR TITLE
Stop restarting an AirPlay speaker when a seek needs a moment

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -10,6 +10,7 @@ from music_assistant_models.enums import ContentType, PlayerFeature
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.constants import CONF_ENTRY_SYNC_ADJUST
+from music_assistant.controllers.streams.constants import SEEK_WAIT_THRESHOLD
 
 DOMAIN = "airplay"
 
@@ -175,6 +176,15 @@ AIRPLAY_GROUP_START_LEAD_MS: Final[int] = 500
 # audibly out of sync. Warm re-anchors reuse a locked clock and keep the
 # short leads above; solo cold starts have no sync partner to miss.
 AIRPLAY_COLD_GROUP_START_LEAD_MS: Final[int] = 2500
+
+# How long a start waits for the source to hand over its first audio before it
+# judges the members on what they never received. A seek may land up to
+# SEEK_WAIT_THRESHOLD seconds ahead of what the source has produced and a
+# realtime source covers that at playback pace, so the wait has to outlast it;
+# the margin covers the source's own spin-up. It is a backstop rather than a
+# budget: this runs under the player lock, so a producer that neither delivers
+# nor gives up would otherwise hold every command for the player behind it.
+AIRPLAY_FEED_START_TIMEOUT: Final[float] = SEEK_WAIT_THRESHOLD + 5
 # Margin added on top of a member's reported warm lead (the splice-timeline
 # queue depth; that timeline is the default for every native AirPlay 2 session)
 # when anchoring a warm re-start: covers the command round-trips between the

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -19,6 +19,7 @@ from .constants import (
     AIRPLAY_CLOCK_READY_LEAD_MS,
     AIRPLAY_CLOCK_READY_TIMEOUT_MS,
     AIRPLAY_COLD_GROUP_START_LEAD_MS,
+    AIRPLAY_FEED_START_TIMEOUT,
     AIRPLAY_GROUP_START_LEAD_MS,
     AIRPLAY_LATE_JOIN_MIN_HEADROOM_MS,
     AIRPLAY_LATE_JOIN_RING_MARGIN_SECONDS,
@@ -1172,15 +1173,22 @@ class AirPlayStreamSession:
         raise PlayerCommandFailed(f"audio feed was not confirmed by {', '.join(silent)}")
 
     async def _wait_feed_settled(self) -> None:
-        """Wait for the first audio to reach the members, or the source to end without any."""
+        """Wait for the source to hand over its first audio, or to end without any."""
         task = self._audio_source_task
         if task is None or self._feed_settled.is_set():
             return
-        settled = asyncio.ensure_future(self._feed_settled.wait())
+        settled = asyncio.create_task(self._feed_settled.wait())
         try:
-            # the streamer settles the event itself, but watching the task too
-            # means a feed that never even starts cannot hold this open
-            await asyncio.wait({settled, task}, return_when=asyncio.FIRST_COMPLETED)
+            # The streamer settles the event itself, but watching the task too
+            # means a feed that never even starts cannot hold this open. The
+            # timeout is the backstop for a producer that neither delivers nor
+            # gives up: this runs under the player lock, where every route that
+            # could stop the session waits behind it.
+            await asyncio.wait(
+                {settled, task},
+                timeout=AIRPLAY_FEED_START_TIMEOUT,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
         finally:
             settled.cancel()
 

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -135,6 +135,10 @@ class AirPlayStreamSession:
         # counter — aligning lengths in isolation can still land mid-sample,
         # which a joiner renders as pure static.
         self._pcm_total_fed: int = 0
+        # Set once the first audio of a start cycle has been handed to the
+        # members, and also when the source ends without ever handing any over,
+        # so a waiter is never left holding on for a feed that is not coming.
+        self._feed_settled = asyncio.Event()
 
     @property
     def effective_start_time(self) -> float:
@@ -286,6 +290,7 @@ class AirPlayStreamSession:
             # describe the OLD timeline; restart them before the new source pumps.
             self.seconds_streamed = 0
             self._pcm_total_fed = 0
+            self._feed_settled.clear()
             self._pcm_buffer.clear()
             # The shared START below re-establishes start_time, so the per-client
             # late-join skip counters and every member's accumulated starvation
@@ -348,6 +353,7 @@ class AirPlayStreamSession:
         # a parked session has no live timeline; the resume re-anchors it
         self.seconds_streamed = 0
         self._pcm_total_fed = 0
+        self._feed_settled.clear()
         self._pcm_buffer.clear()
         self._client_skip_bytes.clear()
         self._reset_member_shifts()
@@ -886,6 +892,9 @@ class AirPlayStreamSession:
                 exc_info=err,
             )
         finally:
+            # a source that ends - or is cancelled - without handing anything
+            # over settles the question for a start still waiting on the feed
+            self._feed_settled.set()
             if stream_error:
                 self.prov.logger.warning(
                     "Stream ended prematurely due to error - notifying players"
@@ -923,6 +932,7 @@ class AirPlayStreamSession:
             # add_client always reads consistent values.
             self.seconds_streamed += len(chunk) / self._pcm_byte_rate
             self._pcm_total_fed += len(chunk)
+            self._feed_settled.set()
             self._observe_write_head_lead()
             self._pcm_buffer.extend(chunk)
             overflow = len(self._pcm_buffer) - self._pcm_buffer_max
@@ -1138,7 +1148,16 @@ class AirPlayStreamSession:
         return anchor
 
     async def _wait_members_audio_present(self) -> None:
-        """Wait until every member's binary reports the new audio flowing."""
+        """
+        Wait until every member's binary reports the new audio flowing.
+
+        A binary can only report audio once it has been handed some, and a seek
+        may land seconds ahead of what the source has produced — a realtime one
+        covers that in real time. So the feed is waited out first and the
+        per-member budget below measures the binary alone; giving up on the
+        source here would only restart the session into the very same wait.
+        """
+        await self._wait_feed_settled()
         members = [(p, p.stream) for p in self.sync_clients if p.stream]
         results = await asyncio.gather(*[stream.wait_audio_present() for _, stream in members])
         if all(results):
@@ -1151,6 +1170,19 @@ class AirPlayStreamSession:
             if not present
         ]
         raise PlayerCommandFailed(f"audio feed was not confirmed by {', '.join(silent)}")
+
+    async def _wait_feed_settled(self) -> None:
+        """Wait for the first audio to reach the members, or the source to end without any."""
+        task = self._audio_source_task
+        if task is None or self._feed_settled.is_set():
+            return
+        settled = asyncio.ensure_future(self._feed_settled.wait())
+        try:
+            # the streamer settles the event itself, but watching the task too
+            # means a feed that never even starts cannot hold this open
+            await asyncio.wait({settled, task}, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            settled.cancel()
 
     async def _wait_members_clock_ready(self) -> int:
         """

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -925,6 +925,52 @@ async def test_start_player_ffmpeg_wires_persistent_cli_stdin() -> None:
 
 
 @pytest.mark.asyncio
+async def test_audio_confirmation_waits_for_the_source_to_feed() -> None:
+    """
+    A binary is only judged silent once it has actually been handed audio.
+
+    A seek can land seconds ahead of what the source has produced, and giving up
+    on the member there would restart the session into the very same wait.
+    """
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.stream.wait_audio_present = AsyncMock(return_value=True)
+    feeding = asyncio.Event()
+
+    async def _source() -> None:
+        await feeding.wait()
+
+    session._audio_source_task = asyncio.create_task(_source())
+
+    waiter = asyncio.create_task(session._wait_members_audio_present())
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert not waiter.done()
+    player.stream.wait_audio_present.assert_not_awaited()
+
+    session._feed_settled.set()
+    await waiter
+
+    player.stream.wait_audio_present.assert_awaited_once()
+    feeding.set()
+    await session._audio_source_task
+
+
+@pytest.mark.asyncio
+async def test_audio_confirmation_is_released_by_a_source_that_never_feeds() -> None:
+    """A source that ends without handing anything over never holds up the start."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.display_name = "Kantoor"
+    player.stream.wait_audio_present = AsyncMock(return_value=False)
+    session._audio_source_task = asyncio.create_task(asyncio.sleep(0))
+    await session._audio_source_task
+
+    with pytest.raises(PlayerCommandFailed, match="audio feed was not confirmed"):
+        await session._wait_members_audio_present()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("transitioning", "live_session_id", "ends_stream"),
     [

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import PlaybackState
-from music_assistant_models.errors import PlayerCommandFailed
+from music_assistant_models.errors import AudioError, PlayerCommandFailed
 
 from music_assistant.providers.airplay.constants import (
     AIRPLAY_CLOCK_READY_LEAD_MS,
@@ -954,6 +954,44 @@ async def test_audio_confirmation_waits_for_the_source_to_feed() -> None:
     player.stream.wait_audio_present.assert_awaited_once()
     feeding.set()
     await session._audio_source_task
+
+
+@pytest.mark.asyncio
+async def test_a_source_that_dies_settles_the_feed_question() -> None:
+    """A source that fails never leaves a start waiting for audio it will not get."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.stream.write_audio_eof = AsyncMock()
+    session.media = MagicMock(source_id=None, queue_session_id=None)
+    no_chunks: list[bytes] = []
+
+    async def failing_source() -> AsyncGenerator[bytes]:
+        for chunk in no_chunks:
+            yield chunk
+        raise AudioError("source died")
+
+    await session._audio_streamer(failing_source())
+
+    assert session._feed_settled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_warm_replace_rearms_the_feed_question() -> None:
+    """The new source answers for its own feed; what the old one delivered does not count."""
+    session = _make_session(0, 0)
+    player: Any = session.sync_clients[0]
+    player.config.get_value = MagicMock(return_value=0)
+    player.stream.flush = AsyncMock(return_value=True)
+    session._feed_settled.set()
+
+    with (
+        patch.object(session, "_start_player_ffmpeg", new_callable=AsyncMock),
+        patch.object(session, "_audio_streamer", new_callable=AsyncMock),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=100.0),
+    ):
+        assert await session.replace(MagicMock(), MagicMock(elapsed_time=0))
+
+    assert not session._feed_settled.is_set()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Seeking far ahead in a track can take a moment: the audio has to be produced before it can be played, and a source that hands over its audio at playback pace (Spotify through the Soloist backend) needs that time in real time. Music Assistant allows a seek up to 20 seconds ahead of what the source has produced, but the AirPlay speaker was given only 5 seconds to report audio flowing before the connection was torn down and rebuilt — which then waits for exactly the same audio, and pays a reconnect and a clock probe on top.

Measured on a real speaker: a seek to 0:30 with 21s produced needed 9 seconds of audio, gave up after 5, and restarted the speaker for nothing.

Changes:

- the speaker is only judged silent once it has actually been handed audio, so its own budget measures the speaker instead of the source
- that wait ends as soon as the source ends, is cancelled, or never delivers anything

**Related issue (if applicable):**

- follow-up on #6050

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
