### PR TITLE
Fix a speaker staying silent after its group is joined with another one

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3362,13 +3362,14 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                     synced_to,
                 )
 
-    async def _dissolve_own_native_group(self, player: Player, target_name: str) -> bool:
+    async def _dissolve_own_group(self, player: Player, target_name: str) -> bool:
         """
-        Dissolve the native group a player leads before it joins another group.
+        Dissolve the group a player leads before it joins another group.
 
-        Only a player whose native members ride its own stream has a group to give up: it
-        stops rendering that stream the moment it joins the other group, which would leave
-        its members silent while they still show up as grouped.
+        Only a player whose members ride its own stream has a group to give up: it stops
+        rendering that stream the moment it joins the other group, which would leave its
+        members silent while they still show up as grouped. A group that is still playing
+        is refused instead, so the player stays out rather than silencing its members.
 
         :param player: The player about to join another group.
         :param target_name: Name of the group being joined, for the log messages.
@@ -3381,6 +3382,16 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         ]
         if not members:
             return True
+        if player.state.playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
+            # Grouping never offers a rendering leader as a target, so reaching this means
+            # the caller worked from a can_group_with snapshot taken before the playback
+            # started. Tearing the group down now would cut its members off mid-track.
+            self.logger.warning(
+                "Player %s is still serving its own group, leaving it out of %s",
+                player.name,
+                target_name,
+            )
+            return False
         self.logger.info(
             "Player %s leads a group of its own, dissolving it before it joins %s",
             player.name,
@@ -3496,7 +3507,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
 
             # handle edge case: the child leads a native group of its own, which it cannot
             # keep serving from inside this one
-            if not await self._dissolve_own_native_group(child_player, parent_player.state.name):
+            if not await self._dissolve_own_group(child_player, parent_player.state.name):
                 continue
 
             # power on the player if needed

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3362,6 +3362,41 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                     synced_to,
                 )
 
+    async def _dissolve_own_native_group(self, player: Player, log_context: str) -> None:
+        """
+        Dissolve the native group a player leads before it joins another group.
+
+        Only a player whose native members ride its own stream has a group to give up: it
+        stops rendering that stream the moment it joins the other group, which would leave
+        its members silent while they still show up as grouped.
+
+        :param player: The player about to join another group.
+        :param log_context: Additional context for the log message (e.g. target player name).
+        """
+        if not player.native_grouping_requires_own_stream:
+            return
+        members = [
+            member_id for member_id in player.state.group_members if member_id != player.player_id
+        ]
+        if not members:
+            return
+        self.logger.info(
+            "Player %s leads a group of its own, dissolving it before %s",
+            player.name,
+            log_context,
+        )
+        # Removing the members rather than the leader keeps this out of the leadership
+        # transfer path, and the internal handler avoids deadlocking on the play lock
+        # (we're already inside a cmd_set_members chain that holds it).
+        try:
+            await self._handle_set_members(player, player_ids_to_remove=members)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger.warning(
+                "Failed to dissolve the group of %s, proceeding anyway", player.name
+            )
+
     async def _handle_set_members(
         self,
         parent_player: Player,
@@ -3451,6 +3486,10 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                 child_player.state.active_group,
             }:
                 await self._auto_ungroup_if_synced(child_player, f"joining {parent_player.name}")
+
+            # handle edge case: the child leads a native group of its own, which it cannot
+            # keep serving from inside this one
+            await self._dissolve_own_native_group(child_player, f"joining {parent_player.name}")
 
             # power on the player if needed
             if (

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3362,7 +3362,7 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
                     synced_to,
                 )
 
-    async def _dissolve_own_native_group(self, player: Player, log_context: str) -> None:
+    async def _dissolve_own_native_group(self, player: Player, target_name: str) -> bool:
         """
         Dissolve the native group a player leads before it joins another group.
 
@@ -3371,19 +3371,20 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         its members silent while they still show up as grouped.
 
         :param player: The player about to join another group.
