### PR TITLE
Keep the queue on an audio player when a group leader drops out

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -35,6 +35,7 @@ from music_assistant_models.errors import (
     InvalidDataError,
     MediaNotFoundError,
     MusicAssistantError,
+    PlayerCommandFailed,
     PlayerUnavailableError,
     QueueEmpty,
 )
@@ -80,6 +81,7 @@ from music_assistant.controllers.player_queues.state import PlayerQueueData
 from music_assistant.controllers.player_queues.stream_feeder import StreamFeederMixin
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.api import api_command
+from music_assistant.helpers.config_entries import PLAYBACK_TARGET_TYPES
 from music_assistant.helpers.uri import parse_uri
 from music_assistant.models.music_provider import ProviderStreamLimitError
 from music_assistant.models.player import Player, PlayerMedia
@@ -1127,6 +1129,10 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         target_player = self.mass.players.get_player(target_queue_id)
         if target_player is None:
             raise PlayerUnavailableError(f"Player {target_queue_id} is not available")
+        # refuse targets that can never render audio (display/visualizer/lighting clients)
+        # before anything is mutated, so a bad target does not destroy the source queue
+        if target_player.state.type not in PLAYBACK_TARGET_TYPES:
+            raise PlayerCommandFailed(f"Player {target_player.name} is not capable of playback")
         if target_player.state.active_group or target_player.state.synced_to:
             # edge case: the user wants to move playback from the group as a whole, to a single
             # player in the group or it is grouped and the command targeted at the single player.

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -126,7 +126,9 @@ class ManagedPool:
         :param queue_id: The queue to fill.
         :param is_initial: True when seeding a fresh pool, False when topping up an existing one.
         """
-        queue_data = self.queues.queue_data(queue_id)
+        if (queue_data := self.queues.queue_data_or_none(queue_id)) is None:
+            # the queue was removed while this background refill was starting up
+            return []
         queue = queue_data.queue
         windows = self.queues.recency_windows()
         snapshot = await self.mass.music.recency.snapshot(windows, userid=queue_data.userid)
@@ -142,7 +144,7 @@ class ManagedPool:
         # recency, not permanent exclusion, decides when a track may return. Besides exact item
         # identity we also dedupe on fuzzy same-song keys (title + artist) so a different
         # release/version of an already-queued song is not pulled in as well.
-        items = self.queues.queue_data(queue_id).items
+        items = queue_data.items
         start = queue.current_index if queue.current_index is not None else 0
         pool_keys: set[Track] = set()
         pool_song_keys: set[tuple[str, str]] = set()
@@ -207,10 +209,13 @@ class ManagedPool:
         :param include_dynamic: Whether to include dynamic sources; skipped on the initial
             fill, where each dynamic source seeds its own first batch directly.
         """
+        if (queue_data := self.queues.queue_data_or_none(queue_id)) is None:
+            # the queue was removed while earlier fetches of this refill were awaited
+            return []
         # multiplicity = how often a source was added (adding a source more than once weights it up)
         counts: dict[str, int] = {}
         items: dict[str, MediaItemType] = {}
-        for item in self.queues.queue_data(queue_id).source_items:
+        for item in queue_data.source_items:
             if is_dynamic_source(item) and not include_dynamic:
                 continue
             if not (uri := _uri(item)):

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -450,6 +450,9 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
         async def _settle_or_resume_delayed() -> None:
             for _ in range(5):
                 await asyncio.sleep(1)
+                if self._queue_data.get(queue.queue_id) is not queue_data:
+                    # the queue was removed or re-registered while we waited
+                    return
                 if queue.state != PlaybackState.IDLE:
                     return
                 if queue.next_item is not None:
@@ -468,8 +471,7 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
                         await self.play_index(queue.queue_id, next_index)
                     return
             # If the queue was started from a dynamic source, fetch fresh tracks and continue.
-            qdata = self._queue_data.get(queue.queue_id)
-            dynamic_source = find_dynamic_source(qdata) if qdata else None
+            dynamic_source = find_dynamic_source(queue_data)
             if dynamic_source is not None:
                 try:
                     # Restore the queue owner's user context so provider filters and
@@ -484,7 +486,7 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
                     dynamic_tracks = await self._media_resolver.get_dynamic_source_tracks(
                         dynamic_source
                     )
