### PR TITLE
Stop AirPlay speakers in a group immediately on pause or stop

### DIFF
--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -431,6 +431,7 @@ class SendspinAirPlayBridge:
                 on_mute_change=self._on_mute_change,
                 on_stream_start=self._on_bridge_stream_start,
                 on_stream_end=self._on_bridge_stream_end,
+                on_explicit_stop=self._on_bridge_explicit_stop,
                 initial_volume=self.airplay_player.volume_level or 25,
                 initial_muted=bool(self.airplay_player.volume_muted),
             )
@@ -1034,17 +1035,64 @@ class SendspinAirPlayBridge:
         """
         Handle the sendspin stream ending: defer the CLI teardown briefly.
 
-        A seek or next-track ends the stream and immediately starts a new one.
-        Tearing the CLI down here would force every such switch through a cold
-        reconnect; instead we keep the connected binary alive for a short grace
-        window so the next stream can reuse it via flush-refill. If no new
-        stream arrives within the window (a real stop), the deferred cleanup
-        kills the CLI so AirPlay stops instead of draining its buffer.
+        A stream end that is immediately followed by a new stream (a seek or
+        next-track on setups that end the stream for those) would force every
+        such switch through a cold reconnect if the CLI were torn down here;
+        instead the connected binary is kept alive for a short grace window so
+        the next stream can reuse it via flush-refill. If no new stream arrives
+        within the window, the deferred cleanup kills the CLI so AirPlay stops
+        instead of draining its buffer. A stop the user asked for skips the
+        window through _on_bridge_explicit_stop.
         """
         self._is_streaming = False
         self._queued_frames = 0
+        if self._transport_state_empty():
+            # A stream end with no transport behind it (an explicit stop already
+            # tore it down, or no chunk ever started one): nothing to keep warm
+            # and nothing to defer.
+            self.logger.debug(
+                "Sendspin stream ended for %s with no transport to keep warm",
+                self.airplay_player.display_name,
+            )
+            return
+        self.logger.debug(
+            "Sendspin stream ended for %s; keeping the CLI warm for %.0fs",
+            self.airplay_player.display_name,
+            BRIDGE_WARM_GRACE_SECONDS,
+        )
         self.mass.call_later(
             BRIDGE_WARM_GRACE_SECONDS, self._deferred_cleanup, task_id=self._teardown_timer_id
+        )
+
+    def _on_bridge_explicit_stop(self) -> None:
+        """
+        Tear the transport down at once for a stop the user asked for.
+
+        The stream end preceding this callback armed the warm grace window,
+        which exists for a next track to ride the connected binary. Nothing
+        follows an explicit stop, and the device holds seconds of buffered
+        audio, so waiting the window out would play out what the user asked to
+        end. The bridge stays registered in its group, so a later play includes
+        this speaker again.
+        """
+        self.mass.cancel_timer(self._teardown_timer_id)
+        if self._is_streaming:
+            # A new stream already took the bridge over; the transport belongs to it now.
+            return
+        if self._transport_state_empty():
+            return
+        self.logger.debug(
+            "Explicit stop for %s: tearing the transport down without the warm grace",
+            self.airplay_player.display_name,
+        )
+        self._schedule_cleanup()
+
+    def _transport_state_empty(self) -> bool:
+        """Return whether the bridge holds no transport, writer or pending start."""
+        return (
+            self._airplay_stream is None
+            and self._writer_task is None
+            and self._airplay_stream_start_task is None
         )
 
     def _deferred_cleanup(self) -> None:

--- a/music_assistant/providers/sendspin/bridge_role.py
+++ b/music_assistant/providers/sendspin/bridge_role.py
@@ -69,6 +69,7 @@ class BridgePlayerRole(Role):
         self._on_mute_change_cb: Callable[[bool], None] | None = None
         self._on_stream_start_cb: Callable[[], None] | None = None
         self._on_stream_end_cb: Callable[[], None] | None = None