-        :param log_context: Additional context for the log message (e.g. target player name).
+        :param target_name: Name of the group being joined, for the log messages.
+        :return: False when the group is still in place, so the player must not join.
         """
         if not player.native_grouping_requires_own_stream:
-            return
+            return True
         members = [
             member_id for member_id in player.state.group_members if member_id != player.player_id
         ]
         if not members:
-            return
+            return True
         self.logger.info(
-            "Player %s leads a group of its own, dissolving it before %s",
+            "Player %s leads a group of its own, dissolving it before it joins %s",
             player.name,
-            log_context,
+            target_name,
         )
         # Removing the members rather than the leader keeps this out of the leadership
         # transfer path, and the internal handler avoids deadlocking on the play lock
@@ -3393,9 +3394,15 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
         except asyncio.CancelledError:
             raise
         except Exception:
+            # Joining on top of a group it still leads is the silent-member state this
+            # dissolve exists to prevent, and one the player can no longer be talked out of.
             self.logger.warning(
-                "Failed to dissolve the group of %s, proceeding anyway", player.name
+                "Could not dissolve the group of %s, leaving it out of %s",
+                player.name,
+                target_name,
             )
+            return False
+        return True
 
     async def _handle_set_members(
         self,
@@ -3489,7 +3496,8 @@ class PlayerController(AnnouncementsMixin, AudioSourceMixin, ProtocolLinkingMixi
 
             # handle edge case: the child leads a native group of its own, which it cannot
             # keep serving from inside this one
-            await self._dissolve_own_native_group(child_player, f"joining {parent_player.name}")
+            if not await self._dissolve_own_native_group(child_player, parent_player.state.name):
+                continue
 
             # power on the player if needed
             if (

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -2512,9 +2512,10 @@ class ProtocolLinkingMixin:
         Move the native members that a switch to the given protocol strands onto that protocol.
 
         Returns the member IDs that are still attached to the parent's own stream, so the
-        caller can release them from it. Empty unless the parent renders that stream itself
-        while its native grouping attaches the members to exactly that stream: only then are
-        they left without anything to play.
+        caller can release them from it. Empty unless the parent's native grouping attaches
+        its members to exactly that stream: only then are they left without anything to play.
+        An idle parent counts too, since its group outlives the session and would otherwise
+        keep members that stay silent on the next play.
 
         :param parent_player: The parent player that is about to switch protocol.
         :param parent_protocol_player: The protocol player the parent will render through.
@@ -2525,8 +2526,6 @@ class ProtocolLinkingMixin:
         if not parent_player.native_grouping_requires_own_stream:
             return []
         if parent_player.active_output_protocol not in (None, "native"):
-            return []
-        if parent_player.state.playback_state not in (PlaybackState.PLAYING, PlaybackState.PAUSED):
             return []
         stranded = [
             member_id
@@ -2540,21 +2539,24 @@ class ProtocolLinkingMixin:
                 protocol_members.append(protocol_id)
         return stranded
 
-    async def _stop_native_session(
+    async def _release_native_members(
         self,
         parent_player: Player,
         parent_protocol_player: Player,
         stranded_native_members: list[str],
+        *,
+        stop_session: bool,
     ) -> None:
         """
-        Release the given members from the parent's own stream and stop it.
+        Release the given members from the parent's own stream, and stop it when it is live.
 
-        :param parent_player: The parent player whose native session is handed over.
+        :param parent_player: The parent player whose native grouping is handed over.
         :param parent_protocol_player: The protocol player taking the output over.
         :param stranded_native_members: The members to release, already migrated.