-                    if self._queue_data.get(queue.queue_id) is not qdata:
+                    if self._queue_data.get(queue.queue_id) is not queue_data:
                         # the queue was removed or re-registered while tracks were fetched
                         return
                     if dynamic_tracks:

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -521,6 +521,9 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
                         queue.display_name,
                         err,
                     )
+            if self._queue_data.get(queue.queue_id) is not queue_data:
+                # the queue was removed or re-registered while the source was fetched
+                return
             self._finish_queue(queue, prev_item)
 
         # all checks passed, we stopped playback at the last (or single) track of the queue

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -484,6 +484,9 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
                     dynamic_tracks = await self._media_resolver.get_dynamic_source_tracks(
                         dynamic_source
                     )
+                    if self._queue_data.get(queue.queue_id) is not qdata:
+                        # the queue was removed or re-registered while tracks were fetched
+                        return
                     if dynamic_tracks:
                         queue_items = [
                             build_queue_item(queue.queue_id, x)

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -667,10 +667,13 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         if not queue_items:
             self.logger.info("Autoplay found no new tracks to add for queue %s", queue.display_name)
             return
+        if queue_id not in self._queue_data:
+            # the queue was removed (player deleted or ungrouped) while tracks were fetched
+            return
         await self.load(
             queue_id,
             queue_items,
-            insert_at_index=len(self._queue_data[queue_id].items) + 1,
+            insert_at_index=len(queue_data.items) + 1,
         )
 
     @handle_play_action

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -512,7 +512,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             "Filling dynamic tracks for queue %s",
             queue_id,
         )
-        queue_data = self._queue_data[queue_id]
+        if (queue_data := self._queue_data.get(queue_id)) is None:
+            # the delayed refill timer can fire after the queue was removed
+            return
         queue = queue_data.queue
         # restore the queue owner's user context so provider filters are respected during this
         # background refill (dynamic-playlist generation honours the current user)

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -527,9 +527,12 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         # the tail cap below is a defensive ceiling so the unplayed tail never grows past
         # MANAGED_POOL_MAX.
         pool_tracks = await self._managed_pool.fill(queue_id, is_initial=False)
+        if queue_id not in self._queue_data:
+            # the queue was removed (player deleted or ungrouped) while tracks were fetched
+            return
         # keep the unplayed tail within the bounded pool size (no current_index => nothing played yet)
         played = 0 if queue.current_index is None else queue.current_index + 1
-        unplayed = max(len(self._queue_data[queue_id].items) - played, 0)
+        unplayed = max(len(queue_data.items) - played, 0)
         headroom = max(MANAGED_POOL_MAX - unplayed, 0)
         queue_items = [build_queue_item(queue_id, x) for x in pool_tracks[:headroom] if x.available]
         if not queue_items:
@@ -537,7 +540,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         await self.load(
             queue_id,
             queue_items,
-            insert_at_index=len(self._queue_data[queue_id].items) + 1,
+            insert_at_index=len(queue_data.items) + 1,
         )
 
     async def _fill_autoplay_tracks(self, queue_id: str) -> None:

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -527,8 +527,8 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         # the tail cap below is a defensive ceiling so the unplayed tail never grows past
         # MANAGED_POOL_MAX.
         pool_tracks = await self._managed_pool.fill(queue_id, is_initial=False)
-        if queue_id not in self._queue_data:
-            # the queue was removed (player deleted or ungrouped) while tracks were fetched
+        if self._queue_data.get(queue_id) is not queue_data:
+            # the queue was removed or re-registered while tracks were fetched
             return
         # keep the unplayed tail within the bounded pool size (no current_index => nothing played yet)
         played = 0 if queue.current_index is None else queue.current_index + 1
@@ -610,6 +610,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         ):
             # already queued (e.g. the user added it themselves), so there is nothing to do
             return