+        self._on_explicit_stop_cb: Callable[[], None] | None = None
         self._audio_requirements: AudioRequirements | None = None
         self._volume: int = 100
         self._muted: bool = False
@@ -85,6 +86,7 @@ class BridgePlayerRole(Role):
         on_mute_change: Callable[[bool], None],
         on_stream_start: Callable[[], None],
         on_stream_end: Callable[[], None],
+        on_explicit_stop: Callable[[], None] | None = None,
         initial_volume: int = 100,
         initial_muted: bool = False,
     ) -> None:
@@ -96,6 +98,9 @@ class BridgePlayerRole(Role):
         :param on_mute_change: Callback when mute state changes.
         :param on_stream_start: Callback when the stream starts.
         :param on_stream_end: Callback when the stream ends.
+        :param on_explicit_stop: Callback when playback was ended by an explicit
+            user command (stop, or removal from the group), so the bridge can
+            silence its player at once instead of keeping its transport warm.
         :param initial_volume: Initial volume level (0-100).
         :param initial_muted: Initial mute state.
         """
@@ -104,6 +109,7 @@ class BridgePlayerRole(Role):
         self._on_mute_change_cb = on_mute_change
         self._on_stream_start_cb = on_stream_start
         self._on_stream_end_cb = on_stream_end
+        self._on_explicit_stop_cb = on_explicit_stop
         self.update_player_state(volume=initial_volume, muted=initial_muted)
 
     @property
@@ -247,6 +253,18 @@ class BridgePlayerRole(Role):
         LOGGER.debug("BridgePlayerRole stream ended for client %s", self._client.client_id)
         if self._on_stream_end_cb:
             self._on_stream_end_cb()
+
+    def notify_explicit_stop(self) -> None:
+        """
+        Notify the bridge that playback ended on an explicit user command.
+
+        Call this after the stop (or group removal) has ended the stream, so
+        the bridge can tear its downstream transport down at once instead of
+        keeping it warm for a next track that will not come.
+        """
+        LOGGER.debug("BridgePlayerRole explicit stop for client %s", self._client.client_id)
+        if self._on_explicit_stop_cb:
+            self._on_explicit_stop_cb()
 
     def _emit_volume_changed(self) -> None:
         """Emit VolumeChangedEvent so the SendspinPlayer stays in sync."""

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import suppress
 from io import BytesIO
 from typing import TYPE_CHECKING, ClassVar, cast
@@ -80,6 +80,7 @@ from music_assistant.helpers.util import is_valid_mac_address, join_task
 from music_assistant.models.player import Player, PlayerMedia
 from music_assistant.models.setup_flow import FINISH_STEP_SILENT, AbortFlow, StepExpiredError
 
+from .bridge_role import BridgePlayerRole
 from .constants import (
     BRIDGE_PREFIX,
     CONF_ACTION_MANAGEMENT_DYNAMIC_PIN_DISABLE,
@@ -1399,6 +1400,11 @@ class SendspinPlayer(SendspinBasePlayer):
         try:
             await self.api.group.stop()
         finally:
+            # Bridge members buffer seconds of audio on their downstream protocol
+            # and keep that transport warm across stream ends; a user stop must
+            # reach them so the device is silenced now instead of playing out its
+            # buffer. Synchronous, so nothing suspends before the cancel below.
+            self._notify_bridges_explicit_stop(self.api.group.clients)
             await self.playback_session.cancel("stop command")
 
     async def play_media(self, media: PlayerMedia) -> None:
@@ -1482,6 +1488,12 @@ class SendspinPlayer(SendspinBasePlayer):
                         self.playback_session = SendspinPlaybackSession(self)
 
             await self.api.group.remove_client(member_player.api)
+            # An explicit removal ends playback for that member; a bridge among
+            # its roles must silence its device now rather than play out the
+            # audio it still holds buffered. A member moving to another group
+            # does not pass here (add_client regroups internally), so a warm
+            # transport handover between groups is unaffected.
+            self._notify_bridges_explicit_stop([member_player.api])
         # Cast-only: reset futures before add so a fatal error on a Cast-bridged
         # member (e.g. AudioContext unsupported) raises PlayerCommandFailed.
         # Only track readiness while streaming, only then add_client launches the app.
@@ -1838,6 +1850,25 @@ class SendspinPlayer(SendspinBasePlayer):
             else DisconnectBehaviour.UNGROUP
         )
         await self.playback_session.sync_members(set(desired_session_members))
+
+    def _notify_bridges_explicit_stop(self, clients: Iterable[SendspinClient]) -> None:
+        """
+        Tell bridge roles among the given clients that playback was explicitly stopped.
+
+        :param clients: The Sendspin clients whose bridge roles to notify.
+        """
+        for client in list(clients):
+            for role in client.roles_by_family("player"):
+                if not isinstance(role, BridgePlayerRole):
+                    continue
+                try:
+                    role.notify_explicit_stop()
+                except Exception:
+                    # Best effort: one bridge failing must not keep the stop
+                    # from reaching the other members or the session teardown.
+                    self.logger.exception(
+                        "Error notifying bridge %s of an explicit stop", client.client_id
+                    )
 
     def _get_cast_bridge_manager(self) -> SendspinBridgeManager | None:
         """Return the Chromecast provider's Sendspin bridge manager, if loaded."""

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -1406,6 +1406,11 @@ class SendspinPlayer(SendspinBasePlayer):
             # buffer. Synchronous, so nothing suspends before the cancel below.
             self._notify_bridges_explicit_stop(self.api.group.clients)
             await self.playback_session.cancel("stop command")