+        :param stop_session: Whether the parent still renders the stream they were attached to.
         """
         self.logger.debug(
-            "Stopping the native session of %s before switching to %s, migrated members: %s",
+            "Releasing the native members of %s before switching to %s: %s",
             parent_player.state.name,
             parent_protocol_player.state.name,
             stranded_native_members,
@@ -2564,7 +2566,8 @@ class ProtocolLinkingMixin:
         # keeps a later native playback command from resurrecting it. Both calls take the
         # provider's own lock, so they must run one after the other.
         await parent_player.set_members(player_ids_to_remove=stranded_native_members)
-        await parent_player.stop()
+        if stop_session:
+            await parent_player.stop()
 
     def _translate_members_for_protocols(
         self,
@@ -2942,8 +2945,8 @@ class ProtocolLinkingMixin:
             return
 
         # Members that ride the parent's own stream are stranded by the protocol switch below,
-        # so they join the protocol group in this very same call and their native session is
-        # torn down afterwards.
+        # so they join the protocol group in this very same call and are released from the
+        # parent's native grouping afterwards.
         stranded_native_members = (
             self._migrate_stranded_native_members(
                 parent_player, parent_protocol_player, filtered_protocol_add
@@ -3014,7 +3017,8 @@ class ProtocolLinkingMixin:
 
         The handover only runs when the parent is actually switching protocol while it is
         rendering; playback is resumed only for a parent that was playing, so adding a member
-        never starts playback on its own.
+        never starts playback on its own. Migrated native members are released regardless,
+        because they moved to the protocol group whether or not the parent was rendering.
 
         :param parent_player: The parent player that just gained protocol members.
         :param parent_protocol_player: The protocol player the members joined.
@@ -3046,19 +3050,26 @@ class ProtocolLinkingMixin:
         if not (is_native_protocol and already_using_native):
             parent_player.set_active_output_protocol(parent_protocol_player.player_id)
 
-        if not (was_rendering and switching_protocols):
+        handing_over = was_rendering and switching_protocols
+        if handing_over:
+            self.logger.info(
+                "Handing the output of %s over to the %s protocol%s",
+                parent_player.state.name,
+                parent_protocol_player.provider.domain,
+                " and resuming playback" if was_playing else "",
+            )
+        if stranded_native_members:
+            # The members joined the protocol group in the same call, so their place on the
+            # parent's own stream is released either way; only a live session needs stopping.
+            await self._release_native_members(
+                parent_player,
+                parent_protocol_player,
+                stranded_native_members,
+                stop_session=handing_over,
+            )
+        if not handing_over:
             return
 
-        self.logger.info(
-            "Handing the output of %s over to the %s protocol%s",
-            parent_player.state.name,
-            parent_protocol_player.provider.domain,
-            " and resuming playback" if was_playing else "",
-        )
-        if stranded_native_members:
-            await self._stop_native_session(
-                parent_player, parent_protocol_player, stranded_native_members
-            )
         old_parent_members = await self._stop_previous_protocol(
             parent_player, parent_protocol_player, previous_protocol
         )

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -769,6 +769,9 @@ class SendspinAirPlayBridge:
 
         :param stream: The stream currently published on the AirPlay player.
         """
+        # Only the transport and its session are this method's: native group membership
+        # belongs to the player controller, which releases it in the grouping command that
+        # hands the speaker over long before any audio reaches the bridge.
         if stream.running:
             # An idle player keeps its last stream published, so only a live one
             # is worth reporting as displaced.

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -771,7 +771,7 @@ class SendspinAirPlayBridge:
         """
         # Only the transport and its session are this method's: native group membership
         # belongs to the player controller, which releases it in the grouping command that
-        # hands the speaker over long before any audio reaches the bridge.
+        # hands the speaker over.
         if stream.running:
             # An idle player keeps its last stream published, so only a live one
             # is worth reporting as displaced.

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -749,6 +749,23 @@ class TestSessionBoundLeaderJoinsAnotherGroup:
         leader.set_members.assert_not_awaited()
         assert target.group_members == ["target", "leader"]
 
+    async def test_a_group_that_cannot_be_dissolved_keeps_the_player_out(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A leader that could not give its group up stays out instead of joining on top of it.
+
+        Joining anyway leaves it leading a group it can no longer serve, and a player that
+        is synced refuses every later member change, so the state cannot be cleaned up.
+        """
+        controller, leader, member, target = self._build(mock_mass, SessionBoundMockPlayer)
+        leader.set_members = AsyncMock(side_effect=RuntimeError("speaker unreachable"))  # type: ignore[method-assign]
+
+        await controller._handle_set_members(target, player_ids_to_add=["leader"])
+
+        assert target.group_members == []
+        assert member.synced_to == "leader"
+
     async def test_a_group_that_survives_the_join_is_left_alone(self, mock_mass: MagicMock) -> None:
         """A provider whose members do not ride the leader's own stream keeps its group."""
         controller, leader, member, target = self._build(mock_mass, MockPlayer)

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -54,6 +54,15 @@ def controller(mock_mass: MagicMock) -> PlayerController:
     return PlayerController(mock_mass)
 
 