+        if self._queue_data.get(queue_id) is not queue_data:
+            # the queue was removed or re-registered while the successor was fetched
+            return
         await self.load(
             queue_id,
             [build_queue_item(queue_id, next_item)],
@@ -670,8 +673,8 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         if not queue_items:
             self.logger.info("Autoplay found no new tracks to add for queue %s", queue.display_name)
             return
-        if queue_id not in self._queue_data:
-            # the queue was removed (player deleted or ungrouped) while tracks were fetched
+        if self._queue_data.get(queue_id) is not queue_data:
+            # the queue was removed or re-registered while tracks were fetched
             return
         await self.load(
             queue_id,

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -568,6 +568,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             else None
         )
         set_current_user(playback_user)
+        if self._queue_data.get(queue_id) is not queue_data:
+            # the queue was removed or re-registered while the user context was restored
+            return
         if last_item.media_type in AUTOPLAY_SERIES_MEDIA_TYPES:
             await self._fill_autoplay_next_in_series(queue_id, last_item)
             return

--- a/music_assistant/controllers/player_queues/stream_feeder.py
+++ b/music_assistant/controllers/player_queues/stream_feeder.py
@@ -156,7 +156,7 @@ class StreamFeederMixin(_PlayerQueuesBase):
                 self.logger.debug(
                     "Enqueued next track %s on queue %s",
                     next_item.name,
-                    self._queue_data[queue_id].queue.display_name,
+                    queue.display_name,
                 )
 
         task_id = f"enqueue_next_item_{queue_id}"

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3383,8 +3383,6 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         # to a remaining member (keeping playback alive) or dissolve the group entirely
         should_stop = False
         if player_ids_to_remove and target_player in player_ids_to_remove:
-            # only audio-capable members qualify as a new leader: a display, visualizer or
-            # lighting member can be grouped along but must never inherit the queue
             remaining_members = [
                 m
                 for m in parent_player.state.group_members
@@ -3392,10 +3390,15 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                 and m not in player_ids_to_remove
                 and (member := self.get_player(m))
                 and member.state.available
-                and member.state.type in PLAYBACK_TARGET_TYPES
             ]
+            # a new leader must be able to render audio: a group with only display,
+            # visualizer or lighting members left has no playback heir and dissolves
+            has_playback_heir = any(
+                (member := self.get_player(m)) and member.state.type in PLAYBACK_TARGET_TYPES
+                for m in remaining_members
+            )
             active_queue = self.get_active_queue(parent_player)
-            if remaining_members and active_queue and active_queue.state != PlaybackState.IDLE:
+            if has_playback_heir and active_queue and active_queue.state != PlaybackState.IDLE:
                 # transfer leadership to a remaining member instead of dissolving
                 await self._transfer_ad_hoc_leadership(parent_player, remaining_members)
                 return
@@ -3650,20 +3653,27 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
 
         :param leader: The current sync leader being removed.
         :param remaining_members: Candidate member player_ids, already filtered for
-            availability and playback capability. Must not be empty.
+            availability. Must contain at least one audio-capable member.
         """
+        # non-audio members (display/visualizer/lighting) stay in the group as followers
+        # but can never inherit the queue
+        candidates = [
+            m
+            for m in remaining_members
+            if (member := self.get_player(m)) and member.state.type in PLAYBACK_TARGET_TYPES
+        ]
         active_domain: str | None = None
         if leader.active_output_protocol and leader.active_output_protocol != "native":
             if protocol_player := self.get_player(leader.active_output_protocol):
                 active_domain = protocol_player.provider.domain
         if active_domain:
-            for member_id in remaining_members:
+            for member_id in candidates:
                 member = self.get_player(member_id)
                 if member is None:
                     continue
                 if active_domain in member.playback_domains:
                     return member_id
-        return remaining_members[0]
+        return candidates[0]
 
     def _clear_sleep_timer(self, player: Player) -> None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -106,6 +106,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
 )
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.colors import get_palette_for_url
+from music_assistant.helpers.config_entries import PLAYBACK_TARGET_TYPES
 from music_assistant.helpers.plugin_engines import create_tts_engine_config_entries
 from music_assistant.helpers.util import (
     TaskManager,
@@ -3382,6 +3383,8 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         # to a remaining member (keeping playback alive) or dissolve the group entirely
         should_stop = False
         if player_ids_to_remove and target_player in player_ids_to_remove:
+            # only audio-capable members qualify as a new leader: a display, visualizer or
+            # lighting member can be grouped along but must never inherit the queue
             remaining_members = [
                 m
                 for m in parent_player.state.group_members
@@ -3389,6 +3392,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                 and m not in player_ids_to_remove
                 and (member := self.get_player(m))
                 and member.state.available
+                and member.state.type in PLAYBACK_TARGET_TYPES
             ]
             active_queue = self.get_active_queue(parent_player)
             if remaining_members and active_queue and active_queue.state != PlaybackState.IDLE:
@@ -3646,7 +3650,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
 
         :param leader: The current sync leader being removed.
         :param remaining_members: Candidate member player_ids, already filtered for
-            availability. Must not be empty.
+            availability and playback capability. Must not be empty.
         """
         active_domain: str | None = None
         if leader.active_output_protocol and leader.active_output_protocol != "native":

--- a/tests/controllers/player_queues/test_autoplay_dispatch.py
+++ b/tests/controllers/player_queues/test_autoplay_dispatch.py
@@ -365,6 +365,28 @@ async def test_auto_music_refill_falls_back_to_library_after_provider_failure() 
     loader._autoplay.get_library_tracks.assert_awaited_once()
 
 
+async def test_music_refill_bails_when_the_queue_is_removed_mid_fetch() -> None:
+    """A queue removed while the refill fetches tracks is left alone instead of crashing."""
+    track = _track()
+    loader = _loader(_queue_item(track), seeds=[track])
+    loader._autoplay.resolve_mode.return_value = AutoplayMode.LIBRARY
+
+    async def _fetch_and_remove_queue(*_args: Any, **_kwargs: Any) -> list[Track]:
+        loader._queue_data.pop("q1")
+        return [track]
+
+    loader._autoplay.get_library_tracks = AsyncMock(side_effect=_fetch_and_remove_queue)
+    loader.mass.music.recency.snapshot = AsyncMock(return_value=MagicMock())
+
+    with patch(
+        "music_assistant.controllers.player_queues.queue_loader.gate_tracks",
+        return_value=[track],
+    ):
+        await QueueLoaderMixin._fill_autoplay_music_tracks(loader, "q1")
+
+    loader.load.assert_not_awaited()
+
+
 # --- appending the resolved successor ---
 
 

--- a/tests/controllers/player_queues/test_autoplay_dispatch.py
+++ b/tests/controllers/player_queues/test_autoplay_dispatch.py
@@ -565,3 +565,46 @@ async def test_settle_task_bails_when_the_queue_is_removed_while_waiting(
     tracker.play_index.assert_not_called()
     tracker.load.assert_not_called()
     tracker._finish_queue.assert_not_called()
+
+
+async def test_settle_task_skips_finish_when_the_queue_vanishes_during_fetch() -> None:
+    """A failed dynamic fetch on a removed queue must not mark anything as ended."""
+    tracker = _tracker()
+    tracker._queue_data["q1"].userid = None
+    prev_state, new_state = _stop_states(
+        SimpleNamespace(media_type=MediaType.TRACK, streamdetails=None, duration=3600)
+    )
+    queue = cast(
+        "PlayerQueue",
+        SimpleNamespace(
+            queue_id="q1",
+            next_item=None,
+            flow_mode=False,
+            state=PlaybackState.IDLE,
+            current_index=None,
+            display_name="Q1",
+        ),
+    )
+    PlaybackTrackerMixin._handle_end_of_queue(tracker, queue, prev_state, new_state)
+    settle_coro = tracker.mass.create_task.call_args.args[0]
+
+    async def _fetch_and_remove_queue(*_args: Any, **_kwargs: Any) -> list[Track]:
+        tracker._queue_data.pop("q1")
+        raise ProviderUnavailableError("provider unloaded")
+
+    tracker._media_resolver.get_dynamic_source_tracks = AsyncMock(
+        side_effect=_fetch_and_remove_queue
+    )
+    with (
+        patch(
+            "music_assistant.controllers.player_queues.playback_tracker.asyncio.sleep",
+            AsyncMock(),
+        ),
+        patch(
+            "music_assistant.controllers.player_queues.playback_tracker.find_dynamic_source",
+            return_value=MagicMock(),
+        ),
+    ):
+        await settle_coro
+
+    tracker._finish_queue.assert_not_called()

--- a/tests/controllers/player_queues/test_autoplay_dispatch.py
+++ b/tests/controllers/player_queues/test_autoplay_dispatch.py
@@ -341,6 +341,23 @@ async def test_autoplay_disabled_appends_nothing() -> None:
     loader._fill_autoplay_next_in_series.assert_not_awaited()
 
 
+async def test_autoplay_dispatch_bails_when_the_queue_is_removed_mid_lookup() -> None:
+    """A queue removed while the owner's user context is restored gets no refill."""
+    loader = _loader(_queue_item(_track()), seeds=[_track()])
+    loader._queue_data["q1"].userid = "u1"
+
+    async def _lookup_and_remove_queue(*_args: Any, **_kwargs: Any) -> Any:
+        loader._queue_data.pop("q1")
+        return MagicMock()
+
+    loader.mass.webserver.auth.get_user = AsyncMock(side_effect=_lookup_and_remove_queue)
+
+    await QueueLoaderMixin._fill_autoplay_tracks(loader, "q1")
+
+    loader._fill_autoplay_music_tracks.assert_not_awaited()
+    loader._fill_autoplay_next_in_series.assert_not_awaited()
+
+
 async def test_music_refill_without_seeds_appends_nothing() -> None:
     """The music refill needs an enqueued item as its seed."""
     loader = _loader(_queue_item(_track()))

--- a/tests/controllers/player_queues/test_autoplay_dispatch.py
+++ b/tests/controllers/player_queues/test_autoplay_dispatch.py
@@ -341,13 +341,20 @@ async def test_autoplay_disabled_appends_nothing() -> None:
     loader._fill_autoplay_next_in_series.assert_not_awaited()
 
 
-async def test_autoplay_dispatch_bails_when_the_queue_is_removed_mid_lookup() -> None:
-    """A queue removed while the owner's user context is restored gets no refill."""
+@pytest.mark.parametrize("reregistered", [False, True])
+async def test_autoplay_dispatch_bails_when_the_queue_is_removed_mid_lookup(
+    reregistered: bool,
+) -> None:
+    """A queue removed (or re-registered fresh) mid-lookup gets no refill."""
     loader = _loader(_queue_item(_track()), seeds=[_track()])
     loader._queue_data["q1"].userid = "u1"
 
     async def _lookup_and_remove_queue(*_args: Any, **_kwargs: Any) -> Any:
         loader._queue_data.pop("q1")
+        if reregistered:
+            loader._queue_data["q1"] = SimpleNamespace(
+                items=[], enqueued_media_items=[], userid="u1"
+            )
         return MagicMock()
 
     loader.mass.webserver.auth.get_user = AsyncMock(side_effect=_lookup_and_remove_queue)
@@ -356,6 +363,34 @@ async def test_autoplay_dispatch_bails_when_the_queue_is_removed_mid_lookup() ->
 
     loader._fill_autoplay_music_tracks.assert_not_awaited()
     loader._fill_autoplay_next_in_series.assert_not_awaited()
+
+
+@pytest.mark.parametrize("reregistered", [False, True])
+async def test_dynamic_refill_bails_when_the_queue_is_removed(reregistered: bool) -> None:
+    """A dynamic refill firing for a removed (or re-registered) queue loads nothing."""
+    loader = MagicMock()
+    loader.load = AsyncMock()
+    if reregistered:
+        loader._queue_data = {
+            "q1": SimpleNamespace(userid=None, queue=SimpleNamespace(current_index=None))
+        }
+
+        async def _fill_and_replace_queue(*_args: Any, **_kwargs: Any) -> list[Track]:
+            loader._queue_data["q1"] = SimpleNamespace(
+                userid=None, queue=SimpleNamespace(current_index=None), items=[]
+            )
+            return [_track()]
+
+        loader._managed_pool.fill = AsyncMock(side_effect=_fill_and_replace_queue)
+    else:
+        # the delayed refill timer fires after the queue was already removed
+        loader._queue_data = {}
+
+    await QueueLoaderMixin._fill_dynamic_tracks(loader, "q1")
+
+    loader.load.assert_not_called()
+    if not reregistered:
+        loader._managed_pool.fill.assert_not_called()
 
 
 async def test_music_refill_without_seeds_appends_nothing() -> None:
@@ -504,3 +539,29 @@ def test_finished_track_queue_is_settled_on_stop() -> None:
     PlaybackTrackerMixin._handle_end_of_queue(tracker, _stopped_queue(), prev_state, new_state)
 
     tracker.mass.create_task.assert_called_once()
+
+
+@pytest.mark.parametrize("reregistered", [False, True])
+async def test_settle_task_bails_when_the_queue_is_removed_while_waiting(
+    reregistered: bool,
+) -> None:
+    """A queue removed (or re-registered) during the settle delay is left alone entirely."""
+    tracker = _tracker()
+    prev_state, new_state = _stop_states(
+        SimpleNamespace(media_type=MediaType.TRACK, streamdetails=None, duration=3600)
+    )
+    PlaybackTrackerMixin._handle_end_of_queue(tracker, _stopped_queue(), prev_state, new_state)
+    settle_coro = tracker.mass.create_task.call_args.args[0]
+
+    tracker._queue_data.pop("q1")
+    if reregistered:
+        tracker._queue_data["q1"] = SimpleNamespace(flow_mode_stream_log=[])
+    with patch(
+        "music_assistant.controllers.player_queues.playback_tracker.asyncio.sleep",
+        AsyncMock(),
+    ):
+        await settle_coro
+
+    tracker.play_index.assert_not_called()
+    tracker.load.assert_not_called()
+    tracker._finish_queue.assert_not_called()

--- a/tests/controllers/player_queues/test_autoplay_dispatch.py
+++ b/tests/controllers/player_queues/test_autoplay_dispatch.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from music_assistant_models.enums import MediaType, PlaybackState
 from music_assistant_models.errors import ProviderUnavailableError
 from music_assistant_models.media_items import (
@@ -365,14 +366,21 @@ async def test_auto_music_refill_falls_back_to_library_after_provider_failure() 
     loader._autoplay.get_library_tracks.assert_awaited_once()
 
 
-async def test_music_refill_bails_when_the_queue_is_removed_mid_fetch() -> None:
-    """A queue removed while the refill fetches tracks is left alone instead of crashing."""
+@pytest.mark.parametrize("reregistered", [False, True])
+async def test_music_refill_bails_when_the_queue_is_removed_mid_fetch(
+    reregistered: bool,
+) -> None:
+    """A queue removed (or re-registered fresh) mid-fetch must not receive the stale batch."""
     track = _track()
     loader = _loader(_queue_item(track), seeds=[track])
     loader._autoplay.resolve_mode.return_value = AutoplayMode.LIBRARY
 
     async def _fetch_and_remove_queue(*_args: Any, **_kwargs: Any) -> list[Track]:
         loader._queue_data.pop("q1")
+        if reregistered:
+            loader._queue_data["q1"] = SimpleNamespace(
+                items=[], enqueued_media_items=[], userid=None
+            )
         return [track]
 
     loader._autoplay.get_library_tracks = AsyncMock(side_effect=_fetch_and_remove_queue)

--- a/tests/controllers/player_queues/test_transfer_queue.py
+++ b/tests/controllers/player_queues/test_transfer_queue.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
-from music_assistant_models.enums import AlbumType, PlaybackState
+import pytest
+from music_assistant_models.enums import AlbumType, PlaybackState, PlayerType
+from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import Album, Track
 from music_assistant_models.player_queue import PlayerQueue
 
@@ -61,6 +63,7 @@ async def test_transfer_queue_ad_hoc_member_ungroups_target_not_leader() -> None
     recurse back into transfer_queue, so only the target may be ungrouped.
     """
     target_player = MagicMock()
+    target_player.state.type = PlayerType.PLAYER
     target_player.state.synced_to = "leaderA"
     target_player.state.active_group = None
     fake = _fake_controller("src", target_player)
@@ -72,9 +75,31 @@ async def test_transfer_queue_ad_hoc_member_ungroups_target_not_leader() -> None
     fake.mass.players.cmd_ungroup.assert_awaited_once_with("memberB")
 
 
+async def test_transfer_queue_refuses_non_audio_target() -> None:
+    """
+    A target that can never render audio is refused before anything is touched.
+
+    The source queue must survive intact: no stop, no clear, no item handover.
+    """
+    target_player = MagicMock()
+    target_player.state.type = PlayerType.VISUALIZER
+    fake = _fake_controller("src", target_player)
+
+    with pytest.raises(PlayerCommandFailed):
+        await PlayerQueuesController.transfer_queue(
+            cast("PlayerQueuesController", fake), "src", "viz", auto_play=False
+        )
+
+    fake.stop.assert_not_awaited()
+    fake._clear.assert_not_called()
+    fake.load.assert_not_awaited()
+    fake.mass.players.cmd_ungroup.assert_not_awaited()
+
+
 async def test_transfer_queue_group_member_ungroups_group() -> None:
     """Transferring onto a virtual-group member releases the group player itself."""
     target_player = MagicMock()
+    target_player.state.type = PlayerType.PLAYER
     target_player.state.synced_to = None
     target_player.state.active_group = "groupP"
     fake = _fake_controller("src", target_player)
@@ -134,6 +159,7 @@ def _shuffle_controller(
     fake._notify_audio_source_transferred = AsyncMock()
     fake.is_smart_shuffle_active = MagicMock(side_effect=lambda queue: queue.is_dynamic)
     target_player = MagicMock()
+    target_player.state.type = PlayerType.PLAYER
     target_player.state.synced_to = None
     target_player.state.active_group = None
     fake.mass.players.get_player = MagicMock(return_value=target_player)

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -743,6 +743,10 @@ class TestAdHocLeadershipTransfer:
         await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
 
         controller._transfer_ad_hoc_leadership.assert_not_awaited()
+        # the dissolve removes the visualizer from the group and stops the leader
+        controller._handle_set_members_with_protocols.assert_awaited_once_with(
+            leader, [], ["visualizer"]
+        )
         controller._handle_cmd_stop.assert_awaited_once_with("leader")
 
     async def test_handle_set_members_dissolves_leader_when_idle(

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -652,6 +652,76 @@ class TestAdHocLeadershipTransfer:
         assert called_leader is leader
         assert set(called_remaining) == {"member_a", "member_b"}
 
+    async def test_handle_set_members_never_transfers_to_non_audio_member(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A visualizer/light/display member is never offered as the new leader."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test", instance_id="test", mass=mock_mass)
+
+        leader = MockPlayer(provider, "leader", "Leader")
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader._attr_can_group_with = {"member_a", "visualizer"}
+        leader._attr_group_members = ["leader", "member_a", "visualizer"]
+        member_a = MockPlayer(provider, "member_a", "Member A")
+        visualizer = MockPlayer(
+            provider, "visualizer", "Visualizer", player_type=PlayerType.VISUALIZER
+        )
+
+        controller._players = {
+            "leader": leader,
+            "member_a": member_a,
+            "visualizer": visualizer,
+        }
+        mock_mass.players = controller
+        # refresh each player's state snapshot so it reflects the mocked player type
+        for player in (leader, member_a, visualizer):
+            player.update_state(signal_event=False)
+
+        playing_queue = MagicMock()
+        playing_queue.state = PlaybackState.PLAYING
+        controller.get_active_queue = MagicMock(return_value=playing_queue)  # type: ignore[method-assign]
+        controller._transfer_ad_hoc_leadership = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
+
+        controller._transfer_ad_hoc_leadership.assert_awaited_once()
+        _, called_remaining = controller._transfer_ad_hoc_leadership.call_args.args
+        assert called_remaining == ["member_a"]
+
+    async def test_handle_set_members_dissolves_when_only_non_audio_members_remain(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """With only non-audio members left there is no heir: dissolve and stop."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test", instance_id="test", mass=mock_mass)
+
+        leader = MockPlayer(provider, "leader", "Leader")
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader._attr_can_group_with = {"visualizer"}
+        leader._attr_group_members = ["leader", "visualizer"]
+        visualizer = MockPlayer(
+            provider, "visualizer", "Visualizer", player_type=PlayerType.VISUALIZER
+        )
+
+        controller._players = {"leader": leader, "visualizer": visualizer}
+        mock_mass.players = controller
+        # refresh each player's state snapshot so it reflects the mocked player type
+        for player in (leader, visualizer):
+            player.update_state(signal_event=False)
+
+        playing_queue = MagicMock()
+        playing_queue.state = PlaybackState.PLAYING
+        controller.get_active_queue = MagicMock(return_value=playing_queue)  # type: ignore[method-assign]
+        controller._transfer_ad_hoc_leadership = AsyncMock()  # type: ignore[method-assign]
+        controller._handle_set_members_with_protocols = AsyncMock()  # type: ignore[method-assign]
+        controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
+
+        controller._transfer_ad_hoc_leadership.assert_not_awaited()
+        controller._handle_cmd_stop.assert_awaited_once_with("leader")
+
     async def test_handle_set_members_dissolves_leader_when_idle(
         self, mock_mass: MagicMock
     ) -> None:

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -618,9 +618,30 @@ class TestAdHocLeadershipTransfer:
         """Without an active protocol to match, fall back to the first remaining member."""
         leader = MagicMock()
         leader.active_output_protocol = None
-        controller._players = {"a": MagicMock(), "b": MagicMock()}
+        member_a = MagicMock()
+        member_a.state.type = PlayerType.PLAYER
+        member_b = MagicMock()
+        member_b.state.type = PlayerType.PLAYER
+        controller._players = {"a": member_a, "b": member_b}
 
         assert controller._select_ad_hoc_leader(leader, ["a", "b"]) == "a"
+
+    def test_select_ad_hoc_leader_never_picks_non_audio_member(
+        self, controller: PlayerController, mock_mass: MagicMock
+    ) -> None:
+        """A visualizer listed before an audio member must never inherit the queue."""
+        provider = MockProvider("test", instance_id="test", mass=mock_mass)
+        visualizer = MockPlayer(provider, "viz", "Visualizer", player_type=PlayerType.VISUALIZER)
+        member_b = MockPlayer(provider, "b", "Member B")
+        controller._players = {"viz": visualizer, "b": member_b}
+        # refresh each player's state snapshot so it reflects the mocked player type
+        for player in (visualizer, member_b):
+            player.update_state(signal_event=False)
+
+        leader = MagicMock()
+        leader.active_output_protocol = None
+
+        assert controller._select_ad_hoc_leader(leader, ["viz", "b"]) == "b"
 
     async def test_handle_set_members_transfers_leader_when_playing(
         self, mock_mass: MagicMock
@@ -652,10 +673,10 @@ class TestAdHocLeadershipTransfer:
         assert called_leader is leader
         assert set(called_remaining) == {"member_a", "member_b"}
 
-    async def test_handle_set_members_never_transfers_to_non_audio_member(
+    async def test_handle_set_members_keeps_non_audio_member_as_follower(
         self, mock_mass: MagicMock
     ) -> None:
-        """A visualizer/light/display member is never offered as the new leader."""
+        """A non-audio member does not block the transfer and stays in the regroup set."""
         controller = PlayerController(mock_mass)
         provider = MockProvider("test", instance_id="test", mass=mock_mass)
 
@@ -687,7 +708,9 @@ class TestAdHocLeadershipTransfer:
 
         controller._transfer_ad_hoc_leadership.assert_awaited_once()
         _, called_remaining = controller._transfer_ad_hoc_leadership.call_args.args
-        assert called_remaining == ["member_a"]
+        # the visualizer stays a group member (it follows the new leader), the
+        # heir itself is picked from the audio-capable members only
+        assert set(called_remaining) == {"member_a", "visualizer"}
 
     async def test_handle_set_members_dissolves_when_only_non_audio_members_remain(
         self, mock_mass: MagicMock


### PR DESCRIPTION
# What does this implement/fix?

When a sync group leader dropped out unexpectedly (e.g. its stream died), leadership could be handed to a group member that cannot play audio at all, such as a visualizer, display or light client. The whole queue was moved onto that hidden player, the transfer then failed and the user was left with an empty queue.

- Only audio-capable members are now considered as the new group leader; if none remain, the group is dissolved as before.
- Transferring a queue to a player that can never render audio is refused up front, so a failed transfer no longer destroys the source queue.
- The background queue refills (autoplay and dynamic sources) no longer crash when their queue is removed while new tracks are being fetched.

**Related issue (if applicable):**

- n/a (reported via logs)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