+            # A group stop that raised before ending the stream left the notify
+            # above without effect (the bridges still saw themselves streaming).
+            # The cancel is what ends the stream on that path, so deliver the
+            # notify again; bridges already torn down ignore it.
+            self._notify_bridges_explicit_stop(self.api.group.clients)
 
     async def play_media(self, media: PlayerMedia) -> None:
         """Play media command."""

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -1495,9 +1495,9 @@ class SendspinPlayer(SendspinBasePlayer):
             await self.api.group.remove_client(member_player.api)
             # An explicit removal ends playback for that member; a bridge among
             # its roles must silence its device now rather than play out the
-            # audio it still holds buffered. A member moving to another group
-            # does not pass here (add_client regroups internally), so a warm
-            # transport handover between groups is unaffected.
+            # audio it still holds buffered. A move to another group passes
+            # here too (the controller ungroups before it adds) and trades its
+            # warm transport handover for that immediate silence.
             self._notify_bridges_explicit_stop([member_player.api])
         # Cast-only: reset futures before add so a fatal error on a Cast-bridged
         # member (e.g. AudioContext unsupported) raises PlayerCommandFailed.

--- a/tests/providers/airplay/test_sendspin_bridge.py
+++ b/tests/providers/airplay/test_sendspin_bridge.py
@@ -2898,6 +2898,91 @@ async def test_a_stop_never_reaches_a_player_without_a_bridge() -> None:
     assert _bridge_manager_for(bridge).stop_streaming("apother") is False
 
 