+class SessionBoundMockPlayer(MockPlayer):
+    """Mock player whose native members ride its own stream session (e.g. AirPlay)."""
+
+    @property
+    def native_grouping_requires_own_stream(self) -> bool:
+        """Return True: native members are attached to this player's own stream session."""
+        return True
+
+
 class TestCanGroupWithBasics:
     """Test basic can_group_with filtering logic."""
 
@@ -680,6 +689,74 @@ class TestAdHocLeadershipTransfer:
 
         controller._transfer_ad_hoc_leadership.assert_not_awaited()
         controller._handle_cmd_stop.assert_awaited_once_with("leader")
+
+
+class TestSessionBoundLeaderJoinsAnotherGroup:
+    """A leader whose members ride its own stream gives that group up when it joins another."""
+
+    def _build(
+        self, mock_mass: MagicMock, leader_class: type[MockPlayer]
+    ) -> tuple[PlayerController, MockPlayer, MockPlayer, MockPlayer]:
+        """Build an idle leader with one native member, plus the group it is about to join."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("airplay", instance_id="airplay", mass=mock_mass)
+
+        leader = leader_class(provider, "leader", "Living Room")
+        leader._attr_supported_features |= {PlayerFeature.SET_MEMBERS, PlayerFeature.PLAY_MEDIA}
+        leader._attr_can_group_with = {"member", "target"}
+        leader._attr_group_members = ["leader", "member"]
+
+        member = MockPlayer(provider, "member", "Kitchen")
+        member._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+
+        target = MockPlayer(provider, "target", "Study")
+        target._attr_supported_features |= {PlayerFeature.SET_MEMBERS, PlayerFeature.PLAY_MEDIA}
+        target._attr_can_group_with = {"leader", "member"}
+
+        controller._players = {p.player_id: p for p in (leader, member, target)}
+        mock_mass.players = controller
+        for player in controller._players.values():
+            player.set_initialized()
+            player.update_state(signal_event=False)
+        assert member.synced_to == "leader"
+        return controller, leader, member, target
+
+    async def test_own_group_is_dissolved_before_it_joins(self, mock_mass: MagicMock) -> None:
+        """
+        The members are released before the leader becomes a member itself.
+
+        A native group outlives its session, so a leader that stopped still lists its
+        members. Joining another group leaves it unable to serve them, and they would be
+        silent while the UI still shows them grouped.
+        """
+        controller, leader, member, target = self._build(mock_mass, SessionBoundMockPlayer)
+
+        await controller._handle_set_members(target, player_ids_to_add=["leader"])
+
+        assert "member" not in leader.group_members
+        assert member.synced_to is None
+        assert target.group_members == ["target", "leader"]
+
+    async def test_a_leader_without_members_is_left_alone(self, mock_mass: MagicMock) -> None:
+        """A player that leads nothing has no group to give up."""
+        controller, leader, _member, target = self._build(mock_mass, SessionBoundMockPlayer)
+        leader._attr_group_members = []
+        leader.update_state(signal_event=False)
+        leader.set_members = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._handle_set_members(target, player_ids_to_add=["leader"])
+
+        leader.set_members.assert_not_awaited()
+        assert target.group_members == ["target", "leader"]
+
+    async def test_a_group_that_survives_the_join_is_left_alone(self, mock_mass: MagicMock) -> None:
+        """A provider whose members do not ride the leader's own stream keeps its group."""
+        controller, leader, member, target = self._build(mock_mass, MockPlayer)
+
+        await controller._handle_set_members(target, player_ids_to_add=["leader"])
+
+        assert leader.group_members == ["leader", "member"]
+        assert member.synced_to == "leader"
 
 
 if __name__ == "__main__":

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -749,6 +749,25 @@ class TestSessionBoundLeaderJoinsAnotherGroup:
         leader.set_members.assert_not_awaited()
         assert target.group_members == ["target", "leader"]
 