+# --- A stop on the Sendspin side skips the warm grace (support#6195) -----------
+
+
+def test_a_sendspin_stop_skips_the_grace_and_tears_the_transport_down() -> None:
+    """
+    A stop reaching the bridge through its role kills the CLI at once.
+
+    The stream end that precedes it arms the warm grace window, during which
+    the device plays out the seconds it holds buffered. The explicit-stop
+    signal cancels that window and hands the transport straight to the
+    cleanup path.
+    """
+    bridge, stream = _make_anchored_bridge(running=True)
+    writer_task = MagicMock()
+    bridge._writer_task = writer_task
+    start_task = bridge._airplay_stream_start_task
+
+    with patch.object(bridge, "_cleanup_old_stream", MagicMock()) as cleanup:
+        bridge._on_bridge_stream_end()
+        bridge._on_bridge_explicit_stop()
+
+    cast("MagicMock", bridge.mass).cancel_timer.assert_called_with(bridge._teardown_timer_id)
+    assert cleanup.call_args.args[:3] == (stream, writer_task, start_task)
+    assert bridge._airplay_stream is None
+
+
+def test_a_sendspin_stop_keeps_the_bridges_seat_in_the_group() -> None:
+    """
+    A group-wide stop leaves the membership alone.
+
+    The group's own STOPPED state is what the visible player reports, and the
+    next play on the group must include this speaker -- unlike a stop aimed at
+    the AirPlay player itself, there is no session to leave here.
+    """
+    bridge, _ = _make_anchored_bridge(running=True)
+
+    with (
+        patch.object(bridge, "_cleanup_old_stream", MagicMock()),
+        patch.object(bridge, "_leave_sendspin_session", MagicMock()) as leave,
+    ):
+        bridge._on_bridge_stream_end()
+        bridge._on_bridge_explicit_stop()
+
+    leave.assert_not_called()
+
+
+def test_an_explicit_stop_spares_a_stream_that_already_took_over() -> None:
+    """A play racing the stop owns the transport; the stop must not kill it."""
+    bridge, stream = _make_anchored_bridge(running=True)
+    bridge._is_streaming = True
+
+    with patch.object(bridge, "_schedule_cleanup", MagicMock()) as schedule:
+        bridge._on_bridge_explicit_stop()
+
+    schedule.assert_not_called()
+    assert bridge._airplay_stream is stream
+
+
+def test_an_explicit_stop_with_nothing_held_is_a_no_op() -> None:
+    """The ungroup that follows a stop finds the transport already gone."""
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+    bridge._is_streaming = False
+
+    with patch.object(bridge, "_schedule_cleanup", MagicMock()) as schedule:
+        bridge._on_bridge_explicit_stop()
+
+    schedule.assert_not_called()
+
+
+def test_a_stream_end_with_no_transport_arms_no_grace_timer() -> None:
+    """
+    A stream end that left nothing behind has nothing to keep warm or defer.
+
+    Removing the member from its Sendspin group ends the stream for its roles
+    a second time after the stop already tore the transport down; re-arming
+    the timer there would only reschedule an empty teardown.
+    """
+    bridge = _make_bridge(clock_now_us=SENDSPIN_EPOCH_US)
+
+    bridge._on_bridge_stream_end()
+
+    cast("MagicMock", bridge.mass).call_later.assert_not_called()
+    assert bridge._is_streaming is False
+
+
 # --- One shared-PTP decision per Sendspin group --------------------------------
 
 

--- a/tests/providers/sendspin/test_explicit_stop_bridge_notify.py
+++ b/tests/providers/sendspin/test_explicit_stop_bridge_notify.py
@@ -58,20 +58,30 @@ async def test_stop_notifies_bridges_between_group_stop_and_session_cancel() -> 
 
     await SendspinPlayer.stop(mock)
 
-    assert order == ["group_stop", "notify", "cancel"]
-    mock._notify_bridges_explicit_stop.assert_called_once_with(mock.api.group.clients)
+    # the trailing notify only exists for the failed-stop path; here it is a no-op
+    assert order == ["group_stop", "notify", "cancel", "notify"]
+    mock._notify_bridges_explicit_stop.assert_called_with(mock.api.group.clients)
 
 
 async def test_stop_notifies_bridges_even_when_the_group_stop_fails() -> None:
-    """A failing group stop must not leave a bridge playing out its buffer."""
+    """
+    A failing group stop must not leave a bridge playing out its buffer.
+
+    A group stop that raises before ending the stream leaves the bridges still
+    streaming, so the notify preceding the cancel does not reach them. The
+    session cancel is what ends the stream on that path, and the notify that
+    matters is the one delivered after it.
+    """
     mock = _player_mock()
+    order: list[str] = []
     mock.api.group.stop = AsyncMock(side_effect=RuntimeError("transport gone"))
+    mock._notify_bridges_explicit_stop = MagicMock(side_effect=lambda _: order.append("notify"))
+    mock.playback_session.cancel.side_effect = lambda _reason: order.append("cancel")
 
     with pytest.raises(RuntimeError):
         await SendspinPlayer.stop(mock)
 
-    mock._notify_bridges_explicit_stop.assert_called_once()
-    mock.playback_session.cancel.assert_awaited_once_with("stop command")
+    assert order == ["notify", "cancel", "notify"]
 
 
 async def test_removing_a_member_notifies_its_bridge_after_the_removal() -> None:

--- a/tests/providers/sendspin/test_explicit_stop_bridge_notify.py
+++ b/tests/providers/sendspin/test_explicit_stop_bridge_notify.py
@@ -1,0 +1,132 @@
+"""
+Tests for bridge players being told about an explicit stop (support#6195).
+
+A bridge player buffers seconds of audio on its downstream protocol and keeps
+that transport warm across stream ends, so seeks and track changes can reuse
+it. At the Sendspin server level a user stop is indistinguishable from those:
+the truthful signal lives in the player commands, so SendspinPlayer.stop() and
+set_members() notify the bridge roles, which is what lets a bridge silence its
+device at once instead of playing out its buffer.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from music_assistant.providers.sendspin.bridge_role import BridgePlayerRole
+from music_assistant.providers.sendspin.player import SendspinPlayer
+
+
+def _player_mock() -> MagicMock:
+    """Create a mock to bind the real methods under test to."""
+    mock = MagicMock()
+    mock.playback_session.cancel = AsyncMock()
+    mock.api.group.stop = AsyncMock()
+    mock.api.group.remove_client = AsyncMock()
+    return mock
+
+
+def _bridge_role(on_explicit_stop: MagicMock | None) -> BridgePlayerRole:
+    """Build a bridge role with only the explicit-stop callback of interest."""
+    role = BridgePlayerRole(client=MagicMock())
+    role.set_callbacks(
+        on_audio_chunk=MagicMock(),
+        on_volume_change=MagicMock(),
+        on_mute_change=MagicMock(),
+        on_stream_start=MagicMock(),
+        on_stream_end=MagicMock(),
+        on_explicit_stop=on_explicit_stop,
+    )
+    return role
+
+
+async def test_stop_notifies_bridges_between_group_stop_and_session_cancel() -> None:
+    """
+    The notify lands after the stream ended and before the session teardown.
+
+    Before group.stop() the bridge would still see itself streaming and ignore
+    the signal; after the session cancel it would have spent that long playing
+    out its buffer.
+    """
+    mock = _player_mock()
+    order: list[str] = []
+    mock.api.group.stop.side_effect = lambda: order.append("group_stop")
+    mock._notify_bridges_explicit_stop = MagicMock(side_effect=lambda _: order.append("notify"))
+    mock.playback_session.cancel.side_effect = lambda _reason: order.append("cancel")
+
+    await SendspinPlayer.stop(mock)
+
+    assert order == ["group_stop", "notify", "cancel"]
+    mock._notify_bridges_explicit_stop.assert_called_once_with(mock.api.group.clients)
+
+
+async def test_stop_notifies_bridges_even_when_the_group_stop_fails() -> None:
+    """A failing group stop must not leave a bridge playing out its buffer."""
+    mock = _player_mock()
+    mock.api.group.stop = AsyncMock(side_effect=RuntimeError("transport gone"))
+
+    with pytest.raises(RuntimeError):
+        await SendspinPlayer.stop(mock)
+
+    mock._notify_bridges_explicit_stop.assert_called_once()
+    mock.playback_session.cancel.assert_awaited_once_with("stop command")
+
+
+async def test_removing_a_member_notifies_its_bridge_after_the_removal() -> None:
+    """
+    An ungrouped member is told to stop once its stream has been ended.
+
+    The removal is what fires the stream end for the member's roles; notifying
+    before it would find the bridge still streaming and be ignored.
+    """
+    mock = _player_mock()
+    member = MagicMock()
+    mock.mass.players.get_player.return_value = member
+    order: list[str] = []
+    mock.api.group.remove_client.side_effect = lambda _client: order.append("remove")
+    mock._notify_bridges_explicit_stop = MagicMock(side_effect=lambda _: order.append("notify"))
+
+    await SendspinPlayer.set_members(mock, player_ids_to_remove=["member1"])
+
+    assert order == ["remove", "notify"]
+    mock._notify_bridges_explicit_stop.assert_called_once_with([member.api])
+
+
+def test_notify_reaches_only_bridge_roles() -> None:
+    """Native player roles have their own stream/end handling and are left alone."""
+    mock = _player_mock()
+    on_explicit_stop = MagicMock()
+    native_role = MagicMock()
+    client = MagicMock()
+    client.roles_by_family.return_value = [native_role, _bridge_role(on_explicit_stop)]
+
+    SendspinPlayer._notify_bridges_explicit_stop(mock, [client])
+
+    on_explicit_stop.assert_called_once_with()
+    native_role.notify_explicit_stop.assert_not_called()
+
+
+def test_a_failing_bridge_does_not_keep_the_stop_from_the_others() -> None:
+    """One bridge raising must not leave the next member playing out its buffer."""
+    mock = _player_mock()
+    failing_client = MagicMock()
+    failing_client.roles_by_family.return_value = [
+        _bridge_role(MagicMock(side_effect=RuntimeError("bridge broke")))
+    ]
+    on_explicit_stop = MagicMock()
+    healthy_client = MagicMock()
+    healthy_client.roles_by_family.return_value = [_bridge_role(on_explicit_stop)]
+
+    SendspinPlayer._notify_bridges_explicit_stop(mock, [failing_client, healthy_client])
+
+    on_explicit_stop.assert_called_once_with()
+    mock.logger.exception.assert_called_once()
+
+
+def test_a_role_without_the_callback_ignores_the_notify() -> None:
+    """A bridge that did not wire the callback (the Cast bridge) is unaffected."""
+    role = _bridge_role(None)
+
+    role.notify_explicit_stop()


### PR DESCRIPTION
# What does this implement/fix?

Pausing or stopping a group with AirPlay speakers in it (through the Sendspin bridge) left those speakers playing for another 4+ seconds, and removing a speaker from a playing group did the same. The bridge kept its AirPlay transport warm so a next track could reuse it, but after a stop there is no next track, so the wait only played out the audio the device still had buffered.

The stop and ungroup commands now tell the bridged speakers to tear the transport down immediately:

- `SendspinPlayer.stop()` and member removal in `set_members()` notify bridge players through a new `on_explicit_stop` role callback
- the AirPlay bridge then cancels the warm-grace window and stops the device at once, while staying in its group so a later play includes it again
- seeks, track changes and the natural end of the queue keep the warm handover exactly as before
- the bridge now logs stream ends at debug level; their silence is what made this issue hard to diagnose

Trade-off: moving a playing speaker straight from one group to another also goes through the remove path, so it now restarts its AirPlay connection on the new group instead of keeping it warm. Going silent at once when leaving a playing group is the expected behaviour, and the warm reuse across groups was best-effort anyway.

The speaker's own internal buffer (~2s on some devices) still plays out; that is an AirPlay protocol limitation. The slow start the reporter also mentions is a separate mechanism and will be handled as a follow-up.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/6195

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have [raised a PR against the documentation repository](https://github.com/music-assistant/music-assistant.io/blob/main/CONTRIBUTING.md) targeting the main or beta branch as appropriate.