+    async def test_a_playing_group_is_never_torn_down(self, mock_mass: MagicMock) -> None:
+        """
+        A leader still serving its own group stays out instead of silencing its members.
+
+        Grouping never offers a rendering leader as a target, but the candidate list is a
+        snapshot: it is only recomputed when a group membership or availability changes, so
+        one taken before playback started still lists the leader.
+        """
+        controller, leader, member, target = self._build(mock_mass, SessionBoundMockPlayer)
+        leader._attr_playback_state = PlaybackState.PLAYING
+        leader.update_state(signal_event=False)
+        leader.set_members = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._handle_set_members(target, player_ids_to_add=["leader"])
+
+        leader.set_members.assert_not_awaited()
+        assert target.group_members == []
+        assert member.synced_to == "leader"
+
     async def test_a_group_that_cannot_be_dissolved_keeps_the_player_out(
         self, mock_mass: MagicMock
     ) -> None:

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -3727,6 +3727,62 @@ class TestProtocolSwitchingDuringPlayback:
             controller.cmd_resume.assert_not_awaited()
         controller._handle_set_members.assert_not_awaited()
 
+    async def test_idle_native_members_migrate_without_stopping_the_parent(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        An idle parent hands its native members over too, with no session to stop.
+
+        A native group outlives the session it was formed for, so the members are still
+        attached to the parent when it switches protocol. Leaving them behind would keep
+        them listed as grouped while nothing feeds them on the next play.
+        """
+        controller, players = self._build_session_bound_group(mock_mass, PlaybackState.IDLE)
+        leader = players["speaker_leader"]
+        bridge_leader = players["bridge_leader"]
+
+        calls: list[tuple[str, Any]] = []
+        leader_set_members = leader.set_members
+        bridge_set_members = bridge_leader.set_members
+
+        async def record_leader_set_members(
+            player_ids_to_add: list[str] | None = None,
+            player_ids_to_remove: list[str] | None = None,
+        ) -> None:
+            calls.append(("leader_set_members", player_ids_to_remove))
+            await leader_set_members(player_ids_to_add, player_ids_to_remove)
+
+        async def record_bridge_set_members(
+            player_ids_to_add: list[str] | None = None,
+            player_ids_to_remove: list[str] | None = None,
+        ) -> None:
+            calls.append(("bridge_set_members", player_ids_to_add))
+            await bridge_set_members(player_ids_to_add, player_ids_to_remove)
+
+        async def record_leader_stop() -> None:
+            calls.append(("leader_stop", None))
+
+        leader.set_members = record_leader_set_members  # type: ignore[method-assign]
+        leader.stop = record_leader_stop  # type: ignore[method-assign]
+        bridge_leader.set_members = record_bridge_set_members  # type: ignore[method-assign]
+        controller.cmd_resume = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._forward_protocol_set_members(
+            parent_player=leader,
+            parent_protocol_player=bridge_leader,
+            protocol_members_to_add=["bridge_only"],
+            protocol_members_to_remove=[],
+        )
+
+        # the native member joins the protocol group and is released from the parent,
+        # but an idle parent has no session to stop and nothing to resume
+        assert calls == [
+            ("bridge_set_members", ["bridge_only", "bridge_member"]),
+            ("leader_set_members", ["speaker_member"]),
+        ]
+        assert leader.active_output_protocol == "bridge_leader"
+        controller.cmd_resume.assert_not_awaited()
+
     async def test_joining_member_protocol_is_active_before_its_stream_starts(
         self, mock_mass: MagicMock
     ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

A sync group outlives the session it was formed for, so a group you stopped
yesterday still has its members. Two grouping actions never released those
members, which left a speaker silent while it still showed up as grouped:

- adding a Sendspin speaker to a stopped group left the group's other speakers
  behind, so only the one you added and the leader played
- adding a speaker that already leads its own group to another group left it
  leading a group it can no longer serve from inside the new one

Both come out of the same missing step: the old group is never given up. Found
while reviewing #6051, which fixed a different route to the same silence.

**Related issue (if applicable):**

- found during review of #6051

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

Changes:

- a stopped group's members move along with it when the group switches to
  another output, the same way a playing group's members already did
- a speaker that leads its own group gives that group up before it joins
  another one
- a speaker stays out of the new group instead of joining it twice when its
  own group is still playing, or when that group cannot be given up

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.

